### PR TITLE
fix: further increase console toggle triangle size

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -571,11 +571,11 @@ input[type="checkbox"]:checked::after { transform: translateX(16px); }
 .terminal-toggle {
   display: flex; align-items: center; gap: 6px;
   font-size: 14px; color: var(--text-muted); cursor: pointer;
-  padding: 6px 4px; user-select: none; flex-shrink: 0;
+  padding: 6px 6px; user-select: none; flex-shrink: 0;
   background: none; border: none;
 }
 .terminal-toggle:hover { color: var(--text); }
-.terminal-toggle-icon { font-size: 14px; }
+.terminal-toggle-icon { font-size: 18px; }
 
 /* View modals */
 .view-modal {


### PR DESCRIPTION
Follow-up to #389. Increase .terminal-toggle-icon from 14px to 18px and widen horizontal padding from 4px to 6px for a larger click target.

Relates to #382