### PR TITLE
fix: hide update/migrate pills during active operations

### DIFF
--- a/src/renderer/src/components/DashboardCard.vue
+++ b/src/renderer/src/components/DashboardCard.vue
@@ -85,11 +85,11 @@ function stopComfyUI(): void {
         <span> · </span>
         <span class="status-danger">{{ $t('running.crashed') }}</span>
       </template>
-      <template v-if="installation.statusTag?.style === 'update'">
+      <template v-if="installation.statusTag?.style === 'update' && !progress">
         <span> · </span>
         <span class="update-pill" role="button" tabindex="0" @click.stop="emit('show-update', installation)" @keydown.enter.stop="emit('show-update', installation)" @keydown.space.prevent.stop="emit('show-update', installation)">{{ installation.statusTag.label }}</span>
       </template>
-      <template v-if="installation.statusTag?.style === 'migrate'">
+      <template v-if="installation.statusTag?.style === 'migrate' && !progress">
         <span> · </span>
         <span class="migrate-pill" role="button" tabindex="0" @click.stop="emit('show-migrate', installation)" @keydown.enter.stop="emit('show-migrate', installation)" @keydown.space.prevent.stop="emit('show-migrate', installation)">{{ installation.statusTag.label }}</span>
       </template>

--- a/src/renderer/src/views/InstallationList.vue
+++ b/src/renderer/src/views/InstallationList.vue
@@ -341,11 +341,11 @@ defineExpose({ refresh })
               <span v-else-if="part.class" :class="part.class">{{ part.text }}</span>
               <template v-else>{{ part.text }}</template>
             </template>
-            <template v-if="inst.statusTag?.style === 'update'">
+            <template v-if="inst.statusTag?.style === 'update' && !isInProgress(inst.id)">
               <template v-if="getMetaParts(inst).length > 0"> · </template>
               <span class="update-pill" role="button" tabindex="0" @click.stop="emit('show-detail', inst, 'update')" @keydown.enter.stop="emit('show-detail', inst, 'update')" @keydown.space.prevent.stop="emit('show-detail', inst, 'update')">{{ inst.statusTag.label }}</span>
             </template>
-            <template v-if="inst.statusTag?.style === 'migrate'">
+            <template v-if="inst.statusTag?.style === 'migrate' && !isInProgress(inst.id)">
               <template v-if="getMetaParts(inst).length > 0"> · </template>
               <span class="migrate-pill" role="button" tabindex="0" @click.stop="emit('show-migrate', inst)" @keydown.enter.stop="emit('show-migrate', inst)" @keydown.space.prevent.stop="emit('show-migrate', inst)">{{ inst.statusTag.label }}</span>
             </template>


### PR DESCRIPTION
## Problem

The update pill (e.g. \Update v0.17.2\) and migrate pill show on installation cards even while that installation has an active update/install/snapshot operation in progress, creating confusing UX.

## Solution

Suppress the update-pill and migrate-pill indicators when an operation is in progress for that installation. The pills reappear automatically when the operation completes and the active session clears.

### Changes

- **\DashboardCard.vue\** — Gate update/migrate pill rendering on \!progress\ (the existing computed that tracks active operations for the card's installation).
- **\InstallationList.vue\** — Gate update/migrate pill rendering on \!isInProgress(inst.id)\ (the existing helper that checks for an active non-running session).

No new state, no main-process changes — purely renderer-side suppression using existing reactive state.

Closes #262