### PR TITLE
fix: hide Change button on primary card when no eligible targets exist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,3 +12,14 @@ pnpm run test
 ```
 
 Typecheck and lint are enforced automatically by a husky pre-commit hook.
+
+## Fix all issues found by checks
+
+Any errors or warnings surfaced by typecheck, lint, audit, or tests are **our responsibility to fix** — even if they appear to be pre-existing. Do not skip, ignore, or work around them with `--no-verify`. If a pre-commit hook fails, fix the underlying issues before committing.
+
+## Post-change review: deduplication
+
+After creating or modifying code, check for duplicated logic before committing:
+
+- Look for repeated filter predicates, conditions, or expressions that could be extracted into a shared variable, computed property, or helper.
+- If two call sites must stay in sync (e.g., a visibility check and the action it guards), extract the shared logic so they cannot diverge.

--- a/scripts/swap-installations.ps1
+++ b/scripts/swap-installations.ps1
@@ -1,0 +1,175 @@
+<#
+.SYNOPSIS
+  Swap the active installations.json with a named profile for testing.
+
+.DESCRIPTION
+  Saves/restores installations.json profiles in a "test-profiles" folder
+  next to the live data file. Useful for testing different installation
+  configurations (e.g. single install, multiple installs, desktop-only).
+
+  The app should be closed before swapping.
+
+.PARAMETER Action
+  save   - Copy the current installations.json into a named profile.
+  load   - Replace the current installations.json with a named profile.
+  empty        - Replace installations.json with an empty array (fresh/new-user state).
+  primary-only - Keep only the current primary installation (remove all others).
+  list         - List all saved profiles.
+  delete       - Delete a saved profile.
+
+.PARAMETER Name
+  Profile name (required for save, load, delete).
+
+.EXAMPLE
+  .\swap-installations.ps1 save single-standalone
+  .\swap-installations.ps1 load single-standalone
+  .\swap-installations.ps1 empty
+  .\swap-installations.ps1 primary-only
+  .\swap-installations.ps1 list
+  .\swap-installations.ps1 delete single-standalone
+#>
+
+param(
+  [Parameter(Mandatory, Position = 0)]
+  [ValidateSet("save", "load", "empty", "primary-only", "list", "delete")]
+  [string]$Action,
+
+  [Parameter(Position = 1)]
+  [string]$Name
+)
+
+$ErrorActionPreference = "Stop"
+
+$dataDir = Join-Path $env:APPDATA "comfyui-desktop-2"
+$installationsFile = Join-Path $dataDir "installations.json"
+$profilesDir = Join-Path $dataDir "test-profiles"
+
+# Warn if the app is running (it will overwrite changes on its own save cycle)
+$appProc = Get-Process -Name "ComfyUI*" -ErrorAction SilentlyContinue
+if ($appProc -and $Action -ne "list") {
+  Write-Warning "ComfyUI Launcher appears to be running. Close it before swapping to avoid the app overwriting your changes."
+  $reply = Read-Host "Continue anyway? (y/N)"
+  if ($reply -notin @("y", "Y")) { exit 0 }
+}
+
+function Require-Name {
+  if (-not $Name) {
+    Write-Error "Profile name is required for '$Action'."
+    exit 1
+  }
+}
+
+function Get-ProfilePath {
+  param([string]$ProfileName)
+  return Join-Path $profilesDir "$ProfileName.json"
+}
+
+switch ($Action) {
+  "save" {
+    Require-Name
+    if (-not (Test-Path $installationsFile)) {
+      Write-Error "No installations.json found at $installationsFile"
+      exit 1
+    }
+    if (-not (Test-Path $profilesDir)) {
+      New-Item -ItemType Directory -Path $profilesDir -Force | Out-Null
+    }
+    $dest = Get-ProfilePath $Name
+    Copy-Item $installationsFile $dest -Force
+    Write-Host "Saved current installations.json as profile '$Name'"
+  }
+
+  "empty" {
+    if (Test-Path $installationsFile) {
+      $backup = Join-Path $dataDir "installations.json.bak"
+      Copy-Item $installationsFile $backup -Force
+      Write-Host "Backed up current installations.json to installations.json.bak"
+    }
+    [System.IO.File]::WriteAllText($installationsFile, "[]", [System.Text.UTF8Encoding]::new($false))
+    Write-Host "Replaced installations.json with empty array (fresh state)"
+  }
+
+  "primary-only" {
+    if (-not (Test-Path $installationsFile)) {
+      Write-Error "No installations.json found at $installationsFile"
+      exit 1
+    }
+    $settingsFile = Join-Path $dataDir "settings.json"
+    $primaryId = $null
+    if (Test-Path $settingsFile) {
+      $settings = Get-Content $settingsFile -Raw | ConvertFrom-Json
+      $primaryId = $settings.primaryInstallId
+    }
+    $installs = Get-Content $installationsFile -Raw | ConvertFrom-Json
+    $primary = $null
+    if ($primaryId -and $primaryId -ne '') {
+      $primary = $installs | Where-Object { $_.id -eq $primaryId }
+    }
+    if (-not $primary) {
+      $primary = $installs | Where-Object { $_.sourceId -ne 'desktop' -and $_.sourceId -ne 'cloud' } | Select-Object -First 1
+    }
+    if (-not $primary) {
+      Write-Error "No eligible primary installation found."
+      exit 1
+    }
+    $backup = Join-Path $dataDir "installations.json.bak"
+    Copy-Item $installationsFile $backup -Force
+    Write-Host "Backed up current installations.json to installations.json.bak"
+    # Ensure the install path exists and isn't considered empty by the app's
+    # startup sweep (which deletes entries whose installPath is missing/empty).
+    $instPath = $primary.installPath
+    if ($instPath -and -not (Test-Path $instPath)) {
+      New-Item -ItemType Directory -Path $instPath -Force | Out-Null
+      # Add a sentinel file so isEffectivelyEmptyInstallDir returns false
+      Set-Content -Path (Join-Path $instPath ".swap-test-sentinel") -Value "created by swap-installations script"
+      Write-Host "Created stub directory at $instPath"
+    }
+    $json = ConvertTo-Json @($primary) -Depth 10
+    [System.IO.File]::WriteAllText($installationsFile, $json, [System.Text.UTF8Encoding]::new($false))
+    Write-Host "Kept only primary installation: $($primary.name) ($($primary.id))"
+  }
+
+  "load" {
+    Require-Name
+    $src = Get-ProfilePath $Name
+    if (-not (Test-Path $src)) {
+      Write-Error "Profile '$Name' not found. Use 'list' to see available profiles."
+      exit 1
+    }
+    if (Test-Path $installationsFile) {
+      $backup = Join-Path $dataDir "installations.json.bak"
+      Copy-Item $installationsFile $backup -Force
+      Write-Host "Backed up current installations.json to installations.json.bak"
+    }
+    Copy-Item $src $installationsFile -Force
+    Write-Host "Loaded profile '$Name' as installations.json"
+  }
+
+  "list" {
+    if (-not (Test-Path $profilesDir)) {
+      Write-Host "No profiles saved yet."
+      return
+    }
+    $profiles = Get-ChildItem $profilesDir -Filter "*.json" | Sort-Object Name
+    if ($profiles.Count -eq 0) {
+      Write-Host "No profiles saved yet."
+      return
+    }
+    Write-Host "Saved profiles:"
+    foreach ($p in $profiles) {
+      $entries = (Get-Content $p.FullName -Raw | ConvertFrom-Json).Count
+      Write-Host "  $($p.BaseName) ($entries installations)"
+    }
+  }
+
+  "delete" {
+    Require-Name
+    $target = Get-ProfilePath $Name
+    if (-not (Test-Path $target)) {
+      Write-Error "Profile '$Name' not found."
+      exit 1
+    }
+    Remove-Item $target -Force
+    Write-Host "Deleted profile '$Name'"
+  }
+}

--- a/scripts/swap-installations.sh
+++ b/scripts/swap-installations.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+#
+# Swap the active installations.json with a named profile for testing.
+#
+# Saves/restores installations.json profiles in a "test-profiles" folder
+# next to the live data file. Useful for testing different installation
+# configurations (e.g. single install, multiple installs, desktop-only).
+#
+# The app should be closed before swapping.
+#
+# Usage:
+#   ./swap-installations.sh save <name>
+#   ./swap-installations.sh load <name>
+#   ./swap-installations.sh empty
+#   ./swap-installations.sh primary-only
+#   ./swap-installations.sh list
+#   ./swap-installations.sh delete <name>
+
+set -euo pipefail
+
+# --- Resolve data directory (matches paths.ts logic) ---
+if [[ "$(uname)" == "Darwin" ]]; then
+  DATA_DIR="${HOME}/Library/Application Support/comfyui-desktop-2"
+  CONFIG_DIR="$DATA_DIR"
+else
+  # Linux: XDG
+  DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/comfyui-desktop-2"
+  CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/comfyui-desktop-2"
+fi
+
+INSTALLATIONS_FILE="$DATA_DIR/installations.json"
+SETTINGS_FILE="$CONFIG_DIR/settings.json"
+PROFILES_DIR="$DATA_DIR/test-profiles"
+
+ACTION="${1:-}"
+NAME="${2:-}"
+
+if [[ -z "$ACTION" ]]; then
+  echo "Usage: $0 {save|load|empty|primary-only|list|delete} [name]" >&2
+  exit 1
+fi
+
+# --- Warn if app is running ---
+if [[ "$ACTION" != "list" ]]; then
+  if pgrep -if "comfyui" > /dev/null 2>&1; then
+    echo "WARNING: ComfyUI Launcher appears to be running. Close it before swapping."
+    read -rp "Continue anyway? (y/N) " reply
+    [[ "$reply" =~ ^[Yy]$ ]] || exit 0
+  fi
+fi
+
+require_name() {
+  if [[ -z "$NAME" ]]; then
+    echo "Error: Profile name is required for '$ACTION'." >&2
+    exit 1
+  fi
+}
+
+profile_path() {
+  echo "$PROFILES_DIR/$1.json"
+}
+
+backup_current() {
+  if [[ -f "$INSTALLATIONS_FILE" ]]; then
+    cp "$INSTALLATIONS_FILE" "$DATA_DIR/installations.json.bak"
+    echo "Backed up current installations.json to installations.json.bak"
+  fi
+}
+
+case "$ACTION" in
+  save)
+    require_name
+    if [[ ! -f "$INSTALLATIONS_FILE" ]]; then
+      echo "Error: No installations.json found at $INSTALLATIONS_FILE" >&2
+      exit 1
+    fi
+    mkdir -p "$PROFILES_DIR"
+    cp "$INSTALLATIONS_FILE" "$(profile_path "$NAME")"
+    echo "Saved current installations.json as profile '$NAME'"
+    ;;
+
+  empty)
+    backup_current
+    printf '[]' > "$INSTALLATIONS_FILE"
+    echo "Replaced installations.json with empty array (fresh state)"
+    ;;
+
+  primary-only)
+    if [[ ! -f "$INSTALLATIONS_FILE" ]]; then
+      echo "Error: No installations.json found at $INSTALLATIONS_FILE" >&2
+      exit 1
+    fi
+
+    # Read primaryInstallId from settings.json
+    PRIMARY_ID=""
+    if [[ -f "$SETTINGS_FILE" ]]; then
+      PRIMARY_ID=$(python3 -c "
+import json, sys
+with open('$SETTINGS_FILE') as f:
+    s = json.load(f)
+print(s.get('primaryInstallId', '') or '')
+" 2>/dev/null || true)
+    fi
+
+    # Extract primary entry (or first eligible) using python3 for reliable JSON handling
+    python3 -c "
+import json, sys
+
+with open('$INSTALLATIONS_FILE') as f:
+    installs = json.load(f)
+
+primary_id = '''$PRIMARY_ID'''
+primary = None
+
+if primary_id:
+    matches = [i for i in installs if i.get('id') == primary_id]
+    if matches:
+        primary = matches[0]
+
+if not primary:
+    eligible = [i for i in installs if i.get('sourceId') not in ('desktop', 'cloud')]
+    if eligible:
+        primary = eligible[0]
+
+if not primary:
+    print('Error: No eligible primary installation found.', file=sys.stderr)
+    sys.exit(1)
+
+# Ensure install path exists
+install_path = primary.get('installPath', '')
+if install_path:
+    import os
+    if not os.path.exists(install_path):
+        os.makedirs(install_path, exist_ok=True)
+        sentinel = os.path.join(install_path, '.swap-test-sentinel')
+        with open(sentinel, 'w') as sf:
+            sf.write('created by swap-installations script')
+        print(f'Created stub directory at {install_path}')
+
+with open('$INSTALLATIONS_FILE', 'w') as f:
+    json.dump([primary], f, indent=2)
+
+print(f\"Kept only primary installation: {primary['name']} ({primary['id']})\")
+"
+    backup_current
+    ;;
+
+  load)
+    require_name
+    src="$(profile_path "$NAME")"
+    if [[ ! -f "$src" ]]; then
+      echo "Error: Profile '$NAME' not found. Use 'list' to see available profiles." >&2
+      exit 1
+    fi
+    backup_current
+    cp "$src" "$INSTALLATIONS_FILE"
+    echo "Loaded profile '$NAME' as installations.json"
+    ;;
+
+  list)
+    if [[ ! -d "$PROFILES_DIR" ]]; then
+      echo "No profiles saved yet."
+      exit 0
+    fi
+    shopt -s nullglob
+    profiles=("$PROFILES_DIR"/*.json)
+    shopt -u nullglob
+    if [[ ${#profiles[@]} -eq 0 ]]; then
+      echo "No profiles saved yet."
+      exit 0
+    fi
+    echo "Saved profiles:"
+    for p in "${profiles[@]}"; do
+      name="$(basename "$p" .json)"
+      count=$(python3 -c "import json; print(len(json.load(open('$p'))))" 2>/dev/null || echo "?")
+      echo "  $name ($count installations)"
+    done
+    ;;
+
+  delete)
+    require_name
+    target="$(profile_path "$NAME")"
+    if [[ ! -f "$target" ]]; then
+      echo "Error: Profile '$NAME' not found." >&2
+      exit 1
+    fi
+    rm "$target"
+    echo "Deleted profile '$NAME'"
+    ;;
+
+  *)
+    echo "Unknown action: $ACTION" >&2
+    echo "Usage: $0 {save|load|empty|primary-only|list|delete} [name]" >&2
+    exit 1
+    ;;
+esac

--- a/src/renderer/src/views/DashboardView.vue
+++ b/src/renderer/src/views/DashboardView.vue
@@ -58,9 +58,10 @@ const primaryInstall = computed(() => {
   return localInstalls.value[0] ?? null
 })
 
-const canChangePrimary = computed(() =>
-  localInstalls.value.some((i) => i.sourceId !== 'desktop' && i.id !== primaryInstall.value?.id)
+const availablePrimaryTargets = computed(() =>
+  localInstalls.value.filter((i) => i.sourceId !== 'desktop' && i.id !== primaryInstall.value?.id)
 )
+const canChangePrimary = computed(() => availablePrimaryTargets.value.length > 0)
 
 const desktopOnlyInstall = computed(() => {
   if (localInstalls.value.length !== 1) return null
@@ -307,8 +308,7 @@ async function handleLaunch(inst: Installation, actions: ListAction[]): Promise<
 
 // --- Change primary ---
 async function changePrimary(): Promise<void> {
-  const items = localInstalls.value
-    .filter((i) => i.sourceId !== 'desktop' && i.id !== primaryInstall.value?.id)
+  const items = availablePrimaryTargets.value
     .map((i) => ({
       value: i.id,
       label: i.name,

--- a/src/renderer/src/views/DashboardView.vue
+++ b/src/renderer/src/views/DashboardView.vue
@@ -58,6 +58,10 @@ const primaryInstall = computed(() => {
   return localInstalls.value[0] ?? null
 })
 
+const canChangePrimary = computed(() =>
+  localInstalls.value.some((i) => i.sourceId !== 'desktop' && i.id !== primaryInstall.value?.id)
+)
+
 const desktopOnlyInstall = computed(() => {
   if (localInstalls.value.length !== 1) return null
   const only = localInstalls.value[0]!
@@ -304,7 +308,7 @@ async function handleLaunch(inst: Installation, actions: ListAction[]): Promise<
 // --- Change primary ---
 async function changePrimary(): Promise<void> {
   const items = localInstalls.value
-    .filter((i) => i.sourceId !== 'desktop' && !prefs.isPrimary(i.id))
+    .filter((i) => i.sourceId !== 'desktop' && i.id !== primaryInstall.value?.id)
     .map((i) => ({
       value: i.id,
       label: i.name,
@@ -390,7 +394,7 @@ async function changePrimary(): Promise<void> {
             <div class="dashboard-card-badge dashboard-card-badge-primary">
               <Star :size="14" />
               {{ $t('dashboard.primary') }}
-              <button class="dashboard-change-btn" :title="$t('dashboard.setPrimaryMessage')" @click="changePrimary">{{ $t('dashboard.changePrimary') }}</button>
+              <button v-if="canChangePrimary" class="dashboard-change-btn" :title="$t('dashboard.setPrimaryMessage')" @click="changePrimary">{{ $t('dashboard.changePrimary') }}</button>
             </div>
             <DashboardCard
               :installation="primaryInstall"


### PR DESCRIPTION
## Problem

The **Change** button on the primary installation card in the dashboard appears even when there are no other compatible installations to switch to. Clicking the button does nothing in this case.

## Root Cause

`canChangePrimary` and `changePrimary()` used `prefs.isPrimary(i.id)` to exclude the current primary from the candidate list. However, `primaryInstall` has a fallback (`localInstalls[0]`) used when `primaryInstallId` is undefined or doesn't match any installation. When this fallback kicks in, `isPrimary()` returns `false` for every install (since `primaryInstallId` is `undefined`), so the button incorrectly appears.

Even without the fallback, `syncPrimaryFromMain()` is async and fires from a `watch` without being awaited — creating a window where `primaryInstallId` is stale/undefined while the UI already renders the primary card.

## Fix

- Extract a shared `availablePrimaryTargets` computed that filters to non-desktop installs excluding the currently-displayed primary (using `primaryInstall.value?.id` instead of `prefs.isPrimary()`)
- `canChangePrimary` derives from `availablePrimaryTargets.length > 0`
- `changePrimary()` reuses `availablePrimaryTargets` directly — no duplicated filter logic that could drift

## Testing Scripts

Added `scripts/swap-installations.ps1` (Windows) and `scripts/swap-installations.sh` (Linux/macOS) to swap installations.json for testing different scenarios:

| Action | Description |
|--------|-------------|
| `save <name>` | Snapshot current installations.json as a named profile |
| `load <name>` | Restore a saved profile |
| `empty` | Replace with empty array (new-user experience) |
| `primary-only` | Keep only the current primary installation |
| `list` | List saved profiles |
| `delete <name>` | Delete a saved profile |

Scripts auto-backup before overwriting, warn if the app is running, and write BOM-free UTF-8 (required for Node.js compatibility).

## AGENTS.md Updates

- **Fix all issues found by checks**: typecheck/lint/audit errors are always our responsibility — no `--no-verify` workarounds
- **Post-change deduplication**: check for duplicated logic before committing; extract shared predicates so coupled call sites can't diverge

Fixes #407