### PR TITLE
feat: add UTM tags for cloud distribution links

### DIFF
--- a/src/main/lib/cloudUrl.test.ts
+++ b/src/main/lib/cloudUrl.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { withCloudDistributionUtm } from './cloudUrl'
+
+describe('withCloudDistributionUtm', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('adds default UTM params for cloud distribution links', () => {
+    const result = withCloudDistributionUtm('https://cloud.comfy.org/')
+    const url = new URL(result)
+
+    expect(url.hostname).toBe('cloud.comfy.org')
+    expect(url.searchParams.get('utm_source')).toBe('comfyui_launcher')
+    expect(url.searchParams.get('utm_medium')).toBe('app_feature')
+    expect(url.searchParams.has('utm_campaign')).toBe(false)
+  })
+
+  it('preserves existing query params and UTM overrides', () => {
+    const result = withCloudDistributionUtm(
+      'https://cloud.comfy.org/path?plan=pro&utm_source=custom-source'
+    )
+    const url = new URL(result)
+
+    expect(url.searchParams.get('plan')).toBe('pro')
+    expect(url.searchParams.get('utm_source')).toBe('custom-source')
+    expect(url.searchParams.get('utm_medium')).toBe('app_feature')
+    expect(url.searchParams.has('utm_campaign')).toBe(false)
+  })
+
+  it('does not modify non-cloud URLs', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const input = 'https://example.com/path?plan=pro'
+    expect(withCloudDistributionUtm(input)).toBe(input)
+    expect(warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns invalid URLs unchanged', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(withCloudDistributionUtm('not a url')).toBe('not a url')
+    expect(warn).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/lib/cloudUrl.ts
+++ b/src/main/lib/cloudUrl.ts
@@ -1,0 +1,34 @@
+const CLOUD_DISTRIBUTION_HOST = 'cloud.comfy.org'
+
+const DEFAULT_UTM_PARAMS: Record<string, string> = {
+  utm_source: 'comfyui_launcher',
+  utm_medium: 'app_feature',
+}
+
+function warnSkippedUtm(reason: string, details: Record<string, string>): void {
+  console.warn(`[cloud-utm] ${reason}`, details)
+}
+
+export function withCloudDistributionUtm(rawUrl: string): string {
+  let url: URL
+  try {
+    url = new URL(rawUrl)
+  } catch {
+    warnSkippedUtm('Skipped UTM tagging because URL parsing failed', { rawUrl })
+    return rawUrl
+  }
+  if (url.hostname.toLowerCase() !== CLOUD_DISTRIBUTION_HOST) {
+    warnSkippedUtm('Skipped UTM tagging because host is not cloud.comfy.org', {
+      host: url.hostname,
+      rawUrl: url.href,
+    })
+    return rawUrl
+  }
+
+  for (const [key, value] of Object.entries(DEFAULT_UTM_PARAMS)) {
+    if (!url.searchParams.has(key)) {
+      url.searchParams.set(key, value)
+    }
+  }
+  return url.href
+}

--- a/src/main/sources/cloud.ts
+++ b/src/main/sources/cloud.ts
@@ -1,4 +1,5 @@
 import { parseUrl } from '../lib/util'
+import { withCloudDistributionUtm } from '../lib/cloudUrl'
 import { t } from '../lib/i18n'
 import type { InstallationRecord } from '../installations'
 import type { SourcePlugin, FieldOption, ActionResult, ActionTools, LaunchCommand } from '../types/sources'
@@ -39,7 +40,7 @@ export const cloud: SourcePlugin = {
   },
 
   getLaunchCommand(installation: InstallationRecord): LaunchCommand | null {
-    const parsed = parseUrl(installation.remoteUrl as string)
+    const parsed = parseUrl(withCloudDistributionUtm((installation.remoteUrl as string) || DEFAULT_URL))
     if (!parsed) return null
     return {
       remote: true,
@@ -110,5 +111,3 @@ export const cloud: SourcePlugin = {
     return []
   },
 }
-
-


### PR DESCRIPTION
## Summary
- add a helper to append UTM parameters to `cloud.comfy.org` links opened from the launcher
- apply that helper in the cloud source launch path so cloud opens are consistently attributed
- keep existing query params and existing UTM overrides intact, while warning on invalid/non-cloud URLs
- adjust defaults to `utm_source=comfyui_launcher` and `utm_medium=app_feature` (no campaign)
- add focused unit tests for the helper behavior

## Testing
- pnpm run typecheck
- pnpm run lint
- pnpm run build
- pnpm run test