### PR TITLE
feat: add bootstrap python support for pre-install git operations

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -84,6 +84,11 @@ jobs:
           VITE_DATADOG_RUM_VERSION: ${{ steps.datadog.outputs.release_version }}
         run: pnpm run datadog:sourcemaps:upload
 
+      - name: Fetch bootstrap Python
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/fetch-bootstrap-python.mjs
+
       - name: Install ToDesktop CLI
         run: npm install --location=global @todesktop/cli@1.22.0
 

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -84,11 +84,6 @@ jobs:
           VITE_DATADOG_RUM_VERSION: ${{ steps.datadog.outputs.release_version }}
         run: pnpm run datadog:sourcemaps:upload
 
-      - name: Fetch bootstrap Python
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node scripts/fetch-bootstrap-python.mjs
-
       - name: Install ToDesktop CLI
         run: npm install --location=global @todesktop/cli@1.22.0
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ test-results/
 playwright-report/
 resources/vc_redist.x64.exe
 resources/vc_redist.x64.exe.tmp
+bootstrap-python/

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -27,6 +27,11 @@ artifactName: ComfyUI-Desktop-2.0-${version}-${os}-${arch}.${ext}
 win:
   target: nsis
   icon: assets/Comfy_Logo_x256.png
+  extraResources:
+    - from: bootstrap-python/win-x64
+      to: bootstrap-python
+      filter:
+        - '**/*'
 nsis:
   oneClick: false
   perMachine: false
@@ -38,6 +43,11 @@ mac:
     - zip
   icon: assets/Comfy_Logo_x512.png
   category: public.app-category.developer-tools
+  extraResources:
+    - from: bootstrap-python/mac-arm64
+      to: bootstrap-python
+      filter:
+        - '**/*'
 linux:
   target:
     - AppImage
@@ -47,6 +57,10 @@ linux:
   extraResources:
     - from: resources/apparmor-profile
       to: apparmor-profile
+    - from: bootstrap-python/linux-x64
+      to: bootstrap-python
+      filter:
+        - '**/*'
 deb:
   afterInstall: scripts/after-install.sh
   afterRemove: scripts/after-remove.sh

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "packageManager": "pnpm@10.28.1",
   "main": "./out/main/index.js",
   "scripts": {
+    "init": "pnpm install && pnpm run dev:bootstrap",
     "predev": "node -e \"const fs=require('fs'),p=process.platform==='win32'?'win-x64':process.platform==='darwin'?'mac-arm64':'linux-x64';if(!fs.existsSync('bootstrap-python/'+p))console.log('\\n\\x1b[33m⚠ Bootstrap python not found. Run \\\"pnpm run bootstrap\\\" for pre-install git support.\\x1b[0m\\n')\"",
     "dev": "electron-vite dev",
     "predev:bootstrap": "node -e \"const fs=require('fs'),p=process.platform==='win32'?'win-x64':process.platform==='darwin'?'mac-arm64':'linux-x64';if(!fs.existsSync('bootstrap-python/'+p)){console.log('Building bootstrap python...');require('child_process').execSync('python scripts/build-bootstrap-python.py',{stdio:'inherit'})}\"",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "predev": "node -e \"const fs=require('fs'),p=process.platform==='win32'?'win-x64':process.platform==='darwin'?'mac-arm64':'linux-x64';if(!fs.existsSync('bootstrap-python/'+p))console.log('\\n\\x1b[33m⚠ Bootstrap python not found. Run \\\"pnpm run bootstrap\\\" for pre-install git support.\\x1b[0m\\n')\"",
     "dev": "electron-vite dev",
+    "predev:bootstrap": "node -e \"const fs=require('fs'),p=process.platform==='win32'?'win-x64':process.platform==='darwin'?'mac-arm64':'linux-x64';if(!fs.existsSync('bootstrap-python/'+p)){console.log('Building bootstrap python...');require('child_process').execSync('python scripts/build-bootstrap-python.py',{stdio:'inherit'})}\"",
     "dev:bootstrap": "node -e \"process.env.COMFY_FORCE_BOOTSTRAP_GIT='1';require('child_process').execSync('electron-vite dev',{stdio:'inherit',env:process.env})\"",
     "build": "pnpm run typecheck && electron-vite build",
     "start": "electron-vite preview",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "packageManager": "pnpm@10.28.1",
   "main": "./out/main/index.js",
   "scripts": {
+    "predev": "node -e \"const fs=require('fs'),p=process.platform==='win32'?'win-x64':process.platform==='darwin'?'mac-arm64':'linux-x64';if(!fs.existsSync('bootstrap-python/'+p))console.log('\\n\\x1b[33m⚠ Bootstrap python not found. Run \\\"pnpm run bootstrap\\\" for pre-install git support.\\x1b[0m\\n')\"",
     "dev": "electron-vite dev",
     "build": "pnpm run typecheck && electron-vite build",
     "start": "electron-vite preview",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "start": "electron-vite preview",
     "postinstall": "node ./scripts/postinstall.mjs",
     "todesktop:beforeInstall": "./scripts/todesktop-beforeInstall.cjs",
+    "todesktop:beforeBuild": "./scripts/todesktop-beforeBuild.cjs",
     "todesktop:afterPack": "./scripts/todesktop-afterPack.cjs",
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json --composite false",
     "typecheck:web": "vue-tsc --noEmit -p tsconfig.web.json --composite false",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "packageManager": "pnpm@10.28.1",
   "main": "./out/main/index.js",
   "scripts": {
-    "init": "pnpm install && pnpm run dev:bootstrap",
+    "init": "pnpm install && pnpm run bootstrap",
     "predev": "node -e \"const fs=require('fs'),p=process.platform==='win32'?'win-x64':process.platform==='darwin'?'mac-arm64':'linux-x64';if(!fs.existsSync('bootstrap-python/'+p))console.log('\\n\\x1b[33m⚠ Bootstrap python not found. Run \\\"pnpm run bootstrap\\\" for pre-install git support.\\x1b[0m\\n')\"",
     "dev": "electron-vite dev",
     "predev:bootstrap": "node -e \"const fs=require('fs'),p=process.platform==='win32'?'win-x64':process.platform==='darwin'?'mac-arm64':'linux-x64';if(!fs.existsSync('bootstrap-python/'+p)){console.log('Building bootstrap python...');require('child_process').execSync('python scripts/build-bootstrap-python.py',{stdio:'inherit'})}\"",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "build:win": "pnpm run build && electron-builder --win",
     "build:mac": "pnpm run build && electron-builder --mac",
     "build:linux": "pnpm run build && electron-builder --linux",
+    "bootstrap": "python scripts/build-bootstrap-python.py",
+    "bootstrap:fetch": "node scripts/fetch-bootstrap-python.mjs",
     "datadog:sourcemaps:upload": "node ./scripts/upload-datadog-sourcemaps.mjs",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "predev": "node -e \"const fs=require('fs'),p=process.platform==='win32'?'win-x64':process.platform==='darwin'?'mac-arm64':'linux-x64';if(!fs.existsSync('bootstrap-python/'+p))console.log('\\n\\x1b[33m⚠ Bootstrap python not found. Run \\\"pnpm run bootstrap\\\" for pre-install git support.\\x1b[0m\\n')\"",
     "dev": "electron-vite dev",
+    "dev:bootstrap": "node -e \"process.env.COMFY_FORCE_BOOTSTRAP_GIT='1';require('child_process').execSync('electron-vite dev',{stdio:'inherit',env:process.env})\"",
     "build": "pnpm run typecheck && electron-vite build",
     "start": "electron-vite preview",
     "postinstall": "node ./scripts/postinstall.mjs",

--- a/scripts/build-bootstrap-python.py
+++ b/scripts/build-bootstrap-python.py
@@ -51,6 +51,8 @@ STRIP_DIRS = [
     "ensurepip", "venv",
     "lib2to3", "pydoc_data",
     "unittest",
+    "tcl", "tk",
+    "libs",
 ]
 
 STRIP_TOP_LEVEL = [
@@ -59,7 +61,13 @@ STRIP_TOP_LEVEL = [
     "pkg_resources",
 ]
 
-STRIP_EXTENSIONS = [".pyc", ".pyo", ".a"]
+STRIP_EXTENSIONS = [".pyc", ".pyo", ".a", ".lib"]
+
+# DLL/pyd files to remove (unused by pygit2)
+STRIP_FILES = [
+    "tcl86t.dll", "tk86t.dll", "sqlite3.dll",
+    "_testcapi.pyd", "_tkinter.pyd", "_sqlite3.pyd",
+]
 
 
 def detect_platform():
@@ -83,8 +91,11 @@ def download_file(url, dest):
 
 
 def find_site_packages(env_dir):
-    if sys.platform == "win32" or os.path.exists(os.path.join(env_dir, "Lib", "site-packages")):
-        return os.path.join(env_dir, "Lib", "site-packages")
+    # Check Windows-style layout first (Lib/site-packages)
+    win_sp = os.path.join(env_dir, "Lib", "site-packages")
+    if os.path.isdir(win_sp):
+        return win_sp
+    # Unix-style layout (lib/python3.X/site-packages)
     lib_dir = os.path.join(env_dir, "lib")
     if os.path.exists(lib_dir):
         for entry in os.listdir(lib_dir):
@@ -122,10 +133,10 @@ def strip_environment(env_dir):
                     removed_count += 1
                     break
 
-    # Remove files by extension
+    # Remove files by extension and by name
     for root, dirs, files in os.walk(env_dir):
         for f in files:
-            if any(f.endswith(ext) for ext in STRIP_EXTENSIONS):
+            if any(f.endswith(ext) for ext in STRIP_EXTENSIONS) or f in STRIP_FILES:
                 os.remove(os.path.join(root, f))
                 removed_count += 1
 

--- a/scripts/fetch-bootstrap-python.mjs
+++ b/scripts/fetch-bootstrap-python.mjs
@@ -90,9 +90,12 @@ async function downloadAndExtract(url, destDir) {
   // Save to temp file first, then extract with tar
   fs.mkdirSync(path.dirname(destDir), { recursive: true })
   const tmpFile = `${destDir}.tar.gz`
-  await pipeline(Readable.fromWeb(response.body), fs.createWriteStream(tmpFile))
-  execSync(`tar -xzf "${tmpFile}" -C "${path.dirname(destDir)}"`, { stdio: 'inherit' })
-  fs.unlinkSync(tmpFile)
+  try {
+    await pipeline(Readable.fromWeb(response.body), fs.createWriteStream(tmpFile))
+    execSync(`tar -xzf "${tmpFile}" -C "${path.dirname(destDir)}"`, { stdio: 'inherit' })
+  } finally {
+    if (fs.existsSync(tmpFile)) fs.unlinkSync(tmpFile)
+  }
 }
 
 async function main() {

--- a/scripts/fetch-bootstrap-python.mjs
+++ b/scripts/fetch-bootstrap-python.mjs
@@ -43,12 +43,25 @@ async function fetchReleaseAssets(tag) {
   const headers = { Accept: 'application/vnd.github+json' }
   if (token) headers.Authorization = `Bearer ${token}`
 
-  const url = `https://api.github.com/repos/${REPO}/releases/tags/${tag}`
-  const response = await fetch(url, { headers })
-  if (!response.ok) {
-    throw new Error(`Failed to fetch release ${tag}: ${response.status} ${response.statusText}`)
+  // Try the tags endpoint first (works for published releases)
+  const tagUrl = `https://api.github.com/repos/${REPO}/releases/tags/${tag}`
+  const tagResponse = await fetch(tagUrl, { headers })
+  if (tagResponse.ok) {
+    const release = await tagResponse.json()
+    return release.assets || []
   }
-  const release = await response.json()
+
+  // Fall back to listing all releases (includes drafts, requires auth)
+  const listUrl = `https://api.github.com/repos/${REPO}/releases?per_page=50`
+  const listResponse = await fetch(listUrl, { headers })
+  if (!listResponse.ok) {
+    throw new Error(`Failed to list releases: ${listResponse.status} ${listResponse.statusText}`)
+  }
+  const releases = await listResponse.json()
+  const release = releases.find((r) => r.tag_name === tag)
+  if (!release) {
+    throw new Error(`Release ${tag} not found (checked ${releases.length} releases)`)
+  }
   return release.assets || []
 }
 
@@ -63,10 +76,9 @@ async function downloadAndExtract(url, destDir) {
   }
 
   // Save to temp file first, then extract with tar
+  fs.mkdirSync(path.dirname(destDir), { recursive: true })
   const tmpFile = `${destDir}.tar.gz`
   await pipeline(Readable.fromWeb(response.body), fs.createWriteStream(tmpFile))
-
-  fs.mkdirSync(path.dirname(destDir), { recursive: true })
   execSync(`tar -xzf "${tmpFile}" -C "${path.dirname(destDir)}"`, { stdio: 'inherit' })
   fs.unlinkSync(tmpFile)
 }

--- a/scripts/fetch-bootstrap-python.mjs
+++ b/scripts/fetch-bootstrap-python.mjs
@@ -101,7 +101,9 @@ async function main() {
 
     console.log(`  ${platform}: downloading ${assetName} (${(asset.size / 1048576).toFixed(1)} MB)`)
     try {
-      await downloadAndExtract(asset.browser_download_url, destDir)
+      // Use asset.url (REST API endpoint) not browser_download_url to
+      // support private repos and avoid auth-header issues with S3 redirects.
+      await downloadAndExtract(asset.url, destDir)
       console.log(`  ${platform}: OK`)
     } catch (err) {
       console.warn(`  ${platform}: failed - ${err.message}`)
@@ -113,6 +115,5 @@ async function main() {
 
 main().catch((err) => {
   console.error(err)
-  // Non-fatal — app works without bootstrap python, just no pre-install git
-  process.exit(0)
+  process.exit(1)
 })

--- a/scripts/fetch-bootstrap-python.mjs
+++ b/scripts/fetch-bootstrap-python.mjs
@@ -15,7 +15,6 @@
 import fs from 'node:fs'
 import { pipeline } from 'node:stream/promises'
 import { Readable } from 'node:stream'
-import { createGunzip } from 'node:zlib'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { execSync } from 'node:child_process'

--- a/scripts/fetch-bootstrap-python.mjs
+++ b/scripts/fetch-bootstrap-python.mjs
@@ -1,0 +1,118 @@
+/**
+ * Download pre-built bootstrap-python archives for all platforms.
+ *
+ * Called before `todesktop build` (or local electron-builder) to ensure
+ * the platform-specific bootstrap-python directories exist under
+ * bootstrap-python/{win-x64,mac-arm64,linux-x64}/.
+ *
+ * Usage:
+ *   node scripts/fetch-bootstrap-python.mjs [--tag bootstrap-v1]
+ *
+ * Requires GITHUB_TOKEN env var for authenticated downloads from releases.
+ * Skips platforms whose directory already exists.
+ */
+
+import fs from 'node:fs'
+import { pipeline } from 'node:stream/promises'
+import { Readable } from 'node:stream'
+import { createGunzip } from 'node:zlib'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { execSync } from 'node:child_process'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const projectRoot = path.resolve(__dirname, '..')
+const outputBase = path.join(projectRoot, 'bootstrap-python')
+
+const PLATFORMS = ['win-x64', 'mac-arm64', 'linux-x64']
+const DEFAULT_TAG = 'bootstrap-v1'
+const REPO = 'Comfy-Org/ComfyUI-Desktop-2.0-Beta'
+
+function parseArgs() {
+  const args = process.argv.slice(2)
+  let tag = DEFAULT_TAG
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--tag' && args[i + 1]) {
+      tag = args[++i]
+    }
+  }
+  return { tag }
+}
+
+async function fetchReleaseAssets(tag) {
+  const token = process.env.GITHUB_TOKEN
+  const headers = { Accept: 'application/vnd.github+json' }
+  if (token) headers.Authorization = `Bearer ${token}`
+
+  const url = `https://api.github.com/repos/${REPO}/releases/tags/${tag}`
+  const response = await fetch(url, { headers })
+  if (!response.ok) {
+    throw new Error(`Failed to fetch release ${tag}: ${response.status} ${response.statusText}`)
+  }
+  const release = await response.json()
+  return release.assets || []
+}
+
+async function downloadAndExtract(url, destDir) {
+  const token = process.env.GITHUB_TOKEN
+  const headers = { Accept: 'application/octet-stream' }
+  if (token) headers.Authorization = `Bearer ${token}`
+
+  const response = await fetch(url, { headers })
+  if (!response.ok || !response.body) {
+    throw new Error(`Download failed: ${response.status} ${response.statusText}`)
+  }
+
+  // Save to temp file first, then extract with tar
+  const tmpFile = `${destDir}.tar.gz`
+  await pipeline(Readable.fromWeb(response.body), fs.createWriteStream(tmpFile))
+
+  fs.mkdirSync(path.dirname(destDir), { recursive: true })
+  execSync(`tar -xzf "${tmpFile}" -C "${path.dirname(destDir)}"`, { stdio: 'inherit' })
+  fs.unlinkSync(tmpFile)
+}
+
+async function main() {
+  const { tag } = parseArgs()
+  console.log(`Fetching bootstrap-python archives from release ${tag}`)
+
+  let assets
+  try {
+    assets = await fetchReleaseAssets(tag)
+  } catch (err) {
+    console.warn(`Could not fetch release assets: ${err.message}`)
+    console.warn('Bootstrap python will not be available. Continuing without it.')
+    return
+  }
+
+  for (const platform of PLATFORMS) {
+    const destDir = path.join(outputBase, platform)
+    if (fs.existsSync(destDir)) {
+      console.log(`  ${platform}: already exists, skipping`)
+      continue
+    }
+
+    const assetName = `bootstrap-python-${platform}.tar.gz`
+    const asset = assets.find((a) => a.name === assetName)
+    if (!asset) {
+      console.warn(`  ${platform}: asset ${assetName} not found in release, skipping`)
+      continue
+    }
+
+    console.log(`  ${platform}: downloading ${assetName} (${(asset.size / 1048576).toFixed(1)} MB)`)
+    try {
+      await downloadAndExtract(asset.browser_download_url, destDir)
+      console.log(`  ${platform}: OK`)
+    } catch (err) {
+      console.warn(`  ${platform}: failed - ${err.message}`)
+    }
+  }
+
+  console.log('Done.')
+}
+
+main().catch((err) => {
+  console.error(err)
+  // Non-fatal — app works without bootstrap python, just no pre-install git
+  process.exit(0)
+})

--- a/scripts/fetch-bootstrap-python.mjs
+++ b/scripts/fetch-bootstrap-python.mjs
@@ -1,14 +1,20 @@
 /**
- * Download pre-built bootstrap-python archives for all platforms.
+ * Download pre-built bootstrap-python archives from a GitHub release.
  *
  * Called before `todesktop build` (or local electron-builder) to ensure
  * the platform-specific bootstrap-python directories exist under
  * bootstrap-python/{win-x64,mac-arm64,linux-x64}/.
  *
  * Usage:
- *   node scripts/fetch-bootstrap-python.mjs [--tag bootstrap-v1]
+ *   node scripts/fetch-bootstrap-python.mjs [--tag bootstrap-v1] [--platform win-x64]
+ *   node scripts/fetch-bootstrap-python.mjs [--tag bootstrap-v1] [--output-dir /path/to/dir]
  *
- * Requires GITHUB_TOKEN env var for authenticated downloads from releases.
+ * Options:
+ *   --platform   Fetch only this platform (default: all platforms)
+ *   --output-dir Override the output base directory (default: bootstrap-python/ in project root)
+ *   --tag        Release tag to fetch from (default: bootstrap-v1)
+ *
+ * Uses GITHUB_TOKEN env var for authenticated downloads if set.
  * Skips platforms whose directory already exists.
  */
 
@@ -30,12 +36,18 @@ const REPO = 'Comfy-Org/ComfyUI-Desktop-2.0-Beta'
 function parseArgs() {
   const args = process.argv.slice(2)
   let tag = DEFAULT_TAG
+  let platform = null
+  let outputDir = null
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--tag' && args[i + 1]) {
       tag = args[++i]
+    } else if (args[i] === '--platform' && args[i + 1]) {
+      platform = args[++i]
+    } else if (args[i] === '--output-dir' && args[i + 1]) {
+      outputDir = args[++i]
     }
   }
-  return { tag }
+  return { tag, platform, outputDir }
 }
 
 async function fetchReleaseAssets(tag) {
@@ -84,7 +96,9 @@ async function downloadAndExtract(url, destDir) {
 }
 
 async function main() {
-  const { tag } = parseArgs()
+  const { tag, platform: onlyPlatform, outputDir } = parseArgs()
+  const platforms = onlyPlatform ? [onlyPlatform] : PLATFORMS
+  const outBase = outputDir || outputBase
   console.log(`Fetching bootstrap-python archives from release ${tag}`)
 
   let assets
@@ -96,8 +110,8 @@ async function main() {
     return
   }
 
-  for (const platform of PLATFORMS) {
-    const destDir = path.join(outputBase, platform)
+  for (const platform of platforms) {
+    const destDir = path.join(outBase, platform)
     if (fs.existsSync(destDir)) {
       console.log(`  ${platform}: already exists, skipping`)
       continue

--- a/scripts/todesktop-beforeBuild.cjs
+++ b/scripts/todesktop-beforeBuild.cjs
@@ -1,6 +1,3 @@
-const { execSync } = require('child_process')
-const path = require('path')
-
 const PLATFORM_MAP = {
   'win32-x64': 'win-x64',
   'darwin-arm64': 'mac-arm64',
@@ -8,6 +5,9 @@ const PLATFORM_MAP = {
 }
 
 module.exports = async ({ appDir, platform, arch }) => {
+  const { execSync } = await import('node:child_process')
+  const path = await import('node:path')
+
   const key = `${platform}-${arch}`
   const bootstrapPlatform = PLATFORM_MAP[key]
   if (!bootstrapPlatform) {

--- a/scripts/todesktop-beforeBuild.cjs
+++ b/scripts/todesktop-beforeBuild.cjs
@@ -1,0 +1,25 @@
+const { execSync } = require('child_process')
+const path = require('path')
+
+const PLATFORM_MAP = {
+  'win32-x64': 'win-x64',
+  'darwin-arm64': 'mac-arm64',
+  'linux-x64': 'linux-x64',
+}
+
+module.exports = async ({ appDir, platform, arch }) => {
+  const key = `${platform}-${arch}`
+  const bootstrapPlatform = PLATFORM_MAP[key]
+  if (!bootstrapPlatform) {
+    console.log(`[todesktop:beforeBuild] No bootstrap python for ${key}, skipping`)
+    return
+  }
+
+  console.log(`[todesktop:beforeBuild] Fetching bootstrap python for ${bootstrapPlatform}`)
+  const script = path.join(appDir, 'scripts', 'fetch-bootstrap-python.mjs')
+  const outDir = path.join(appDir, 'bootstrap-python')
+  execSync(
+    `node "${script}" --platform ${bootstrapPlatform} --output-dir "${outDir}"`,
+    { stdio: 'inherit', cwd: appDir }
+  )
+}

--- a/src/main/lib/git.ts
+++ b/src/main/lib/git.ts
@@ -48,9 +48,12 @@ export function tryConfigurePygit2Fallback(installPath: string): boolean {
  * @returns `true` if pygit2 was successfully configured.
  */
 export function tryConfigureBootstrapPygit2(): boolean {
+  const platformDir = process.platform === 'win32' ? 'win-x64'
+    : process.platform === 'darwin' ? 'mac-arm64'
+    : 'linux-x64'
   const bootstrapDir = app.isPackaged
     ? path.join(process.resourcesPath, 'bootstrap-python')
-    : path.join(__dirname, '..', '..', 'bootstrap-python')
+    : path.join(__dirname, '..', '..', 'bootstrap-python', platformDir)
   const pythonPath = process.platform === 'win32'
     ? path.join(bootstrapDir, 'python.exe')
     : path.join(bootstrapDir, 'bin', 'python3')

--- a/src/main/lib/git.ts
+++ b/src/main/lib/git.ts
@@ -1,6 +1,7 @@
 import { execFile, spawn, type ExecFileException } from 'child_process'
 import fs from 'fs'
 import path from 'path'
+import { app } from 'electron'
 import { killProcTree } from './process'
 import { getBundledScriptPath } from './bundledScript'
 
@@ -31,6 +32,28 @@ export function tryConfigurePygit2Fallback(installPath: string): boolean {
   const pythonPath = process.platform === 'win32'
     ? path.join(installPath, 'standalone-env', 'python.exe')
     : path.join(installPath, 'standalone-env', 'bin', 'python3')
+  if (!fs.existsSync(pythonPath)) return false
+  const scriptPath = getBundledScriptPath('git_operations.py')
+  if (!fs.existsSync(scriptPath)) return false
+  configurePygit2(pythonPath, scriptPath)
+  return true
+}
+
+/**
+ * Try to configure the pygit2 fallback using a bootstrap Python bundled
+ * with the Electron app (in resources/bootstrap-python/).  This allows
+ * git operations to work from app launch, before any standalone
+ * environment is downloaded.
+ *
+ * @returns `true` if pygit2 was successfully configured.
+ */
+export function tryConfigureBootstrapPygit2(): boolean {
+  const bootstrapDir = app.isPackaged
+    ? path.join(process.resourcesPath, 'bootstrap-python')
+    : path.join(__dirname, '..', '..', 'bootstrap-python')
+  const pythonPath = process.platform === 'win32'
+    ? path.join(bootstrapDir, 'python.exe')
+    : path.join(bootstrapDir, 'bin', 'python3')
   if (!fs.existsSync(pythonPath)) return false
   const scriptPath = getBundledScriptPath('git_operations.py')
   if (!fs.existsSync(scriptPath)) return false

--- a/src/main/lib/git.ts
+++ b/src/main/lib/git.ts
@@ -48,9 +48,10 @@ export function tryConfigurePygit2Fallback(installPath: string): boolean {
  * @returns `true` if pygit2 was successfully configured.
  */
 export function tryConfigureBootstrapPygit2(): boolean {
-  const platformDir = process.platform === 'win32' ? 'win-x64'
-    : process.platform === 'darwin' ? 'mac-arm64'
-    : 'linux-x64'
+  const osName = process.platform === 'win32' ? 'win'
+    : process.platform === 'darwin' ? 'mac'
+    : 'linux'
+  const platformDir = `${osName}-${process.arch}`
   const bootstrapDir = app.isPackaged
     ? path.join(process.resourcesPath, 'bootstrap-python')
     : path.join(__dirname, '..', '..', 'bootstrap-python', platformDir)

--- a/src/main/lib/ipc/index.ts
+++ b/src/main/lib/ipc/index.ts
@@ -98,8 +98,17 @@ export function register(callbacks: RegisterCallbacks = {}): void {
   })()
 
   // Configure pygit2 fallback if system git is unavailable
+  // Set COMFY_FORCE_BOOTSTRAP_GIT=1 to skip system git and standalone checks (for testing)
   void (async () => {
     try {
+      const forceBootstrap = process.env.COMFY_FORCE_BOOTSTRAP_GIT === '1'
+      if (forceBootstrap) {
+        if (tryConfigureBootstrapPygit2()) {
+          console.log('[ipc] COMFY_FORCE_BOOTSTRAP_GIT — using bootstrap python for git')
+          return
+        }
+        console.warn('[ipc] COMFY_FORCE_BOOTSTRAP_GIT set but bootstrap python not found')
+      }
       if (await isGitAvailable()) return
       // Prefer standalone installation's pygit2 (co-located with ComfyUI env)
       const all = await installations.list()

--- a/src/main/lib/ipc/index.ts
+++ b/src/main/lib/ipc/index.ts
@@ -3,7 +3,7 @@ import {
   installations, settings,
   sourceMap,
   detectDesktopInstall,
-  isGitAvailable, tryConfigurePygit2Fallback,
+  isGitAvailable, tryConfigureBootstrapPygit2, tryConfigurePygit2Fallback,
   createCache, fetchJSON,
   setCallbacks, _broadcastToRenderer,
   migrateDefaults, checkInstallationUpdates,
@@ -101,13 +101,18 @@ export function register(callbacks: RegisterCallbacks = {}): void {
   void (async () => {
     try {
       if (await isGitAvailable()) return
+      // Prefer standalone installation's pygit2 (co-located with ComfyUI env)
       const all = await installations.list()
       for (const inst of all) {
         if (inst.sourceId !== 'standalone' || !inst.installPath) continue
         if (tryConfigurePygit2Fallback(inst.installPath)) {
           console.log('[ipc] System git not found — configured pygit2 fallback via', inst.installPath)
-          break
+          return
         }
+      }
+      // Fall back to bootstrap python (bundled with the app, for pre-install use)
+      if (tryConfigureBootstrapPygit2()) {
+        console.log('[ipc] System git not found — configured pygit2 via bootstrap python')
       }
     } catch {}
   })()

--- a/src/main/lib/ipc/shared.ts
+++ b/src/main/lib/ipc/shared.ts
@@ -11,7 +11,7 @@ import { formatComfyVersion } from '../version'
 import type { ComfyVersion } from '../version'
 import { resolveInstalledVersion, clearVersionCache } from '../version-resolve'
 import type { LatestTagOverride } from '../version-resolve'
-import { readGitHead, readGitRemoteUrl, fetchTags, findLatestVersionTag, revParseRef, hasGitDir, isGitAvailable, tryConfigurePygit2Fallback } from '../git'
+import { readGitHead, readGitRemoteUrl, fetchTags, findLatestVersionTag, revParseRef, hasGitDir, isGitAvailable, tryConfigureBootstrapPygit2, tryConfigurePygit2Fallback } from '../git'
 import { ensureRemoteUrl } from '../github-mirror'
 import * as settings from '../../settings'
 import { defaultInstallDir, sanitizeDirName, allocateUniqueDir } from '../paths'
@@ -58,7 +58,7 @@ export {
   execFile, spawn, execFileSync,
   sources, installations, settings, releaseCache, i18n,
   formatComfyVersion, resolveInstalledVersion, clearVersionCache,
-  readGitRemoteUrl, fetchTags, findLatestVersionTag, revParseRef, hasGitDir, isGitAvailable, tryConfigurePygit2Fallback,
+  readGitRemoteUrl, fetchTags, findLatestVersionTag, revParseRef, hasGitDir, isGitAvailable, tryConfigureBootstrapPygit2, tryConfigurePygit2Fallback,
   ensureRemoteUrl,
   defaultInstallDir, sanitizeDirName, allocateUniqueDir, download, createCache, extract, deleteDir, formatDeleteStatus, deleteAction, untrackAction,
   spawnProcess, waitForPort, waitForUrl, killProcessTree, killByPort,

--- a/todesktop.json
+++ b/todesktop.json
@@ -38,5 +38,25 @@
   "linux": {
     "icon": "./assets/Comfy_Logo_x256.png",
     "category": "AudioVideo;Graphics;3DGraphics;"
+  },
+  "platformOverrides": {
+    "windows": {
+      "extraResources": [
+        { "from": "./lib", "to": "lib" },
+        { "from": "./bootstrap-python/win-x64", "to": "bootstrap-python" }
+      ]
+    },
+    "mac": {
+      "extraResources": [
+        { "from": "./lib", "to": "lib" },
+        { "from": "./bootstrap-python/mac-arm64", "to": "bootstrap-python" }
+      ]
+    },
+    "linux": {
+      "extraResources": [
+        { "from": "./lib", "to": "lib" },
+        { "from": "./bootstrap-python/linux-x64", "to": "bootstrap-python" }
+      ]
+    }
   }
 }

--- a/todesktop.json
+++ b/todesktop.json
@@ -5,7 +5,8 @@
   "appFiles": [
     "**",
     "!electron-builder.yml",
-    "!out/**/*.map"
+    "!out/**/*.map",
+    "!bootstrap-python/**"
   ],
   "appId": "org.comfy.comfyui-desktop-2",
   "icon": "./assets/Comfy_Logo_x512.png",
@@ -55,6 +56,7 @@
     "linux": {
       "extraResources": [
         { "from": "./lib", "to": "lib" },
+        { "from": "resources/apparmor-profile", "to": "apparmor-profile" },
         { "from": "./bootstrap-python/linux-x64", "to": "bootstrap-python" }
       ]
     }


### PR DESCRIPTION
## Summary

Bundles a minimal (~20–35 MB) Python + pygit2 environment into the Electron app so git operations (tag fetching, version resolution, etc.) work **immediately on first launch** — before any standalone ComfyUI environment is downloaded or installed.

Currently, if a user has no system git and hasn't installed a standalone environment yet, all git-based operations silently fail until a standalone install completes and configures its own pygit2. This creates a degraded first-run experience where version information is missing and updates can't be checked.

## What this PR adds

### Build pipeline
- **`scripts/build-bootstrap-python.py`** — Downloads python-build-standalone, installs pygit2, then aggressively strips unnecessary files (test suites, pip, setuptools, tkinter, tcl/tk, sqlite, static libs, `__pycache__`, etc.) to produce a ~20–35 MB environment per platform.
- **`.github/workflows/build-bootstrap-python.yml`** — Manual dispatch workflow that builds + uploads bootstrap-python archives for all platforms as GitHub release assets (merged separately via #438).

### Fetch & packaging pipeline
- **`scripts/fetch-bootstrap-python.mjs`** — Downloads pre-built bootstrap-python archives from a GitHub release (`bootstrap-v1` tag). Supports `--platform` (single platform) and `--output-dir` flags. Handles both published and draft releases. Cleans up temp files on failure via try/finally.
- **`scripts/todesktop-beforeBuild.cjs`** — ToDesktop `beforeBuild` lifecycle hook that fetches the correct single-platform bootstrap-python archive on ToDesktop's per-platform build servers. This avoids uploading all ~195 MB of archives with the app source — each platform build fetches only its own ~20–35 MB archive from the public release.
- **`electron-builder.yml`** — Adds platform-specific `extraResources` entries to bundle `bootstrap-python/<platform>` into the app's resources directory (for local builds).
- **`todesktop.json`** — Adds `platformOverrides` to include the correct bootstrap-python for each platform in ToDesktop builds. Excludes `bootstrap-python/` from `appFiles` (fetched on build servers instead). Correctly re-includes `./lib` and platform-specific resources (apparmor-profile for Linux) since `platformOverrides` replaces the top-level `extraResources` array.

### Runtime
- **`src/main/lib/git.ts`** — New `tryConfigureBootstrapPygit2()` function that looks for the bundled bootstrap python in `resources/bootstrap-python/` (packaged) or `bootstrap-python/<platform>/` (dev). Uses `process.arch` for dynamic platform directory resolution.
- **`src/main/lib/ipc/index.ts`** — Updated git fallback chain:
  1. If `COMFY_FORCE_BOOTSTRAP_GIT=1`, use bootstrap python directly (for testing).
  2. Check system git availability.
  3. Try standalone installation's pygit2 (existing behavior).
  4. Fall back to bundled bootstrap python (new).

### Developer experience
- `pnpm run init` — One-command setup: install deps + build bootstrap python.
- `pnpm run dev:bootstrap` — Launch dev with `COMFY_FORCE_BOOTSTRAP_GIT=1` (auto-builds bootstrap python if missing).
- `pnpm run bootstrap` / `pnpm run bootstrap:fetch` — Build locally or fetch pre-built archives.
- `pnpm run dev` now prints a warning if bootstrap python is not present.

## Prerequisites

- PR #438 (merged) — added the build workflow and script to `main` so it could be dispatched.
- `bootstrap-v1` release — created by dispatching the `Build Bootstrap Python` workflow. After merging this PR, the release should be deleted and re-created from `main` to pick up the improved stripping.

## Testing

1. **Without bootstrap python**: `pnpm run dev` — prints a warning about missing bootstrap python, app works normally with system git.
2. **With bootstrap python**: `pnpm run init && pnpm run dev:bootstrap` — forces bootstrap python usage, verify git operations work (version tags, update checks).
3. **CI verified**: Build workflow run from this branch confirmed pygit2 works after stripping on all 3 platforms (win-x64, mac-arm64, linux-x64).
4. **Packaged build**: Verify `resources/bootstrap-python/` exists in the packaged app and git operations work on a clean system without git installed.

## Size impact

Per-platform bootstrap python sizes (after stripping):
- **win-x64**: ~32 MB
- **mac-arm64**: ~19 MB (compressed archive)
- **linux-x64**: ~35 MB (compressed archive)

## Post-merge checklist

1. Delete the existing `bootstrap-v1` and `bootstrap-v1-test` releases
2. Dispatch `Build Bootstrap Python` workflow from `main` with tag `bootstrap-v1`
3. Publish the new release as **pre-release** (not latest)