### PR TITLE
fix: show delete/remove actions for unknown-source installations

### DIFF
--- a/src/main/lib/ipc.ts
+++ b/src/main/lib/ipc.ts
@@ -13,6 +13,7 @@ import { download } from './download'
 import { createCache } from './cache'
 import { extractNested as extract } from './extract'
 import { deleteDir } from './delete'
+import { deleteAction, untrackAction } from './actions'
 import {
   spawnProcess, waitForPort, waitForUrl, killProcessTree, killByPort,
   findPidsByPort, getProcessInfo, looksLikeComfyUI, setPortArg,
@@ -752,7 +753,17 @@ export function register(callbacks: RegisterCallbacks = {}): void {
     const inst = await installations.get(installationId)
     if (!inst) return []
     const source = sourceMap[inst.sourceId]
-    if (!source) return []
+    if (!source) {
+      const actions = [untrackAction()]
+      if (inst.installPath && fs.existsSync(inst.installPath)) {
+        actions.unshift(deleteAction(inst))
+      }
+      return [{
+        title: i18n.t('errors.unknownSource'),
+        pinBottom: true,
+        actions,
+      }]
+    }
     return source.getDetailSections(inst)
   })
 


### PR DESCRIPTION
## Problem

Follow-up to #89. Installations with unknown `sourceId` now gracefully avoid crashing, but `get-detail-sections` returns `[]` — leaving the detail view empty with no way to remove the stale installation from the UI.

## Fix

When the source is unknown, return a fallback section containing:
- The `errors.unknownSource` message as the section title
- A **Delete** action (if the install directory exists on disk)
- A **Remove** (untrack) action to remove it from the launcher database

This reuses the existing `deleteAction()` and `untrackAction()` helpers from `lib/actions.ts`.

## Testing

- All 123 tests pass
- Typecheck (node + web + e2e) clean
- ESLint clean
