### PR TITLE
fix: pin progress modal buttons to a sticky bottom bar

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -584,8 +584,14 @@ input[type="checkbox"]:checked::after { transform: translateX(16px); }
 .view-modal-body {
   flex: 1; min-height: 0;
   display: flex; flex-direction: column;
-  padding: 20px; overflow: hidden;
+  padding: 20px; overflow-y: auto;
 }
+.view-modal-footer {
+  flex-shrink: 0;
+  padding: 12px 20px;
+  border-top: 1px solid var(--border);
+}
+.view-modal-footer .view-bottom { padding-top: 0; }
 
 /* Modal dialog */
 .modal-overlay {

--- a/src/renderer/src/views/ProgressModal.vue
+++ b/src/renderer/src/views/ProgressModal.vue
@@ -377,6 +377,18 @@ defineExpose({ startOperation, showOperation })
           </div>
         </template>
 
+        <!-- Terminal output -->
+        <div
+          v-if="currentOp.terminalOutput"
+          id="progress-terminal"
+          ref="terminalRef"
+          class="terminal-output"
+          @scroll="handleTerminalScroll"
+        >{{ currentOp.terminalOutput }}</div>
+      </div>
+
+      <!-- Bottom bar (pinned outside scrollable body) -->
+      <div class="view-modal-footer">
         <!-- Port conflict actions -->
         <div
           v-if="
@@ -407,16 +419,6 @@ defineExpose({ startOperation, showOperation })
           </button>
         </div>
 
-        <!-- Terminal output -->
-        <div
-          v-if="currentOp.terminalOutput"
-          id="progress-terminal"
-          ref="terminalRef"
-          class="terminal-output"
-          @scroll="handleTerminalScroll"
-        >{{ currentOp.terminalOutput }}</div>
-
-        <!-- Bottom actions -->
         <div class="view-bottom">
           <button
             v-if="currentOp.finished && currentOp.result?.ok"


### PR DESCRIPTION
## Summary

Moves Cancel/Done buttons and port-conflict actions in the ProgressModal to a pinned bottom bar so they no longer slide around as content grows during operations.

## Changes

- **ProgressModal.vue**: Moved bottom action buttons and port-conflict actions out of the scrollable \iew-modal-body\ into a new \iew-modal-footer\ sibling element
- **main.css**: Added \iew-modal-footer\ styles (pinned via \lex-shrink: 0\, separated by \order-top\), made \iew-modal-body\ scrollable (\overflow-y: auto\), and zeroed out nested \.view-bottom\ padding to avoid double spacing

## Testing

- All pre-commit checks pass (typecheck, lint, build, 260 tests)
- Buttons stay fixed at the bottom of the modal regardless of terminal output length

Fixes #133