### PR TITLE
Increase ComfyUI boot timeout from 2 minutes to 5 minutes

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,7 +10,7 @@ import * as updater from './lib/updater'
 import * as settings from './settings'
 import * as i18n from './lib/i18n'
 import { configDir, migrateXdgPaths } from './lib/paths'
-import { waitForPort } from './lib/process'
+import { waitForPort, COMFY_BOOT_TIMEOUT_MS } from './lib/process'
 import { isQuitInProgress, setQuitReason } from './lib/quit-state'
 import type { InstallationRecord } from './installations'
 import type { DatadogForwardedError } from '../types/ipc'
@@ -383,7 +383,7 @@ function onComfyRestarted({ installationId, process: _proc }: { installationId?:
   const port = parseInt(url.port, 10)
   if (!port) return
 
-  waitForPort(port, '127.0.0.1', { timeoutMs: 120000 })
+  waitForPort(port, '127.0.0.1', { timeoutMs: COMFY_BOOT_TIMEOUT_MS })
     .then(() => {
       if (!win.isDestroyed()) {
         win.webContents.stop()

--- a/src/main/lib/ipc.ts
+++ b/src/main/lib/ipc.ts
@@ -23,6 +23,7 @@ import {
   spawnProcess, waitForPort, waitForUrl, killProcessTree, killByPort,
   findPidsByPort, getProcessInfo, looksLikeComfyUI, setPortArg,
   findAvailablePort, writePortLock, readPortLock, removePortLock,
+  COMFY_BOOT_TIMEOUT_MS,
 } from './process'
 import { detectGPU, validateHardware, checkNvidiaDriver } from './gpu'
 import { detectDesktopInstall, stageDesktopSnapshot } from './desktopDetect'
@@ -2195,7 +2196,7 @@ export function register(callbacks: RegisterCallbacks = {}): void {
         try {
           await Promise.race([
             waitForPort(launchCmd.port!, '127.0.0.1', {
-              timeoutMs: 120000,
+              timeoutMs: COMFY_BOOT_TIMEOUT_MS,
               signal: abort.signal,
               onPoll: ({ elapsedMs }) => {
                 const secs = Math.round(elapsedMs / 1000)

--- a/src/main/lib/process.ts
+++ b/src/main/lib/process.ts
@@ -6,6 +6,9 @@ import path from 'path'
 import net from 'net'
 import { stateDir } from './paths'
 
+/** Default timeout for waiting for ComfyUI to boot (5 minutes). */
+export const COMFY_BOOT_TIMEOUT_MS = 300_000
+
 export interface WaitOptions {
   timeoutMs?: number
   intervalMs?: number


### PR DESCRIPTION
The hardcoded 120s timeout for waiting for ComfyUI's HTTP port to respond during startup/restart may not be enough on slower hardware (e.g. AMD laptops with many custom nodes).

This PR extracts a shared `COMFY_BOOT_TIMEOUT_MS` constant set to 300s (5 minutes) and uses it in both call sites (initial launch in `ipc.ts` and restart in `index.ts`).

Fixes #268