### PR TITLE
fix: remove unsafe-best-match index strategy to improve resolution speed

### DIFF
--- a/src/main/lib/pip.test.ts
+++ b/src/main/lib/pip.test.ts
@@ -18,16 +18,12 @@ describe('getPipIndexArgs', () => {
     expect(extraCount).toBe(PYPI_MIRROR_URLS.length)
   })
 
-  it('always includes --index-strategy unsafe-best-match', () => {
+  it('does not include --index-strategy', () => {
     const noMirror = getPipIndexArgs()
-    const idx1 = noMirror.indexOf('--index-strategy')
-    expect(idx1).toBeGreaterThanOrEqual(0)
-    expect(noMirror[idx1 + 1]).toBe('unsafe-best-match')
+    expect(noMirror).not.toContain('--index-strategy')
 
     const withMirror = getPipIndexArgs('https://custom.mirror.example/simple/')
-    const idx2 = withMirror.indexOf('--index-strategy')
-    expect(idx2).toBeGreaterThanOrEqual(0)
-    expect(withMirror[idx2 + 1]).toBe('unsafe-best-match')
+    expect(withMirror).not.toContain('--index-strategy')
   })
 
   it('adds user mirror as --extra-index-url when provided', () => {

--- a/src/main/lib/pip.ts
+++ b/src/main/lib/pip.ts
@@ -84,19 +84,16 @@ export const PYPI_MIRROR_URLS: string[] = [
 ]
 
 /**
- * Build `--index-url`, `--extra-index-url`, and `--index-strategy` arguments
- * for uv pip commands.
+ * Build `--index-url` and `--extra-index-url` arguments for uv pip commands.
  *
  * pypi.org is always the primary `--index-url`.  The Chinese mirrors are
  * added as `--extra-index-url`.  When a user-configured mirror is set it is
  * also added as an extra (de-duplicated against the lists above).
  *
- * We always pass `--index-strategy unsafe-best-match` so that uv queries
- * **all** indexes and picks the best available version.  Without this, uv's
- * default `first-match` strategy stops at the first index that carries the
- * package name — if that index lags behind on versions the install fails
- * even though pypi.org has the required version.  This is safe here because
- * every configured index is a public PyPI mirror (no private indexes).
+ * uv's default `first-match` strategy checks the primary index first and
+ * only falls back to extras when a package is not found there.  This keeps
+ * resolution fast for users with good connectivity to pypi.org while still
+ * providing fallback mirrors for regions where pypi.org is unreachable.
  */
 
 /** Trim whitespace and ensure a trailing slash for consistent URL comparison. */
@@ -131,7 +128,6 @@ export function getPipIndexArgs(pypiMirror?: string): string[] {
   for (const url of extras) {
     args.push('--extra-index-url', url)
   }
-  args.push('--index-strategy', 'unsafe-best-match')
   return args
 }
 


### PR DESCRIPTION
## Summary

Remove the `--index-strategy unsafe-best-match` flag from `getPipIndexArgs()` to fix a performance regression in uv/pip resolution during updates.

## Problem

With `unsafe-best-match`, uv queries **every** configured index (pypi.org, Aliyun, Tencent) for **every** package during resolution. For users outside China who cannot reach the mirrors quickly, this adds ~10-20s of unnecessary latency to each resolve step.

Example from an update:
- `Resolved 97 packages in 11.64s` (ComfyUI requirements)
- `Resolved 43 packages in 6.98s` (Manager requirements)

## Fix

Use uv's default `first-match` strategy instead. This checks the primary `--index-url` (pypi.org) first and only falls back to `--extra-index-url` mirrors (Aliyun, Tencent) when a package is not found there. Resolution is near-instant for users with good connectivity to pypi.org, while Chinese users still get mirror fallback when pypi.org is unreachable.

## Changes

- **`pip.ts`**: Remove `--index-strategy unsafe-best-match` from `getPipIndexArgs()`, update JSDoc
- **`pip.test.ts`**: Update test to assert no `--index-strategy` is set

Fixes #201
