### PR TITLE
fix: display error message in flat progress modal on immediate failure

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -456,6 +456,7 @@ input[type="checkbox"]:checked::after { transform: translateX(16px); }
 
 /* Progress */
 .progress-status { font-size: 14px; color: var(--text-muted); margin-bottom: 12px; user-select: text; }
+.progress-error-message { color: var(--danger); }
 .progress-bar-track { width: 100%; height: 8px; background: var(--border); border-radius: 4px; overflow: hidden; margin-bottom: 16px; }
 .progress-bar-fill { height: 100%; background: var(--accent); border-radius: 4px; width: 0%; transition: width 0.3s ease; }
 .progress-bar-track.indeterminate {

--- a/src/renderer/src/views/ProgressModal.vue
+++ b/src/renderer/src/views/ProgressModal.vue
@@ -353,7 +353,8 @@ defineExpose({ startOperation, showOperation })
 
         <!-- Flat progress -->
         <template v-else>
-          <div class="progress-status">{{ currentOp.flatStatus }}</div>
+          <div v-if="currentOp.finished && currentOp.error" class="progress-status progress-error-message">{{ currentOp.error }}</div>
+          <div v-else class="progress-status">{{ currentOp.flatStatus }}</div>
           <div
             v-if="!currentOp.finished"
             class="progress-bar-track"


### PR DESCRIPTION
## Problem

When an action with `showProgress: true` fails immediately (before any progress events are sent), the progress modal shows:
- **Banner**: "Operation failed" (correct)
- **Status**: "Starting..." (wrong — should show the actual error)

This happens because `op.error` is set with the message but the flat progress template only renders `flatStatus`, which stays at its initial "Starting..." value. The stepped progress path already handles this via `getStepStatus()`, but flat progress has no equivalent.

Example: clicking Delete on an installation whose directory wasn't created by the Launcher triggers a safety check that returns an error immediately, but the user only sees "Starting..." with no indication of what went wrong.

## Fix

In the flat progress template, show `op.error` instead of `flatStatus` when the operation has finished with an error. Styled with `--danger` color to match the error banner.

## Testing

- All 123 tests pass
- Typecheck (node + web + e2e) clean
- ESLint clean
