### PR TITLE
ci: run CI checks for pull requests targeting any branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: CI
 
 on:
   pull_request:
-    branches:
-      - main
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary
- remove the `pull_request.branches: [main]` filter from the CI workflow
- keep push checks scoped to `main`

## Why
We now use stacked PRs and non-`main` base branches. Restricting CI to PRs targeting `main` skips checks for intermediate stacked PRs. This change makes CI run for all pull requests regardless of base branch.

## Validation
- `pnpm run typecheck`
- `pnpm run lint` (existing warnings only)
- `pnpm run build`
- `pnpm run test`