### PR TITLE
feat: add tabbed layout (Status, Update, Settings) to DetailModal

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -86,7 +86,10 @@
     "useSharedPaths": "Use Shared Directories",
     "done": "Done",
     "noItems": "No items available.",
-    "advanced": "Advanced"
+    "advanced": "Advanced",
+    "tabStatus": "Status",
+    "tabUpdate": "Update",
+    "tabSettings": "Settings"
   },
 
   "list": {

--- a/src/main/sources/cloud.ts
+++ b/src/main/sources/cloud.ts
@@ -59,6 +59,7 @@ export const cloud: SourcePlugin = {
   getDetailSections(installation: InstallationRecord): Record<string, unknown>[] {
     return [
       {
+        tab: 'status',
         title: t('remote.connectionInfo'),
         fields: [
           { label: t('common.installMethod'), value: installation.sourceLabel as string },
@@ -67,6 +68,7 @@ export const cloud: SourcePlugin = {
         ],
       },
       {
+        tab: 'settings',
         title: t('common.launchSettings'),
         fields: [
           { id: 'browserPartition', label: t('common.browserPartition'), value: (installation.browserPartition as string) || 'shared', editable: true,

--- a/src/main/sources/git.ts
+++ b/src/main/sources/git.ts
@@ -68,6 +68,7 @@ export const gitSource: SourcePlugin = {
   getDetailSections(installation: InstallationRecord) {
     return [
       {
+        tab: 'status',
         title: 'Installation Info',
         fields: [
           { label: 'Install Method', value: installation.sourceLabel as string },
@@ -79,6 +80,7 @@ export const gitSource: SourcePlugin = {
         ],
       },
       {
+        tab: 'settings',
         title: 'Launch Settings',
         fields: [
           { id: 'browserPartition', label: 'Browser Cache',

--- a/src/main/sources/portable.ts
+++ b/src/main/sources/portable.ts
@@ -122,6 +122,7 @@ export const portable: SourcePlugin = {
     const installed = installation.status === 'installed'
     const sections: Record<string, unknown>[] = [
       {
+        tab: 'status',
         title: t('common.installInfo'),
         fields: [
           { label: t('common.installMethod'), value: installation.sourceLabel as string },
@@ -180,6 +181,7 @@ export const portable: SourcePlugin = {
       id: 'check-update', label: t('actions.checkForUpdate'), style: 'default', enabled: installed,
     })
     sections.push({
+      tab: 'update',
       title: t('portable.updates'),
       fields: updateFields,
       actions: updateActions,
@@ -187,6 +189,7 @@ export const portable: SourcePlugin = {
 
     sections.push(
       {
+        tab: 'settings',
         title: t('common.launchSettings'),
         fields: [
           { id: 'useSharedPaths', label: t('common.useSharedPaths'), value: (installation.useSharedPaths as boolean | undefined) !== false, editable: true, editType: 'boolean' },

--- a/src/main/sources/remote.ts
+++ b/src/main/sources/remote.ts
@@ -60,6 +60,7 @@ export const remote: SourcePlugin = {
   getDetailSections(installation: InstallationRecord): Record<string, unknown>[] {
     return [
       {
+        tab: 'status',
         title: t('remote.connectionInfo'),
         fields: [
           { label: t('common.installMethod'), value: installation.sourceLabel as string },
@@ -68,6 +69,7 @@ export const remote: SourcePlugin = {
         ],
       },
       {
+        tab: 'settings',
         title: t('common.launchSettings'),
         fields: [
           { id: 'browserPartition', label: t('common.browserPartition'), value: (installation.browserPartition as string) || 'shared', editable: true,

--- a/src/main/sources/standalone.ts
+++ b/src/main/sources/standalone.ts
@@ -312,6 +312,7 @@ export const standalone: SourcePlugin = {
 
     const sections: Record<string, unknown>[] = [
       {
+        tab: 'status',
         title: t('common.installInfo'),
         fields: [
           { label: t('common.installMethod'), value: installation.sourceLabel as string },
@@ -391,6 +392,7 @@ export const standalone: SourcePlugin = {
       id: 'check-update', label: t('actions.checkForUpdate'), style: 'default', enabled: installed,
     })
     sections.push({
+      tab: 'update',
       title: t('standalone.updates'),
       fields: updateFields,
       actions: updateActions,
@@ -398,6 +400,7 @@ export const standalone: SourcePlugin = {
 
     sections.push(
       {
+        tab: 'settings',
         title: t('common.launchSettings'),
         fields: [
           { id: 'useSharedPaths', label: t('common.useSharedPaths'), value: (installation.useSharedPaths as boolean | undefined) !== false, editable: true, editType: 'boolean' },
@@ -442,6 +445,7 @@ export const standalone: SourcePlugin = {
         ],
       },
       {
+        tab: 'settings',
         title: t('common.advanced'),
         collapsed: true,
         actions: [

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -344,6 +344,21 @@ input[type="checkbox"]:checked::after { transform: translateX(16px); }
 .view-bottom { flex-shrink: 0; display: flex; gap: 10px; padding-top: 12px; }
 .view-list-scroll { flex: 1; min-height: 0; overflow-y: auto; overflow-x: hidden; padding-right: 8px; }
 
+/* Detail tabs */
+.detail-tabs { display: flex; gap: 4px; margin-bottom: 16px; border-bottom: 1px solid var(--border); flex-shrink: 0; }
+.detail-tab {
+  padding: 6px 16px; border: none; border-radius: 0;
+  background: none; color: var(--text-faint); font-size: 14px;
+  font-weight: 500; cursor: pointer; position: relative;
+}
+.detail-tab:hover { color: var(--text-muted); }
+.detail-tab.active { color: var(--text); font-weight: 600; }
+.detail-tab.active::after {
+  content: ""; position: absolute; bottom: -1px;
+  left: 4px; right: 4px; height: 2px;
+  background: var(--accent); border-radius: 1px;
+}
+
 /* Detail sections */
 .detail-section { margin-bottom: 18px; }
 .detail-section-title {

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -71,6 +71,7 @@ export interface DetailSection {
   description?: string
   collapsed?: boolean
   pinBottom?: boolean
+  tab?: string
   items?: DetailItem[]
   fields?: DetailField[]
   actions?: ActionDef[]


### PR DESCRIPTION
## Summary

Adds tab navigation to the Manage/Detail view so users no longer need to scroll past the Info section to reach Updates and Settings.

## Changes

- Add optional `tab` field to `DetailSection` IPC type
- Tag sections with tab ids (`status`, `update`, `settings`) in all 5 source plugins (standalone, portable, git, remote, cloud)
- Filter displayed sections by active tab in `DetailModal.vue`
- Keep `pinBottom` (Actions) sections always visible outside tabs
- Hide tab bar when only 1 tab is available
- Reset active tab to `status` when opening a new installation
- Use `computed` for tab labels to support reactive i18n
- Support unknown tab ids from future plugins (appended after known tabs)
- Add `.detail-tabs` CSS mirroring existing `.filter-tabs` pattern
- Add i18n keys: `tabStatus`, `tabUpdate`, `tabSettings`

## Files changed (9)

- `src/types/ipc.ts` — optional `tab` field on `DetailSection`
- `src/main/sources/{standalone,portable,git,remote,cloud}.ts` — tab assignments
- `src/renderer/src/views/DetailModal.vue` — tab filtering and UI
- `src/renderer/src/assets/main.css` — tab styling
- `locales/en.json` — i18n keys

## Verification

- [x] Typecheck passes
- [x] Lint passes (0 new warnings)
- [x] Build succeeds
- [x] All 46 tests pass
