### PR TITLE
feat: desktop migration banner on dashboard when desktop is only install

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -20,7 +20,11 @@
     "pinToDashboard": "Pin to Dashboard",
     "unpinFromDashboard": "Unpin from Dashboard",
     "telemetryNotice": "Anonymous telemetry is collected to improve ComfyUI Launcher.",
-    "telemetrySettings": "Manage in Settings"
+    "telemetrySettings": "Manage in Settings",
+    "migrateBannerTitle": "Migrate to Standalone",
+    "migrateBannerDesc": "Your Desktop installation was detected. Migrate to a Standalone install for better performance, easier updates, and full Launcher management.",
+    "migrateBannerAction": "Migrate Now",
+    "migrateBannerLaunch": "Launch Desktop"
   },
 
   "sidebar": {

--- a/src/main/lib/desktopDetect.ts
+++ b/src/main/lib/desktopDetect.ts
@@ -1,10 +1,12 @@
 import fs from 'fs'
 import path from 'path'
+import os from 'os'
 import { execFile } from 'child_process'
 import { homedir } from 'os'
 import { MODEL_FOLDER_TYPES } from './models'
 import { scanCustomNodes } from './nodes'
-import type { Snapshot } from './snapshots'
+import { buildExportEnvelope } from './snapshots'
+import type { Snapshot, SnapshotExportEnvelope } from './snapshots'
 
 export interface DesktopInstallInfo {
   configDir: string
@@ -206,4 +208,24 @@ export async function captureDesktopSnapshot(info: DesktopInstallInfo): Promise<
     pipPackages,
     skipPipSync: true,
   }
+}
+
+/**
+ * Capture a Desktop snapshot, wrap it in an export envelope, and write it to a
+ * temp file.  Returns the envelope (for preview) and the staged file path.
+ */
+export async function stageDesktopSnapshot(
+  info: DesktopInstallInfo
+): Promise<{ envelope: SnapshotExportEnvelope; stagedFile: string }> {
+  const snapshot = await captureDesktopSnapshot(info)
+  const envelope = buildExportEnvelope('Desktop Migration', [
+    { filename: 'desktop-migration.json', snapshot },
+  ])
+
+  const stagingDir = path.join(os.tmpdir(), 'comfyui-launcher-snapshots')
+  await fs.promises.mkdir(stagingDir, { recursive: true })
+  const stagedFile = path.join(stagingDir, `desktop-migrate-${Date.now()}.json`)
+  await fs.promises.writeFile(stagedFile, JSON.stringify(envelope, null, 2))
+
+  return { envelope, stagedFile }
 }

--- a/src/main/lib/desktopMigration.ts
+++ b/src/main/lib/desktopMigration.ts
@@ -1,0 +1,198 @@
+import path from 'path'
+import fs from 'fs'
+import { detectDesktopInstall, stageDesktopSnapshot } from './desktopDetect'
+import { detectGPU } from './gpu'
+import { mergeDirFlat } from './migrate'
+import { download } from './download'
+import { createCache } from './cache'
+import { extractNested as extract } from './extract'
+import { defaultInstallDir } from './paths'
+import {
+  validateExportEnvelope, importSnapshots,
+  saveSnapshot, getSnapshotCount, restoreCustomNodes, restorePipPackages,
+} from './snapshots'
+import * as installations from '../installations'
+import type { InstallationRecord } from '../installations'
+import * as settings from '../settings'
+import * as i18n from './i18n'
+import type { SourcePlugin } from '../types/sources'
+
+const MARKER_FILE = '.comfyui-launcher'
+
+export interface MigrationTools {
+  sendProgress: (phase: string, detail: Record<string, unknown>) => void
+  sendOutput: (text: string) => void
+  signal: AbortSignal
+  sourceMap: Record<string, SourcePlugin>
+  uniqueName: (baseName: string) => Promise<string>
+  ensureDefaultPrimary: (entry: InstallationRecord) => void
+}
+
+export async function performDesktopMigration(
+  actionData: Record<string, unknown> | undefined,
+  tools: MigrationTools
+): Promise<{ entry: InstallationRecord; destPath: string }> {
+  const { sendProgress, sendOutput, signal, sourceMap, uniqueName, ensureDefaultPrimary } = tools
+
+  const desktopInfo = detectDesktopInstall()
+  if (!desktopInfo) {
+    throw new Error(i18n.t('desktop.notFound'))
+  }
+
+  sendProgress('steps', { steps: [
+    ...(!actionData?.snapshotPath ? [{ phase: 'scan', label: i18n.t('desktop.scanningDesktop') }] : []),
+    { phase: 'download', label: i18n.t('common.download') },
+    { phase: 'extract', label: i18n.t('common.extract') },
+    { phase: 'setup', label: i18n.t('standalone.setupEnv') },
+    { phase: 'restore-nodes', label: i18n.t('standalone.snapshotRestoreNodesPhase') },
+    { phase: 'migrate', label: i18n.t('desktop.copyingUserData') },
+  ] })
+
+  // 1. Prepare snapshot (use pre-staged file or scan live)
+  let stagedFile: string
+  // Track whether we created the staged file so we can clean it up on failure
+  let ownsStagedFile = false
+  if (actionData?.snapshotPath && typeof actionData.snapshotPath === 'string' && fs.existsSync(actionData.snapshotPath)) {
+    stagedFile = actionData.snapshotPath
+  } else {
+    sendProgress('scan', { percent: 0, status: i18n.t('desktop.scanningDesktop') })
+    sendProgress('scan', { percent: 30, status: i18n.t('desktop.creatingSnapshot') })
+    const staged = await stageDesktopSnapshot(desktopInfo)
+    stagedFile = staged.stagedFile
+    ownsStagedFile = true
+    sendProgress('scan', { percent: 100, status: i18n.t('common.done') })
+  }
+
+  const cleanupStagedFile = (): void => {
+    if (ownsStagedFile) fs.promises.unlink(stagedFile).catch(() => {})
+  }
+
+  // 2. Auto-detect GPU and pick release/variant
+  const standaloneSource = sourceMap['standalone']!
+  const releaseOptions = await standaloneSource.getFieldOptions('release', {}, {})
+  if (releaseOptions.length === 0) {
+    cleanupStagedFile()
+    throw new Error('No releases available.')
+  }
+  const latestRelease = releaseOptions[0]!
+
+  const gpu = await detectGPU()
+  const variantOptions = await standaloneSource.getFieldOptions('variant', { release: latestRelease }, { gpu: gpu?.id })
+  if (variantOptions.length === 0) {
+    cleanupStagedFile()
+    throw new Error('No compatible variants found for this platform.')
+  }
+  const matched = variantOptions.find((v) => v.recommended) || variantOptions[0]!
+
+  const instData = {
+    sourceId: 'standalone',
+    sourceLabel: standaloneSource.label,
+    ...standaloneSource.buildInstallation({ release: latestRelease, variant: matched }),
+  }
+
+  // 3. Create new standalone installation
+  const baseName = 'ComfyUI (from Desktop)'
+  const name = await uniqueName(baseName)
+  const dirName = name.replace(/[<>:"/\\|?*]+/g, '_').trim() || 'ComfyUI'
+  const installDir = defaultInstallDir()
+  let destPath = path.join(installDir, dirName)
+  let suffix = 1
+  while (fs.existsSync(destPath)) {
+    destPath = path.join(installDir, `${dirName} (${suffix})`)
+    suffix++
+  }
+
+  const entry = await installations.add({
+    name,
+    installPath: destPath,
+    pendingSnapshotRestore: stagedFile,
+    ...instData,
+    seen: false,
+  })
+  ensureDefaultPrimary(entry)
+
+  // 4. Install standalone (download + extract + setup env)
+  fs.mkdirSync(destPath, { recursive: true })
+  fs.writeFileSync(path.join(destPath, MARKER_FILE), entry.id)
+  const cache = createCache(settings.get('cacheDir') as string, settings.get('maxCachedFiles') as number)
+  const installRecord = { ...instData, installPath: destPath } as unknown as InstallationRecord
+  await standaloneSource.install!(installRecord, { sendProgress, download, cache, extract, signal })
+
+  const update = (data: Record<string, unknown>): Promise<void> =>
+    installations.update(entry.id, data).then(() => {})
+  await standaloneSource.postInstall!(installRecord, { sendProgress, update })
+
+  // 5. Restore snapshot (custom nodes + pip packages)
+  const freshInst = await installations.get(entry.id)
+  if (freshInst && fs.existsSync(stagedFile)) {
+    try {
+      const fileContent = await fs.promises.readFile(stagedFile, 'utf-8')
+      const importEnvelope = validateExportEnvelope(JSON.parse(fileContent))
+      await importSnapshots(freshInst.installPath, importEnvelope)
+      const targetSnapshot = importEnvelope.snapshots[0]!
+
+      sendOutput('\n── Restore Nodes ──\n')
+      await restoreCustomNodes(freshInst.installPath, freshInst, targetSnapshot, sendProgress, sendOutput, signal)
+
+      if (!signal.aborted && !targetSnapshot.skipPipSync) {
+        sendOutput('\n── Restore Packages ──\n')
+        await restorePipPackages(freshInst.installPath, freshInst, targetSnapshot,
+          (phase, data) => sendProgress(phase === 'restore' ? 'restore-pip' : phase, data),
+          sendOutput, signal)
+      }
+
+      try {
+        const snapFilename = await saveSnapshot(freshInst.installPath, freshInst, 'post-restore')
+        const snapshotCount = await getSnapshotCount(freshInst.installPath)
+        await update({ lastSnapshot: snapFilename, snapshotCount })
+      } catch {}
+    } catch (restoreErr) {
+      sendOutput(`\n⚠ Snapshot restore failed: ${(restoreErr as Error).message}\nYou can restore manually from the Snapshots tab.\n`)
+    } finally {
+      cleanupStagedFile()
+      await update({ pendingSnapshotRestore: undefined })
+    }
+  }
+
+  // 6. Copy user data (workflows + settings)
+  sendProgress('migrate', { percent: 0, status: i18n.t('desktop.copyingUserData') })
+  const srcUserDir = path.join(desktopInfo.basePath, 'user')
+  const dstComfyUI = path.join(destPath, 'ComfyUI')
+  if (fs.existsSync(srcUserDir)) {
+    const dstUserDir = path.join(dstComfyUI, 'user')
+    await mergeDirFlat(srcUserDir, dstUserDir, (copied, skipped, fileTotal) => {
+      const pct = fileTotal > 0 ? Math.round(((copied + skipped) / fileTotal) * 30) : 30
+      sendProgress('migrate', { percent: pct, status: i18n.t('desktop.copyingUserData') })
+    })
+  }
+
+  // 7. Copy input/output to shared directories
+  const srcInput = path.join(desktopInfo.basePath, 'input')
+  const dstInput = (settings.get('inputDir') as string | undefined) || settings.defaults.inputDir
+  if (fs.existsSync(srcInput)) {
+    sendProgress('migrate', { percent: 40, status: i18n.t('desktop.copyingInput') })
+    await mergeDirFlat(srcInput, dstInput)
+  }
+
+  const srcOutput = path.join(desktopInfo.basePath, 'output')
+  const dstOutput = (settings.get('outputDir') as string | undefined) || settings.defaults.outputDir
+  if (fs.existsSync(srcOutput)) {
+    sendProgress('migrate', { percent: 60, status: i18n.t('desktop.copyingOutput') })
+    await mergeDirFlat(srcOutput, dstOutput)
+  }
+
+  // 8. Add Desktop's models dir to shared paths (no copy)
+  sendProgress('migrate', { percent: 90, status: i18n.t('desktop.addingModels') })
+  const desktopModelsDir = path.resolve(path.join(desktopInfo.basePath, 'models'))
+  const currentModelsDirs = (settings.get('modelsDirs') as string[] | undefined) || [...settings.defaults.modelsDirs]
+  const normalizedCurrent = currentModelsDirs.map((d) => path.resolve(d))
+  if (fs.existsSync(desktopModelsDir) && !normalizedCurrent.includes(desktopModelsDir)) {
+    currentModelsDirs.push(desktopModelsDir)
+    settings.set('modelsDirs', currentModelsDirs)
+  }
+
+  sendProgress('migrate', { percent: 100, status: i18n.t('common.done') })
+  await installations.update(entry.id, { status: 'installed' })
+
+  return { entry, destPath }
+}

--- a/src/main/lib/ipc.ts
+++ b/src/main/lib/ipc.ts
@@ -20,8 +20,8 @@ import {
   findAvailablePort, writePortLock, readPortLock, removePortLock,
 } from './process'
 import { detectGPU, validateHardware, checkNvidiaDriver } from './gpu'
-import { detectDesktopInstall, syncSharedModelPaths, captureDesktopSnapshot } from './desktopDetect'
-import { mergeDirFlat } from './migrate'
+import { detectDesktopInstall, syncSharedModelPaths, stageDesktopSnapshot } from './desktopDetect'
+import { performDesktopMigration } from './desktopMigration'
 import { getDiskSpace, validateInstallPath } from './disk'
 import type { GpuInfo } from './gpu'
 import { formatTime } from './util'
@@ -89,21 +89,22 @@ async function uniqueName(baseName: string): Promise<string> {
 }
 
 /** Re-assign primary to the first remaining local install, or clear it. */
+function isPromotableLocal(sourceId: string): boolean {
+  const source = sourceMap[sourceId]
+  return !!source && source.category === 'local' && sourceId !== 'desktop'
+}
+
 async function autoAssignPrimary(removedId: string): Promise<void> {
   const currentPrimary = settings.get('primaryInstallId')
   if (currentPrimary !== removedId) return
   const all = (await installations.list()).filter((i) => i.id !== removedId)
-  const firstLocal = all.find((i) => {
-    const source = sourceMap[i.sourceId]
-    return source && source.category === 'local'
-  })
+  const firstLocal = all.find((i) => isPromotableLocal(i.sourceId))
   settings.set('primaryInstallId', firstLocal?.id)
 }
 
 /** Set as primary if this is the first local install and no primary is set. */
 function ensureDefaultPrimary(entry: InstallationRecord): void {
-  const source = sourceMap[entry.sourceId]
-  if (source && source.category === 'local' && !settings.get('primaryInstallId')) {
+  if (isPromotableLocal(entry.sourceId) && !settings.get('primaryInstallId')) {
     settings.set('primaryInstallId', entry.id)
   }
 }
@@ -555,13 +556,10 @@ export function register(callbacks: RegisterCallbacks = {}): void {
   ipcMain.handle('get-installations', async () => {
     const list = await installations.list()
 
-    // Ensure a primary is always set when local installs exist
+    // Ensure a primary is always set when promotable local installs exist
     const currentPrimary = settings.get('primaryInstallId')
     if (!currentPrimary || !list.some((i) => i.id === currentPrimary)) {
-      const firstLocal = list.find((i) => {
-        const s = sourceMap[i.sourceId]
-        return s && s.category === 'local'
-      })
+      const firstLocal = list.find((i) => isPromotableLocal(i.sourceId))
       const newPrimary = firstLocal?.id
       if (currentPrimary !== newPrimary) {
         settings.set('primaryInstallId', newPrimary)
@@ -1027,13 +1025,7 @@ export function register(callbacks: RegisterCallbacks = {}): void {
       const desktopInfo = detectDesktopInstall()
       if (!desktopInfo) return { ok: false, message: i18n.t('desktop.notFound') }
 
-      const snapshot = await captureDesktopSnapshot(desktopInfo)
-      const envelope = buildExportEnvelope('Desktop Migration', [{ filename: 'desktop-migration.json', snapshot }])
-
-      const stagingDir = path.join(os.tmpdir(), 'comfyui-launcher-snapshots')
-      await fs.promises.mkdir(stagingDir, { recursive: true })
-      const stagedFile = path.join(stagingDir, `desktop-migrate-${Date.now()}.json`)
-      await fs.promises.writeFile(stagedFile, JSON.stringify(envelope, null, 2))
+      const { envelope, stagedFile } = await stageDesktopSnapshot(desktopInfo)
 
       _lastDesktopPreviewFile = stagedFile
       return { ok: true, preview: buildSnapshotPreview(stagedFile, envelope), snapshotPath: stagedFile }
@@ -1363,6 +1355,9 @@ export function register(callbacks: RegisterCallbacks = {}): void {
       return { ok: true, navigate: 'list' }
     }
     if (actionId === 'set-primary-install') {
+      if (inst.sourceId === 'desktop') {
+        return { ok: false, message: 'Desktop installations cannot be set as primary.' }
+      }
       settings.set('primaryInstallId', installationId)
       return { ok: true }
     }
@@ -1569,168 +1564,23 @@ export function register(callbacks: RegisterCallbacks = {}): void {
       const abort = new AbortController()
       _operationAborts.set(installationId, abort)
 
-      const desktopInfo = detectDesktopInstall()
-      if (!desktopInfo) {
-        _operationAborts.delete(installationId)
-        return { ok: false, message: i18n.t('desktop.notFound') }
-      }
-
       let entry: InstallationRecord | null = null
       let destPath = ''
       try {
-        sendProgress('steps', { steps: [
-          ...(!actionData?.snapshotPath ? [{ phase: 'scan', label: i18n.t('desktop.scanningDesktop') }] : []),
-          { phase: 'download', label: i18n.t('common.download') },
-          { phase: 'extract', label: i18n.t('common.extract') },
-          { phase: 'setup', label: i18n.t('standalone.setupEnv') },
-          { phase: 'restore-nodes', label: i18n.t('standalone.snapshotRestoreNodesPhase') },
-          { phase: 'migrate', label: i18n.t('desktop.copyingUserData') },
-        ] })
-
-        let stagedFile: string
-        if (actionData?.snapshotPath && typeof actionData.snapshotPath === 'string' && fs.existsSync(actionData.snapshotPath)) {
-          stagedFile = actionData.snapshotPath
-        } else {
-          sendProgress('scan', { percent: 0, status: i18n.t('desktop.scanningDesktop') })
-          sendProgress('scan', { percent: 30, status: i18n.t('desktop.creatingSnapshot') })
-          const snapshot = await captureDesktopSnapshot(desktopInfo)
-          const envelope = buildExportEnvelope('Desktop Migration', [{ filename: 'desktop-migration.json', snapshot }])
-
-          const stagingDir = path.join(os.tmpdir(), 'comfyui-launcher-snapshots')
-          await fs.promises.mkdir(stagingDir, { recursive: true })
-          stagedFile = path.join(stagingDir, `desktop-migrate-${Date.now()}.json`)
-          await fs.promises.writeFile(stagedFile, JSON.stringify(envelope, null, 2))
-          sendProgress('scan', { percent: 100, status: i18n.t('common.done') })
-        }
-
-        // Auto-detect GPU and pick release/variant
-        const standaloneSource = sourceMap['standalone']!
-        const releaseOptions = await standaloneSource.getFieldOptions('release', {}, {})
-        if (releaseOptions.length === 0) {
-          _operationAborts.delete(installationId)
-          fs.promises.unlink(stagedFile).catch(() => {})
-          return { ok: false, message: 'No releases available.' }
-        }
-        const latestRelease = releaseOptions[0]!
-
-        const gpu = await detectGPU()
-        const variantOptions = await standaloneSource.getFieldOptions('variant', { release: latestRelease }, { gpu: gpu?.id })
-        if (variantOptions.length === 0) {
-          _operationAborts.delete(installationId)
-          fs.promises.unlink(stagedFile).catch(() => {})
-          return { ok: false, message: 'No compatible variants found for this platform.' }
-        }
-        const matched = variantOptions.find((v) => v.recommended) || variantOptions[0]!
-
-        const instData = {
-          sourceId: 'standalone',
-          sourceLabel: standaloneSource.label,
-          ...standaloneSource.buildInstallation({ release: latestRelease, variant: matched }),
-        }
-
-        // 3. Create new standalone installation
-        const baseName = 'ComfyUI (from Desktop)'
-        const name = await uniqueName(baseName)
-        const dirName = name.replace(/[<>:"/\\|?*]+/g, '_').trim() || 'ComfyUI'
-        const installDir = defaultInstallDir()
-        destPath = path.join(installDir, dirName)
-        let suffix = 1
-        while (fs.existsSync(destPath)) {
-          destPath = path.join(installDir, `${dirName} (${suffix})`)
-          suffix++
-        }
-
-        entry = await installations.add({
-          name,
-          installPath: destPath,
-          pendingSnapshotRestore: stagedFile,
-          ...instData,
-          seen: false,
+        const result = await performDesktopMigration(actionData, {
+          sendProgress,
+          sendOutput,
+          signal: abort.signal,
+          sourceMap,
+          uniqueName,
+          ensureDefaultPrimary,
         })
-        ensureDefaultPrimary(entry)
+        entry = result.entry
+        destPath = result.destPath
 
-        // 4. Install standalone (download + extract + setup env)
-        fs.mkdirSync(destPath, { recursive: true })
-        fs.writeFileSync(path.join(destPath, MARKER_FILE), entry.id)
-        const cache = createCache(settings.get('cacheDir') as string, settings.get('maxCachedFiles') as number)
-        const installRecord = { ...instData, installPath: destPath } as unknown as InstallationRecord
-        await standaloneSource.install!(installRecord, { sendProgress, download, cache, extract, signal: abort.signal })
+        // Promote the new standalone install to primary so the dashboard features it
+        settings.set('primaryInstallId', entry.id)
 
-        const update = (data: Record<string, unknown>): Promise<void> =>
-          installations.update(entry!.id, data).then(() => {})
-        await standaloneSource.postInstall!(installRecord, { sendProgress, update })
-
-        // 5. Restore snapshot (custom nodes + pip packages)
-        const freshInst = await installations.get(entry.id)
-        if (freshInst && fs.existsSync(stagedFile)) {
-          try {
-            const fileContent = await fs.promises.readFile(stagedFile, 'utf-8')
-            const importEnvelope = validateExportEnvelope(JSON.parse(fileContent))
-            await importSnapshots(freshInst.installPath, importEnvelope)
-            const targetSnapshot = importEnvelope.snapshots[0]!
-
-            sendOutput('\n── Restore Nodes ──\n')
-            await restoreCustomNodes(freshInst.installPath, freshInst, targetSnapshot, sendProgress, sendOutput, abort.signal)
-
-            if (!abort.signal.aborted && !targetSnapshot.skipPipSync) {
-              sendOutput('\n── Restore Packages ──\n')
-              await restorePipPackages(freshInst.installPath, freshInst, targetSnapshot,
-                (phase, data) => sendProgress(phase === 'restore' ? 'restore-pip' : phase, data),
-                sendOutput, abort.signal)
-            }
-
-            try {
-              const snapFilename = await saveSnapshot(freshInst.installPath, freshInst, 'post-restore')
-              const snapshotCount = await getSnapshotCount(freshInst.installPath)
-              await update({ lastSnapshot: snapFilename, snapshotCount })
-            } catch {}
-          } catch (restoreErr) {
-            sendOutput(`\n⚠ Snapshot restore failed: ${(restoreErr as Error).message}\nYou can restore manually from the Snapshots tab.\n`)
-          } finally {
-            fs.promises.unlink(stagedFile).catch(() => {})
-            await update({ pendingSnapshotRestore: undefined })
-          }
-        }
-
-        // 6. Copy user data (workflows + settings)
-        sendProgress('migrate', { percent: 0, status: i18n.t('desktop.copyingUserData') })
-        const srcUserDir = path.join(desktopInfo.basePath, 'user')
-        const dstComfyUI = path.join(destPath, 'ComfyUI')
-        if (fs.existsSync(srcUserDir)) {
-          const dstUserDir = path.join(dstComfyUI, 'user')
-          await mergeDirFlat(srcUserDir, dstUserDir, (copied, skipped, fileTotal) => {
-            const pct = fileTotal > 0 ? Math.round(((copied + skipped) / fileTotal) * 30) : 30
-            sendProgress('migrate', { percent: pct, status: i18n.t('desktop.copyingUserData') })
-          })
-        }
-
-        // 7. Copy input/output to shared directories
-        const srcInput = path.join(desktopInfo.basePath, 'input')
-        const dstInput = (settings.get('inputDir') as string | undefined) || settings.defaults.inputDir
-        if (fs.existsSync(srcInput)) {
-          sendProgress('migrate', { percent: 40, status: i18n.t('desktop.copyingInput') })
-          await mergeDirFlat(srcInput, dstInput)
-        }
-
-        const srcOutput = path.join(desktopInfo.basePath, 'output')
-        const dstOutput = (settings.get('outputDir') as string | undefined) || settings.defaults.outputDir
-        if (fs.existsSync(srcOutput)) {
-          sendProgress('migrate', { percent: 60, status: i18n.t('desktop.copyingOutput') })
-          await mergeDirFlat(srcOutput, dstOutput)
-        }
-
-        // 8. Add Desktop's models dir to shared paths (no copy)
-        sendProgress('migrate', { percent: 90, status: i18n.t('desktop.addingModels') })
-        const desktopModelsDir = path.resolve(path.join(desktopInfo.basePath, 'models'))
-        const currentModelsDirs = (settings.get('modelsDirs') as string[] | undefined) || [...settings.defaults.modelsDirs]
-        const normalizedCurrent = currentModelsDirs.map((d) => path.resolve(d))
-        if (fs.existsSync(desktopModelsDir) && !normalizedCurrent.includes(desktopModelsDir)) {
-          currentModelsDirs.push(desktopModelsDir)
-          settings.set('modelsDirs', currentModelsDirs)
-        }
-
-        sendProgress('migrate', { percent: 100, status: i18n.t('common.done') })
-        await installations.update(entry.id, { status: 'installed' })
         _operationAborts.delete(installationId)
         sendProgress('done', { percent: 100, status: 'Complete' })
         return { ok: true, navigate: 'list' }

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -721,7 +721,7 @@ input[type="checkbox"]:checked::after { transform: translateX(16px); }
 .dashboard-welcome-desc { font-size: 16px; color: var(--text-muted); margin-bottom: 28px; max-width: 400px; }
 .dashboard-cta-btn { display: inline-flex; align-items: center; gap: 8px; padding: 10px 24px; font-size: 14px; }
 .dashboard-telemetry-notice {
-  margin-top: 14px;
+  margin-top: 28px;
   max-width: 460px;
   font-size: 13px;
   color: var(--text-muted);

--- a/src/renderer/src/components/MigrationBanner.vue
+++ b/src/renderer/src/components/MigrationBanner.vue
@@ -1,0 +1,103 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useModal } from '../composables/useModal'
+import { ArrowRightLeft } from 'lucide-vue-next'
+import type { Installation } from '../types/ipc'
+
+const props = defineProps<{
+  installation: Installation
+}>()
+
+const emit = defineEmits<{
+  'show-progress': [opts: {
+    installationId: string
+    title: string
+    apiCall: () => Promise<unknown>
+    cancellable?: boolean
+  }]
+  'show-settings': []
+}>()
+
+const { t } = useI18n()
+const modal = useModal()
+const migrating = ref(false)
+
+async function startMigration(): Promise<void> {
+  if (migrating.value) return
+  migrating.value = true
+  try {
+    let previewResult: Awaited<ReturnType<typeof window.api.previewDesktopMigration>>
+    try {
+      previewResult = await window.api.previewDesktopMigration()
+    } catch (err) {
+      await modal.alert({
+        title: t('desktop.migrateToStandalone'),
+        message: (err as Error)?.message ?? String(err),
+      })
+      return
+    }
+    if (!previewResult.ok) {
+      if (previewResult.message) {
+        await modal.alert({ title: t('desktop.migrateToStandalone'), message: previewResult.message })
+      }
+      return
+    }
+    const confirmed = await modal.confirm({
+      title: t('desktop.migrateConfirmTitle'),
+      message: t('desktop.migrateConfirmMessage'),
+      snapshotPreview: previewResult.preview?.newestSnapshot,
+      messageDetails: [{
+        label: t('desktop.migrateConfirmTitle'),
+        items: [
+          t('desktop.copyingUserData'),
+          t('desktop.copyingInput'),
+          t('desktop.copyingOutput'),
+          t('desktop.addingModels'),
+        ],
+      }],
+      confirmLabel: t('desktop.migrateConfirm'),
+      confirmStyle: 'primary',
+    })
+    if (!confirmed) return
+
+    emit('show-progress', {
+      installationId: props.installation.id,
+      title: `${t('desktop.migrating')} — ${props.installation.name}`,
+      apiCall: () => window.api.runAction(
+        props.installation.id,
+        'migrate-to-standalone',
+        { snapshotPath: previewResult.snapshotPath }
+      ),
+      cancellable: true,
+    })
+  } finally {
+    migrating.value = false
+  }
+}
+
+</script>
+
+<template>
+  <div class="dashboard-welcome">
+    <div class="dashboard-welcome-icon">
+      <ArrowRightLeft :size="48" />
+    </div>
+    <h1 class="dashboard-welcome-title">{{ $t('dashboard.migrateBannerTitle') }}</h1>
+    <p class="dashboard-welcome-desc">{{ $t('dashboard.migrateBannerDesc') }}</p>
+    <button
+      class="primary dashboard-cta-btn"
+      :disabled="migrating"
+      @click="startMigration"
+    >
+      <ArrowRightLeft :size="18" />
+      {{ $t('dashboard.migrateBannerAction') }}
+    </button>
+    <p class="dashboard-telemetry-notice">
+      {{ $t('dashboard.telemetryNotice') }}
+      <button class="dashboard-telemetry-link" @click="emit('show-settings')">
+        {{ $t('dashboard.telemetrySettings') }}
+      </button>
+    </p>
+  </div>
+</template>

--- a/src/renderer/src/composables/useInstallContextMenu.ts
+++ b/src/renderer/src/composables/useInstallContextMenu.ts
@@ -22,7 +22,7 @@ export function useInstallContextMenu(onShowDetail: (inst: Installation) => void
       })
     }
 
-    if (inst.sourceCategory === 'local') {
+    if (inst.sourceCategory === 'local' && inst.sourceId !== 'desktop') {
       items.push({
         id: 'set-primary',
         label: t('dashboard.setPrimary'),

--- a/src/renderer/src/views/DashboardView.vue
+++ b/src/renderer/src/views/DashboardView.vue
@@ -10,6 +10,7 @@ import { useInstallContextMenu } from '../composables/useInstallContextMenu'
 import { emitTelemetryAction, toErrorBucket } from '../lib/telemetry'
 import { Download, Star, Clock, Cloud, Pin } from 'lucide-vue-next'
 import DashboardCard from '../components/DashboardCard.vue'
+import MigrationBanner from '../components/MigrationBanner.vue'
 import ContextMenu from '../components/ContextMenu.vue'
 import type { Installation, ListAction } from '../types/ipc'
 
@@ -54,10 +55,16 @@ const primaryInstall = computed(() => {
   return localInstalls.value[0] ?? null
 })
 
-// --- Latest install ---
+const desktopOnlyInstall = computed(() => {
+  if (localInstalls.value.length !== 1) return null
+  const only = localInstalls.value[0]!
+  return only.sourceId === 'desktop' ? only : null
+})
+
+// --- Latest install (exclude desktop) ---
 const latestInstall = computed(() => {
   const withTimestamp = installationStore.installations.filter(
-    (i) => i.sourceCategory !== 'cloud' && typeof i.lastLaunchedAt === 'number'
+    (i) => i.sourceCategory !== 'cloud' && i.sourceId !== 'desktop' && typeof i.lastLaunchedAt === 'number'
   )
   if (withTimestamp.length === 0) return null
   return withTimestamp.reduce((a, b) =>
@@ -279,7 +286,7 @@ async function handleLaunch(inst: Installation, actions: ListAction[]): Promise<
 
 // --- Change primary ---
 async function changePrimary(): Promise<void> {
-  const items = localInstalls.value.map((i) => ({
+  const items = localInstalls.value.filter((i) => i.sourceId !== 'desktop').map((i) => ({
     value: i.id,
     label: i.name,
     description: [i.sourceLabel, i.version].filter(Boolean).join(' · '),
@@ -318,8 +325,16 @@ async function changePrimary(): Promise<void> {
         </p>
       </div>
 
+      <!-- Desktop-only migration banner -->
+      <MigrationBanner
+        v-if="desktopOnlyInstall"
+        :installation="desktopOnlyInstall"
+        @show-progress="(opts) => emit('show-progress', opts)"
+        @show-settings="emit('show-settings')"
+      />
+
       <!-- Quick Launch section -->
-      <div v-if="primaryInstall" class="dashboard-section">
+      <div v-else-if="primaryInstall" class="dashboard-section">
         <div class="dashboard-section-label">{{ $t('dashboard.quickLaunch') }}</div>
         <div class="dashboard-quick-launch">
           <!-- Latest card -->

--- a/src/renderer/src/views/DetailModal.vue
+++ b/src/renderer/src/views/DetailModal.vue
@@ -44,6 +44,7 @@ const prefs = useLauncherPrefs()
 const installationStore = useInstallationStore()
 
 const isLocal = computed(() => props.installation?.sourceCategory === 'local')
+const isDesktop = computed(() => props.installation?.sourceId === 'desktop')
 const isCloud = computed(() => props.installation?.sourceCategory === 'cloud')
 const isPrimary = computed(() => props.installation ? prefs.isPrimary(props.installation.id) : false)
 const isPinned = computed(() => props.installation ? prefs.isPinned(props.installation.id) : false)
@@ -450,7 +451,7 @@ onUnmounted(() => {
         </div>
         <div class="detail-header-actions">
           <button
-            v-if="isLocal"
+            v-if="isLocal && !isDesktop"
             class="detail-header-btn"
             :class="{ active: isPrimary }"
             :disabled="isPrimary"


### PR DESCRIPTION
When Desktop is the only local installation, the dashboard shows a prominent migration banner instead of the normal Quick Launch section, encouraging users to migrate to a Standalone install.

## Changes

- **MigrationBanner component**: Full-page hero matching the welcome screen style, with a "Migrate Now" CTA that runs the preview/confirm/progress flow
- **Desktop installs excluded from primary**: New `isPromotableLocal()` helper in ipc.ts ensures desktop can never be set as primary
- **Desktop excluded from dashboard "Recent"**: `latestInstall` computed in DashboardView filters out desktop
- **Primary promotion after migration**: After successful migrate-to-standalone, the new standalone install is automatically set as primary
- **UI guards**: "Set as Primary" hidden in context menu and detail modal star button for desktop installs
- **Telemetry notice**: Shown on migration banner since it may be the user's first screen
- **Unified visual style**: Migration banner uses the same `dashboard-welcome` layout as the new-install welcome screen

Closes #116
