### PR TITLE
ci: build app before ToDesktop release build

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -27,10 +27,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 22
+          cache: pnpm
 
       - name: Validate ToDesktop credentials
         run: |
@@ -38,6 +44,12 @@ jobs:
             echo "TODESKTOP_EMAIL and TODESKTOP_ACCESS_TOKEN must be set in repository secrets."
             exit 1
           fi
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build app
+        run: pnpm run build
 
       - name: Ensure tag matches package.json version
         if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
## Summary
- install pnpm in the release workflow
- enable pnpm dependency caching in `actions/setup-node`
- install dependencies and run `pnpm run build` before `todesktop build`
- keep ToDesktop credential validation early so bad secrets fail fast

## Why
`package.json` sets `main` to `./out/main/index.js`. In a clean GitHub runner this file does not exist until `pnpm run build` runs, causing ToDesktop preflight to fail with:

`APP invalid. The "main" file specified in your package.json (./out/main/index.js) does not exist`

## Validation
- `pnpm run typecheck`
- `pnpm run lint` (warnings only, no errors)
- `pnpm run build`
- `pnpm run test`