### PR TITLE
feat: sync custom node model directories to shared models root

### DIFF
--- a/src/main/lib/ipc.ts
+++ b/src/main/lib/ipc.ts
@@ -1646,8 +1646,11 @@ export function register(callbacks: RegisterCallbacks = {}): void {
         const modelsDirs = settings.get('modelsDirs') as string[] | undefined
         // Sync any custom-node model dirs from the install into the shared root
         // BEFORE generating the YAML, so they're included when ComfyUI loads it.
+        console.log('[models] === PRE-LAUNCH SYNC ===')
+        console.log('[models] pre-launch: installPath =', inst.installPath, 'modelsDirs =', modelsDirs)
         syncCustomModelFolders(inst.installPath, modelsDirs)
-        const modelPathsConfig = ensureModelPathsConfig(modelsDirs)
+        const modelPathsConfig = ensureModelPathsConfig(modelsDirs, 'pre-launch')
+        console.log('[models] pre-launch: YAML path =', modelPathsConfig)
         if (modelPathsConfig) {
           launchCmd.args.push('--extra-model-paths-config', modelPathsConfig)
         }
@@ -1911,7 +1914,10 @@ export function register(callbacks: RegisterCallbacks = {}): void {
       // Sync custom-node model directories to shared models root
       if ((inst.useSharedPaths as boolean | undefined) !== false) {
         const syncModelsDirs = settings.get('modelsDirs') as string[] | undefined
+        console.log('[models] === POST-LAUNCH SYNC ===')
+        console.log('[models] post-launch: installPath =', inst.installPath, 'modelsDirs =', syncModelsDirs)
         syncCustomModelFolders(inst.installPath, syncModelsDirs)
+        console.log('[models] === POST-LAUNCH SYNC DONE ===')
       }
 
       function attachExitHandler(p: ChildProcess): void {

--- a/src/main/lib/models.ts
+++ b/src/main/lib/models.ts
@@ -60,7 +60,13 @@ function extraFoldersIn(dir: string): string[] {
 function discoverExtraFoldersFromSharedDirs(modelsDirs: string[]): string[] {
   const seen = new Set<string>()
   for (const dir of modelsDirs) {
-    for (const name of extraFoldersIn(dir)) {
+    const extras = extraFoldersIn(dir)
+    if (extras.length > 0) {
+      console.log('[models] discoverExtraFoldersFromSharedDirs: found', extras, 'in', dir)
+    } else {
+      console.log('[models] discoverExtraFoldersFromSharedDirs: no extras in', dir, '(exists:', fs.existsSync(dir), ')')
+    }
+    for (const name of extras) {
       seen.add(name)
     }
   }
@@ -97,11 +103,15 @@ function buildYaml(modelsDirs: string[], extraFolders: string[] = []): string {
  * shared model directories (previously discovered from custom nodes).
  * Returns the path to the YAML file, or null if no directories are configured.
  */
-export function ensureModelPathsConfig(modelsDirs: string[] | null | undefined): string | null {
-  if (!modelsDirs || !Array.isArray(modelsDirs) || modelsDirs.length === 0) return null
+export function ensureModelPathsConfig(modelsDirs: string[] | null | undefined, caller?: string): string | null {
+  const tag = caller ? `ensureModelPathsConfig(${caller})` : 'ensureModelPathsConfig'
+  if (!modelsDirs || !Array.isArray(modelsDirs) || modelsDirs.length === 0) {
+    console.log(`[models] ${tag}: no modelsDirs, returning null`)
+    return null
+  }
   const resolved = modelsDirs.map((d) => path.resolve(d))
   const extraFolders = discoverExtraFoldersFromSharedDirs(resolved)
-  console.log('[models] ensureModelPathsConfig: shared dirs =', resolved, 'extras =', extraFolders)
+  console.log(`[models] ${tag}: shared dirs =`, resolved, 'extras =', extraFolders)
   const yaml = buildYaml(resolved, extraFolders)
 
   let existing: string | null = null
@@ -110,8 +120,11 @@ export function ensureModelPathsConfig(modelsDirs: string[] | null | undefined):
   } catch {}
 
   if (existing !== yaml) {
-    console.log('[models] ensureModelPathsConfig: writing updated YAML')
+    console.log(`[models] ${tag}: writing updated YAML to`, YAML_PATH)
+    console.log(`[models] ${tag}: YAML content (last 500 chars):`, yaml.slice(-500))
     writeFileSafe(YAML_PATH, yaml)
+  } else {
+    console.log(`[models] ${tag}: YAML unchanged, skipping write`)
   }
 
   return YAML_PATH
@@ -130,7 +143,13 @@ export function discoverExtraModelFolders(installPath: string): string[] {
   ]
   const seen = new Set<string>()
   for (const dir of candidates) {
-    for (const name of extraFoldersIn(dir)) {
+    const extras = extraFoldersIn(dir)
+    if (extras.length > 0) {
+      console.log('[models] discoverExtraModelFolders: found', extras, 'in', dir)
+    } else {
+      console.log('[models] discoverExtraModelFolders: no extras in', dir, '(exists:', fs.existsSync(dir), ')')
+    }
+    for (const name of extras) {
       seen.add(name)
     }
   }
@@ -147,10 +166,16 @@ export function syncCustomModelFolders(
   installPath: string,
   modelsDirs: string[] | null | undefined,
 ): void {
-  if (!modelsDirs || !Array.isArray(modelsDirs) || modelsDirs.length === 0) return
+  if (!modelsDirs || !Array.isArray(modelsDirs) || modelsDirs.length === 0) {
+    console.log('[models] syncCustomModelFolders: no modelsDirs, skipping')
+    return
+  }
   const extraFolders = discoverExtraModelFolders(installPath)
   console.log('[models] syncCustomModelFolders: installPath =', installPath, 'extras from install =', extraFolders)
-  if (extraFolders.length === 0) return
+  if (extraFolders.length === 0) {
+    console.log('[models] syncCustomModelFolders: no extras found in install, skipping')
+    return
+  }
 
   // Create matching subdirectories in each shared models root
   for (const dir of modelsDirs) {
@@ -158,11 +183,13 @@ export function syncCustomModelFolders(
       const target = path.join(dir, folder)
       try {
         fs.mkdirSync(target, { recursive: true })
-        console.log('[models] syncCustomModelFolders: created', target)
-      } catch {}
+        console.log('[models] syncCustomModelFolders: ensured dir', target)
+      } catch (err) {
+        console.log('[models] syncCustomModelFolders: failed to create', target, (err as Error).message)
+      }
     }
   }
 
   // Rewrite the YAML (ensureModelPathsConfig will pick up the new dirs)
-  ensureModelPathsConfig(modelsDirs)
+  ensureModelPathsConfig(modelsDirs, 'syncCustomModelFolders')
 }


### PR DESCRIPTION
## Problem

When custom nodes register new model folder types (e.g. `mmaudio`, `RMBG`, `ultralytics`), they create subdirectories under the installation's `ComfyUI/models/` directory. These directories were not mirrored to the shared models directory (`~/ComfyUI-Shared/models/`) or included in the generated `shared_model_paths.yaml`, so models placed in the shared directory for these types weren't found by ComfyUI.

## Solution

After ComfyUI confirms startup (custom nodes have loaded and created their directories), scan the installation's models directory for subdirectories not in `MODEL_FOLDER_TYPES`, create matching directories in the shared model roots, and rewrite the YAML. On the **next** launch, `ensureModelPathsConfig` scans the shared dirs and automatically includes any previously discovered extras.

### Key design decisions

- **Shared dirs are the persistence mechanism** — no separate state file. Once a directory is created in the shared root, it's automatically included in every subsequent YAML generation, across all installations.
- **Multi-install safe** — extras from Installation A and Installation B accumulate in the shared dirs; neither overwrites the other.
- **Supports both layouts** — scans `{installPath}/ComfyUI/models` (standalone) and `{installPath}/models` (portable).
- **Non-destructive** — only adds directories and YAML entries, never removes them.
- **First launch caveat** — the first time a custom node creates a new model type, it won't be routed to shared until the next launch (the directory doesn't exist before the node runs).

## Changes

- **`models.ts`**: Added `discoverExtraModelFolders`, `syncCustomModelFolders`, and internal `extraFoldersIn`/`discoverExtraFoldersFromSharedDirs` helpers. `ensureModelPathsConfig` now auto-discovers extras from the shared dirs.
- **`ipc.ts`**: Calls `syncCustomModelFolders` after successful launch when shared paths are enabled.
