### PR TITLE
feat: add ver and platform URL params to Give Feedback link

### DIFF
--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -96,7 +96,7 @@ function switchView(view: TabView): void {
 
 function openFeedback(): void {
   emitTelemetryAction('launcher.feedback.opened')
-  window.api.openExternal(buildSupportUrl())
+  window.api.openExternal(buildSupportUrl(appVersion.value || undefined))
 }
 
 // --- Modal handlers ---

--- a/src/renderer/src/lib/supportUrl.ts
+++ b/src/renderer/src/lib/supportUrl.ts
@@ -1,5 +1,16 @@
 const FEEDBACK_URL = 'https://form.typeform.com/to/VhOXmuaL'
 
-export function buildSupportUrl(): string {
-  return FEEDBACK_URL
+function detectPlatform(): string {
+  const ua = navigator.userAgent.toLowerCase()
+  if (ua.includes('win')) return 'windows'
+  if (ua.includes('mac')) return 'mac'
+  if (ua.includes('linux')) return 'linux'
+  return 'unknown'
+}
+
+export function buildSupportUrl(version?: string): string {
+  const url = new URL(FEEDBACK_URL)
+  if (version) url.searchParams.set('ver', version)
+  url.searchParams.set('platform', detectPlatform())
+  return url.toString()
 }


### PR DESCRIPTION
Adds \er\ (app version) and \platform\ (windows/mac/linux) URL query parameters to the Typeform feedback link so that submissions automatically include context about the user's environment.

- \supportUrl.ts\: \uildSupportUrl()\ now accepts an optional version string and derives platform from \
avigator.userAgent\
- \App.vue\: passes the already-fetched \ppVersion\ to \uildSupportUrl()\

Closes #215