### PR TITLE
fix: resolve version display from local git state instead of stale manifest ref

### DIFF
--- a/src/main/lib/git.test.ts
+++ b/src/main/lib/git.test.ts
@@ -7,7 +7,7 @@ vi.mock('child_process', async (importOriginal) => {
 })
 
 import { execFile } from 'child_process'
-import { countCommitsAhead, findNearestTag, findLatestVersionTag } from './git'
+import { countCommitsAhead, findNearestTag, findLatestVersionTag, isAncestorOf } from './git'
 
 const mockedExecFile = vi.mocked(execFile)
 
@@ -79,5 +79,19 @@ describe('findLatestVersionTag', () => {
   it('returns undefined for empty output', async () => {
     mockExecFile((_cmd, _args, _opts, cb) => { cb(null, '\n', '') })
     expect(await findLatestVersionTag('/repo')).toBeUndefined()
+  })
+})
+
+describe('isAncestorOf', () => {
+  beforeEach(() => { vi.resetAllMocks() })
+
+  it('returns true when git exits with 0', async () => {
+    mockExecFile((_cmd, _args, _opts, cb) => { cb(null, '', '') })
+    expect(await isAncestorOf('/repo', 'v0.17.0', 'v0.17.1')).toBe(true)
+  })
+
+  it('returns false when git exits with error', async () => {
+    mockExecFile((_cmd, _args, _opts, cb) => { cb(new Error('not ancestor'), '', '') })
+    expect(await isAncestorOf('/repo', 'v0.18.0', 'v0.17.1')).toBe(false)
   })
 })

--- a/src/main/lib/git.ts
+++ b/src/main/lib/git.ts
@@ -93,9 +93,9 @@ function redactUrl(url: string): string {
  * asynchronously (local operation, no network).  Returns undefined if git is
  * unavailable, the tag doesn't exist, or any error occurs.
  */
-export function countCommitsAhead(repoPath: string, tag: string): Promise<number | undefined> {
+export function countCommitsAhead(repoPath: string, tag: string, commit: string = 'HEAD'): Promise<number | undefined> {
   return new Promise((resolve) => {
-    execFile('git', ['rev-list', '--count', `${tag}..HEAD`], {
+    execFile('git', ['rev-list', '--count', `${tag}..${commit}`], {
       cwd: repoPath,
       encoding: 'utf-8',
       windowsHide: true,
@@ -113,9 +113,9 @@ export function countCommitsAhead(repoPath: string, tag: string): Promise<number
  * asynchronously (local operation, no network).  Returns undefined if git is
  * unavailable, no tags exist, or any error occurs.
  */
-export function findNearestTag(repoPath: string): Promise<string | undefined> {
+export function findNearestTag(repoPath: string, commit: string = 'HEAD'): Promise<string | undefined> {
   return new Promise((resolve) => {
-    execFile('git', ['describe', '--tags', '--abbrev=0', 'HEAD'], {
+    execFile('git', ['describe', '--tags', '--abbrev=0', commit], {
       cwd: repoPath,
       encoding: 'utf-8',
       windowsHide: true,
@@ -130,9 +130,12 @@ export function findNearestTag(repoPath: string): Promise<string | undefined> {
 
 /**
  * Find the highest version tag in the repository.  Runs `git tag` with
- * version-sort, so it works even when the latest release is a backport on
- * a separate branch (not an ancestor of HEAD).  Returns undefined if git
- * is unavailable, no `v*` tags exist, or any error occurs.
+ * version-sort, so it includes tags on release branches that are not
+ * ancestors of HEAD.  This is a display heuristic — the result may refer
+ * to a tag whose commit is on a different branch.  Callers should verify
+ * ancestry (via {@link isAncestorOf}) before using it as a base tag.
+ * Returns undefined if git is unavailable, no `v*` tags exist, or any
+ * error occurs.
  */
 export function findLatestVersionTag(repoPath: string): Promise<string | undefined> {
   return new Promise((resolve) => {
@@ -145,6 +148,24 @@ export function findLatestVersionTag(repoPath: string): Promise<string | undefin
       if (error) { resolve(undefined); return }
       const tag = stdout.trim().split('\n')[0]?.trim()
       resolve(tag || undefined)
+    })
+  })
+}
+
+/**
+ * Check whether `ancestor` is an ancestor of `descendant` in the commit
+ * graph.  Runs `git merge-base --is-ancestor` (local, no network).
+ * Returns true if ancestor is reachable from descendant, false otherwise
+ * (including on error).
+ */
+export function isAncestorOf(repoPath: string, ancestor: string, descendant: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    execFile('git', ['merge-base', '--is-ancestor', ancestor, descendant], {
+      cwd: repoPath,
+      windowsHide: true,
+      timeout: 1000,
+    }, (error) => {
+      resolve(!error)
     })
   })
 }

--- a/src/main/lib/ipc.ts
+++ b/src/main/lib/ipc.ts
@@ -9,6 +9,7 @@ import * as installations from '../installations'
 import type { InstallationRecord } from '../installations'
 import { formatComfyVersion } from './version'
 import type { ComfyVersion } from './version'
+import { resolveLocalVersion } from './version-resolve'
 import * as settings from '../settings'
 import { defaultInstallDir } from './paths'
 import { download } from './download'
@@ -289,6 +290,33 @@ function _broadcastToRenderer(channel: string, data: Record<string, unknown>): v
   BrowserWindow.getAllWindows().forEach((win) => {
     if (!win.isDestroyed()) win.webContents.send(channel, data)
   })
+}
+
+/**
+ * Resolve versions from git state for all installations in parallel and
+ * broadcast updates to the renderer if any resolved version differs from
+ * the stored one.  Called in the background after get-installations returns.
+ */
+async function _resolveAndBroadcastVersions(list: InstallationRecord[]): Promise<void> {
+  const updates: { id: string; version: string }[] = []
+  await Promise.all(list.map(async (inst) => {
+    const cv = inst.comfyVersion as ComfyVersion | undefined
+    if (!cv?.commit || !inst.installPath) return
+    const comfyuiDir = path.join(inst.installPath, 'ComfyUI')
+    try {
+      const resolved = await resolveLocalVersion(comfyuiDir, cv.commit)
+      const resolvedStr = formatComfyVersion(resolved, 'short')
+      const storedStr = formatComfyVersion(cv, 'short')
+      if (resolvedStr !== storedStr) {
+        updates.push({ id: inst.id, version: resolvedStr })
+      }
+    } catch {
+      // ignore — keep stored version
+    }
+  }))
+  if (updates.length > 0) {
+    _broadcastToRenderer('installations-versions-updated', { updates })
+  }
 }
 
 function _addSession(installationId: string, { proc, port, url, mode, installationName }: Omit<SessionInfo, 'startedAt'>): void {
@@ -576,7 +604,7 @@ export function register(callbacks: RegisterCallbacks = {}): void {
       }
     }
 
-    return list.map((inst) => {
+    const result = list.map((inst) => {
       const source = sourceMap[inst.sourceId]
       if (!source) return inst
       const listPreview = source.getListPreview ? source.getListPreview(inst) : undefined
@@ -585,8 +613,9 @@ export function register(callbacks: RegisterCallbacks = {}): void {
         : inst.status === 'failed'
         ? { label: i18n.t('errors.installFailed'), style: 'danger' }
         : (source.getStatusTag ? source.getStatusTag(inst) : undefined)
-      // Derive version display string from comfyVersion ground truth, falling back to legacy string.
+      // Derive version display string from stored comfyVersion, falling back to legacy string.
       // Omit version when it just duplicates the source type (e.g. 'cloud', 'desktop').
+      // Resolved versions are sent asynchronously via 'installations-versions-updated'.
       const cv = inst.comfyVersion as ComfyVersion | undefined
       const rawVersion = cv ? formatComfyVersion(cv, 'short') : (inst.version as string | undefined)
       const version = rawVersion === inst.sourceId ? undefined : rawVersion
@@ -600,6 +629,12 @@ export function register(callbacks: RegisterCallbacks = {}): void {
         ...(statusTag ? { statusTag } : {}),
       }
     })
+
+    // Resolve versions from git state in the background; push updates to
+    // the renderer if any differ from the stored values.
+    _resolveAndBroadcastVersions(list).catch(() => {})
+
+    return result
   })
 
   ipcMain.handle('get-unique-name', async (_event, baseName: string) => {
@@ -878,7 +913,31 @@ export function register(callbacks: RegisterCallbacks = {}): void {
         },
       ]
     }
-    return source.getDetailSections(inst)
+    const sections = source.getDetailSections(inst)
+
+    // Resolve version from git state for the detail view so it stays
+    // consistent with snapshot cards (which also use resolveLocalVersion).
+    const cv = inst.comfyVersion as ComfyVersion | undefined
+    if (cv?.commit && inst.installPath) {
+      const comfyuiDir = path.join(inst.installPath, 'ComfyUI')
+      try {
+        const resolved = await resolveLocalVersion(comfyuiDir, cv.commit)
+        const display = formatComfyVersion(resolved, 'detail')
+        for (const section of sections) {
+          const fields = (section as Record<string, unknown>).fields as Record<string, unknown>[] | undefined
+          if (!fields) continue
+          for (const f of fields) {
+            if ((f as Record<string, unknown>).key === 'comfyui-version') {
+              (f as Record<string, unknown>).value = display
+            }
+          }
+        }
+      } catch {
+        // Fall through with stored version
+      }
+    }
+
+    return sections
   })
 
   // Snapshots

--- a/src/main/lib/snapshots.ts
+++ b/src/main/lib/snapshots.ts
@@ -1,7 +1,8 @@
 import fs from 'fs'
 import path from 'path'
 import { spawn } from 'child_process'
-import { readGitHead, isGitAvailable, gitClone, gitCheckoutCommit, gitFetchAndCheckout } from './git'
+import { readGitHead, isGitAvailable, gitClone, gitCheckoutCommit, gitFetchAndCheckout, hasGitDir } from './git'
+import { resolveLocalVersion } from './version-resolve'
 import { scanCustomNodes, nodeKey } from './nodes'
 import { pipFreeze, runUvPip as sharedRunUvPip, installFilteredRequirements, getPipIndexArgs } from './pip'
 import { installCnrNode, switchCnrVersion, isSafePathComponent } from './cnr'
@@ -11,11 +12,42 @@ import type { InstallationRecord } from '../installations'
 import { formatComfyVersion } from './version'
 import type { ComfyVersion } from './version'
 
-export function formatSnapshotVersion(comfyui: Snapshot['comfyui'], style: 'short' | 'detail'): string {
+export function formatSnapshotVersion(comfyui: { ref: string; commit: string | null; baseTag?: string; commitsAhead?: number }, style: 'short' | 'detail'): string {
   if (comfyui.commit) {
     return formatComfyVersion({ commit: comfyui.commit, baseTag: comfyui.baseTag, commitsAhead: comfyui.commitsAhead }, style)
   }
   return comfyui.ref
+}
+
+/**
+ * Resolve the version for a snapshot's commit from local git state, then
+ * format for display.  Falls back to stored baseTag/commitsAhead when git
+ * is unavailable or the commit is missing from the repo.
+ */
+/** Subset of Snapshot['comfyui'] needed for version resolution. */
+interface VersionResolvable {
+  ref: string
+  commit: string | null
+  baseTag?: string
+  commitsAhead?: number
+}
+
+async function resolveSnapshotVersion(
+  installPath: string,
+  comfyui: VersionResolvable,
+  style: 'short' | 'detail',
+): Promise<string> {
+  if (!comfyui.commit) return comfyui.ref
+  const comfyuiDir = path.join(installPath, 'ComfyUI')
+  if (!hasGitDir(comfyuiDir)) {
+    return formatSnapshotVersion(comfyui, style)
+  }
+  try {
+    const cv = await resolveLocalVersion(comfyuiDir, comfyui.commit)
+    return formatComfyVersion(cv, style)
+  } catch {
+    return formatSnapshotVersion(comfyui, style)
+  }
 }
 
 // --- Types ---
@@ -558,7 +590,9 @@ export async function diffAgainstCurrent(
     label: null,
     ...state,
   }
-  return diffSnapshots(current, target)
+  const diff = diffSnapshots(current, target)
+  await resolveDiffVersions(installPath, diff)
+  return diff
 }
 
 /**
@@ -1518,6 +1552,11 @@ function summarizeDiff(diff: SnapshotDiff): SnapshotDiffSummary {
 
 export async function getSnapshotListData(installPath: string): Promise<{ snapshots: SnapshotSummary[]; totalCount: number }> {
   const entries = await listSnapshots(installPath)
+  // Resolve versions for all unique commits in parallel (cache makes dupes free)
+  const versionPromises = entries.map((entry) =>
+    resolveSnapshotVersion(installPath, entry.snapshot.comfyui, 'short')
+  )
+  const resolvedVersions = await Promise.all(versionPromises)
   const summaries: SnapshotSummary[] = entries.map((entry, i) => {
     const s = entry.snapshot
     const summary: SnapshotSummary = {
@@ -1525,7 +1564,7 @@ export async function getSnapshotListData(installPath: string): Promise<{ snapsh
       createdAt: s.createdAt,
       trigger: s.trigger,
       label: s.label,
-      comfyuiVersion: formatSnapshotVersion(s.comfyui, 'short'),
+      comfyuiVersion: resolvedVersions[i]!,
       nodeCount: s.customNodes.length,
       pipPackageCount: Object.keys(s.pipPackages).length,
     }
@@ -1552,7 +1591,7 @@ export async function getSnapshotDetailData(installPath: string, filename: strin
     createdAt: snapshot.createdAt,
     trigger: snapshot.trigger,
     label: snapshot.label,
-    comfyuiVersion: formatSnapshotVersion(snapshot.comfyui, 'detail'),
+    comfyuiVersion: await resolveSnapshotVersion(installPath, snapshot.comfyui, 'detail'),
     comfyui: snapshot.comfyui,
     pythonVersion: snapshot.pythonVersion,
     updateChannel: snapshot.updateChannel,
@@ -1578,6 +1617,7 @@ export async function getSnapshotDiffVsPrevious(installPath: string, filename: s
   const current = entries[idx]!.snapshot
   const prev = entries[idx + 1]!.snapshot
   const diff = diffSnapshots(prev, current)
+  await resolveDiffVersions(installPath, diff)
   const prevDate = new Date(prev.createdAt).toLocaleString()
   return {
     mode: 'previous',
@@ -1587,4 +1627,18 @@ export async function getSnapshotDiffVsPrevious(installPath: string, filename: s
            diff.nodesChanged.length === 0 && diff.pipsAdded.length === 0 && diff.pipsRemoved.length === 0 &&
            diff.pipsChanged.length === 0,
   }
+}
+
+/**
+ * Post-process a diff to resolve formattedVersion fields from git state.
+ * Mutates diff.comfyui in place.
+ */
+async function resolveDiffVersions(installPath: string, diff: SnapshotDiff): Promise<void> {
+  if (!diff.comfyui) return
+  const [fromVersion, toVersion] = await Promise.all([
+    resolveSnapshotVersion(installPath, diff.comfyui.from, 'detail'),
+    resolveSnapshotVersion(installPath, diff.comfyui.to, 'detail'),
+  ])
+  diff.comfyui.from.formattedVersion = fromVersion
+  diff.comfyui.to.formattedVersion = toVersion
 }

--- a/src/main/lib/version-resolve.test.ts
+++ b/src/main/lib/version-resolve.test.ts
@@ -1,0 +1,164 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('./git', () => ({
+  findNearestTag: vi.fn(),
+  findLatestVersionTag: vi.fn(),
+  countCommitsAhead: vi.fn(),
+  isAncestorOf: vi.fn(),
+}))
+
+import { findNearestTag, findLatestVersionTag, countCommitsAhead, isAncestorOf } from './git'
+import { resolveLocalVersion, clearVersionCache } from './version-resolve'
+
+const mockedFindNearestTag = vi.mocked(findNearestTag)
+const mockedFindLatestVersionTag = vi.mocked(findLatestVersionTag)
+const mockedCountCommitsAhead = vi.mocked(countCommitsAhead)
+const mockedIsAncestorOf = vi.mocked(isAncestorOf)
+
+describe('resolveLocalVersion', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    clearVersionCache()
+  })
+
+  it('returns ancestor tag when HEAD is exactly on it (stable channel)', async () => {
+    mockedFindNearestTag.mockResolvedValue('v0.17.0')
+    mockedFindLatestVersionTag.mockResolvedValue('v0.17.0')
+    mockedCountCommitsAhead.mockResolvedValue(0)
+
+    const result = await resolveLocalVersion('/repo', 'abc1234')
+    expect(result).toEqual({ commit: 'abc1234', baseTag: 'v0.17.0', commitsAhead: 0 })
+  })
+
+  it('upgrades to latest tag when ancestor is behind and is an ancestor of latest', async () => {
+    mockedFindNearestTag.mockResolvedValue('v0.16.4')
+    mockedFindLatestVersionTag.mockResolvedValue('v0.17.1')
+    mockedCountCommitsAhead.mockImplementation(async (_repo, tag) => {
+      if (tag === 'v0.16.4') return 38
+      if (tag === 'v0.17.1') return 7
+      return undefined
+    })
+    mockedIsAncestorOf.mockResolvedValue(true)
+
+    const result = await resolveLocalVersion('/repo', 'abc1234')
+    expect(result).toEqual({ commit: 'abc1234', baseTag: 'v0.17.1', commitsAhead: 7 })
+  })
+
+  it('keeps ancestor tag when it is NOT an ancestor of latest (different branch)', async () => {
+    mockedFindNearestTag.mockResolvedValue('v0.16.4')
+    mockedFindLatestVersionTag.mockResolvedValue('v0.17.1')
+    mockedCountCommitsAhead.mockResolvedValue(38)
+    mockedIsAncestorOf.mockResolvedValue(false)
+
+    const result = await resolveLocalVersion('/repo', 'abc1234')
+    expect(result).toEqual({ commit: 'abc1234', baseTag: 'v0.16.4', commitsAhead: 38 })
+  })
+
+  it('falls back to ancestor tag when countCommitsAhead for latest tag fails', async () => {
+    mockedFindNearestTag.mockResolvedValue('v0.16.4')
+    mockedFindLatestVersionTag.mockResolvedValue('v0.17.1')
+    mockedCountCommitsAhead.mockImplementation(async (_repo, tag) => {
+      if (tag === 'v0.16.4') return 38
+      if (tag === 'v0.17.1') return undefined
+      return undefined
+    })
+    mockedIsAncestorOf.mockResolvedValue(true)
+
+    const result = await resolveLocalVersion('/repo', 'abc1234')
+    expect(result).toEqual({ commit: 'abc1234', baseTag: 'v0.16.4', commitsAhead: 38 })
+  })
+
+  it('uses fallbackTag when no git tags exist', async () => {
+    mockedFindNearestTag.mockResolvedValue(undefined)
+    mockedFindLatestVersionTag.mockResolvedValue(undefined)
+
+    const result = await resolveLocalVersion('/repo', 'abc1234', 'v0.14.0')
+    expect(result).toEqual({ commit: 'abc1234', baseTag: 'v0.14.0', commitsAhead: undefined })
+  })
+
+  it('returns no baseTag when no tags and no fallback', async () => {
+    mockedFindNearestTag.mockResolvedValue(undefined)
+    mockedFindLatestVersionTag.mockResolvedValue(undefined)
+
+    const result = await resolveLocalVersion('/repo', 'abc1234')
+    expect(result).toEqual({ commit: 'abc1234', baseTag: undefined, commitsAhead: undefined })
+  })
+
+  it('does not upgrade when ancestor and latest are the same tag', async () => {
+    mockedFindNearestTag.mockResolvedValue('v0.17.1')
+    mockedFindLatestVersionTag.mockResolvedValue('v0.17.1')
+    mockedCountCommitsAhead.mockResolvedValue(3)
+
+    const result = await resolveLocalVersion('/repo', 'abc1234')
+    expect(result).toEqual({ commit: 'abc1234', baseTag: 'v0.17.1', commitsAhead: 3 })
+    expect(mockedIsAncestorOf).not.toHaveBeenCalled()
+  })
+
+  describe('caching', () => {
+    it('returns cached result on second call', async () => {
+      mockedFindNearestTag.mockResolvedValue('v0.17.0')
+      mockedFindLatestVersionTag.mockResolvedValue('v0.17.0')
+      mockedCountCommitsAhead.mockResolvedValue(0)
+
+      await resolveLocalVersion('/repo', 'abc1234')
+      vi.resetAllMocks()
+
+      const result = await resolveLocalVersion('/repo', 'abc1234')
+      expect(result).toEqual({ commit: 'abc1234', baseTag: 'v0.17.0', commitsAhead: 0 })
+      expect(mockedFindNearestTag).not.toHaveBeenCalled()
+    })
+
+    it('does not bake fallbackTag into cache', async () => {
+      mockedFindNearestTag.mockResolvedValue(undefined)
+      mockedFindLatestVersionTag.mockResolvedValue(undefined)
+
+      const r1 = await resolveLocalVersion('/repo', 'abc1234', 'v0.14.0')
+      expect(r1.baseTag).toBe('v0.14.0')
+
+      // Second call without fallback should NOT get the previous fallback
+      const r2 = await resolveLocalVersion('/repo', 'abc1234')
+      expect(r2.baseTag).toBeUndefined()
+    })
+
+    it('applies different fallbackTags to the same cached entry', async () => {
+      mockedFindNearestTag.mockResolvedValue(undefined)
+      mockedFindLatestVersionTag.mockResolvedValue(undefined)
+
+      await resolveLocalVersion('/repo', 'abc1234')
+
+      const r1 = await resolveLocalVersion('/repo', 'abc1234', 'v0.14.0')
+      expect(r1.baseTag).toBe('v0.14.0')
+
+      const r2 = await resolveLocalVersion('/repo', 'abc1234', 'v0.15.0')
+      expect(r2.baseTag).toBe('v0.15.0')
+    })
+
+    it('clears cache on clearVersionCache', async () => {
+      mockedFindNearestTag.mockResolvedValue('v0.17.0')
+      mockedFindLatestVersionTag.mockResolvedValue('v0.17.0')
+      mockedCountCommitsAhead.mockResolvedValue(0)
+
+      await resolveLocalVersion('/repo', 'abc1234')
+      clearVersionCache()
+
+      await resolveLocalVersion('/repo', 'abc1234')
+      expect(mockedFindNearestTag).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('latest tag caching', () => {
+    it('reuses findLatestVersionTag result for same repo within TTL', async () => {
+      mockedFindNearestTag.mockResolvedValue('v0.16.4')
+      mockedFindLatestVersionTag.mockResolvedValue('v0.17.1')
+      mockedCountCommitsAhead.mockResolvedValue(0)
+
+      // Two different commits in the same repo
+      await resolveLocalVersion('/repo', 'aaa1111')
+      await resolveLocalVersion('/repo', 'bbb2222')
+
+      // findLatestVersionTag should only be called once (cached for same repo)
+      expect(mockedFindLatestVersionTag).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/src/main/lib/version-resolve.ts
+++ b/src/main/lib/version-resolve.ts
@@ -1,0 +1,101 @@
+import { findNearestTag, findLatestVersionTag, countCommitsAhead, isAncestorOf } from './git'
+import type { ComfyVersion } from './version'
+
+/**
+ * In-memory cache for resolved versions, keyed by "repoPath\0commitSha".
+ * Stores only git-derived data (no fallbackTag) so callers with different
+ * fallbacks share the same cache entry safely.
+ */
+const _cache = new Map<string, ComfyVersion>()
+
+/** Short-lived cache for the latest version tag per repo path. */
+let _latestTagCache: { repoPath: string; tag: string | undefined; ts: number } | null = null
+const LATEST_TAG_TTL_MS = 5_000
+
+async function getCachedLatestTag(repoPath: string): Promise<string | undefined> {
+  if (_latestTagCache && _latestTagCache.repoPath === repoPath && Date.now() - _latestTagCache.ts < LATEST_TAG_TTL_MS) {
+    return _latestTagCache.tag
+  }
+  const tag = await findLatestVersionTag(repoPath)
+  _latestTagCache = { repoPath, tag, ts: Date.now() }
+  return tag
+}
+
+/**
+ * Resolve a {@link ComfyVersion} from local git state.  Uses the nearest
+ * ancestor tag as a base, upgrading to the repo-wide latest version tag
+ * when the commit is ahead (latest/master channel) AND the ancestor tag is
+ * an ancestor of that latest tag — meaning the backport branched from a
+ * point the commit has already passed.
+ *
+ * Results are cached by (repoPath, commit) so repeated calls (e.g. for
+ * multiple snapshots sharing the same commit) only spawn git once.
+ *
+ * @param comfyuiDir  Path to the ComfyUI git working tree.
+ * @param commit      The commit SHA to resolve.
+ * @param fallbackTag Optional tag to use when no git tags exist (e.g. manifest comfyui_ref).
+ */
+export async function resolveLocalVersion(comfyuiDir: string, commit: string, fallbackTag?: string): Promise<ComfyVersion> {
+  const cacheKey = `${comfyuiDir}\0${commit}`
+  const cached = _cache.get(cacheKey)
+  if (cached) {
+    // Cache stores git-only data; apply fallbackTag at read time without
+    // mutating the cached entry.
+    if (fallbackTag && !cached.baseTag) {
+      return { ...cached, baseTag: fallbackTag }
+    }
+    return cached
+  }
+
+  const [ancestorTag, latestTag] = await Promise.all([
+    findNearestTag(comfyuiDir, commit),
+    getCachedLatestTag(comfyuiDir),
+  ])
+  const ancestorDist = ancestorTag ? await countCommitsAhead(comfyuiDir, ancestorTag, commit) : undefined
+
+  // Use the global latest tag only when the commit is ahead of the ancestor
+  // tag (latest channel) AND the ancestor tag is an ancestor of the latest
+  // tag.  The ancestry check ensures we only upgrade when the backport
+  // release branched from a point the commit has already passed — i.e. the
+  // backport's commits are accounted for by the commit's position in history.
+  let useLatest = false
+  if (latestTag && latestTag !== ancestorTag && ancestorDist !== undefined && ancestorDist > 0) {
+    useLatest = ancestorTag ? await isAncestorOf(comfyuiDir, ancestorTag, latestTag) : false
+  }
+
+  let baseTag: string | undefined
+  let commitsAhead: number | undefined
+  if (useLatest) {
+    const latestDist = await countCommitsAhead(comfyuiDir, latestTag!, commit)
+    if (latestDist !== undefined) {
+      // Successfully counted relative to the latest tag.
+      baseTag = latestTag
+      commitsAhead = latestDist
+    } else {
+      // Could not count relative to latestTag — fall back to ancestorTag
+      // so the tag and count stay consistent.
+      baseTag = ancestorTag
+      commitsAhead = ancestorDist
+    }
+  } else {
+    baseTag = ancestorTag
+    commitsAhead = ancestorDist
+  }
+
+  // Cache stores git-only data (no fallbackTag) so different callers
+  // sharing the same (repoPath, commit) don't poison each other.
+  const result: ComfyVersion = { commit, baseTag, commitsAhead }
+  _cache.set(cacheKey, result)
+
+  // Apply fallbackTag for the caller if git found no tag.
+  if (fallbackTag && !baseTag) {
+    return { ...result, baseTag: fallbackTag }
+  }
+  return result
+}
+
+/** Clear the version cache (e.g. after an update changes tags). */
+export function clearVersionCache(): void {
+  _cache.clear()
+  _latestTagCache = null
+}

--- a/src/main/sources/standalone.ts
+++ b/src/main/sources/standalone.ts
@@ -12,7 +12,8 @@ import type { ComfyVersion } from '../lib/version'
 import { deleteAction, untrackAction } from '../lib/actions'
 import { downloadAndExtract, downloadAndExtractMulti } from '../lib/installer'
 import { copyDirWithProgress } from '../lib/copy'
-import { readGitHead, countCommitsAhead, findNearestTag, findLatestVersionTag } from '../lib/git'
+import { readGitHead } from '../lib/git'
+import { resolveLocalVersion, clearVersionCache } from '../lib/version-resolve'
 import { parseArgs, extractPort, formatTime } from '../lib/util'
 import { PYTORCH_RE, installFilteredRequirements, getPipIndexArgs } from '../lib/pip'
 import { t } from '../lib/i18n'
@@ -410,7 +411,7 @@ export const standalone: SourcePlugin = {
 
     const infoFields: Record<string, unknown>[] = [
       { label: t('common.installMethod'), value: installation.sourceLabel as string },
-      { label: t('standalone.comfyui'), value: installation.comfyVersion ? formatComfyVersion(installation.comfyVersion as ComfyVersion, 'detail') : (installation.version as string | undefined) || 'unknown' },
+      { key: 'comfyui-version', label: t('standalone.comfyui'), value: installation.comfyVersion ? formatComfyVersion(installation.comfyVersion as ComfyVersion, 'detail') : (installation.version as string | undefined) || 'unknown' },
       { label: t('common.release'), value: (installation.releaseTag as string | undefined) || '—' },
       { label: t('standalone.variant'), value: (installation.variant as string | undefined) ? getVariantLabel(installation.variant as string) : '—' },
       { label: t('standalone.python'), value: (installation.pythonVersion as string | undefined) || '—' },
@@ -681,25 +682,7 @@ export const standalone: SourcePlugin = {
     const headCommit = readGitHead(comfyuiDir)
     if (headCommit) {
       const ref = installation.version as string | undefined
-      // Use the nearest ancestor tag as the primary source.  When HEAD is
-      // ahead of it (latest channel), upgrade to the highest version tag in
-      // the repo so backport releases (e.g. v0.17.1 on a release branch)
-      // are reported correctly.
-      const [ancestorTag, latestTag] = await Promise.all([
-        findNearestTag(comfyuiDir),
-        findLatestVersionTag(comfyuiDir),
-      ])
-      const ancestorDist = ancestorTag ? await countCommitsAhead(comfyuiDir, ancestorTag) : undefined
-      const useLatest = latestTag && ancestorDist !== undefined && ancestorDist > 0
-      const baseTag = (useLatest ? latestTag : ancestorTag) ?? ref
-      const commitsAhead = baseTag
-        ? (useLatest ? await countCommitsAhead(comfyuiDir, baseTag) ?? ancestorDist ?? 0 : ancestorDist ?? 0)
-        : undefined
-      const comfyVersion: ComfyVersion = {
-        commit: headCommit,
-        baseTag,
-        commitsAhead,
-      }
+      const comfyVersion = await resolveLocalVersion(comfyuiDir, headCommit, ref)
       await update({ comfyVersion })
       // Use updated installation for snapshot so it captures the version
       installation = { ...installation, comfyVersion } as InstallationRecord
@@ -738,24 +721,8 @@ export const standalone: SourcePlugin = {
       const comfyuiDir = path.join(dirPath, 'ComfyUI')
       const commit = readGitHead(comfyuiDir)
       if (commit) {
-        // Use the nearest ancestor tag as the primary source.  When HEAD is
-        // ahead of it (latest channel), upgrade to the highest version tag
-        // in the repo so backport releases (e.g. v0.17.1 on a release
-        // branch) are reported correctly.  When HEAD is exactly on a tag
-        // (stable channel / rollback), keep the ancestor tag as-is.
-        // Falls back to the manifest's comfyui_ref when no tags exist.
         const manifestTag = version !== 'unknown' ? version : undefined
-        const [ancestorTag, latestTag] = await Promise.all([
-          findNearestTag(comfyuiDir),
-          findLatestVersionTag(comfyuiDir),
-        ])
-        const ancestorDist = ancestorTag ? await countCommitsAhead(comfyuiDir, ancestorTag) : undefined
-        const useLatest = latestTag && ancestorDist !== undefined && ancestorDist > 0
-        const baseTag = (useLatest ? latestTag : ancestorTag) ?? manifestTag
-        const commitsAhead = useLatest
-          ? await countCommitsAhead(comfyuiDir, latestTag) ?? ancestorDist
-          : ancestorDist
-        comfyVersion = { commit, baseTag, commitsAhead }
+        comfyVersion = await resolveLocalVersion(comfyuiDir, commit, manifestTag)
       }
     }
 
@@ -873,11 +840,27 @@ export const standalone: SourcePlugin = {
 
       // Restore update channel and version/lastRollback state so the
       // release cache sees accurate state for the restored channel.
+      // Recompute comfyVersion from git state so that old snapshots captured
+      // before the baseTag fix don't propagate stale version metadata.
+      const comfyuiDir = path.join(installation.installPath, 'ComfyUI')
+      const restoredHead = comfyResult.commit || readGitHead(comfyuiDir)
+      let freshComfyVersion: ComfyVersion | undefined
+      if (!comfyResult.error && restoredHead) {
+        freshComfyVersion = await resolveLocalVersion(comfyuiDir, restoredHead)
+      }
       const restoreState = snapshots.buildPostRestoreState(
         targetSnapshot, comfyResult,
         installation.updateInfoByChannel as Record<string, Record<string, unknown>> | undefined,
         installation.comfyVersion as ComfyVersion | undefined
       )
+      // Override the snapshot-based comfyVersion with the freshly resolved one
+      if (freshComfyVersion) {
+        restoreState.comfyVersion = freshComfyVersion
+        const tag = formatComfyVersion(freshComfyVersion, 'short')
+        const channelInfo = restoreState.updateInfoByChannel as Record<string, Record<string, unknown>>
+        const ch = targetSnapshot.updateChannel || 'stable'
+        channelInfo[ch] = { ...channelInfo[ch], installedTag: tag }
+      }
       await update(restoreState)
 
       // Capture a new snapshot reflecting the restored state
@@ -1208,6 +1191,10 @@ export const standalone: SourcePlugin = {
 
       const cachedRelease = releaseCache.get(COMFYUI_REPO, channel) || {}
       const fullPostHead = markers.POST_UPDATE_HEAD || null
+
+      // Tags may have changed after the update; clear the cache so
+      // subsequent resolveLocalVersion calls see the new tags.
+      clearVersionCache()
 
       // Build structured comfyVersion from raw data.
       // For stable updates, CHECKED_OUT_TAG is the most reliable baseTag source

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -170,6 +170,14 @@ const api: ElectronApi = {
     ipcRenderer.on('installations-changed', handler)
     return () => ipcRenderer.removeListener('installations-changed', handler)
   },
+  onInstallationsVersionsUpdated: (callback) => {
+    const handler = (_event: IpcRendererEvent, data: unknown) => {
+      const updates = (data as Record<string, unknown>).updates as { id: string; version: string }[]
+      callback(updates)
+    }
+    ipcRenderer.on('installations-versions-updated', handler)
+    return () => ipcRenderer.removeListener('installations-versions-updated', handler)
+  },
   onUpdateAvailable: (callback) => {
     const handler = (_event: IpcRendererEvent, data: unknown) => callback(data as Parameters<typeof callback>[0])
     ipcRenderer.on('update-available', handler)

--- a/src/renderer/src/components/InstanceCard.test.ts
+++ b/src/renderer/src/components/InstanceCard.test.ts
@@ -10,6 +10,7 @@ vi.stubGlobal('window', {
   api: {
     getInstallations: vi.fn(),
     onInstallationsChanged: vi.fn(),
+    onInstallationsVersionsUpdated: vi.fn(),
     getSetting: vi.fn().mockResolvedValue(null),
     runAction: vi.fn().mockResolvedValue(undefined),
   }

--- a/src/renderer/src/composables/useLauncherPrefs.test.ts
+++ b/src/renderer/src/composables/useLauncherPrefs.test.ts
@@ -7,6 +7,7 @@ vi.stubGlobal('window', {
   api: {
     getInstallations: vi.fn().mockResolvedValue([]),
     onInstallationsChanged: vi.fn(),
+    onInstallationsVersionsUpdated: vi.fn(),
     getSetting: vi.fn().mockResolvedValue(undefined),
     runAction: vi.fn().mockResolvedValue(undefined),
   }

--- a/src/renderer/src/composables/useLocalInstanceGuard.test.ts
+++ b/src/renderer/src/composables/useLocalInstanceGuard.test.ts
@@ -20,6 +20,7 @@ vi.stubGlobal('window', {
   api: {
     getInstallations: vi.fn().mockResolvedValue([]),
     onInstallationsChanged: vi.fn(),
+    onInstallationsVersionsUpdated: vi.fn(),
     stopComfyUI: vi.fn().mockResolvedValue(undefined),
   }
 })

--- a/src/renderer/src/stores/installationStore.test.ts
+++ b/src/renderer/src/stores/installationStore.test.ts
@@ -24,7 +24,8 @@ vi.stubGlobal('window', {
   ...window,
   api: {
     getInstallations: vi.fn(),
-    onInstallationsChanged: vi.fn()
+    onInstallationsChanged: vi.fn(),
+    onInstallationsVersionsUpdated: vi.fn(),
   }
 })
 

--- a/src/renderer/src/stores/installationStore.ts
+++ b/src/renderer/src/stores/installationStore.ts
@@ -20,6 +20,13 @@ export const useInstallationStore = defineStore('installation', () => {
     fetchInstallations()
   })
 
+  window.api.onInstallationsVersionsUpdated((updates) => {
+    for (const { id, version } of updates) {
+      const inst = installations.value.find((i) => i.id === id)
+      if (inst) inst.version = version
+    }
+  })
+
   function getById(id: string): Installation | undefined {
     return installations.value.find((i) => i.id === id)
   }

--- a/src/renderer/src/stores/progressStore.test.ts
+++ b/src/renderer/src/stores/progressStore.test.ts
@@ -17,6 +17,7 @@ vi.stubGlobal('window', {
   api: {
     getInstallations: vi.fn().mockResolvedValue([]),
     onInstallationsChanged: vi.fn(),
+    onInstallationsVersionsUpdated: vi.fn(),
     onInstallProgress: vi.fn(() => vi.fn()),
     onComfyOutput: vi.fn(() => vi.fn()),
     cancelOperation: vi.fn(),

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -588,6 +588,7 @@ export interface ElectronApi {
   onLocaleChanged(callback: (messages: Record<string, unknown>) => void): Unsubscribe
   onConfirmQuit(callback: (details: QuitActiveItem[]) => void): Unsubscribe
   onInstallationsChanged(callback: () => void): Unsubscribe
+  onInstallationsVersionsUpdated(callback: (updates: { id: string; version: string }[]) => void): Unsubscribe
   onUpdateAvailable(callback: (info: UpdateInfo) => void): Unsubscribe
   onUpdateDownloadProgress(callback: (progress: UpdateDownloadProgress) => void): Unsubscribe
   onUpdateDownloaded(callback: (info: UpdateInfo) => void): Unsubscribe


### PR DESCRIPTION
## Problem

When tracking an existing standalone install that was initialized on an older release (e.g. \0.16.4\), the version display shows commits relative to that old release (\0.16.4+38\) instead of the most recent stable release (\0.17.1+7\).

The manifest's \comfyui_ref\ is set at install time and never updated, so \probeInstallation\ and \postInstall\ were always using the original release as the \aseTag\ for version offset computation.

## Solution

Add \indNearestTag()\ to \src/main/lib/git.ts\ which runs \git describe --tags --abbrev=0 HEAD\ to resolve the actual nearest ancestor tag from the local repo. This is a local-only operation (no network), and gives the correct answer as long as tags have been fetched (which the update script already does via \git fetch --tags\).

Updated both \probeInstallation\ and \postInstall\ in \standalone.ts\ to prefer \indNearestTag()\ over the manifest's \comfyui_ref\, falling back to the manifest ref only when tags aren't available.

## Changes

- **\src/main/lib/git.ts\** — Added \indNearestTag(repoPath)\
- **\src/main/sources/standalone.ts\** — Updated \probeInstallation\ and \postInstall\ to use \indNearestTag\ for \aseTag\
- **\src/main/lib/git.test.ts\** — Added 3 tests for \indNearestTag\

Fixes #258