### PR TITLE
fix: whitelist electron/esbuild postinstall scripts for pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,5 +69,12 @@
     "vue-eslint-parser": "^10.4.0",
     "vue-i18n": "^11.1.6",
     "vue-tsc": "^3.1.6"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "electron",
+      "electron-winstaller",
+      "esbuild"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Fixes `Electron uninstall` error when running `pnpm dev` after the npm → pnpm migration.

## Problem

pnpm 10 blocks postinstall scripts by default for security. Electron, electron-winstaller, and esbuild all require postinstall scripts to download platform-specific binaries. Without them, `electron-vite dev` fails with `Error: Electron uninstall`.

## Fix

Adds `pnpm.onlyBuiltDependencies` to `package.json` to explicitly whitelist the three packages that need build scripts.
