### PR TITLE
fix: guard popup removeMenu() for Windows/Linux only

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -599,7 +599,7 @@ function onLaunch({ port, url, process: proc, installation, mode }: {
   comfyWindow.on('move', () => saveWindowBounds(installationId, comfyWindow))
   comfyWindow.webContents.on('did-create-window', (childWindow) => {
     childWindow.setIcon(APP_ICON)
-    childWindow.setMenu(null)
+    if (process.platform !== 'darwin') childWindow.removeMenu()
     injectMacPasskeyWarning(childWindow)
   })
   comfyWindow.webContents.on('page-title-updated', (e, title) => {


### PR DESCRIPTION
## Summary
Follow-up to #350 — the `setMenu(null)` call merged in that PR is a Windows/Linux-only API (`@platform linux,win32`). This PR:

1. Adds a `process.platform !== 'darwin'` guard to skip the call on macOS
2. Uses `removeMenu()` (the preferred API) instead of the deprecated `setMenu(null)`