### PR TITLE
proposal(6): ESLint + Prettier

### DIFF
--- a/.github/proposals/proposal-eslint-prettier.md
+++ b/.github/proposals/proposal-eslint-prettier.md
@@ -1,0 +1,44 @@
+# Proposal #6: ESLint + Prettier
+
+## Summary
+
+Add ESLint (flat config) and Prettier to the codebase for linting and formatting.
+This is foundational — every subsequent migration benefits from consistent, linted code.
+
+## Motivation
+
+- **No linting** — zero static analysis. Bugs like unused variables, empty catch blocks, and undeclared globals go undetected.
+- **No formatting** — inconsistent style across files.
+- **Architecture rules exist only as prose** — `DESIGN_PROCESS.md` describes layer boundaries, but nothing enforces them.
+
+## What's Added
+
+| Package | Version | Purpose |
+|---|---|---|
+| `eslint` | 9.39.2 | Linter (flat config) |
+| `@eslint/js` | 9.39.2 | ESLint recommended rules |
+| `eslint-config-prettier` | 10.1.8 | Disables ESLint rules that conflict with Prettier |
+| `eslint-plugin-n` | 17.24.0 | `n/no-restricted-require` for architecture boundary enforcement |
+| `globals` | 15.15.0 | Predefined global variable sets (Node, browser) |
+| `prettier` | 3.8.1 | Code formatter |
+
+## Architecture Boundary Rules
+
+| DESIGN_PROCESS.md Rule | ESLint Enforcement |
+|---|---|
+| §1 Sources own their data — no reverse dep on renderer | `n/no-restricted-require` on `sources/**/*.js` blocks `require("../renderer/*")` |
+| §Architecture — renderer is separate from lib | `no-undef` in renderer (sourceType: "script") catches accidental `require()` |
+| §5 Common logic lives in lib — no upward deps | `n/no-restricted-require` on `lib/**/*.js` (except `ipc.js`) blocks renderer and sources imports |
+| §4 No native dialogs | `no-restricted-globals` bans `alert`, `confirm`, `prompt` in renderer |
+
+## Current Lint Report (no fixes applied)
+
+33 errors (mostly `no-empty` — empty catch blocks), 21 warnings (`no-unused-vars`).
+Zero architecture boundary violations detected.
+
+## Tradeoffs
+
+1. Empty catches (`catch {}`) are flagged as errors — consider downgrading `no-empty` to `"warn"` for adoption.
+2. Renderer uses `sourceType: "script"` — must change to `"module"` if renderer migrates to ESM bundling.
+3. ESLint 9 used (not 10) because ecosystem plugins haven't released ESLint 10 compatible versions yet.
+4. No auto-fix applied — config only. A follow-up commit should run `prettier --write .` and `eslint --fix .`.

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+result/
+out/
+package-lock.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "printWidth": 120,
+  "tabWidth": 2,
+  "endOfLine": "lf"
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,140 @@
+const js = require("@eslint/js");
+const globals = require("globals");
+const eslintConfigPrettier = require("eslint-config-prettier");
+const pluginN = require("eslint-plugin-n");
+
+module.exports = [
+  // ── Global ignores ──────────────────────────────────────────────────
+  {
+    ignores: [
+      "node_modules/**",
+      "dist/**",
+      "result/**",
+      "out/**",
+      "poc/**",
+      "renderer/vue-poc/**",
+      "tests/**",
+      "forge.config.js",
+    ],
+  },
+
+  // ── Base: ESLint recommended ────────────────────────────────────────
+  js.configs.recommended,
+
+  // ── Main process files (CommonJS, Node) ─────────────────────────────
+  {
+    files: [
+      "eslint.config.js",
+      "main.js",
+      "preload.js",
+      "settings.js",
+      "installations.js",
+      "lib/**/*.js",
+      "sources/**/*.js",
+    ],
+    languageOptions: {
+      sourceType: "commonjs",
+      ecmaVersion: "latest",
+      globals: {
+        ...globals.node,
+      },
+    },
+    plugins: {
+      n: pluginN,
+    },
+    rules: {
+      "no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
+      "no-console": "off",
+    },
+  },
+
+  // ── Sources: cannot require renderer/ ──────────────────────────────
+  // DESIGN_PROCESS.md §1: "Sources own their data and behavior"
+  {
+    files: ["sources/**/*.js"],
+    plugins: {
+      n: pluginN,
+    },
+    rules: {
+      "n/no-restricted-require": [
+        "error",
+        [
+          {
+            name: ["../renderer/*", "../renderer/**"],
+            message:
+              "Sources must not require renderer modules. " +
+              "Sources describe data; the renderer renders it. " +
+              "(DESIGN_PROCESS.md §1)",
+          },
+        ],
+      ],
+    },
+  },
+
+  // ── lib/: cannot require renderer/ or sources/ ─────────────────────
+  // DESIGN_PROCESS.md §5: "Common logic lives in lib/"
+  // Exception: lib/ipc.js legitimately requires ../sources.
+  {
+    files: ["lib/**/*.js"],
+    ignores: ["lib/ipc.js"],
+    plugins: {
+      n: pluginN,
+    },
+    rules: {
+      "n/no-restricted-require": [
+        "error",
+        [
+          {
+            name: ["../renderer/*", "../renderer/**"],
+            message:
+              "lib/ must not require renderer modules. " +
+              "(DESIGN_PROCESS.md §Architecture)",
+          },
+          {
+            name: ["../sources", "../sources/*", "../sources/**"],
+            message:
+              "lib/ must not require source modules (except ipc.js). " +
+              "(DESIGN_PROCESS.md §5)",
+          },
+        ],
+      ],
+    },
+  },
+
+  // ── Renderer files (browser globals, no Node) ─────────────────────
+  {
+    files: ["renderer/**/*.js"],
+    languageOptions: {
+      sourceType: "script",
+      ecmaVersion: "latest",
+      globals: {
+        ...globals.browser,
+      },
+    },
+    rules: {
+      "no-undef": "error",
+
+      // DESIGN_PROCESS.md §4: no native dialogs
+      "no-restricted-globals": [
+        "error",
+        {
+          name: "alert",
+          message: "Use window.Launcher.modal.alert() instead (DESIGN_PROCESS.md §4).",
+        },
+        {
+          name: "confirm",
+          message: "Use window.Launcher.modal.confirm() instead (DESIGN_PROCESS.md §4).",
+        },
+        {
+          name: "prompt",
+          message: "Use window.Launcher.modal.prompt() instead (DESIGN_PROCESS.md §4).",
+        },
+      ],
+
+      "no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
+    },
+  },
+
+  // ── Prettier: disable conflicting formatting rules (must be last) ─
+  eslintConfigPrettier,
+];

--- a/package.json
+++ b/package.json
@@ -11,14 +11,24 @@
   "scripts": {
     "postinstall": "node -e \"if(process.platform!=='win32'){try{require('fs').chmodSync(require('7zip-bin').path7za,0o755)}catch{}}\"",
     "start": "electron .",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "dist": "electron-builder",
     "dist:win": "electron-builder --win",
     "dist:mac": "electron-builder --mac",
     "dist:linux": "electron-builder --linux"
   },
   "devDependencies": {
+    "@eslint/js": "9.39.2",
     "electron": "^40.4.1",
     "electron-builder": "^26.7.0",
+    "eslint": "9.39.2",
+    "eslint-config-prettier": "10.1.8",
+    "eslint-plugin-n": "17.24.0",
+    "globals": "15.15.0",
+    "prettier": "3.8.1",
     "tar": "^7.5.9"
   },
   "dependencies": {


### PR DESCRIPTION
## Proposal #6: ESLint + Prettier

Adds ESLint (flat config, v9) and Prettier to the codebase. This is foundational — every subsequent migration benefits from consistent, linted code.

### What's Added

| Package | Purpose |
|---|---|
| `eslint` 9.39.2 | Linter with flat config |
| `@eslint/js` 9.39.2 | ESLint recommended rules |
| `eslint-config-prettier` 10.1.8 | Disables conflicting formatting rules |
| `eslint-plugin-n` 17.24.0 | `n/no-restricted-require` for architecture boundary enforcement |
| `globals` 15.15.0 | Predefined global variable sets |
| `prettier` 3.8.1 | Code formatter |

### Architecture Boundary Enforcement

Every rule from `DESIGN_PROCESS.md` is mapped to an ESLint rule:

- **§1 Sources own their data** → `n/no-restricted-require` blocks `require("../renderer/*")` in sources
- **§5 Common logic lives in lib** → `n/no-restricted-require` blocks renderer + sources imports in lib (except `ipc.js`)
- **§4 No native dialogs** → `no-restricted-globals` bans `alert`, `confirm`, `prompt` in renderer
- **Renderer ≠ Node** → `sourceType: "script"` + browser globals catches accidental `require()` calls

### Current Lint Report (no fixes applied)

- **33 errors**: Mostly `no-empty` (empty catch blocks in `lib/ipc.js`, `lib/process.js`, etc.)
- **21 warnings**: `no-unused-vars` (`id` in for-of loops, destructured-but-unused vars)
- **Zero architecture boundary violations** — existing code correctly follows the layer rules

### npm Scripts

```
npm run lint          # eslint .
npm run lint:fix      # eslint . --fix
npm run format        # prettier --write .
npm run format:check  # prettier --check .
```

### Files Changed

- `eslint.config.js` (new) — ESLint flat config with 6 config objects
- `.prettierrc` (new) — `semi: true, singleQuote: false, printWidth: 120`
- `.prettierignore` (new)
- `.github/proposals/proposal-eslint-prettier.md` (new) — Full proposal document
- `package.json` — devDependencies + npm scripts

### Not done (intentionally)

- No auto-fix/reformat of existing code
- No `eslint-plugin-import-x` (doesn't support ESLint 10 peer dep yet; `eslint-plugin-n` covers our needs)
- No CI integration (separate concern)

See [`.github/proposals/proposal-eslint-prettier.md`](.github/proposals/proposal-eslint-prettier.md) for the full proposal with tradeoff analysis.