### PR TITLE
fix: fetch both stable and latest channels for update checks

### DIFF
--- a/src/main/lib/ipc.ts
+++ b/src/main/lib/ipc.ts
@@ -341,20 +341,12 @@ function resolveTheme(): ResolvedTheme {
   return theme === 'system' ? (nativeTheme.shouldUseDarkColors ? 'dark' : 'light') : theme
 }
 
+const ALL_UPDATE_CHANNELS = ['stable', 'latest']
+
 async function checkInstallationUpdates(): Promise<void> {
   try {
-    const all = await installations.list()
-    const channels = new Set<string>()
-    for (const inst of all) {
-      const source = sourceMap[inst.sourceId]
-      if (!source || source.skipInstall) continue
-      if (inst.status !== 'installed') continue
-      const channel = (inst.updateChannel as string | undefined) || 'stable'
-      channels.add(channel)
-    }
-    if (channels.size === 0) return
     await Promise.allSettled(
-      [...channels].map((channel) =>
+      ALL_UPDATE_CHANNELS.map((channel) =>
         releaseCache.getOrFetch(COMFYUI_REPO, channel, async () => {
           const release = await fetchLatestRelease(channel)
           if (!release) return null

--- a/src/main/sources/portable.ts
+++ b/src/main/sources/portable.ts
@@ -7,7 +7,7 @@ import { downloadAndExtract } from '../lib/installer'
 import * as releaseCache from '../lib/release-cache'
 import { parseArgs } from '../lib/util'
 import { t } from '../lib/i18n'
-import { truncateNotes } from '../lib/comfyui-releases'
+import { fetchLatestRelease, truncateNotes } from '../lib/comfyui-releases'
 import type { InstallationRecord } from '../installations'
 import type {
   SourcePlugin,
@@ -268,6 +268,23 @@ export const portable: SourcePlugin = {
 
     if (actionId === 'check-update') {
       const channel = (installation.updateChannel as string | undefined) || 'stable'
+      const otherChannels = ['stable', 'latest'].filter((ch) => ch !== channel)
+      await Promise.allSettled(
+        otherChannels.map((ch) =>
+          releaseCache.getOrFetch(COMFYUI_REPO, ch, async () => {
+            const release = await fetchLatestRelease(ch)
+            if (!release) return null
+            return {
+              checkedAt: Date.now(),
+              latestTag: release.tag_name as string,
+              releaseName: (release.name as string) || (release.tag_name as string),
+              releaseNotes: truncateNotes(release.body as string, 4000),
+              releaseUrl: release.html_url as string,
+              publishedAt: release.published_at as string,
+            }
+          }, true)
+        )
+      )
       return releaseCache.checkForUpdate(COMFYUI_REPO, channel, installation, update)
     }
 

--- a/src/main/sources/standalone.ts
+++ b/src/main/sources/standalone.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import { app } from 'electron'
 import { spawn, execFile } from 'child_process'
 import { fetchJSON } from '../lib/fetch'
-import { truncateNotes } from '../lib/comfyui-releases'
+import { fetchLatestRelease, truncateNotes } from '../lib/comfyui-releases'
 import * as releaseCache from '../lib/release-cache'
 import { deleteAction, untrackAction } from '../lib/actions'
 import { downloadAndExtract, downloadAndExtractMulti } from '../lib/installer'
@@ -812,6 +812,23 @@ export const standalone: SourcePlugin = {
 
     if (actionId === 'check-update') {
       const channel = (installation.updateChannel as string | undefined) || 'stable'
+      const otherChannels = ['stable', 'latest'].filter((ch) => ch !== channel)
+      await Promise.allSettled(
+        otherChannels.map((ch) =>
+          releaseCache.getOrFetch(COMFYUI_REPO, ch, async () => {
+            const release = await fetchLatestRelease(ch)
+            if (!release) return null
+            return {
+              checkedAt: Date.now(),
+              latestTag: release.tag_name as string,
+              releaseName: (release.name as string) || (release.tag_name as string),
+              releaseNotes: truncateNotes(release.body as string, 4000),
+              releaseUrl: release.html_url as string,
+              publishedAt: release.published_at as string,
+            }
+          }, true)
+        )
+      )
       return releaseCache.checkForUpdate(COMFYUI_REPO, channel, installation, update)
     }
 


### PR DESCRIPTION
## Problem

`checkInstallationUpdates()` only fetched release info for channels that existing installations were currently on. If all installs were on `stable`, the `latest` channel data was never fetched, leaving the channel card empty when viewing the update tab. Similarly, the manual "Check for Update" action only checked the current channel.

## Fix

- **`ipc.ts`**: Always fetch both `stable` and `latest` in the periodic auto-check instead of collecting channels from installations
- **`standalone.ts` / `portable.ts`**: Fetch both channels on manual `check-update` action so the other channel card also gets populated

## Testing

1. Delete `%APPDATA%\ComfyUI-Launcher\release-cache.json`
2. Launch with `pnpm dev`
3. Open an installation's detail → Update tab
4. Verify both channel cards show version info after the 3-second auto-check
5. Verify clicking "Check for Update" populates both cards

Fixes #115
