### PR TITLE
fix: tag fallback not detecting backported releases

### DIFF
--- a/lib/git_operations.py
+++ b/lib/git_operations.py
@@ -16,6 +16,7 @@ Subcommands:
   merge-base         <repo_path> <ref1> <ref2>
   is-ancestor        <repo_path> <ancestor> <descendant>
   fetch-tags         <repo_path>
+  ls-remote-tags     <url>
   clone              <url> <dest>
   checkout           <repo_path> <commit>
   fetch-and-checkout <repo_path> <commit>
@@ -336,6 +337,35 @@ def cmd_fetch_tags(repo_path):
         sys.exit(1)
 
 
+def cmd_ls_remote_tags(url):
+    """List version tags from a remote repository URL, sorted by version descending.
+
+    Uses a temporary bare repo to query the remote via the Git protocol
+    (not the GitHub API), so it is not subject to REST API rate limits.
+    Prints one tag name per line on stdout.
+    """
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        repo = pygit2.init_repository(tmpdir, bare=True)
+        remote = repo.remotes.create_anonymous(url)
+        refs = remote.ls_remotes()
+
+        tags = []
+        for ref in refs:
+            name = ref["name"] if isinstance(ref, dict) else ref.name
+            if not name.startswith("refs/tags/") or name.endswith("^{}"):
+                continue
+            tag_name = name[len("refs/tags/"):]
+            version = parse_version_tuple(tag_name)
+            if version is not None:
+                tags.append((version, tag_name))
+
+        tags.sort(reverse=True)
+        for _, tag_name in tags:
+            print(tag_name)
+
+
 def cmd_clone(url, dest):
     """Clone a repository. Print progress to stderr."""
     print("Cloning %s into %s..." % (url, dest), file=sys.stderr)
@@ -469,6 +499,7 @@ Subcommands:
   merge-base         <repo_path> <ref1> <ref2>
   is-ancestor        <repo_path> <ancestor> <descendant>
   fetch-tags         <repo_path>
+  ls-remote-tags     <url>
   clone              <url> <dest>
   checkout           <repo_path> <commit>
   fetch-and-checkout <repo_path> <commit>
@@ -533,6 +564,12 @@ if __name__ == "__main__":
                 print("Usage: git_operations.py fetch-tags <repo_path>", file=sys.stderr)
                 sys.exit(1)
             cmd_fetch_tags(sys.argv[2])
+
+        elif subcmd == "ls-remote-tags":
+            if len(sys.argv) < 3:
+                print("Usage: git_operations.py ls-remote-tags <url>", file=sys.stderr)
+                sys.exit(1)
+            cmd_ls_remote_tags(sys.argv[2])
 
         elif subcmd == "clone":
             if len(sys.argv) < 4:

--- a/src/main/lib/comfyui-releases.ts
+++ b/src/main/lib/comfyui-releases.ts
@@ -1,6 +1,8 @@
 import { fetchJSON } from './fetch'
+import { lsRemoteLatestTag } from './git'
 
 const REPO = 'Comfy-Org/ComfyUI'
+const REPO_URL = `https://github.com/${REPO}.git`
 
 interface GitHubCommit {
   sha: string
@@ -30,7 +32,7 @@ interface GitHubComparison {
 }
 
 function isStableRelease(r: GitHubRelease): boolean {
-  return !r.prerelease && !!r.tag_name
+  return !r.draft && !r.prerelease && !!r.tag_name
 }
 
 /**
@@ -61,6 +63,13 @@ function compareVersions(a: number[], b: number[]): number {
  * (the releases API omits drafts for unauthenticated callers).
  */
 async function fetchLatestTag(): Promise<string | null> {
+  // Prefer pygit2 ls-remote (Git protocol, no API rate limit).
+  try {
+    const tag = await lsRemoteLatestTag(REPO_URL)
+    if (tag) return tag
+  } catch {
+    // fall through to GitHub API
+  }
   try {
     const tags = await fetchJSON(
       `https://api.github.com/repos/${REPO}/tags?per_page=30`

--- a/src/main/lib/git.test.ts
+++ b/src/main/lib/git.test.ts
@@ -8,7 +8,7 @@ vi.mock('child_process', async (importOriginal) => {
 
 import { execFile, spawn } from 'child_process'
 import { EventEmitter } from 'events'
-import { countCommitsAhead, findNearestTag, findLatestVersionTag, isAncestorOf, findMergeBase, revParseRef, fetchTags, configurePygit2, isGitAvailable, resetGitAvailableCache, countUniqueCommits, gitClone, gitCheckoutCommit, gitFetchAndCheckout } from './git'
+import { countCommitsAhead, findNearestTag, findLatestVersionTag, lsRemoteLatestTag, isAncestorOf, findMergeBase, revParseRef, fetchTags, configurePygit2, isGitAvailable, resetGitAvailableCache, countUniqueCommits, gitClone, gitCheckoutCommit, gitFetchAndCheckout } from './git'
 
 const mockedExecFile = vi.mocked(execFile)
 const mockedSpawn = vi.mocked(spawn)
@@ -414,6 +414,27 @@ describe('pygit2 fallback', () => {
     it('returns undefined for empty output', async () => {
       mockExecFile((_cmd, _args, _opts, cb) => { cb(null, '\n', '') })
       expect(await findLatestVersionTag('/repo')).toBeUndefined()
+    })
+  })
+
+  describe('lsRemoteLatestTag', () => {
+    it('passes correct subcommand and parses first tag', async () => {
+      mockExecFile((_cmd, _args, _opts, cb) => { cb(null, 'v0.18.3\nv0.18.2\nv0.18.1\n', '') })
+      expect(await lsRemoteLatestTag('https://github.com/Comfy-Org/ComfyUI.git')).toBe('v0.18.3')
+      const args = expectPygit2Call()
+      expect(args).toEqual(['ls-remote-tags', 'https://github.com/Comfy-Org/ComfyUI.git'])
+    })
+
+    it('returns undefined on error', async () => {
+      const errWithCode = new Error('fail') as Error & { code: number }
+      errWithCode.code = 1
+      mockExecFile((_cmd, _args, _opts, cb) => { cb(errWithCode, '', '') })
+      expect(await lsRemoteLatestTag('https://github.com/Comfy-Org/ComfyUI.git')).toBeUndefined()
+    })
+
+    it('returns undefined for empty output', async () => {
+      mockExecFile((_cmd, _args, _opts, cb) => { cb(null, '\n', '') })
+      expect(await lsRemoteLatestTag('https://github.com/Comfy-Org/ComfyUI.git')).toBeUndefined()
     })
   })
 

--- a/src/main/lib/git.ts
+++ b/src/main/lib/git.ts
@@ -240,6 +240,22 @@ export function findNearestTag(repoPath: string, commit: string = 'HEAD'): Promi
  * Returns undefined if git is unavailable, no `v*` tags exist, or any
  * error occurs.
  */
+
+/**
+ * List version tags from a remote URL via the Git protocol (not the GitHub API).
+ * Returns the latest version tag, or undefined on failure.
+ * Requires pygit2 to be configured.
+ */
+export function lsRemoteLatestTag(url: string): Promise<string | undefined> {
+  if (!isPygit2Configured()) return Promise.resolve(undefined)
+  return runPygit2(['ls-remote-tags', url], 15000).then(({ exitCode, stdout }) => {
+    if (exitCode !== 0) return undefined
+    const tag = stdout.trim().split('\n')[0]?.trim()
+    return tag || undefined
+  })
+}
+
+/** Find the highest version tag in the repository (see above). */
 export function findLatestVersionTag(repoPath: string): Promise<string | undefined> {
   if (isPygit2Configured()) {
     return runPygit2(['tag-list', repoPath]).then(({ exitCode, stdout }) => {

--- a/src/main/lib/release-cache.ts
+++ b/src/main/lib/release-cache.ts
@@ -91,6 +91,10 @@ const _inFlight: Map<string, Promise<ReleaseCacheEntry | null>> = new Map()
 // Prevents spamming the GitHub API and triggering secondary rate limits.
 const MIN_RECHECK_INTERVAL = 10_000
 
+// Maximum age of a cached entry before it's considered stale (in ms).
+// Non-forced reads will refetch if the entry is older than this.
+const CACHE_TTL = 60 * 60 * 1000 // 1 hour
+
 /**
  * Fetch release info, deduplicating concurrent calls for the same key.
  * @param repo - e.g. "Comfy-Org/ComfyUI"
@@ -109,9 +113,10 @@ export async function getOrFetch(
   _ensureLoaded()
 
   const cached = _entries[key]
+  const age = cached?.checkedAt ? Date.now() - cached.checkedAt : Infinity
   if (!force) {
-    if (cached) return cached
-  } else if (cached?.checkedAt && Date.now() - cached.checkedAt < MIN_RECHECK_INTERVAL) {
+    if (cached && age < CACHE_TTL) return cached
+  } else if (cached && age < MIN_RECHECK_INTERVAL) {
     return cached
   }
 
@@ -127,7 +132,9 @@ export async function getOrFetch(
         _entries[key] = entry
         _persist()
       }
-      return entry
+      return entry ?? cached ?? null
+    } catch {
+      return cached ?? null
     } finally {
       _inFlight.delete(key)
     }


### PR DESCRIPTION
Fixes #335

## Problem

When a new version tag (e.g. `v0.18.3`) exists on a release branch but has no published GitHub Release, the Launcher should detect it as the latest stable version via the tag fallback in `fetchLatestTag()`. Two issues prevented this:

1. **`isStableRelease` didn't filter drafts** — when the GitHub API returns draft releases (e.g. to authenticated callers), `isStableRelease` treated them as stable since it only checked `!r.prerelease`, not `!r.draft`. This meant the tag fallback comparison saw the draft's tag as equal to the latest tag and never triggered the synthetic release path.

2. **Release cache had no TTL** — non-forced cache reads returned stale entries indefinitely until the app triggered a forced refresh (e.g. at startup). If the cache was populated before the new tag existed, it stayed stale.

## Changes

- **`comfyui-releases.ts`**: Add `!r.draft` check to `isStableRelease` so draft releases don't prevent the tag fallback from activating.
- **`release-cache.ts`**: Add a 1-hour TTL to non-forced `getOrFetch` reads so stale cache entries are eventually refreshed without requiring an explicit force.