### PR TITLE
fix: remove delete action from git manual installs to prevent accidental data loss

### DIFF
--- a/src/main/sources/git.ts
+++ b/src/main/sources/git.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import { spawn, execFile } from 'child_process'
 import { fetchJSON } from '../lib/fetch'
-import { deleteAction, untrackAction } from '../lib/actions'
+import { untrackAction } from '../lib/actions'
 import { parseArgs, extractPort } from '../lib/util'
 import { t } from '../lib/i18n'
 import type { InstallationRecord } from '../installations'
@@ -227,7 +227,6 @@ export const gitSource: SourcePlugin = {
               confirmLabel: t('migrate.migrateToStandaloneConfirm'),
             },
           },
-          deleteAction(installation),
           untrackAction(),
         ],
       },


### PR DESCRIPTION
Git manual installs are user-managed directories that may contain custom nodes, uncommitted work, and hand-configured venvs. The Launcher should not offer to delete these directories.

Only the **Untrack** action (which removes the install from the Launcher's list without touching files on disk) is now available for git installs.

**Changes:**
- Removed \deleteAction(installation)\ from git source's \getDetailSections\ actions list
- Cleaned up unused \deleteAction\ import

Fixes #256