### PR TITLE
fix: add gap between drag handle and text on instance cards

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -344,7 +344,7 @@ input[type="checkbox"]:checked::after { transform: translateX(16px); }
   --card-pad-y: 14px; --card-pad-x: 16px;
   background: var(--surface); border: 1px solid var(--border);
   border-radius: 8px; padding: var(--card-pad-y) var(--card-pad-x);
-  display: flex; justify-content: space-between; align-items: center;
+  display: flex; justify-content: space-between; align-items: center; gap: 12px;
 }
 .instance-card.is-idle { transition: transform 0.12s ease; }
 .instance-card.is-draggable { z-index: 10; user-select: none; }


### PR DESCRIPTION
Fixes #188

The instance card text (installation name) was flush against the drag handle on the left with no spacing. Added \gap: 12px\ to the \.instance-card\ flex container so there's consistent spacing between the drag handle, text content, and action buttons.