### PR TITLE
Use BEN_PAT workaround for version bump PR creation steps

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Find existing version bump pull request
         id: find_pr
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.BEN_PAT }}
           TARGET_BRANCH: ${{ inputs.target_branch }}
           PR_BRANCH: ${{ steps.prepare.outputs.pr_branch }}
         run: |
@@ -186,7 +186,7 @@ jobs:
       - name: Create or update version bump pull request
         id: upsert_pr
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.BEN_PAT }}
           TARGET_BRANCH: ${{ inputs.target_branch }}
           PR_BRANCH: ${{ steps.prepare.outputs.pr_branch }}
           BODY_FILE: ${{ steps.body.outputs.body_file }}


### PR DESCRIPTION
## Summary
- use `BEN_PAT` only for version bump PR create/update operations in `version-bump.yml`
- keep label-management steps on `GITHUB_TOKEN`

## Why
- current repo/org policy blocks `GITHUB_TOKEN` from creating pull requests
- `BEN_PAT` has pull-request write access and can be scoped to only the PR creation path
- label operations may require issue permissions, so they remain on `GITHUB_TOKEN`

## Validation
- pnpm run typecheck
- pnpm run lint
- pnpm run build
- pnpm run test
