### PR TITLE
docs: link to Standalone Environments repo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 An Electron app for managing multiple ComfyUI installations.
 
+## Related Repositories
+
+- [ComfyUI-Standalone-Environments](https://github.com/Comfy-Org/ComfyUI-Standalone-Environments) — Standalone environment definitions used by this app to provision Python environments for ComfyUI installations.
+
 ## Downloads
 
 ### Windows


### PR DESCRIPTION
Adds a **Related Repositories** section to the README linking to [ComfyUI-Standalone-Environments](https://github.com/Comfy-Org/ComfyUI-Standalone-Environments), which provides the standalone environment definitions used by this app.

Closes #239