### PR TITLE
perf: cache drag height to avoid layout thrashing during drag

### DIFF
--- a/src/renderer/src/lib/draggableList.ts
+++ b/src/renderer/src/lib/draggableList.ts
@@ -27,6 +27,7 @@ export class DraggableList {
   private dragStartTop = 0
   private listMinY = 0
   private listMaxY = 0
+  private dragHeight = 0
   private scrollParent: HTMLElement | null = null
 
   private boundDragStart = this.dragStart.bind(this)
@@ -105,6 +106,7 @@ export class DraggableList {
     // any transforms are applied, so clamping stays stable throughout the drag.
     const dragRect = item.getBoundingClientRect()
     this.dragStartTop = dragRect.top
+    this.dragHeight = dragRect.height
     const idleItems = this.getIdleItems()
     if (idleItems.length > 0) {
       this.listMinY = Math.min(dragRect.top, idleItems[0]!.getBoundingClientRect().top)
@@ -157,9 +159,8 @@ export class DraggableList {
 
     // Clamp vertical offset so the dragged item stays within the list bounds.
     // Uses positions snapshotted at drag start so swap animations don't shift the clamp.
-    const dragHeight = this.draggableItem.offsetHeight
-    const minY = this.listMinY - this.dragStartTop - dragHeight / 2
-    const maxY = this.listMaxY - this.dragStartTop - dragHeight / 2
+    const minY = this.listMinY - this.dragStartTop - this.dragHeight / 2
+    const maxY = this.listMaxY - this.dragStartTop - this.dragHeight / 2
     offsetY = Math.max(minY, Math.min(maxY, offsetY))
 
     this.updateIdleItemsStateAndPosition()


### PR DESCRIPTION
## Summary

Avoids a synchronous reflow on every mousemove event during drag-to-reorder.

offsetHeight forces the browser to perform a full layout calculation each time it is read. Since the dragged item dimensions do not change during the drag, we can cache dragRect.height at drag start and reuse it in the clamp calculation.

Follow-up to #252.

## Changes

- Cache dragRect.height into this.dragHeight during dragStart()
- Replace this.draggableItem.offsetHeight with the cached value in updateDragPosition()