### PR TITLE
feat: show release notes in Copy & Update prompt dialog

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -536,6 +536,7 @@
     "copyAndUpdateTitle": "Copy & Update",
     "copyAndUpdateMessage": "Create a copy of this install and update the copy from {installed} to {latest}.\nThe original install will not be modified.\n\nEnter a name for the copy:",
     "copyAndUpdateConfirm": "Copy & Update",
+    "releaseNotesLabel": "Release Notes",
     "copyUpdatingTitle": "Copy & Update to {version}",
     "releaseUpdate": "Release Update",
     "releaseUpdateSelectRelease": "Select Release",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -402,6 +402,7 @@
     "copyAndUpdateTitle": "复制并更新",
     "copyAndUpdateMessage": "创建此安装的副本，并将副本从 {installed} 更新到 {latest}。\n原始安装不会被修改。\n\n输入副本名称：",
     "copyAndUpdateConfirm": "复制并更新",
+    "releaseNotesLabel": "发行说明",
     "copyUpdatingTitle": "复制并更新到 {version}",
     "releaseUpdate": "版本更新",
     "releaseUpdateSelectRelease": "选择版本",

--- a/src/main/sources/standalone.ts
+++ b/src/main/sources/standalone.ts
@@ -526,6 +526,7 @@ export const standalone: SourcePlugin = {
             confirmLabel: t('standalone.copyAndUpdateConfirm'),
             required: true,
             field: 'name',
+            messageDetails: notes ? [{ label: t('standalone.releaseNotesLabel'), items: [notes] }] : undefined,
           },
         })
       } else if (card.value !== channel && hasGit) {

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -655,7 +655,8 @@ input[type="checkbox"]:checked::after { transform: translateX(16px); }
 .modal-detail-group { margin-bottom: 6px; }
 .modal-detail-label { font-weight: 600; color: var(--text); font-size: 13px; text-transform: uppercase; }
 .modal-detail-list { margin: 4px 0 0; padding-left: 20px; list-style: disc; }
-.modal-detail-list li { font-size: 14px; color: var(--text-muted); line-height: 1.6; }
+.modal-detail-list li { font-size: 14px; color: var(--text-muted); line-height: 1.6; white-space: pre-line; }
+.modal-detail-list li a { color: var(--accent); text-decoration: underline; cursor: pointer; }
 
 /* Snapshot preview in confirm dialog */
 .sp-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 6px 16px; margin-bottom: 10px; }

--- a/src/renderer/src/components/ModalDialog.vue
+++ b/src/renderer/src/components/ModalDialog.vue
@@ -46,13 +46,15 @@ function escapeHtml(text: string): string {
 
 const URL_RE = /https?:\/\/[^\s<>"']+/g
 
-const linkifiedMessage = computed(() => {
-  if (!state.message) return ''
-  const escaped = escapeHtml(state.message)
+function linkify(text: string): string {
+  if (!text) return ''
+  const escaped = escapeHtml(text)
   return escaped.replace(URL_RE, (url) => {
     return `<a href="#" class="modal-link" data-url="${escapeHtml(url)}">${escapeHtml(url)}</a>`
   })
-})
+}
+
+const linkifiedMessage = computed(() => linkify(state.message))
 
 function handleMessageClick(event: MouseEvent): void {
   const target = event.target as HTMLElement
@@ -299,7 +301,7 @@ onUnmounted(() => {
             <div v-for="(group, gi) in state.messageDetails" :key="gi" class="modal-detail-group">
               <span class="modal-detail-label">{{ group.label }}</span>
               <ul class="modal-detail-list">
-                <li v-for="(item, ii) in group.items" :key="ii">{{ item }}</li>
+                <li v-for="(item, ii) in group.items" :key="ii" @click="handleMessageClick" v-html="linkify(item)"></li>
               </ul>
             </div>
           </div>
@@ -341,9 +343,19 @@ onUnmounted(() => {
       </div>
 
       <!-- Prompt -->
-      <div v-else-if="state.type === 'prompt'" class="modal-box">
+      <div v-else-if="state.type === 'prompt'" class="modal-box" :class="{ 'modal-box-wide': state.messageDetails.length > 0 }">
         <div class="modal-title">{{ state.title }}</div>
-        <div class="modal-message">{{ state.message }}</div>
+        <div class="modal-body">
+          <div class="modal-message">{{ state.message }}</div>
+          <div v-if="state.messageDetails.length" class="modal-details">
+            <div v-for="(group, gi) in state.messageDetails" :key="gi" class="modal-detail-group">
+              <span class="modal-detail-label">{{ group.label }}</span>
+              <ul class="modal-detail-list">
+                <li v-for="(item, ii) in group.items" :key="ii" @click="handleMessageClick" v-html="linkify(item)"></li>
+              </ul>
+            </div>
+          </div>
+        </div>
         <div class="modal-input-wrap">
           <input
             ref="inputRef"

--- a/src/renderer/src/composables/useModal.ts
+++ b/src/renderer/src/composables/useModal.ts
@@ -1,6 +1,6 @@
 import { reactive, readonly } from 'vue'
 import { i18n } from '../main'
-import type { SnapshotDetailData, FieldOption } from '../types/ipc'
+import type { SnapshotDetailData, FieldOption, ModalDetailGroup } from '../types/ipc'
 
 export type ModalType = 'alert' | 'confirm' | 'confirmWithOptions' | 'prompt' | 'select'
 
@@ -16,10 +16,7 @@ export interface ModalOption {
   checked?: boolean
 }
 
-export interface ModalDetailGroup {
-  label: string
-  items: string[]
-}
+export type { ModalDetailGroup }
 
 export interface ModalCheckbox {
   id: string
@@ -143,7 +140,7 @@ export function useModal() {
       state.loading = opts.loading ?? false
       state.title = opts.title
       state.message = opts.message
-      state.messageDetails = opts.messageDetails ?? []
+      state.messageDetails = (opts.messageDetails ?? []).map((g) => ({ ...g, items: [...g.items] }))
       state.snapshotPreview = opts.snapshotPreview ?? null
       state.checkboxes = (opts.checkboxes ?? []).map((c) => ({ ...c }))
       state.confirmLabel = opts.confirmLabel ?? i18n.global.t('modal.confirm')
@@ -165,7 +162,7 @@ export function useModal() {
     if (!state.visible || state.type !== 'confirm') return
     if (opts.loading !== undefined) state.loading = opts.loading
     if (opts.message !== undefined) state.message = opts.message
-    if (opts.messageDetails !== undefined) state.messageDetails = opts.messageDetails
+    if (opts.messageDetails !== undefined) state.messageDetails = opts.messageDetails.map((g) => ({ ...g, items: [...g.items] }))
     if (opts.snapshotPreview !== undefined) state.snapshotPreview = opts.snapshotPreview
     if (opts.variantCards !== undefined) state.variantCards = opts.variantCards
     if (opts.selectedVariant !== undefined) state.selectedVariant = opts.selectedVariant
@@ -200,6 +197,7 @@ export function useModal() {
     defaultValue?: string
     confirmLabel?: string
     required?: boolean | string
+    messageDetails?: ModalDetailGroup[]
   }): Promise<string | null> {
     return new Promise((resolve) => {
       reset()
@@ -207,6 +205,7 @@ export function useModal() {
       state.type = 'prompt'
       state.title = opts.title
       state.message = opts.message
+      state.messageDetails = (opts.messageDetails ?? []).map((g) => ({ ...g, items: [...g.items] }))
       state.placeholder = opts.placeholder ?? ''
       state.defaultValue = opts.defaultValue ?? ''
       state.confirmLabel = opts.confirmLabel ?? 'OK'

--- a/src/renderer/src/types/ipc.ts
+++ b/src/renderer/src/types/ipc.ts
@@ -17,6 +17,7 @@ export type {
   FieldSelectDef,
   SelectDef,
   PromptDef,
+  ModalDetailGroup,
   ListAction,
   ActionResult,
   PortConflictInfo,

--- a/src/renderer/src/views/DetailModal.vue
+++ b/src/renderer/src/views/DetailModal.vue
@@ -361,7 +361,8 @@ async function runAction(action: ActionDef, btn: HTMLButtonElement | null): Prom
       placeholder: mutableAction.prompt.placeholder,
       defaultValue: mutableAction.prompt.defaultValue,
       confirmLabel: mutableAction.prompt.confirmLabel || mutableAction.label,
-      required: mutableAction.prompt.required
+      required: mutableAction.prompt.required,
+      messageDetails: mutableAction.prompt.messageDetails
     })
     if (!value) return
     mutableAction = {

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -172,6 +172,12 @@ export interface PromptDef {
   confirmLabel?: string
   field: string
   required?: boolean | string
+  messageDetails?: ModalDetailGroup[]
+}
+
+export interface ModalDetailGroup {
+  label: string
+  items: string[]
 }
 
 // --- List actions ---


### PR DESCRIPTION
## Summary

Extends the prompt modal to support `messageDetails` — the same rich content pattern already used by the confirm dialog. When an update has release notes, the **Copy & Update** prompt now displays them in a details section below the message text, matching the UX of the Update confirmation dialog.

## Changes

- **`PromptDef`** (`ipc.ts`): Added optional `messageDetails` field
- **`useModal.ts`**: `prompt()` now accepts and sets `messageDetails` on the modal state  
- **`ModalDialog.vue`**: Prompt template renders `messageDetails` using the existing `modal-details` / `modal-detail-group` CSS classes; widens the box (`modal-box-wide`) when details are present
- **`DetailModal.vue`**: Passes `messageDetails` through from the action definition to the modal
- **`standalone.ts`**: Populates `messageDetails` with release notes on the `copy-update` action
- **`en.json`**: Added `releaseNotesLabel` i18n key

## Closes #167