### PR TITLE
Fix restart-and-update getting trapped in tray mode

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -9,6 +9,7 @@ import * as settings from './settings'
 import * as i18n from './lib/i18n'
 import { configDir, migrateXdgPaths } from './lib/paths'
 import { waitForPort } from './lib/process'
+import { isQuitInProgress, setQuitReason } from './lib/quit-state'
 import type { InstallationRecord } from './installations'
 import {
   attachSessionDownloadHandler,
@@ -137,7 +138,6 @@ function attachContextMenu(comfyWindow: BrowserWindow): void {
 let launcherWindow: BrowserWindow | null = null
 let tray: Tray | null = null
 const comfyWindows = new Map<string, BrowserWindow>()
-let isQuitting = false
 
 function createLauncherWindow(): void {
   launcherWindow = new BrowserWindow({
@@ -200,7 +200,7 @@ function createLauncherWindow(): void {
   }
 
   launcherWindow.on('close', (e) => {
-    if (isQuitting) return
+    if (isQuitInProgress()) return
 
     const onClose = (settings.get('onLauncherClose') as string | undefined) || 'tray'
     if (onClose === 'tray') {
@@ -251,7 +251,7 @@ function showLauncher(): void {
 }
 
 function quitApp(): void {
-  isQuitting = true
+  setQuitReason('user-quit')
   ipc.cancelAll()
   for (const [_id, win] of comfyWindows) {
     if (!win.isDestroyed()) win.destroy()
@@ -486,7 +486,7 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
   })
 
   app.on('before-quit', () => {
-    isQuitting = true
+    if (!isQuitInProgress()) setQuitReason('user-quit')
     cleanupTempDownloads()
   })
 

--- a/src/main/lib/quit-state.ts
+++ b/src/main/lib/quit-state.ts
@@ -1,0 +1,23 @@
+export type QuitReason = 'none' | 'user-quit' | 'update-install'
+
+let quitReason: QuitReason = 'none'
+
+export function setQuitReason(reason: QuitReason): void {
+  quitReason = reason
+}
+
+export function clearQuitReason(): void {
+  quitReason = 'none'
+}
+
+export function getQuitReason(): QuitReason {
+  return quitReason
+}
+
+export function isQuitInProgress(): boolean {
+  return quitReason !== 'none'
+}
+
+export function isUpdateInstallQuit(): boolean {
+  return quitReason === 'update-install'
+}

--- a/src/main/lib/updater.ts
+++ b/src/main/lib/updater.ts
@@ -1,6 +1,7 @@
 import { ipcMain, BrowserWindow } from 'electron'
 import todesktop from '@todesktop/runtime'
 import * as settings from '../settings'
+import { clearQuitReason, setQuitReason } from './quit-state'
 
 interface UpdateInfo {
   version: string
@@ -90,6 +91,7 @@ function bindUpdaterEvents(): void {
   })
 
   updater.on('error', (...args: unknown[]) => {
+    clearQuitReason()
     broadcast('update-error', { message: updaterErrorMessage(args) })
   })
 }
@@ -141,8 +143,10 @@ export function register(): void {
       return
     }
     try {
+      setQuitReason('update-install')
       updater.restartAndInstall()
     } catch (err) {
+      clearQuitReason()
       broadcast('update-error', { message: err instanceof Error ? err.message : String(err) })
     }
   })


### PR DESCRIPTION
## Summary
- fix updater install flow when `onLauncherClose` is set to `tray`
- introduce a small shared quit-state module for quit intent (`user-quit` vs `update-install`)
- make launcher close handler bypass tray-hide behavior whenever a quit is in progress
- set quit reason to `update-install` before `restartAndInstall()` and clear it on updater errors

## Why
When users clicked **Restart & Update**, the window could close to tray instead of allowing app shutdown for install. That left the process running and prevented update installation.

## Changes
- `src/main/lib/quit-state.ts`
  - adds centralized quit reason state and helpers
- `src/main/index.ts`
  - replaces local `isQuitting` guard with shared quit-state checks
  - marks user-initiated quits with `setQuitReason('user-quit')`
- `src/main/lib/updater.ts`
  - marks update install with `setQuitReason('update-install')` before `restartAndInstall()`
  - clears quit reason on updater errors/catch

## Validation
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test`
- manual simulated updater flow with packaged app and `--runtime-simulate-updates=update-available`
