### PR TITLE
Refactor settings unset semantics and schema metadata

### DIFF
--- a/src/main/lib/ipc.ts
+++ b/src/main/lib/ipc.ts
@@ -88,14 +88,14 @@ async function uniqueName(baseName: string): Promise<string> {
 
 /** Re-assign primary to the first remaining local install, or clear it. */
 async function autoAssignPrimary(removedId: string): Promise<void> {
-  const currentPrimary = settings.get('primaryInstallId') as string | undefined
+  const currentPrimary = settings.get('primaryInstallId')
   if (currentPrimary !== removedId) return
   const all = (await installations.list()).filter((i) => i.id !== removedId)
   const firstLocal = all.find((i) => {
     const source = sourceMap[i.sourceId]
     return source && source.category === 'local'
   })
-  settings.set('primaryInstallId', firstLocal?.id ?? null)
+  settings.set('primaryInstallId', firstLocal?.id)
 }
 
 /** Set as primary if this is the first local install and no primary is set. */
@@ -419,7 +419,7 @@ export function register(callbacks: RegisterCallbacks = {}): void {
       const validIds = new Set(remaining.map((i) => i.id))
       let settingsChanged = false
 
-      const currentPrimary = settings.get('primaryInstallId') as string | undefined
+      const currentPrimary = settings.get('primaryInstallId')
       if (currentPrimary && !validIds.has(currentPrimary)) {
         await autoAssignPrimary(currentPrimary)
         settingsChanged = true
@@ -537,13 +537,13 @@ export function register(callbacks: RegisterCallbacks = {}): void {
     const list = await installations.list()
 
     // Ensure a primary is always set when local installs exist
-    const currentPrimary = settings.get('primaryInstallId') as string | undefined
+    const currentPrimary = settings.get('primaryInstallId')
     if (!currentPrimary || !list.some((i) => i.id === currentPrimary)) {
       const firstLocal = list.find((i) => {
         const s = sourceMap[i.sourceId]
         return s && s.category === 'local'
       })
-      const newPrimary = firstLocal?.id ?? null
+      const newPrimary = firstLocal?.id
       if (currentPrimary !== newPrimary) {
         settings.set('primaryInstallId', newPrimary)
       }
@@ -1118,7 +1118,7 @@ export function register(callbacks: RegisterCallbacks = {}): void {
               { value: 'github', label: i18n.t('settings.themeGithub') },
             ] },
           { id: 'autoUpdate', label: i18n.t('settings.autoUpdate'), type: 'boolean', value: s.autoUpdate !== false },
-          { id: 'onLauncherClose', label: i18n.t('settings.onLauncherClose'), type: 'select', value: s.onLauncherClose || 'quit',
+          { id: 'onLauncherClose', label: i18n.t('settings.onLauncherClose'), type: 'select', value: s.onLauncherClose || settings.defaults.onLauncherClose,
             options: [
               { value: 'quit', label: i18n.t('settings.closeQuit') },
               { value: 'tray', label: i18n.t('settings.closeTray') },

--- a/src/main/settings.test.ts
+++ b/src/main/settings.test.ts
@@ -1,0 +1,92 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'comfyui-launcher-settings-'))
+const homePath = path.join(tmpRoot, 'home')
+const userDataPath = path.join(tmpRoot, 'user-data')
+const xdgConfigHome = path.join(tmpRoot, 'xdg-config')
+const xdgCacheHome = path.join(tmpRoot, 'xdg-cache')
+const originalXdgConfigHome = process.env.XDG_CONFIG_HOME
+const originalXdgCacheHome = process.env.XDG_CACHE_HOME
+
+process.env.XDG_CONFIG_HOME = xdgConfigHome
+process.env.XDG_CACHE_HOME = xdgCacheHome
+fs.mkdirSync(homePath, { recursive: true })
+fs.mkdirSync(userDataPath, { recursive: true })
+fs.mkdirSync(xdgConfigHome, { recursive: true })
+fs.mkdirSync(xdgCacheHome, { recursive: true })
+
+let settings: {
+  set: (key: string, value: unknown) => void
+  get: (key: string) => unknown
+  defaults: { onLauncherClose: 'tray' | 'quit' }
+}
+
+const settingsPath = path.join(xdgConfigHome, 'comfyui-launcher', 'settings.json')
+
+function readPersistedSettings(): Record<string, unknown> {
+  const raw = fs.readFileSync(settingsPath, 'utf-8')
+  return JSON.parse(raw) as Record<string, unknown>
+}
+
+beforeEach(async () => {
+  fs.rmSync(path.dirname(settingsPath), { recursive: true, force: true })
+  vi.resetModules()
+  vi.doMock('electron', () => ({
+    app: {
+      getPath: (name: string) => {
+        if (name === 'home') return homePath
+        return userDataPath
+      },
+    },
+  }))
+  settings = await import('./settings')
+})
+
+afterAll(() => {
+  if (originalXdgConfigHome === undefined) delete process.env.XDG_CONFIG_HOME
+  else process.env.XDG_CONFIG_HOME = originalXdgConfigHome
+  if (originalXdgCacheHome === undefined) delete process.env.XDG_CACHE_HOME
+  else process.env.XDG_CACHE_HOME = originalXdgCacheHome
+  fs.rmSync(tmpRoot, { recursive: true, force: true })
+})
+
+describe('settings unset/default semantics', () => {
+  it('treats undefined as unset and falls back to default', () => {
+    settings.set('onLauncherClose', 'quit')
+    expect(settings.get('onLauncherClose')).toBe('quit')
+
+    settings.set('onLauncherClose', undefined)
+
+    expect(settings.get('onLauncherClose')).toBe(settings.defaults.onLauncherClose)
+    const persisted = readPersistedSettings()
+    expect(persisted).not.toHaveProperty('onLauncherClose')
+  })
+
+  it('normalizes legacy null values to unset on write', () => {
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true })
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({ primaryInstallId: null, autoUpdate: null }, null, 2),
+      'utf-8'
+    )
+
+    expect(settings.get('primaryInstallId')).toBeUndefined()
+    expect(settings.get('autoUpdate')).toBeUndefined()
+
+    settings.set('theme', 'dark')
+
+    const persisted = readPersistedSettings()
+    expect(persisted).not.toHaveProperty('primaryInstallId')
+    expect(persisted).not.toHaveProperty('autoUpdate')
+    expect(persisted['theme']).toBe('dark')
+  })
+
+  it('treats null for unknown keys as passthrough values', () => {
+    settings.set('customKey' as string, null)
+    expect(settings.get('customKey' as string)).toBeNull()
+    expect(readPersistedSettings()['customKey']).toBeNull()
+  })
+})

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -4,21 +4,65 @@ import { configDir, cacheDir, homeDir } from './lib/paths'
 import { MODEL_FOLDER_TYPES } from './lib/models'
 import { readFileSafe, writeFileSafe } from './lib/safe-file'
 
-export interface Settings {
+export interface KnownSettings {
   cacheDir: string
   maxCachedFiles: number
-  onLauncherClose: string
+  onLauncherClose: 'tray' | 'quit'
   modelsDirs: string[]
   inputDir: string
   outputDir: string
-  [key: string]: unknown
+  language?: string
+  theme?: string
+  autoUpdate?: boolean
+  primaryInstallId?: string
+  pinnedInstallIds?: string[]
 }
+
+export type Settings = KnownSettings & Record<string, unknown>
+
+type DefaultedSettingKey =
+  | 'cacheDir'
+  | 'maxCachedFiles'
+  | 'onLauncherClose'
+  | 'modelsDirs'
+  | 'inputDir'
+  | 'outputDir'
+type SettingsDefaults = Pick<KnownSettings, DefaultedSettingKey>
 
 const dataPath = path.join(configDir(), "settings.json")
 
 const SHARED_ROOT = path.join(homeDir(), "ComfyUI-Shared")
 
-export const defaults: Settings = {
+const SETTINGS_SCHEMA = {
+  cacheDir: { nullable: false },
+  maxCachedFiles: { nullable: false },
+  onLauncherClose: { nullable: false },
+  modelsDirs: { nullable: false },
+  inputDir: { nullable: false },
+  outputDir: { nullable: false },
+  language: { nullable: false },
+  theme: { nullable: false },
+  autoUpdate: { nullable: false },
+  primaryInstallId: { nullable: false },
+  pinnedInstallIds: { nullable: false },
+} as const satisfies Record<keyof KnownSettings, { nullable: boolean }>
+
+export type KnownSettingKey = keyof typeof SETTINGS_SCHEMA
+export type NullableKnownSettingKey = {
+  [K in KnownSettingKey]-?: (typeof SETTINGS_SCHEMA)[K]['nullable'] extends true ? K : never
+}[KnownSettingKey]
+
+const KNOWN_SETTING_KEYS = Object.keys(SETTINGS_SCHEMA) as KnownSettingKey[]
+
+function isKnownSettingKey(key: string): key is KnownSettingKey {
+  return Object.prototype.hasOwnProperty.call(SETTINGS_SCHEMA, key)
+}
+
+function isNullableKnownSettingKey(key: KnownSettingKey): key is NullableKnownSettingKey {
+  return SETTINGS_SCHEMA[key].nullable
+}
+
+export const defaults: SettingsDefaults = {
   cacheDir: path.join(cacheDir(), "download-cache"),
   maxCachedFiles: 5,
   onLauncherClose: "tray",
@@ -37,6 +81,13 @@ function load(): Settings {
       const obj: unknown = JSON.parse(raw)
       if (obj && typeof obj === 'object' && !Array.isArray(obj)) parsed = obj as Record<string, unknown>
     } catch {}
+  }
+  if (parsed) {
+    for (const key of KNOWN_SETTING_KEYS) {
+      if (parsed[key] === null && !isNullableKnownSettingKey(key)) {
+        delete parsed[key]
+      }
+    }
   }
   const result: Settings = { ...defaults, ...(parsed || {}) }
   // Ensure system default directory is always present in modelsDirs
@@ -66,12 +117,27 @@ function save(settings: Settings): void {
   writeFileSafe(dataPath, JSON.stringify(settings, null, 2), true)
 }
 
+export function get<K extends KnownSettingKey>(key: K): KnownSettings[K]
+export function get(key: string): unknown
 export function get(key: string): unknown {
   return load()[key]
 }
 
-export function set(key: string, value: unknown): void {
+export function set<K extends string>(
+  key: K,
+  value: K extends KnownSettingKey ? KnownSettings[K] | undefined : unknown
+): void {
   const settings = load()
+  // `undefined` is the canonical "unset/default" value in settings.
+  // For known non-nullable keys, treat `null` the same way.
+  if (
+    value === undefined
+    || (value === null && isKnownSettingKey(key) && !isNullableKnownSettingKey(key))
+  ) {
+    delete settings[key]
+    save(settings)
+    return
+  }
   settings[key] = value
   save(settings)
 }

--- a/src/renderer/src/composables/useLauncherPrefs.test.ts
+++ b/src/renderer/src/composables/useLauncherPrefs.test.ts
@@ -7,7 +7,7 @@ vi.stubGlobal('window', {
   api: {
     getInstallations: vi.fn().mockResolvedValue([]),
     onInstallationsChanged: vi.fn(),
-    getSetting: vi.fn().mockResolvedValue(null),
+    getSetting: vi.fn().mockResolvedValue(undefined),
     runAction: vi.fn().mockResolvedValue(undefined),
   }
 })
@@ -27,7 +27,7 @@ describe('useLauncherPrefs', () => {
     vi.clearAllMocks()
     prefs = useLauncherPrefs()
     // Reset module-level shared state to isolate tests
-    prefs.primaryInstallId.value = null
+    prefs.primaryInstallId.value = undefined
     prefs.pinnedInstallIds.value = []
   })
 
@@ -36,7 +36,7 @@ describe('useLauncherPrefs', () => {
       vi.mocked(window.api.getSetting).mockImplementation((key: string) => {
         if (key === 'primaryInstallId') return Promise.resolve('inst-1')
         if (key === 'pinnedInstallIds') return Promise.resolve(['inst-2', 'inst-3'])
-        return Promise.resolve(null)
+        return Promise.resolve(undefined)
       })
 
       await prefs.loadPrefs()

--- a/src/renderer/src/composables/useLauncherPrefs.ts
+++ b/src/renderer/src/composables/useLauncherPrefs.ts
@@ -2,7 +2,7 @@ import { ref, watch } from 'vue'
 import { useInstallationStore } from '../stores/installationStore'
 
 // Module-level shared state so all components see the same values
-const primaryInstallId = ref<string | null>(null)
+const primaryInstallId = ref<string | undefined>(undefined)
 const pinnedInstallIds = ref<string[]>([])
 const loaded = ref(false)
 let loadPromise: Promise<void> | null = null
@@ -14,7 +14,7 @@ export function useLauncherPrefs() {
     loadPromise = (async () => {
       const [, pinned] = await Promise.all([
         syncPrimaryFromMain(),
-        window.api.getSetting('pinnedInstallIds') as Promise<string[] | null>,
+        window.api.getSetting('pinnedInstallIds') as Promise<string[] | undefined>,
       ])
       pinnedInstallIds.value = Array.isArray(pinned) ? pinned : []
       loaded.value = true
@@ -23,7 +23,7 @@ export function useLauncherPrefs() {
   }
 
   async function syncPrimaryFromMain(): Promise<void> {
-    primaryInstallId.value = (await window.api.getSetting('primaryInstallId') as string | null) ?? null
+    primaryInstallId.value = await window.api.getSetting('primaryInstallId') as string | undefined
   }
 
   // Re-sync primary from main process whenever installations change


### PR DESCRIPTION
## Summary
- define known launcher settings in a single schema object and derive key/nullability types from it
- make `undefined` the canonical unset/default value for known settings and normalize legacy `null` values for known keys
- make `primaryInstallId` non-nullable (unset via `undefined`) and align renderer launcher prefs to match
- add focused settings tests for unset/default semantics and legacy-null normalization

## Testing
- pnpm run typecheck
- pnpm run lint
- pnpm run build
- pnpm run test