### PR TITLE
fix: populate baseTag for stable channel to prevent bare-hash version display

### DIFF
--- a/src/main/lib/comfyui-releases.ts
+++ b/src/main/lib/comfyui-releases.ts
@@ -60,7 +60,14 @@ export async function fetchLatestRelease(
   const releases = await fetchJSON(
     'https://api.github.com/repos/Comfy-Org/ComfyUI/releases?per_page=30'
   ) as GitHubRelease[]
-  return (releases.find((r) => !r.draft && !r.prerelease) as Record<string, unknown> | undefined) ?? null
+  const stable = releases.find((r) => !r.draft && !r.prerelease)
+  if (!stable) return null
+  // Populate structured version fields so buildCacheEntry stores them.
+  // A stable release IS the tag, so commitsAhead is always 0.
+  const release = stable as unknown as Record<string, unknown>
+  release.baseTag = stable.tag_name
+  release.commitsAhead = 0
+  return release
 }
 
 export function truncateNotes(text: string, maxLen: number): string {

--- a/src/main/sources/standalone.ts
+++ b/src/main/sources/standalone.ts
@@ -1161,12 +1161,18 @@ export const standalone: SourcePlugin = {
       const cachedRelease = releaseCache.get(COMFYUI_REPO, channel) || {}
       const fullPostHead = markers.POST_UPDATE_HEAD || null
 
-      // Build structured comfyVersion from raw data
+      // Build structured comfyVersion from raw data.
+      // For stable updates, CHECKED_OUT_TAG is the most reliable baseTag source
+      // (comes directly from the git checkout). The cache may lack baseTag if
+      // the release was fetched before the structured-version fields were added.
+      const checkedOutTag = markers.CHECKED_OUT_TAG || undefined
       const comfyVersion: ComfyVersion | undefined = fullPostHead
         ? {
           commit: fullPostHead,
-          baseTag: cachedRelease.baseTag as string | undefined,
-          commitsAhead: cachedRelease.commitsAhead as number | undefined,
+          baseTag: (cachedRelease.baseTag as string | undefined) ?? checkedOutTag,
+          commitsAhead: checkedOutTag
+            ? (cachedRelease.commitsAhead as number | undefined) ?? 0
+            : (cachedRelease.commitsAhead as number | undefined),
         }
         : undefined
       const installedTag = comfyVersion


### PR DESCRIPTION
## Problem

When switching from the **latest** update channel to **stable**, the version displayed as a bare commit hash (e.g. `a1b2c3d`) instead of the tag (e.g. `v0.14.2`). This triggered a false update prompt because `isUpdateAvailable` saw a mismatch between the hash-based `installedTag` and the tag-based `latestTag`.

## Root Cause

`fetchLatestRelease('stable')` returned a raw GitHub release object without `baseTag`, `commitsAhead`, or `commitSha` fields. When `buildCacheEntry` processed this, it stored them all as `undefined`. The post-update code in `standalone.ts` then built a `ComfyVersion` with `baseTag: undefined`, causing `formatComfyVersion` to hit the `if (!baseTag) return shortSha` fallback.

## Fix

**Two-part fix for defense in depth:**

1. **`comfyui-releases.ts`** — The stable path now populates `baseTag = tag_name` and `commitsAhead = 0` on the release object before returning it, so `buildCacheEntry` stores proper structured version data.

2. **`standalone.ts`** — Post-update version building now uses the `CHECKED_OUT_TAG` marker (emitted by the Python update script) as a fallback for `baseTag`, with `commitsAhead = 0`. This protects against stale or pre-refactor cache entries that lack the structured fields.

## Testing

- All 304 existing tests pass
- Typecheck, lint, build all clean
