### PR TITLE
fix: stop syncing shared model dirs into Desktop's extra_models_config

### DIFF
--- a/src/main/lib/desktopDetect.test.ts
+++ b/src/main/lib/desktopDetect.test.ts
@@ -10,7 +10,7 @@ vi.mock('./nodes', () => ({
   scanCustomNodes: vi.fn().mockResolvedValue([]),
 }))
 
-import { detectDesktopInstall, findDesktopExecutable, syncSharedModelPaths, captureDesktopSnapshot } from './desktopDetect'
+import { detectDesktopInstall, findDesktopExecutable, captureDesktopSnapshot } from './desktopDetect'
 import type { DesktopInstallInfo } from './desktopDetect'
 
 describe('detectDesktopInstall', () => {
@@ -146,84 +146,6 @@ describe('findDesktopExecutable', () => {
     existsSyncSpy.mockReturnValue(false)
     expect(findDesktopExecutable()).toBeNull()
     vi.unstubAllGlobals()
-  })
-})
-
-describe('syncSharedModelPaths', () => {
-  let readFileSyncSpy: MockInstance
-  let writeFileSyncSpy: MockInstance
-  let mkdirSyncSpy: MockInstance
-
-  beforeEach(() => {
-    vi.restoreAllMocks()
-    readFileSyncSpy = vi.spyOn(fs, 'readFileSync')
-    writeFileSyncSpy = vi.spyOn(fs, 'writeFileSync').mockImplementation(() => {})
-    mkdirSyncSpy = vi.spyOn(fs, 'mkdirSync').mockReturnValue(undefined)
-  })
-
-  it('creates config with launcher sections when file does not exist', () => {
-    readFileSyncSpy.mockImplementation(() => { throw new Error('ENOENT') })
-
-    syncSharedModelPaths('/config/ComfyUI', ['/shared/models'])
-
-    expect(mkdirSyncSpy).toHaveBeenCalledWith('/config/ComfyUI', { recursive: true })
-    expect(writeFileSyncSpy).toHaveBeenCalledOnce()
-    const written = writeFileSyncSpy.mock.calls[0]![1] as string
-    expect(written).toContain('comfyui_launcher_0:')
-    expect(written).toContain('checkpoints: checkpoints/')
-    expect(written).toContain('loras: loras/')
-  })
-
-  it('preserves existing Desktop sections and appends launcher sections', () => {
-    readFileSyncSpy.mockReturnValue(
-      'comfyui_desktop:\n  base_path: /docs/ComfyUI\n  is_default: true\n'
-    )
-
-    syncSharedModelPaths('/config/ComfyUI', ['/shared/models'])
-
-    const written = writeFileSyncSpy.mock.calls[0]![1] as string
-    expect(written).toContain('comfyui_desktop:')
-    expect(written).toContain('base_path: /docs/ComfyUI')
-    expect(written).toContain('comfyui_launcher_0:')
-  })
-
-  it('replaces existing launcher sections on re-sync', () => {
-    readFileSyncSpy.mockReturnValue(
-      'comfyui_desktop:\n  base_path: /docs/ComfyUI\n\n' +
-      'comfyui_launcher_0:\n  base_path: /old/models\n  checkpoints: checkpoints/\n'
-    )
-
-    const newDir = path.resolve('/new/models')
-    syncSharedModelPaths('/config/ComfyUI', ['/new/models'])
-
-    const written = writeFileSyncSpy.mock.calls[0]![1] as string
-    expect(written).not.toContain('/old/models')
-    expect(written).toContain(newDir)
-    expect(written).toContain('comfyui_desktop:')
-    // Should have exactly one launcher section
-    expect(written.match(/comfyui_launcher_0:/g)).toHaveLength(1)
-  })
-
-  it('handles multiple model directories', () => {
-    readFileSyncSpy.mockImplementation(() => { throw new Error('ENOENT') })
-
-    syncSharedModelPaths('/config/ComfyUI', ['/models/a', '/models/b'])
-
-    const written = writeFileSyncSpy.mock.calls[0]![1] as string
-    expect(written).toContain('comfyui_launcher_0:')
-    expect(written).toContain('comfyui_launcher_1:')
-  })
-
-  it('writes no launcher sections when modelsDirs is empty', () => {
-    readFileSyncSpy.mockReturnValue(
-      'comfyui_desktop:\n  base_path: /docs/ComfyUI\n'
-    )
-
-    syncSharedModelPaths('/config/ComfyUI', [])
-
-    const written = writeFileSyncSpy.mock.calls[0]![1] as string
-    expect(written).toContain('comfyui_desktop:')
-    expect(written).not.toContain('comfyui_launcher_')
   })
 })
 

--- a/src/main/lib/desktopDetect.ts
+++ b/src/main/lib/desktopDetect.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import os from 'os'
 import { execFile } from 'child_process'
 import { homedir } from 'os'
-import { MODEL_FOLDER_TYPES } from './models'
+
 import { scanCustomNodes } from './nodes'
 import { buildExportEnvelope } from './snapshots'
 import type { Snapshot, SnapshotExportEnvelope } from './snapshots'
@@ -70,57 +70,6 @@ export function detectDesktopInstall(): DesktopInstallInfo | null {
     executablePath: findDesktopExecutable(),
     hasVenv: fs.existsSync(path.join(basePath, '.venv')),
   }
-}
-
-const LAUNCHER_KEY_PREFIX = 'comfyui_launcher_'
-
-/**
- * Inject the Launcher's shared model directories into Desktop's
- * extra_models_config.yaml so Desktop's ComfyUI instance can find them.
- */
-export function syncSharedModelPaths(configDir: string, modelsDirs: string[]): void {
-  const configPath = path.join(configDir, 'extra_models_config.yaml')
-
-  // Read existing config, preserving Desktop's own sections
-  const lines: string[] = []
-  try {
-    const existing = fs.readFileSync(configPath, 'utf-8')
-    // Keep all lines that don't belong to comfyui_launcher_* sections
-    let inLauncherSection = false
-    for (const line of existing.split(/\r?\n/)) {
-      if (/^\S/.test(line)) {
-        // Top-level key — check if it's one of ours
-        inLauncherSection = line.startsWith(LAUNCHER_KEY_PREFIX)
-      }
-      if (!inLauncherSection) {
-        lines.push(line)
-      }
-    }
-    // Remove trailing blank lines left from stripping
-    while (lines.length > 0 && lines[lines.length - 1]!.trim() === '') {
-      lines.pop()
-    }
-  } catch {
-    // Config doesn't exist yet — Desktop may not have run. Start fresh.
-    lines.push(`# ComfyUI extra_models_config.yaml`)
-  }
-
-  // Append Launcher shared model sections
-  if (modelsDirs.length > 0) {
-    lines.push('')
-    for (let i = 0; i < modelsDirs.length; i++) {
-      const escaped = path.resolve(modelsDirs[i]!).replace(/'/g, "''")
-      lines.push(`${LAUNCHER_KEY_PREFIX}${i}:`)
-      lines.push(`  base_path: '${escaped}'`)
-      for (const folder of MODEL_FOLDER_TYPES) {
-        lines.push(`  ${folder}: ${folder}/`)
-      }
-      lines.push('')
-    }
-  }
-
-  fs.mkdirSync(configDir, { recursive: true })
-  fs.writeFileSync(configPath, lines.join('\n'), 'utf-8')
 }
 
 function getDesktopPythonPath(basePath: string): string | null {

--- a/src/main/lib/ipc.ts
+++ b/src/main/lib/ipc.ts
@@ -20,7 +20,7 @@ import {
   findAvailablePort, writePortLock, readPortLock, removePortLock,
 } from './process'
 import { detectGPU, validateHardware, checkNvidiaDriver } from './gpu'
-import { detectDesktopInstall, syncSharedModelPaths, stageDesktopSnapshot } from './desktopDetect'
+import { detectDesktopInstall, stageDesktopSnapshot } from './desktopDetect'
 import { performDesktopMigration } from './desktopMigration'
 import { getDiskSpace, getDirectorySize, validateInstallPath } from './disk'
 import type { GpuInfo } from './gpu'
@@ -408,14 +408,6 @@ export function register(callbacks: RegisterCallbacks = {}): void {
         desktopExePath: desktopInfo.executablePath || undefined,
         status: 'installed',
       })
-
-      // Sync Launcher's shared model directories into Desktop's config
-      const modelsDirs = settings.get('modelsDirs') as string[] | undefined
-      if (modelsDirs && modelsDirs.length > 0) {
-        try {
-          syncSharedModelPaths(desktopInfo.configDir, modelsDirs)
-        } catch {}
-      }
     }
   }
 
@@ -1328,15 +1320,6 @@ export function register(callbacks: RegisterCallbacks = {}): void {
         if (!win.isDestroyed()) win.webContents.send('locale-changed', msgs)
       })
       if (_onLocaleChanged) _onLocaleChanged()
-    }
-    if (key === 'modelsDirs') {
-      // Re-sync shared model paths into Desktop's config if Desktop is tracked
-      const desktopInfo = detectDesktopInstall()
-      if (desktopInfo) {
-        try {
-          syncSharedModelPaths(desktopInfo.configDir, value as string[])
-        } catch {}
-      }
     }
     if (key === 'telemetryEnabled') {
       BrowserWindow.getAllWindows().forEach((win) => {


### PR DESCRIPTION
## Summary

Remove \syncSharedModelPaths\ so the Launcher no longer writes its shared model directories into Desktop's \xtra_models_config.yaml\.

## Problem

On startup and whenever \modelsDirs\ changed, the Launcher would inject \comfyui_launcher_*\ sections into Desktop's config file. This could cause:
- Stale entries if paths were removed from Launcher but not cleaned from Desktop's config
- Conflicts if Desktop was running concurrently
- Unexpected model paths appearing in Desktop's ComfyUI instance

## Changes

- **desktopDetect.ts** — Removed \syncSharedModelPaths\ function, \LAUNCHER_KEY_PREFIX\ constant, and \MODEL_FOLDER_TYPES\ import
- **ipc.ts** — Removed startup sync call and \modelsDirs\ setting change handler that triggered re-sync
- **desktopDetect.test.ts** — Removed associated test block (5 tests)

## Not affected

The migration flow (\desktopMigration.ts\) that adds Desktop's models dir to the Launcher's own \modelsDirs\ setting is unchanged — that's a one-time operation in the opposite direction.