### PR TITLE
fix: ship AppArmor profile in deb for Ubuntu 24.04+

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -42,3 +42,9 @@ linux:
     - deb
   icon: assets/Comfy_Logo_x256.png
   category: Development
+  extraResources:
+    - from: resources/apparmor-profile
+      to: apparmor-profile
+deb:
+  afterInstall: scripts/after-install.sh
+  afterRemove: scripts/after-remove.sh

--- a/resources/apparmor-profile
+++ b/resources/apparmor-profile
@@ -1,0 +1,9 @@
+abi <abi/4.0>,
+include <tunables/global>
+
+profile "comfyui-desktop-2" "/opt/ComfyUI Desktop 2.0/comfyui-desktop-2" flags=(unconfined) {
+  userns,
+
+  # Site-specific additions and overrides. See local/README for details.
+  include if exists <local/comfyui-desktop-2>
+}

--- a/scripts/after-install.sh
+++ b/scripts/after-install.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Install AppArmor profile for Ubuntu 24.04+ where
+# kernel.apparmor_restrict_unprivileged_userns=1 blocks Electron's sandbox.
+#
+# First check if the version of AppArmor running on the device supports our profile.
+# This keeps backwards compatibility with Ubuntu 22.04 which does not support abi/4.0.
+# In that case, we skip installing the profile since the app runs fine without it on 22.04.
+#
+# Those apparmor_parser flags are akin to performing a dry run of loading a profile.
+# https://wiki.debian.org/AppArmor/HowToUse#Dumping_profiles
+if apparmor_status --enabled > /dev/null 2>&1; then
+  APPARMOR_PROFILE_SOURCE='/opt/ComfyUI Desktop 2.0/resources/apparmor-profile'
+  APPARMOR_PROFILE_TARGET='/etc/apparmor.d/comfyui-desktop-2'
+  if apparmor_parser --skip-kernel-load --debug "$APPARMOR_PROFILE_SOURCE" > /dev/null 2>&1; then
+    cp -f "$APPARMOR_PROFILE_SOURCE" "$APPARMOR_PROFILE_TARGET"
+
+    # Skip live profile reload inside chroot environments (e.g. image builders).
+    if ! { [ -x '/usr/bin/ischroot' ] && /usr/bin/ischroot; } && hash apparmor_parser 2>/dev/null; then
+      # Extra flags taken from dh_apparmor:
+      # > By using '-W -T' we ensure that any abstraction updates are also pulled in.
+      # https://wiki.debian.org/AppArmor/Contribute/FirstTimeProfileImport
+      apparmor_parser --replace --write-cache --skip-read-cache "$APPARMOR_PROFILE_TARGET"
+    fi
+  else
+    echo "Skipping AppArmor profile installation: this version of AppArmor does not support the bundled profile"
+  fi
+fi

--- a/scripts/after-remove.sh
+++ b/scripts/after-remove.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+APPARMOR_PROFILE='/etc/apparmor.d/comfyui-desktop-2'
+
+if [ -f "$APPARMOR_PROFILE" ]; then
+  rm -f "$APPARMOR_PROFILE"
+
+  # Unload the profile from the running kernel if possible.
+  if hash apparmor_parser 2>/dev/null; then
+    apparmor_parser --remove "comfyui-desktop-2" 2>/dev/null || true
+  fi
+fi


### PR DESCRIPTION
## Summary

Ubuntu 24.04 enables `kernel.apparmor_restrict_unprivileged_userns=1` by default, which blocks Electron's sandbox from creating user namespaces. This causes the deb package to crash with SIGTRAP on launch.

## Changes

- **`resources/apparmor-profile`** — AppArmor profile granting `userns` permission to `comfyui-desktop-2` at `/opt/ComfyUI Desktop 2.0/`. Quoted path handles the space in the install directory.
- **`scripts/after-install.sh`** — deb postinst hook that detects AppArmor support, copies the profile to `/etc/apparmor.d/comfyui-desktop-2`, and reloads it. Gracefully skips on older systems (e.g. Ubuntu 22.04) where AppArmor does not support abi/4.0.
- **`scripts/after-remove.sh`** — deb postrm hook that removes the profile and unloads it from the kernel on uninstall.
- **`electron-builder.yml`** — added `linux.extraResources` to bundle the profile, and `deb.afterInstall`/`deb.afterRemove` to wire up the hooks.

## Testing

- Built deb locally, verified `apparmor-profile` is in `resources/` and postinst/postrm scripts contain the correct logic
- Installed on Ubuntu 24.04 with `apparmor_restrict_unprivileged_userns=1` — app launches without SIGTRAP
- All 304 tests pass, typecheck/lint/build clean