### PR TITLE
fix: unify migration flow via useMigrateAction composable

### DIFF
--- a/src/main/lib/ipc.ts
+++ b/src/main/lib/ipc.ts
@@ -566,7 +566,7 @@ export function register(callbacks: RegisterCallbacks = {}): void {
 
   // Installations
   ipcMain.handle('get-installations', async () => {
-    const list = await installations.list()
+    const list = (await installations.list()).filter((i) => i.status !== 'installing')
 
     // Ensure a primary is always set when promotable local installs exist
     const currentPrimary = settings.get('primaryInstallId')

--- a/src/main/lib/standaloneMigration.ts
+++ b/src/main/lib/standaloneMigration.ts
@@ -239,6 +239,7 @@ export async function migrateToStandaloneFromSnapshot(
     installPath: destPath,
     pendingSnapshotRestore: stagedSnapshot.path,
     ...instData,
+    status: 'installing',
     seen: false,
   })
   ensureDefaultPrimary(entry)

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -626,7 +626,7 @@ input[type="checkbox"]:checked::after { transform: translateX(16px); }
 .modal-message a { color: var(--accent); text-decoration: underline; cursor: pointer; }
 .modal-body { max-height: 50vh; overflow-y: auto; margin-bottom: 20px; }
 .modal-body .modal-message { max-height: none; overflow-y: visible; margin-bottom: 8px; }
-.modal-box-wide { max-width: 720px; }
+.modal-box-wide { max-width: 720px; width: 720px; }
 .modal-box-wide .modal-body { max-height: 70vh; }
 .modal-details { margin-bottom: 0; margin-top: 12px; }
 .modal-detail-group { margin-bottom: 6px; }
@@ -760,6 +760,7 @@ input[type="checkbox"]:checked::after { transform: translateX(16px); }
 .dashboard-welcome-title { font-size: 28px; font-weight: 700; color: var(--text); margin-bottom: 8px; }
 .dashboard-welcome-desc { font-size: 16px; color: var(--text-muted); margin-bottom: 28px; max-width: 400px; }
 .dashboard-cta-btn { display: inline-flex; align-items: center; gap: 8px; padding: 10px 24px; font-size: 14px; }
+.migration-banner-progress { max-width: 400px; margin-bottom: 20px; }
 .dashboard-telemetry-notice {
   margin-top: 28px;
   max-width: 460px;

--- a/src/renderer/src/components/MigrationBanner.vue
+++ b/src/renderer/src/components/MigrationBanner.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { useModal } from '../composables/useModal'
+import { useMigrateAction } from '../composables/useMigrateAction'
+import { useProgressStore } from '../stores/progressStore'
 import { ArrowRightLeft } from 'lucide-vue-next'
 import type { Installation } from '../types/ipc'
 
@@ -20,46 +21,25 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
-const modal = useModal()
+const { confirmMigration } = useMigrateAction()
+const progressStore = useProgressStore()
 const migrating = ref(false)
+
+const activeOp = computed(() => {
+  const op = progressStore.operations.get(props.installation.id)
+  return op && !op.finished ? op : null
+})
+
+const progressInfo = computed(() =>
+  progressStore.getProgressInfo(props.installation.id)
+)
 
 async function startMigration(): Promise<void> {
   if (migrating.value) return
   migrating.value = true
   try {
-    let previewResult: Awaited<ReturnType<typeof window.api.previewDesktopMigration>>
-    try {
-      previewResult = await window.api.previewDesktopMigration()
-    } catch (err) {
-      await modal.alert({
-        title: t('desktop.migrateToStandalone'),
-        message: (err as Error)?.message ?? String(err),
-      })
-      return
-    }
-    if (!previewResult.ok) {
-      if (previewResult.message) {
-        await modal.alert({ title: t('desktop.migrateToStandalone'), message: previewResult.message })
-      }
-      return
-    }
-    const confirmed = await modal.confirm({
-      title: t('desktop.migrateConfirmTitle'),
-      message: t('desktop.migrateConfirmMessage'),
-      snapshotPreview: previewResult.preview?.newestSnapshot,
-      messageDetails: [{
-        label: t('migrate.migrationWill'),
-        items: [
-          t('desktop.copyUserData'),
-          t('desktop.copyInput'),
-          t('desktop.copyOutput'),
-          t('desktop.addModels'),
-        ],
-      }],
-      confirmLabel: t('desktop.migrateConfirm'),
-      confirmStyle: 'primary',
-    })
-    if (!confirmed) return
+    const result = await confirmMigration(props.installation)
+    if (!result) return
 
     emit('show-progress', {
       installationId: props.installation.id,
@@ -67,7 +47,7 @@ async function startMigration(): Promise<void> {
       apiCall: () => window.api.runAction(
         props.installation.id,
         'migrate-to-standalone',
-        { snapshotPath: previewResult.snapshotPath }
+        result,
       ),
       cancellable: true,
     })
@@ -76,6 +56,15 @@ async function startMigration(): Promise<void> {
   }
 }
 
+function viewProgress(): void {
+  // Emit with a dummy apiCall — App.vue's showProgress detects the existing
+  // in-progress operation and just reopens the ProgressModal without starting a new one.
+  emit('show-progress', {
+    installationId: props.installation.id,
+    title: '',
+    apiCall: () => Promise.resolve({} as unknown),
+  })
+}
 </script>
 
 <template>
@@ -83,16 +72,39 @@ async function startMigration(): Promise<void> {
     <div class="dashboard-welcome-icon">
       <ArrowRightLeft :size="48" />
     </div>
-    <h1 class="dashboard-welcome-title">{{ $t('dashboard.migrateBannerTitle') }}</h1>
-    <p class="dashboard-welcome-desc">{{ $t('dashboard.migrateBannerDesc') }}</p>
-    <button
-      class="primary dashboard-cta-btn"
-      :disabled="migrating"
-      @click="startMigration"
-    >
-      <ArrowRightLeft :size="18" />
-      {{ $t('dashboard.migrateBannerAction') }}
-    </button>
+
+    <!-- In-progress state -->
+    <template v-if="activeOp">
+      <h1 class="dashboard-welcome-title">{{ $t('desktop.migrating') }}</h1>
+      <p class="dashboard-welcome-desc">{{ progressInfo?.status || $t('progress.starting') }}</p>
+      <div
+        class="progress-bar-track migration-banner-progress"
+        :class="{ indeterminate: !progressInfo || progressInfo.percent < 0 }"
+      >
+        <div
+          class="progress-bar-fill"
+          :style="{ width: progressInfo && progressInfo.percent >= 0 ? `${progressInfo.percent}%` : '0%' }"
+        ></div>
+      </div>
+      <button class="primary dashboard-cta-btn" @click="viewProgress">
+        {{ $t('list.viewProgress') }}
+      </button>
+    </template>
+
+    <!-- Default state -->
+    <template v-else>
+      <h1 class="dashboard-welcome-title">{{ $t('dashboard.migrateBannerTitle') }}</h1>
+      <p class="dashboard-welcome-desc">{{ $t('dashboard.migrateBannerDesc') }}</p>
+      <button
+        class="primary dashboard-cta-btn"
+        :disabled="migrating"
+        @click="startMigration"
+      >
+        <ArrowRightLeft :size="18" />
+        {{ $t('dashboard.migrateBannerAction') }}
+      </button>
+    </template>
+
     <p class="dashboard-telemetry-notice">
       {{ $t('dashboard.telemetryNotice') }}
       <button class="dashboard-telemetry-link" @click="emit('show-settings')">

--- a/src/renderer/src/components/ModalDialog.vue
+++ b/src/renderer/src/components/ModalDialog.vue
@@ -181,7 +181,7 @@ onUnmounted(() => {
       </div>
 
       <!-- Confirm -->
-      <div v-else-if="state.type === 'confirm'" class="modal-box" :class="{ 'modal-box-wide': state.snapshotPreview || state.loading }">
+      <div v-else-if="state.type === 'confirm'" class="modal-box" :class="{ 'modal-box-wide': state.snapshotPreview || state.loading || state.variantLoading || state.variantCards.length > 0 }">
         <div class="modal-title">{{ state.title }}</div>
         <div class="modal-body">
           <div

--- a/src/renderer/src/composables/useMigrateAction.ts
+++ b/src/renderer/src/composables/useMigrateAction.ts
@@ -1,0 +1,153 @@
+import { toRaw } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useModal } from './useModal'
+import { useActionGuard } from './useActionGuard'
+import { findBestVariant } from '../lib/variants'
+import type { Installation, FieldOption } from '../types/ipc'
+
+export interface MigrateActionResult {
+  snapshotPath?: string
+  enablePipSync: boolean
+  target?: {
+    mode: 'selected'
+    release: FieldOption
+    variant: FieldOption
+  }
+  [key: string]: unknown
+}
+
+interface MigrateConfirmOptions {
+  title?: string
+  message?: string
+  confirmLabel?: string
+}
+
+/**
+ * Composable that encapsulates the full migration confirmation flow:
+ * action guard → preview → confirm with variant/device selection → return data.
+ *
+ * Used by both MigrationBanner (Dashboard) and DetailModal (Installs → Manage)
+ * to ensure a single code path for all migration entry points.
+ */
+export function useMigrateAction() {
+  const { t } = useI18n()
+  const modal = useModal()
+  const actionGuard = useActionGuard()
+
+  /**
+   * Run the migration confirmation flow for an installation.
+   * Returns the data payload to pass to `runAction`, or `null` if cancelled.
+   */
+  async function confirmMigration(
+    installation: Installation,
+    confirm?: MigrateConfirmOptions,
+  ): Promise<MigrateActionResult | null> {
+    // Pre-flight: check if the installation is busy or running
+    if (!await actionGuard.checkBeforeAction(installation.id, t('migrate.migrateToStandalone'))) {
+      return null
+    }
+
+    const isDesktop = installation.sourceId === 'desktop'
+    const migrateItems = isDesktop
+      ? [
+          t('desktop.copyUserData'),
+          t('desktop.copyInput'),
+          t('desktop.copyOutput'),
+          t('desktop.addModels'),
+        ]
+      : [
+          t('migrate.mergeUserData'),
+          t('migrate.mergeInput'),
+          t('migrate.mergeOutput'),
+          t('migrate.addModels'),
+        ]
+
+    // Show the modal immediately with a loading indicator
+    const confirmPromise = modal.confirm({
+      title: confirm?.title || t('migrate.migrateToStandaloneConfirmTitle'),
+      message: confirm?.message || '',
+      loading: true,
+      confirmLabel: confirm?.confirmLabel || t('migrate.migrateToStandaloneConfirm'),
+      confirmStyle: 'primary',
+    })
+
+    // Fetch the preview in the background
+    let previewResult: Awaited<ReturnType<typeof window.api.previewDesktopMigration>>
+    try {
+      previewResult = isDesktop
+        ? await window.api.previewDesktopMigration()
+        : await window.api.previewLocalMigration(installation.id)
+    } catch (err) {
+      modal.close(false)
+      await modal.alert({
+        title: t('migrate.migrateToStandalone'),
+        message: (err as Error)?.message ?? String(err),
+      })
+      return null
+    }
+    if (!previewResult.ok) {
+      modal.close(false)
+      if (previewResult.message) {
+        await modal.alert({ title: t('migrate.migrateToStandalone'), message: previewResult.message })
+      }
+      return null
+    }
+
+    // Update the modal with the loaded preview data + start loading variant options
+    modal.updateConfirm({
+      loading: false,
+      snapshotPreview: previewResult.preview?.newestSnapshot,
+      variantLoading: true,
+      messageDetails: [{
+        label: t('migrate.migrationWill'),
+        items: migrateItems,
+      }],
+      checkboxes: isDesktop ? [] : [
+        { id: 'enablePipSync', label: t('migrate.enablePipSync'), checked: false },
+      ],
+    })
+
+    // Fetch release + variant options for device selection
+    let migrateRelease: FieldOption | null = null
+    try {
+      const releaseOptions = await window.api.getFieldOptions('standalone', 'release', {})
+      migrateRelease = releaseOptions[0] || null
+      if (migrateRelease) {
+        const variantOptions = await window.api.getFieldOptions('standalone', 'variant', { release: toRaw(migrateRelease) })
+        const snapshotVariantId = previewResult.preview?.newestSnapshot.comfyui.variant || ''
+        const defaultVariant = findBestVariant(variantOptions, snapshotVariantId)
+
+        modal.updateConfirm({
+          variantCards: variantOptions,
+          selectedVariant: defaultVariant,
+          variantLoading: false,
+        })
+      } else {
+        modal.updateConfirm({ variantLoading: false })
+      }
+    } catch {
+      modal.updateConfirm({ variantLoading: false })
+    }
+
+    const confirmed = await confirmPromise
+    if (!confirmed) return null
+    const checkboxValues = modal.getLastCheckboxValues()
+
+    const selectedVariant = modal.state.selectedVariant
+    const result: MigrateActionResult = {
+      snapshotPath: previewResult.snapshotPath,
+      enablePipSync: !!checkboxValues.enablePipSync,
+    }
+    if (selectedVariant && migrateRelease) {
+      result.target = {
+        mode: 'selected',
+        release: toRaw(migrateRelease),
+        variant: toRaw(selectedVariant),
+      }
+    }
+
+    return result
+  }
+
+  return { confirmMigration }
+}

--- a/src/renderer/src/views/DetailModal.vue
+++ b/src/renderer/src/views/DetailModal.vue
@@ -8,7 +8,7 @@ import DetailSectionComponent from '../components/DetailSection.vue'
 import SnapshotTab from '../components/SnapshotTab.vue'
 import { useInstallationStore } from '../stores/installationStore'
 import { emitTelemetryAction, toErrorBucket } from '../lib/telemetry'
-import { findBestVariant } from '../lib/variants'
+import { useMigrateAction } from '../composables/useMigrateAction'
 import { REQUIRES_STOPPED } from '../types/ipc'
 import { Star, Pin } from 'lucide-vue-next'
 import type {
@@ -51,6 +51,7 @@ const modal = useModal()
 const prefs = useLauncherPrefs()
 const installationStore = useInstallationStore()
 const actionGuard = useActionGuard()
+const { confirmMigration } = useMigrateAction()
 
 const isLocal = computed(() => props.installation?.sourceCategory === 'local')
 const isDesktop = computed(() => props.installation?.sourceId === 'desktop')
@@ -210,7 +211,8 @@ async function runAction(action: ActionDef, btn: HTMLButtonElement | null): Prom
   }
 
   // Pre-flight: check if the installation is busy or running
-  if (REQUIRES_STOPPED.has(action.id)) {
+  // Skip for migrate-to-standalone — the useMigrateAction composable handles its own guard
+  if (action.id !== 'migrate-to-standalone' && REQUIRES_STOPPED.has(action.id)) {
     if (!await actionGuard.checkBeforeAction(props.installation.id, action.label)) return
   }
 
@@ -310,111 +312,16 @@ async function runAction(action: ActionDef, btn: HTMLButtonElement | null): Prom
     }
   }
 
-  // Migration preview — replaces the static confirm with a live snapshot preview
+  // Migration preview — delegates to useMigrateAction composable
   if (mutableAction.id === 'migrate-to-standalone') {
-    const isDesktop = props.installation.sourceId === 'desktop'
-    const migrateItems = isDesktop
-      ? [
-          t('desktop.copyUserData'),
-          t('desktop.copyInput'),
-          t('desktop.copyOutput'),
-          t('desktop.addModels'),
-        ]
-      : [
-          t('migrate.mergeUserData'),
-          t('migrate.mergeInput'),
-          t('migrate.mergeOutput'),
-          t('migrate.addModels'),
-        ]
-
-    // Show the modal immediately with a loading indicator
-    const confirmPromise = modal.confirm({
-      title: mutableAction.confirm?.title || t('migrate.migrateToStandaloneConfirmTitle'),
-      message: mutableAction.confirm?.message || '',
-      loading: true,
-      confirmLabel: mutableAction.confirm?.confirmLabel || t('migrate.migrateToStandaloneConfirm'),
-      confirmStyle: 'primary',
-    })
-
-    // Fetch the preview in the background
-    let previewResult: Awaited<ReturnType<typeof window.api.previewDesktopMigration>>
-    try {
-      previewResult = isDesktop
-        ? await window.api.previewDesktopMigration()
-        : await window.api.previewLocalMigration(props.installation.id)
-    } catch (err) {
-      modal.close(false)
-      await modal.alert({
-        title: mutableAction.label,
-        message: (err as Error)?.message ?? String(err),
-      })
-      return
-    }
-    if (!previewResult.ok) {
-      modal.close(false)
-      if (previewResult.message) {
-        await modal.alert({ title: mutableAction.label, message: previewResult.message })
-      }
-      return
-    }
-
-    // Update the modal with the loaded preview data + start loading variant options
-    modal.updateConfirm({
-      loading: false,
-      snapshotPreview: previewResult.preview?.newestSnapshot,
-      variantLoading: true,
-      messageDetails: [{
-        label: t('migrate.migrationWill'),
-        items: migrateItems,
-      }],
-      checkboxes: isDesktop ? [] : [
-        { id: 'enablePipSync', label: t('migrate.enablePipSync'), checked: false },
-      ],
-    })
-
-    // Fetch release + variant options for device selection
-    let migrateRelease: FieldOption | null = null
-    try {
-      const releaseOptions = await window.api.getFieldOptions('standalone', 'release', {})
-      migrateRelease = releaseOptions[0] || null
-      if (migrateRelease) {
-        const variantOptions = await window.api.getFieldOptions('standalone', 'variant', { release: toRaw(migrateRelease) })
-        const snapshotVariantId = previewResult.preview?.newestSnapshot.comfyui.variant || ''
-        const defaultVariant = findBestVariant(variantOptions, snapshotVariantId)
-
-        modal.updateConfirm({
-          variantCards: variantOptions,
-          selectedVariant: defaultVariant,
-          variantLoading: false,
-        })
-      } else {
-        modal.updateConfirm({ variantLoading: false })
-      }
-    } catch {
-      modal.updateConfirm({ variantLoading: false })
-    }
-
-    const confirmed = await confirmPromise
-    if (!confirmed) return
-    const checkboxValues = modal.getLastCheckboxValues()
-
-    const selectedVariant = modal.state.selectedVariant
-    const targetData: Record<string, unknown> = {}
-    if (selectedVariant && migrateRelease) {
-      targetData.target = {
-        mode: 'selected' as const,
-        release: toRaw(migrateRelease),
-        variant: toRaw(selectedVariant),
-      }
-    }
+    const migrateResult = await confirmMigration(props.installation, mutableAction.confirm)
+    if (!migrateResult) return
 
     mutableAction = {
       ...mutableAction,
       data: {
         ...mutableAction.data,
-        snapshotPath: previewResult.snapshotPath,
-        enablePipSync: !!checkboxValues.enablePipSync,
-        ...targetData,
+        ...migrateResult,
       },
     }
   }


### PR DESCRIPTION
## Summary

Unifies the migration confirmation flow across Dashboard and Installs views. Previously, the Dashboard's MigrationBanner had its own simplified migration logic that was missing device/variant selection, the enablePipSync checkbox, and the action guard — all of which were present in the DetailModal path used by the Installs view.

## Changes

### New composable: `useMigrateAction`
- Extracts the full migration confirmation flow (action guard → snapshot preview → variant/device selection → pip sync checkbox) into a shared composable
- Used by both MigrationBanner (Dashboard) and DetailModal (Installs → Manage)

### MigrationBanner improvements
- Calls the composable directly — no longer opens the Manage panel first
- Shows live progress state during migration: status text, progress bar, and a "View Progress" button to reopen the ProgressModal

### Modal width fix
- `modal-box-wide` class now also triggers when variant cards or variant loading state is present
- Uses explicit `width: 720px` to prevent content-dependent sizing differences between entry points

### Hidden mid-migration installations
- New installations created during migration start with `status: 'installing'`
- `get-installations` filters out `installing` records so the incomplete card doesn't appear in the UI
- On cancellation/error, the record is removed by existing cleanup logic
- On success, `status: 'installed'` is set and the card appears normally

## Files changed

- **`src/renderer/src/composables/useMigrateAction.ts`** — new composable
- **`src/renderer/src/components/MigrationBanner.vue`** — uses composable, shows progress state
- **`src/renderer/src/views/DetailModal.vue`** — delegates to composable
- **`src/renderer/src/views/DashboardView.vue`** — wires banner to show-progress
- **`src/renderer/src/components/ModalDialog.vue`** — wider class condition
- **`src/renderer/src/assets/main.css`** — modal width + banner progress bar
- **`src/main/lib/standaloneMigration.ts`** — `status: 'installing'` on new record
- **`src/main/lib/ipc.ts`** — filters installing records from get-installations

## Testing

- All 304 tests pass
- Typecheck, lint, and build all pass
- Code review clean (1 minor comment addressed)
