### PR TITLE
fix: open Google auth in system browser on macOS for passkey support

### DIFF
--- a/src/main/lib/allowedPopups.test.ts
+++ b/src/main/lib/allowedPopups.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { afterEach, describe, it, expect } from 'vitest'
 import { POPUP_ALLOWED_PREFIXES, shouldOpenInPopup } from './allowedPopups'
 
 describe('POPUP_ALLOWED_PREFIXES', () => {
@@ -42,5 +42,28 @@ describe('shouldOpenInPopup', () => {
 
   it('returns false for partial prefix matches', () => {
     expect(shouldOpenInPopup('https://dreamboothy.firebaseapp.com.evil.com/')).toBe(false)
+  })
+})
+
+describe('shouldOpenInPopup on macOS', () => {
+  const originalPlatform = process.platform
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform })
+  })
+
+  it('returns false for Google accounts URL on macOS (passkey workaround)', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' })
+    expect(shouldOpenInPopup('https://accounts.google.com/o/oauth2/auth?client_id=abc')).toBe(false)
+  })
+
+  it('returns true for Google accounts URL on non-macOS', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    expect(shouldOpenInPopup('https://accounts.google.com/o/oauth2/auth?client_id=abc')).toBe(true)
+  })
+
+  it('returns true for non-Google allowed URLs on macOS', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' })
+    expect(shouldOpenInPopup('https://dreamboothy.firebaseapp.com/__/auth/handler')).toBe(true)
   })
 })

--- a/src/main/lib/allowedPopups.ts
+++ b/src/main/lib/allowedPopups.ts
@@ -9,6 +9,15 @@ export const POPUP_ALLOWED_PREFIXES = [
   'https://github.com/login/oauth/',
 ]
 
+/**
+ * URLs that must open in the system browser on macOS because Electron's
+ * WebAuthn / passkey support is broken on that platform (electron#24573).
+ */
+const MACOS_EXTERNAL_PREFIXES = ['https://accounts.google.com/']
+
 export function shouldOpenInPopup(url: string): boolean {
+  if (process.platform === 'darwin' && MACOS_EXTERNAL_PREFIXES.some((prefix) => url.startsWith(prefix))) {
+    return false
+  }
   return POPUP_ALLOWED_PREFIXES.some((prefix) => url.startsWith(prefix))
 }


### PR DESCRIPTION
Electron's WebAuthn/passkey API is broken on macOS (electron#24573). On macOS, shouldOpenInPopup now returns false for accounts.google.com URLs, causing them to fall through to shell.openExternal and open in the system browser where passkeys work natively.

Closes #277
