### PR TITLE
fix: launch app from installer finish page

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -30,6 +30,7 @@ nsis:
   oneClick: false
   perMachine: false
   allowToChangeInstallationDirectory: true
+  include: scripts/installer.nsh
 mac:
   target:
     - dmg

--- a/scripts/installer.nsh
+++ b/scripts/installer.nsh
@@ -1,0 +1,30 @@
+!include 'MUI2.nsh'
+!include 'LogicLib.nsh'
+
+# Custom finish page: launch the app as the current user (not elevated)
+!macro customFinishPage
+  !ifndef HIDE_RUN_AFTER_FINISH
+    Function StartApp
+      ${if} ${isUpdated}
+        StrCpy $1 "--updated"
+      ${else}
+        StrCpy $1 ""
+      ${endif}
+      ${StdUtils.ExecShellAsUser} $0 "$launchLink" "open" "$1"
+    FunctionEnd
+
+    !define MUI_FINISHPAGE_RUN
+    !define MUI_FINISHPAGE_RUN_FUNCTION "StartApp"
+  !endif
+
+  !define MUI_PAGE_CUSTOMFUNCTION_PRE FinishPagePreCheck
+  !insertmacro MUI_PAGE_FINISH
+
+  # Skip finish page during updates — auto-launch instead
+  Function FinishPagePreCheck
+    ${if} ${isUpdated}
+      ${StdUtils.ExecShellAsUser} $0 "$launchLink" "open" "--updated"
+      Abort
+    ${endif}
+  FunctionEnd
+!macroend

--- a/todesktop.json
+++ b/todesktop.json
@@ -28,7 +28,8 @@
     "node_modules/7zip-bin/**/*"
   ],
   "windows": {
-    "icon": "./assets/Comfy_Logo_x256.png"
+    "icon": "./assets/Comfy_Logo_x256.png",
+    "nsisInclude": "./scripts/installer.nsh"
   },
   "mac": {
     "icon": "./assets/Comfy_Logo_x512.png",


### PR DESCRIPTION
## Problem
When "Launch app" is checked on the final screen of the NSIS installer, clicking Finish does not launch the application.

Closes #214

## Root Cause
The NSIS config had no custom finish page macro. The default launch mechanism runs the app in the elevated installer context, which fails silently.

## Solution
Add a custom NSIS script (`scripts/installer.nsh`) that:
- Uses `StdUtils.ExecShellAsUser` to launch the app as the current user (not elevated)
- Wires up `MUI_FINISHPAGE_RUN` / `MUI_FINISHPAGE_RUN_FUNCTION` for the checkbox
- Auto-launches and skips the finish page during updates

This follows the same pattern used in the [desktop](https://github.com/Comfy-Org/desktop) project's `scripts/installer.nsh`.

## Changes
- `scripts/installer.nsh` — new custom NSIS finish page macro
- `electron-builder.yml` — added `include: scripts/installer.nsh`
- `todesktop.json` — added `nsisInclude` for the ToDesktop build pipeline
