### PR TITLE
fix: show passkey warning banner on Google auth popup on macOS

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -554,6 +554,29 @@ function onLaunch({ port, url, process: proc, installation, mode }: {
   comfyWindow.on('move', () => saveWindowBounds(installationId, comfyWindow))
   comfyWindow.webContents.on('did-create-window', (childWindow) => {
     childWindow.setIcon(APP_ICON)
+    // On macOS, Electron's WebAuthn/passkey support is broken (electron#24573).
+    // Show a warning banner when the auth popup navigates to Google so users
+    // know to use password + OTP instead of passkeys.
+    if (process.platform === 'darwin') {
+      childWindow.webContents.on('did-navigate', (_e, url) => {
+        if (url.startsWith('https://accounts.google.com/')) {
+          childWindow.webContents
+            .insertCSS(
+              `#comfy-passkey-banner{background:#fef3c7;color:#92400e;font:13px/1.4 system-ui,sans-serif;` +
+                `padding:8px 12px;text-align:center;border-bottom:1px solid #f59e0b;}`
+            )
+            .then(() =>
+              childWindow.webContents.executeJavaScript(
+                `if(!document.getElementById('comfy-passkey-banner')){` +
+                  `const b=document.createElement('div');b.id='comfy-passkey-banner';` +
+                  `b.textContent='Passkeys are not supported in Desktop 2.0 on macOS. Please use your password or verification code to sign in.';` +
+                  `document.body.prepend(b)}`
+              )
+            )
+            .catch(() => {})
+        }
+      })
+    }
   })
   comfyWindow.webContents.on('page-title-updated', (e, title) => {
     e.preventDefault()


### PR DESCRIPTION
## Problem

Electron's WebAuthn/passkey API is broken on macOS ([electron#24573](https://github.com/electron/electron/issues/24573)), causing Google passkey sign-in to fail silently in the auth popup.

## Investigation

The previous approach (PR #282) tried to redirect Google auth URLs to the system browser on macOS, but this breaks Firebase's `signInWithPopup` OAuth flow because sessionStorage state is lost across browser contexts.

Using a native WebAuthn addon (e.g. `electron-webauthn`) would require Apple Developer entitlements (`com.apple.developer.web-browser.public-key-credential` needs Apple approval, and `com.apple.developer.associated-domains` requires Google to list our app — not feasible).

## Solution

On macOS only, inject a warning banner at the top of the Google accounts page inside the auth popup, informing users to use their password or verification code instead of passkeys. The banner is a normal-flow element that pushes page content down (not an overlay).

- Only affects macOS; other platforms are unaffected
- No changes to `allowedPopups.ts` or the auth flow itself
- Single file change in `index.ts`

Closes #277