### PR TITLE
Remove 'All Installs' section from dashboard

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -14,9 +14,6 @@
     "changePrimary": "Change",
     "setPrimary": "Set as Primary",
     "cloudSection": "ComfyUI Cloud",
-    "allInstalls": "All Installs",
-    "viewAllInstalls": "View All",
-    "installCount": "{count} Install | {count} Installs",
     "pinned": "Pinned",
     "pinToDashboard": "Pin to Dashboard",
     "unpinFromDashboard": "Unpin from Dashboard"

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -15,9 +15,6 @@
     "changePrimary": "更改",
     "setPrimary": "设为主要",
     "cloudSection": "ComfyUI 云",
-    "allInstalls": "所有安装",
-    "viewAllInstalls": "查看全部",
-    "installCount": "{count} 个安装",
     "pinned": "已固定",
     "pinToDashboard": "固定到仪表盘",
     "unpinFromDashboard": "从仪表盘取消固定"

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -238,7 +238,6 @@ onMounted(async () => {
         @show-detail="openDetail"
         @show-console="openConsole"
         @show-progress="showProgress"
-        @show-list="switchView('list')"
       />
 
       <InstallationList

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -662,17 +662,6 @@ input[type="checkbox"]:checked::after { transform: translateX(16px); }
   display: flex; justify-content: space-between; align-items: center;
 }
 
-/* All Installs summary */
-.dashboard-summary-card {
-  background: var(--surface); border: 1px solid var(--border);
-  border-radius: 10px; padding: 14px 20px;
-  display: flex; justify-content: space-between; align-items: center;
-}
-.dashboard-summary-count {
-  font-size: 20px; font-weight: 700; color: var(--text);
-  line-height: 1;
-}
-
 /* Model directory cards */
 .dir-card-list { display: flex; flex-direction: column; gap: 8px; margin-top: 8px; }
 .dir-card {

--- a/src/renderer/src/views/DashboardView.vue
+++ b/src/renderer/src/views/DashboardView.vue
@@ -33,7 +33,7 @@ const emit = defineEmits<{
     apiCall: () => Promise<unknown>
     cancellable?: boolean
   }]
-  'show-list': []
+
 }>()
 
 const { ctxMenu, ctxMenuItems, openCardMenu, handleCtxMenuSelect, closeMenu } =
@@ -81,11 +81,6 @@ const pinnedInstalls = computed(() => {
     .map((id) => installationStore.installations.find((i) => i.id === id))
     .filter((i): i is Installation => !!i && i.sourceCategory !== 'cloud' && !excludeIds.has(i.id))
 })
-
-// --- Non-cloud installs for summary ---
-const nonCloudInstalls = computed(() =>
-  installationStore.installations.filter((i) => i.sourceCategory !== 'cloud')
-)
 
 // --- Actions for cards (separate generation counters) ---
 const primaryActions = ref<ListAction[]>([])
@@ -390,14 +385,6 @@ async function changePrimary(): Promise<void> {
         </div>
       </div>
 
-      <!-- All Installs summary -->
-      <div v-if="nonCloudInstalls.length > 0" class="dashboard-section">
-        <div class="dashboard-section-label">{{ $t('dashboard.allInstalls') }}</div>
-        <div class="dashboard-summary-card">
-          <span class="dashboard-summary-count">{{ $t('dashboard.installCount', nonCloudInstalls.length) }}</span>
-          <button @click="emit('show-list')">{{ $t('dashboard.viewAllInstalls') }}</button>
-        </div>
-      </div>
     </div>
 
     <!-- Context menu -->


### PR DESCRIPTION
Remove the 'All Installs' summary section from the Launcher dashboard.

Changes:
- Remove the All Installs summary card from DashboardView
- Remove unused nonCloudInstalls computed property and show-list emit
- Remove @show-list binding from App.vue
- Remove associated CSS classes (.dashboard-summary-card, .dashboard-summary-count)
- Remove orphaned i18n keys from en.json and zh.json