### PR TITLE
fix: dashboard action race condition, DashboardCard extraction, cloud persistence

### DIFF
--- a/src/main/installations.ts
+++ b/src/main/installations.ts
@@ -86,6 +86,17 @@ export async function reorder(orderedIds: string[]): Promise<void> {
   await save(reordered)
 }
 
+export async function ensureExists(sourceId: string, data: Record<string, unknown>): Promise<void> {
+  const existing = await load()
+  if (existing.some((i) => i.sourceId === sourceId)) return
+  existing.push({
+    id: `inst-${Date.now()}`,
+    createdAt: new Date().toISOString(),
+    ...data,
+  } as InstallationRecord)
+  await save(existing)
+}
+
 export async function seedDefaults(defaults: Record<string, unknown>[]): Promise<void> {
   const installations = await load()
   if (installations.length > 0) return

--- a/src/main/lib/ipc.ts
+++ b/src/main/lib/ipc.ts
@@ -224,7 +224,9 @@ function _broadcastToRenderer(channel: string, data: Record<string, unknown>): v
 function _addSession(installationId: string, { proc, port, url, mode, installationName }: Omit<SessionInfo, 'startedAt'>): void {
   _runningSessions.set(installationId, { proc, port, url, mode, installationName, startedAt: Date.now() })
   _broadcastToRenderer('instance-started', { installationId, port, url, mode, installationName })
-  installations.update(installationId, { lastLaunchedAt: Date.now() }).catch(() => {})
+  installations.update(installationId, { lastLaunchedAt: Date.now() }).catch((err) => {
+    console.error('Failed to update lastLaunchedAt:', err)
+  })
 }
 
 function _removeSession(installationId: string): void {
@@ -341,6 +343,15 @@ export function register(callbacks: RegisterCallbacks = {}): void {
       browserPartition: 'shared',
     },
   ])
+  installations.ensureExists('cloud', {
+    name: 'Comfy Cloud',
+    sourceId: 'cloud',
+    version: 'cloud',
+    remoteUrl: 'https://cloud.comfy.org/',
+    launchMode: 'window',
+    browserPartition: 'shared',
+    status: 'installed',
+  })
   migrateDefaults()
 
   // Sweep empty/broken local installations on startup

--- a/src/renderer/src/components/DashboardCard.vue
+++ b/src/renderer/src/components/DashboardCard.vue
@@ -1,0 +1,131 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useSessionStore } from '../stores/sessionStore'
+import { useProgressStore } from '../stores/progressStore'
+import { Play, ExternalLink, Square } from 'lucide-vue-next'
+import type { Installation, ListAction } from '../types/ipc'
+
+const props = defineProps<{
+  installation: Installation
+  actions: ListAction[]
+}>()
+
+const emit = defineEmits<{
+  launch: [inst: Installation, actions: ListAction[]]
+  'show-detail': [inst: Installation]
+  'show-console': [installationId: string]
+  'show-progress': [opts: {
+    installationId: string
+    title: string
+    apiCall: () => Promise<unknown>
+    cancellable?: boolean
+  }]
+}>()
+
+const sessionStore = useSessionStore()
+const progressStore = useProgressStore()
+
+const running = computed(() =>
+  sessionStore.runningInstances.get(props.installation.id) ?? null
+)
+
+const progress = computed(() =>
+  progressStore.getProgressInfo(props.installation.id)
+)
+
+const launchAction = computed(() =>
+  props.actions.find((a) => a.style === 'primary') ?? props.actions[0] ?? null
+)
+
+const isInstalled = computed(() => props.installation.status === 'installed')
+
+function focusComfyWindow(): void {
+  window.api.focusComfyWindow(props.installation.id)
+}
+
+function stopComfyUI(): void {
+  window.api.stopComfyUI(props.installation.id)
+}
+</script>
+
+<template>
+  <div class="dashboard-card-info">
+    <div class="dashboard-card-name">{{ installation.name }}</div>
+    <div class="dashboard-card-meta">
+      <span>{{ installation.listPreview || installation.sourceLabel }}</span>
+      <template v-if="installation.version && !installation.listPreview">
+        <span> · </span>
+        <span>{{ installation.version }}</span>
+      </template>
+      <template v-if="running">
+        <span> · </span>
+        <span class="status-running">{{ $t('list.running') }}</span>
+      </template>
+    </div>
+    <slot name="detail" />
+
+    <div v-if="progress" class="card-progress">
+      <div class="card-progress-status">{{ progress.status }}</div>
+      <div class="card-progress-track">
+        <div
+          class="card-progress-fill"
+          :class="{ indeterminate: progress.percent < 0 }"
+          :style="progress.percent >= 0 ? { width: progress.percent + '%' } : { width: '100%' }"
+        ></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="dashboard-card-actions">
+    <!-- Running -->
+    <template v-if="running">
+      <button
+        v-if="running.mode !== 'console'"
+        class="primary dashboard-cta-btn"
+        @click="focusComfyWindow()"
+      >
+        <ExternalLink :size="18" />
+        {{ $t('running.showWindow') }}
+      </button>
+      <button v-if="installation.hasConsole" @click="emit('show-console', installation.id)">
+        {{ $t('list.console') }}
+      </button>
+      <button class="danger" @click="stopComfyUI()">
+        <Square :size="16" />
+        {{ $t('console.stop') }}
+      </button>
+    </template>
+
+    <!-- In-progress -->
+    <template v-else-if="sessionStore.activeSessions.has(installation.id)">
+      <button
+        class="primary dashboard-cta-btn"
+        @click="emit('show-progress', {
+          installationId: installation.id,
+          title: '',
+          apiCall: async () => ({}),
+        })"
+      >
+        {{ $t('list.viewProgress') }}
+      </button>
+    </template>
+
+    <!-- Idle -->
+    <template v-else-if="isInstalled">
+      <button
+        v-if="launchAction"
+        class="primary dashboard-cta-btn"
+        :class="{ 'looks-disabled': launchAction.enabled === false && launchAction.disabledMessage }"
+        :disabled="launchAction.enabled === false && !launchAction.disabledMessage"
+        @click="emit('launch', installation, actions)"
+      >
+        <Play :size="18" />
+        {{ launchAction.label }}
+      </button>
+    </template>
+
+    <button @click="emit('show-detail', installation)">
+      {{ $t('list.view') }}
+    </button>
+  </div>
+</template>

--- a/src/renderer/src/views/DashboardView.vue
+++ b/src/renderer/src/views/DashboardView.vue
@@ -3,10 +3,10 @@ import { computed, watch, ref, onMounted, onBeforeUnmount } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useInstallationStore } from '../stores/installationStore'
 import { useSessionStore } from '../stores/sessionStore'
-import { useProgressStore } from '../stores/progressStore'
 import { useModal } from '../composables/useModal'
 import { useLocalInstanceGuard } from '../composables/useLocalInstanceGuard'
-import { Play, Download, ExternalLink, Square, Star, Clock, Cloud } from 'lucide-vue-next'
+import { Download, Star, Clock, Cloud } from 'lucide-vue-next'
+import DashboardCard from '../components/DashboardCard.vue'
 import type { Installation, ListAction } from '../types/ipc'
 
 const props = defineProps<{
@@ -16,7 +16,6 @@ const props = defineProps<{
 const { t } = useI18n()
 const installationStore = useInstallationStore()
 const sessionStore = useSessionStore()
-const progressStore = useProgressStore()
 const modal = useModal()
 const localInstanceGuard = useLocalInstanceGuard()
 
@@ -78,23 +77,25 @@ const nonCloudInstalls = computed(() =>
   installationStore.installations.filter((i) => i.sourceCategory !== 'cloud')
 )
 
-// --- Actions for cards ---
+// --- Actions for cards (separate generation counters) ---
 const primaryActions = ref<ListAction[]>([])
 const latestActions = ref<ListAction[]>([])
 const cloudActions = ref<ListAction[]>([])
 
-let actionGeneration = 0
+let primaryGen = 0
+let latestGen = 0
+let cloudGen = 0
+
+const sessionDeps = [
+  () => sessionStore.runningInstances.size,
+  () => sessionStore.activeSessions.size,
+  () => sessionStore.errorInstances.size,
+]
 
 watch(
-  [
-    () => primaryInstall.value?.id,
-    () => props.visible,
-    () => sessionStore.runningInstances.size,
-    () => sessionStore.activeSessions.size,
-    () => sessionStore.errorInstances.size,
-  ],
+  [() => primaryInstall.value?.id, () => props.visible, ...sessionDeps],
   async () => {
-    const gen = ++actionGeneration
+    const gen = ++primaryGen
     const id = primaryInstall.value?.id
     if (!id || !props.visible) { primaryActions.value = []; return }
     if (
@@ -103,7 +104,7 @@ watch(
       !sessionStore.errorInstances.has(id)
     ) {
       const actions = await window.api.getListActions(id)
-      if (gen === actionGeneration) primaryActions.value = actions
+      if (gen === primaryGen) primaryActions.value = actions
     } else {
       primaryActions.value = []
     }
@@ -112,15 +113,9 @@ watch(
 )
 
 watch(
-  [
-    () => latestInstall.value?.id,
-    () => props.visible,
-    () => sessionStore.runningInstances.size,
-    () => sessionStore.activeSessions.size,
-    () => sessionStore.errorInstances.size,
-  ],
+  [() => latestInstall.value?.id, () => props.visible, ...sessionDeps],
   async () => {
-    const gen = ++actionGeneration
+    const gen = ++latestGen
     const id = latestInstall.value?.id
     if (!id || !props.visible || id === primaryInstall.value?.id) { latestActions.value = []; return }
     if (
@@ -129,7 +124,7 @@ watch(
       !sessionStore.errorInstances.has(id)
     ) {
       const actions = await window.api.getListActions(id)
-      if (gen === actionGeneration) latestActions.value = actions
+      if (gen === latestGen) latestActions.value = actions
     } else {
       latestActions.value = []
     }
@@ -138,14 +133,10 @@ watch(
 )
 
 watch(
-  [
-    () => cloudInstall.value?.id,
-    () => props.visible,
-    () => sessionStore.runningInstances.size,
-    () => sessionStore.activeSessions.size,
-  ],
+  [() => cloudInstall.value?.id, () => props.visible,
+    () => sessionStore.runningInstances.size, () => sessionStore.activeSessions.size],
   async () => {
-    const gen = ++actionGeneration
+    const gen = ++cloudGen
     const id = cloudInstall.value?.id
     if (!id || !props.visible) { cloudActions.value = []; return }
     if (
@@ -153,25 +144,13 @@ watch(
       !sessionStore.activeSessions.has(id)
     ) {
       const actions = await window.api.getListActions(id)
-      if (gen === actionGeneration) cloudActions.value = actions
+      if (gen === cloudGen) cloudActions.value = actions
     } else {
       cloudActions.value = []
     }
   },
   { immediate: true }
 )
-
-function getLaunchAction(actions: ListAction[]): ListAction | null {
-  return actions.find((a) => a.style === 'primary') ?? actions[0] ?? null
-}
-
-function getProgress(installId: string) {
-  return progressStore.getProgressInfo(installId)
-}
-
-function getRunning(installId: string) {
-  return sessionStore.runningInstances.get(installId) ?? null
-}
 
 // --- Relative time (reactive) ---
 const now = ref(Date.now())
@@ -197,7 +176,7 @@ function timeAgo(timestamp: number): string {
 
 // --- Launch handling ---
 async function handleLaunch(inst: Installation, actions: ListAction[]): Promise<void> {
-  const action = getLaunchAction(actions)
+  const action = actions.find((a) => a.style === 'primary') ?? actions[0] ?? null
   if (!inst || !action) return
 
   if (action.enabled === false && action.disabledMessage) {
@@ -234,14 +213,6 @@ async function handleLaunch(inst: Installation, actions: ListAction[]): Promise<
   if (result.message) {
     await modal.alert({ title: action.label, message: result.message })
   }
-}
-
-function focusComfyWindow(installationId: string): void {
-  window.api.focusComfyWindow(installationId)
-}
-
-function stopComfyUI(installationId: string): void {
-  window.api.stopComfyUI(installationId)
 }
 
 // --- Change primary ---
@@ -283,93 +254,26 @@ async function changePrimary(): Promise<void> {
       <div v-if="primaryInstall" class="dashboard-section">
         <div class="dashboard-section-label">{{ $t('dashboard.quickLaunch') }}</div>
         <div class="dashboard-quick-launch">
-          <!-- Latest card (only when different from primary and has been launched) -->
+          <!-- Latest card -->
           <div v-if="showLatestCard && latestInstall" class="dashboard-card">
             <div class="dashboard-card-badge">
               <Clock :size="14" />
               {{ $t('dashboard.latest') }}
             </div>
-            <div class="dashboard-card-info">
-              <div class="dashboard-card-name">{{ latestInstall.name }}</div>
-              <div class="dashboard-card-meta">
-                <span>{{ latestInstall.sourceLabel }}</span>
-                <template v-if="latestInstall.version">
-                  <span> · </span>
-                  <span>{{ latestInstall.version }}</span>
-                </template>
-                <template v-if="getRunning(latestInstall.id)">
-                  <span> · </span>
-                  <span class="status-running">{{ $t('list.running') }}</span>
-                </template>
-              </div>
-              <div v-if="typeof latestInstall.lastLaunchedAt === 'number'" class="dashboard-card-detail">
-                {{ $t('dashboard.launchedAgo', { time: timeAgo(latestInstall.lastLaunchedAt as number) }) }}
-              </div>
-
-              <div v-if="getProgress(latestInstall.id)" class="card-progress">
-                <div class="card-progress-status">{{ getProgress(latestInstall.id)!.status }}</div>
-                <div class="card-progress-track">
-                  <div
-                    class="card-progress-fill"
-                    :class="{ indeterminate: getProgress(latestInstall.id)!.percent < 0 }"
-                    :style="getProgress(latestInstall.id)!.percent >= 0 ? { width: getProgress(latestInstall.id)!.percent + '%' } : { width: '100%' }"
-                  ></div>
+            <DashboardCard
+              :installation="latestInstall"
+              :actions="latestActions"
+              @launch="handleLaunch"
+              @show-detail="(inst) => emit('show-detail', inst)"
+              @show-console="(id) => emit('show-console', id)"
+              @show-progress="(opts) => emit('show-progress', opts)"
+            >
+              <template #detail>
+                <div v-if="typeof latestInstall.lastLaunchedAt === 'number'" class="dashboard-card-detail">
+                  {{ $t('dashboard.launchedAgo', { time: timeAgo(latestInstall.lastLaunchedAt as number) }) }}
                 </div>
-              </div>
-            </div>
-
-            <div class="dashboard-card-actions">
-              <!-- Running -->
-              <template v-if="getRunning(latestInstall.id)">
-                <button
-                  v-if="getRunning(latestInstall.id)?.mode !== 'console'"
-                  class="primary dashboard-cta-btn"
-                  @click="focusComfyWindow(latestInstall.id)"
-                >
-                  <ExternalLink :size="18" />
-                  {{ $t('running.showWindow') }}
-                </button>
-                <button v-if="latestInstall.hasConsole" @click="emit('show-console', latestInstall.id)">
-                  {{ $t('list.console') }}
-                </button>
-                <button class="danger" @click="stopComfyUI(latestInstall.id)">
-                  <Square :size="16" />
-                  {{ $t('console.stop') }}
-                </button>
               </template>
-
-              <!-- In-progress -->
-              <template v-else-if="sessionStore.activeSessions.has(latestInstall.id)">
-                <button
-                  class="primary dashboard-cta-btn"
-                  @click="emit('show-progress', {
-                    installationId: latestInstall.id,
-                    title: '',
-                    apiCall: async () => ({}),
-                  })"
-                >
-                  {{ $t('list.viewProgress') }}
-                </button>
-              </template>
-
-              <!-- Idle -->
-              <template v-else-if="latestInstall.status === 'installed'">
-                <button
-                  v-if="getLaunchAction(latestActions)"
-                  class="primary dashboard-cta-btn"
-                  :class="{ 'looks-disabled': getLaunchAction(latestActions)!.enabled === false && getLaunchAction(latestActions)!.disabledMessage }"
-                  :disabled="getLaunchAction(latestActions)!.enabled === false && !getLaunchAction(latestActions)!.disabledMessage"
-                  @click="handleLaunch(latestInstall, latestActions)"
-                >
-                  <Play :size="18" />
-                  {{ getLaunchAction(latestActions)!.label }}
-                </button>
-              </template>
-
-              <button @click="emit('show-detail', latestInstall)">
-                {{ $t('list.view') }}
-              </button>
-            </div>
+            </DashboardCard>
           </div>
 
           <!-- Primary card -->
@@ -379,90 +283,23 @@ async function changePrimary(): Promise<void> {
               {{ $t('dashboard.primary') }}
               <button class="dashboard-change-btn" @click="changePrimary">{{ $t('dashboard.changePrimary') }}</button>
             </div>
-            <div class="dashboard-card-info">
-              <div class="dashboard-card-name">{{ primaryInstall.name }}</div>
-              <div class="dashboard-card-meta">
-                <span>{{ primaryInstall.sourceLabel }}</span>
-                <template v-if="primaryInstall.version">
-                  <span> · </span>
-                  <span>{{ primaryInstall.version }}</span>
-                </template>
-                <template v-if="getRunning(primaryInstall.id)">
-                  <span> · </span>
-                  <span class="status-running">{{ $t('list.running') }}</span>
-                </template>
-              </div>
-              <div v-if="typeof primaryInstall.lastLaunchedAt === 'number'" class="dashboard-card-detail">
-                {{ $t('dashboard.launchedAgo', { time: timeAgo(primaryInstall.lastLaunchedAt as number) }) }}
-              </div>
-              <div v-else class="dashboard-card-detail">
-                {{ $t('dashboard.neverLaunched') }}
-              </div>
-
-              <div v-if="getProgress(primaryInstall.id)" class="card-progress">
-                <div class="card-progress-status">{{ getProgress(primaryInstall.id)!.status }}</div>
-                <div class="card-progress-track">
-                  <div
-                    class="card-progress-fill"
-                    :class="{ indeterminate: getProgress(primaryInstall.id)!.percent < 0 }"
-                    :style="getProgress(primaryInstall.id)!.percent >= 0 ? { width: getProgress(primaryInstall.id)!.percent + '%' } : { width: '100%' }"
-                  ></div>
+            <DashboardCard
+              :installation="primaryInstall"
+              :actions="primaryActions"
+              @launch="handleLaunch"
+              @show-detail="(inst) => emit('show-detail', inst)"
+              @show-console="(id) => emit('show-console', id)"
+              @show-progress="(opts) => emit('show-progress', opts)"
+            >
+              <template #detail>
+                <div v-if="typeof primaryInstall.lastLaunchedAt === 'number'" class="dashboard-card-detail">
+                  {{ $t('dashboard.launchedAgo', { time: timeAgo(primaryInstall.lastLaunchedAt as number) }) }}
                 </div>
-              </div>
-            </div>
-
-            <div class="dashboard-card-actions">
-              <!-- Running -->
-              <template v-if="getRunning(primaryInstall.id)">
-                <button
-                  v-if="getRunning(primaryInstall.id)?.mode !== 'console'"
-                  class="primary dashboard-cta-btn"
-                  @click="focusComfyWindow(primaryInstall.id)"
-                >
-                  <ExternalLink :size="18" />
-                  {{ $t('running.showWindow') }}
-                </button>
-                <button v-if="primaryInstall.hasConsole" @click="emit('show-console', primaryInstall.id)">
-                  {{ $t('list.console') }}
-                </button>
-                <button class="danger" @click="stopComfyUI(primaryInstall.id)">
-                  <Square :size="16" />
-                  {{ $t('console.stop') }}
-                </button>
+                <div v-else class="dashboard-card-detail">
+                  {{ $t('dashboard.neverLaunched') }}
+                </div>
               </template>
-
-              <!-- In-progress -->
-              <template v-else-if="sessionStore.activeSessions.has(primaryInstall.id)">
-                <button
-                  class="primary dashboard-cta-btn"
-                  @click="emit('show-progress', {
-                    installationId: primaryInstall.id,
-                    title: '',
-                    apiCall: async () => ({}),
-                  })"
-                >
-                  {{ $t('list.viewProgress') }}
-                </button>
-              </template>
-
-              <!-- Idle -->
-              <template v-else-if="primaryInstall.status === 'installed'">
-                <button
-                  v-if="getLaunchAction(primaryActions)"
-                  class="primary dashboard-cta-btn"
-                  :class="{ 'looks-disabled': getLaunchAction(primaryActions)!.enabled === false && getLaunchAction(primaryActions)!.disabledMessage }"
-                  :disabled="getLaunchAction(primaryActions)!.enabled === false && !getLaunchAction(primaryActions)!.disabledMessage"
-                  @click="handleLaunch(primaryInstall, primaryActions)"
-                >
-                  <Play :size="18" />
-                  {{ getLaunchAction(primaryActions)!.label }}
-                </button>
-              </template>
-
-              <button @click="emit('show-detail', primaryInstall)">
-                {{ $t('list.view') }}
-              </button>
-            </div>
+            </DashboardCard>
           </div>
         </div>
       </div>
@@ -474,61 +311,14 @@ async function changePrimary(): Promise<void> {
           {{ $t('dashboard.cloudSection') }}
         </div>
         <div class="dashboard-cloud-card">
-          <div class="dashboard-card-info">
-            <div class="dashboard-card-name">{{ cloudInstall.name }}</div>
-            <div class="dashboard-card-meta">
-              <span>{{ cloudInstall.listPreview || cloudInstall.sourceLabel }}</span>
-              <template v-if="getRunning(cloudInstall.id)">
-                <span> · </span>
-                <span class="status-running">{{ $t('list.running') }}</span>
-              </template>
-            </div>
-          </div>
-
-          <div class="dashboard-card-actions">
-            <template v-if="getRunning(cloudInstall.id)">
-              <button
-                v-if="getRunning(cloudInstall.id)?.mode !== 'console'"
-                class="primary dashboard-cta-btn"
-                @click="focusComfyWindow(cloudInstall.id)"
-              >
-                <ExternalLink :size="18" />
-                {{ $t('running.showWindow') }}
-              </button>
-              <button class="danger" @click="stopComfyUI(cloudInstall.id)">
-                <Square :size="16" />
-                {{ $t('console.stop') }}
-              </button>
-            </template>
-
-            <template v-else-if="sessionStore.activeSessions.has(cloudInstall.id)">
-              <button
-                class="primary dashboard-cta-btn"
-                @click="emit('show-progress', {
-                  installationId: cloudInstall.id,
-                  title: '',
-                  apiCall: async () => ({}),
-                })"
-              >
-                {{ $t('list.viewProgress') }}
-              </button>
-            </template>
-
-            <template v-else-if="cloudInstall.status === 'installed'">
-              <button
-                v-if="getLaunchAction(cloudActions)"
-                class="primary dashboard-cta-btn"
-                @click="handleLaunch(cloudInstall, cloudActions)"
-              >
-                <Play :size="18" />
-                {{ getLaunchAction(cloudActions)!.label }}
-              </button>
-            </template>
-
-            <button @click="emit('show-detail', cloudInstall)">
-              {{ $t('list.view') }}
-            </button>
-          </div>
+          <DashboardCard
+            :installation="cloudInstall"
+            :actions="cloudActions"
+            @launch="handleLaunch"
+            @show-detail="(inst) => emit('show-detail', inst)"
+            @show-console="(id) => emit('show-console', id)"
+            @show-progress="(opts) => emit('show-progress', opts)"
+          />
         </div>
       </div>
 

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -19,6 +19,7 @@ export interface Installation {
   hasConsole?: boolean
   installPath?: string
   status?: string
+  lastLaunchedAt?: number
   [key: string]: unknown // allow extra fields from sources
 }
 


### PR DESCRIPTION
Follow-up fixes from code review of the dashboard redesign.

## Bug Fixes
- Split shared action generation counter into per-watcher counters to prevent stale async responses from discarding valid action buttons on initial mount

## Improvements
- Extract DashboardCard.vue component to eliminate template duplication across Latest, Primary, and Cloud cards
- Add installations.ensureExists() to guarantee the cloud install exists on startup for existing users
- Add lastLaunchedAt to Installation interface for type safety
- Log errors from fire-and-forget lastLaunchedAt persistence