### PR TITLE
refactor: replace regex TOML parsing with smol-toml library

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
   "dependencies": {
     "7zip-bin": "^5.2.0",
     "@todesktop/runtime": "^2.1.3",
-    "electron-updater": "^6.7.3"
+    "electron-updater": "^6.7.3",
+    "smol-toml": "^1.6.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       electron-updater:
         specifier: ^6.7.3
         version: 6.8.3
+      smol-toml:
+        specifier: ^1.6.0
+        version: 1.6.0
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
@@ -2692,6 +2695,10 @@ packages:
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  smol-toml@1.6.0:
+    resolution: {integrity: sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==}
+    engines: {node: '>= 18'}
 
   socks-proxy-agent@8.0.5:
     resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
@@ -5751,6 +5758,8 @@ snapshots:
     optional: true
 
   smart-buffer@4.2.0: {}
+
+  smol-toml@1.6.0: {}
 
   socks-proxy-agent@8.0.5:
     dependencies:

--- a/src/main/lib/nodes.ts
+++ b/src/main/lib/nodes.ts
@@ -1,5 +1,6 @@
 import fs from 'fs'
 import path from 'path'
+import { parse as parseToml } from 'smol-toml'
 import { hasGitDir, readGitHead, readGitRemoteUrl } from './git'
 
 export interface ScannedNode {
@@ -20,16 +21,9 @@ export function nodeKey(node: ScannedNode): string {
 function readTomlProjectField(tomlPath: string, field: string): string | null {
   try {
     const content = fs.readFileSync(tomlPath, 'utf-8')
-    // Simple TOML parser: find [project] section, then the field
-    const projectMatch = content.match(/\[project\]/)
-    if (!projectMatch) return null
-    const afterProject = content.slice(projectMatch.index! + projectMatch[0].length)
-    // Stop at next section header
-    const nextSection = afterProject.search(/^\[/m)
-    const section = nextSection >= 0 ? afterProject.slice(0, nextSection) : afterProject
-    const escapedField = field.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-    const fieldMatch = section.match(new RegExp(`^${escapedField}\\s*=\\s*["']([^"']*)["']`, 'm'))
-    return fieldMatch ? fieldMatch[1]! : null
+    const parsed = parseToml(content)
+    const value = (parsed.project as Record<string, unknown> | undefined)?.[field]
+    return typeof value === 'string' ? value : null
   } catch {
     return null
   }


### PR DESCRIPTION
Replace the hand-rolled regex-based TOML parser in `readTomlProjectField` with [smol-toml](https://github.com/nicolo-ribaudo/smol-toml), a lightweight (~4KB), zero-dependency, TOML v1.0 compliant parser.

## Why

The regex approach only handled simple `key = "value"` patterns and could fail on valid TOML syntax (multiline strings, inline tables, comments between fields, etc.).

## Changes

- Add `smol-toml` dependency
- Rewrite `readTomlProjectField` in `src/main/lib/nodes.ts` to use `parse()` instead of regex matching
- No API changes — function signature and behavior are identical

## Verification

- `pnpm run typecheck` ✅
- `pnpm run lint` ✅
- `pnpm run build` ✅
- `pnpm run test` (88/88) ✅
- `pnpm audit` — no new vulnerabilities
