### PR TITLE
fix: refresh installation list after adding Remote/Cloud installations

### DIFF
--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -263,12 +263,14 @@ onMounted(async () => {
     ref="newInstallRef"
     @close="closeNewInstall"
     @show-progress="showProgress"
+    @navigate-list="handleNavigateList"
   />
 
   <TrackModal
     v-if="showTrack"
     ref="trackRef"
     @close="closeTrack"
+    @navigate-list="handleNavigateList"
   />
 
   <!-- Global modal dialog (alerts/confirms/prompts/selects) -->


### PR DESCRIPTION
NewInstallModal emits navigate-list when a skipInstall source (Remote, Cloud) is added, but App.vue was not handling that event. The installation list was not refreshed, so the new entry only appeared after navigating away and back. Wire up the existing handleNavigateList handler.