### PR TITLE
Add zoom reset on startup and zoom change banner

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -240,6 +240,12 @@
     "language": "Language"
   },
 
+  "zoom": {
+    "changed": "Zoom level has been changed",
+    "reset": "Reset Zoom",
+    "dismiss": "Dismiss"
+  },
+
   "update": {
     "available": "Update available: **v{version}**",
     "download": "Download",

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -68,6 +68,7 @@ const api: ElectronApi = {
 
   // App
   quitApp: () => ipcRenderer.invoke('quit-app'),
+  resetZoom: () => ipcRenderer.invoke('reset-zoom'),
 
   // Updates
   checkForUpdate: () => ipcRenderer.invoke('check-for-update'),
@@ -140,6 +141,11 @@ const api: ElectronApi = {
     const handler = (_event: IpcRendererEvent, data: unknown) => callback(data as Parameters<typeof callback>[0])
     ipcRenderer.on('update-error', handler)
     return () => ipcRenderer.removeListener('update-error', handler)
+  },
+  onZoomChanged: (callback) => {
+    const handler = (_event: IpcRendererEvent, level: unknown) => callback(level as number)
+    ipcRenderer.on('zoom-changed', handler)
+    return () => ipcRenderer.removeListener('zoom-changed', handler)
   },
 }
 

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -11,6 +11,7 @@ import type { Installation, ActionResult } from './types/ipc'
 
 import ModalDialog from './components/ModalDialog.vue'
 import UpdateBanner from './components/UpdateBanner.vue'
+import ZoomBanner from './components/ZoomBanner.vue'
 import DashboardView from './views/DashboardView.vue'
 import InstallationList from './views/InstallationList.vue'
 import RunningView from './views/RunningView.vue'
@@ -231,6 +232,7 @@ onMounted(async () => {
 
     <!-- Content Area -->
     <main class="content">
+      <ZoomBanner />
       <DashboardView
         v-show="activeView === 'dashboard'"
         :visible="activeView === 'dashboard'"

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -587,6 +587,17 @@ input[type="checkbox"]:checked::after { transform: translateX(16px); }
 .update-banner .update-text strong { color: var(--accent); }
 .update-banner button { flex-shrink: 0; }
 
+/* Zoom banner */
+.zoom-banner {
+  display: flex; align-items: center; gap: 12px;
+  padding: 10px 14px;
+  border: 1px solid var(--border); border-radius: 8px;
+  background: var(--surface); font-size: 14px;
+  color: var(--text-muted);
+}
+.zoom-banner-actions { display: flex; gap: 8px; margin-left: auto; }
+.zoom-banner-actions button { flex-shrink: 0; }
+
 /* Card progress bar */
 .card-progress { flex: 1; min-width: 0; margin-top: 4px; }
 .card-progress-status {

--- a/src/renderer/src/components/ZoomBanner.vue
+++ b/src/renderer/src/components/ZoomBanner.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useElectronApi } from '../composables/useElectronApi'
+
+const { api, listen } = useElectronApi()
+
+const visible = ref(false)
+
+listen<number>(api.onZoomChanged, (level) => {
+  visible.value = level !== 0
+})
+
+async function reset() {
+  await api.resetZoom()
+  visible.value = false
+}
+
+function dismiss() {
+  visible.value = false
+}
+</script>
+
+<template>
+  <div v-if="visible" class="zoom-banner">
+    <span>{{ $t('zoom.changed') }}</span>
+    <div class="zoom-banner-actions">
+      <button class="primary" @click="reset">{{ $t('zoom.reset') }}</button>
+      <button @click="dismiss">{{ $t('zoom.dismiss') }}</button>
+    </div>
+  </div>
+</template>

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -389,6 +389,7 @@ export interface ElectronApi {
 
   // App
   quitApp(): Promise<void>
+  resetZoom(): Promise<void>
 
   // Updates
   checkForUpdate(): Promise<void>
@@ -410,4 +411,5 @@ export interface ElectronApi {
   onUpdateDownloadProgress(callback: (progress: UpdateDownloadProgress) => void): Unsubscribe
   onUpdateDownloaded(callback: (info: UpdateInfo) => void): Unsubscribe
   onUpdateError(callback: (err: { message: string }) => void): Unsubscribe
+  onZoomChanged(callback: (level: number) => void): Unsubscribe
 }


### PR DESCRIPTION
## Problem

Users can accidentally change the zoom level via keyboard shortcuts (Ctrl/Cmd + =/-/0) or pinch-to-zoom. The zoom persists across app restarts, causing the UI to render incorrectly.

## Solution

1. **Reset zoom on startup** — after the page finishes loading, zoom is reset to 100% so persisted zoom from previous sessions doesn't carry over
2. **Zoom change banner** — when zoom changes during a session, a non-intrusive banner appears at the top of the content area with \Reset Zoom\ and \Dismiss\ buttons

### Changes

- \src/main/index.ts\: Reset zoom on \did-finish-load\; detect zoom changes from both keyboard shortcuts (\efore-input-event\) and pinch gestures (\zoom-changed\); handle \eset-zoom\ IPC
- \src/types/ipc.ts\: Add \esetZoom()\ and \onZoomChanged()\ to the API interface
- \src/preload/index.ts\: Wire up the new IPC channels
- \src/renderer/src/components/ZoomBanner.vue\: New banner component
- \src/renderer/src/App.vue\: Mount ZoomBanner at top of content area
- \locales/en.json\: Add zoom-related locale strings
- \src/renderer/src/assets/main.css\: Zoom banner styles