### PR TITLE
refactor: replace envs/default/ with ComfyUI/.venv/

### DIFF
--- a/src/main/lib/ipc/sessionActions/launch.ts
+++ b/src/main/lib/ipc/sessionActions/launch.ts
@@ -20,7 +20,8 @@ import {
 import type { ChildProcess, LaunchCmd } from '../shared'
 import type { ActionContext, ActionResult } from './types'
 
-export async function handleLaunch({ event, installationId, inst, actionData }: ActionContext): Promise<ActionResult> {
+export async function handleLaunch({ event, installationId, inst: instArg, actionData }: ActionContext): Promise<ActionResult> {
+  let inst = instArg
   if (_runningSessions.has(installationId)) {
     return { ok: false, message: i18n.t('errors.alreadyRunning') }
   }
@@ -32,6 +33,18 @@ export async function handleLaunch({ event, installationId, inst, actionData }: 
   if (!source.skipInstall && isEffectivelyEmptyInstallDir(inst.installPath)) {
     return { ok: false, message: i18n.t('errors.installDirEmpty') }
   }
+  // Migrate legacy envs/default/ → ComfyUI/.venv/ for standalone installations
+  if (inst.sourceId === 'standalone') {
+    const { migrateEnvLayout } = await import('../../../sources/standalone/install')
+    const updateFn = async (data: Record<string, unknown>): Promise<unknown> => installations.update(installationId, data)
+    try {
+      const migrated = await migrateEnvLayout(inst.installPath, updateFn)
+      if (migrated) inst = (await installations.get(installationId)) || inst
+    } catch (err) {
+      console.warn('Env layout migration failed:', err)
+    }
+  }
+
   const launchCmdRaw = source.getLaunchCommand(inst)
   if (!launchCmdRaw) {
     return { ok: false, message: i18n.t('errors.noEnvFound') }

--- a/src/main/lib/pythonEnv.ts
+++ b/src/main/lib/pythonEnv.ts
@@ -2,9 +2,6 @@ import fs from 'fs'
 import path from 'path'
 import type { InstallationRecord } from '../installations'
 
-export const ENVS_DIR = 'envs'
-export const DEFAULT_ENV = 'default'
-
 export function getUvPath(installPath: string): string {
   if (process.platform === 'win32') {
     return path.join(installPath, 'standalone-env', 'uv.exe')
@@ -12,37 +9,25 @@ export function getUvPath(installPath: string): string {
   return path.join(installPath, 'standalone-env', 'bin', 'uv')
 }
 
-export function getEnvPythonPath(installPath: string, envName: string): string {
-  const envDir = path.join(installPath, ENVS_DIR, envName)
+export function getVenvDir(installPath: string): string {
+  return path.join(installPath, 'ComfyUI', '.venv')
+}
+
+export function getVenvPythonPath(installPath: string): string {
+  const venvDir = getVenvDir(installPath)
   if (process.platform === 'win32') {
-    return path.join(envDir, 'Scripts', 'python.exe')
+    return path.join(venvDir, 'Scripts', 'python.exe')
   }
-  return path.join(envDir, 'bin', 'python3')
-}
-
-export function listEnvs(installPath: string): string[] {
-  const envsPath = path.join(installPath, ENVS_DIR)
-  if (!fs.existsSync(envsPath)) return []
-  try {
-    return fs.readdirSync(envsPath, { withFileTypes: true })
-      .filter((d) => d.isDirectory())
-      .map((d) => d.name)
-  } catch {
-    return []
-  }
-}
-
-export function resolveActiveEnv(installation: InstallationRecord): string | null {
-  const preferred = (installation.activeEnv as string | undefined) || DEFAULT_ENV
-  const envs = listEnvs(installation.installPath)
-  if (envs.includes(preferred)) return preferred
-  return envs.length > 0 ? envs[0]! : null
+  return path.join(venvDir, 'bin', 'python3')
 }
 
 export function getActivePythonPath(installation: InstallationRecord): string | null {
-  const env = resolveActiveEnv(installation)
-  if (!env) return null
-  const envPython = getEnvPythonPath(installation.installPath, env)
-  if (fs.existsSync(envPython)) return envPython
+  const pythonPath = getVenvPythonPath(installation.installPath)
+  if (fs.existsSync(pythonPath)) return pythonPath
+  // Fallback: legacy envs/default/ layout (pre-migration)
+  const legacyPath = process.platform === 'win32'
+    ? path.join(installation.installPath, 'envs', 'default', 'Scripts', 'python.exe')
+    : path.join(installation.installPath, 'envs', 'default', 'bin', 'python3')
+  if (fs.existsSync(legacyPath)) return legacyPath
   return null
 }

--- a/src/main/lib/snapshots.test.ts
+++ b/src/main/lib/snapshots.test.ts
@@ -665,13 +665,13 @@ describe('restorePipPackages', () => {
   beforeEach(async () => {
     tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'pip-restore-test-'))
     // Create the directory structure that restorePipPackages expects
-    const envDir = path.join(tmpDir, 'envs', 'default')
+    const venvDir = path.join(tmpDir, 'ComfyUI', '.venv')
     if (process.platform === 'win32') {
-      sitePackagesDir = path.join(envDir, 'Lib', 'site-packages')
-      pythonPath = path.join(envDir, 'Scripts', 'python.exe')
+      sitePackagesDir = path.join(venvDir, 'Lib', 'site-packages')
+      pythonPath = path.join(venvDir, 'Scripts', 'python.exe')
     } else {
-      sitePackagesDir = path.join(envDir, 'lib', 'python3.11', 'site-packages')
-      pythonPath = path.join(envDir, 'bin', 'python3')
+      sitePackagesDir = path.join(venvDir, 'lib', 'python3.11', 'site-packages')
+      pythonPath = path.join(venvDir, 'bin', 'python3')
     }
     await fs.promises.mkdir(sitePackagesDir, { recursive: true })
     await fs.promises.mkdir(path.dirname(pythonPath), { recursive: true })

--- a/src/main/lib/snapshots/restore.ts
+++ b/src/main/lib/snapshots/restore.ts
@@ -8,7 +8,7 @@ import { pipFreeze, runUvPip as sharedRunUvPip, installFilteredRequirements, get
 import { installCnrNode, switchCnrVersion, isSafePathComponent } from '../cnr'
 import { killProcTree } from '../process'
 import { formatComfyVersion } from '../version'
-import { getUvPath, getActivePythonPath } from '../pythonEnv'
+import { getUvPath, getActivePythonPath, getVenvDir } from '../pythonEnv'
 import type { Snapshot, RestoreResult, NodeRestoreResult } from './types'
 import type { ScannedNode } from '../nodes'
 import type { InstallationRecord } from '../../installations'
@@ -366,9 +366,13 @@ export async function restorePipPackages(
 
   // 3. Create targeted backup of packages that will be modified or removed
   sendProgress('restore', { percent: 10, status: 'Creating backup of affected packages…' })
-  const envName = (installation.activeEnv as string | undefined) || 'default'
-  const envDir = path.join(installPath, 'envs', envName)
-  const sitePackages = findSitePackagesDir(envDir)
+  let envDir = getVenvDir(installPath)
+  let sitePackages = findSitePackagesDir(envDir)
+  if (!sitePackages) {
+    // Fallback: legacy envs/default/ layout (pre-migration)
+    envDir = path.join(installPath, 'envs', 'default')
+    sitePackages = findSitePackagesDir(envDir)
+  }
   if (!sitePackages) {
     throw new Error('Could not locate site-packages directory')
   }

--- a/src/main/sources/standalone/envPaths.ts
+++ b/src/main/sources/standalone/envPaths.ts
@@ -1,10 +1,8 @@
 import fs from 'fs'
 import path from 'path'
 export {
-  ENVS_DIR, DEFAULT_ENV,
-  getUvPath, getActivePythonPath, getEnvPythonPath, listEnvs, resolveActiveEnv,
+  getUvPath, getActivePythonPath, getVenvDir, getVenvPythonPath,
 } from '../../lib/pythonEnv'
-export const ENV_METHOD = 'copy'
 export const MANIFEST_FILE = 'manifest.json'
 export const DEFAULT_LAUNCH_ARGS = '--enable-manager'
 

--- a/src/main/sources/standalone/index.ts
+++ b/src/main/sources/standalone/index.ts
@@ -5,9 +5,9 @@ import { parseArgs, extractPort } from '../../lib/util'
 import { t } from '../../lib/i18n'
 import { launchAction } from '../../lib/actions'
 import {
-  PLATFORM_PREFIX, DEFAULT_LAUNCH_ARGS, ENVS_DIR,
+  PLATFORM_PREFIX, DEFAULT_LAUNCH_ARGS,
   getVariantLabel, stripPlatform, getActivePythonPath,
-  listEnvs, recommendVariant,
+  getVenvDir, recommendVariant,
 } from './envPaths'
 import { install, postInstall, probeInstallation } from './install'
 import { getListPreview, getStatusTag, getDetailSections, RELEASE_REPO } from './updateSections'
@@ -129,34 +129,30 @@ export const standalone: SourcePlugin = {
   handleAction,
 
   async fixupCopy(srcPath: string, destPath: string): Promise<void> {
-    const envsDir = path.join(destPath, ENVS_DIR)
-    if (!fs.existsSync(envsDir)) return
+    const venvPath = getVenvDir(destPath)
+    if (!fs.existsSync(venvPath)) return
 
-    for (const envName of listEnvs(destPath)) {
-      const envPath = path.join(envsDir, envName)
+    const cfgPath = path.join(venvPath, 'pyvenv.cfg')
+    if (fs.existsSync(cfgPath)) {
+      let content = await fs.promises.readFile(cfgPath, 'utf-8')
+      content = content.replaceAll(srcPath, destPath)
+      await fs.promises.writeFile(cfgPath, content, 'utf-8')
+    }
 
-      const cfgPath = path.join(envPath, 'pyvenv.cfg')
-      if (fs.existsSync(cfgPath)) {
-        let content = await fs.promises.readFile(cfgPath, 'utf-8')
-        content = content.replaceAll(srcPath, destPath)
-        await fs.promises.writeFile(cfgPath, content, 'utf-8')
-      }
-
-      if (process.platform !== 'win32') {
-        const binDir = path.join(envPath, 'bin')
-        if (fs.existsSync(binDir)) {
-          const entries = await fs.promises.readdir(binDir, { withFileTypes: true })
-          for (const entry of entries) {
-            if (!entry.isFile()) continue
-            const filePath = path.join(binDir, entry.name)
-            try {
-              let content = await fs.promises.readFile(filePath, 'utf-8')
-              if (content.startsWith('#!') && content.includes(srcPath)) {
-                content = content.replaceAll(srcPath, destPath)
-                await fs.promises.writeFile(filePath, content, 'utf-8')
-              }
-            } catch {}
-          }
+    if (process.platform !== 'win32') {
+      const binDir = path.join(venvPath, 'bin')
+      if (fs.existsSync(binDir)) {
+        const entries = await fs.promises.readdir(binDir, { withFileTypes: true })
+        for (const entry of entries) {
+          if (!entry.isFile()) continue
+          const filePath = path.join(binDir, entry.name)
+          try {
+            let content = await fs.promises.readFile(filePath, 'utf-8')
+            if (content.startsWith('#!') && content.includes(srcPath)) {
+              content = content.replaceAll(srcPath, destPath)
+              await fs.promises.writeFile(filePath, content, 'utf-8')
+            }
+          } catch {}
         }
       }
     }

--- a/src/main/sources/standalone/install.ts
+++ b/src/main/sources/standalone/install.ts
@@ -10,8 +10,8 @@ import { t } from '../../lib/i18n'
 import * as snapshots from '../../lib/snapshots'
 import { repairMacBinaries, codesignBinaries } from './macRepair'
 import {
-  ENVS_DIR, DEFAULT_ENV, ENV_METHOD, MANIFEST_FILE, DEFAULT_LAUNCH_ARGS,
-  getUvPath, findSitePackages, getMasterPythonPath,
+  MANIFEST_FILE, DEFAULT_LAUNCH_ARGS,
+  getUvPath, getVenvDir, findSitePackages, getMasterPythonPath,
 } from './envPaths'
 import type { InstallationRecord } from '../../installations'
 import type { ComfyVersion } from '../../lib/version'
@@ -39,18 +39,17 @@ async function stripMasterPackages(installPath: string): Promise<void> {
 
 async function createEnv(
   installPath: string,
-  envName: string,
   onProgress: (copied: number, total: number, elapsedSecs: number, etaSecs: number) => void,
   signal?: AbortSignal
 ): Promise<void> {
   const uvPath = getUvPath(installPath)
   const masterPython = getMasterPythonPath(installPath)
-  const envPath = path.join(installPath, ENVS_DIR, envName)
+  const venvPath = getVenvDir(installPath)
   await new Promise<void>((resolve, reject) => {
     if (signal?.aborted) return reject(new Error('Cancelled'))
-    const proc = execFile(uvPath, ['venv', '--python', masterPython, envPath], { cwd: installPath }, (err, _stdout, stderr) => {
+    const proc = execFile(uvPath, ['venv', '--python', masterPython, venvPath], { cwd: installPath }, (err, _stdout, stderr) => {
       if (signal?.aborted) return reject(new Error('Cancelled'))
-      if (err) return reject(new Error(`Failed to create environment "${envName}": ${stderr || err.message}`))
+      if (err) return reject(new Error(`Failed to create .venv: ${stderr || err.message}`))
       resolve()
     })
     signal?.addEventListener('abort', () => { try { proc.kill() } catch {} }, { once: true })
@@ -58,14 +57,14 @@ async function createEnv(
 
   try {
     const masterSitePackages = findSitePackages(path.join(installPath, 'standalone-env'))
-    const envSitePackages = findSitePackages(envPath)
+    const envSitePackages = findSitePackages(venvPath)
     if (!masterSitePackages || !envSitePackages || !fs.existsSync(masterSitePackages)) {
-      throw new Error(`Could not locate site-packages for environment "${envName}".`)
+      throw new Error('Could not locate site-packages for .venv.')
     }
     await copyDirWithProgress(masterSitePackages, envSitePackages, onProgress, { signal })
     await codesignBinaries(envSitePackages)
   } catch (err) {
-    await fs.promises.rm(envPath, { recursive: true, force: true }).catch(() => {})
+    await fs.promises.rm(venvPath, { recursive: true, force: true }).catch(() => {})
     throw err
   }
 }
@@ -97,16 +96,14 @@ export async function postInstall(installation: InstallationRecord, { sendProgre
   }
   await repairMacBinaries(installation.installPath, sendProgress)
   if (signal?.aborted) throw new Error('Cancelled')
-  sendProgress('setup', { percent: 0, status: 'Creating default Python environment…' })
-  await createEnv(installation.installPath, DEFAULT_ENV, (copied, total, elapsedSecs, etaSecs) => {
+  sendProgress('setup', { percent: 0, status: 'Creating Python environment…' })
+  await createEnv(installation.installPath, (copied, total, elapsedSecs, etaSecs) => {
     const percent = Math.round((copied / total) * 100)
     const elapsed = formatTime(elapsedSecs)
     const eta = etaSecs >= 0 ? formatTime(etaSecs) : '—'
     sendProgress('setup', { percent, status: `Copying packages… ${copied} / ${total} files  ·  ${elapsed} elapsed  ·  ${eta} remaining` })
   }, signal)
   if (signal?.aborted) throw new Error('Cancelled')
-  const envMethods = { ...(installation.envMethods as Record<string, string> | undefined), [DEFAULT_ENV]: ENV_METHOD }
-  await update({ envMethods })
   sendProgress('cleanup', { percent: -1, status: t('standalone.cleanupEnvStatus') })
   await stripMasterPackages(installation.installPath)
 
@@ -143,6 +140,8 @@ export async function probeInstallation(dirPath: string): Promise<Record<string,
   const envExists = fs.existsSync(path.join(dirPath, 'standalone-env'))
   const mainExists = fs.existsSync(path.join(dirPath, 'ComfyUI', 'main.py'))
   if (!envExists || !mainExists) return null
+  const hasVenv = fs.existsSync(path.join(dirPath, 'ComfyUI', '.venv'))
+  const hasLegacyEnvs = fs.existsSync(path.join(dirPath, 'envs'))
   const hasGit = fs.existsSync(path.join(dirPath, 'ComfyUI', '.git'))
 
   let version = 'unknown'
@@ -176,5 +175,73 @@ export async function probeInstallation(dirPath: string): Promise<Record<string,
     hasGit,
     launchArgs: DEFAULT_LAUNCH_ARGS,
     launchMode: 'window',
+    ...(hasLegacyEnvs && !hasVenv ? { needsEnvMigration: true } : {}),
   }
+}
+
+export async function migrateEnvLayout(
+  installPath: string,
+  update: (data: Record<string, unknown>) => Promise<unknown>,
+  sendProgress?: (step: string, data: { percent: number; status: string }) => void,
+): Promise<boolean> {
+  const venvDir = getVenvDir(installPath)
+  if (fs.existsSync(venvDir)) return false
+
+  const legacyEnvDir = path.join(installPath, 'envs', 'default')
+  if (!fs.existsSync(legacyEnvDir)) return false
+
+  sendProgress?.('migration', { percent: 0, status: 'Migrating environment layout…' })
+
+  // Move envs/default/ → ComfyUI/.venv/
+  await fs.promises.rename(legacyEnvDir, venvDir)
+
+  // Fix up pyvenv.cfg home path (old path included envs/default/)
+  const cfgPath = path.join(venvDir, 'pyvenv.cfg')
+  if (fs.existsSync(cfgPath)) {
+    let content = await fs.promises.readFile(cfgPath, 'utf-8')
+    const oldEnvPath = path.join(installPath, 'envs', 'default')
+    content = content.replaceAll(oldEnvPath, venvDir)
+    await fs.promises.writeFile(cfgPath, content, 'utf-8')
+  }
+
+  // Fix up shebangs on unix
+  if (process.platform !== 'win32') {
+    const binDir = path.join(venvDir, 'bin')
+    if (fs.existsSync(binDir)) {
+      const entries = await fs.promises.readdir(binDir, { withFileTypes: true })
+      const oldEnvPath = path.join(installPath, 'envs', 'default')
+      for (const entry of entries) {
+        if (!entry.isFile()) continue
+        const filePath = path.join(binDir, entry.name)
+        try {
+          let content = await fs.promises.readFile(filePath, 'utf-8')
+          if (content.startsWith('#!') && content.includes(oldEnvPath)) {
+            content = content.replaceAll(oldEnvPath, venvDir)
+            await fs.promises.writeFile(filePath, content, 'utf-8')
+          }
+        } catch {}
+      }
+    }
+  }
+
+  // On macOS, re-codesign moved binaries
+  if (process.platform === 'darwin') {
+    sendProgress?.('migration', { percent: 50, status: 'Codesigning migrated binaries…' })
+    await codesignBinaries(venvDir)
+  }
+
+  // Remove empty envs/ directory
+  const envsDir = path.join(installPath, 'envs')
+  try {
+    const remaining = await fs.promises.readdir(envsDir)
+    if (remaining.length === 0) {
+      await fs.promises.rmdir(envsDir)
+    }
+  } catch {}
+
+  // Clean up stale metadata fields
+  await update({ activeEnv: undefined, envMethods: undefined, needsEnvMigration: undefined })
+
+  sendProgress?.('migration', { percent: 100, status: 'Migration complete' })
+  return true
 }

--- a/src/main/sources/standalone/macRepair.ts
+++ b/src/main/sources/standalone/macRepair.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import { execFile } from 'child_process'
-import { ENVS_DIR } from './envPaths'
+import { getVenvDir } from './envPaths'
 
 export async function removeQuarantine(dir: string, log?: (text: string) => void): Promise<void> {
   if (process.platform !== 'darwin') return
@@ -24,11 +24,11 @@ export async function repairMacBinaries(
   await removeQuarantine(standaloneEnvDir, sendOutput)
   sendProgress('repair', { percent: -1, status: 'Codesigning binaries…' })
   await codesignBinaries(standaloneEnvDir, sendOutput)
-  const envsDir = path.join(installPath, ENVS_DIR)
-  if (fs.existsSync(envsDir)) {
+  const venvDir = getVenvDir(installPath)
+  if (fs.existsSync(venvDir)) {
     sendProgress('repair', { percent: -1, status: 'Codesigning environment binaries…' })
-    await removeQuarantine(envsDir, sendOutput)
-    await codesignBinaries(envsDir, sendOutput)
+    await removeQuarantine(venvDir, sendOutput)
+    await codesignBinaries(venvDir, sendOutput)
   }
 }
 


### PR DESCRIPTION
## Summary

Simplify environment layout by removing the multi-env abstraction and placing the venv directly at `ComfyUI/.venv/`.

## Changes

- **`pythonEnv.ts`** — removed `ENVS_DIR`, `DEFAULT_ENV`, `getEnvPythonPath`, `listEnvs`, `resolveActiveEnv`; added `getVenvDir`, `getVenvPythonPath`; simplified `getActivePythonPath` to a direct path check
- **`envPaths.ts`** — removed dead re-exports (`ENVS_DIR`, `DEFAULT_ENV`, `listEnvs`, `resolveActiveEnv`, `getEnvPythonPath`), removed `ENV_METHOD` constant
- **`install.ts`** — `createEnv()` targets `ComfyUI/.venv/` instead of `envs/default/`; removed `envMethods` metadata write; `probeInstallation()` detects both old and new layouts; added `migrateEnvLayout()` function
- **`index.ts`** — `fixupCopy()` rewrites `ComfyUI/.venv/pyvenv.cfg` + shebangs at new path
- **`macRepair.ts`** — codesigns at `ComfyUI/.venv/` instead of `envs/`
- **`snapshots/restore.ts`** — replaced hardcoded `envs/` + `activeEnv` lookup with `getVenvDir()`
- **`launch.ts`** — added automatic migration on first launch for existing installations with `envs/default/` layout

## Migration

On first launch after upgrade, if `ComfyUI/.venv/` doesn't exist but `envs/default/` does:
1. Renames `envs/default/` → `ComfyUI/.venv/`
2. Fixes up `pyvenv.cfg` paths and shebangs
3. On macOS, re-runs codesigning on moved binaries
4. Removes empty `envs/` directory
5. Cleans `activeEnv`, `envMethods`, `needsEnvMigration` from installation metadata

## Benefits

- **Standard Python convention** — `.venv` in project root is auto-discovered by IDEs (VS Code, PyCharm), `pip`, and Python tooling
- **Custom node development** — developers can `cd ComfyUI && .venv/Scripts/activate`
- **Removes dead abstraction** — eliminates multi-env scanning, fallback logic, and metadata fields
- **Simpler code paths** — `getActivePythonPath()` is now a direct path check

## Verification

- `pnpm run typecheck` ✅
- `pnpm run lint` ✅
- `pnpm run build` ✅
- `pnpm run test` ✅ (518/518 passing)

Closes #368