### PR TITLE
fix: hide menu bar on login popup windows

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -599,6 +599,7 @@ function onLaunch({ port, url, process: proc, installation, mode }: {
   comfyWindow.on('move', () => saveWindowBounds(installationId, comfyWindow))
   comfyWindow.webContents.on('did-create-window', (childWindow) => {
     childWindow.setIcon(APP_ICON)
+    childWindow.setMenu(null)
     injectMacPasskeyWarning(childWindow)
   })
   comfyWindow.webContents.on('page-title-updated', (e, title) => {


### PR DESCRIPTION
## Summary
Remove the menu entirely from child popup windows (e.g. Google sign-in, Firebase auth) by calling `setMenu(null)` in the `did-create-window` handler.

## Problem
The cloud login popup (Google sign-in, etc.) shows the Electron menu bar (File, Edit, etc.). Clicking File → Exit closes the app to tray but leaves it in an unrecoverable state — the window can't be reopened without quitting entirely.

## Fix
Call `childWindow.setMenu(null)` on popup windows created via `did-create-window`, which fully removes the menu rather than just hiding it. This is stronger than `setMenuBarVisibility(false)` since the menu can't be toggled back with Alt.

Fixes #347