### PR TITLE
fix: set 7za execute permission at build time for AppImage

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -18,6 +18,7 @@ extraResources:
     to: lib
 asarUnpack:
   - node_modules/7zip-bin/**/*
+afterPack: ./scripts/afterPack.mjs
 publish:
   provider: github
   owner: Comfy-Org

--- a/scripts/afterPack.mjs
+++ b/scripts/afterPack.mjs
@@ -1,0 +1,30 @@
+import fs from 'fs'
+import path from 'path'
+
+/**
+ * electron-builder afterPack hook.
+ * Ensures the 7zip-bin binary has the execute permission in the packaged output.
+ * This is necessary because AppImage mounts are read-only, so runtime chmod fails.
+ */
+export default async function afterPack(context) {
+  if (process.platform === 'win32') return
+
+  const unpackedDir = path.join(
+    context.appOutDir,
+    'resources',
+    'app.asar.unpacked',
+    'node_modules',
+    '7zip-bin',
+  )
+
+  if (!fs.existsSync(unpackedDir)) return
+
+  // Find all 7za binaries under the unpacked 7zip-bin directory
+  for (const entry of fs.readdirSync(unpackedDir, { recursive: true })) {
+    if (path.basename(String(entry)) === '7za') {
+      const binPath = path.join(unpackedDir, String(entry))
+      fs.chmodSync(binPath, 0o755)
+      console.log(`afterPack: set +x on ${binPath}`)
+    }
+  }
+}


### PR DESCRIPTION
## Problem

On Linux AppImage, the FUSE mount is read-only. The runtime \chmod\ in \get7zBin()\ (extract.ts:32) silently fails because the filesystem doesn't allow writes, leaving the \7za\ binary non-executable. This causes:

\\\
Error: Extraction failed: spawn /node_modules/7zip-bin/linux/x64/7za EACCES
\\\

## Solution

Add an \fterPack\ electron-builder hook that sets \+x\ on all \7za\ binaries in the unpacked \7zip-bin\ directory **at build time**, so the permission is baked into the packaged artifact and works on read-only mounts.

## Changes

- \scripts/afterPack.mjs\ — New hook that recursively finds \7za\ binaries under unpacked \7zip-bin\ and sets \chmod 755\
- \lectron-builder.yml\ — Wire up the \fterPack\ hook

Fixes #242