### PR TITLE
chore: bump version to 0.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-desktop-2",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "ComfyUI Desktop 2.0",
   "author": {
     "name": "Jedrzej Kosinski",


### PR DESCRIPTION
Bump patch version from 0.4.1 to 0.4.2.

### Changes since 0.4.1
- fix: hide update/migrate pills during active operations (#264)
- fix: unify version resolution across all display surfaces (#261)
- fix: resolve version display from local git state instead of stale manifest ref (#260)
- fix: use white outline for selection cards, reserve blue for running state (#259)
- fix: remove delete action from git manual installs to prevent accidental data loss (#257)