### PR TITLE
fix: download tab not appearing after Desktop 2.0 rename

### DIFF
--- a/src/main/lib/comfyContentScript.ts
+++ b/src/main/lib/comfyContentScript.ts
@@ -775,7 +775,7 @@ export function getModelDownloadContentScript(): string {
     hidePanel();
   }, true);
 
-  window.__comfyLauncher.onDownloadProgress(function(data) {
+  window.__comfyDesktop2.onDownloadProgress(function(data) {
     updateDlCard(data);
   });
 })();`


### PR DESCRIPTION
The content script's `onDownloadProgress` listener was still calling `window.__comfyLauncher` (the pre-rename bridge name) instead of `window.__comfyDesktop2`. This meant download progress events from the main process never reached the injected UI, so the download tab/panel never appeared in the ComfyUI webview.

**Root cause:** Line 778 of `comfyContentScript.ts` was missed during the PR #207 rename because it's inside a raw JS string (not TypeScript), so the bridge name wasn't caught by the find-and-replace.

Fixes #212
