### PR TITLE
fix: show API errors prominently in New Install wizard

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -852,6 +852,7 @@ input[type="checkbox"]:checked::after { transform: translateX(16px); }
 /* Install wizard */
 .wizard-step { display: flex; flex-direction: column; gap: 12px; }
 .wizard-loading { font-size: 14px; color: var(--text-muted); padding: 12px 0; }
+.wizard-error { font-size: 14px; color: var(--danger); padding: 12px 0; }
 
 /* Source cards (Step 1) */
 .source-card {

--- a/src/renderer/src/views/NewInstallModal.vue
+++ b/src/renderer/src/views/NewInstallModal.vue
@@ -33,6 +33,7 @@ const detectedGpu = ref('')
 const saveDisabled = ref(true)
 const sourcesLoading = ref(false)
 const initializing = ref(false)
+const sourceError = ref('')
 const currentStep = ref(1)
 
 // Per-field state
@@ -219,6 +220,7 @@ async function open(): Promise<void> {
   diskSpace.value = null
   diskSpaceLoading.value = false
   pathIssues.value = []
+  sourceError.value = ''
   initializing.value = true
 
   try {
@@ -280,6 +282,7 @@ async function selectSource(source: Source): Promise<void> {
   fieldErrors.value.clear()
   textFieldValues.value.clear()
   saveDisabled.value = true
+  sourceError.value = ''
 
   // Initialize text fields with defaults
   for (const f of source.fields) {
@@ -390,6 +393,8 @@ async function loadFieldOptions(fieldIndex: number): Promise<void> {
     }
     if (errorFieldId) {
       fieldErrors.value.set(errorFieldId, errMsg)
+    } else if (field.renderAs === 'cards' || field.type === 'select') {
+      sourceError.value = errMsg
     } else {
       fieldErrors.value.set(field.id, errMsg)
     }
@@ -768,6 +773,10 @@ defineExpose({ open })
             <!-- For local sources: configuration fields -->
             <template v-else>
               <div class="detected-hardware">{{ detectedGpu }}</div>
+
+              <div v-if="sourceError" class="wizard-error">
+                {{ sourceError }}
+              </div>
 
               <div v-if="currentSource" id="source-fields">
                 <div


### PR DESCRIPTION
## Summary

When `getFieldOptions` fails (e.g. GitHub API rate limit) on the Installs tab's New Install wizard, the error was either buried in a disabled `<option>` dropdown or completely invisible for downstream card fields. The Dashboard's Quick Install modal shows these errors prominently — this PR brings the same behavior to the full wizard.

## Problem

1. The `release` field is a regular `<select>` with no `errorTarget` and no preceding text field
2. When the API call fails, the error is set on the field itself — but it renders inside a disabled `<option>` tag which is easy to miss
3. The downstream `variant` card field never loads, so it falls through all template conditions and renders **nothing** — no error, no loading indicator, no "no options" message

## Fix

- Added `sourceError` ref to capture errors from select/card fields that have no suitable inline display target
- Display `sourceError` prominently via a `wizard-error` div above the source fields in step 2
- Added `.wizard-error` CSS class matching the existing `.field-error` danger color styling

## Testing

- All 304 tests pass, typecheck/lint/build clean