### PR TITLE
proposal(2): TypeScript + Typed IPC

### DIFF
--- a/.github/proposals/proposal-typescript-typed-ipc.md
+++ b/.github/proposals/proposal-typescript-typed-ipc.md
@@ -1,0 +1,202 @@
+# Proposal #2: TypeScript + Typed IPC
+
+**Depends on:** Proposal #1 (electron-vite)
+
+## Summary
+
+Migrate the codebase from vanilla JavaScript to TypeScript and introduce type-safe IPC communication between main and renderer processes. The 30+ IPC channels in `preload.js` (lines 3–107) are currently stringly-typed — a typo or wrong argument type is a silent runtime failure. TypeScript + typed IPC catches these at compile time.
+
+## Motivation
+
+### The Problem
+
+Every IPC call in this codebase is a string-keyed `ipcRenderer.invoke("channel-name", ...)` with zero type checking:
+
+```js
+// preload.js — no type safety
+getFieldOptions: (sourceId, fieldId, selections) =>
+  ipcRenderer.invoke("get-field-options", sourceId, fieldId, selections),
+```
+
+If a renderer file passes `(sourceId, selections)` instead of `(sourceId, fieldId, selections)`, or if someone renames the channel in `lib/ipc.js` but forgets `preload.js`, the error is silent at compile time and crashes at runtime.
+
+### Scope of the Problem
+
+| Category | Count | Files |
+|---|---|---|
+| Invoke channels (renderer → main, expects return) | 27 | `preload.js` lines 4–86 |
+| Event channels (main → renderer, push) | 9 | `preload.js` lines 23–105 |
+| Total IPC channels | 36 | — |
+| Main-process `.js` files to convert | 22 | `main.js`, `preload.js`, `settings.js`, `installations.js`, `lib/*.js` (16), `sources/*.js` (5 + index) |
+| Renderer `.js` files (deferred — see note) | 14 | `renderer/*.js` |
+| **Total `.js` files** | **37** | — |
+
+> **Note:** Renderer files currently load as raw `<script>` tags in `index.html` (lines 239–252). They cannot be converted to TypeScript until Proposal #1 (electron-vite) provides a bundler. This proposal focuses on main-process and preload TypeScript, with renderer types provided via a `.d.ts` declaration file.
+
+### IPC Channel Catalog
+
+#### Invoke Channels (renderer → main, two-way)
+
+| Channel | Arguments | Return Type | Handler |
+|---|---|---|---|
+| `get-sources` | — | `SourceInfo[]` | `lib/ipc.js:203` |
+| `get-field-options` | `sourceId, fieldId, selections` | `FieldOption[]` | `lib/ipc.js:207` |
+| `detect-gpu` | — | `GPUInfo \| null` | `lib/ipc.js:213` |
+| `build-installation` | `sourceId, selections` | `BuildResult` | `lib/ipc.js:218` |
+| `get-default-install-dir` | — | `string` | `lib/ipc.js:228` |
+| `browse-folder` | `defaultPath?` | `string \| null` | `lib/ipc.js:230` |
+| `open-path` | `targetPath` | `string` | `lib/ipc.js:240` |
+| `open-external` | `url` | `void` | `lib/ipc.js:241` |
+| `get-locale-messages` | — | `Record<string, string>` | `lib/ipc.js:533` |
+| `get-available-locales` | — | `LocaleInfo[]` | `lib/ipc.js:534` |
+| `get-installations` | — | `Installation[]` | `lib/ipc.js:244` |
+| `add-installation` | `data` | `{ ok, entry? }` | `lib/ipc.js:259` |
+| `reorder-installations` | `orderedIds` | `void` | `lib/ipc.js:279` |
+| `probe-installation` | `dirPath` | `ProbeResult[]` | `lib/ipc.js:283` |
+| `track-installation` | `data` | `{ ok, entry? }` | `lib/ipc.js:296` |
+| `install-instance` | `installationId` | `{ ok, message? }` | `lib/ipc.js:313` |
+| `stop-comfyui` | `installationId?` | `void` | `lib/ipc.js:546` |
+| `focus-comfy-window` | `installationId` | `boolean` | `main.js:240` |
+| `get-running-instances` | — | `SessionInfo[]` | `lib/ipc.js:555` |
+| `cancel-launch` | — | `void` | `lib/ipc.js:557` |
+| `cancel-operation` | `installationId` | `void` | `lib/ipc.js:565` |
+| `kill-port-process` | `port` | `{ ok }` | `lib/ipc.js:573` |
+| `get-list-actions` | `installationId` | `Action[]` | `lib/ipc.js:404` |
+| `update-installation` | `installationId, data` | `void` | `lib/ipc.js:411` |
+| `get-detail-sections` | `installationId` | `Section[]` | `lib/ipc.js:429` |
+| `run-action` | `installationId, actionId, actionData?` | `ActionResult` | `lib/ipc.js:582` |
+| `get-settings-sections` | — | `Section[]` | `lib/ipc.js:435` |
+| `get-models-sections` | — | `ModelsData` | `lib/ipc.js:494` |
+| `set-setting` | `key, value` | `void` | `lib/ipc.js:509` |
+| `get-setting` | `key` | `any` | `lib/ipc.js:529` |
+| `get-resolved-theme` | — | `"dark" \| "light"` | `lib/ipc.js:536` |
+| `quit-app` | — | `void` | `main.js:238` |
+| `check-for-update` | — | `UpdateCheckResult` | `lib/updater.js:86` |
+| `download-update` | — | `void` | `lib/updater.js:94` |
+| `install-update` | — | `void` | `lib/updater.js:112` |
+| `get-pending-update` | — | `UpdateInfo \| null` | `lib/updater.js:119` |
+
+#### Event Channels (main → renderer, push)
+
+| Channel | Payload | Sent From |
+|---|---|---|
+| `install-progress` | `{ installationId, phase, percent?, status? }` | `lib/ipc.js` (multiple) |
+| `comfy-output` | `{ installationId, text }` | `lib/ipc.js:776` |
+| `comfy-exited` | `{ installationId, crashed, exitCode }` | `lib/ipc.js:860` |
+| `instance-started` | `{ installationId, port, url, mode }` | `lib/ipc.js:114` |
+| `instance-stopped` | `{ installationId }` | `lib/ipc.js:122` |
+| `theme-changed` | `"dark" \| "light"` | `lib/ipc.js:515` |
+| `locale-changed` | `Record<string, string>` | `lib/ipc.js:522` |
+| `confirm-quit` | — | `main.js:44` |
+| `update-available` | `UpdateInfo` | `lib/updater.js:48` |
+| `update-download-progress` | `{ percent, transferred, total }` | `lib/updater.js:64` |
+| `update-downloaded` | `UpdateInfo` | `lib/updater.js:72` |
+| `update-error` | `{ message }` | `lib/updater.js:76` |
+
+## Approach: Shared Type Definitions (No New Runtime Dependencies)
+
+### Why Not electron-trpc?
+
+After researching the options, we **reject electron-trpc** for this codebase:
+
+1. **Runtime overhead** — electron-trpc adds ~28KB of JavaScript (tRPC client, SuperJSON, ipcLink adapter) parsed at startup. Every IPC call goes through 7 abstraction layers instead of 3. For an app with 36 channels — most being simple getters/setters — this is disproportionate overhead. See [this detailed analysis](https://seed.hyper.media/hm/z6MkuBbsB1HbSNXLvJCRCrPhimY6g7tzhr4qvcYKPuSZzhno/tech-talks/the-case-against-electron-trpc-when-type-safety-becomes-a-performance-tax) from a team that migrated _away_ from electron-trpc.
+2. **Coupling** — tRPC would force the sources architecture (data-driven, declarative action schemas) to conform to tRPC's router/procedure model, fighting the existing design.
+3. **This app doesn't need it** — electron-trpc shines in complex web-like APIs. Our IPC is a flat list of invoke channels with simple argument shapes.
+
+### Why Not @electron-toolkit/typed-ipc?
+
+Decent library but only 360 weekly downloads, requires `@electron-toolkit/preload` (replaces our custom `contextBridge` setup), and adds an opinionated preload pattern. For this codebase, a zero-dependency shared type definition is simpler and more maintainable.
+
+### Recommended: Manual Shared Types
+
+Create a single `src/shared/ipc-types.ts` that declares the typed contract for all IPC channels. Both main and preload/renderer reference this file. **Zero runtime dependencies. Zero bundle impact. Full type safety.**
+
+```ts
+// src/shared/ipc-types.ts (representative subset)
+
+export interface IpcInvokeChannels {
+  'get-sources': { args: []; return: SourceInfo[] };
+  'get-field-options': { args: [sourceId: string, fieldId: string, selections: Record<string, string>]; return: FieldOption[] };
+  'detect-gpu': { args: []; return: GPUInfo | null };
+  'browse-folder': { args: [defaultPath?: string]; return: string | null };
+  'set-setting': { args: [key: string, value: unknown]; return: void };
+  'get-setting': { args: [key: string]; return: unknown };
+  // ... all 35 channels
+}
+
+export interface IpcEventChannels {
+  'install-progress': { installationId: string; phase: string; percent?: number; status?: string };
+  'comfy-output': { installationId: string; text: string };
+  'theme-changed': 'dark' | 'light';
+  // ... all 12 event channels
+}
+```
+
+The preload script and main-process handlers can then use typed wrappers:
+
+```ts
+// In preload — compile-time enforcement
+function typedInvoke<C extends keyof IpcInvokeChannels>(
+  channel: C,
+  ...args: IpcInvokeChannels[C]['args']
+): Promise<IpcInvokeChannels[C]['return']> {
+  return ipcRenderer.invoke(channel, ...args);
+}
+```
+
+## Migration Plan
+
+### Phase 1: Infrastructure (this PR)
+- Add `typescript` as a devDependency
+- Create `tsconfig.json` files for main, preload, and renderer
+- Create `src/shared/ipc-types.ts` with a representative subset of typed channels
+- Convert `settings.js` → `settings.ts` as a PoC
+
+### Phase 2: Main Process (follow-up PRs)
+- Convert `lib/*.js` → `lib/*.ts` one file at a time, starting with leaf modules (`lib/util.js`, `lib/paths.js`, `lib/models.js`)
+- Convert `sources/*.js` → `sources/*.ts`
+- Convert `installations.js`, `main.js`, `preload.js`
+- Wire up typed IPC handlers in `lib/ipc.ts`
+
+### Phase 3: Renderer (after Proposal #1)
+- Once electron-vite bundles the renderer, convert `renderer/*.js` → `renderer/*.ts`
+- Replace `window.api` usage with typed API from preload declarations
+
+### Estimated Effort
+
+| Phase | Files | Estimated Time |
+|---|---|---|
+| Phase 1 (this PR) | 4 new + 1 converted | 2–3 hours |
+| Phase 2 (main process) | 22 files | 2–3 days |
+| Phase 3 (renderer) | 14 files | 1–2 days |
+
+## tsgo / TypeScript 7 (Future Optimization)
+
+Once TypeScript is adopted, this codebase will benefit from [TypeScript 7 (Project Corsa)](https://devblogs.microsoft.com/typescript/progress-on-typescript-7-december-2025/) — a native Go rewrite of the compiler delivering **~10× faster builds**:
+
+- The `tsgo` compiler is already in preview (`@typescript/native-preview` on npm)
+- VS Code extension available for instant IDE feedback
+- Type-checking is nearly 100% compatible with TS 5.x/6.x
+- Expected stable release: Q2 2026
+- This codebase is small (~37 files), so `tsc` performance isn't a bottleneck today. But once TS is in place, switching to `tsgo` is a one-line change in `package.json` scripts — zero code changes required.
+
+## Files Changed in This PR
+
+| File | Change |
+|---|---|
+| `.github/proposals/proposal-typescript-typed-ipc.md` | This proposal |
+| `tsconfig.json` | Root config with shared compiler options |
+| `tsconfig.main.json` | Main process config (extends root) |
+| `tsconfig.preload.json` | Preload config (extends root) |
+| `tsconfig.renderer.json` | Renderer config (extends root, declaration-only for now) |
+| `src/shared/ipc-types.ts` | Typed IPC channel definitions (representative subset) |
+| `settings.ts` | Converted from `settings.js` as PoC |
+| `package.json` | Added `typescript` devDependency + `typecheck` script |
+
+## Tradeoffs
+
+1. **Incremental migration required** — Can't convert everything at once. `.js` and `.ts` files will coexist during migration. TypeScript's `allowJs: true` makes this safe.
+2. **Renderer blocked on Proposal #1** — Renderer files load as raw `<script>` tags. They can't use TypeScript imports until a bundler (electron-vite) is in place. In the interim, renderer gets type safety via a `renderer.d.ts` declaration file for `window.api`.
+3. **No runtime type validation** — TypeScript types are erased at compile time. If the renderer sends malformed data, the main process won't reject it. For this app (single-user desktop, no untrusted input), this is acceptable. Zod validation can be added later if needed.
+4. **Learning curve** — Contributors must know TypeScript. Given TS market dominance (>90% of JS projects use it), this is minimal risk.
+5. **Build step required** — TypeScript requires compilation. Currently there's no build step (raw `.js` served directly). After Proposal #1 (electron-vite), this is handled by the bundler. For this PoC, `tsc --noEmit` is type-check only — no output files needed since electron-vite will handle emit.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,12 @@
         "electron-updater": "^6.7.3"
       },
       "devDependencies": {
+        "@types/node": "^25.3.0",
         "electron": "^40.4.1",
         "electron-builder": "^26.7.0",
-        "tar": "^7.5.9"
+        "tar": "^7.5.9",
+        "typescript": "^5.9.3",
+        "vitest": "^4.0.18"
       }
     },
     "node_modules/@develar/schema-utils": {
@@ -485,6 +488,448 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
@@ -507,6 +952,13 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@malept/cross-spawn-promise": {
       "version": "2.0.0",
@@ -647,6 +1099,356 @@
         "node": ">=14"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
+      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -659,6 +1461,13 @@
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
@@ -686,6 +1495,17 @@
         "@types/responselike": "^1.0.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -695,6 +1515,20 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/fs-extra": {
       "version": "9.0.13",
@@ -731,13 +1565,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.10.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.13.tgz",
-      "integrity": "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==",
+      "version": "25.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.0.tgz",
+      "integrity": "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/plist": {
@@ -779,6 +1613,117 @@
       "optional": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@xmldom/xmldom": {
@@ -1058,6 +2003,16 @@
       "optional": true,
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/astral-regex": {
@@ -1537,6 +2492,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -2375,6 +3340,23 @@
         "node": ">=6 <7 || >=8"
       }
     },
+    "node_modules/electron/node_modules/@types/node": {
+      "version": "24.10.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.13.tgz",
+      "integrity": "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/electron/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -2440,6 +3422,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -2477,6 +3466,48 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -2499,6 +3530,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/exponential-backoff": {
@@ -2703,6 +3754,21 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -3380,6 +4446,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/make-fetch-happen": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-14.0.3.tgz",
@@ -3661,6 +4737,25 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -3806,6 +4901,17 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3946,6 +5052,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pe-library": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/pe-library/-/pe-library-0.4.1.tgz",
@@ -4001,6 +5114,35 @@
       },
       "engines": {
         "node": ">=10.4.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/postject": {
@@ -4247,6 +5389,51 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
+      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.57.1",
+        "@rollup/rollup-android-arm64": "4.57.1",
+        "@rollup/rollup-darwin-arm64": "4.57.1",
+        "@rollup/rollup-darwin-x64": "4.57.1",
+        "@rollup/rollup-freebsd-arm64": "4.57.1",
+        "@rollup/rollup-freebsd-x64": "4.57.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
+        "@rollup/rollup-linux-arm64-musl": "4.57.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
+        "@rollup/rollup-linux-loong64-musl": "4.57.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-musl": "4.57.1",
+        "@rollup/rollup-openbsd-x64": "4.57.1",
+        "@rollup/rollup-openharmony-arm64": "4.57.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
+        "@rollup/rollup-win32-x64-gnu": "4.57.1",
+        "@rollup/rollup-win32-x64-msvc": "4.57.1",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -4352,6 +5539,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -4452,6 +5646,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -4484,6 +5688,13 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stat-mode": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
@@ -4493,6 +5704,13 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -4705,6 +5923,23 @@
       "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -4720,6 +5955,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tmp": {
@@ -4766,10 +6011,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },
@@ -4849,6 +6108,159 @@
         "node": ">=0.6.0"
       }
     },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -4873,6 +6285,23 @@
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -14,12 +14,18 @@
     "dist": "electron-builder",
     "dist:win": "electron-builder --win",
     "dist:mac": "electron-builder --mac",
-    "dist:linux": "electron-builder --linux"
+    "dist:linux": "electron-builder --linux",
+    "typecheck": "tsc -p tsconfig.main.json --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "devDependencies": {
+    "@types/node": "^25.3.0",
     "electron": "^40.4.1",
     "electron-builder": "^26.7.0",
-    "tar": "^7.5.9"
+    "tar": "^7.5.9",
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.18"
   },
   "dependencies": {
     "7zip-bin": "^5.2.0",

--- a/settings.ts
+++ b/settings.ts
@@ -1,0 +1,93 @@
+import * as path from "path";
+import * as fs from "fs";
+import * as paths from "./lib/paths";
+import { MODEL_FOLDER_TYPES } from "./lib/models";
+
+const dataPath: string = path.join(paths.configDir(), "settings.json");
+
+const SHARED_ROOT: string = path.join(paths.homeDir(), "ComfyUI-Shared");
+
+interface SettingsDefaults {
+  cacheDir: string;
+  maxCachedFiles: number;
+  onLauncherClose: "tray" | "quit";
+  modelsDirs: string[];
+  inputDir: string;
+  outputDir: string;
+}
+
+interface Settings extends Record<string, unknown> {
+  cacheDir: string;
+  maxCachedFiles: number;
+  onLauncherClose: "tray" | "quit";
+  modelsDirs: string[];
+  inputDir: string;
+  outputDir: string;
+  language?: string;
+  theme?: "system" | "dark" | "light";
+  autoUpdate?: boolean;
+}
+
+const defaults: SettingsDefaults = {
+  cacheDir: path.join(paths.cacheDir(), "download-cache"),
+  maxCachedFiles: 5,
+  onLauncherClose: "tray",
+  modelsDirs: [path.join(SHARED_ROOT, "models")],
+  inputDir: path.join(SHARED_ROOT, "input"),
+  outputDir: path.join(SHARED_ROOT, "output"),
+};
+
+function load(): Settings {
+  let result: Settings;
+  try {
+    result = { ...defaults, ...JSON.parse(fs.readFileSync(dataPath, "utf-8")) };
+  } catch {
+    result = { ...defaults };
+  }
+  // Ensure system default directory is always present in modelsDirs
+  const systemDefault = defaults.modelsDirs[0];
+  if (!Array.isArray(result.modelsDirs)) {
+    result.modelsDirs = [systemDefault];
+  } else if (!result.modelsDirs.some((d) => path.resolve(d) === path.resolve(systemDefault))) {
+    result.modelsDirs.unshift(systemDefault);
+  }
+  // Create the system default directory and model subdirectories on disk
+  try {
+    fs.mkdirSync(systemDefault, { recursive: true });
+    for (const folder of MODEL_FOLDER_TYPES) {
+      fs.mkdirSync(path.join(systemDefault, folder), { recursive: true });
+    }
+  } catch {
+    // Ignore filesystem errors during directory creation
+  }
+  // Create shared input/output directories
+  try {
+    for (const key of ["inputDir", "outputDir"] as const) {
+      fs.mkdirSync((result[key] as string) || defaults[key], { recursive: true });
+    }
+  } catch {
+    // Ignore filesystem errors during directory creation
+  }
+  return result;
+}
+
+function save(settings: Settings): void {
+  fs.mkdirSync(path.dirname(dataPath), { recursive: true });
+  fs.writeFileSync(dataPath, JSON.stringify(settings, null, 2));
+}
+
+function get(key: string): unknown {
+  return load()[key];
+}
+
+function set(key: string, value: unknown): void {
+  const settings = load();
+  settings[key] = value;
+  save(settings);
+}
+
+function getAll(): Settings {
+  return load();
+}
+
+module.exports = { get, set, getAll, defaults };

--- a/src/renderer.d.ts
+++ b/src/renderer.d.ts
@@ -1,0 +1,119 @@
+/**
+ * Type declarations for the renderer process.
+ *
+ * Since renderer files currently load as raw <script> tags (no bundler),
+ * this .d.ts file provides type information for `window.api` without
+ * requiring any code changes. Once Proposal #1 (electron-vite) lands,
+ * this can be replaced with proper TypeScript imports.
+ */
+
+import type {
+  IpcInvokeChannels,
+  IpcEventChannels,
+} from "./shared/ipc-types";
+
+/**
+ * The `window.api` object exposed by preload.js via contextBridge.
+ * Each method corresponds to an IPC channel defined in ipc-types.ts.
+ */
+interface ElectronApi {
+  // Invoke channels (renderer → main, two-way)
+  getSources(): Promise<IpcInvokeChannels["get-sources"]["return"]>;
+  getFieldOptions(
+    ...args: IpcInvokeChannels["get-field-options"]["args"]
+  ): Promise<IpcInvokeChannels["get-field-options"]["return"]>;
+  buildInstallation(
+    ...args: IpcInvokeChannels["build-installation"]["args"]
+  ): Promise<IpcInvokeChannels["build-installation"]["return"]>;
+  getDefaultInstallDir(): Promise<IpcInvokeChannels["get-default-install-dir"]["return"]>;
+  detectGPU(): Promise<IpcInvokeChannels["detect-gpu"]["return"]>;
+  browseFolder(
+    ...args: IpcInvokeChannels["browse-folder"]["args"]
+  ): Promise<IpcInvokeChannels["browse-folder"]["return"]>;
+  openPath(
+    ...args: IpcInvokeChannels["open-path"]["args"]
+  ): Promise<IpcInvokeChannels["open-path"]["return"]>;
+  openExternal(
+    ...args: IpcInvokeChannels["open-external"]["args"]
+  ): Promise<IpcInvokeChannels["open-external"]["return"]>;
+  getLocaleMessages(): Promise<IpcInvokeChannels["get-locale-messages"]["return"]>;
+  getAvailableLocales(): Promise<IpcInvokeChannels["get-available-locales"]["return"]>;
+  getInstallations(): Promise<IpcInvokeChannels["get-installations"]["return"]>;
+  addInstallation(
+    ...args: IpcInvokeChannels["add-installation"]["args"]
+  ): Promise<IpcInvokeChannels["add-installation"]["return"]>;
+  reorderInstallations(
+    ...args: IpcInvokeChannels["reorder-installations"]["args"]
+  ): Promise<IpcInvokeChannels["reorder-installations"]["return"]>;
+  probeInstallation(
+    ...args: IpcInvokeChannels["probe-installation"]["args"]
+  ): Promise<IpcInvokeChannels["probe-installation"]["return"]>;
+  trackInstallation(
+    ...args: IpcInvokeChannels["track-installation"]["args"]
+  ): Promise<IpcInvokeChannels["track-installation"]["return"]>;
+  installInstance(
+    ...args: IpcInvokeChannels["install-instance"]["args"]
+  ): Promise<IpcInvokeChannels["install-instance"]["return"]>;
+  stopComfyUI(
+    ...args: IpcInvokeChannels["stop-comfyui"]["args"]
+  ): Promise<IpcInvokeChannels["stop-comfyui"]["return"]>;
+  focusComfyWindow(
+    ...args: IpcInvokeChannels["focus-comfy-window"]["args"]
+  ): Promise<IpcInvokeChannels["focus-comfy-window"]["return"]>;
+  getRunningInstances(): Promise<IpcInvokeChannels["get-running-instances"]["return"]>;
+  cancelLaunch(): Promise<IpcInvokeChannels["cancel-launch"]["return"]>;
+  cancelOperation(
+    ...args: IpcInvokeChannels["cancel-operation"]["args"]
+  ): Promise<IpcInvokeChannels["cancel-operation"]["return"]>;
+  killPortProcess(
+    ...args: IpcInvokeChannels["kill-port-process"]["args"]
+  ): Promise<IpcInvokeChannels["kill-port-process"]["return"]>;
+  getListActions(
+    ...args: IpcInvokeChannels["get-list-actions"]["args"]
+  ): Promise<IpcInvokeChannels["get-list-actions"]["return"]>;
+  updateInstallation(
+    ...args: IpcInvokeChannels["update-installation"]["args"]
+  ): Promise<IpcInvokeChannels["update-installation"]["return"]>;
+  getDetailSections(
+    ...args: IpcInvokeChannels["get-detail-sections"]["args"]
+  ): Promise<IpcInvokeChannels["get-detail-sections"]["return"]>;
+  runAction(
+    ...args: IpcInvokeChannels["run-action"]["args"]
+  ): Promise<IpcInvokeChannels["run-action"]["return"]>;
+  getSettingsSections(): Promise<IpcInvokeChannels["get-settings-sections"]["return"]>;
+  getModelsSections(): Promise<IpcInvokeChannels["get-models-sections"]["return"]>;
+  setSetting(
+    ...args: IpcInvokeChannels["set-setting"]["args"]
+  ): Promise<IpcInvokeChannels["set-setting"]["return"]>;
+  getSetting(
+    ...args: IpcInvokeChannels["get-setting"]["args"]
+  ): Promise<IpcInvokeChannels["get-setting"]["return"]>;
+  getResolvedTheme(): Promise<IpcInvokeChannels["get-resolved-theme"]["return"]>;
+  quitApp(): Promise<IpcInvokeChannels["quit-app"]["return"]>;
+  checkForUpdate(): Promise<IpcInvokeChannels["check-for-update"]["return"]>;
+  downloadUpdate(): Promise<IpcInvokeChannels["download-update"]["return"]>;
+  installUpdate(): Promise<IpcInvokeChannels["install-update"]["return"]>;
+  getPendingUpdate(): Promise<IpcInvokeChannels["get-pending-update"]["return"]>;
+
+  // Event channels (main → renderer, push)
+  onInstallProgress(callback: (data: IpcEventChannels["install-progress"]) => void): () => void;
+  onComfyOutput(callback: (data: IpcEventChannels["comfy-output"]) => void): () => void;
+  onComfyExited(callback: (data: IpcEventChannels["comfy-exited"]) => void): () => void;
+  onInstanceStarted(callback: (data: IpcEventChannels["instance-started"]) => void): () => void;
+  onInstanceStopped(callback: (data: IpcEventChannels["instance-stopped"]) => void): () => void;
+  onThemeChanged(callback: (data: IpcEventChannels["theme-changed"]) => void): () => void;
+  onLocaleChanged(callback: (data: IpcEventChannels["locale-changed"]) => void): () => void;
+  onConfirmQuit(callback: () => void): () => void;
+  onUpdateAvailable(callback: (data: IpcEventChannels["update-available"]) => void): () => void;
+  onUpdateDownloadProgress(
+    callback: (data: IpcEventChannels["update-download-progress"]) => void
+  ): () => void;
+  onUpdateDownloaded(callback: (data: IpcEventChannels["update-downloaded"]) => void): () => void;
+  onUpdateError(callback: (data: IpcEventChannels["update-error"]) => void): () => void;
+}
+
+declare global {
+  interface Window {
+    api: ElectronApi;
+  }
+}

--- a/src/shared/ipc-types.ts
+++ b/src/shared/ipc-types.ts
@@ -1,0 +1,346 @@
+/**
+ * Typed IPC channel definitions for ComfyUI Launcher.
+ *
+ * This file is the single source of truth for all IPC channel signatures.
+ * Both main-process handlers and renderer-side callers reference these types.
+ *
+ * Convention: add new channels here FIRST, then implement the handler and caller.
+ * The compiler will enforce that signatures match on both sides.
+ *
+ * This is a representative subset — expand as files are converted to TypeScript.
+ */
+
+// ---------------------------------------------------------------------------
+// Domain types (used by IPC channels)
+// ---------------------------------------------------------------------------
+
+/** GPU detection result from lib/gpu.js */
+export interface GPUInfo {
+  id: string;
+  name: string;
+  vendor: string;
+}
+
+/** A single source (install method) as exposed to the renderer */
+export interface SourceInfo {
+  id: string;
+  label: string;
+  fields: SourceField[];
+  skipInstall: boolean;
+  hideInstallPath: boolean;
+}
+
+export interface SourceField {
+  id: string;
+  label: string;
+  type: "select" | "text";
+  defaultValue?: string;
+  action?: { label: string };
+}
+
+export interface FieldOption {
+  value: string;
+  label: string;
+}
+
+/** Persisted installation record */
+export interface Installation {
+  id: string;
+  name: string;
+  sourceId: string;
+  installPath?: string;
+  status?: "installed" | "failed" | "partial-delete";
+  createdAt: string;
+  seen?: boolean;
+  launchMode?: "window" | "console";
+  browserPartition?: string;
+  useSharedPaths?: boolean;
+  launchArgs?: string;
+  portConflict?: "auto" | "ask";
+  updateTrack?: string;
+  updateInfoByTrack?: Record<string, unknown>;
+  remoteUrl?: string;
+  [key: string]: unknown;
+}
+
+/** Installation as returned to the renderer (with computed fields) */
+export interface InstallationView extends Installation {
+  sourceLabel: string;
+  sourceCategory?: string;
+  hasConsole: boolean;
+  listPreview?: string;
+  statusTag?: { label: string; style: string };
+}
+
+/** Result from add-installation / track-installation */
+export interface AddInstallationResult {
+  ok: boolean;
+  message?: string;
+  entry?: Installation;
+}
+
+/** Result from run-action */
+export interface ActionResult {
+  ok: boolean;
+  message?: string;
+  navigate?: string;
+  portConflict?: {
+    port: number;
+    pids: number[];
+    isComfy: boolean;
+    nextPort: number | null;
+  };
+  mode?: "window" | "console";
+  port?: number;
+  url?: string;
+}
+
+/** Action descriptor (from getListActions / getDetailSections) */
+export interface Action {
+  id: string;
+  label: string;
+  style?: "primary" | "danger" | "default";
+  enabled?: boolean;
+  confirm?: { title: string; message: string };
+  showProgress?: boolean;
+  progressTitle?: string;
+}
+
+/** Detail/settings section */
+export interface Section {
+  title: string;
+  fields?: SectionField[];
+  actions?: Action[];
+}
+
+export interface SectionField {
+  id?: string;
+  label: string;
+  value?: unknown;
+  type?: "text" | "path" | "number" | "select" | "boolean" | "pathList";
+  editable?: boolean;
+  readonly?: boolean;
+  options?: Array<{ value: string; label: string }>;
+  openable?: boolean;
+  min?: number;
+  max?: number;
+}
+
+/** Probe result from scanning a directory */
+export interface ProbeResult {
+  sourceId: string;
+  sourceLabel: string;
+  name?: string;
+  [key: string]: unknown;
+}
+
+/** Running ComfyUI session info */
+export interface SessionInfo {
+  installationId: string;
+  port: number;
+  url?: string;
+  mode: "window" | "console";
+  installationName: string;
+  startedAt: number;
+}
+
+/** Update info */
+export interface UpdateInfo {
+  version: string;
+  tag: string;
+  url: string;
+}
+
+export interface UpdateCheckResult {
+  available: boolean;
+  version?: string;
+  error?: string;
+}
+
+/** Locale info */
+export interface LocaleInfo {
+  value: string;
+  label: string;
+}
+
+/** Install progress event payload */
+export interface InstallProgress {
+  installationId: string;
+  phase: string;
+  percent?: number;
+  status?: string;
+  steps?: string[];
+}
+
+/** Comfy output event payload */
+export interface ComfyOutput {
+  installationId: string;
+  text: string;
+}
+
+/** Comfy exited event payload */
+export interface ComfyExited {
+  installationId: string;
+  crashed: boolean;
+  exitCode: number | null;
+  installationName: string;
+}
+
+/** Instance lifecycle event payload */
+export interface InstanceEvent {
+  installationId: string;
+  port?: number;
+  url?: string;
+  mode?: string;
+  installationName?: string;
+}
+
+/** Update download progress */
+export interface UpdateDownloadProgress {
+  percent: number;
+  transferred: string;
+  total: string;
+}
+
+/** Models data returned by get-models-sections */
+export interface ModelsData {
+  systemDefault: string;
+  sections: Section[];
+}
+
+// ---------------------------------------------------------------------------
+// IPC Channel Maps
+// ---------------------------------------------------------------------------
+
+/**
+ * Invoke channels: renderer calls, main responds.
+ * Key = channel name, args = tuple of arguments, return = resolved value.
+ */
+export interface IpcInvokeChannels {
+  // Sources
+  "get-sources": { args: []; return: SourceInfo[] };
+  "get-field-options": {
+    args: [sourceId: string, fieldId: string, selections: Record<string, string>];
+    return: FieldOption[];
+  };
+  "detect-gpu": { args: []; return: GPUInfo | null };
+  "build-installation": {
+    args: [sourceId: string, selections: Record<string, string>];
+    return: Record<string, unknown>;
+  };
+
+  // Paths
+  "get-default-install-dir": { args: []; return: string };
+  "browse-folder": { args: [defaultPath?: string]; return: string | null };
+  "open-path": { args: [targetPath: string]; return: string };
+  "open-external": { args: [url: string]; return: void };
+
+  // Installations
+  "get-installations": { args: []; return: InstallationView[] };
+  "add-installation": { args: [data: Partial<Installation>]; return: AddInstallationResult };
+  "reorder-installations": { args: [orderedIds: string[]]; return: void };
+  "probe-installation": { args: [dirPath: string]; return: ProbeResult[] };
+  "track-installation": { args: [data: Partial<Installation>]; return: AddInstallationResult };
+  "install-instance": { args: [installationId: string]; return: ActionResult };
+  "update-installation": {
+    args: [installationId: string, data: Record<string, unknown>];
+    return: void;
+  };
+
+  // Actions
+  "get-list-actions": { args: [installationId: string]; return: Action[] };
+  "get-detail-sections": { args: [installationId: string]; return: Section[] };
+  "run-action": {
+    args: [installationId: string, actionId: string, actionData?: Record<string, unknown>];
+    return: ActionResult;
+  };
+
+  // Sessions
+  "stop-comfyui": { args: [installationId?: string]; return: void };
+  "focus-comfy-window": { args: [installationId: string]; return: boolean };
+  "get-running-instances": { args: []; return: SessionInfo[] };
+  "cancel-launch": { args: []; return: void };
+  "cancel-operation": { args: [installationId: string]; return: void };
+  "kill-port-process": { args: [port: number]; return: { ok: boolean } };
+
+  // Settings
+  "get-settings-sections": { args: []; return: Section[] };
+  "get-models-sections": { args: []; return: ModelsData };
+  "set-setting": { args: [key: string, value: unknown]; return: void };
+  "get-setting": { args: [key: string]; return: unknown };
+  "get-resolved-theme": { args: []; return: "dark" | "light" };
+
+  // i18n
+  "get-locale-messages": { args: []; return: Record<string, string> };
+  "get-available-locales": { args: []; return: LocaleInfo[] };
+
+  // App lifecycle
+  "quit-app": { args: []; return: void };
+
+  // Updates
+  "check-for-update": { args: []; return: UpdateCheckResult };
+  "download-update": { args: []; return: void };
+  "install-update": { args: []; return: void };
+  "get-pending-update": { args: []; return: UpdateInfo | null };
+}
+
+/**
+ * Event channels: main pushes to renderer.
+ * Key = channel name, value = payload type.
+ */
+export interface IpcEventChannels {
+  "install-progress": InstallProgress;
+  "comfy-output": ComfyOutput;
+  "comfy-exited": ComfyExited;
+  "instance-started": InstanceEvent;
+  "instance-stopped": InstanceEvent;
+  "theme-changed": "dark" | "light";
+  "locale-changed": Record<string, string>;
+  "confirm-quit": void;
+  "update-available": UpdateInfo;
+  "update-download-progress": UpdateDownloadProgress;
+  "update-downloaded": UpdateInfo;
+  "update-error": { message: string };
+}
+
+// ---------------------------------------------------------------------------
+// Type-safe IPC helpers (used in preload and main process)
+// ---------------------------------------------------------------------------
+
+/**
+ * Type-safe wrapper for ipcRenderer.invoke.
+ * Usage in preload:
+ *   const result = await typedInvoke(ipcRenderer, 'get-sources');
+ *   // result is typed as SourceInfo[]
+ */
+export type TypedInvoke = <C extends keyof IpcInvokeChannels>(
+  channel: C,
+  ...args: IpcInvokeChannels[C]["args"]
+) => Promise<IpcInvokeChannels[C]["return"]>;
+
+/**
+ * Type-safe wrapper for ipcMain.handle.
+ * Usage in main:
+ *   typedHandle(ipcMain, 'get-sources', async () => { ... });
+ *   // handler return type must match SourceInfo[]
+ */
+export type TypedHandle = <C extends keyof IpcInvokeChannels>(
+  channel: C,
+  handler: (
+    event: unknown,
+    ...args: IpcInvokeChannels[C]["args"]
+  ) => IpcInvokeChannels[C]["return"] | Promise<IpcInvokeChannels[C]["return"]>
+) => void;
+
+/**
+ * Type-safe wrapper for webContents.send / ipcRenderer.on.
+ */
+export type TypedSend = <C extends keyof IpcEventChannels>(
+  channel: C,
+  ...args: IpcEventChannels[C] extends void ? [] : [data: IpcEventChannels[C]]
+) => void;
+
+export type TypedOn = <C extends keyof IpcEventChannels>(
+  channel: C,
+  callback: IpcEventChannels[C] extends void ? () => void : (data: IpcEventChannels[C]) => void
+) => () => void;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "noEmit": true,
+    "allowJs": true,
+    "checkJs": false,
+    "isolatedModules": true,
+    "baseUrl": ".",
+    "paths": {
+      "@shared/*": ["src/shared/*"]
+    }
+  },
+  "exclude": ["node_modules", "dist", "renderer"]
+}

--- a/tsconfig.main.json
+++ b/tsconfig.main.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": [
+    "main.js",
+    "settings.ts",
+    "installations.js",
+    "lib/**/*",
+    "sources/**/*",
+    "src/shared/**/*"
+  ]
+}

--- a/tsconfig.preload.json
+++ b/tsconfig.preload.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": [
+    "preload.js",
+    "src/shared/**/*"
+  ]
+}

--- a/tsconfig.renderer.json
+++ b/tsconfig.renderer.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": []
+  },
+  "include": [
+    "renderer/**/*",
+    "src/shared/**/*",
+    "src/renderer.d.ts"
+  ]
+}


### PR DESCRIPTION
## Summary

Migration proposal to add TypeScript and type-safe IPC to ComfyUI Launcher.

**Depends on:** Proposal #1 (electron-vite)

## What's Included

- **Proposal document** (`.github/proposals/proposal-typescript-typed-ipc.md`) — full analysis of all 36 IPC channels (27 invoke + 9 event), approach comparison (electron-trpc vs @electron-toolkit/typed-ipc vs manual shared types), migration plan, effort estimates, and tradeoffs
- **TypeScript configuration** — `tsconfig.json` (root) + `tsconfig.{main,preload,renderer}.json` for each Electron process
- **Shared IPC types** (`src/shared/ipc-types.ts`) — typed channel definitions for every IPC channel in `preload.js` and `lib/ipc.js`, with domain types and type-safe helper types (`TypedInvoke`, `TypedHandle`, `TypedSend`, `TypedOn`)
- **Renderer declarations** (`src/renderer.d.ts`) — `window.api` type declarations derived from the shared types
- **PoC conversion** (`settings.ts`) — `settings.js` converted to TypeScript as a working demonstration
- **Typecheck script** — `npm run typecheck` passes with zero errors

## Approach

**Shared type definitions with zero runtime dependencies.** No electron-trpc (runtime overhead, 7-layer abstraction for simple getters), no third-party typed-ipc libraries. Just TypeScript interfaces that enforce correctness at compile time and vanish at runtime.

## Key Decisions

| Decision | Rationale |
|---|---|
| Reject electron-trpc | 28KB runtime overhead, 133% complexity tax for simple IPC. [Detailed analysis](https://seed.hyper.media/hm/z6MkuBbsB1HbSNXLvJCRCrPhimY6g7tzhr4qvcYKPuSZzhno/tech-talks/the-case-against-electron-trpc-when-type-safety-becomes-a-performance-tax) |
| Reject @electron-toolkit/typed-ipc | 360 weekly downloads, requires replacing preload pattern |
| Manual shared types | Zero dependencies, zero bundle impact, full type safety |
| Renderer deferred | Can't convert `renderer/*.js` until bundler (Proposal #1) replaces `<script>` tags |
| tsgo mention | TypeScript 7 native compiler (~10× faster) is a free upgrade once TS is in place |

## Files Changed

| File | Purpose |
|---|---|
| `.github/proposals/proposal-typescript-typed-ipc.md` | Full proposal |
| `tsconfig.json` | Root config (shared options) |
| `tsconfig.main.json` | Main process config |
| `tsconfig.preload.json` | Preload config |
| `tsconfig.renderer.json` | Renderer config (declaration-only for now) |
| `src/shared/ipc-types.ts` | All 36 typed IPC channel definitions |
| `src/renderer.d.ts` | `window.api` declarations for renderer |
| `settings.ts` | PoC: settings.js → TypeScript |
| `package.json` | `typescript`, `@types/node` devDeps + `typecheck` script |
