### PR TITLE
fix: put installation name first in window title

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -642,7 +642,7 @@ function onLaunch({ port, url, process: proc, installation, mode }: {
   })
   comfyWindow.webContents.on('page-title-updated', (e, title) => {
     e.preventDefault()
-    comfyWindow.setTitle(`${title} — ${installation.name} — Desktop 2.0 v${APP_VERSION}`)
+    comfyWindow.setTitle(`${installation.name} — ${title} — Desktop 2.0 v${APP_VERSION}`)
   })
   comfyWindow.webContents.setWindowOpenHandler(({ url }) => {
     if (shouldOpenInPopup(url)) {


### PR DESCRIPTION
## Problem

The Electron window title renders the browser tab status (loading/idle indicator) **before** the installation name, making it hard to distinguish multiple open ComfyUI windows in the taskbar.

**Before:** `ComfyUI — My Install — Desktop 2.0 v0.4.5`
**After:** `My Install — ComfyUI — Desktop 2.0 v0.4.5`

## Fix

Swap the order of `title` and `installation.name` in the `page-title-updated` event handler so the installation name comes first.

Fixes #399