### PR TITLE
fix: allow Google passkey and GitHub OAuth popups in Electron window

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -461,7 +461,7 @@ function onLaunch({ port, url, process: proc, installation, mode }: {
   })
   comfyWindow.webContents.setWindowOpenHandler(({ url }) => {
     if (shouldOpenInPopup(url)) {
-      return { action: 'allow' }
+      return { action: 'allow', overrideBrowserWindowOptions: { webPreferences: { preload: undefined } } }
     }
     shell.openExternal(url)
     return { action: 'deny' }

--- a/src/main/lib/allowedPopups.test.ts
+++ b/src/main/lib/allowedPopups.test.ts
@@ -9,6 +9,14 @@ describe('POPUP_ALLOWED_PREFIXES', () => {
   it('includes the checkout domain', () => {
     expect(POPUP_ALLOWED_PREFIXES).toContain('https://checkout.comfy.org/')
   })
+
+  it('includes the Google accounts domain', () => {
+    expect(POPUP_ALLOWED_PREFIXES).toContain('https://accounts.google.com/')
+  })
+
+  it('includes the GitHub OAuth domain', () => {
+    expect(POPUP_ALLOWED_PREFIXES).toContain('https://github.com/login/oauth/')
+  })
 })
 
 describe('shouldOpenInPopup', () => {
@@ -18,6 +26,14 @@ describe('shouldOpenInPopup', () => {
 
   it('returns true for checkout URLs', () => {
     expect(shouldOpenInPopup('https://checkout.comfy.org/session/abc123')).toBe(true)
+  })
+
+  it('returns true for Google accounts URLs', () => {
+    expect(shouldOpenInPopup('https://accounts.google.com/o/oauth2/auth?client_id=abc')).toBe(true)
+  })
+
+  it('returns true for GitHub OAuth URLs', () => {
+    expect(shouldOpenInPopup('https://github.com/login/oauth/authorize?client_id=abc')).toBe(true)
   })
 
   it('returns false for unknown URLs', () => {

--- a/src/main/lib/allowedPopups.ts
+++ b/src/main/lib/allowedPopups.ts
@@ -5,6 +5,8 @@
 export const POPUP_ALLOWED_PREFIXES = [
   'https://dreamboothy.firebaseapp.com/',
   'https://checkout.comfy.org/',
+  'https://accounts.google.com/',
+  'https://github.com/login/oauth/',
 ]
 
 export function shouldOpenInPopup(url: string): boolean {


### PR DESCRIPTION
## Problem

When signing in with Google passkey or GitHub OAuth, Firebase Auth opens a popup to \ccounts.google.com\ or \github.com/login/oauth/...\. The \setWindowOpenHandler\ only allowed \dreamboothy.firebaseapp.com\ and \checkout.comfy.org\, so these auth popups were denied and opened in the system browser instead. This breaks the credential relay back to the Electron app.

## Fix

Add \ccounts.google.com\ and \github.com/login/oauth/\ to \POPUP_ALLOWED_PREFIXES\ so they open as child Electron windows, allowing passkey and OAuth flows to complete.

## Testing

- Added unit tests for the new prefixes
- All 10 tests pass

Fixes #227