### PR TITLE
proposal(10): Zod

### DIFF
--- a/.github/proposals/proposal-zod.md
+++ b/.github/proposals/proposal-zod.md
@@ -1,0 +1,267 @@
+# Proposal #10: Zod — Runtime Schema Validation
+
+**Status:** Draft  
+**Depends on:** Proposal #2 (TypeScript) — `z.infer<>` requires TS; Zod itself works in plain JS  
+**Library:** [zod](https://github.com/colinhacks/zod) v3 (`^3.25`)
+
+---
+
+## Problem
+
+The codebase has **zero runtime validation** at every system boundary:
+
+| Boundary | Current behaviour | Risk |
+|---|---|---|
+| **IPC (renderer→main)** | `ipcMain.handle` trusts all arguments blindly (`preload.js` lines 3–107, `lib/ipc.js` lines 203–889) | Renderer compromise ⇒ arbitrary main-process operations |
+| **JSON data on disk** | `installations.js:9` — `JSON.parse()` with try/catch, no shape check; `settings.js:22` — same pattern | Corrupt/tampered file ⇒ silent data loss or crash |
+| **External API responses** | `sources/git.js:121–147` — GitHub API responses destructured without validation; `sources/standalone.js:477–520` — CDN manifest trusted as-is | API changes ⇒ cryptic `undefined` errors |
+| **Source module contracts** | Each source exports `buildInstallation()` returning ad-hoc objects (`standalone.js:240–253`, `portable.js:107–116`, `git.js:42–49`, `remote.js:23–31`, `cloud.js:25–33`) | Typo in a source ⇒ silent data corruption in `installations.json` |
+| **Settings defaults** | `settings.js:10–17` defines a `defaults` object but loaded JSON can have any shape; `modelsDirs` guard at line 28 is the only runtime check | Settings with wrong types ⇒ crashes in consumers |
+
+## Proposed Solution
+
+Add **Zod schemas** at every system boundary listed above. Zod schemas serve double duty:
+
+1. **Runtime validation** — parse untrusted data through the schema; reject or transform on failure.
+2. **Single source of truth for types** — `z.infer<typeof InstallationSchema>` generates the TypeScript type, eliminating type/runtime drift (requires Proposal #2).
+
+### Why Zod v3 (not v4)?
+
+Zod v4 was released in mid-2025 with significant performance gains for **repeated parsing** (6.5× faster object parsing). However, it has concerning tradeoffs:
+
+- **CommonJS bundle size**: v4 is ~288 KB minified vs. v3's ~68 KB when used with CommonJS (`require()`), which is what this codebase uses today ([source](https://github.com/colinhacks/zod/issues/4637)).
+- **Schema creation overhead**: v4 uses JIT compilation (`new Function`), making schema creation ~15× slower — fine for long-lived schemas but relevant if schemas are created dynamically.
+- **Maturity**: v4 is relatively new; v3 is battle-tested at 31M weekly downloads.
+
+Since this is an Electron app using CommonJS, **Zod v3 is the pragmatic choice today**. When the codebase migrates to ESM (Proposal #2 scope), v4 or `zod/mini` (~6 KB gzipped with tree-shaking) becomes attractive.
+
+### Alternatives Considered
+
+| Library | Min+gzip | Pros | Cons |
+|---|---|---|---|
+| **Zod v3** | ~13.5 kB | Ecosystem leader, `z.infer<>`, excellent docs, chainable API | Largest bundle; class-based (less tree-shakable) |
+| **Valibot** | ~1.4 kB (tree-shaken) | Smallest bundle, modular functions | Smaller ecosystem, less documentation, newer |
+| **TypeBox** | ~22.8 kB | Fastest runtime (JIT), JSON Schema native | No `parse()` out of the box (only `assert`), verbose |
+| **io-ts** | ~6 kB | Functional, fp-ts integration | Abandoned (last release 2022), steep learning curve |
+
+**Zod wins** for this project because:
+- The app is Electron (bundle size less critical than in a browser — Electron itself is ~120 MB).
+- `z.infer<>` is the most ergonomic way to keep types and validation in sync.
+- Ecosystem support (tRPC, React Hook Form, etc.) is unmatched if the app ever adds those.
+- The chainable API is easy to read and mirrors the existing ad-hoc shape definitions.
+
+## Bundle Size Impact
+
+| Metric | Value |
+|---|---|
+| Zod v3 full bundle (minified, CJS) | ~68 KB |
+| Zod v3 gzipped | ~13.5 KB |
+| Current `node_modules` (electron + 7zip-bin + electron-updater) | ~350 MB |
+| Impact on packaged app size | < 0.02% increase |
+
+For an Electron desktop app, 68 KB of validation logic is negligible. This is **not** a browser SPA where every kilobyte matters.
+
+## Implementation Plan
+
+### Phase 1: Schema Definitions (`schemas/` directory)
+
+Define Zod schemas for the core data shapes:
+
+```typescript
+// schemas/installation.ts
+import { z } from "zod";
+
+export const InstallationSchema = z.object({
+  id: z.string().startsWith("inst-"),
+  createdAt: z.string().datetime(),
+  name: z.string().min(1),
+  sourceId: z.enum(["standalone", "portable", "git", "remote", "cloud"]),
+  status: z.enum(["pending", "installed", "failed", "partial-delete"]).optional(),
+  installPath: z.string().optional(),
+  seen: z.boolean().optional(),
+
+  // Source-specific fields (union would be ideal but start permissive)
+  version: z.string().optional(),
+  releaseTag: z.string().optional(),
+  variant: z.string().optional(),
+  downloadUrl: z.string().url().optional().or(z.literal("")),
+  downloadFiles: z.array(z.object({
+    url: z.string().url(),
+    filename: z.string(),
+    size: z.number().nonnegative(),
+  })).optional(),
+  pythonVersion: z.string().optional(),
+  launchArgs: z.string().optional(),
+  launchMode: z.enum(["window", "console"]).optional(),
+  browserPartition: z.enum(["shared", "unique"]).optional(),
+  portConflict: z.enum(["ask", "auto"]).optional(),
+  useSharedPaths: z.boolean().optional(),
+  remoteUrl: z.string().optional(),
+  repo: z.string().optional(),
+  branch: z.string().optional(),
+  commit: z.string().optional(),
+  commitMessage: z.string().optional(),
+  asset: z.string().optional(),
+  activeEnv: z.string().optional(),
+  envMethods: z.record(z.string()).optional(),
+  updateTrack: z.enum(["stable", "latest"]).optional(),
+  updateInfoByTrack: z.record(z.object({
+    checkedAt: z.number().optional(),
+    installedTag: z.string().optional(),
+    latestTag: z.string().optional(),
+    available: z.boolean().optional(),
+    releaseName: z.string().optional(),
+    releaseNotes: z.string().optional(),
+    releaseUrl: z.string().optional(),
+    publishedAt: z.string().optional(),
+  })).optional(),
+}).passthrough(); // Allow unknown fields for forward compatibility
+
+export type Installation = z.infer<typeof InstallationSchema>;
+export const InstallationsArraySchema = z.array(InstallationSchema);
+```
+
+```typescript
+// schemas/settings.ts
+import { z } from "zod";
+
+export const SettingsSchema = z.object({
+  cacheDir: z.string().optional(),
+  maxCachedFiles: z.number().int().min(1).max(50).optional(),
+  onLauncherClose: z.enum(["quit", "tray"]).optional(),
+  modelsDirs: z.array(z.string()).optional(),
+  inputDir: z.string().optional(),
+  outputDir: z.string().optional(),
+  language: z.string().optional(),
+  theme: z.enum(["system", "dark", "light"]).optional(),
+  autoUpdate: z.boolean().optional(),
+}).passthrough();
+
+export type Settings = z.infer<typeof SettingsSchema>;
+```
+
+### Phase 2: Validate Data Loaded from Disk
+
+```typescript
+// In installations.js load():
+async function load(): Promise<Installation[]> {
+  try {
+    const raw = JSON.parse(await fs.promises.readFile(dataPath, "utf-8"));
+    const result = InstallationsArraySchema.safeParse(raw);
+    if (!result.success) {
+      console.error("Invalid installations.json:", result.error.format());
+      return []; // or attempt partial recovery
+    }
+    return result.data;
+  } catch {
+    return [];
+  }
+}
+```
+
+### Phase 3: Validate IPC Inputs
+
+Example for a high-risk channel:
+
+```typescript
+// In lib/ipc.js:
+const AddInstallationInput = z.object({
+  name: z.string().min(1),
+  sourceId: z.enum(["standalone", "portable", "git", "remote", "cloud"]),
+  installPath: z.string().optional(),
+}).passthrough();
+
+ipcMain.handle("add-installation", async (_event, data) => {
+  const parsed = AddInstallationInput.safeParse(data);
+  if (!parsed.success) {
+    return { ok: false, message: `Invalid input: ${parsed.error.message}` };
+  }
+  // ... use parsed.data instead of raw data
+});
+```
+
+### Phase 4: Validate External API Responses
+
+```typescript
+// Lightweight schema for GitHub release API responses
+const GitHubReleaseSchema = z.object({
+  id: z.number(),
+  tag_name: z.string(),
+  name: z.string().nullable(),
+  draft: z.boolean(),
+  prerelease: z.boolean(),
+  body: z.string().nullable().optional(),
+  html_url: z.string().url(),
+  published_at: z.string().nullable().optional(),
+  assets: z.array(z.object({
+    name: z.string(),
+    size: z.number(),
+    browser_download_url: z.string().url(),
+  })),
+}).passthrough();
+```
+
+### Phase 5: Validate Source Module Contracts
+
+Each source's `buildInstallation()` return value gets validated against a base schema + source-specific schema.
+
+## Migration Strategy
+
+1. **Non-breaking rollout**: Use `safeParse()` everywhere — log validation failures but don't crash. This allows gradual adoption.
+2. **Strict mode later**: Once confidence is high (all existing data passes), switch to `parse()` which throws on invalid data.
+3. **Incremental**: Validate one boundary at a time. Start with disk data (most impactful for data integrity), then IPC, then external APIs.
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Existing `installations.json` files have data that doesn't pass new schemas | Use `.passthrough()` + `.optional()` liberally; run validation in "warn" mode first |
+| Performance overhead of validating every IPC call | Negligible — Zod v3 parses simple objects in ~0.8ms; IPC calls are already async with disk/network I/O |
+| Schema drift from actual usage | `z.infer<>` eliminates this by construction — the type IS the schema |
+| Bundle size concern | 68 KB is < 0.02% of packaged Electron app |
+
+## PoC Scope (This PR)
+
+This PR includes:
+1. This proposal document
+2. `schemas/installation.ts` — Zod schema for the installation object
+3. `schemas/settings.ts` — Zod schema for the settings object
+4. `schemas/ipc.ts` — Zod schemas for selected IPC channel inputs
+5. `schemas/github.ts` — Zod schema for GitHub API responses
+6. `schemas/validate-example.ts` — A standalone example showing validation of `installations.json`
+
+**No existing application code is modified.**
+
+## IPC Channel Catalog
+
+For reference, all 30+ IPC channels identified in `preload.js` (lines 3–107):
+
+### Invoke channels (renderer→main, with arguments)
+| Channel | Arguments | File |
+|---|---|---|
+| `get-field-options` | `sourceId: string, fieldId: string, selections: object` | preload.js:6 |
+| `build-installation` | `sourceId: string, selections: object` | preload.js:8 |
+| `browse-folder` | `defaultPath?: string` | preload.js:11 |
+| `open-path` | `targetPath: string` | preload.js:12 |
+| `open-external` | `url: string` | preload.js:13 |
+| `add-installation` | `data: object` | preload.js:17 |
+| `reorder-installations` | `orderedIds: string[]` | preload.js:18 |
+| `probe-installation` | `dirPath: string` | preload.js:19 |
+| `track-installation` | `data: object` | preload.js:20 |
+| `install-instance` | `installationId: string` | preload.js:21 |
+| `stop-comfyui` | `installationId?: string` | preload.js:38 |
+| `focus-comfy-window` | `installationId: string` | preload.js:39 |
+| `cancel-operation` | `installationId: string` | preload.js:52 |
+| `kill-port-process` | `port: number` | preload.js:53 |
+| `get-list-actions` | `installationId: string` | preload.js:54 |
+| `update-installation` | `installationId: string, data: object` | preload.js:56 |
+| `get-detail-sections` | `installationId: string` | preload.js:58 |
+| `run-action` | `installationId: string, actionId: string, actionData?: object` | preload.js:60 |
+| `set-setting` | `key: string, value: any` | preload.js:64 |
+| `get-setting` | `key: string` | preload.js:65 |
+
+### Invoke channels (no arguments)
+`get-sources`, `get-default-install-dir`, `detect-gpu`, `get-locale-messages`, `get-available-locales`, `get-installations`, `get-settings-sections`, `get-models-sections`, `get-resolved-theme`, `quit-app`, `check-for-update`, `download-update`, `install-update`, `get-pending-update`, `cancel-launch`, `get-running-instances`
+
+### Push channels (main→renderer)
+`install-progress`, `comfy-output`, `comfy-exited`, `instance-started`, `instance-stopped`, `theme-changed`, `locale-changed`, `confirm-quit`, `update-available`, `update-download-progress`, `update-downloaded`, `update-error`

--- a/schemas/github.ts
+++ b/schemas/github.ts
@@ -1,0 +1,105 @@
+/**
+ * Zod schemas for external API responses.
+ *
+ * These validate the subset of fields actually used by the codebase,
+ * with .passthrough() to tolerate additional fields from the APIs.
+ *
+ * Derived from:
+ *   - sources/git.js       getFieldOptions()  — lines 117–150
+ *   - sources/portable.js  getFieldOptions()  — lines 379–406
+ *   - sources/standalone.js getFieldOptions() — lines 474–523
+ */
+import { z } from "zod";
+
+// ── GitHub Release Asset ────────────────────────────────────────────────────
+export const GitHubAssetSchema = z
+  .object({
+    name: z.string(),
+    size: z.number().nonnegative(),
+    browser_download_url: z.string().url(),
+  })
+  .passthrough();
+
+export type GitHubAsset = z.infer<typeof GitHubAssetSchema>;
+
+// ── GitHub Release ──────────────────────────────────────────────────────────
+// Used by portable.js:381–388 and standalone.js:477–489
+export const GitHubReleaseSchema = z
+  .object({
+    id: z.number(),
+    tag_name: z.string(),
+    name: z.string().nullable().optional(),
+    draft: z.boolean(),
+    prerelease: z.boolean(),
+    body: z.string().nullable().optional(),
+    html_url: z.string().url(),
+    published_at: z.string().nullable().optional(),
+    assets: z.array(GitHubAssetSchema),
+  })
+  .passthrough();
+
+export type GitHubRelease = z.infer<typeof GitHubReleaseSchema>;
+
+// ── GitHub Branch ───────────────────────────────────────────────────────────
+// Used by git.js:123 — branches endpoint
+export const GitHubBranchSchema = z
+  .object({
+    name: z.string(),
+  })
+  .passthrough();
+
+export type GitHubBranch = z.infer<typeof GitHubBranchSchema>;
+
+// ── GitHub Commit ───────────────────────────────────────────────────────────
+// Used by git.js:140–146 — commits endpoint
+export const GitHubCommitSchema = z
+  .object({
+    sha: z.string(),
+    commit: z.object({
+      message: z.string(),
+      committer: z
+        .object({
+          date: z.string().optional(),
+        })
+        .optional(),
+    }),
+    html_url: z.string().url().optional(),
+  })
+  .passthrough();
+
+export type GitHubCommit = z.infer<typeof GitHubCommitSchema>;
+
+// ── GitHub Repo Info ────────────────────────────────────────────────────────
+// Used by git.js:122 — repo info endpoint
+export const GitHubRepoSchema = z
+  .object({
+    default_branch: z.string(),
+  })
+  .passthrough();
+
+export type GitHubRepo = z.infer<typeof GitHubRepoSchema>;
+
+// ── GitHub Compare ──────────────────────────────────────────────────────────
+// Used by portable.js:42–43 — compare endpoint
+export const GitHubCompareSchema = z
+  .object({
+    ahead_by: z.number(),
+  })
+  .passthrough();
+
+export type GitHubCompare = z.infer<typeof GitHubCompareSchema>;
+
+// ── Standalone CDN Manifest ─────────────────────────────────────────────────
+// Used by standalone.js:500–520 — manifests.json from release assets
+export const StandaloneManifestSchema = z
+  .object({
+    id: z.string(), // e.g. "win-nvidia-cu128"
+    comfyui_ref: z.string().optional(),
+    python_version: z.string().optional(),
+    files: z.array(z.string()).optional(),
+  })
+  .passthrough();
+
+export type StandaloneManifest = z.infer<typeof StandaloneManifestSchema>;
+
+export const StandaloneManifestsArraySchema = z.array(StandaloneManifestSchema);

--- a/schemas/installation.ts
+++ b/schemas/installation.ts
@@ -1,0 +1,100 @@
+/**
+ * Zod schema for ComfyUI Launcher installation records.
+ *
+ * Derived from the implicit shapes in:
+ *   - installations.js (add/update/seedDefaults — lines 24–77)
+ *   - sources/standalone.js buildInstallation() — lines 240–253
+ *   - sources/portable.js  buildInstallation() — lines 107–116
+ *   - sources/git.js        buildInstallation() — lines 42–49
+ *   - sources/remote.js     buildInstallation() — lines 23–31
+ *   - sources/cloud.js      buildInstallation() — lines 25–33
+ *   - lib/ipc.js            migrateDefaults()   — lines 136–161
+ */
+import { z } from "zod";
+
+// ── Update info stored per-track (stable / latest) ──────────────────────────
+export const UpdateInfoSchema = z.object({
+  checkedAt: z.number().optional(),
+  installedTag: z.string().optional(),
+  latestTag: z.string().optional(),
+  available: z.boolean().optional(),
+  releaseName: z.string().optional(),
+  releaseNotes: z.string().optional(),
+  releaseUrl: z.string().optional(),
+  publishedAt: z.string().nullable().optional(),
+});
+
+export type UpdateInfo = z.infer<typeof UpdateInfoSchema>;
+
+// ── Download file entry (standalone source) ─────────────────────────────────
+export const DownloadFileSchema = z.object({
+  url: z.string().url(),
+  filename: z.string().min(1),
+  size: z.number().nonnegative(),
+});
+
+export type DownloadFile = z.infer<typeof DownloadFileSchema>;
+
+// ── Source IDs ──────────────────────────────────────────────────────────────
+export const SourceId = z.enum(["standalone", "portable", "git", "remote", "cloud"]);
+
+// ── Installation record ─────────────────────────────────────────────────────
+export const InstallationSchema = z.object({
+  // Core fields added by installations.js add() — line 27–28
+  id: z.string().regex(/^inst-\d+$/, "Must be 'inst-' followed by a timestamp"),
+  createdAt: z.string().datetime({ offset: true }),
+  name: z.string().min(1),
+  sourceId: SourceId,
+
+  // Status lifecycle: pending → installed | failed | partial-delete
+  status: z
+    .enum(["pending", "installed", "failed", "partial-delete"])
+    .optional(),
+
+  // Filesystem location (absent for skipInstall sources like remote/cloud)
+  installPath: z.string().optional(),
+
+  // UI state
+  seen: z.boolean().optional(),
+
+  // ── Fields common across multiple sources ─────────────────────────────
+  version: z.string().optional(),
+  launchArgs: z.string().optional(),
+  launchMode: z.enum(["window", "console"]).optional(),
+  browserPartition: z.enum(["shared", "unique"]).optional(),
+  portConflict: z.enum(["ask", "auto"]).optional(),
+  useSharedPaths: z.boolean().optional(),
+
+  // ── Standalone-specific ───────────────────────────────────────────────
+  releaseTag: z.string().optional(),
+  variant: z.string().optional(),
+  downloadUrl: z.string().optional(), // May be empty string
+  downloadFiles: z.array(DownloadFileSchema).optional(),
+  pythonVersion: z.string().optional(),
+  activeEnv: z.string().optional(),
+  envMethods: z.record(z.string(), z.string()).optional(),
+
+  // ── Portable-specific ─────────────────────────────────────────────────
+  asset: z.string().optional(),
+  updateTrack: z.enum(["stable", "latest"]).optional(),
+  updateInfoByTrack: z.record(z.string(), UpdateInfoSchema).optional(),
+
+  // ── Git-specific ──────────────────────────────────────────────────────
+  repo: z.string().optional(),
+  branch: z.string().optional(),
+  commit: z.string().optional(),
+  commitMessage: z.string().optional(),
+
+  // ── Remote/Cloud-specific ─────────────────────────────────────────────
+  remoteUrl: z.string().optional(),
+
+  // Source label injected by ipc.js get-installations handler — line 255
+  sourceLabel: z.string().optional(),
+})
+  // Allow unknown fields for forward compatibility and source-specific extensions
+  .passthrough();
+
+export type Installation = z.infer<typeof InstallationSchema>;
+
+// ── Array of installations (the shape of installations.json) ────────────────
+export const InstallationsArraySchema = z.array(InstallationSchema);

--- a/schemas/ipc.ts
+++ b/schemas/ipc.ts
@@ -1,0 +1,93 @@
+/**
+ * Zod schemas for selected IPC channel inputs (renderer → main).
+ *
+ * These cover the highest-risk channels — those that accept structured
+ * data from the renderer and use it to mutate state or spawn processes.
+ *
+ * Derived from preload.js (lines 3–107) and lib/ipc.js handler implementations.
+ */
+import { z } from "zod";
+import { SourceId } from "./installation";
+
+// ── add-installation (preload.js:17, ipc.js:259–277) ────────────────────────
+export const AddInstallationInput = z.object({
+  name: z.string().min(1),
+  sourceId: SourceId,
+  installPath: z.string().optional(),
+  // Source-specific fields passed through from buildInstallation()
+}).passthrough();
+
+export type AddInstallationInput = z.infer<typeof AddInstallationInput>;
+
+// ── track-installation (preload.js:20, ipc.js:296–311) ──────────────────────
+export const TrackInstallationInput = z.object({
+  name: z.string().min(1),
+  sourceId: SourceId,
+  installPath: z.string().min(1),
+}).passthrough();
+
+export type TrackInstallationInput = z.infer<typeof TrackInstallationInput>;
+
+// ── update-installation (preload.js:56–57, ipc.js:411–427) ──────────────────
+// The data payload is a partial record of editable fields.
+export const UpdateInstallationInput = z.object({
+  name: z.string().min(1).optional(),
+  seen: z.boolean().optional(),
+  launchArgs: z.string().optional(),
+  launchMode: z.enum(["window", "console"]).optional(),
+  browserPartition: z.enum(["shared", "unique"]).optional(),
+  portConflict: z.enum(["ask", "auto"]).optional(),
+  useSharedPaths: z.boolean().optional(),
+  remoteUrl: z.string().optional(),
+  updateTrack: z.enum(["stable", "latest"]).optional(),
+}).passthrough();
+
+export type UpdateInstallationInput = z.infer<typeof UpdateInstallationInput>;
+
+// ── set-setting (preload.js:64, ipc.js:509–527) ────────────────────────────
+export const SetSettingInput = z.object({
+  key: z.string().min(1),
+  value: z.unknown(), // Value type depends on key; validated further downstream
+});
+
+export type SetSettingInput = z.infer<typeof SetSettingInput>;
+
+// ── reorder-installations (preload.js:18, ipc.js:279–281) ───────────────────
+export const ReorderInstallationsInput = z.array(
+  z.string().regex(/^inst-\d+$/)
+);
+
+export type ReorderInstallationsInput = z.infer<typeof ReorderInstallationsInput>;
+
+// ── run-action (preload.js:60–61, ipc.js:582–889) ──────────────────────────
+export const RunActionInput = z.object({
+  installationId: z.string().regex(/^inst-\d+$/),
+  actionId: z.string().min(1),
+  actionData: z.record(z.unknown()).optional(),
+});
+
+export type RunActionInput = z.infer<typeof RunActionInput>;
+
+// ── get-field-options (preload.js:5–6, ipc.js:207–211) ──────────────────────
+export const GetFieldOptionsInput = z.object({
+  sourceId: SourceId,
+  fieldId: z.string().min(1),
+  selections: z.record(z.unknown()),
+});
+
+export type GetFieldOptionsInput = z.infer<typeof GetFieldOptionsInput>;
+
+// ── build-installation (preload.js:7–8, ipc.js:218–225) ─────────────────────
+export const BuildInstallationInput = z.object({
+  sourceId: SourceId,
+  selections: z.record(z.unknown()),
+});
+
+export type BuildInstallationInput = z.infer<typeof BuildInstallationInput>;
+
+// ── kill-port-process (preload.js:53, ipc.js:573–580) ───────────────────────
+export const KillPortProcessInput = z.object({
+  port: z.number().int().min(1).max(65535),
+});
+
+export type KillPortProcessInput = z.infer<typeof KillPortProcessInput>;

--- a/schemas/settings.ts
+++ b/schemas/settings.ts
@@ -1,0 +1,33 @@
+/**
+ * Zod schema for ComfyUI Launcher settings.
+ *
+ * Derived from:
+ *   - settings.js defaults object   — lines 10–17
+ *   - lib/ipc.js settings sections  — lines 435–507
+ */
+import { z } from "zod";
+
+export const SettingsSchema = z.object({
+  // Downloads — settings.js:11–12
+  cacheDir: z.string().optional(),
+  maxCachedFiles: z.number().int().min(1).max(50).optional(),
+
+  // Behaviour — settings.js:13
+  onLauncherClose: z.enum(["quit", "tray"]).optional(),
+
+  // Shared directories — settings.js:14–16
+  modelsDirs: z.array(z.string()).optional(),
+  inputDir: z.string().optional(),
+  outputDir: z.string().optional(),
+
+  // Appearance — ipc.js:441–448
+  language: z.string().optional(),
+  theme: z.enum(["system", "dark", "light"]).optional(),
+
+  // Auto-update — ipc.js:449
+  autoUpdate: z.boolean().optional(),
+})
+  // Allow unknown fields so source-contributed settings aren't rejected
+  .passthrough();
+
+export type Settings = z.infer<typeof SettingsSchema>;

--- a/schemas/validate-example.ts
+++ b/schemas/validate-example.ts
@@ -1,0 +1,106 @@
+/**
+ * PoC: Validate installations.json against the Zod schema.
+ *
+ * This is a standalone example showing how schema validation would work
+ * when integrated into installations.js load(). It does NOT modify
+ * any existing application code.
+ *
+ * Usage (after `npm install zod` and `npx tsx`):
+ *   npx tsx schemas/validate-example.ts
+ *
+ * Or in plain Node with ts-node:
+ *   npx ts-node schemas/validate-example.ts
+ */
+import * as fs from "fs";
+import * as path from "path";
+import { InstallationsArraySchema } from "./installation";
+import { SettingsSchema } from "./settings";
+
+// ── Resolve data paths (mirrors lib/paths.js logic) ─────────────────────────
+const homeDir = process.env.HOME || process.env.USERPROFILE || "";
+const dataDir =
+  process.platform === "darwin"
+    ? path.join(homeDir, "Library", "Application Support", "comfyui-launcher")
+    : process.platform === "win32"
+      ? path.join(process.env.APPDATA || homeDir, "comfyui-launcher")
+      : path.join(process.env.XDG_DATA_HOME || path.join(homeDir, ".local", "share"), "comfyui-launcher");
+
+const configDir =
+  process.platform === "darwin"
+    ? dataDir
+    : process.platform === "win32"
+      ? dataDir
+      : path.join(process.env.XDG_CONFIG_HOME || path.join(homeDir, ".config"), "comfyui-launcher");
+
+// ── Validate installations.json ─────────────────────────────────────────────
+function validateInstallations() {
+  const filePath = path.join(dataDir, "installations.json");
+  console.log(`\n📂 Checking ${filePath}`);
+
+  if (!fs.existsSync(filePath)) {
+    console.log("   ⏭  File does not exist (no installations yet)");
+    return;
+  }
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+  } catch (err) {
+    console.error("   ❌ Failed to parse JSON:", err);
+    return;
+  }
+
+  const result = InstallationsArraySchema.safeParse(raw);
+  if (result.success) {
+    console.log(`   ✅ Valid — ${result.data.length} installation(s)`);
+    for (const inst of result.data) {
+      console.log(`      • ${inst.id} — "${inst.name}" (${inst.sourceId}, status: ${inst.status ?? "pending"})`);
+    }
+  } else {
+    console.error("   ❌ Validation failed:");
+    for (const issue of result.error.issues) {
+      console.error(`      • [${issue.path.join(".")}] ${issue.message}`);
+    }
+  }
+}
+
+// ── Validate settings.json ──────────────────────────────────────────────────
+function validateSettings() {
+  const filePath = path.join(configDir, "settings.json");
+  console.log(`\n📂 Checking ${filePath}`);
+
+  if (!fs.existsSync(filePath)) {
+    console.log("   ⏭  File does not exist (using defaults)");
+    return;
+  }
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+  } catch (err) {
+    console.error("   ❌ Failed to parse JSON:", err);
+    return;
+  }
+
+  const result = SettingsSchema.safeParse(raw);
+  if (result.success) {
+    console.log("   ✅ Valid");
+    const keys = Object.keys(result.data);
+    console.log(`      Keys: ${keys.join(", ")}`);
+  } else {
+    console.error("   ❌ Validation failed:");
+    for (const issue of result.error.issues) {
+      console.error(`      • [${issue.path.join(".")}] ${issue.message}`);
+    }
+  }
+}
+
+// ── Run ─────────────────────────────────────────────────────────────────────
+console.log("🔍 ComfyUI Launcher — Zod Schema Validation PoC\n");
+console.log("This validates existing data files against the proposed schemas.");
+console.log("No data is modified.\n");
+
+validateInstallations();
+validateSettings();
+
+console.log("\n✨ Done");


### PR DESCRIPTION
## Proposal #10: Zod — Runtime Schema Validation

### Summary

Adds a migration proposal and PoC schema definitions for **Zod v3** runtime schema validation at all system boundaries: IPC channel inputs, JSON data loaded from disk, external API responses, and source module contracts.

### What's Included

| File | Purpose |
|---|---|
| `.github/proposals/proposal-zod.md` | Full proposal with problem analysis, alternatives comparison, implementation plan, and risk assessment |
| `schemas/installation.ts` | Zod schema for the installation record (derived from 5 source modules + `installations.js`) |
| `schemas/settings.ts` | Zod schema for the settings object (derived from `settings.js` defaults + `ipc.js` sections) |
| `schemas/ipc.ts` | Zod schemas for 9 high-risk IPC channel inputs |
| `schemas/github.ts` | Zod schemas for GitHub API responses + CDN manifests |
| `schemas/validate-example.ts` | Standalone PoC that validates existing `installations.json` and `settings.json` against the schemas |

### Key Decisions

- **Zod v3** over v4 — v4's CJS bundle is ~288 KB vs v3's ~68 KB (this codebase uses `require()`)
- **Zod** over Valibot/TypeBox — `z.infer<>` type inference is the killer feature for eliminating type/runtime drift; bundle size is irrelevant in an Electron app (~120 MB baseline)
- **`.passthrough()`** on all schemas — allows forward compatibility and source-specific extensions
- **`safeParse()` rollout strategy** — log validation failures first, don't crash; switch to strict `parse()` later

### Dependencies

- Proposal #2 (TypeScript) — Zod works in plain JS but the `z.infer<>` benefit requires TS

### No Application Code Modified

This PR only adds new files (proposal doc + schema definitions). No existing code is changed.