### PR TITLE
feat: persist ComfyUI logs to disk and send scrubbed stderr to telemetry

### DIFF
--- a/src/main/lib/ipc/sessionActions/launch.ts
+++ b/src/main/lib/ipc/sessionActions/launch.ts
@@ -19,6 +19,20 @@ import {
 } from '../shared'
 import type { ChildProcess, LaunchCmd } from '../shared'
 import type { ActionContext, ActionResult } from './types'
+import { scrubStderr, lastNLines } from '../../scrubStderr'
+import { rotateLogFiles, getLogDir } from '../../logRotation'
+import type { WriteStream } from 'fs'
+
+async function openLogStream(installPath: string): Promise<WriteStream> {
+  const logDir = getLogDir(installPath)
+  fs.mkdirSync(logDir, { recursive: true })
+  await rotateLogFiles(logDir, 'comfyui.log')
+  return fs.createWriteStream(path.join(logDir, 'comfyui.log'), { flags: 'w' })
+}
+
+function writeLog(stream: WriteStream, text: string): void {
+  if (!stream.writableEnded) stream.write(text)
+}
 
 export async function handleLaunch({ event, installationId, inst: instArg, actionData }: ActionContext): Promise<ActionResult> {
   let inst = instArg
@@ -135,13 +149,21 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
     _broadcastToRenderer('instance-launching', { installationId, installationName: inst.name })
     const sendOutput = makeSendOutput(sender, installationId)
     const launchEnv = buildLaunchEnv(inst)
+
+    const logStream = await openLogStream(inst.installPath)
+
     const proc = spawnProcess(launchCmd.cmd!, launchCmd.args!, launchCmd.cwd!, launchEnv, { showWindow: launchCmd.showWindow })
     let stderrBuf = ''
-    proc.stdout?.on('data', (chunk: Buffer) => sendOutput(chunk.toString('utf-8')))
+    proc.stdout?.on('data', (chunk: Buffer) => {
+      const text = chunk.toString('utf-8')
+      writeLog(logStream, text)
+      sendOutput(text)
+    })
     proc.stderr?.on('data', (chunk: Buffer) => {
       const text = chunk.toString('utf-8')
       stderrBuf += text
       if (stderrBuf.length > 8192) stderrBuf = stderrBuf.slice(-4096)
+      writeLog(logStream, text)
       sendOutput(text)
     })
 
@@ -150,10 +172,12 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
     _addSession(installationId, { proc, port: 0, mode, installationName: inst.name }, Date.now() - launchStartedAt)
 
     proc.on('exit', (code) => {
+      logStream.end()
       const crashed = _runningSessions.has(installationId) && code !== 0
+      const lastStderr = scrubStderr(lastNLines(stderrBuf, 100))
       _removeSession(installationId)
       if (!sender.isDestroyed()) {
-        sender.send('comfy-exited', { installationId, crashed, exitCode: code, installationName: inst.name })
+        sender.send('comfy-exited', { installationId, crashed, exitCode: code, installationName: inst.name, lastStderr })
       }
       if (_onComfyExited) _onComfyExited({ installationId })
     })
@@ -252,14 +276,21 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
     }
   }
 
+  const logStream = await openLogStream(inst.installPath)
+
   function spawnComfy(): { proc: ChildProcess; getStderr: () => string } {
     const p = spawnProcess(launchCmd.cmd!, launchCmd.args!, launchCmd.cwd!, launchEnv, { showWindow: launchCmd.showWindow })
     let stderrBuf = ''
-    p.stdout!.on('data', (chunk: Buffer) => sendOutput(chunk.toString('utf-8')))
+    p.stdout!.on('data', (chunk: Buffer) => {
+      const text = chunk.toString('utf-8')
+      writeLog(logStream, text)
+      sendOutput(text)
+    })
     p.stderr!.on('data', (chunk: Buffer) => {
       const text = chunk.toString('utf-8')
       stderrBuf += text
       if (stderrBuf.length > 8192) stderrBuf = stderrBuf.slice(-4096)
+      writeLog(logStream, text)
       sendOutput(text)
     })
     return { proc: p, getStderr: () => stderrBuf }
@@ -339,6 +370,7 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
 
   const launchResult = await tryLaunch()
   if (!launchResult.ok) {
+    logStream.end()
     _releasePort(launchCmd.port!)
     _operationAborts.delete(installationId)
     _broadcastToRenderer('instance-launch-failed', { installationId })
@@ -352,6 +384,11 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
   const mode = (inst.launchMode as string | undefined) || 'window'
   _addSession(installationId, { proc, port: launchCmd.port!, mode, installationName: inst.name }, Date.now() - launchStartedAt)
   writePortLock(launchCmd.port!, { pid: proc.pid!, installationName: inst.name })
+
+  if (!sender.isDestroyed()) {
+    const bootStderr = scrubStderr(lastNLines(launchResult.getStderr(), 50))
+    sender.send('comfy-boot-log', { installationId, bootStderr })
+  }
 
   // Capture snapshot in background after successful launch
   if (inst.sourceId === 'standalone') {
@@ -397,6 +434,7 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
           relaunchEarlyExit,
         ])
       } catch (err) {
+        logStream.end()
         await killProcessTree(proc)
         _removeSession(installationId)
         _broadcastToRenderer('instance-launch-failed', { installationId })
@@ -412,6 +450,7 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
   )
   let pendingModelFolderRelaunch = false
   let rebootModelCheckAbort: AbortController | null = null
+  let currentGetStderr = launchResult.getStderr
 
   function attachExitHandler(p: ChildProcess): void {
     p.on('exit', (code) => {
@@ -442,6 +481,7 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
         }
         const spawned = spawnComfy()
         proc = spawned.proc
+        currentGetStderr = spawned.getStderr
         const session = _runningSessions.get(installationId)
         if (session) session.proc = proc
         writePortLock(launchCmd.port!, { pid: proc.pid!, installationName: inst.name })
@@ -489,10 +529,12 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
         }
         return
       }
+      logStream.end()
       const crashed = _runningSessions.has(installationId)
+      const lastStderr = scrubStderr(lastNLines(currentGetStderr(), 100))
       _removeSession(installationId)
       if (!sender.isDestroyed()) {
-        sender.send('comfy-exited', { installationId, crashed, exitCode: code, installationName: inst.name })
+        sender.send('comfy-exited', { installationId, crashed, exitCode: code, installationName: inst.name, lastStderr })
       }
       if (_onComfyExited) _onComfyExited({ installationId })
     })

--- a/src/main/lib/ipc/sessionActions/launch.ts
+++ b/src/main/lib/ipc/sessionActions/launch.ts
@@ -19,7 +19,7 @@ import {
 } from '../shared'
 import type { ChildProcess, LaunchCmd } from '../shared'
 import type { ActionContext, ActionResult } from './types'
-import { scrubStderr, lastNLines } from '../../scrubStderr'
+import { scrubStderr, lastNLines, stripAnsi } from '../../scrubStderr'
 import { rotateLogFiles, getLogDir } from '../../logRotation'
 import type { WriteStream } from 'fs'
 
@@ -31,7 +31,7 @@ async function openLogStream(installPath: string): Promise<WriteStream> {
 }
 
 function writeLog(stream: WriteStream, text: string): void {
-  if (!stream.writableEnded) stream.write(text)
+  if (!stream.writableEnded) stream.write(stripAnsi(text))
 }
 
 export async function handleLaunch({ event, installationId, inst: instArg, actionData }: ActionContext): Promise<ActionResult> {

--- a/src/main/lib/logRotation.test.ts
+++ b/src/main/lib/logRotation.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, it, expect } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { rotateLogFiles, getLogDir } from './logRotation'
+
+describe('rotateLogFiles', () => {
+  let tmpDir: string
+
+  afterEach(() => {
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  it('renames current log file to timestamped version', async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'log-rotate-'))
+    const baseName = 'app.log'
+    fs.writeFileSync(path.join(tmpDir, baseName), 'log content')
+
+    await rotateLogFiles(tmpDir, baseName)
+
+    const files = fs.readdirSync(tmpDir)
+    expect(files).toHaveLength(1)
+    expect(files[0]).not.toBe(baseName)
+    expect(files[0]).toMatch(/^app\.log_\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z\.log$/)
+  })
+
+  it('does nothing when log dir does not exist', async () => {
+    tmpDir = path.join(os.tmpdir(), `log-rotate-nonexistent-${Date.now()}`)
+
+    await expect(rotateLogFiles(tmpDir, 'app.log')).resolves.toBeUndefined()
+  })
+
+  it('does nothing when current log file does not exist', async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'log-rotate-'))
+
+    await expect(rotateLogFiles(tmpDir, 'app.log')).resolves.toBeUndefined()
+
+    const files = fs.readdirSync(tmpDir)
+    expect(files).toHaveLength(0)
+  })
+
+  it('deletes oldest file when count exceeds maxFiles', async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'log-rotate-'))
+    const baseName = 'app.log'
+
+    // Create rotated files that exceed maxFiles
+    const oldFile = `${baseName}_2020-01-01T00-00-00-000Z.log`
+    const newFile = `${baseName}_2025-01-01T00-00-00-000Z.log`
+    fs.writeFileSync(path.join(tmpDir, oldFile), 'old')
+    fs.writeFileSync(path.join(tmpDir, newFile), 'new')
+    fs.writeFileSync(path.join(tmpDir, baseName), 'current')
+
+    await rotateLogFiles(tmpDir, baseName, 1)
+
+    const files = fs.readdirSync(tmpDir)
+    expect(files).not.toContain(oldFile)
+    expect(files).toContain(newFile)
+  })
+
+  it('works with maxFiles=0 (no deletion)', async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'log-rotate-'))
+    const baseName = 'app.log'
+
+    const existingFile = `${baseName}_2020-01-01T00-00-00-000Z.log`
+    fs.writeFileSync(path.join(tmpDir, existingFile), 'old')
+    fs.writeFileSync(path.join(tmpDir, baseName), 'current')
+
+    await rotateLogFiles(tmpDir, baseName, 0)
+
+    const files = fs.readdirSync(tmpDir)
+    expect(files).toContain(existingFile)
+    expect(files).toHaveLength(2)
+  })
+})
+
+describe('getLogDir', () => {
+  it('returns <installPath>/logs', () => {
+    const installPath = '/some/install/path'
+    expect(getLogDir(installPath)).toBe(path.join(installPath, 'logs'))
+  })
+})

--- a/src/main/lib/logRotation.ts
+++ b/src/main/lib/logRotation.ts
@@ -1,0 +1,33 @@
+import fs from 'fs'
+import path from 'path'
+
+export function getLogDir(installPath: string): string {
+  return path.join(installPath, 'logs')
+}
+
+export async function rotateLogFiles(logDir: string, baseName: string, maxFiles = 50): Promise<void> {
+  const currentLogPath = path.join(logDir, baseName)
+  try {
+    await fs.promises.access(logDir, fs.constants.R_OK | fs.constants.W_OK)
+    await fs.promises.access(currentLogPath)
+  } catch {
+    return
+  }
+
+  if (maxFiles > 0) {
+    const files = await fs.promises.readdir(logDir, { withFileTypes: true })
+    const names: string[] = []
+    const logFileRegex = new RegExp(`^${baseName}_\\d{4}-\\d{2}-\\d{2}T\\d{2}-\\d{2}-\\d{2}-\\d{3}Z\\.log$`)
+    for (const file of files) {
+      if (file.isFile() && logFileRegex.test(file.name)) names.push(file.name)
+    }
+    if (names.length > maxFiles) {
+      names.sort()
+      try { await fs.promises.unlink(path.join(logDir, names[0]!)) } catch {}
+    }
+  }
+
+  const timestamp = new Date().toISOString().replaceAll(/[.:]/g, '-')
+  const newLogPath = path.join(logDir, `${baseName}_${timestamp}.log`)
+  try { await fs.promises.rename(currentLogPath, newLogPath) } catch {}
+}

--- a/src/main/lib/scrubStderr.test.ts
+++ b/src/main/lib/scrubStderr.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { scrubStderr, lastNLines } from './scrubStderr'
+import { scrubStderr, lastNLines, stripAnsi } from './scrubStderr'
 
 describe('scrubStderr', () => {
   it('redacts Windows user paths', () => {
@@ -60,6 +60,20 @@ describe('scrubStderr', () => {
     expect(result).toContain('C:\\Users\\[REDACTED]\\AppData\\foo')
     expect(result).not.toContain('JohnDoe')
     expect(result).not.toContain('sk-abc123')
+  })
+})
+
+describe('stripAnsi', () => {
+  it('removes color codes', () => {
+    expect(stripAnsi('\u001B[31mError\u001B[0m')).toBe('Error')
+  })
+
+  it('removes multiple escape sequences', () => {
+    expect(stripAnsi('\u001B[1m\u001B[32mOK\u001B[0m done')).toBe('OK done')
+  })
+
+  it('leaves plain text unchanged', () => {
+    expect(stripAnsi('no codes here')).toBe('no codes here')
   })
 })
 

--- a/src/main/lib/scrubStderr.test.ts
+++ b/src/main/lib/scrubStderr.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import { scrubStderr, lastNLines } from './scrubStderr'
+
+describe('scrubStderr', () => {
+  it('redacts Windows user paths', () => {
+    expect(scrubStderr('C:\\Users\\JohnDoe\\AppData\\foo')).toBe('C:\\Users\\[REDACTED]\\AppData\\foo')
+  })
+
+  it('redacts macOS user paths', () => {
+    expect(scrubStderr('/Users/alice/Library/foo')).toBe('/Users/[REDACTED]/Library/foo')
+  })
+
+  it('redacts Linux user paths', () => {
+    expect(scrubStderr('/home/bob/.config/foo')).toBe('/home/[REDACTED]/.config/foo')
+  })
+
+  it('redacts OpenAI-style API keys', () => {
+    expect(scrubStderr('key is sk-abc123def456ghi789jk')).toBe('key is [REDACTED]')
+  })
+
+  it('redacts HuggingFace tokens', () => {
+    expect(scrubStderr('hf_AbCdEfGhIjKlMnOpQrSt')).toBe('[REDACTED]')
+  })
+
+  it('redacts Bearer tokens', () => {
+    expect(scrubStderr('Bearer eyJhbGciOiJIUzI1NiJ9.abc')).toBe('Bearer [REDACTED]')
+  })
+
+  it('redacts URL credentials', () => {
+    expect(scrubStderr('https://user:pass123@example.com/repo')).toBe('https://[REDACTED]@example.com/repo')
+  })
+
+  it('redacts env var values for API_KEY', () => {
+    expect(scrubStderr('API_KEY=mysecretkey123')).toBe('API_KEY=[REDACTED]')
+  })
+
+  it('redacts env var values for TOKEN', () => {
+    expect(scrubStderr('MY_TOKEN=abc123')).toBe('MY_TOKEN=[REDACTED]')
+  })
+
+  it('redacts env var values for SECRET', () => {
+    expect(scrubStderr('MY_SECRET=abc123')).toBe('MY_SECRET=[REDACTED]')
+  })
+
+  it('redacts env var values for PASSWORD', () => {
+    expect(scrubStderr('PASSWORD=abc123')).toBe('PASSWORD=[REDACTED]')
+  })
+
+  it('redacts case-insensitive Windows paths', () => {
+    expect(scrubStderr('c:\\users\\johndoe\\appdata\\foo')).toBe('c:\\users\\[REDACTED]\\appdata\\foo')
+  })
+
+  it('leaves non-sensitive text unchanged', () => {
+    expect(scrubStderr('Python 3.11.5 loading module...')).toBe('Python 3.11.5 loading module...')
+  })
+
+  it('handles multiple scrub types in one string', () => {
+    const input = 'Error at C:\\Users\\JohnDoe\\AppData\\foo with key sk-abc123def456ghi789jk'
+    const result = scrubStderr(input)
+    expect(result).toContain('C:\\Users\\[REDACTED]\\AppData\\foo')
+    expect(result).not.toContain('JohnDoe')
+    expect(result).not.toContain('sk-abc123')
+  })
+})
+
+describe('lastNLines', () => {
+  it('returns last 3 lines of a 5-line string', () => {
+    const input = 'line1\nline2\nline3\nline4\nline5'
+    expect(lastNLines(input, 3)).toBe('line3\nline4\nline5')
+  })
+
+  it('returns all lines when n > total lines', () => {
+    const input = 'line1\nline2'
+    expect(lastNLines(input, 5)).toBe('line1\nline2')
+  })
+
+  it('returns empty string for empty input', () => {
+    expect(lastNLines('', 3)).toBe('')
+  })
+
+  it('handles single line', () => {
+    expect(lastNLines('only line', 3)).toBe('only line')
+  })
+})

--- a/src/main/lib/scrubStderr.ts
+++ b/src/main/lib/scrubStderr.ts
@@ -23,6 +23,13 @@ export function scrubStderr(text: string): string {
   return scrubbed
 }
 
+// eslint-disable-next-line no-control-regex
+const ANSI_RE = /[\u001B\u009B][#();?[]*(?:\d{1,4}(?:;\d{0,4})*)?[\d<=>A-ORZcf-nqry]/g
+
+export function stripAnsi(text: string): string {
+  return text.replace(ANSI_RE, '')
+}
+
 export function lastNLines(text: string, n: number): string {
   return text.split('\n').slice(-n).join('\n')
 }

--- a/src/main/lib/scrubStderr.ts
+++ b/src/main/lib/scrubStderr.ts
@@ -1,0 +1,28 @@
+const PII_PATH_PATTERNS = [
+  /([A-Za-z]:[\\/]Users[\\/])[^\\/]+?(?=[\\/]|$)/gi,
+  /(\/Users\/)[^\\/]+?(?=\/|$)/gi,
+  /(\/home\/)[^\\/]+?(?=\/|$)/gi,
+]
+
+const SECRET_REPLACEMENTS: [RegExp, string | ((...args: string[]) => string)][] = [
+  [/sk-[A-Za-z0-9_-]{20,}/g, '[REDACTED]'],
+  [/hf_[A-Za-z0-9]{20,}/g, '[REDACTED]'],
+  [/Bearer\s+[A-Za-z0-9._\-/+]{20,}/g, 'Bearer [REDACTED]'],
+  [/\/\/[^\s@/]*:[^\s@/]*@/g, '//[REDACTED]@'],
+  [/(API_KEY|TOKEN|SECRET|PASSWORD)=[^\s]+/gi, '$1=[REDACTED]'],
+]
+
+export function scrubStderr(text: string): string {
+  let scrubbed = text
+  for (const pattern of PII_PATH_PATTERNS) {
+    scrubbed = scrubbed.replace(pattern, (_match, prefix: string) => `${prefix}[REDACTED]`)
+  }
+  for (const [pattern, replacement] of SECRET_REPLACEMENTS) {
+    scrubbed = scrubbed.replace(pattern, replacement as string)
+  }
+  return scrubbed
+}
+
+export function lastNLines(text: string, n: number): string {
+  return text.split('\n').slice(-n).join('\n')
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -132,6 +132,11 @@ const api: ElectronApi = {
     ipcRenderer.on('comfy-exited', handler)
     return () => ipcRenderer.removeListener('comfy-exited', handler)
   },
+  onComfyBootLog: (callback) => {
+    const handler = (_event: IpcRendererEvent, data: unknown) => callback(data as Parameters<typeof callback>[0])
+    ipcRenderer.on('comfy-boot-log', handler)
+    return () => ipcRenderer.removeListener('comfy-boot-log', handler)
+  },
   onInstanceLaunching: (callback) => {
     const handler = (_event: IpcRendererEvent, data: unknown) => callback(data as Parameters<typeof callback>[0])
     ipcRenderer.on('instance-launching', handler)

--- a/src/renderer/src/main.ts
+++ b/src/renderer/src/main.ts
@@ -219,6 +219,15 @@ window.api.onComfyExited((data) => {
     installation_id: data.installationId,
     crashed: data.crashed ?? false,
     exit_code: data.exitCode ?? null,
+    last_stderr: data.lastStderr ?? null,
+  })
+})
+
+window.api.onComfyBootLog((data) => {
+  if (!isDatadogInitialized) return
+  trackTelemetryAction('launcher.comfyui.boot_log', {
+    installation_id: data.installationId,
+    boot_stderr: data.bootStderr,
   })
 })
 

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -309,6 +309,12 @@ export interface ComfyExitedData {
   installationName: string
   crashed?: boolean
   exitCode?: number
+  lastStderr?: string
+}
+
+export interface ComfyBootLogData {
+  installationId: string
+  bootStderr: string
 }
 
 export interface GPUInfo {
@@ -711,6 +717,7 @@ export interface ElectronApi {
   onInstallProgress(callback: (data: ProgressData) => void): Unsubscribe
   onComfyOutput(callback: (data: ComfyOutputData) => void): Unsubscribe
   onComfyExited(callback: (data: ComfyExitedData) => void): Unsubscribe
+  onComfyBootLog(callback: (data: ComfyBootLogData) => void): Unsubscribe
   onInstanceLaunching(callback: (data: { installationId: string; installationName: string }) => void): Unsubscribe
   onInstanceLaunchFailed(callback: (data: { installationId: string }) => void): Unsubscribe
   onInstanceStarted(callback: (data: RunningInstance) => void): Unsubscribe


### PR DESCRIPTION
## Summary

Addresses #378 (stderr telemetry) and #403 (log persistence).

### Log Persistence (#403)
- **Log rotation** ported from Desktop 1.0's `rotateLogFiles`: on each boot, the current `comfyui.log` is renamed to `comfyui_<timestamp>.log`, capped at 50 historical files
- **Tee approach**: stdout/stderr are written to `<installPath>/logs/comfyui.log` AND streamed over IPC for real-time display
- **ANSI stripping**: terminal color/escape codes are removed before writing to disk (matching Desktop 1.0's `removeAnsiCodesTransform`), keeping log files clean and readable
- Logs survive both ComfyUI and Launcher crashes
- Each session gets its own timestamped log file

### Stderr Telemetry (#378)
- **`scrubStderr()`** applies PII scrubbing (case-insensitive username paths) plus patterns for API keys (`sk-`/`hf_`), Bearer tokens, URL credentials (`user:pass@`), and env vars (`API_KEY=`, `TOKEN=`, `SECRET=`, `PASSWORD=`)
- **On crash/exit**: includes scrubbed last 100 lines of stderr in the existing `launcher.comfyui.exited` Datadog event
- **On successful boot**: fires new `launcher.comfyui.boot_log` event with scrubbed last 50 lines of stderr

### Files Changed
| File | Change |
|------|--------|
| `src/main/lib/scrubStderr.ts` | New — `scrubStderr()`, `stripAnsi()`, and `lastNLines()` |
| `src/main/lib/scrubStderr.test.ts` | New — 21 unit tests |
| `src/main/lib/logRotation.ts` | New — `rotateLogFiles()` and `getLogDir()` |
| `src/main/lib/logRotation.test.ts` | New — 6 unit tests |
| `src/types/ipc.ts` | Add `lastStderr` to `ComfyExitedData`, add `ComfyBootLogData` |
| `src/main/lib/ipc/sessionActions/launch.ts` | Tee to log file with ANSI stripping, send scrubbed stderr; `openLogStream()` and `writeLog()` helpers with write-after-end guard |
| `src/preload/index.ts` | Bridge `comfy-boot-log` IPC channel |
| `src/renderer/src/main.ts` | Handle boot_log + forward last_stderr in exited |

### Testing
All 610 tests pass (including 27 new tests for `scrubStderr`, `stripAnsi`, and `logRotation`).

Closes #378, closes #403