### PR TITLE
feat: identify which process is locking a file on delete failure

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -697,6 +697,7 @@
     "installFailed": "Install Failed",
     "deleteInterrupted": "Delete Interrupted",
     "deleteLocked": "A file could not be deleted because it is in use by another program. Close any applications that may have files open in this directory and try again.\n{path}",
+    "deleteLockedBy": "A file could not be deleted because it is in use by: {processes}. Close these applications and try again.\n{path}",
     "cannotAdd": "Cannot Add",
     "dirNotExist": "Directory does not exist: {path}",
     "cannotOpenDir": "Could not open directory: {error}",

--- a/src/main/lib/file-lock-info.test.ts
+++ b/src/main/lib/file-lock-info.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import { findLockingProcesses } from './file-lock-info'
+import { fork } from 'child_process'
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+
+describe('findLockingProcesses', () => {
+  it('returns an empty array for a file not locked by any process', async () => {
+    const tmpFile = path.join(os.tmpdir(), `file-lock-test-${Date.now()}.txt`)
+    fs.writeFileSync(tmpFile, 'test')
+    try {
+      const result = await findLockingProcesses(tmpFile)
+      expect(Array.isArray(result)).toBe(true)
+    } finally {
+      try { fs.unlinkSync(tmpFile) } catch {}
+    }
+  })
+
+  it('returns an empty array for a non-existent file', async () => {
+    const result = await findLockingProcesses('/tmp/nonexistent-file-lock-test-' + Date.now())
+    expect(result).toEqual([])
+  })
+
+  it('returns results with pid and name fields', async () => {
+    const tmpFile = path.join(os.tmpdir(), `file-lock-shape-test-${Date.now()}.txt`)
+    fs.writeFileSync(tmpFile, 'test')
+    try {
+      const result = await findLockingProcesses(tmpFile)
+      for (const entry of result) {
+        expect(typeof entry.pid).toBe('number')
+        expect(typeof entry.name).toBe('string')
+      }
+    } finally {
+      try { fs.unlinkSync(tmpFile) } catch {}
+    }
+  })
+
+  it('detects a process holding a file open', async () => {
+    const tmpFile = path.join(os.tmpdir(), `file-lock-held-test-${Date.now()}.txt`)
+    fs.writeFileSync(tmpFile, 'test')
+
+    // Spawn a child process that opens the file and holds it open
+    const child = fork(
+      '-e',
+      [
+        `const fs = require('fs');` +
+        `const fd = fs.openSync(${JSON.stringify(tmpFile)}, 'r+');` +
+        `process.send('ready');` +
+        `process.on('message', () => { fs.closeSync(fd); process.exit(); });`,
+      ],
+      { stdio: ['pipe', 'pipe', 'pipe', 'ipc'] }
+    )
+
+    // Wait for the child to signal it has the file open
+    await new Promise<void>((resolve) => { child.on('message', () => resolve()) })
+
+    try {
+      const result = await findLockingProcesses(tmpFile)
+      // On Windows the Restart Manager should detect the child; on Linux/macOS lsof should.
+      // The child is a node process, so we expect at least one result with a matching PID.
+      expect(result.length).toBeGreaterThanOrEqual(1)
+      const pids = result.map((r) => r.pid)
+      expect(pids).toContain(child.pid)
+      for (const entry of result) {
+        expect(entry.pid).toBeGreaterThan(0)
+        expect(entry.name.length).toBeGreaterThan(0)
+      }
+    } finally {
+      child.send('close')
+      await new Promise<void>((resolve) => { child.on('exit', () => resolve()) })
+      try { fs.unlinkSync(tmpFile) } catch {}
+    }
+  })
+})

--- a/src/main/lib/file-lock-info.ts
+++ b/src/main/lib/file-lock-info.ts
@@ -1,0 +1,143 @@
+import { execFile } from 'child_process'
+
+export interface LockingProcess {
+  pid: number
+  name: string
+}
+
+const TIMEOUT_MS = 2000
+
+/**
+ * Best-effort attempt to identify which processes hold a lock on `filePath`.
+ * Returns an empty array if detection fails or times out.
+ */
+export function findLockingProcesses(filePath: string): Promise<LockingProcess[]> {
+  if (process.platform === 'win32') {
+    return findLockingProcessesWindows(filePath)
+  }
+  return findLockingProcessesUnix(filePath)
+}
+
+/**
+ * Windows: use PowerShell + Restart Manager API via inline C# to query which
+ * processes hold handles on the given file. This is a built-in Windows API —
+ * no third-party tools required.
+ */
+function findLockingProcessesWindows(filePath: string): Promise<LockingProcess[]> {
+  // Escape single quotes for PowerShell string embedding
+  const escaped = filePath.replace(/'/g, "''")
+  const script = `
+$code = @'
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+public static class RmUtil {
+    [StructLayout(LayoutKind.Sequential)] public struct RM_UNIQUE_PROCESS {
+        public int dwProcessId;
+        public System.Runtime.InteropServices.ComTypes.FILETIME ProcessStartTime;
+    }
+    const int RmRebootReasonNone = 0;
+    const int CCH_RM_MAX_APP_NAME = 255;
+    const int CCH_RM_MAX_SVC_NAME = 63;
+    public enum RM_APP_TYPE { RmUnknownApp=0, RmMainWindow=1, RmOtherWindow=2, RmService=3, RmExplorer=4, RmConsole=5, RmCritical=1000 }
+    [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Unicode)]
+    public struct RM_PROCESS_INFO {
+        public RM_UNIQUE_PROCESS Process;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst=CCH_RM_MAX_APP_NAME+1)] public string strAppName;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst=CCH_RM_MAX_SVC_NAME+1)] public string strServiceShortName;
+        public RM_APP_TYPE ApplicationType;
+        public uint AppStatus;
+        public uint TSSessionId;
+        [MarshalAs(UnmanagedType.Bool)] public bool bRestartable;
+    }
+    [DllImport("rstrtmgr.dll", CharSet=CharSet.Unicode)] static extern int RmStartSession(out uint h, int flags, string key);
+    [DllImport("rstrtmgr.dll")] static extern int RmEndSession(uint h);
+    [DllImport("rstrtmgr.dll", CharSet=CharSet.Unicode)] static extern int RmRegisterResources(uint h, uint nFiles, string[] rgFiles, uint nApps, RM_UNIQUE_PROCESS[] rgApps, uint nSvcs, string[] rgSvcs);
+    [DllImport("rstrtmgr.dll")] static extern int RmGetList(uint h, out uint nProcInfoNeeded, ref uint nProcInfo, [In,Out] RM_PROCESS_INFO[] rgAffectedApps, ref uint lpdwRebootReasons);
+
+    public static string Query(string path) {
+        uint handle;
+        if (RmStartSession(out handle, 0, Guid.NewGuid().ToString()) != 0) return "";
+        try {
+            if (RmRegisterResources(handle, 1, new[]{path}, 0, null, 0, null) != 0) return "";
+            uint needed = 0, count = 0, reasons = 0;
+            int rc = RmGetList(handle, out needed, ref count, null, ref reasons);
+            if (rc == 234 && needed > 0) { count = needed; }
+            else if (rc != 0) return "";
+            else return "";
+            var info = new RM_PROCESS_INFO[count];
+            rc = RmGetList(handle, out needed, ref count, info, ref reasons);
+            if (rc != 0) return "";
+            var results = new List<string>();
+            for (int i = 0; i < count; i++) {
+                try {
+                    var p = Process.GetProcessById(info[i].Process.dwProcessId);
+                    results.Add(p.Id + "\\t" + p.ProcessName);
+                } catch {
+                    results.Add(info[i].Process.dwProcessId + "\\t" + info[i].strAppName);
+                }
+            }
+            return string.Join("\\n", results);
+        } finally { RmEndSession(handle); }
+    }
+}
+'@
+Add-Type -TypeDefinition $code
+[RmUtil]::Query('${escaped}')
+`
+  return new Promise((resolve) => {
+    execFile(
+      'powershell.exe',
+      ['-NoProfile', '-NonInteractive', '-Command', script],
+      { timeout: TIMEOUT_MS, windowsHide: true },
+      (err, stdout) => {
+        if (err || !stdout.trim()) return resolve([])
+        const results: LockingProcess[] = []
+        for (const line of stdout.trim().split('\n')) {
+          const parts = line.trim().split('\t')
+          if (parts.length >= 2) {
+            const pid = parseInt(parts[0]!, 10)
+            const name = parts[1]!
+            if (pid > 0 && name) results.push({ pid, name })
+          }
+        }
+        resolve(results)
+      }
+    )
+  })
+}
+
+/**
+ * Linux / macOS: use lsof -F pc for machine-readable output.
+ * Each record is a pair of lines: "p<pid>\n" followed by "c<command>\n".
+ * This avoids the column-width parsing issues of the default human-readable
+ * format (process names with spaces would shift the PID column).
+ */
+function findLockingProcessesUnix(filePath: string): Promise<LockingProcess[]> {
+  return new Promise((resolve) => {
+    execFile(
+      'lsof',
+      ['-F', 'pc', '--', filePath],
+      { timeout: TIMEOUT_MS, windowsHide: true },
+      (err, stdout) => {
+        if (err || !stdout.trim()) return resolve([])
+        const results: LockingProcess[] = []
+        const seen = new Set<number>()
+        let currentPid = 0
+        for (const line of stdout.trim().split('\n')) {
+          if (line.startsWith('p')) {
+            currentPid = parseInt(line.slice(1), 10)
+          } else if (line.startsWith('c') && currentPid > 0) {
+            if (!seen.has(currentPid)) {
+              seen.add(currentPid)
+              results.push({ pid: currentPid, name: line.slice(1) })
+            }
+          }
+        }
+        resolve(results)
+      }
+    )
+  })
+}

--- a/src/main/lib/ipc.ts
+++ b/src/main/lib/ipc.ts
@@ -41,6 +41,7 @@ import { getVariantLabel } from '../sources/standalone'
 import type { FieldOption, SourcePlugin } from '../types/sources'
 import { REQUIRES_STOPPED } from '../../types/ipc'
 import type { Theme, ResolvedTheme, QuitActiveItem } from '../../types/ipc'
+import { findLockingProcesses } from './file-lock-info'
 import type { LaunchCmd } from './process'
 
 const MARKER_FILE = '.comfyui-desktop-2'
@@ -1473,6 +1474,17 @@ export function register(callbacks: RegisterCallbacks = {}): void {
         let message = raw.message
         if (raw.code === 'EBUSY' || raw.code === 'EPERM') {
           message = i18n.t('errors.deleteLocked', { path: raw.path ?? '' })
+          // Fire-and-forget: resolve which process holds the lock, then push an updated message
+          const lockedPath = raw.path
+          if (lockedPath) {
+            findLockingProcesses(lockedPath).then((procs) => {
+              if (procs.length > 0 && !sender.isDestroyed()) {
+                const names = [...new Set(procs.map((p) => p.name))].join(', ')
+                const detail = i18n.t('errors.deleteLockedBy', { processes: names, path: lockedPath })
+                sender.send('error-detail', { installationId, message: detail })
+              }
+            }).catch((err) => { console.error('Failed to identify locking processes:', err) })
+          }
         }
         return { ok: false, message }
       }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -210,6 +210,11 @@ const api: ElectronApi = {
     ipcRenderer.on('dd-error', handler)
     return () => ipcRenderer.removeListener('dd-error', handler)
   },
+  onErrorDetail: (callback) => {
+    const handler = (_event: IpcRendererEvent, data: unknown) => callback(data as Parameters<typeof callback>[0])
+    ipcRenderer.on('error-detail', handler)
+    return () => ipcRenderer.removeListener('error-detail', handler)
+  },
 }
 
 if (process.contextIsolated) {

--- a/src/renderer/src/stores/progressStore.test.ts
+++ b/src/renderer/src/stores/progressStore.test.ts
@@ -25,6 +25,7 @@ vi.stubGlobal('window', {
     onInstanceStarted: vi.fn(() => vi.fn()),
     onInstanceStopped: vi.fn(() => vi.fn()),
     onComfyExited: vi.fn(() => vi.fn()),
+    onErrorDetail: vi.fn(() => vi.fn()),
   }
 })
 

--- a/src/renderer/src/stores/progressStore.ts
+++ b/src/renderer/src/stores/progressStore.ts
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n'
 import { useSessionStore } from './sessionStore'
 import type {
   ActionResult,
+  ErrorDetailData,
   ProgressData,
   ProgressStep,
   ComfyOutputData,
@@ -35,6 +36,16 @@ export const useProgressStore = defineStore('progress', () => {
   const sessionStore = useSessionStore()
 
   const operations = reactive(new Map<string, Operation>())
+
+  // Listen for async error detail updates (e.g. locking process names resolved after the initial error)
+  window.api.onErrorDetail((data: ErrorDetailData) => {
+    const op = operations.get(data.installationId)
+    if (op?.error) {
+      op.error = data.message
+      const session = sessionStore.errorInstances.get(data.installationId)
+      if (session) session.message = data.message
+    }
+  })
 
   function cleanupOperation(installationId: string): void {
     const op = operations.get(installationId)

--- a/src/renderer/src/types/ipc.ts
+++ b/src/renderer/src/types/ipc.ts
@@ -54,6 +54,7 @@ export type {
   SnapshotDiffResult,
   SnapshotDiffData,
   SnapshotFilePreview,
+  ErrorDetailData,
   ElectronApi,
 } from '../../../types/ipc'
 export { REQUIRES_STOPPED } from '../../../types/ipc'

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -467,6 +467,12 @@ export interface SnapshotFilePreview {
   newestSnapshot: SnapshotDetailData
 }
 
+// --- Error detail (async follow-up after a locked-file error) ---
+export interface ErrorDetailData {
+  installationId: string
+  message: string
+}
+
 // --- IPC API interface ---
 export interface ElectronApi {
   // Sources / New Install
@@ -590,6 +596,7 @@ export interface ElectronApi {
   onModelDownloadProgress(callback: (progress: ModelDownloadProgress) => void): Unsubscribe
   onTelemetrySettingChanged(callback: (enabled: boolean | undefined) => void): Unsubscribe
   onDatadogError(callback: (payload: DatadogForwardedError) => void): Unsubscribe
+  onErrorDetail(callback: (data: ErrorDetailData) => void): Unsubscribe
 }
 
 /** Action IDs that require the installation to be stopped before running.


### PR DESCRIPTION
## Summary

Closes #198.

When deleting an installation fails because a file is held open by another process (EBUSY/EPERM), the error message now identifies **which process** is responsible.

## How it works

1. **Immediate feedback** - The generic "file in use" error is shown instantly so the UI never appears to hang.
2. **Async resolution** - A fire-and-forget background lookup identifies the locking process(es) within a 2-second timeout.
3. **Reactive update** - When process names are resolved, a new `error-detail` IPC event pushes an updated message to the renderer, which reactively replaces the generic error with something like: *"in use by: python, explorer"*.

## Platform support

| Platform | Method | Dependencies |
|----------|--------|-------------|
| Windows | PowerShell + Restart Manager API (rstrtmgr.dll) | Built-in, no third-party tools |
| Linux | lsof | Pre-installed on most distros |
| macOS | lsof | Pre-installed |

All methods are best-effort with a 2-second timeout. If detection fails, the original generic message remains.

## Changes

- **New:** `src/main/lib/file-lock-info.ts` - `findLockingProcesses(filePath)` utility
- **New:** `src/main/lib/file-lock-info.test.ts` - Unit tests
- **Modified:** `src/types/ipc.ts` - Added `ErrorDetailData` type + `onErrorDetail` on `ElectronApi`
- **Modified:** `src/preload/index.ts` - Wired `onErrorDetail` to `error-detail` channel
- **Modified:** `src/renderer/src/types/ipc.ts` - Re-exported `ErrorDetailData`
- **Modified:** `src/renderer/src/stores/progressStore.ts` - Listens for `error-detail` to update `op.error`
- **Modified:** `src/main/lib/ipc.ts` - Fire-and-forget process lookup on EBUSY/EPERM
- **Modified:** `locales/en.json` - Added `deleteLockedBy` i18n key
- **Modified:** `progressStore.test.ts` - Added `onErrorDetail` mock

## Testing

- All 308 tests pass (pnpm run test)
- Typecheck, lint, and build all pass
