### PR TITLE
fix: make Windows NSIS updates run silently

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -28,9 +28,7 @@ win:
   target: nsis
   icon: assets/Comfy_Logo_x256.png
 nsis:
-  oneClick: false
   perMachine: false
-  allowToChangeInstallationDirectory: true
   include: scripts/installer.nsh
 mac:
   target:

--- a/scripts/installer.nsh
+++ b/scripts/installer.nsh
@@ -2,6 +2,9 @@
 !include 'FileFunc.nsh'
 !include 'LogicLib.nsh'
 
+# Enable directory picker in oneClick mode (silent updates, interactive first install)
+!define allowToChangeInstallationDirectory
+
 ; Optional installer command-line overrides:
 ;   /ALLUSERS    force a per-machine install
 ;   /CURRENTUSER force a per-user install


### PR DESCRIPTION
## Summary

Switch to oneClick mode (default) so auto-updates run silently without showing the full installer wizard UI. The directory picker is preserved for first-time installs via `!define allowToChangeInstallationDirectory` in installer.nsh, matching the legacy desktop pattern.

## Problem

Every Windows update currently shows the complete NSIS installation wizard (directory selection, progress bar, finish page) instead of updating silently in the background. This is because `electron-builder.yml` sets `oneClick: false`.

## Changes

- **electron-builder.yml**: Removed `oneClick: false` and `allowToChangeInstallationDirectory: true` from the nsis section (oneClick now defaults to `true`)
- **scripts/installer.nsh**: Added `!define allowToChangeInstallationDirectory` to preserve the directory picker in oneClick mode

## What still works

- First install: directory picker + VC++ Redist installation + finish page
- Updates: fully silent (no UI), VC++ Redist skipped, app auto-relaunches
- `/ALLUSERS` flag: still works for per-machine installs
- `customInstallMode` / `customInstall` / `customFinishPage` macros: unchanged

## Testing needed

- [ ] Fresh Windows install: directory picker appears
- [ ] Fresh install: VC++ Redist installs
- [ ] Update: fully silent, no installer UI
- [ ] `/ALLUSERS` flag: per-machine install works
- [ ] Install path remains stable across upgrade

Part of #434. Related to #429.