### PR TITLE
fix: propagate AbortSignal to postInstall so cancellation is respected

### DIFF
--- a/src/main/lib/ipc.ts
+++ b/src/main/lib/ipc.ts
@@ -699,7 +699,7 @@ export function register(callbacks: RegisterCallbacks = {}): void {
         if (source.postInstall) {
           const update = (data: Record<string, unknown>): Promise<void> =>
             installations.update(installationId, data).then(() => {})
-          await source.postInstall(inst, { sendProgress, update })
+          await source.postInstall(inst, { sendProgress, update, signal: abort.signal })
         }
 
         // After postInstall, check for pending snapshot restore
@@ -1734,7 +1734,7 @@ export function register(callbacks: RegisterCallbacks = {}): void {
 
         const newUpdate = (data: Record<string, unknown>): Promise<void> =>
           installations.update(entry!.id, data).then(() => {})
-        await source.postInstall!(installRecord, { sendProgress, update: newUpdate })
+        await source.postInstall!(installRecord, { sendProgress, update: newUpdate, signal: abort.signal })
         installComplete = true
 
         const newInst = await installations.get(entry.id)

--- a/src/main/sources/standalone.ts
+++ b/src/main/sources/standalone.ts
@@ -214,16 +214,20 @@ async function stripMasterPackages(installPath: string): Promise<void> {
 async function createEnv(
   installPath: string,
   envName: string,
-  onProgress: (copied: number, total: number, elapsedSecs: number, etaSecs: number) => void
+  onProgress: (copied: number, total: number, elapsedSecs: number, etaSecs: number) => void,
+  signal?: AbortSignal
 ): Promise<void> {
   const uvPath = getUvPath(installPath)
   const masterPython = getMasterPythonPath(installPath)
   const envPath = path.join(installPath, ENVS_DIR, envName)
   await new Promise<void>((resolve, reject) => {
-    execFile(uvPath, ['venv', '--python', masterPython, envPath], { cwd: installPath }, (err, _stdout, stderr) => {
+    if (signal?.aborted) return reject(new Error('Cancelled'))
+    const proc = execFile(uvPath, ['venv', '--python', masterPython, envPath], { cwd: installPath }, (err, _stdout, stderr) => {
+      if (signal?.aborted) return reject(new Error('Cancelled'))
       if (err) return reject(new Error(`Failed to create environment "${envName}": ${stderr || err.message}`))
       resolve()
     })
+    signal?.addEventListener('abort', () => { try { proc.kill() } catch {} }, { once: true })
   })
 
   try {
@@ -232,7 +236,7 @@ async function createEnv(
     if (!masterSitePackages || !envSitePackages || !fs.existsSync(masterSitePackages)) {
       throw new Error(`Could not locate site-packages for environment "${envName}".`)
     }
-    await copyDirWithProgress(masterSitePackages, envSitePackages, onProgress)
+    await copyDirWithProgress(masterSitePackages, envSitePackages, onProgress, { signal })
     await codesignBinaries(envSitePackages)
   } catch (err) {
     await fs.promises.rm(envPath, { recursive: true, force: true }).catch(() => {})
@@ -644,7 +648,7 @@ export const standalone: SourcePlugin = {
     }
   },
 
-  async postInstall(installation: InstallationRecord, { sendProgress, update }: PostInstallTools): Promise<void> {
+  async postInstall(installation: InstallationRecord, { sendProgress, update, signal }: PostInstallTools): Promise<void> {
     const standaloneEnvDir = path.join(installation.installPath, 'standalone-env')
     if (process.platform !== 'win32') {
       const binDir = path.join(standaloneEnvDir, 'bin')
@@ -657,13 +661,15 @@ export const standalone: SourcePlugin = {
       } catch {}
     }
     await repairMacBinaries(installation.installPath, sendProgress)
+    if (signal?.aborted) throw new Error('Cancelled')
     sendProgress('setup', { percent: 0, status: 'Creating default Python environment…' })
     await createEnv(installation.installPath, DEFAULT_ENV, (copied, total, elapsedSecs, etaSecs) => {
       const percent = Math.round((copied / total) * 100)
       const elapsed = formatTime(elapsedSecs)
       const eta = etaSecs >= 0 ? formatTime(etaSecs) : '—'
       sendProgress('setup', { percent, status: `Copying packages… ${copied} / ${total} files  ·  ${elapsed} elapsed  ·  ${eta} remaining` })
-    })
+    }, signal)
+    if (signal?.aborted) throw new Error('Cancelled')
     const envMethods = { ...(installation.envMethods as Record<string, string> | undefined), [DEFAULT_ENV]: ENV_METHOD }
     await update({ envMethods })
     sendProgress('cleanup', { percent: -1, status: t('standalone.cleanupEnvStatus') })

--- a/src/main/types/sources.ts
+++ b/src/main/types/sources.ts
@@ -61,6 +61,7 @@ export interface ActionTools {
 export interface PostInstallTools {
   sendProgress: (step: string, data: { percent: number; status: string }) => void
   update: (data: Record<string, unknown>) => Promise<void>
+  signal?: AbortSignal
 }
 
 // --- Action / detail section types ---


### PR DESCRIPTION
## Problem

Fixes #231.

Cancelling during the **Setting up Environment** phase of installation was silently ignored. The AbortSignal from the install handler was passed to source.install() but **not** to source.postInstall(), so the long-running createEnv file-copy operation would run to completion even after the user clicked Cancel.

## Root Cause

- PostInstallTools interface had no signal field
- Neither call site (install-instance handler nor release-update handler) forwarded abort.signal to postInstall()
- createEnv() had no abort support - neither the uv subprocess nor the copyDirWithProgress call received the signal

## Changes

1. **types/sources.ts** - Added signal?: AbortSignal to PostInstallTools
2. **ipc.ts** - Pass signal: abort.signal to postInstall() at both call sites (standard install and release-update)
3. **standalone.ts**:
   - postInstall() destructures signal and checks signal?.aborted between phases
   - createEnv() accepts signal, checks it before spawning, kills the uv process on abort, and forwards it to copyDirWithProgress (which already has built-in signal support)

## Testing

- TypeScript compiles cleanly (tsc --noEmit)
- All 309 tests pass (vitest run)
- Lint passes