### PR TITLE
fix: restore marker file and set partial-delete status on all delete errors

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -609,6 +609,7 @@
     "installNotReady": "This install is not ready to launch. It may still be installing or may have failed.",
     "installFailed": "Install Failed",
     "deleteInterrupted": "Delete Interrupted",
+    "deleteLocked": "A file could not be deleted because it is in use by another program. Close any applications that may have files open in this directory and try again.\n{path}",
     "cannotAdd": "Cannot Add",
     "dirNotExist": "Directory does not exist: {path}",
     "cannotOpenDir": "Could not open directory: {error}",

--- a/src/main/lib/ipc.ts
+++ b/src/main/lib/ipc.ts
@@ -1324,14 +1324,18 @@ export function register(callbacks: RegisterCallbacks = {}): void {
         }, { signal: abort.signal })
       } catch (err) {
         _operationAborts.delete(installationId)
-        if (abort.signal.aborted) {
-          try {
-            fs.mkdirSync(inst.installPath, { recursive: true })
-            fs.writeFileSync(markerPath, markerContent)
-          } catch {}
-          await installations.update(installationId, { status: 'partial-delete' })
+        // Always restore marker so future delete attempts don't hit the safety check
+        try {
+          fs.mkdirSync(inst.installPath, { recursive: true })
+          fs.writeFileSync(markerPath, markerContent)
+        } catch {}
+        await installations.update(installationId, { status: 'partial-delete' })
+        const raw = (err as NodeJS.ErrnoException)
+        let message = raw.message
+        if (raw.code === 'EBUSY' || raw.code === 'EPERM') {
+          message = i18n.t('errors.deleteLocked', { path: raw.path ?? '' })
         }
-        return { ok: false, message: (err as Error).message }
+        return { ok: false, message }
       }
       _operationAborts.delete(installationId)
       await installations.remove(installationId)

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -513,6 +513,7 @@ input[type="checkbox"]:checked::after { transform: translateX(16px); }
   overflow-y: auto; max-height: 300px; user-select: text;
 }
 #console-terminal { max-height: none; flex: 1; min-height: 0; }
+.console-error-message { color: var(--danger); font-size: 14px; padding: 10px 12px; white-space: pre-wrap; user-select: text; }
 
 /* View modals */
 .view-modal {

--- a/src/renderer/src/views/ConsoleModal.vue
+++ b/src/renderer/src/views/ConsoleModal.vue
@@ -140,6 +140,7 @@ function handleOverlayClick(event: MouseEvent): void {
         <button class="view-modal-close" @click="emit('close')">✕</button>
       </div>
       <div class="view-modal-body">
+        <div v-if="errorInfo?.message" class="console-error-message">{{ errorInfo.message }}</div>
         <div
           id="console-terminal"
           ref="terminalRef"


### PR DESCRIPTION
## Problem

When `deleteDir` fails due to a real error (e.g. EBUSY from a file locked by VS Code), the `.comfyui-launcher` marker file has likely already been deleted during the recursive walk. The catch block only restored it on user cancellation, not on other errors. This left the installation in a dead-end state where future delete attempts fail with "Safety check failed."

Additionally, the `partial-delete` status was only set on cancellation, so the UI showed no indication that the directory was partially deleted.

## Fix

- **Always restore the marker file** in the catch block, not just on abort — ensures the safety check passes on retry
- **Always set `partial-delete` status** — the installation list shows the "Delete Interrupted" badge regardless of failure reason
- **User-friendly error for locked files** — EBUSY/EPERM errors now show a clear i18n message ("in use by another program, close and try again") instead of the raw Node.js errno string
