### PR TITLE
Add cancellation support for download, extract, and delete operations

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,107 +82,16 @@
         <button class="primary add-btn" id="btn-new"><svg width="14" height="14"><use href="#icon-plus"/></svg> <span data-i18n="list.newInstall">New Install</span></button>
       </div>
     </div>
+    <div id="list-filter-tabs" class="filter-tabs">
+      <button class="filter-tab active" data-filter="all" data-i18n="list.filterAll">All</button>
+      <button class="filter-tab" data-filter="local" data-i18n="list.filterLocal">Local</button>
+      <button class="filter-tab" data-filter="remote" data-i18n="list.filterRemote">Remote</button>
+      <button class="filter-tab" data-filter="cloud" data-i18n="list.filterCloud">Cloud</button>
+    </div>
     <div class="view-list-scroll">
       <div id="instance-list" class="instance-list"></div>
     </div>
     <div id="update-banner" class="update-banner" style="display:none"></div>
-  </div>
-
-  <!-- New Install View -->
-  <div id="view-new" class="view">
-    <div class="toolbar">
-      <div id="new-install-title" class="breadcrumb"></div>
-    </div>
-    <div class="view-scroll">
-      <div id="detected-gpu" class="detected-hardware"></div>
-
-      <div class="field">
-        <label for="inst-name" data-i18n="common.name">Name</label>
-        <input type="text" id="inst-name" placeholder="e.g. ComfyUI Main">
-      </div>
-
-      <div class="field">
-        <label for="source" data-i18n="newInstall.installMethod">Install Method</label>
-        <select id="source" disabled><option>Loading…</option></select>
-      </div>
-
-      <div id="source-fields"></div>
-
-      <div class="field">
-        <label for="inst-path" data-i18n="newInstall.installLocation">Install Location</label>
-        <div class="path-input">
-          <input type="text" id="inst-path" placeholder="Loading…" readonly>
-          <button id="btn-browse" type="button" data-i18n="common.browse">Browse…</button>
-        </div>
-      </div>
-    </div>
-    <div class="view-bottom">
-      <button class="primary" id="btn-save" disabled data-i18n="newInstall.addInstallation">Add Installation</button>
-    </div>
-  </div>
-
-  <!-- Progress View -->
-  <div id="view-progress" class="view">
-    <div class="toolbar">
-      <div id="progress-title" class="breadcrumb"></div>
-      <div class="toolbar-actions">
-        <button class="danger" id="btn-progress-cancel" style="display:none" data-i18n="common.cancel">Cancel</button>
-      </div>
-    </div>
-    <div class="view-scroll" id="progress-content"></div>
-  </div>
-
-  <!-- Instance Detail View -->
-  <div id="view-detail" class="view">
-    <div class="toolbar">
-      <div id="detail-title" class="breadcrumb"></div>
-    </div>
-    <div class="view-scroll" id="detail-sections"></div>
-    <div id="detail-bottom-actions"></div>
-  </div>
-
-  <!-- Track Existing View -->
-  <div id="view-track" class="view">
-    <div class="toolbar">
-      <div id="track-title" class="breadcrumb"></div>
-    </div>
-    <div class="view-scroll">
-      <div class="field">
-        <label for="track-path" data-i18n="track.installDir">Installation Directory</label>
-        <div class="path-input">
-          <input type="text" id="track-path" placeholder="Select a directory…" readonly>
-          <button id="btn-track-browse" type="button" data-i18n="common.browse">Browse…</button>
-        </div>
-      </div>
-
-      <div class="field">
-        <label for="track-source" data-i18n="track.detectedType">Detected Type</label>
-        <select id="track-source" disabled><option>Browse to a directory first</option></select>
-      </div>
-
-      <div class="field">
-        <label for="track-name" data-i18n="common.name">Name</label>
-        <input type="text" id="track-name" placeholder="e.g. ComfyUI Main">
-      </div>
-
-      <div id="track-detail"></div>
-    </div>
-    <div class="view-bottom">
-      <button class="primary" id="btn-track-save" disabled data-i18n="track.trackInstallation">Track Installation</button>
-    </div>
-  </div>
-
-  <!-- Console View -->
-  <div id="view-console" class="view">
-    <div class="toolbar">
-      <div id="console-title" class="breadcrumb"></div>
-      <div class="toolbar-actions">
-        <button id="btn-console-show-window" class="primary" style="display:none" data-i18n="running.showWindow">Show Window</button>
-        <button id="btn-console-browser" data-i18n="console.openInBrowser">Open in Browser</button>
-        <button class="danger" id="btn-console-stop" data-i18n="console.stop">Stop</button>
-      </div>
-    </div>
-    <div class="terminal-output" id="console-terminal"></div>
   </div>
 
   <!-- Models View -->
@@ -210,6 +119,121 @@
   </div>
 
   </main>
+  </div>
+
+  <!-- View Modal: Detail -->
+  <div id="modal-detail" class="view-modal">
+    <div class="view-modal-content">
+      <div class="view-modal-header">
+        <div class="view-modal-title" id="detail-modal-title"></div>
+        <button class="view-modal-close" data-modal="detail">✕</button>
+      </div>
+      <div class="view-modal-body">
+        <div class="view-scroll" id="detail-sections"></div>
+        <div id="detail-bottom-actions"></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- View Modal: Console -->
+  <div id="modal-console" class="view-modal">
+    <div class="view-modal-content">
+      <div class="view-modal-header">
+        <div class="view-modal-title" id="console-modal-title"></div>
+        <div class="view-modal-header-actions">
+          <button id="btn-console-show-window" class="primary" style="display:none" data-i18n="running.showWindow">Show Window</button>
+          <button id="btn-console-browser" data-i18n="console.openInBrowser">Open in Browser</button>
+          <button class="danger" id="btn-console-stop" data-i18n="console.stop">Stop</button>
+        </div>
+        <button class="view-modal-close" data-modal="console">✕</button>
+      </div>
+      <div class="view-modal-body">
+        <div class="terminal-output" id="console-terminal"></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- View Modal: Progress -->
+  <div id="modal-progress" class="view-modal">
+    <div class="view-modal-content">
+      <div class="view-modal-header">
+        <div class="view-modal-title" id="progress-modal-title"></div>
+        <div class="view-modal-header-actions">
+          <button class="danger" id="btn-progress-cancel" style="display:none" data-i18n="common.cancel">Cancel</button>
+        </div>
+        <button class="view-modal-close" data-modal="progress">✕</button>
+      </div>
+      <div class="view-modal-body">
+        <div class="view-scroll" id="progress-content"></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- View Modal: New Install -->
+  <div id="modal-new" class="view-modal">
+    <div class="view-modal-content">
+      <div class="view-modal-header">
+        <div class="view-modal-title" id="new-modal-title"></div>
+        <button class="view-modal-close" data-modal="new">✕</button>
+      </div>
+      <div class="view-modal-body">
+        <div class="view-scroll">
+          <div id="detected-gpu" class="detected-hardware"></div>
+          <div class="field">
+            <label for="inst-name" data-i18n="common.name">Name</label>
+            <input type="text" id="inst-name" placeholder="e.g. ComfyUI Main">
+          </div>
+          <div class="field">
+            <label for="source" data-i18n="newInstall.installMethod">Install Method</label>
+            <select id="source" disabled><option>Loading…</option></select>
+          </div>
+          <div id="source-fields"></div>
+          <div class="field">
+            <label for="inst-path" data-i18n="newInstall.installLocation">Install Location</label>
+            <div class="path-input">
+              <input type="text" id="inst-path" placeholder="Loading…" readonly>
+              <button id="btn-browse" type="button" data-i18n="common.browse">Browse…</button>
+            </div>
+          </div>
+        </div>
+        <div class="view-bottom">
+          <button class="primary" id="btn-save" disabled data-i18n="newInstall.addInstallation">Add Installation</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- View Modal: Track Existing -->
+  <div id="modal-track" class="view-modal">
+    <div class="view-modal-content">
+      <div class="view-modal-header">
+        <div class="view-modal-title" id="track-modal-title"></div>
+        <button class="view-modal-close" data-modal="track">✕</button>
+      </div>
+      <div class="view-modal-body">
+        <div class="view-scroll">
+          <div class="field">
+            <label for="track-path" data-i18n="track.installDir">Installation Directory</label>
+            <div class="path-input">
+              <input type="text" id="track-path" placeholder="Select a directory…" readonly>
+              <button id="btn-track-browse" type="button" data-i18n="common.browse">Browse…</button>
+            </div>
+          </div>
+          <div class="field">
+            <label for="track-source" data-i18n="track.detectedType">Detected Type</label>
+            <select id="track-source" disabled><option>Browse to a directory first</option></select>
+          </div>
+          <div class="field">
+            <label for="track-name" data-i18n="common.name">Name</label>
+            <input type="text" id="track-name" placeholder="e.g. ComfyUI Main">
+          </div>
+          <div id="track-detail"></div>
+        </div>
+        <div class="view-bottom">
+          <button class="primary" id="btn-track-save" disabled data-i18n="track.trackInstallation">Track Installation</button>
+        </div>
+      </div>
+    </div>
   </div>
 
   <script src="renderer/i18n.js"></script>
@@ -265,6 +289,16 @@
         confirmStyle: "danger",
       });
       if (confirmed) window.api.quitApp();
+    });
+
+    // View modal close buttons
+    document.querySelectorAll(".view-modal-close").forEach((btn) => {
+      btn.onclick = () => window.Launcher.closeViewModal(btn.dataset.modal);
+    });
+
+    // Filter tabs
+    document.querySelectorAll("#list-filter-tabs .filter-tab").forEach((btn) => {
+      btn.onclick = () => window.Launcher.list.setFilter(btn.dataset.filter);
     });
 
     // Wait for i18n before first render to avoid showing raw keys

--- a/installations.js
+++ b/installations.js
@@ -28,7 +28,7 @@ async function add(installation) {
     createdAt: new Date().toISOString(),
     ...installation,
   };
-  installations.push(entry);
+  installations.unshift(entry);
   await save(installations);
   return entry;
 }
@@ -62,4 +62,18 @@ async function reorder(orderedIds) {
   await save(reordered);
 }
 
-module.exports = { list, add, remove, update, get, reorder };
+async function seedDefaults(defaults) {
+  const installations = await load();
+  if (installations.length > 0) return;
+  for (const entry of defaults) {
+    installations.push({
+      id: `inst-${Date.now()}`,
+      createdAt: new Date().toISOString(),
+      status: "installed",
+      ...entry,
+    });
+  }
+  if (installations.length > 0) await save(installations);
+}
+
+module.exports = { list, add, remove, update, get, reorder, seedDefaults };

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -3,7 +3,7 @@ const { t } = require("./i18n");
 function deleteAction(installation) {
   return {
     id: "delete", label: t("actions.delete"), style: "danger", enabled: true,
-    showProgress: true, progressTitle: "Deleting…",
+    showProgress: true, progressTitle: "Deleting…", cancellable: true,
     confirm: {
       title: t("actions.deleteConfirmTitle"),
       message: t("actions.deleteConfirmMessage") + `\n${installation.installPath}`

--- a/lib/delete.js
+++ b/lib/delete.js
@@ -4,18 +4,20 @@ const path = require("path");
 /**
  * Count entries in a directory, yielding to the event loop periodically.
  */
-function countEntries(dir, onBatch) {
+function countEntries(dir, onBatch, signal) {
   return new Promise((resolve, reject) => {
     let total = 0;
     const batchSize = 500;
     let sinceYield = 0;
 
     function countDir(d, done) {
+      if (signal && signal.aborted) return done(new Error("Delete cancelled"));
       fs.readdir(d, { withFileTypes: true }, (err, entries) => {
         if (err) return done(err);
 
         let i = 0;
         function next() {
+          if (signal && signal.aborted) return done(new Error("Delete cancelled"));
           while (i < entries.length) {
             const entry = entries[i++];
             total++;
@@ -57,13 +59,16 @@ function countEntries(dir, onBatch) {
  * Recursively delete a directory with progress reporting.
  * @param {string} dir
  * @param {(p: {deleted: number, total: number, percent: number, elapsedSecs: number}) => void} [onProgress]
+ * @param {{ signal?: AbortSignal }} [options]
  */
-async function deleteDir(dir, onProgress) {
+async function deleteDir(dir, onProgress, options = {}) {
+  const { signal } = options;
   if (!fs.existsSync(dir)) return;
+  if (signal && signal.aborted) throw new Error("Delete cancelled");
 
   const total = await countEntries(dir, (counted) => {
     if (onProgress) onProgress({ deleted: 0, total: counted, percent: 0, elapsedSecs: 0 });
-  });
+  }, signal);
 
   let deleted = 0;
   const batchSize = 200;
@@ -74,17 +79,19 @@ async function deleteDir(dir, onProgress) {
     if (onProgress) {
       const elapsedSecs = (Date.now() - startTime) / 1000;
       const etaSecs = deleted > 0 ? elapsedSecs * ((total - deleted) / deleted) : -1;
-      onProgress({ deleted, total, percent: Math.round((deleted / total) * 100), elapsedSecs, etaSecs });
+      onProgress({ deleted, total, percent: total > 0 ? Math.round((deleted / total) * 100) : 100, elapsedSecs, etaSecs });
     }
   };
 
   await new Promise((resolve, reject) => {
     function walkAsync(d, done) {
+      if (signal && signal.aborted) return done(new Error("Delete cancelled"));
       fs.readdir(d, { withFileTypes: true }, (err, entries) => {
         if (err) return done(err);
 
         let i = 0;
         function next() {
+          if (signal && signal.aborted) return done(new Error("Delete cancelled"));
           if (i >= entries.length) return done(null);
           const entry = entries[i++];
           const fullPath = path.join(d, entry.name);

--- a/lib/download.js
+++ b/lib/download.js
@@ -7,18 +7,42 @@ const path = require("path");
  * @param {string} url
  * @param {string} destPath - full path to save file
  * @param {(progress: {percent: number, receivedMB: string, totalMB: string}) => void} onProgress
+ * @param {{ signal?: AbortSignal, _maxRedirects?: number }} [options]
  * @returns {Promise<string>} destPath on success
  */
-function download(url, destPath, onProgress, _maxRedirects = 5) {
+function download(url, destPath, onProgress, options = {}) {
+  // Support legacy positional _maxRedirects parameter
+  if (typeof options === "number") {
+    options = { _maxRedirects: options };
+  }
+  const { signal, _maxRedirects = 5 } = options;
+
   return new Promise((resolve, reject) => {
+    if (signal && signal.aborted) {
+      reject(new Error("Download cancelled"));
+      return;
+    }
+
     fs.mkdirSync(path.dirname(destPath), { recursive: true });
 
     const request = net.request(url);
     request.setHeader("User-Agent", "ComfyUI-Launcher");
 
+    let aborted = false;
+    const onAbort = () => {
+      aborted = true;
+      request.abort();
+    };
+    if (signal) signal.addEventListener("abort", onAbort, { once: true });
+
+    const cleanup = () => {
+      if (signal) signal.removeEventListener("abort", onAbort);
+    };
+
     request.on("response", (response) => {
       // Follow redirects (net.request handles 3xx automatically, but just in case)
       if (response.statusCode >= 300 && response.statusCode < 400 && response.headers.location) {
+        cleanup();
         if (_maxRedirects <= 0) {
           reject(new Error("Download failed: too many redirects"));
           return;
@@ -26,10 +50,11 @@ function download(url, destPath, onProgress, _maxRedirects = 5) {
         const loc = Array.isArray(response.headers.location)
           ? response.headers.location[0]
           : response.headers.location;
-        download(loc, destPath, onProgress, _maxRedirects - 1).then(resolve, reject);
+        download(loc, destPath, onProgress, { signal, _maxRedirects: _maxRedirects - 1 }).then(resolve, reject);
         return;
       }
       if (response.statusCode !== 200) {
+        cleanup();
         reject(new Error(`Download failed: HTTP ${response.statusCode}`));
         return;
       }
@@ -64,17 +89,36 @@ function download(url, destPath, onProgress, _maxRedirects = 5) {
       });
 
       response.on("end", () => {
+        cleanup();
+        if (aborted) {
+          fileStream.close();
+          try { fs.unlinkSync(destPath); } catch {}
+          reject(new Error("Download cancelled"));
+          return;
+        }
         fileStream.end(() => resolve(destPath));
       });
 
       response.on("error", (err) => {
+        cleanup();
         fileStream.close();
-        fs.unlinkSync(destPath);
+        try { fs.unlinkSync(destPath); } catch {}
+        if (aborted) {
+          reject(new Error("Download cancelled"));
+          return;
+        }
         reject(err);
       });
     });
 
-    request.on("error", reject);
+    request.on("error", (err) => {
+      cleanup();
+      if (aborted) {
+        reject(new Error("Download cancelled"));
+        return;
+      }
+      reject(err);
+    });
     request.end();
   });
 }

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -1,5 +1,14 @@
-const { spawn } = require("child_process");
+const { spawn, execFile } = require("child_process");
 const fs = require("fs");
+
+function killTree(child) {
+  if (!child || child.killed) return;
+  if (process.platform === "win32") {
+    execFile("taskkill", ["/T", "/F", "/PID", String(child.pid)], { windowsHide: true }, () => {});
+  } else {
+    child.kill();
+  }
+}
 
 function get7zBin() {
   const sevenZip = require("7zip-bin");
@@ -21,10 +30,17 @@ function get7zBin() {
  * @param {string} archivePath
  * @param {string} destDir
  * @param {function} [onProgress] - called with { percent, elapsedSecs, etaSecs }
+ * @param {{ signal?: AbortSignal }} [options]
  * @returns {Promise<void>}
  */
-function extract(archivePath, destDir, onProgress) {
+function extract(archivePath, destDir, onProgress, options = {}) {
+  const { signal } = options;
   return new Promise((resolve, reject) => {
+    if (signal && signal.aborted) {
+      reject(new Error("Extraction cancelled"));
+      return;
+    }
+
     fs.mkdirSync(destDir, { recursive: true });
 
     const bin = get7zBin();
@@ -32,7 +48,15 @@ function extract(archivePath, destDir, onProgress) {
 
     const child = spawn(bin, args);
     let stderr = "";
+    let cancelled = false;
     const startTime = Date.now();
+
+    const onAbort = () => {
+      cancelled = true;
+      killTree(child);
+    };
+    if (signal) signal.addEventListener("abort", onAbort, { once: true });
+    const cleanup = () => { if (signal) signal.removeEventListener("abort", onAbort); };
 
     child.stdout.on("data", (data) => {
       const lines = data.toString().split(/\r?\n/);
@@ -54,10 +78,14 @@ function extract(archivePath, destDir, onProgress) {
     });
 
     child.on("error", (err) => {
+      cleanup();
+      if (cancelled) { reject(new Error("Extraction cancelled")); return; }
       reject(new Error(`Extraction failed: ${err.message}`));
     });
 
     child.on("close", (code) => {
+      cleanup();
+      if (cancelled) { reject(new Error("Extraction cancelled")); return; }
       if (code !== 0) {
         // "Unsupported Method" errors are non-fatal — they only affect files
         // compressed with filters the bundled 7zip doesn't support (e.g. ARM64
@@ -78,13 +106,31 @@ function extract(archivePath, destDir, onProgress) {
 /**
  * Extract a .tar using native tar command (preserves symlinks).
  */
-function extractTarNative(archivePath, destDir) {
+function extractTarNative(archivePath, destDir, options = {}) {
+  const { signal } = options;
   return new Promise((resolve, reject) => {
+    if (signal && signal.aborted) {
+      reject(new Error("Extraction cancelled"));
+      return;
+    }
+
     const child = spawn("tar", ["xf", archivePath, "-C", destDir]);
     let stderr = "";
+    let cancelled = false;
+
+    const onAbort = () => { cancelled = true; killTree(child); };
+    if (signal) signal.addEventListener("abort", onAbort, { once: true });
+    const cleanup = () => { if (signal) signal.removeEventListener("abort", onAbort); };
+
     child.stderr.on("data", (data) => { stderr += data.toString(); });
-    child.on("error", (err) => reject(new Error(`tar extraction failed: ${err.message}`)));
+    child.on("error", (err) => {
+      cleanup();
+      if (cancelled) { reject(new Error("Extraction cancelled")); return; }
+      reject(new Error(`tar extraction failed: ${err.message}`));
+    });
     child.on("close", (code) => {
+      cleanup();
+      if (cancelled) { reject(new Error("Extraction cancelled")); return; }
       if (code !== 0) reject(new Error(`tar extraction failed: ${stderr || `exit code ${code}`}`));
       else resolve();
     });
@@ -97,8 +143,8 @@ function extractTarNative(archivePath, destDir) {
  * extract it in-place and remove it.
  * On non-Windows, uses native tar for the inner .tar to preserve symlinks.
  */
-async function extractNested(archivePath, destDir, onProgress) {
-  await extract(archivePath, destDir, onProgress);
+async function extractNested(archivePath, destDir, onProgress, options = {}) {
+  await extract(archivePath, destDir, onProgress, options);
 
   // Check if extraction produced a single .tar that needs a second pass
   try {
@@ -106,9 +152,9 @@ async function extractNested(archivePath, destDir, onProgress) {
     if (entries.length === 1 && entries[0].endsWith(".tar")) {
       const innerTar = require("path").join(destDir, entries[0]);
       if (process.platform !== "win32") {
-        await extractTarNative(innerTar, destDir);
+        await extractTarNative(innerTar, destDir, options);
       } else {
-        await extract(innerTar, destDir);
+        await extract(innerTar, destDir, undefined, options);
       }
       fs.unlinkSync(innerTar);
     }

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -3,7 +3,7 @@ const path = require("path");
 const { formatTime } = require("./util");
 const { t } = require("./i18n");
 
-async function downloadAndExtract(url, dest, cacheKey, { sendProgress, download, cache, extract }) {
+async function downloadAndExtract(url, dest, cacheKey, { sendProgress, download, cache, extract, signal }) {
   const filename = url.split("/").pop();
   const cacheBase = cache.getCachePath(cacheKey);
   fs.mkdirSync(cacheBase, { recursive: true });
@@ -14,15 +14,21 @@ async function downloadAndExtract(url, dest, cacheKey, { sendProgress, download,
     cache.touch(cacheKey);
   } else {
     sendProgress("download", { percent: 0, status: t("installer.startingDownload") });
-    await download(url, cachePath, (p) => {
-      const speed = `${p.speedMBs.toFixed(1)} MB/s`;
-      const elapsed = formatTime(p.elapsedSecs);
-      const eta = p.etaSecs >= 0 ? formatTime(p.etaSecs) : "—";
-      sendProgress("download", {
-        percent: p.percent,
-        status: t("installer.downloading", { progress: `${p.receivedMB} / ${p.totalMB} MB  ·  ${speed}  ·  ${elapsed} elapsed  ·  ${eta} remaining` }),
-      });
-    });
+    try {
+      await download(url, cachePath, (p) => {
+        const speed = `${p.speedMBs.toFixed(1)} MB/s`;
+        const elapsed = formatTime(p.elapsedSecs);
+        const eta = p.etaSecs >= 0 ? formatTime(p.etaSecs) : "—";
+        sendProgress("download", {
+          percent: p.percent,
+          status: t("installer.downloading", { progress: `${p.receivedMB} / ${p.totalMB} MB  ·  ${speed}  ·  ${elapsed} elapsed  ·  ${eta} remaining` }),
+        });
+      }, { signal });
+    } catch (err) {
+      // Remove partial cache file so a retry doesn't mistake it for a complete download
+      try { fs.unlinkSync(cachePath); } catch {}
+      throw err;
+    }
     cache.touch(cacheKey);
     cache.evict();
   }
@@ -35,10 +41,10 @@ async function downloadAndExtract(url, dest, cacheKey, { sendProgress, download,
       percent: p.percent,
       status: t("installer.extracting", { progress: `${p.percent}%  ·  ${elapsed} elapsed  ·  ${eta} remaining` }),
     });
-  });
+  }, { signal });
 }
 
-async function downloadAndExtractMulti(files, dest, cacheDir, { sendProgress, download, cache, extract }) {
+async function downloadAndExtractMulti(files, dest, cacheDir, { sendProgress, download, cache, extract, signal }) {
   const cacheBase = cache.getCachePath(cacheDir);
   fs.mkdirSync(cacheBase, { recursive: true });
 
@@ -47,6 +53,7 @@ async function downloadAndExtractMulti(files, dest, cacheDir, { sendProgress, do
   const totalMB = totalBytes > 0 ? (totalBytes / 1048576).toFixed(0) : null;
   let completedBytes = 0;
   let allCached = true;
+  const overallStart = Date.now();
 
   for (let i = 0; i < count; i++) {
     const file = files[i];
@@ -61,20 +68,28 @@ async function downloadAndExtractMulti(files, dest, cacheDir, { sendProgress, do
       allCached = false;
       const basePercent = totalBytes > 0 ? Math.round((completedBytes / totalBytes) * 100) : Math.round((i / count) * 100);
       sendProgress("download", { percent: basePercent, status: `${t("installer.startingDownload")}${fileLabel}` });
-      await download(file.url, fileCachePath, (p) => {
-        const speed = `${p.speedMBs.toFixed(1)} MB/s`;
-        const elapsed = formatTime(p.elapsedSecs);
-        const eta = p.etaSecs >= 0 ? formatTime(p.etaSecs) : "—";
-        const receivedTotal = ((completedBytes + p.receivedBytes) / 1048576).toFixed(0);
-        const sizeDisplay = totalMB ? `${receivedTotal} / ${totalMB} MB` : `${p.receivedMB} / ${p.totalMB} MB`;
-        const percent = totalBytes > 0
-          ? Math.round(((completedBytes + p.receivedBytes) / totalBytes) * 100)
-          : Math.round((i + p.percent / 100) / count * 100);
-        sendProgress("download", {
-          percent,
-          status: t("installer.downloading", { progress: `${fileLabel} ${sizeDisplay}  ·  ${speed}  ·  ${elapsed} elapsed  ·  ${eta} remaining` }),
-        });
-      });
+      try {
+        await download(file.url, fileCachePath, (p) => {
+          const speed = `${p.speedMBs.toFixed(1)} MB/s`;
+          const overallElapsed = (Date.now() - overallStart) / 1000;
+          const elapsed = formatTime(overallElapsed);
+          const receivedTotal = completedBytes + p.receivedBytes;
+          const overallSpeed = overallElapsed > 0 ? receivedTotal / 1048576 / overallElapsed : 0;
+          const remainingBytes = totalBytes - receivedTotal;
+          const eta = overallSpeed > 0 && totalBytes > 0 ? formatTime(remainingBytes / 1048576 / overallSpeed) : "—";
+          const sizeDisplay = totalMB ? `${(receivedTotal / 1048576).toFixed(0)} / ${totalMB} MB` : `${p.receivedMB} / ${p.totalMB} MB`;
+          const percent = totalBytes > 0
+            ? Math.round((receivedTotal / totalBytes) * 100)
+            : Math.round((i + p.percent / 100) / count * 100);
+          sendProgress("download", {
+            percent,
+            status: t("installer.downloading", { progress: `${fileLabel} ${sizeDisplay}  ·  ${speed}  ·  ${elapsed} elapsed  ·  ${eta} remaining` }),
+          });
+        }, { signal });
+      } catch (err) {
+        try { fs.unlinkSync(fileCachePath); } catch {}
+        throw err;
+      }
       completedBytes += file.size || 0;
     }
   }
@@ -100,7 +115,7 @@ async function downloadAndExtractMulti(files, dest, cacheDir, { sendProgress, do
       percent: p.percent,
       status: t("installer.extracting", { progress: `${p.percent}%  ·  ${elapsed} elapsed  ·  ${eta} remaining` }),
     });
-  });
+  }, { signal });
 }
 
 module.exports = { downloadAndExtract, downloadAndExtractMulti };

--- a/lib/ipc.js
+++ b/lib/ipc.js
@@ -78,8 +78,10 @@ let _onLaunch = null;
 let _onStop = null;
 let _onComfyExited = null;
 let _onComfyRestarted = null;
-let _launchAbort = null;
 let _detectedGPU = undefined;
+
+// Per-operation AbortController registry — tracks cancellable operations by installationId
+const _operationAborts = new Map(); // installationId -> AbortController
 
 // Session registry — tracks all running ComfyUI instances
 const _runningSessions = new Map(); // installationId -> { proc, port, url, mode, installationName, startedAt }
@@ -152,6 +154,16 @@ function register({ onLaunch, onStop, onComfyExited, onComfyRestarted } = {}) {
   _onComfyExited = onComfyExited;
   _onComfyRestarted = onComfyRestarted;
 
+  installations.seedDefaults([
+    {
+      name: "Comfy Cloud",
+      sourceId: "cloud",
+      version: "cloud",
+      remoteUrl: "https://cloud.comfy.org/",
+      launchMode: "window",
+      browserPartition: "shared",
+    },
+  ]);
   migrateDefaults();
 
   // Sources
@@ -202,7 +214,9 @@ function register({ onLaunch, onStop, onComfyExited, onComfyRestarted } = {}) {
       const source = sourceMap[inst.sourceId];
       if (!source) return inst;
       const listPreview = source.getListPreview ? source.getListPreview(inst) : undefined;
-      const statusTag = inst.status === "failed"
+      const statusTag = inst.status === "partial-delete"
+        ? { label: "Delete Interrupted", style: "danger" }
+        : inst.status === "failed"
         ? { label: "Install Failed", style: "danger" }
         : (source.getStatusTag ? source.getStatusTag(inst) : undefined);
       return { ...inst, sourceLabel: source.label, ...(listPreview != null ? { listPreview } : {}), ...(statusTag ? { statusTag } : {}) };
@@ -265,6 +279,9 @@ function register({ onLaunch, onStop, onComfyExited, onComfyRestarted } = {}) {
 
   ipcMain.handle("install-instance", async (_event, installationId) => {
     const inst = await resolveInstallation(installationId);
+    if (_operationAborts.has(installationId)) {
+      return { ok: false, message: "Another operation is already running for this installation." };
+    }
     const source = resolveSource(inst.sourceId);
     const sender = _event.sender;
 
@@ -280,18 +297,63 @@ function register({ onLaunch, onStop, onComfyExited, onComfyRestarted } = {}) {
       if (source.installSteps) {
         sendProgress("steps", { steps: source.installSteps });
       }
+      const abort = new AbortController();
+      _operationAborts.set(installationId, abort);
       const cache = createCache(settings.get("cacheDir"), settings.get("maxCachedFiles"));
       try {
-        await source.install(inst, { sendProgress, download, cache, extract });
+        await source.install(inst, { sendProgress, download, cache, extract, signal: abort.signal });
         if (source.postInstall) {
           const update = (data) => installations.update(installationId, data);
           await source.postInstall(inst, { sendProgress, update });
         }
         sendProgress("done", { percent: 100, status: "Complete" });
       } catch (err) {
+        _operationAborts.delete(installationId);
+        if (abort.signal.aborted) {
+          // Try quick cleanup first (works if cancelled during download)
+          let cleaned = !fs.existsSync(inst.installPath);
+          if (!cleaned) {
+            try {
+              fs.rmSync(inst.installPath, { recursive: true, force: true });
+              cleaned = true;
+            } catch {}
+          }
+          if (cleaned) {
+            await installations.remove(installationId);
+            return { ok: true, navigate: "list" };
+          }
+          // Quick cleanup failed (locked files after extraction) — switch to
+          // a full delete task with progress reporting
+          const markerPath = path.join(inst.installPath, MARKER_FILE);
+          try { fs.writeFileSync(markerPath, installationId); } catch {}
+          await installations.update(installationId, { status: "partial-delete" });
+          const deleteAbort = new AbortController();
+          _operationAborts.set(installationId, deleteAbort);
+          sendProgress("delete", { percent: 0, status: "Counting files…" });
+          try {
+            await deleteDir(inst.installPath, (p) => {
+              const elapsed = formatTime(p.elapsedSecs);
+              const eta = p.etaSecs >= 0 ? formatTime(p.etaSecs) : "—";
+              sendProgress("delete", {
+                percent: p.percent,
+                status: `Deleting… ${p.deleted} / ${p.total} items  ·  ${elapsed} elapsed  ·  ${eta} remaining`,
+              });
+            }, { signal: deleteAbort.signal });
+            _operationAborts.delete(installationId);
+            await installations.remove(installationId);
+          } catch (delErr) {
+            _operationAborts.delete(installationId);
+            if (deleteAbort.signal.aborted) {
+              try { fs.writeFileSync(markerPath, installationId); } catch {}
+              await installations.update(installationId, { status: "partial-delete" });
+            }
+          }
+          return { ok: true, navigate: "list" };
+        }
         await installations.update(installationId, { status: "failed" });
         return { ok: false, message: err.message };
       }
+      _operationAborts.delete(installationId);
       await installations.update(installationId, { status: "installed" });
       return { ok: true };
     }
@@ -436,9 +498,18 @@ function register({ onLaunch, onStop, onComfyExited, onComfyRestarted } = {}) {
   ipcMain.handle("get-running-instances", () => _getPublicSessions());
 
   ipcMain.handle("cancel-launch", () => {
-    if (_launchAbort) {
-      _launchAbort.abort();
-      _launchAbort = null;
+    // Legacy — cancel all operations (kept for backwards compatibility)
+    for (const [id, abort] of _operationAborts) {
+      abort.abort();
+    }
+    _operationAborts.clear();
+  });
+
+  ipcMain.handle("cancel-operation", (_event, installationId) => {
+    const abort = _operationAborts.get(installationId);
+    if (abort) {
+      abort.abort();
+      _operationAborts.delete(installationId);
     }
   });
 
@@ -458,6 +529,14 @@ function register({ onLaunch, onStop, onComfyExited, onComfyRestarted } = {}) {
       return { ok: true, navigate: "list" };
     }
     if (actionId === "delete") {
+      // If the directory is already gone, just remove the record
+      if (!fs.existsSync(inst.installPath)) {
+        await installations.remove(installationId);
+        return { ok: true, navigate: "list" };
+      }
+      if (_operationAborts.has(installationId)) {
+        return { ok: false, message: "Another operation is already running for this installation." };
+      }
       const markerPath = path.join(inst.installPath, MARKER_FILE);
       let markerContent;
       try { markerContent = fs.readFileSync(markerPath, "utf-8").trim(); } catch { markerContent = null; }
@@ -473,15 +552,31 @@ function register({ onLaunch, onStop, onComfyExited, onComfyRestarted } = {}) {
           sender.send("install-progress", { installationId, phase, ...detail });
         }
       };
+      const abort = new AbortController();
+      _operationAborts.set(installationId, abort);
       sendProgress("delete", { percent: 0, status: "Counting files…" });
-      await deleteDir(inst.installPath, (p) => {
-        const elapsed = formatTime(p.elapsedSecs);
-        const eta = p.etaSecs >= 0 ? formatTime(p.etaSecs) : "—";
-        sendProgress("delete", {
-          percent: p.percent,
-          status: `Deleting… ${p.deleted} / ${p.total} items  ·  ${elapsed} elapsed  ·  ${eta} remaining`,
-        });
-      });
+      try {
+        await deleteDir(inst.installPath, (p) => {
+          const elapsed = formatTime(p.elapsedSecs);
+          const eta = p.etaSecs >= 0 ? formatTime(p.etaSecs) : "—";
+          sendProgress("delete", {
+            percent: p.percent,
+            status: `Deleting… ${p.deleted} / ${p.total} items  ·  ${elapsed} elapsed  ·  ${eta} remaining`,
+          });
+        }, { signal: abort.signal });
+      } catch (err) {
+        _operationAborts.delete(installationId);
+        if (abort.signal.aborted) {
+          // Restore the marker file so the safety check passes on retry
+          try {
+            fs.mkdirSync(inst.installPath, { recursive: true });
+            fs.writeFileSync(markerPath, markerContent);
+          } catch {}
+          await installations.update(installationId, { status: "partial-delete" });
+        }
+        return { ok: false, message: err.message };
+      }
+      _operationAborts.delete(installationId);
       await installations.remove(installationId);
       return { ok: true, navigate: "list" };
     }
@@ -499,6 +594,9 @@ function register({ onLaunch, onStop, onComfyExited, onComfyRestarted } = {}) {
     if (actionId === "launch") {
       if (_runningSessions.has(installationId)) {
         return { ok: false, message: i18n.t("errors.alreadyRunning") };
+      }
+      if (_operationAborts.has(installationId)) {
+        return { ok: false, message: "Another operation is already running for this installation." };
       }
       const source = resolveSource(inst.sourceId);
       const launchCmd = source.getLaunchCommand ? source.getLaunchCommand(inst) : null;
@@ -522,7 +620,7 @@ function register({ onLaunch, onStop, onComfyExited, onComfyRestarted } = {}) {
       };
 
       const abort = new AbortController();
-      _launchAbort = abort;
+      _operationAborts.set(installationId, abort);
 
       // Remote connection — no process to spawn, just verify connectivity
       if (launchCmd.remote) {
@@ -537,12 +635,12 @@ function register({ onLaunch, onStop, onComfyExited, onComfyRestarted } = {}) {
             },
           });
         } catch (err) {
-          _launchAbort = null;
+          _operationAborts.delete(installationId);
           if (abort.signal.aborted) return { ok: false, message: i18n.t("errors.launchCancelled") };
           return { ok: false, message: i18n.t("errors.cannotConnect", { url: launchCmd.url }) };
         }
 
-        _launchAbort = null;
+        _operationAborts.delete(installationId);
         const mode = inst.launchMode || "window";
         _addSession(installationId, { proc: null, port: launchCmd.port, url: launchCmd.url, mode, installationName: inst.name });
         if (_onLaunch) {
@@ -553,6 +651,7 @@ function register({ onLaunch, onStop, onComfyExited, onComfyRestarted } = {}) {
 
       // Local process launch
       if (!fs.existsSync(launchCmd.cmd)) {
+        _operationAborts.delete(installationId);
         return { ok: false, message: `Executable not found: ${launchCmd.cmd}` };
       }
 
@@ -596,6 +695,7 @@ function register({ onLaunch, onStop, onComfyExited, onComfyRestarted } = {}) {
               ? i18n.t("errors.portConflictComfy", { port: launchCmd.port, process: processDesc })
               : i18n.t("errors.portConflictOther", { port: launchCmd.port, process: processDesc });
           }
+          _operationAborts.delete(installationId);
           return { ok: false, message, portConflict: { port: launchCmd.port, pids: existingPids, isComfy, nextPort } };
         }
       }
@@ -659,12 +759,12 @@ function register({ onLaunch, onStop, onComfyExited, onComfyRestarted } = {}) {
           earlyExitPromise,
         ]);
       } catch (err) {
-        _launchAbort = null;
+        _operationAborts.delete(installationId);
         killProcessTree(proc);
         return { ok: false, message: err.message };
       }
 
-      _launchAbort = null;
+      _operationAborts.delete(installationId);
       const mode = inst.launchMode || "window";
       _addSession(installationId, { proc, port: launchCmd.port, mode, installationName: inst.name });
       writePortLock(launchCmd.port, { pid: proc.pid, installationName: inst.name });
@@ -745,14 +845,14 @@ function hasRunningSessions() {
 }
 
 function hasActiveOperations() {
-  return _runningSessions.size > 0 || _launchAbort !== null;
+  return _runningSessions.size > 0 || _operationAborts.size > 0;
 }
 
 function cancelAll() {
-  if (_launchAbort) {
-    _launchAbort.abort();
-    _launchAbort = null;
+  for (const [id, abort] of _operationAborts) {
+    abort.abort();
   }
+  _operationAborts.clear();
   stopRunning();
 }
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -57,13 +57,19 @@
     "title": "Installations",
     "trackExisting": "Track Existing",
     "newInstall": "New Install",
-    "empty": "No installations yet.\nClick **+ New Install** to get started.",
-    "view": "View",
+    "empty": "No installations yet.",
+    "emptyHint": "Install or track an existing version of ComfyUI.",
+    "emptyFilter": "No installations match this filter.",
+    "view": "Manage",
     "new": "New",
     "running": "Running",
     "console": "Console",
     "viewProgress": "View Progress",
-    "dragToReorder": "Drag to reorder"
+    "dragToReorder": "Drag to reorder",
+    "filterAll": "All",
+    "filterLocal": "Local",
+    "filterRemote": "Remote",
+    "filterCloud": "Cloud"
   },
 
   "newInstall": {
@@ -96,6 +102,7 @@
   "progress": {
     "working": "Working…",
     "starting": "Starting…",
+    "cancelling": "Cancelling…",
     "error": "Error: {message}"
   },
 

--- a/preload.js
+++ b/preload.js
@@ -49,6 +49,7 @@ contextBridge.exposeInMainWorld("api", {
     return () => ipcRenderer.removeListener("instance-stopped", handler);
   },
   cancelLaunch: () => ipcRenderer.invoke("cancel-launch"),
+  cancelOperation: (installationId) => ipcRenderer.invoke("cancel-operation", installationId),
   killPortProcess: (port) => ipcRenderer.invoke("kill-port-process", port),
   getListActions: (installationId) =>
     ipcRenderer.invoke("get-list-actions", installationId),

--- a/renderer/console.js
+++ b/renderer/console.js
@@ -2,25 +2,19 @@ window.Launcher = window.Launcher || {};
 
 window.Launcher.console = {
   _installationId: null,
-  _from: null,
 
   /** Show console for any running (or recently exited) installation. */
-  show(installationId, { from } = {}) {
+  show(installationId) {
     this._installationId = installationId;
-    this._from = from || null;
 
     const session = window.Launcher.sessions.get(installationId);
     const runningInfo = window.Launcher._runningInstances.get(installationId);
     const errorInfo = window.Launcher._errorInstances.get(installationId);
     const isExited = session ? session.exited : true;
 
-    // Breadcrumb: [Parent] › Console — InstallName
     const instName = runningInfo?.installationName || errorInfo?.installationName;
-    const titleEl = document.getElementById("console-title");
-    const segments = [];
-    segments.push(this._parentSegment());
-    segments.push({ label: instName ? `${window.t("console.title")} — ${instName}` : window.t("console.title") });
-    window.Launcher.renderBreadcrumb(titleEl, segments);
+    document.getElementById("console-modal-title").textContent =
+      instName ? `${window.t("console.title")} — ${instName}` : window.t("console.title");
 
     const terminal = document.getElementById("console-terminal");
     terminal.textContent = session ? session.output : "";
@@ -44,7 +38,6 @@ window.Launcher.console = {
     browserBtn.style.display = comfyUrl ? "" : "none";
     browserBtn.onclick = comfyUrl ? () => window.api.openPath(comfyUrl) : null;
 
-    // Stop button (hidden when exited — breadcrumb handles navigation)
     const stopBtn = document.getElementById("btn-console-stop");
     if (isExited) {
       stopBtn.style.display = "none";
@@ -74,12 +67,5 @@ window.Launcher.console = {
     document.getElementById("btn-console-show-window").style.display = "none";
     document.getElementById("btn-console-browser").style.display = "none";
     document.getElementById("btn-console-stop").style.display = "none";
-  },
-
-  _parentSegment() {
-    if (this._from === "running") {
-      return { label: window.t("sidebar.running"), action: () => window.Launcher.running.show() };
-    }
-    return { label: window.t("sidebar.installations"), action: () => { window.Launcher.showView("list"); window.Launcher.list.render(); } };
   },
 };

--- a/renderer/list.js
+++ b/renderer/list.js
@@ -3,32 +3,77 @@ window.Launcher = window.Launcher || {};
 window.Launcher.list = {
   _dragSrcEl: null,
   _renderGen: 0,
+  _filter: "all",
+
+  _sourceCategory: {
+    standalone: "local",
+    portable: "local",
+    git: "local",
+    remote: "remote",
+    cloud: "cloud",
+  },
+
+  _matchesFilter(inst) {
+    if (this._filter === "all") return true;
+    return this._sourceCategory[inst.sourceId] === this._filter;
+  },
+
+  _buildInstallPrompt() {
+    const div = document.createElement("div");
+    div.className = "empty-state";
+    const title = document.createElement("div");
+    title.style.cssText = "font-weight: 700; color: var(--text-faint);";
+    title.textContent = window.t("list.empty");
+    div.appendChild(title);
+    const hint = document.createElement("div");
+    hint.textContent = window.t("list.emptyHint");
+    hint.style.marginTop = "4px";
+    div.appendChild(hint);
+    const btn = document.createElement("button");
+    btn.className = "accent add-btn";
+    btn.style.marginTop = "8px";
+    btn.innerHTML = `<svg width="14" height="14"><use href="#icon-plus"/></svg> ${window.Launcher.esc(window.t("list.newInstall"))}`;
+    btn.onclick = () => document.getElementById("btn-new").click();
+    div.appendChild(btn);
+    return div;
+  },
+
+  setFilter(filter) {
+    this._filter = filter;
+    document.querySelectorAll("#list-filter-tabs .filter-tab").forEach((btn) => {
+      btn.classList.toggle("active", btn.dataset.filter === filter);
+    });
+    this.render();
+  },
 
   async render() {
     const gen = ++this._renderGen;
     const { esc, showView } = window.Launcher;
     const el = document.getElementById("instance-list");
-    const installations = await window.api.getInstallations();
+    const allInstallations = await window.api.getInstallations();
     if (gen !== this._renderGen) return;
     el.innerHTML = "";
 
+    const installations = allInstallations.filter((inst) => this._matchesFilter(inst));
+    const hasLocal = allInstallations.some((inst) => this._sourceCategory[inst.sourceId] === "local");
+
     if (installations.length === 0) {
-      const msg = window.t("list.empty");
-      el.innerHTML = '<div class="empty-state">' + msg.replace(/\n/g, "<br>").replace(/\*\*(.+?)\*\*/g, (_, s) => `<strong>${window.Launcher.esc(s)}</strong>`) + '</div>';
+      if (hasLocal) {
+        el.innerHTML = '<div class="empty-state">' + esc(window.t("list.emptyFilter")) + '</div>';
+      } else {
+        el.appendChild(this._buildInstallPrompt());
+      }
       return;
     }
 
     for (const inst of installations) {
-      const card = document.createElement("div");
-      card.className = "instance-card";
-      card.dataset.id = inst.id;
       const isRunning = window.Launcher.isInstanceRunning(inst.id);
       const activeSession = window.Launcher.getActiveSessionForInstallation(inst.id);
       const hasError = window.Launcher._errorInstances.has(inst.id);
       const runningTag = isRunning ? ` · <span class="status-running">${esc(window.t("list.running"))}</span>` : "";
       const errorTag = hasError ? ` · <span class="status-danger">${esc(window.t("running.crashed"))}</span>` : "";
       const statusTag = inst.statusTag ? ` · <span class="status-${inst.statusTag.style}">${esc(inst.statusTag.label)}</span>` : "";
-      const newTag = inst.seen === false ? ` · <span class="status-new">${esc(window.t("list.new"))}</span>` : "";
+      const newTag = inst.seen === false ? `<span class="status-new-wrap"> · <span class="status-new">${esc(window.t("list.new"))}</span></span>` : "";
       // Show in-progress status when there's an active session but not yet running
       const inProgressTag = (!isRunning && activeSession)
         ? ` · <span class="status-in-progress">${esc(activeSession.label)}</span>`
@@ -38,55 +83,54 @@ window.Launcher.list = {
         : inst.launchMode
           ? `${esc(inst.launchMode)}${inst.launchArgs ? " · " + esc(inst.launchArgs) : ""}`
           : "";
-      card.innerHTML = `
-        <div class="drag-handle" title="${window.t("list.dragToReorder")}"><span></span><span></span><span></span></div>
-        <div class="instance-info">
-          <div class="instance-name">${esc(inst.name)}</div>
-          <div class="instance-meta">${esc(inst.sourceLabel)}${inst.version ? " · " + esc(inst.version) : ""}${runningTag}${errorTag}${inProgressTag}${statusTag}${newTag}</div>
-          ${launchMeta ? `<div class="instance-meta">${launchMeta}</div>` : ""}
-        </div>
-        <div class="instance-actions"></div>`;
+
+      const { card, infoEl, actionsEl } = window.Launcher.buildCard({
+        installationId: inst.id,
+        name: inst.name,
+        metaHtml: `${esc(inst.sourceLabel)}${inst.version ? " · " + esc(inst.version) : ""}${runningTag}${errorTag}${inProgressTag}${statusTag}${newTag}`,
+        draggable: true,
+      });
+      if (launchMeta) {
+        const metaEl = document.createElement("div");
+        metaEl.className = "instance-meta";
+        metaEl.innerHTML = launchMeta;
+        infoEl.appendChild(metaEl);
+      }
+
+      // Add mini progress bar for in-progress operations
+      if (activeSession && !isRunning) {
+        infoEl.appendChild(window.Launcher.buildCardProgress(inst.id));
+      }
+
+      if (inst.seen === false) {
+        card.addEventListener("mousedown", () => {
+          if (inst.seen === false) {
+            inst.seen = true;
+            window.api.updateInstallation(inst.id, { seen: true });
+            const wrap = card.querySelector(".status-new-wrap");
+            if (wrap) wrap.remove();
+          }
+        });
+      }
 
       const handle = card.querySelector(".drag-handle");
       handle.addEventListener("mousedown", () => { card.draggable = true; });
       handle.addEventListener("mouseup", () => { card.draggable = false; });
       card.addEventListener("dragend", () => { card.draggable = false; });
 
-      const actionsEl = card.querySelector(".instance-actions");
-
       // In-progress (installing/launching/deleting) — show View Progress button
       if (activeSession) {
-        const sessionBtn = document.createElement("button");
-        sessionBtn.className = "primary";
-        sessionBtn.textContent = window.t("list.viewProgress");
-        sessionBtn.onclick = () => window.Launcher.progress.showOperation(inst.id);
-        actionsEl.appendChild(sessionBtn);
+        actionsEl.appendChild(window.Launcher.buildProgressBtn(inst.id));
       } else if (isRunning) {
         // Confirmed running — show Show Window (if app window mode), Console, Stop
         const runningInfo = window.Launcher._runningInstances.get(inst.id);
         if (runningInfo && runningInfo.mode !== "console") {
-          const focusBtn = document.createElement("button");
-          focusBtn.className = "primary";
-          focusBtn.textContent = window.t("running.showWindow");
-          focusBtn.onclick = () => window.api.focusComfyWindow(inst.id);
-          actionsEl.appendChild(focusBtn);
+          actionsEl.appendChild(window.Launcher.buildFocusBtn(inst.id));
         }
-        const consoleBtn = document.createElement("button");
-        consoleBtn.textContent = window.t("list.console");
-        consoleBtn.onclick = () => window.Launcher.console.show(inst.id);
-        actionsEl.appendChild(consoleBtn);
-        const stopBtn = document.createElement("button");
-        stopBtn.className = "danger";
-        stopBtn.textContent = window.t("console.stop");
-        stopBtn.onclick = async () => {
-          await window.api.stopComfyUI(inst.id);
-        };
-        actionsEl.appendChild(stopBtn);
+        actionsEl.appendChild(window.Launcher.buildConsoleBtn(inst.id));
+        actionsEl.appendChild(window.Launcher.buildStopBtn(inst.id));
       } else if (hasError) {
-        const consoleBtn = document.createElement("button");
-        consoleBtn.textContent = window.t("list.console");
-        consoleBtn.onclick = () => window.Launcher.console.show(inst.id);
-        actionsEl.appendChild(consoleBtn);
+        actionsEl.appendChild(window.Launcher.buildConsoleBtn(inst.id));
         const dismissBtn = document.createElement("button");
         dismissBtn.textContent = window.t("running.dismiss");
         dismissBtn.onclick = () => window.Launcher.clearErrorInstance(inst.id);
@@ -134,11 +178,7 @@ window.Launcher.list = {
         });
       }
 
-      const viewBtn = document.createElement("button");
-      viewBtn.className = "view-btn";
-      viewBtn.textContent = window.t("list.view");
-      viewBtn.onclick = () => window.Launcher.detail.show(inst);
-      actionsEl.appendChild(viewBtn);
+      actionsEl.appendChild(window.Launcher.buildManageBtn(inst));
 
       card.addEventListener("dragstart", (e) => {
         this._dragSrcEl = card;
@@ -177,6 +217,10 @@ window.Launcher.list = {
       });
 
       el.appendChild(card);
+    }
+
+    if (!hasLocal && this._filter === "all") {
+      el.appendChild(this._buildInstallPrompt());
     }
   },
 };

--- a/renderer/new-install.js
+++ b/renderer/new-install.js
@@ -15,11 +15,7 @@ window.Launcher.newInstall = {
       document.getElementById("inst-name").value = "";
       this._selections = {};
       document.getElementById("btn-save").disabled = true;
-      const goBack = () => { window.Launcher.showView("list"); window.Launcher.list.render(); };
-      window.Launcher.renderBreadcrumb(document.getElementById("new-install-title"), [
-        { label: window.t("sidebar.installations"), action: goBack },
-        { label: window.t("newInstall.title") },
-      ]);
+      document.getElementById("new-modal-title").textContent = window.t("newInstall.title");
       window.Launcher.showView("new");
       this._initSources();
 
@@ -266,7 +262,7 @@ window.Launcher.newInstall = {
         await window.Launcher.modal.alert({ title: window.t("errors.cannotAdd"), message: result.message });
         return;
       }
-      window.Launcher.showView("list");
+      window.Launcher.closeViewModal("new");
       window.Launcher.list.render();
       return;
     }
@@ -277,6 +273,7 @@ window.Launcher.newInstall = {
       await window.Launcher.modal.alert({ title: window.t("errors.cannotAdd"), message: result.message });
       return;
     }
+    window.Launcher.closeViewModal("new");
     window.Launcher.progress.show({
       installationId: result.entry.id,
       title: window.t("newInstall.installing"),

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -63,7 +63,7 @@ body {
 }
 .sidebar-brand {
   padding: 12px 20px 24px;
-  font-size: 14px;
+  font-size: 15px;
   font-weight: 700;
   color: var(--text);
   letter-spacing: -0.2px;
@@ -84,7 +84,7 @@ body {
   border-radius: 6px;
   background: none;
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 500;
   cursor: pointer;
   text-align: left;
@@ -119,7 +119,7 @@ body {
 }
 .sidebar-count {
   margin-left: auto;
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 600;
   background: var(--accent);
   color: var(--bg);
@@ -143,7 +143,7 @@ body {
 .icon-btn {
   background: none;
   border: none;
-  font-size: 18px;
+  font-size: 19px;
   color: var(--text-faint);
   cursor: pointer;
   padding: 4px 8px;
@@ -160,7 +160,7 @@ button {
   border-radius: 6px;
   background: var(--surface);
   color: var(--text);
-  font-size: 13px;
+  font-size: 14px;
   cursor: pointer;
 }
 button:hover { background: var(--border); }
@@ -171,6 +171,8 @@ button.primary {
   font-weight: 600;
 }
 button.primary:hover { background: var(--accent-hover); border-color: var(--accent-hover); }
+button.accent { color: var(--accent); border-color: var(--accent); font-weight: 600; }
+button.accent:hover { background: var(--accent); color: var(--bg); }
 button.danger { color: var(--danger); border-color: var(--danger); }
 button.danger:hover { background: var(--danger); color: var(--bg); }
 button.looks-disabled { opacity: 0.4; }
@@ -194,7 +196,7 @@ button.back-btn,
 button.add-btn { display: inline-flex; align-items: center; gap: 4px; }
 
 /* Forms */
-label { font-size: 13px; color: var(--text-muted); }
+label { font-size: 14px; color: var(--text-muted); }
 select, input[type="text"], input[type="number"] {
   width: 100%;
   padding: 8px 10px;
@@ -203,7 +205,7 @@ select, input[type="text"], input[type="number"] {
   border-radius: 6px;
   background: var(--surface);
   color: var(--text);
-  font-size: 14px;
+  font-size: 15px;
   outline: none;
 }
 select:focus, input[type="text"]:focus, input[type="number"]:focus { border-color: var(--accent); }
@@ -245,10 +247,48 @@ input[type="checkbox"]:checked::after { transform: translateX(16px); }
 }
 .path-input button { flex-shrink: 0; }
 .field-error {
-  font-size: 12px;
+  font-size: 13px;
   color: var(--danger);
   margin-top: 4px;
   min-height: 0;
+}
+
+/* Filter tabs */
+.filter-tabs {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 12px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+.filter-tab {
+  padding: 6px 12px;
+  border: none;
+  border-radius: 0;
+  background: none;
+  color: var(--text-faint);
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  position: relative;
+}
+.filter-tab:hover {
+  color: var(--text-muted);
+  background: none;
+}
+.filter-tab.active {
+  color: var(--text);
+  font-weight: 600;
+}
+.filter-tab.active::after {
+  content: "";
+  position: absolute;
+  bottom: -1px;
+  left: 4px;
+  right: 4px;
+  height: 2px;
+  background: var(--accent);
+  border-radius: 1px;
 }
 
 /* Instance list */
@@ -283,8 +323,8 @@ input[type="checkbox"]:checked::after { transform: translateX(16px); }
   border-radius: 1px;
 }
 .instance-info { display: flex; flex-direction: column; gap: 3px; min-width: 0; flex: 1; }
-.instance-name { font-size: 15px; font-weight: 600; }
-.instance-meta { font-size: 12px; color: var(--text-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.instance-name { font-size: 16px; font-weight: 600; }
+.instance-meta { font-size: 13px; color: var(--text-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .status-danger { color: var(--danger); font-weight: 600; }
 .status-running { color: var(--accent); font-weight: 600; }
 .status-new { color: var(--accent); font-weight: 600; }
@@ -295,7 +335,7 @@ input[type="checkbox"]:checked::after { transform: translateX(16px); }
   text-align: center;
   padding: 40px 20px;
   color: var(--text-faint);
-  font-size: 14px;
+  font-size: 15px;
 }
 
 .toolbar {
@@ -305,7 +345,7 @@ input[type="checkbox"]:checked::after { transform: translateX(16px); }
   min-height: 34px;
   margin-bottom: 16px;
 }
-.toolbar h2 { font-size: 15px; font-weight: 600; color: var(--text-muted); }
+.toolbar h2 { font-size: 24px; font-weight: 600; color: var(--text-muted); }
 .toolbar-actions { display: flex; gap: 8px; }
 
 /* Breadcrumbs */
@@ -315,38 +355,17 @@ input[type="checkbox"]:checked::after { transform: translateX(16px); }
   gap: 8px;
   min-width: 0;
 }
-.breadcrumb-link {
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--text-faint);
-  cursor: pointer;
-  white-space: nowrap;
-}
-.breadcrumb-link:hover { color: var(--text); }
-.breadcrumb-sep {
-  font-size: 14px;
-  color: var(--text-faint);
-  flex-shrink: 0;
-}
 .breadcrumb-current {
-  font-size: 15px;
+  font-size: 24px;
   font-weight: 600;
   color: var(--text-muted);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.breadcrumb-current[contenteditable] {
-  cursor: text;
-  border-bottom: 1px dashed var(--border);
-  outline: none;
-}
-.breadcrumb-current[contenteditable]:focus {
-  border-bottom-color: var(--accent);
-}
 
 .detected-hardware {
-  font-size: 12px;
+  font-size: 13px;
   color: var(--text-muted);
   background: var(--surface);
   border: 1px solid var(--border);
@@ -371,7 +390,7 @@ input[type="checkbox"]:checked::after { transform: translateX(16px); }
 /* Detail sections */
 .detail-section { margin-bottom: 18px; }
 .detail-section-title {
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 600;
   color: var(--text-faint);
   text-transform: uppercase;
@@ -387,16 +406,16 @@ input[type="checkbox"]:checked::after { transform: translateX(16px); }
   flex-direction: column;
   gap: 10px;
 }
-.detail-field-label { font-size: 12px; color: var(--text-muted); }
-.detail-field-value { font-size: 14px; margin-top: 1px; }
+.detail-field-label { font-size: 13px; color: var(--text-muted); }
+.detail-field-value { font-size: 15px; margin-top: 1px; }
 .detail-field-input {
   width: 100%;
   margin-top: 4px;
   padding: 6px 8px;
-  font-size: 13px;
+  font-size: 14px;
 }
 .detail-section-desc {
-  font-size: 13px;
+  font-size: 14px;
   color: var(--text-muted);
   margin-bottom: 8px;
 }
@@ -419,14 +438,14 @@ input[type="checkbox"]:checked::after { transform: translateX(16px); }
   font-weight: 600;
 }
 .detail-item-label {
-  font-size: 14px;
+  font-size: 15px;
 }
 .detail-item-actions {
   display: flex;
   gap: 6px;
 }
 .detail-item-actions button {
-  font-size: 12px;
+  font-size: 13px;
   padding: 3px 10px;
 }
 .detail-actions { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 8px; }
@@ -438,7 +457,7 @@ input[type="checkbox"]:checked::after { transform: translateX(16px); }
 .settings-section .field:last-child { margin-bottom: 0; }
 .path-list { display: flex; flex-direction: column; gap: 6px; margin-top: 6px; }
 .path-primary-tag {
-  font-size: 11px;
+  font-size: 12px;
   color: var(--text-muted);
   background: var(--surface);
   padding: 2px 8px;
@@ -449,7 +468,7 @@ input[type="checkbox"]:checked::after { transform: translateX(16px); }
 
 /* Progress */
 .progress-status {
-  font-size: 13px;
+  font-size: 14px;
   color: var(--text-muted);
   margin-bottom: 12px;
   user-select: text;
@@ -512,7 +531,7 @@ input[type="checkbox"]:checked::after { transform: translateX(16px); }
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 600;
   color: var(--text-faint);
   flex-shrink: 0;
@@ -527,7 +546,7 @@ input[type="checkbox"]:checked::after { transform: translateX(16px); }
   color: var(--bg);
 }
 .progress-step-label {
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 500;
   color: var(--text-faint);
 }
@@ -542,7 +561,7 @@ input[type="checkbox"]:checked::after { transform: translateX(16px); }
   margin-top: 6px;
 }
 .progress-step-status {
-  font-size: 12px;
+  font-size: 13px;
   color: var(--text-muted);
   margin-bottom: 6px;
   user-select: text;
@@ -550,7 +569,7 @@ input[type="checkbox"]:checked::after { transform: translateX(16px); }
 .progress-step-summary {
   margin-left: 32px;
   margin-top: 2px;
-  font-size: 12px;
+  font-size: 13px;
   color: var(--text-faint);
   user-select: text;
 }
@@ -569,7 +588,7 @@ input[type="checkbox"]:checked::after { transform: translateX(16px); }
   border-radius: 6px;
   padding: 10px 12px;
   font-family: "Cascadia Mono", "Consolas", monospace;
-  font-size: 12px;
+  font-size: 13px;
   color: var(--text-muted);
   white-space: pre-wrap;
   word-break: break-all;
@@ -581,6 +600,76 @@ input[type="checkbox"]:checked::after { transform: translateX(16px); }
   max-height: none;
   flex: 1;
   min-height: 0;
+}
+
+/* View modals (large, full-content modals for sub-views) */
+.view-modal {
+  position: fixed;
+  inset: 0;
+  background: var(--overlay-bg);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+}
+.view-modal.active {
+  display: flex;
+}
+.view-modal-content {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  width: calc(100vw - 260px);
+  height: calc(100vh - 60px);
+  max-width: 900px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.view-modal-header {
+  display: flex;
+  align-items: center;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+  gap: 12px;
+}
+.view-modal-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text);
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.view-modal-header-actions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+}
+.view-modal-close {
+  background: none;
+  border: none;
+  font-size: 20px;
+  color: var(--text-faint);
+  cursor: pointer;
+  padding: 4px 8px;
+  flex-shrink: 0;
+  line-height: 1;
+}
+.view-modal-close:hover {
+  color: var(--text);
+  background: none;
+}
+.view-modal-body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  padding: 20px;
+  overflow: hidden;
 }
 
 /* Modal */
@@ -602,12 +691,12 @@ input[type="checkbox"]:checked::after { transform: translateX(16px); }
   max-width: 400px;
 }
 .modal-title {
-  font-size: 15px;
+  font-size: 16px;
   font-weight: 600;
   margin-bottom: 8px;
 }
 .modal-message {
-  font-size: 13px;
+  font-size: 14px;
   color: var(--text-muted);
   margin-bottom: 20px;
   white-space: pre-line;
@@ -624,7 +713,7 @@ input[type="checkbox"]:checked::after { transform: translateX(16px); }
   margin-bottom: 4px;
 }
 .modal-error {
-  font-size: 12px;
+  font-size: 13px;
   color: var(--danger);
   min-height: 12px;
   margin-bottom: 4px;
@@ -632,7 +721,7 @@ input[type="checkbox"]:checked::after { transform: translateX(16px); }
 .modal-input {
   width: 100%;
   padding: 6px 8px;
-  font-size: 13px;
+  font-size: 14px;
 }
 .modal-actions {
   display: flex;
@@ -650,7 +739,7 @@ input[type="checkbox"]:checked::after { transform: translateX(16px); }
   border: 1px solid var(--accent);
   border-radius: 8px;
   background: var(--surface);
-  font-size: 13px;
+  font-size: 14px;
 }
 .update-banner .update-text { flex: 1; color: var(--text); }
 .update-banner .update-text strong { color: var(--accent); }
@@ -658,5 +747,39 @@ input[type="checkbox"]:checked::after { transform: translateX(16px); }
 
 /* In-progress status tag on list cards */
 .status-in-progress { color: var(--accent); font-weight: 600; }
+
+/* Card progress bar (inline on cards) */
+.card-progress {
+  flex: 1;
+  min-width: 0;
+  margin-top: 4px;
+}
+.card-progress-status {
+  font-size: 12px;
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin-bottom: 4px;
+}
+.card-progress-track {
+  width: 100%;
+  height: 4px;
+  background: var(--border);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.card-progress-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 2px;
+  width: 0%;
+  transition: width 0.3s ease;
+}
+.card-progress-fill.indeterminate {
+  animation: indeterminate 1.5s ease-in-out infinite;
+  background: linear-gradient(90deg, var(--accent) 0%, var(--accent-hover) 50%, var(--accent) 100%);
+  background-size: 200% 100%;
+}
 
 

--- a/renderer/track.js
+++ b/renderer/track.js
@@ -7,11 +7,7 @@ window.Launcher.track = {
   init() {
     document.getElementById("btn-track").onclick = () => {
       this._reset();
-      const goBack = () => { window.Launcher.showView("list"); window.Launcher.list.render(); };
-      window.Launcher.renderBreadcrumb(document.getElementById("track-title"), [
-        { label: window.t("sidebar.installations"), action: goBack },
-        { label: window.t("track.title") },
-      ]);
+      document.getElementById("track-modal-title").textContent = window.t("track.title");
       window.Launcher.showView("track");
     };
 
@@ -124,7 +120,7 @@ window.Launcher.track = {
       await window.Launcher.modal.alert({ title: window.t("track.cannotTrack"), message: result.message });
       return;
     }
-    window.Launcher.showView("list");
+    window.Launcher.closeViewModal("track");
     window.Launcher.list.render();
   },
 };

--- a/renderer/util.js
+++ b/renderer/util.js
@@ -17,8 +17,6 @@ window.Launcher.applyTheme = function applyTheme(theme) {
   document.documentElement.setAttribute("data-theme", theme || "dark");
 };
 
-window.Launcher._previousView = "list";
-
 // Running instances registry — tracks which installations have active ComfyUI processes
 window.Launcher._runningInstances = new Map(); // installationId -> { port, url, mode, installationName }
 
@@ -61,6 +59,7 @@ window.Launcher.setActiveSession = function setActiveSession(installationId, lab
   window.Launcher._errorInstances.delete(installationId);
   window.Launcher._updateRunningTab();
   window.Launcher._refreshRunningViewIfActive();
+  window.Launcher.list.render();
 };
 
 window.Launcher.clearActiveSession = function clearActiveSession(installationId) {
@@ -93,8 +92,8 @@ window.Launcher.clearErrorInstance = function clearErrorInstance(installationId)
 };
 
 window.Launcher.isConsoleViewActive = function isConsoleViewActive(installationId) {
-  const view = document.getElementById("view-console");
-  return view && view.classList.contains("active") && window.Launcher.console._installationId === installationId;
+  const modal = document.getElementById("modal-console");
+  return modal && modal.classList.contains("active") && window.Launcher.console._installationId === installationId;
 };
 
 window.Launcher._updateRunningTab = function _updateRunningTab() {
@@ -115,53 +114,173 @@ window.Launcher._updateRunningTab = function _updateRunningTab() {
 // Map each view to its parent sidebar item
 window.Launcher._sidebarMap = {
   list: "list",
-  detail: "list",
-  "new": "list",
-  track: "list",
-  progress: "running",
-  console: "running",
   running: "running",
   models: "models",
   settings: "settings",
 };
 
+// Modal views — sub-views shown as overlays instead of replacing content
+window.Launcher._modalViews = new Set(["detail", "console", "progress", "new", "track"]);
+
 /**
- * Render a breadcrumb trail into a container element.
- * @param {HTMLElement} el - The container (replaces its contents).
- * @param {Array<{label: string, action?: Function}>} segments
- *   Last segment is the current page (not clickable).
+ * Build the skeleton of an instance card (card container, info area, actions area).
+ * @param {Object} opts
+ * @param {string} opts.name - Display name
+ * @param {string} opts.metaHtml - innerHTML for the meta line
+ * @param {string} [opts.installationId] - dataset.id for the card
+ * @param {boolean} [opts.draggable] - include drag handle
+ * @returns {{ card: HTMLElement, infoEl: HTMLElement, actionsEl: HTMLElement }}
  */
-window.Launcher.renderBreadcrumb = function renderBreadcrumb(el, segments) {
-  el.innerHTML = "";
-  segments.forEach((seg, i) => {
-    if (i > 0) {
-      const sep = document.createElement("span");
-      sep.className = "breadcrumb-sep";
-      sep.textContent = "›";
-      el.appendChild(sep);
+window.Launcher.buildCard = function buildCard({ name, metaHtml, installationId, draggable } = {}) {
+  const card = document.createElement("div");
+  card.className = "instance-card";
+  if (installationId) card.dataset.id = installationId;
+
+  if (draggable) {
+    const handle = document.createElement("div");
+    handle.className = "drag-handle";
+    handle.title = window.t("list.dragToReorder");
+    handle.innerHTML = "<span></span><span></span><span></span>";
+    card.appendChild(handle);
+  }
+
+  const infoEl = document.createElement("div");
+  infoEl.className = "instance-info";
+  const nameEl = document.createElement("div");
+  nameEl.className = "instance-name";
+  nameEl.textContent = name;
+  infoEl.appendChild(nameEl);
+  if (metaHtml) {
+    const meta = document.createElement("div");
+    meta.className = "instance-meta";
+    meta.innerHTML = metaHtml;
+    infoEl.appendChild(meta);
+  }
+  card.appendChild(infoEl);
+
+  const actionsEl = document.createElement("div");
+  actionsEl.className = "instance-actions";
+  card.appendChild(actionsEl);
+
+  return { card, infoEl, actionsEl };
+};
+
+window.Launcher.buildManageBtn = function buildManageBtn(inst) {
+  const btn = document.createElement("button");
+  btn.className = "manage-btn";
+  btn.textContent = window.t("list.view");
+  btn.onclick = () => window.Launcher.detail.show(inst);
+  return btn;
+};
+
+window.Launcher.buildConsoleBtn = function buildConsoleBtn(installationId) {
+  const btn = document.createElement("button");
+  btn.textContent = window.t("list.console");
+  btn.onclick = () => window.Launcher.console.show(installationId);
+  return btn;
+};
+
+window.Launcher.buildStopBtn = function buildStopBtn(installationId) {
+  const btn = document.createElement("button");
+  btn.className = "danger";
+  btn.textContent = window.t("console.stop");
+  btn.onclick = () => window.api.stopComfyUI(installationId);
+  return btn;
+};
+
+window.Launcher.buildFocusBtn = function buildFocusBtn(installationId) {
+  const btn = document.createElement("button");
+  btn.className = "primary";
+  btn.textContent = window.t("running.showWindow");
+  btn.onclick = () => window.api.focusComfyWindow(installationId);
+  return btn;
+};
+
+window.Launcher.buildProgressBtn = function buildProgressBtn(installationId) {
+  const btn = document.createElement("button");
+  btn.className = "primary";
+  btn.textContent = window.t("list.viewProgress");
+  btn.onclick = () => window.Launcher.progress.showOperation(installationId);
+  return btn;
+};
+
+/**
+ * Build a mini progress bar for an instance card.
+ * Returns a container element with status text and a thin progress bar.
+ */
+window.Launcher.buildCardProgress = function buildCardProgress(installationId) {
+  const info = window.Launcher.progress.getProgressInfo(installationId);
+  const wrap = document.createElement("div");
+  wrap.className = "card-progress";
+  wrap.dataset.progressId = installationId;
+  const status = document.createElement("div");
+  status.className = "card-progress-status";
+  status.textContent = info ? info.status : "";
+  wrap.appendChild(status);
+  const track = document.createElement("div");
+  track.className = "card-progress-track";
+  const fill = document.createElement("div");
+  fill.className = "card-progress-fill";
+  if (info && info.percent >= 0) {
+    fill.style.width = `${info.percent}%`;
+  } else {
+    fill.style.width = "100%";
+    fill.classList.add("indeterminate");
+  }
+  track.appendChild(fill);
+  wrap.appendChild(track);
+  return wrap;
+};
+
+/**
+ * Update all visible card progress bars in-place (called from progress tick).
+ */
+window.Launcher._updateCardProgress = function _updateCardProgress(installationId) {
+  document.querySelectorAll(`.card-progress[data-progress-id="${installationId}"]`).forEach((wrap) => {
+    const info = window.Launcher.progress.getProgressInfo(installationId);
+    if (!info) return;
+    const status = wrap.querySelector(".card-progress-status");
+    if (status) status.textContent = info.status;
+    const fill = wrap.querySelector(".card-progress-fill");
+    if (fill) {
+      if (info.percent >= 0) {
+        fill.style.width = `${info.percent}%`;
+        fill.classList.remove("indeterminate");
+      } else {
+        fill.style.width = "100%";
+        fill.classList.add("indeterminate");
+      }
     }
-    const isLast = i === segments.length - 1;
-    const span = document.createElement("span");
-    if (isLast) {
-      span.className = "breadcrumb-current";
-      span.textContent = seg.label;
-    } else {
-      span.className = "breadcrumb-link";
-      span.textContent = seg.label;
-      span.onclick = seg.action || null;
-    }
-    el.appendChild(span);
   });
 };
 
+window.Launcher.showViewModal = function showViewModal(name) {
+  const modal = document.getElementById(`modal-${name}`);
+  if (!modal) return;
+  // Close any other open view modals first
+  document.querySelectorAll(".view-modal.active").forEach((m) => {
+    if (m !== modal) m.classList.remove("active");
+  });
+  modal.classList.add("active");
+  modal.onclick = (e) => {
+    if (e.target === modal) window.Launcher.closeViewModal(name);
+  };
+};
+
+window.Launcher.closeViewModal = function closeViewModal(name) {
+  const modal = document.getElementById(`modal-${name}`);
+  if (modal) modal.classList.remove("active");
+};
+
 window.Launcher.showView = function showView(name) {
-  const current = document.querySelector(".view.active");
-  if (current) {
-    const currentName = current.id.replace("view-", "");
-    if (currentName !== name) window.Launcher._previousView = currentName;
+  if (window.Launcher._modalViews.has(name)) {
+    window.Launcher.showViewModal(name);
+    return;
   }
+  // Tab view — switch content and close any open modals
   document.querySelectorAll(".view").forEach((v) => v.classList.remove("active"));
   document.getElementById(`view-${name}`).classList.add("active");
+  document.querySelectorAll(".view-modal").forEach((m) => m.classList.remove("active"));
 
   // Update sidebar active state
   const sidebarKey = window.Launcher._sidebarMap[name] || "list";


### PR DESCRIPTION
- Add AbortSignal support to download.js, extract.js, and delete.js
- Replace single _launchAbort with per-operation AbortController registry
- Thread signals through installer.js to download/extract calls
- Add cancel-operation IPC handler and cancelOperation preload API
- Clean up partial files on cancelled downloads (installer.js)
- Auto-cleanup or transition to delete task on cancelled installs
- Track interrupted deletes with partial-delete status and marker restore
- Auto-remove installation record if directory is already gone
- Show immediate 'Cancelling...' UI feedback with sticky cancelRequested flag
- Guard against concurrent operations per installationId
- Hide empty terminal output box until content arrives
- Use process-tree kill (taskkill /T) for extraction on Windows
- Fix NaN percent in deleteDir when directory is empty
- Fix AbortController leak on early returns in launch action
- Mark delete action as cancellable in actions.js
- Add cancelling i18n string
- New installs prepend to list (unshift)
- Fix New tag removal leaving orphaned divider dot

Amp-Thread-ID: https://ampcode.com/threads/T-019c70f9-9bec-73ba-a85c-58c9102add89