### PR TITLE
fix: install VC++ redistributable with Windows installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ out/
 result
 test-results/
 playwright-report/
+resources/vc_redist.x64.exe
+resources/vc_redist.x64.exe.tmp

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "start": "electron-vite preview",
     "postinstall": "node ./scripts/postinstall.mjs",
     "todesktop:beforeInstall": "./scripts/todesktop-beforeInstall.cjs",
+    "todesktop:afterPack": "./scripts/todesktop-afterPack.cjs",
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json --composite false",
     "typecheck:web": "vue-tsc --noEmit -p tsconfig.web.json --composite false",
     "typecheck:e2e": "tsc --noEmit -p tsconfig.e2e.json --composite false",

--- a/scripts/afterPack.mjs
+++ b/scripts/afterPack.mjs
@@ -1,5 +1,31 @@
-import fs from 'fs'
-import path from 'path'
+import fs from 'node:fs'
+import { Readable } from 'node:stream'
+import { pipeline } from 'node:stream/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+const vcRedistUrl = 'https://aka.ms/vc14/vc_redist.x64.exe'
+
+async function ensureVcRedist(context) {
+  const buildResourcesDir = context.packager.buildResourcesDir
+  const vcRedistPath = path.join(buildResourcesDir, 'vc_redist.x64.exe')
+  const vcRedistTempPath = `${vcRedistPath}.tmp`
+
+  if (fs.existsSync(vcRedistPath)) return
+
+  console.log(`afterPack: downloading ${vcRedistUrl}`)
+  const response = await fetch(vcRedistUrl)
+
+  if (!response.ok || !response.body) {
+    throw new Error(`Failed to download VC++ redistributable (${response.status} ${response.statusText})`)
+  }
+
+  fs.mkdirSync(buildResourcesDir, { recursive: true })
+  await pipeline(Readable.fromWeb(response.body), fs.createWriteStream(vcRedistTempPath))
+  fs.renameSync(vcRedistTempPath, vcRedistPath)
+  console.log(`afterPack: saved ${vcRedistPath}`)
+}
 
 /**
  * electron-builder afterPack hook.
@@ -7,7 +33,10 @@ import path from 'path'
  * This is necessary because AppImage mounts are read-only, so runtime chmod fails.
  */
 export default async function afterPack(context) {
-  if (process.platform === 'win32') return
+  if (process.platform === 'win32') {
+    await ensureVcRedist(context)
+    return
+  }
 
   const unpackedDir = path.join(
     context.appOutDir,

--- a/scripts/installer.nsh
+++ b/scripts/installer.nsh
@@ -24,6 +24,24 @@
   ${EndIf}
 !macroend
 
+!macro installVcRedist
+  File /oname=$PLUGINSDIR\vc_redist.x64.exe "${BUILD_RESOURCES_DIR}\vc_redist.x64.exe"
+  ExecWait '"$PLUGINSDIR\vc_redist.x64.exe" /install /passive /norestart' $0
+
+  ${If} $0 <> 0
+  ${AndIf} $0 <> 1638
+  ${AndIf} $0 <> 3010
+    MessageBox MB_ICONSTOP|MB_OK "Microsoft Visual C++ Redistributable installation failed (exit code $0). ComfyUI Desktop requires it to run."
+    Abort
+  ${EndIf}
+!macroend
+
+!macro customInstall
+  ${IfNot} ${isUpdated}
+    !insertmacro installVcRedist
+  ${EndIf}
+!macroend
+
 # Custom finish page: launch the app as the current user (not elevated)
 !macro customFinishPage
   !ifndef HIDE_RUN_AFTER_FINISH

--- a/scripts/todesktop-afterPack.cjs
+++ b/scripts/todesktop-afterPack.cjs
@@ -1,0 +1,1 @@
+module.exports = async (context) => (await import('./afterPack.mjs')).default(context)


### PR DESCRIPTION
## Summary
- bundle the Visual C++ redistributable into Windows installer builds
- run the redistributable during fresh NSIS installs before first launch
- wire the same after-pack hook into ToDesktop cloud builds

## Verification
- pnpm run typecheck
- pnpm run lint
- pnpm run build
- pnpm run test

## Notes
- this uses the x64 redistributable package, which Microsoft documents as containing both x64 and ARM64 binaries on ARM64 devices
- Windows installer execution path was not exercised from this macOS worktree