### PR TITLE
Add tooltips to Update and Copy & Update action buttons

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -743,7 +743,9 @@
     "inputDir": "Shared folder for input files (images, masks, etc.) accessible to all installations.",
     "outputDir": "Shared folder where ComfyUI saves generated outputs, accessible to all installations.",
     "customNodes": "Third-party extensions that add new node types and functionality to ComfyUI.",
-    "pipPackages": "Python packages installed in the environment. Custom nodes often install their own pip dependencies."
+    "pipPackages": "Python packages installed in the environment. Custom nodes often install their own pip dependencies.",
+    "updateNow": "Update this installation in-place.",
+    "copyAndUpdate": "Create a copy of this installation and update the copy. The original will not be modified."
   },
 
   "contextMenu": {

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -483,5 +483,10 @@
     "portConflictKilling": "正在停止…",
     "portConflictKillFailed": "无法释放端口 {port}。该进程可能需要手动终止。",
     "duplicateName": "名为 \"{name}\" 的安装已存在。请选择其他名称。"
+  },
+
+  "tooltips": {
+    "updateNow": "就地更新此安装。",
+    "copyAndUpdate": "创建此安装的副本并更新副本。原始安装不会被修改。"
   }
 }

--- a/src/main/sources/portable.ts
+++ b/src/main/sources/portable.ts
@@ -168,6 +168,7 @@ export const portable: SourcePlugin = {
         })
         actions.push({
           id: 'update-comfyui', label: t('portable.updateNow'), style: 'primary', enabled: installed,
+          tooltip: t('tooltips.updateNow'),
           showProgress: true, progressTitle: t('portable.updatingTitle', { version: channelInfo.latestTag || '' }),
           data: isSwitching ? { channel: card.value } : undefined,
           confirm: {

--- a/src/main/sources/standalone.ts
+++ b/src/main/sources/standalone.ts
@@ -505,6 +505,7 @@ export const standalone: SourcePlugin = {
         })
         actions.push({
           id: 'update-comfyui', label: t('standalone.updateNow'), style: 'primary', enabled: installed,
+          tooltip: t('tooltips.updateNow'),
           showProgress: true, progressTitle: t('standalone.updatingTitle', { version: latestDisplay }),
           data: isSwitching ? { channel: card.value } : undefined,
           confirm: {
@@ -514,6 +515,7 @@ export const standalone: SourcePlugin = {
         })
         actions.push({
           id: 'copy-update', label: t('standalone.copyAndUpdate'), style: 'default', enabled: installed,
+          tooltip: t('tooltips.copyAndUpdate'),
           showProgress: true, progressTitle: t('standalone.copyUpdatingTitle', { version: latestDisplay }),
           cancellable: true,
           data: isSwitching ? { channel: card.value } : undefined,

--- a/src/renderer/src/components/DetailSection.vue
+++ b/src/renderer/src/components/DetailSection.vue
@@ -2,6 +2,7 @@
 import { ref, reactive, watch, nextTick } from 'vue'
 import type { DetailItem, DetailField, DetailFieldOption, ActionDef } from '../types/ipc'
 import InfoTooltip from './InfoTooltip.vue'
+import TooltipWrap from './TooltipWrap.vue'
 import ArgsBuilder from './ArgsBuilder.vue'
 
 interface Props {
@@ -175,14 +176,15 @@ v-for="a in item.actions" :key="a.id"
               <span v-if="getDraft(f) !== String(f.value)" class="channel-switch-hint">
                 {{ $t('channelCards.switchTo', { channel: getSelectedOption(f)?.label }) }}
               </span>
-              <button
-                v-for="a in getSelectedActions(f)" :key="a.id"
-                :class="[a.style, { 'looks-disabled': a.enabled === false && a.disabledMessage }]"
-                :disabled="a.enabled === false && !a.disabledMessage"
-                @click="handleAction(a, $event)"
-              >
-                {{ a.label }}
-              </button>
+              <TooltipWrap v-for="a in getSelectedActions(f)" :key="a.id" :text="a.tooltip">
+                <button
+                  :class="[a.style, { 'looks-disabled': a.enabled === false && a.disabledMessage }]"
+                  :disabled="a.enabled === false && !a.disabledMessage"
+                  @click="handleAction(a, $event)"
+                >
+                  {{ a.label }}
+                </button>
+              </TooltipWrap>
             </div>
           </template>
           <!-- Args builder -->
@@ -225,13 +227,14 @@ v-else-if="f.editable" type="text" class="detail-field-input"
 
       <!-- Actions -->
       <div v-if="actions?.length" class="detail-actions">
-        <button
-v-for="a in actions" :key="a.id"
-                :class="[a.style, { 'looks-disabled': a.enabled === false && a.disabledMessage }]"
-                :disabled="a.enabled === false && !a.disabledMessage"
-                @click="handleAction(a, $event)">
-          {{ a.label }}
-        </button>
+        <TooltipWrap v-for="a in actions" :key="a.id" :text="a.tooltip">
+          <button
+            :class="[a.style, { 'looks-disabled': a.enabled === false && a.disabledMessage }]"
+            :disabled="a.enabled === false && !a.disabledMessage"
+            @click="handleAction(a, $event)">
+            {{ a.label }}
+          </button>
+        </TooltipWrap>
       </div>
     </div>
   </div>

--- a/src/renderer/src/components/InfoTooltip.vue
+++ b/src/renderer/src/components/InfoTooltip.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { CircleHelp } from 'lucide-vue-next'
+import { useTooltip } from '../composables/useTooltip'
 
 const props = withDefaults(
   defineProps<{
@@ -11,30 +12,7 @@ const props = withDefaults(
 )
 
 const iconRef = ref<HTMLElement | null>(null)
-const bubbleStyle = ref<Record<string, string>>({})
-const visible = ref(false)
-
-function show(): void {
-  if (!iconRef.value) return
-  const rect = iconRef.value.getBoundingClientRect()
-  const x = rect.left + rect.width / 2
-  if (props.side === 'bottom') {
-    bubbleStyle.value = {
-      top: `${rect.bottom + 6}px`,
-      left: `${x}px`,
-    }
-  } else {
-    bubbleStyle.value = {
-      bottom: `${window.innerHeight - rect.top + 6}px`,
-      left: `${x}px`,
-    }
-  }
-  visible.value = true
-}
-
-function hide(): void {
-  visible.value = false
-}
+const { bubbleStyle, visible, show, hide } = useTooltip(iconRef, () => props.side)
 </script>
 
 <template>

--- a/src/renderer/src/components/TooltipWrap.vue
+++ b/src/renderer/src/components/TooltipWrap.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useTooltip } from '../composables/useTooltip'
+
+const props = withDefaults(
+  defineProps<{
+    text?: string
+    side?: 'top' | 'bottom'
+  }>(),
+  { text: undefined, side: 'top' }
+)
+
+const wrapRef = ref<HTMLElement | null>(null)
+const { bubbleStyle, visible, show, hide } = useTooltip(
+  wrapRef,
+  () => props.side,
+  () => !!props.text,
+)
+</script>
+
+<template>
+  <span
+    ref="wrapRef"
+    class="tooltip-wrap"
+    @mouseenter="show"
+    @mouseleave="hide"
+    @focusin="show"
+    @focusout="hide"
+  >
+    <slot />
+    <Teleport to="body">
+      <span
+        v-if="visible"
+        class="info-tooltip-bubble"
+        :style="bubbleStyle"
+      >{{ text }}</span>
+    </Teleport>
+  </span>
+</template>
+
+<style scoped>
+.tooltip-wrap {
+  display: inline-flex;
+}
+</style>

--- a/src/renderer/src/composables/useTooltip.ts
+++ b/src/renderer/src/composables/useTooltip.ts
@@ -1,0 +1,35 @@
+import { type Ref, ref } from 'vue'
+
+export function useTooltip(
+  triggerRef: Ref<HTMLElement | null>,
+  side: () => 'top' | 'bottom',
+  canShow?: () => boolean,
+) {
+  const bubbleStyle = ref<Record<string, string>>({})
+  const visible = ref(false)
+
+  function show(): void {
+    if (!triggerRef.value) return
+    if (canShow && !canShow()) return
+    const rect = triggerRef.value.getBoundingClientRect()
+    const x = rect.left + rect.width / 2
+    if (side() === 'bottom') {
+      bubbleStyle.value = {
+        top: `${rect.bottom + 6}px`,
+        left: `${x}px`,
+      }
+    } else {
+      bubbleStyle.value = {
+        bottom: `${window.innerHeight - rect.top + 6}px`,
+        left: `${x}px`,
+      }
+    }
+    visible.value = true
+  }
+
+  function hide(): void {
+    visible.value = false
+  }
+
+  return { bubbleStyle, visible, show, hide }
+}

--- a/src/renderer/src/views/DetailModal.vue
+++ b/src/renderer/src/views/DetailModal.vue
@@ -11,6 +11,7 @@ import { emitTelemetryAction, toErrorBucket } from '../lib/telemetry'
 import { useMigrateAction } from '../composables/useMigrateAction'
 import { REQUIRES_STOPPED } from '../types/ipc'
 import { Star, Pin, Pencil } from 'lucide-vue-next'
+import TooltipWrap from '../components/TooltipWrap.vue'
 import type {
   Installation,
   ActionDef,
@@ -629,18 +630,22 @@ onUnmounted(() => {
         <!-- Bottom pinned actions -->
         <div v-if="bottomSection" id="detail-bottom-actions">
           <div class="detail-actions">
-            <button
+            <TooltipWrap
               v-for="a in bottomSection.actions"
               :key="a.id"
-              :class="[
-                a.style,
-                { 'looks-disabled': a.enabled === false && a.disabledMessage }
-              ]"
-              :disabled="a.enabled === false && !a.disabledMessage"
-              @click="handleActionClick(a, $event)"
+              :text="a.tooltip"
             >
-              {{ a.label }}
-            </button>
+              <button
+                :class="[
+                  a.style,
+                  { 'looks-disabled': a.enabled === false && a.disabledMessage }
+                ]"
+                :disabled="a.enabled === false && !a.disabledMessage"
+                @click="handleActionClick(a, $event)"
+              >
+                {{ a.label }}
+              </button>
+            </TooltipWrap>
           </div>
         </div>
       </div>

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -121,6 +121,7 @@ export interface ActionDef {
   style?: 'primary' | 'danger'
   enabled?: boolean
   disabledMessage?: string
+  tooltip?: string
   confirm?: ConfirmDef
   showProgress?: boolean
   progressTitle?: string


### PR DESCRIPTION
Add hover tooltips to the **Update Now** and **Copy & Update** buttons so users can understand what each action does before clicking.

## Changes

- Add `tooltip` field to `ActionDef` and `ListAction` interfaces in `ipc.ts`
- Add `TooltipWrap` component — a generic slot wrapper that shows the existing styled tooltip bubble on hover of the wrapped content
- Wire tooltip strings through standalone and portable source backends
- Apply `TooltipWrap` to action buttons in `DetailSection` and `DetailModal`
- Add `tooltips.updateNow` and `tooltips.copyAndUpdate` locale strings

Closes #322