### PR TITLE
fix: code review hardening - security, robustness, and cleanup

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -55,7 +55,7 @@ export default defineConfig([
     },
     rules: {
       'no-empty': ['error', { allowEmptyCatch: true }],
-      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/no-unused-vars': 'off',
       '@typescript-eslint/consistent-type-imports': 'error',
       '@typescript-eslint/no-import-type-side-effects': 'error',

--- a/lib/update_comfyui.py
+++ b/lib/update_comfyui.py
@@ -147,7 +147,12 @@ def main():
             refspecs = ["+refs/heads/master:refs/remotes/origin/master"]
             if stable:
                 refspecs.append("+refs/tags/*:refs/tags/*")
-            remote.fetch(refspecs)
+            try:
+                remote.fetch(refspecs)
+            except Exception as e:
+                print("[ERROR] Failed to fetch from origin: %s" % e)
+                print("Check your internet connection and try again.")
+                sys.exit(1)
             break
 
     # Checkout master — create local branch if needed

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -123,7 +123,15 @@ function onComfyRestarted({ installationId, process: _proc }: { installationId?:
         win.loadURL(currentUrl)
       }
     })
-    .catch(() => {})
+    .catch((err) => {
+      console.error(`ComfyUI restart failed for ${installationId}:`, err)
+      if (launcherWindow && !launcherWindow.isDestroyed()) {
+        launcherWindow.webContents.send('comfy-output', {
+          installationId,
+          text: `\n--- Restart failed: ${err.message || err} ---\n`,
+        })
+      }
+    })
 }
 
 function onStop({ installationId }: { installationId?: string } = {}): void {

--- a/src/main/lib/process.ts
+++ b/src/main/lib/process.ts
@@ -161,6 +161,7 @@ export function waitForUrl(url: string, { timeoutMs = 60000, intervalMs = 500, o
 }
 
 export function getProcessInfo(pid: number): Promise<ProcessInfo | null> {
+  if (!Number.isInteger(pid) || pid <= 0) return Promise.resolve(null)
   return new Promise((resolve) => {
     if (process.platform === "win32") {
       // Use PowerShell Get-CimInstance with JSON output (wmic is deprecated/removed on modern Windows)

--- a/src/main/sources/git.ts
+++ b/src/main/sources/git.ts
@@ -35,6 +35,7 @@ export const gitSource: SourcePlugin = {
   get label() { return t('git.label') },
   get description() { return t('git.desc') },
   category: 'local',
+  hidden: true,
 
   fields: [
     { id: 'repo', label: 'Git Repository', type: 'text',

--- a/src/main/sources/portable.ts
+++ b/src/main/sources/portable.ts
@@ -51,6 +51,7 @@ export const portable: SourcePlugin = {
   get label() { return t('portable.label') },
   get description() { return t('portable.desc') },
   category: 'local',
+  platforms: ['win32'],
 
   get fields() {
     return [

--- a/src/main/types/sources.ts
+++ b/src/main/types/sources.ts
@@ -85,6 +85,8 @@ export interface SourcePlugin {
   category: string
   hasConsole?: boolean
   skipInstall?: boolean
+  platforms?: readonly string[]
+  hidden?: boolean
   fields: readonly SourceField[]
   defaultLaunchArgs?: string
   installSteps?: readonly InstallStep[]

--- a/src/renderer/src/stores/sessionStore.ts
+++ b/src/renderer/src/stores/sessionStore.ts
@@ -79,6 +79,7 @@ export const useSessionStore = defineStore('session', () => {
 
   /** Initialize IPC listeners. Call once from App.vue. */
   async function init(): Promise<void> {
+    dispose()
     const instances = await window.api.getRunningInstances()
     for (const inst of instances) {
       runningInstances.set(inst.installationId, inst)


### PR DESCRIPTION
## Summary

Deep code review findings addressed across 10 issues in 9 files.

### Security
- **Validate IPC handlers**: `open-path` now verifies paths exist before opening; `open-external` restricted to `http/https` URLs only
- **Redact sensitive args**: Launch args matching `--api-key`, `--token`, `--secret`, `--password`, `--auth` are masked as `***` in console output
- **PID validation**: `getProcessInfo` guards against invalid PID values before interpolating into PowerShell commands

### Robustness
- **Port retry loop**: When ComfyUI exits immediately with "address already in use", retries up to 3 times on the next available port
- **Restart error reporting**: ComfyUI restart failures are now logged and reported to the renderer (was silently swallowed)
- **Python fetch error handling**: `remote.fetch()` in `update_comfyui.py` wrapped in try/except with a structured `[ERROR]` marker and user-friendly message

### Source visibility
- **Hide git source**: Marked as `hidden: true` — not shown in the new install UI until launch/update are implemented (probing still works for tracked installs)
- **Portable Windows-only**: Declares `platforms: ['win32']` and filtered out of `get-sources` on non-Windows platforms
- Added `platforms` and `hidden` fields to `SourcePlugin` type

### Cleanup
- **ESLint**: `@typescript-eslint/no-explicit-any` changed from `off` to `warn`
- **sessionStore**: `init()` now calls `dispose()` first to prevent duplicate IPC listeners on re-init (HMR, tests)

### Verification
- TypeScript compiles clean (`tsc --noEmit`)
- All 46 tests pass
