### PR TITLE
fix: fast stop with stopping state and Windows kill fix

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -268,6 +268,7 @@
     "title": "ComfyUI Console",
     "openInBrowser": "Open in Browser",
     "stop": "Stop",
+    "stopping": "Stopping…",
     "disconnect": "Disconnect",
     "connectedTo": "Connected to {url}",
     "processExited": "Process exited",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -193,6 +193,7 @@
     "title": "ComfyUI 控制台",
     "openInBrowser": "在浏览器中打开",
     "stop": "停止",
+    "stopping": "正在停止…",
     "disconnect": "断开连接",
     "connectedTo": "已连接到 {url}",
     "processExited": "进程已退出",

--- a/src/main/lib/ipc.ts
+++ b/src/main/lib/ipc.ts
@@ -2193,20 +2193,35 @@ export async function stopRunning(installationId?: string): Promise<void> {
   if (installationId) {
     const session = _runningSessions.get(installationId)
     if (!session) return
-    _removeSession(installationId)
+    _broadcastToRenderer('instance-stopping', { installationId })
+    // Remove from running map BEFORE killing so the exit handler in
+    // attachExitHandler sees this as a clean (intentional) stop, not a crash.
+    if (session.port) removePortLock(session.port)
+    _runningSessions.delete(installationId)
     if (session.proc && !session.proc.killed) {
       await killProcessTree(session.proc)
     }
+    _broadcastToRenderer('instance-stopped', { installationId })
   } else {
-    const kills: Promise<void>[] = []
-    for (const [_id, session] of _runningSessions) {
-      if (session.proc && !session.proc.killed) {
-        kills.push(killProcessTree(session.proc))
-      }
+    const sessions = [..._runningSessions.entries()]
+    for (const [id] of sessions) {
+      _broadcastToRenderer('instance-stopping', { installationId: id })
+    }
+    // Remove all from running map before killing
+    for (const [, session] of sessions) {
       if (session.port) removePortLock(session.port)
     }
     _runningSessions.clear()
+    const kills: Promise<void>[] = []
+    for (const [, session] of sessions) {
+      if (session.proc && !session.proc.killed) {
+        kills.push(killProcessTree(session.proc))
+      }
+    }
     await Promise.all(kills)
+    for (const [id] of sessions) {
+      _broadcastToRenderer('instance-stopped', { installationId: id })
+    }
   }
 }
 

--- a/src/main/lib/process.ts
+++ b/src/main/lib/process.ts
@@ -57,13 +57,27 @@ export function killProcTree(proc: ChildProcess): void {
 export function killProcessTree(proc: ChildProcess | null): Promise<void> {
   if (!proc || proc.killed) return Promise.resolve()
   return new Promise<void>((resolve) => {
+    let settled = false
+    const done = (): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timeout)
+      proc.stdout?.destroy()
+      proc.stderr?.destroy()
+      resolve()
+    }
     // Resolve once the process actually exits, or after a timeout
-    const timeout = setTimeout(resolve, 5000)
-    proc.once('exit', () => { clearTimeout(timeout); resolve() })
+    const timeout = setTimeout(done, 5000)
+    proc.once('exit', done)
     if (process.platform === "win32") {
+      // Kill the direct child via process.kill() which is instant on Windows.
+      // Then fire-and-forget taskkill /T /F to clean up any orphaned
+      // grandchildren (e.g. Python subprocesses). We don't await taskkill
+      // because it can take 5-7+ seconds on Windows even for simple kills.
+      try { process.kill(proc.pid!) } catch { done() }
       execFile("taskkill", ["/T", "/F", "/PID", String(proc.pid)], { windowsHide: true }, () => {})
     } else {
-      try { process.kill(-proc.pid!, "SIGKILL") } catch {}
+      try { process.kill(-proc.pid!, "SIGKILL") } catch { done() }
     }
   })
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -144,6 +144,11 @@ const api: ElectronApi = {
     ipcRenderer.on('instance-started', handler)
     return () => ipcRenderer.removeListener('instance-started', handler)
   },
+  onInstanceStopping: (callback) => {
+    const handler = (_event: IpcRendererEvent, data: unknown) => callback(data as Parameters<typeof callback>[0])
+    ipcRenderer.on('instance-stopping', handler)
+    return () => ipcRenderer.removeListener('instance-stopping', handler)
+  },
   onInstanceStopped: (callback) => {
     const handler = (_event: IpcRendererEvent, data: unknown) => callback(data as Parameters<typeof callback>[0])
     ipcRenderer.on('instance-stopped', handler)

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -364,6 +364,7 @@ input[type="checkbox"]:checked::after { transform: translateX(16px); }
 .update-pill:hover { background: var(--warning); color: #1a1a1a; }
 .status-in-progress { color: var(--accent); font-weight: 600; }
 .instance-card.card-running { border-color: var(--accent); }
+.instance-card.card-stopping { border-color: var(--accent); animation: card-breathe 2s ease-in-out infinite; }
 .instance-card.card-in-progress { border-color: var(--accent); animation: card-breathe 2s ease-in-out infinite; }
 .instance-actions { display: flex; gap: 8px; }
 
@@ -804,6 +805,7 @@ select.field-input { cursor: pointer; }
   display: flex; flex-direction: column; gap: 12px;
 }
 .dashboard-card.card-running, .dashboard-cloud-card.card-running { border-color: var(--accent); }
+.dashboard-card.card-stopping, .dashboard-cloud-card.card-stopping { border-color: var(--accent); animation: card-breathe 2s ease-in-out infinite; }
 .dashboard-card.card-in-progress, .dashboard-cloud-card.card-in-progress { border-color: var(--accent); animation: card-breathe 2s ease-in-out infinite; }
 .dashboard-card-badge {
   display: flex; align-items: center; gap: 6px;

--- a/src/renderer/src/components/DashboardCard.vue
+++ b/src/renderer/src/components/DashboardCard.vue
@@ -32,6 +32,10 @@ const running = computed(() =>
   sessionStore.runningInstances.get(props.installation.id) ?? null
 )
 
+const stopping = computed(() =>
+  sessionStore.isStopping(props.installation.id)
+)
+
 const progress = computed(() =>
   progressStore.getProgressInfo(props.installation.id)
 )
@@ -68,7 +72,11 @@ function stopComfyUI(): void {
         <span> · </span>
         <span>{{ installation.version }}</span>
       </template>
-      <template v-if="running">
+      <template v-if="stopping">
+        <span> · </span>
+        <span class="status-in-progress">{{ $t('console.stopping') }}</span>
+      </template>
+      <template v-else-if="running">
         <span> · </span>
         <span class="status-running">{{ $t('list.running') }}</span>
       </template>
@@ -96,8 +104,15 @@ function stopComfyUI(): void {
   </div>
 
   <div class="dashboard-card-actions">
+    <!-- Stopping -->
+    <template v-if="stopping">
+      <button class="danger-solid dashboard-cta-btn" disabled>
+        {{ $t('console.stopping') }}
+      </button>
+    </template>
+
     <!-- Running -->
-    <template v-if="running">
+    <template v-else-if="running">
       <button
         v-if="running.mode !== 'console'"
         class="primary dashboard-cta-btn"

--- a/src/renderer/src/components/InstanceCard.vue
+++ b/src/renderer/src/components/InstanceCard.vue
@@ -8,6 +8,7 @@ const props = defineProps<{
   draggable?: boolean
   sourceCategory?: string
   running?: boolean
+  stopping?: boolean
   inProgress?: boolean
 }>()
 
@@ -17,7 +18,7 @@ const prefs = useLauncherPrefs()
 <template>
   <div
     class="instance-card"
-    :class="{ 'card-running': running, 'card-in-progress': inProgress }"
+    :class="{ 'card-running': running && !stopping, 'card-stopping': stopping, 'card-in-progress': inProgress }"
     :data-id="installationId"
   >
     <div

--- a/src/renderer/src/stores/sessionStore.test.ts
+++ b/src/renderer/src/stores/sessionStore.test.ts
@@ -181,6 +181,10 @@ describe('useSessionStore', () => {
           handlers['instance-stopped'] = cb
           return () => {}
         }),
+        onInstanceStopping: vi.fn((cb: (data: unknown) => void) => {
+          handlers['instance-stopping'] = cb
+          return () => {}
+        }),
         onComfyOutput: vi.fn(() => () => {}),
         onComfyExited: vi.fn(() => () => {}),
       }

--- a/src/renderer/src/stores/sessionStore.ts
+++ b/src/renderer/src/stores/sessionStore.ts
@@ -22,6 +22,7 @@ export const useSessionStore = defineStore('session', () => {
   const launchingInstances = reactive(new Map<string, { installationName: string }>())
   const activeSessions = reactive(new Map<string, ActiveSession>())
   const errorInstances = reactive(new Map<string, ErrorInstance>())
+  const stoppingInstances = reactive(new Set<string>())
   const sessions = reactive(new Map<string, SessionBuffer>())
 
   const runningTabCount = computed(() => activeSessions.size + runningInstances.size)
@@ -36,6 +37,10 @@ export const useSessionStore = defineStore('session', () => {
 
   function isLaunching(installationId: string): boolean {
     return launchingInstances.has(installationId)
+  }
+
+  function isStopping(installationId: string): boolean {
+    return stoppingInstances.has(installationId)
   }
 
   function setActiveSession(installationId: string, label: string): void {
@@ -120,6 +125,10 @@ export const useSessionStore = defineStore('session', () => {
       }),
       window.api.onInstanceStopped((data: { installationId: string }) => {
         runningInstances.delete(data.installationId)
+        stoppingInstances.delete(data.installationId)
+      }),
+      window.api.onInstanceStopping((data: { installationId: string }) => {
+        stoppingInstances.add(data.installationId)
       }),
       window.api.onComfyOutput((data: ComfyOutputData) => {
         appendOutput(data.installationId, data.text)
@@ -158,6 +167,8 @@ export const useSessionStore = defineStore('session', () => {
     hasErrors,
     isRunning,
     isLaunching,
+    stoppingInstances,
+    isStopping,
     setActiveSession,
     clearActiveSession,
     clearErrorInstance,

--- a/src/renderer/src/views/ConsoleModal.vue
+++ b/src/renderer/src/views/ConsoleModal.vue
@@ -36,6 +36,11 @@ const errorInfo = computed(() => {
   return sessionStore.errorInstances.get(props.installationId)
 })
 
+const isStopping = computed(() => {
+  if (!props.installationId) return false
+  return sessionStore.isStopping(props.installationId)
+})
+
 const isExited = computed(() => {
   return session.value ? session.value.exited : true
 })
@@ -150,7 +155,14 @@ function handleOverlayClick(event: MouseEvent): void {
             {{ $t('console.openInBrowser') }}
           </button>
           <button
-            v-if="!isExited && !errorInfo"
+            v-if="isStopping"
+            class="danger-solid"
+            disabled
+          >
+            {{ $t('console.stopping') }}
+          </button>
+          <button
+            v-else-if="!isExited && !errorInfo"
             class="danger-solid"
             @click="api.stopComfyUI(installationId!)"
           >

--- a/src/renderer/src/views/DashboardView.vue
+++ b/src/renderer/src/views/DashboardView.vue
@@ -354,7 +354,7 @@ async function changePrimary(): Promise<void> {
         <div class="dashboard-section-label">{{ $t('dashboard.quickLaunch') }}</div>
         <div class="dashboard-quick-launch">
           <!-- Latest card -->
-          <div v-if="showLatestCard && latestInstall" class="dashboard-card" :class="{ 'card-running': sessionStore.isRunning(latestInstall.id), 'card-in-progress': isInProgress(latestInstall.id) }" @contextmenu.prevent="openCardMenu($event, latestInstall!)">
+          <div v-if="showLatestCard && latestInstall" class="dashboard-card" :class="{ 'card-running': sessionStore.isRunning(latestInstall.id) && !sessionStore.isStopping(latestInstall.id), 'card-stopping': sessionStore.isStopping(latestInstall.id), 'card-in-progress': isInProgress(latestInstall.id) }" @contextmenu.prevent="openCardMenu($event, latestInstall!)">
             <div class="dashboard-card-badge">
               <Clock :size="14" />
               {{ $t('dashboard.recent') }}
@@ -377,7 +377,7 @@ async function changePrimary(): Promise<void> {
           </div>
 
           <!-- Primary card -->
-          <div class="dashboard-card" :class="{ 'card-running': sessionStore.isRunning(primaryInstall.id), 'card-in-progress': isInProgress(primaryInstall.id) }" @contextmenu.prevent="openCardMenu($event, primaryInstall!)">
+          <div class="dashboard-card" :class="{ 'card-running': sessionStore.isRunning(primaryInstall.id) && !sessionStore.isStopping(primaryInstall.id), 'card-stopping': sessionStore.isStopping(primaryInstall.id), 'card-in-progress': isInProgress(primaryInstall.id) }" @contextmenu.prevent="openCardMenu($event, primaryInstall!)">
             <div class="dashboard-card-badge dashboard-card-badge-primary">
               <Star :size="14" />
               {{ $t('dashboard.primary') }}
@@ -417,7 +417,7 @@ async function changePrimary(): Promise<void> {
             v-for="pinned in pinnedInstalls"
             :key="pinned.id"
             class="dashboard-card"
-            :class="{ 'card-running': sessionStore.isRunning(pinned.id), 'card-in-progress': isInProgress(pinned.id) }"
+            :class="{ 'card-running': sessionStore.isRunning(pinned.id) && !sessionStore.isStopping(pinned.id), 'card-stopping': sessionStore.isStopping(pinned.id), 'card-in-progress': isInProgress(pinned.id) }"
             @contextmenu.prevent="openCardMenu($event, pinned)"
           >
             <DashboardCard

--- a/src/renderer/src/views/InstallationList.vue
+++ b/src/renderer/src/views/InstallationList.vue
@@ -328,6 +328,7 @@ defineExpose({ refresh })
           :source-category="inst.sourceCategory"
           :draggable="true"
           :running="sessionStore.isRunning(inst.id)"
+          :stopping="sessionStore.isStopping(inst.id)"
           :in-progress="isInProgress(inst.id)"
           @mousedown="markSeen(inst)"
           @contextmenu.prevent="openCardMenu($event, inst)"
@@ -365,8 +366,15 @@ defineExpose({ refresh })
           </template>
 
           <template #actions>
+            <!-- Stopping -->
+            <template v-if="sessionStore.isStopping(inst.id)">
+              <button class="danger-solid" disabled>
+                {{ $t('console.stopping') }}
+              </button>
+            </template>
+
             <!-- In-progress -->
-            <template v-if="sessionStore.activeSessions.has(inst.id) && !sessionStore.isRunning(inst.id)">
+            <template v-else-if="sessionStore.activeSessions.has(inst.id) && !sessionStore.isRunning(inst.id)">
               <button
                 class="primary"
                 @click="emit('show-progress', {

--- a/src/renderer/src/views/RunningView.vue
+++ b/src/renderer/src/views/RunningView.vue
@@ -155,6 +155,7 @@ const emit = defineEmits<{
               :key="installationId"
               :name="getRunningName(installationId)"
               :running="true"
+              :stopping="sessionStore.isStopping(installationId)"
             >
               <template #meta>
                 <template v-for="(part, i) in getRunningMetaParts(installationId)" :key="i">
@@ -164,22 +165,29 @@ const emit = defineEmits<{
                 </template>
               </template>
               <template #actions>
-                <button
-                  v-if="sessionStore.runningInstances.get(installationId)?.mode !== 'console'"
-                  class="primary"
-                  @click="focusComfyWindow(installationId)"
-                >
-                  {{ $t('running.showWindow') }}
-                </button>
-                <button
-                  v-if="!instMap.get(installationId) || instMap.get(installationId)?.hasConsole"
-                  @click="emit('show-console', installationId)"
-                >
-                  {{ $t('list.console') }}
-                </button>
-                <button class="danger-solid" @click="stopComfyUI(installationId)">
-                  {{ $t('console.stop') }}
-                </button>
+                <template v-if="sessionStore.isStopping(installationId)">
+                  <button class="danger-solid" disabled>
+                    {{ $t('console.stopping') }}
+                  </button>
+                </template>
+                <template v-else>
+                  <button
+                    v-if="sessionStore.runningInstances.get(installationId)?.mode !== 'console'"
+                    class="primary"
+                    @click="focusComfyWindow(installationId)"
+                  >
+                    {{ $t('running.showWindow') }}
+                  </button>
+                  <button
+                    v-if="!instMap.get(installationId) || instMap.get(installationId)?.hasConsole"
+                    @click="emit('show-console', installationId)"
+                  >
+                    {{ $t('list.console') }}
+                  </button>
+                  <button class="danger-solid" @click="stopComfyUI(installationId)">
+                    {{ $t('console.stop') }}
+                  </button>
+                </template>
                 <button
                   v-if="instMap.get(installationId)"
                   class="manage-btn"

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -589,6 +589,7 @@ export interface ElectronApi {
   onInstanceLaunching(callback: (data: { installationId: string; installationName: string }) => void): Unsubscribe
   onInstanceLaunchFailed(callback: (data: { installationId: string }) => void): Unsubscribe
   onInstanceStarted(callback: (data: RunningInstance) => void): Unsubscribe
+  onInstanceStopping(callback: (data: { installationId: string }) => void): Unsubscribe
   onInstanceStopped(callback: (data: { installationId: string }) => void): Unsubscribe
   onThemeChanged(callback: (theme: ResolvedTheme) => void): Unsubscribe
   onLocaleChanged(callback: (messages: Record<string, unknown>) => void): Unsubscribe


### PR DESCRIPTION
Fixes #179

## Problem
Clicking Stop or closing the ComfyUI window caused three issues:
1. **UI desync:** The card instantly flipped to idle while the process was still alive
2. **Slow stop on Windows:** `taskkill /T /F` takes 5-7+ seconds on Windows, blocking the entire stop flow
3. **False crash detection:** After fixing the speed, the exit handler saw the non-zero exit code and registered a crash

## Solution

### 1. Stopping intermediate state
Add an `instance-stopping` IPC event so cards show a pulsing border and disabled "Stopping..." button while the process is being killed, instead of instantly flipping to idle.

- Broadcast `instance-stopping` immediately when stop is requested
- Broadcast `instance-stopped` only after the process is actually dead
- Renderer tracks `stoppingInstances` Set with `isStopping()` helper

### 2. Fast Windows process kill
Replace the slow `taskkill`-only approach with a two-step strategy:
- `process.kill(pid)` first — instant on Windows, fires the `exit` event in ~2ms
- Fire-and-forget `taskkill /T /F` in the background to clean up any orphaned grandchildren (Python subprocesses)
- Destroy piped stdout/stderr on completion to prevent lingering handles

### 3. Crash detection fix
Remove the session from `_runningSessions` **before** killing, so the `attachExitHandler` exit callback sees `_runningSessions.has(id) === false` and correctly treats it as a clean (intentional) stop rather than a crash.

## Changes

| File | Change |
|------|--------|
| `src/main/lib/process.ts` | Two-step kill: `process.kill()` + fire-and-forget `taskkill`; destroy pipes; resolve if already dead |
| `src/main/lib/ipc.ts` | `stopRunning()`: broadcast stopping, remove session before kill, broadcast stopped after |
| `src/types/ipc.ts` | Add `onInstanceStopping` type |
| `src/preload/index.ts` | Add `onInstanceStopping` IPC listener |
| `src/renderer/src/stores/sessionStore.ts` | Add `stoppingInstances` Set, `isStopping()` helper, IPC listener |
| `src/renderer/src/components/InstanceCard.vue` | Add `stopping` prop, `card-stopping` CSS class |
| `src/renderer/src/components/DashboardCard.vue` | Show "Stopping..." status text and disabled button |
| `src/renderer/src/views/DashboardView.vue` | `card-stopping` class on dashboard cards |
| `src/renderer/src/views/InstallationList.vue` | Stopping prop + disabled button |
| `src/renderer/src/views/RunningView.vue` | Stopping prop + disabled button |
| `src/renderer/src/views/ConsoleModal.vue` | Disabled "Stopping..." button |
| `src/renderer/src/assets/main.css` | `.card-stopping` with breathing animation |
| `locales/en.json` + `locales/zh.json` | `console.stopping` translation key |
| `src/renderer/src/stores/sessionStore.test.ts` | Add `onInstanceStopping` mock |

## Testing
- All 267 tests pass
- Typecheck, lint, and build all pass
- Manually verified: stop is now near-instant on Windows with no false crash
