### PR TITLE
feat: add Datadog RUM version as package+sha

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -1,7 +1,41 @@
+import { execSync } from 'child_process'
+import { readFileSync } from 'fs'
 import { resolve } from 'path'
 import { defineConfig } from 'electron-vite'
 import vue from '@vitejs/plugin-vue'
 import tailwindcss from '@tailwindcss/vite'
+
+function readPackageVersion(): string {
+  try {
+    const raw = readFileSync(resolve(__dirname, 'package.json'), 'utf8')
+    const parsed = JSON.parse(raw) as { version?: string }
+    if (typeof parsed.version === 'string' && parsed.version.trim().length > 0) {
+      return parsed.version.trim()
+    }
+  } catch {}
+  return '0.0.0'
+}
+
+function readGitSha(): string {
+  try {
+    return execSync('git rev-parse --short=12 HEAD', {
+      cwd: __dirname,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim()
+  } catch {
+    return ''
+  }
+}
+
+const packageVersion = (process.env.npm_package_version || readPackageVersion()).trim() || '0.0.0'
+const commitSha = (process.env.GITHUB_SHA || process.env.VITE_GIT_SHA || readGitSha()).trim()
+
+if (!process.env.VITE_DATADOG_RUM_VERSION) {
+  process.env.VITE_DATADOG_RUM_VERSION = commitSha
+    ? `${packageVersion}+${commitSha.slice(0, 12)}`
+    : packageVersion
+}
 
 export default defineConfig({
   main: {},

--- a/src/renderer/src/main.ts
+++ b/src/renderer/src/main.ts
@@ -52,6 +52,7 @@ const datadogApplicationId = (
 const datadogSite = (import.meta.env.VITE_DATADOG_RUM_SITE || 'us5.datadoghq.com').trim()
 const datadogService = (import.meta.env.VITE_DATADOG_RUM_SERVICE || DEFAULT_DATADOG_SERVICE).trim()
 const datadogEnv = (import.meta.env.VITE_DATADOG_RUM_ENV || 'prod-v2').trim()
+const datadogVersion = (import.meta.env.VITE_DATADOG_RUM_VERSION || '').trim()
 
 const isDatadogEnabled = !isFlagDisabled(import.meta.env.VITE_DATADOG_RUM_ENABLED)
   && datadogClientToken.length > 0
@@ -64,6 +65,7 @@ if (isDatadogEnabled) {
     site: datadogSite,
     service: datadogService,
     env: datadogEnv,
+    version: datadogVersion || undefined,
     sessionSampleRate: parseSampleRate(import.meta.env.VITE_DATADOG_RUM_SESSION_SAMPLE_RATE, 100),
     sessionReplaySampleRate: parseSampleRate(import.meta.env.VITE_DATADOG_RUM_SESSION_REPLAY_SAMPLE_RATE, 0),
     trackResources: true,


### PR DESCRIPTION
## Summary
- set a default `VITE_DATADOG_RUM_VERSION` at build time as `<package.json version>+<short git sha>`
- allow explicit override by respecting pre-set `VITE_DATADOG_RUM_VERSION`
- pass `version` into `datadogRum.init` so RUM events are grouped by release

## Testing
- pnpm run typecheck
- pnpm run lint
- pnpm run build
- pnpm run test