### PR TITLE
chore: bump version to 0.4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-desktop-2",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "ComfyUI Desktop 2.0",
   "author": {
     "name": "Jedrzej Kosinski",


### PR DESCRIPTION
Bump patch version from 0.4.4 → 0.4.5 for a new release.