### PR TITLE
fix: improve macOS passkey warning banner reliability

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -514,6 +514,51 @@ function onStop({ installationId }: { installationId?: string } = {}): void {
   }
 }
 
+/**
+ * On macOS, Electron's WebAuthn/passkey support is broken (electron#24573).
+ * Inject a fixed warning banner into auth popups (Google, GitHub) so users
+ * know to use password + OTP instead of passkeys.
+ */
+const PASSKEY_BANNER_PREFIXES = [
+  'https://accounts.google.com/',
+  'https://github.com/login',
+]
+
+const PASSKEY_BANNER_CSS =
+  `#comfy-passkey-banner{position:fixed;top:0;left:0;right:0;z-index:999999;` +
+  `background:#eff6ff;color:#1e40af;font:13px/1.4 system-ui,sans-serif;` +
+  `padding:8px 12px;text-align:center;border-bottom:1px solid #93c5fd;box-sizing:border-box;}`
+
+const PASSKEY_BANNER_JS =
+  `(function(){` +
+    `if(document.getElementById('comfy-passkey-banner'))return;` +
+    `const b=document.createElement('div');b.id='comfy-passkey-banner';` +
+    `b.textContent='\\u24d8 Passkeys are not supported in Desktop 2.0 on macOS. Please use your password or verification code to sign in.';` +
+    `document.body.prepend(b);` +
+    `document.body.style.paddingTop=(b.offsetHeight)+'px';` +
+    `new MutationObserver(function(){` +
+      `if(!document.getElementById('comfy-passkey-banner')){` +
+        `document.body.prepend(b);document.body.style.paddingTop=(b.offsetHeight)+'px'` +
+      `}` +
+    `}).observe(document.body,{childList:true});` +
+  `})()`
+
+function injectMacPasskeyWarning(childWindow: BrowserWindow): void {
+  if (process.platform !== 'darwin') return
+
+  const inject = (): void => {
+    const url = childWindow.webContents.getURL()
+    if (!PASSKEY_BANNER_PREFIXES.some((prefix) => url.startsWith(prefix))) return
+    childWindow.webContents
+      .insertCSS(PASSKEY_BANNER_CSS)
+      .then(() => childWindow.webContents.executeJavaScript(PASSKEY_BANNER_JS))
+      .catch(() => {})
+  }
+
+  childWindow.webContents.on('dom-ready', inject)
+  childWindow.webContents.on('did-navigate-in-page', inject)
+}
+
 function onLaunch({ port, url, process: proc, installation, mode }: {
   port: number
   url?: string
@@ -554,29 +599,7 @@ function onLaunch({ port, url, process: proc, installation, mode }: {
   comfyWindow.on('move', () => saveWindowBounds(installationId, comfyWindow))
   comfyWindow.webContents.on('did-create-window', (childWindow) => {
     childWindow.setIcon(APP_ICON)
-    // On macOS, Electron's WebAuthn/passkey support is broken (electron#24573).
-    // Show a warning banner when the auth popup navigates to Google so users
-    // know to use password + OTP instead of passkeys.
-    if (process.platform === 'darwin') {
-      childWindow.webContents.on('did-navigate', (_e, url) => {
-        if (url.startsWith('https://accounts.google.com/')) {
-          childWindow.webContents
-            .insertCSS(
-              `#comfy-passkey-banner{background:#fef3c7;color:#92400e;font:13px/1.4 system-ui,sans-serif;` +
-                `padding:8px 12px;text-align:center;border-bottom:1px solid #f59e0b;}`
-            )
-            .then(() =>
-              childWindow.webContents.executeJavaScript(
-                `if(!document.getElementById('comfy-passkey-banner')){` +
-                  `const b=document.createElement('div');b.id='comfy-passkey-banner';` +
-                  `b.textContent='Passkeys are not supported in Desktop 2.0 on macOS. Please use your password or verification code to sign in.';` +
-                  `document.body.prepend(b)}`
-              )
-            )
-            .catch(() => {})
-        }
-      })
-    }
+    injectMacPasskeyWarning(childWindow)
   })
   comfyWindow.webContents.on('page-title-updated', (e, title) => {
     e.preventDefault()


### PR DESCRIPTION
Follow-up to #337. Addresses code review findings:

### Changes

1. **Use `dom-ready` instead of `did-navigate`** — Avoids race condition where `executeJavaScript` runs before DOM is constructed, causing silent failures
2. **Handle SPA navigations** — Listen to `did-navigate-in-page` since Google's login rewrites the DOM between steps (email → password → passkey prompt)
3. **MutationObserver** — Re-injects the banner if Google's page scripts remove it during DOM rewrites
4. **`position:fixed` with body padding** — Prevents breaking Google's flex/absolute layout while keeping content accessible underneath
5. **GitHub OAuth coverage** — Also shows the banner on `github.com/login/` since GitHub also promotes passkeys
6. **Extracted helper function** — `injectMacPasskeyWarning()` keeps `onLaunch` clean

### Testing

- Build the app on macOS
- Click Sign In → Google: banner should appear at the top and persist across email/password steps
- Click Sign In → GitHub: banner should also appear
- On Windows/Linux: no banner should appear