### PR TITLE
Harden release flow from labeled merged PRs

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -73,10 +73,42 @@ jobs:
         run: npm install --location=global @todesktop/cli@1.22.0
 
       - name: Build with ToDesktop
-        run: todesktop build --config=todesktop.json --ephemeral
+        shell: bash
+        run: |
+          set -euo pipefail
+          todesktop build --config=todesktop.json --ephemeral | tee todesktop-build.log
 
-      - name: Fetch latest ToDesktop build metadata
-        run: todesktop builds --config=todesktop.json --format=json --count=1 --exit > todesktop-builds.json
+      - name: Extract ToDesktop build ID
+        id: build_id
+        shell: bash
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs')
+
+          const log = fs.readFileSync('todesktop-build.log', 'utf8')
+          const matches = [
+            ...log.matchAll(
+              /https?:\/\/(?:app\.todesktop\.com\/apps|dl\.todesktop\.com)\/[^/\s]+\/builds\/([A-Za-z0-9_-]+)/g
+            )
+          ]
+          const buildIds = [...new Set(matches.map((match) => match[1]).filter(Boolean))]
+
+          if (buildIds.length === 0) {
+            throw new Error('Could not extract a ToDesktop build ID from CLI output.')
+          }
+          if (buildIds.length > 1) {
+            throw new Error(`Multiple build IDs found in CLI output (${buildIds.join(', ')}).`)
+          }
+
+          const output = process.env.GITHUB_OUTPUT
+          if (!output) throw new Error('GITHUB_OUTPUT not set')
+          fs.appendFileSync(output, `build_id=${buildIds[0]}\n`)
+          NODE
+
+      - name: Fetch ToDesktop build metadata by ID
+        env:
+          BUILD_ID: ${{ steps.build_id.outputs.build_id }}
+        run: todesktop builds "${BUILD_ID}" --config=todesktop.json --format=json --exit > todesktop-build.json
 
       - name: Extract build details
         id: extract
@@ -85,25 +117,40 @@ jobs:
           node <<'NODE'
           const fs = require('node:fs')
 
-          const raw = fs.readFileSync('todesktop-builds.json', 'utf8')
-          const start = raw.indexOf('[')
-          const end = raw.lastIndexOf(']')
-          const jsonText = start !== -1 && end !== -1 && end > start ? raw.slice(start, end + 1) : raw
+          const parseBuildOutput = (filePath) => {
+            const raw = fs.readFileSync(filePath, 'utf8')
+            const start = raw.indexOf('[')
+            const end = raw.lastIndexOf(']')
+            const jsonText =
+              start !== -1 && end !== -1 && end > start
+                ? raw.slice(start, end + 1)
+                : raw.slice(raw.indexOf('{'), raw.lastIndexOf('}') + 1)
 
-          let builds
-          try {
-            builds = JSON.parse(jsonText)
-          } catch (err) {
-            console.error('Failed to parse ToDesktop builds JSON output')
-            console.error(raw.slice(0, 1000))
-            throw err
+            let parsed
+            try {
+              parsed = JSON.parse(jsonText)
+            } catch (err) {
+              console.error(`Failed to parse ToDesktop build JSON output from ${filePath}`)
+              console.error(raw.slice(0, 1000))
+              throw err
+            }
+
+            if (Array.isArray(parsed)) {
+              if (parsed.length === 0) {
+                throw new Error(`No builds returned in ${filePath}`)
+              }
+              return parsed[0]
+            }
+
+            if (parsed && typeof parsed === 'object') {
+              return parsed
+            }
+
+            throw new Error(`Unexpected ToDesktop build output shape in ${filePath}`)
           }
 
-          if (!Array.isArray(builds) || builds.length === 0) {
-            throw new Error('No builds found in ToDesktop builds output')
-          }
-
-          const build = builds[0]
+          const expectedBuildId = process.env.EXPECTED_BUILD_ID || ''
+          const build = parseBuildOutput('todesktop-build.json')
           const safeUrl = (value) => (typeof value === 'string' ? value : '')
           const macUrl = safeUrl(build?.mac?.standardDownloadUrl)
           const windowsUrl = safeUrl(build?.windows?.standardDownloadUrl)
@@ -114,6 +161,9 @@ jobs:
 
           if (!buildId) {
             throw new Error('Build ID missing from ToDesktop build output')
+          }
+          if (expectedBuildId && String(buildId) !== expectedBuildId) {
+            throw new Error(`Build ID mismatch. Expected ${expectedBuildId}, received ${buildId}`)
           }
 
           const titleCase = (value) =>
@@ -219,6 +269,8 @@ jobs:
             throw new Error(`ToDesktop build did not succeed (status=${status})`)
           }
           NODE
+        env:
+          EXPECTED_BUILD_ID: ${{ steps.build_id.outputs.build_id }}
 
       - name: Upload release metadata artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release-from-pr-label.yml
+++ b/.github/workflows/release-from-pr-label.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   actions: write
+  pull-requests: read
 
 concurrency:
   group: release-from-pr-${{ github.event.pull_request.number }}
@@ -35,22 +36,40 @@ jobs:
         with:
           node-version: 22
 
-      - name: Detect package.json version change
+      - name: Detect package.json version change from pull request files
         id: version
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
         run: |
           set -euo pipefail
 
-          PREV_VERSION="$(git show "${MERGE_SHA}^:package.json" | node -e 'let d = ""; process.stdin.on("data", (c) => d += c); process.stdin.on("end", () => { process.stdout.write(String(JSON.parse(d).version ?? "")); });')"
+          PACKAGE_PATCH="$(gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files?per_page=100" \
+            --jq '.[] | select(.filename=="package.json") | .patch // ""')"
           CUR_VERSION="$(node -p "require('./package.json').version")"
+          PREV_VERSION="$(printf '%s\n' "${PACKAGE_PATCH}" | sed -nE 's/^- *\"version\": *\"([^\"]+)\".*/\1/p' | head -n1)"
+          PATCH_NEXT_VERSION="$(printf '%s\n' "${PACKAGE_PATCH}" | sed -nE 's/^\+ *\"version\": *\"([^\"]+)\".*/\1/p' | head -n1)"
 
           echo "previous_version=${PREV_VERSION}" >> "$GITHUB_OUTPUT"
           echo "current_version=${CUR_VERSION}" >> "$GITHUB_OUTPUT"
 
-          if [ "${PREV_VERSION}" = "${CUR_VERSION}" ]; then
+          if [ -z "${PACKAGE_PATCH}" ]; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "No package.json version change detected in ${MERGE_SHA}; skipping tag/release."
+            echo "No package.json change detected in PR #${PR_NUMBER}; skipping tag/release."
+            exit 0
+          fi
+
+          if [ -z "${PREV_VERSION}" ] || [ -z "${PATCH_NEXT_VERSION}" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "package.json changed but version field diff was not detected; skipping tag/release."
+            exit 0
+          fi
+
+          if [ "${PREV_VERSION}" = "${PATCH_NEXT_VERSION}" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "package.json version did not change (${CUR_VERSION}); skipping tag/release."
             exit 0
           fi
 

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -133,21 +133,18 @@ jobs:
           git commit -m "chore: bump version to ${NEW_VERSION}"
           git push --force origin "${PR_BRANCH}"
 
-      - name: Create or update version bump pull request
-        id: pr
+      - name: Build pull request body
+        id: body
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TARGET_BRANCH: ${{ inputs.target_branch }}
-          PR_BRANCH: ${{ steps.prepare.outputs.pr_branch }}
           OLD_VERSION: ${{ steps.bump.outputs.old_version }}
           NEW_VERSION: ${{ steps.bump.outputs.new_version }}
           BUMP_TYPE: ${{ inputs.bump }}
           RELEASE_REQUESTED: ${{ inputs.release }}
-          RELEASE_LABEL: Release
         run: |
           set -euo pipefail
 
-          BODY_FILE="$(mktemp)"
+          BODY_FILE="${RUNNER_TEMP}/version-bump-pr-body.md"
           cat > "${BODY_FILE}" <<EOF
           ## Summary
           - bump \`package.json\` version from \`${OLD_VERSION}\` to \`${NEW_VERSION}\`
@@ -159,6 +156,17 @@ jobs:
           - release label requested: \`${RELEASE_REQUESTED}\`
           EOF
 
+          echo "body_file=${BODY_FILE}" >> "$GITHUB_OUTPUT"
+
+      - name: Find existing version bump pull request
+        id: find_pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+          PR_BRANCH: ${{ steps.prepare.outputs.pr_branch }}
+        run: |
+          set -euo pipefail
+
           EXISTING_PR_NUMBER="$(gh pr list \
             --repo "${GITHUB_REPOSITORY}" \
             --base "${TARGET_BRANCH}" \
@@ -168,51 +176,131 @@ jobs:
             --jq '.[0].number // ""')"
 
           if [ -n "${EXISTING_PR_NUMBER}" ]; then
-            gh pr edit "${EXISTING_PR_NUMBER}" \
+            echo "Found existing PR #${EXISTING_PR_NUMBER} for ${PR_BRANCH}."
+          else
+            echo "No existing PR found for ${PR_BRANCH}; a new PR will be created."
+          fi
+
+          echo "existing_pr_number=${EXISTING_PR_NUMBER}" >> "$GITHUB_OUTPUT"
+
+      - name: Create or update version bump pull request
+        id: upsert_pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+          PR_BRANCH: ${{ steps.prepare.outputs.pr_branch }}
+          BODY_FILE: ${{ steps.body.outputs.body_file }}
+          NEW_VERSION: ${{ steps.bump.outputs.new_version }}
+          EXISTING_PR_NUMBER: ${{ steps.find_pr.outputs.existing_pr_number }}
+        run: |
+          set -euo pipefail
+
+          if [ -n "${EXISTING_PR_NUMBER}" ]; then
+            if ! gh pr edit "${EXISTING_PR_NUMBER}" \
               --repo "${GITHUB_REPOSITORY}" \
               --title "chore: bump version to ${NEW_VERSION}" \
-              --body-file "${BODY_FILE}"
-
-            PR_URL="$(gh pr view "${EXISTING_PR_NUMBER}" \
-              --repo "${GITHUB_REPOSITORY}" \
-              --json url \
-              --jq '.url')"
-            PR_NUMBER="${EXISTING_PR_NUMBER}"
+              --body-file "${BODY_FILE}"; then
+              echo "Failed to update existing PR #${EXISTING_PR_NUMBER}."
+              exit 1
+            fi
           else
-            PR_URL="$(gh pr create \
+            CREATE_OUTPUT=""
+            if ! CREATE_OUTPUT="$(gh pr create \
               --repo "${GITHUB_REPOSITORY}" \
               --base "${TARGET_BRANCH}" \
               --head "${PR_BRANCH}" \
               --title "chore: bump version to ${NEW_VERSION}" \
-              --body-file "${BODY_FILE}")"
-            PR_NUMBER="${PR_URL##*/}"
+              --body-file "${BODY_FILE}" 2>&1)"; then
+              echo "Failed to create PR for ${PR_BRANCH} -> ${TARGET_BRANCH}."
+              echo "${CREATE_OUTPUT}"
+              exit 1
+            fi
+            echo "${CREATE_OUTPUT}"
           fi
 
-          if [ "${RELEASE_REQUESTED}" = "true" ]; then
-            if ! gh api --silent --method GET "repos/${GITHUB_REPOSITORY}/labels/${RELEASE_LABEL}" >/dev/null 2>&1; then
-              gh api --method POST "repos/${GITHUB_REPOSITORY}/labels" \
-                -f name="${RELEASE_LABEL}" \
-                -f color="0e8a16" \
-                -f description="Create a post-merge version tag and draft release" >/dev/null
-            fi
+          PR_NUMBER="$(gh pr list \
+            --repo "${GITHUB_REPOSITORY}" \
+            --base "${TARGET_BRANCH}" \
+            --head "${PR_BRANCH}" \
+            --state open \
+            --json number \
+            --jq '.[0].number // ""')"
+          PR_URL="$(gh pr list \
+            --repo "${GITHUB_REPOSITORY}" \
+            --base "${TARGET_BRANCH}" \
+            --head "${PR_BRANCH}" \
+            --state open \
+            --json url \
+            --jq '.[0].url // ""')"
 
-            gh pr edit "${PR_NUMBER}" \
+          if [ -z "${PR_NUMBER}" ] || [ -z "${PR_URL}" ]; then
+            echo "Could not resolve PR metadata after create/update."
+            gh pr list \
               --repo "${GITHUB_REPOSITORY}" \
-              --add-label "${RELEASE_LABEL}"
-          else
-            gh pr edit "${PR_NUMBER}" \
-              --repo "${GITHUB_REPOSITORY}" \
-              --remove-label "${RELEASE_LABEL}" >/dev/null 2>&1 || true
+              --base "${TARGET_BRANCH}" \
+              --head "${PR_BRANCH}" \
+              --state open \
+              --json number,url
+            exit 1
           fi
 
           echo "pull_request_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
           echo "pull_request_url=${PR_URL}" >> "$GITHUB_OUTPUT"
-          echo "release_label=${RELEASE_REQUESTED}" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure Release label exists
+        if: inputs.release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_LABEL: Release
+        run: |
+          set -euo pipefail
+
+          if gh api --silent --method GET "repos/${GITHUB_REPOSITORY}/labels/${RELEASE_LABEL}" >/dev/null 2>&1; then
+            echo "Label ${RELEASE_LABEL} already exists."
+            exit 0
+          fi
+
+          if ! gh api --method POST "repos/${GITHUB_REPOSITORY}/labels" \
+            -f name="${RELEASE_LABEL}" \
+            -f color="0e8a16" \
+            -f description="Create a post-merge version tag and draft release" >/dev/null; then
+            echo "Failed to create label ${RELEASE_LABEL}."
+            exit 1
+          fi
+
+      - name: Apply Release label to pull request
+        if: inputs.release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.upsert_pr.outputs.pull_request_number }}
+          RELEASE_LABEL: Release
+        run: |
+          set -euo pipefail
+
+          if ! gh pr edit "${PR_NUMBER}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --add-label "${RELEASE_LABEL}"; then
+            echo "Failed to add label ${RELEASE_LABEL} to PR #${PR_NUMBER}."
+            exit 1
+          fi
+
+      - name: Remove Release label from pull request
+        if: ${{ !inputs.release }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.upsert_pr.outputs.pull_request_number }}
+          RELEASE_LABEL: Release
+        run: |
+          set -euo pipefail
+
+          gh pr edit "${PR_NUMBER}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --remove-label "${RELEASE_LABEL}" >/dev/null 2>&1 || true
 
       - name: Print results
         run: |
-          echo "pull_request_url=${{ steps.pr.outputs.pull_request_url }}"
-          if [ "${{ steps.pr.outputs.release_label }}" = "true" ]; then
+          echo "pull_request_url=${{ steps.upsert_pr.outputs.pull_request_url }}"
+          if [ "${{ inputs.release }}" = "true" ]; then
             echo "release_label=Release"
             echo "post_merge_release=v${{ steps.bump.outputs.new_version }}"
           fi


### PR DESCRIPTION
## Summary
- add `release-from-pr-label.yml` to handle post-merge release orchestration for `Release`-labeled PRs
- require merged same-repo PR + `Release` label + non-empty merge SHA before tagging
- verify `package.json` version changed before creating a tag and dispatching `build-release`
- set `version-bump` `release` input default to `true`
- add guardrails in `build-release` to avoid duplicate bot-triggered runs and add per-tag concurrency

## Validation
- pnpm run typecheck
- pnpm run lint
- pnpm run build
- pnpm run test
