### PR TITLE
fix: add loading spinners to all modals and prevent dashboard flash

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -677,6 +677,8 @@ input[type="checkbox"]:checked::after { transform: translateX(16px); }
 
 .modal-loading { display: flex; align-items: center; gap: 10px; padding: 24px 0; justify-content: center; color: var(--text-muted); font-size: 14px; }
 .modal-loading-spinner { width: 20px; height: 20px; border: 2px solid var(--border); border-top-color: var(--accent); border-radius: 50%; animation: btn-spin 0.6s linear infinite; }
+.with-spinner { display: flex; align-items: center; gap: 10px; }
+.with-spinner::before { content: ""; display: inline-block; width: 16px; height: 16px; border: 2px solid var(--border); border-top-color: var(--accent); border-radius: 50%; animation: btn-spin 0.6s linear infinite; flex-shrink: 0; }
 
 .modal-select-box { min-width: 340px; max-width: 440px; }
 .modal-select-list { display: flex; flex-direction: column; gap: 4px; margin-bottom: 16px; max-height: 40vh; overflow-y: auto; }
@@ -861,6 +863,7 @@ input[type="checkbox"]:checked::after { transform: translateX(16px); }
 .wizard-step { display: flex; flex-direction: column; gap: 12px; }
 .wizard-loading { font-size: 14px; color: var(--text-muted); padding: 12px 0; }
 .wizard-error { font-size: 14px; color: var(--danger); padding: 12px 0; }
+.track-probing { font-size: 14px; color: var(--text-muted); padding: 8px 0; margin-top: 6px; }
 
 /* Source cards (Step 1) */
 .source-card {

--- a/src/renderer/src/components/RestoreModal.vue
+++ b/src/renderer/src/components/RestoreModal.vue
@@ -57,7 +57,7 @@ onUnmounted(() => {
       <div class="modal-box restore-modal-box">
         <div class="modal-title">{{ t('snapshots.restorePreviewTitle') }}</div>
 
-        <div v-if="loading" class="restore-modal-loading">{{ t('common.loading') }}</div>
+        <div v-if="loading" class="restore-modal-loading with-spinner">{{ t('common.loading') }}</div>
 
         <template v-else-if="diffData">
           <div v-if="diffData.empty" class="restore-modal-empty">
@@ -110,6 +110,7 @@ onUnmounted(() => {
 }
 
 .restore-modal-loading {
+  justify-content: center;
   color: var(--text-muted);
   font-size: 13px;
   padding: 16px 0;

--- a/src/renderer/src/components/SnapshotTab.vue
+++ b/src/renderer/src/components/SnapshotTab.vue
@@ -389,7 +389,7 @@ function diffHasChanges(diff: SnapshotDiffResult): boolean {
     </div>
 
     <!-- Loading -->
-    <div v-if="loading" class="snapshot-loading">{{ t('common.loading') }}</div>
+    <div v-if="loading" class="snapshot-loading with-spinner">{{ t('common.loading') }}</div>
 
     <!-- Timeline -->
     <div v-if="!loading && snapshots.length > 0" class="snapshot-timeline">
@@ -475,7 +475,7 @@ function diffHasChanges(diff: SnapshotDiffResult): boolean {
 
           <!-- Inspector (inline, shown when selected) -->
           <div v-if="selectedFilename === item.snapshot.filename" class="snapshot-inspector" @click.stop>
-          <div v-if="detailLoading" class="snapshot-loading">{{ t('common.loading') }}</div>
+          <div v-if="detailLoading" class="snapshot-loading with-spinner">{{ t('common.loading') }}</div>
           <template v-else-if="detail">
             <!-- Diff toggle buttons -->
             <div class="diff-toggle">
@@ -502,7 +502,7 @@ function diffHasChanges(diff: SnapshotDiffResult): boolean {
               </div>
               <SnapshotDiffView v-else :diff="diffData.diff" />
             </div>
-            <div v-else-if="diffMode && diffLoading" class="snapshot-loading">{{ t('common.loading') }}</div>
+            <div v-else-if="diffMode && diffLoading" class="snapshot-loading with-spinner">{{ t('common.loading') }}</div>
 
             <!-- Environment info -->
             <div class="inspector-section">

--- a/src/renderer/src/stores/installationStore.test.ts
+++ b/src/renderer/src/stores/installationStore.test.ts
@@ -40,7 +40,7 @@ describe('useInstallationStore', () => {
 
   it('should have empty initial state', () => {
     expect(store.installations).toEqual([])
-    expect(store.loading).toBe(false)
+    expect(store.loading).toBe(true)
   })
 
   describe('fetchInstallations', () => {

--- a/src/renderer/src/stores/installationStore.ts
+++ b/src/renderer/src/stores/installationStore.ts
@@ -4,7 +4,7 @@ import type { Installation } from '../types/ipc'
 
 export const useInstallationStore = defineStore('installation', () => {
   const installations = ref<Installation[]>([])
-  const loading = ref(false)
+  const loading = ref(true)
 
   async function fetchInstallations(): Promise<Installation[]> {
     loading.value = true

--- a/src/renderer/src/views/DashboardView.vue
+++ b/src/renderer/src/views/DashboardView.vue
@@ -322,8 +322,11 @@ async function changePrimary(): Promise<void> {
 <template>
   <div class="view active">
     <div class="view-scroll">
+      <!-- Loading state -->
+      <div v-if="!primaryInstall && installationStore.loading" class="modal-loading with-spinner">{{ $t('common.loading') }}</div>
+
       <!-- Welcome state: no local installations -->
-      <div v-if="!primaryInstall" class="dashboard-welcome">
+      <div v-else-if="!primaryInstall" class="dashboard-welcome">
         <div class="dashboard-welcome-icon">
           <Download :size="48" />
         </div>

--- a/src/renderer/src/views/DetailModal.vue
+++ b/src/renderer/src/views/DetailModal.vue
@@ -64,6 +64,7 @@ const scrollRef = ref<HTMLDivElement | null>(null)
 const mouseDownOnOverlay = ref(false)
 
 const sections = ref<DetailSection[]>([])
+const sectionsLoading = ref(false)
 const installationSize = ref<number | null>(null)
 const installationSizeLoading = ref(false)
 
@@ -122,6 +123,7 @@ watch(
   async (inst) => {
     if (!inst) {
       sections.value = []
+      sectionsLoading.value = false
       previousInstId.value = null
       installationSize.value = null
       installationSizeLoading.value = false
@@ -133,7 +135,12 @@ watch(
     const isNewInstallation = inst.id !== previousInstId.value
     previousInstId.value = inst.id
     if (isNewInstallation) autoActionRun.value = false
-    sections.value = await window.api.getDetailSections(inst.id)
+    if (isNewInstallation) sectionsLoading.value = true
+    try {
+      sections.value = await window.api.getDetailSections(inst.id)
+    } finally {
+      sectionsLoading.value = false
+    }
     if (isNewInstallation) {
       const tabExists = sections.value.some((s) => s.tab === props.initialTab)
       activeTab.value = tabExists ? props.initialTab : 'status'
@@ -543,8 +550,9 @@ onUnmounted(() => {
           </button>
         </div>
         <div ref="scrollRef" class="view-scroll">
+          <div v-if="sectionsLoading" class="modal-loading with-spinner">{{ $t('common.loading') }}</div>
           <SnapshotTab
-            v-if="activeTab === 'snapshots'"
+            v-else-if="activeTab === 'snapshots'"
             :installation-id="installation.id"
             @run-action="runAction"
             @refresh-all="refreshAllSections"

--- a/src/renderer/src/views/LoadSnapshotModal.vue
+++ b/src/renderer/src/views/LoadSnapshotModal.vue
@@ -314,7 +314,7 @@ defineExpose({ open })
               @dragleave="handleDragLeave"
               @drop="handleDrop"
             >
-              <div v-if="loading" class="ls-drop-text">{{ $t('newInstall.loading') }}</div>
+              <div v-if="loading" class="ls-drop-loading with-spinner">{{ $t('newInstall.loading') }}</div>
               <template v-else>
                 <div class="ls-drop-text">{{ $t('list.snapshotDropHint') }}</div>
                 <div class="ls-drop-or">{{ $t('common.or') }}</div>
@@ -357,7 +357,7 @@ defineExpose({ open })
                     {{ opt.label }}{{ opt.recommended ? ` (${$t('newInstall.latest')})` : '' }}
                   </option>
                 </select>
-                <span v-else-if="releaseLoading" class="ls-value">{{ $t('newInstall.loading') }}</span>
+                <span v-else-if="releaseLoading" class="ls-value ls-value-loading with-spinner">{{ $t('newInstall.loading') }}</span>
                 <span v-else class="ls-value">{{ $t('newInstall.noOptions') }}</span>
                 <span v-if="preview.newestSnapshot.comfyui.releaseTag" class="ls-release-hint">
                   {{ $t('list.snapshotOriginalRelease', { tag: preview.newestSnapshot.comfyui.releaseTag }) }}
@@ -369,7 +369,7 @@ defineExpose({ open })
             <div class="ls-section">
               <div class="ls-field">
                 <span class="ls-label">{{ $t('list.snapshotDevice') }}</span>
-                <div v-if="variantLoading" class="ls-value">{{ $t('newInstall.loading') }}</div>
+                <div v-if="variantLoading" class="ls-value ls-value-loading with-spinner">{{ $t('newInstall.loading') }}</div>
                 <div
                   v-else-if="variantOptions.length > 0"
                   class="variant-cards"
@@ -548,6 +548,13 @@ defineExpose({ open })
   pointer-events: none;
 }
 
+.ls-drop-loading {
+  flex-direction: column;
+  justify-content: center;
+  font-size: 14px;
+  color: var(--text-muted);
+}
+
 .ls-drop-text {
   font-size: 14px;
   color: var(--text-muted);
@@ -610,6 +617,10 @@ defineExpose({ open })
   font-size: 14px;
   color: var(--text);
   user-select: text;
+}
+
+.ls-value-loading {
+  color: var(--text-muted);
 }
 
 .ls-name-input {

--- a/src/renderer/src/views/NewInstallModal.vue
+++ b/src/renderer/src/views/NewInstallModal.vue
@@ -689,7 +689,7 @@ defineExpose({ open })
         <div class="view-scroll">
           <!-- Step 1: Source Selection -->
           <div v-if="currentStep === 1" class="wizard-step">
-            <div v-if="sourcesLoading || initializing" class="wizard-loading">
+            <div v-if="sourcesLoading || initializing" class="wizard-loading with-spinner">
               {{ $t('newInstall.loading') }}
             </div>
             <template v-else>
@@ -812,7 +812,7 @@ defineExpose({ open })
 
                   <!-- Card-rendered select field -->
                   <template v-else-if="field.renderAs === 'cards'">
-                    <div v-if="fieldLoading.get(field.id)" class="wizard-loading">
+                    <div v-if="fieldLoading.get(field.id)" class="wizard-loading with-spinner">
                       {{ $t('newInstall.loading') }}
                     </div>
                     <div

--- a/src/renderer/src/views/QuickInstallModal.vue
+++ b/src/renderer/src/views/QuickInstallModal.vue
@@ -448,7 +448,7 @@ defineExpose({ open })
       </div>
       <div class="view-modal-body">
         <div class="view-scroll">
-          <div v-if="loading" class="wizard-loading">
+          <div v-if="loading" class="wizard-loading with-spinner">
             {{ $t('newInstall.loading') }}
           </div>
 
@@ -546,6 +546,7 @@ defineExpose({ open })
           <div></div>
           <button
             class="primary quick-install-btn"
+            :class="{ loading: installing }"
             :disabled="!canInstall"
             @click="handleInstall"
           >

--- a/src/renderer/src/views/TrackModal.vue
+++ b/src/renderer/src/views/TrackModal.vue
@@ -208,13 +208,14 @@ defineExpose({ open })
           <!-- Detected type -->
           <div class="field">
             <label for="track-source">{{ $t('track.detectedType') }}</label>
+            <div v-if="probing" class="track-probing with-spinner">{{ $t('track.detecting') }}</div>
             <select
+              v-else
               id="track-source"
               :disabled="probeResults.length <= 1"
               @change="handleSourceChange"
             >
-              <option v-if="probing">{{ $t('track.detecting') }}</option>
-              <option v-else-if="probeResults.length === 0">
+              <option v-if="probeResults.length === 0">
                 {{
                   trackPath
                     ? $t('track.noDetected')


### PR DESCRIPTION
Closes #192, closes #161

## Summary

Two related polish fixes:
1. **#192** — Adds loading spinner animations to all modal/view components that perform async operations where the user must wait. Previously several showed only plain text or no indicator at all.
2. **#161** — Prevents a brief flash of the "Welcome — Install ComfyUI" screen on startup while installations are loading.

## Approach

Introduces a reusable `.with-spinner` CSS utility class that injects a spinning border animation via `::before` pseudo-element. Any element with this class gets a spinner — no extra DOM nodes needed.

## Changes

| File | What changed |
|---|---|
| **main.css** | Added `.with-spinner` utility (flex layout + `::before` spinner); added `.track-probing` layout class |
| **DashboardView.vue** | Show spinner while `installationStore.loading` is true to prevent welcome-screen flash (#161) |
| **RestoreModal.vue** | Added spinner during diff preview loading |
| **SnapshotTab.vue** | Added spinner to initial snapshot list, detail, and diff load states |
| **DetailModal.vue** | Added `sectionsLoading` ref with spinner for the initial `getDetailSections()` fetch |
| **LoadSnapshotModal.vue** | Added spinner to drop zone, release selector, and variant selector loading |
| **QuickInstallModal.vue** | Added `.loading` class to install button while installing; added spinner to initial loading |
| **NewInstallModal.vue** | Added spinner to source loading and card-field loading states |
| **TrackModal.vue** | Replaced hidden select `<option>` with visible spinner + text during directory probing |

## Notes

- `.wizard-loading` no longer has a built-in spinner (it was also used for error text). Loading usages now pair it with `.with-spinner` explicitly.
- Existing `modal-loading-spinner` DOM-based pattern in `ModalDialog.vue` is left untouched.