### PR TITLE
chore: update repo references from Kosinkadink to Comfy-Org

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ sources/         # Installation source plugins
 ### Setup
 
 ```bash
-git clone https://github.com/Kosinkadink/ComfyUI-Launcher.git
+git clone https://github.com/Comfy-Org/ComfyUI-Launcher.git
 cd ComfyUI-Launcher
 npm install
 ```

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,4 +1,4 @@
-appId: com.kosinkadink.comfyui-launcher
+appId: org.comfy.comfyui-launcher
 productName: ComfyUI Launcher
 directories:
   buildResources: resources
@@ -16,7 +16,7 @@ asarUnpack:
   - node_modules/7zip-bin/**/*
 publish:
   provider: github
-  owner: Kosinkadink
+  owner: Comfy-Org
   repo: ComfyUI-Launcher
 artifactName: ComfyUI-Launcher-${version}-${os}-${arch}.${ext}
 win:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "name": "Jedrzej Kosinski",
     "email": "kosinkadink@users.noreply.github.com"
   },
-  "repository": "github:Kosinkadink/ComfyUI-Launcher",
+  "repository": "github:Comfy-Org/ComfyUI-Launcher",
   "engines": {
     "node": ">=22"
   },

--- a/src/main/lib/ipc.ts
+++ b/src/main/lib/ipc.ts
@@ -319,8 +319,8 @@ export function register(callbacks: RegisterCallbacks = {}): void {
   void (async () => {
     try {
       await Promise.allSettled([
-        fetchJSON('https://api.github.com/repos/Kosinkadink/ComfyUI-Launcher-Environments/releases?per_page=30'),
-        fetchJSON('https://api.github.com/repos/Kosinkadink/ComfyUI-Launcher-Environments/releases/latest'),
+        fetchJSON('https://api.github.com/repos/Comfy-Org/ComfyUI-Launcher-Environments/releases?per_page=30'),
+        fetchJSON('https://api.github.com/repos/Comfy-Org/ComfyUI-Launcher-Environments/releases/latest'),
         fetchJSON('https://api.github.com/repos/Comfy-Org/ComfyUI/releases?per_page=30'),
       ])
     } catch {}
@@ -634,7 +634,7 @@ export function register(callbacks: RegisterCallbacks = {}): void {
         { label: i18n.t('settings.platform'), value: `${process.platform} (${process.arch})`, readonly: true },
       ],
       actions: [
-        { id: 'github', label: 'GitHub', url: 'https://github.com/Kosinkadink/ComfyUI-Launcher' },
+        { id: 'github', label: 'GitHub', url: 'https://github.com/Comfy-Org/ComfyUI-Launcher' },
       ],
     }
     return [...appSections, ...sourceSections, aboutSection]

--- a/src/main/lib/updater.ts
+++ b/src/main/lib/updater.ts
@@ -4,7 +4,7 @@ import * as settings from '../settings'
 import type { AppUpdater } from 'electron-updater'
 import type { ProgressInfo } from 'builder-util-runtime'
 
-const REPO = 'Kosinkadink/ComfyUI-Launcher'
+const REPO = 'Comfy-Org/ComfyUI-Launcher'
 const RELEASES_URL = `https://api.github.com/repos/${REPO}/releases/latest`
 
 interface UpdateInfo {

--- a/src/main/sources/standalone.ts
+++ b/src/main/sources/standalone.ts
@@ -26,7 +26,7 @@ import type {
 } from '../types/sources'
 
 const COMFYUI_REPO = 'Comfy-Org/ComfyUI'
-const RELEASE_REPO = 'Kosinkadink/ComfyUI-Launcher-Environments'
+const RELEASE_REPO = 'Comfy-Org/ComfyUI-Launcher-Environments'
 const ENVS_DIR = 'envs'
 const DEFAULT_ENV = 'default'
 const ENV_METHOD = 'copy'


### PR DESCRIPTION
Migrate all hardcoded owner/repo references to reflect the repository transfer to the Comfy-Org GitHub organization.

### Changes
- **electron-builder.yml**: appId to org.comfy.comfyui-launcher, publish owner to Comfy-Org
- **package.json**: repository field
- **updater.ts**: update check URL (REPO constant)
- **ipc.ts**: GitHub API URLs for environment releases, about section link
- **standalone.ts**: RELEASE_REPO to Comfy-Org/ComfyUI-Launcher-Environments
- **README.md**: clone URL

### Notes
- The author email in package.json is intentionally left as-is (personal identity, not a repo reference)
- Old installs should continue to receive updates via GitHub transfer redirects, which forward API calls from the old Kosinkadink/ path to Comfy-Org/