### PR TITLE
chore: update GitHub repo URLs after repository renames

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -21,7 +21,7 @@ asarUnpack:
 publish:
   provider: github
   owner: Comfy-Org
-  repo: ComfyUI-Launcher
+  repo: ComfyUI-Desktop-2.0-Beta
 artifactName: ComfyUI-Desktop-2.0-${version}-${os}-${arch}.${ext}
 win:
   target: nsis

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "name": "Jedrzej Kosinski",
     "email": "kosinkadink@users.noreply.github.com"
   },
-  "repository": "github:Comfy-Org/ComfyUI-Launcher",
-  "homepage": "https://github.com/Comfy-Org/ComfyUI-Launcher",
+  "repository": "github:Comfy-Org/ComfyUI-Desktop-2.0-Beta",
+  "homepage": "https://github.com/Comfy-Org/ComfyUI-Desktop-2.0-Beta",
   "engines": {
     "node": ">=22",
     "pnpm": ">=10"

--- a/src/main/lib/ipc.ts
+++ b/src/main/lib/ipc.ts
@@ -469,8 +469,8 @@ export function register(callbacks: RegisterCallbacks = {}): void {
   void (async () => {
     try {
       await Promise.allSettled([
-        fetchJSON('https://api.github.com/repos/Comfy-Org/ComfyUI-Launcher-Environments/releases?per_page=30'),
-        fetchJSON('https://api.github.com/repos/Comfy-Org/ComfyUI-Launcher-Environments/releases/latest'),
+        fetchJSON('https://api.github.com/repos/Comfy-Org/ComfyUI-Standalone-Environments/releases?per_page=30'),
+        fetchJSON('https://api.github.com/repos/Comfy-Org/ComfyUI-Standalone-Environments/releases/latest'),
         fetchJSON('https://api.github.com/repos/Comfy-Org/ComfyUI/releases?per_page=30'),
       ])
     } catch {}
@@ -1278,7 +1278,7 @@ export function register(callbacks: RegisterCallbacks = {}): void {
         { label: i18n.t('settings.platform'), value: `${process.platform} (${process.arch})`, readonly: true },
       ],
       actions: [
-        { id: 'github', label: 'GitHub', url: 'https://github.com/Comfy-Org/ComfyUI-Launcher' },
+        { id: 'github', label: 'GitHub', url: 'https://github.com/Comfy-Org/ComfyUI-Desktop-2.0-Beta' },
       ],
     }
     return [...appSections, ...sourceSections, aboutSection]

--- a/src/main/sources/standalone.ts
+++ b/src/main/sources/standalone.ts
@@ -33,7 +33,7 @@ import type {
 } from '../types/sources'
 
 const COMFYUI_REPO = 'Comfy-Org/ComfyUI'
-const RELEASE_REPO = 'Comfy-Org/ComfyUI-Launcher-Environments'
+const RELEASE_REPO = 'Comfy-Org/ComfyUI-Standalone-Environments'
 const ENVS_DIR = 'envs'
 const DEFAULT_ENV = 'default'
 const ENV_METHOD = 'copy'


### PR DESCRIPTION
Update all functional GitHub repo URL references after the repository renames:

- `ComfyUI-Launcher` -> `ComfyUI-Desktop-2.0-Beta`
- `ComfyUI-Launcher-Environments` -> `ComfyUI-Standalone-Environments`

### Changed files

- **package.json**: `repository` and `homepage` URLs
- **electron-builder.yml**: `publish.repo` (used by electron-builder for auto-update)
- **src/main/lib/ipc.ts**: GitHub API URLs for environment release pre-warming, about section GitHub link
- **src/main/sources/standalone.ts**: `RELEASE_REPO` constant

### Not changed (documentation only)

README.md, DESIGN_PROCESS.md, and REFERENCE_COMFY_DESKTOP.md still reference the old repo names in prose/badges — these can be updated in a separate README refresh PR.
