### PR TITLE
fix: version tag regression on Latest channel after updates

### DIFF
--- a/lib/update_comfyui.py
+++ b/lib/update_comfyui.py
@@ -104,9 +104,10 @@ def main():
     print("Fetching from origin…")
     for remote in repo.remotes:
         if remote.name == "origin":
-            refspecs = ["+refs/heads/master:refs/remotes/origin/master"]
-            if stable:
-                refspecs.append("+refs/tags/*:refs/tags/*")
+            refspecs = [
+                "+refs/heads/master:refs/remotes/origin/master",
+                "+refs/tags/*:refs/tags/*",
+            ]
             try:
                 remote.fetch(refspecs)
             except Exception as e:

--- a/src/main/lib/version-resolve.ts
+++ b/src/main/lib/version-resolve.ts
@@ -37,10 +37,11 @@ const MAX_BACKPORT_WALK = 10
  * whose content is fully represented in `commit` (cherry-pick–aware).
  *
  * Collects candidate tags by walking backward, then evaluates from lowest
- * to highest.  A tag at position N (1-based, counting from `stopTag`)
- * qualifies when `countUniqueCommits(tag, commit) ≤ N` — each tag in the
- * chain is expected to contribute one version-bump commit that has no
- * equivalent on the commit's branch.
+ * to highest.  A tag qualifies when its unique commits (those with no
+ * cherry-pick equivalent on the commit's branch) do not exceed the total
+ * number of commits between `stopTag` and the candidate on the release
+ * branch.  This accommodates release branches that carry version bumps
+ * plus additional cherry-picks with no master equivalent.
  *
  * @returns The qualifying tag name and cherry-pick–aware "+N" count, or
  *          undefined if no qualifying tag is found before reaching `stopTag`.
@@ -64,8 +65,11 @@ async function findBestBackportTag(
   if (candidates.length === 0) return undefined
 
   // Phase 2: evaluate from lowest (closest to stopTag) to highest.
-  // Each tag adds one version-bump commit, so the threshold grows with
-  // the tag's position in the chain.
+  // The threshold for each candidate is the total number of commits
+  // between stopTag and that candidate on the release branch — this
+  // accounts for version-bump commits plus any release-only cherry-picks
+  // (e.g. workflow template bumps) that have no patch-id equivalent on
+  // the commit's branch.
   //
   // Sanity check: in shallow clones, countUniqueCommits can return wildly
   // inflated values because the truncated graph prevents patch-id matching.
@@ -75,14 +79,15 @@ async function findBestBackportTag(
   let best: { tag: string; commitsAhead: number } | undefined
   for (let pos = candidates.length - 1; pos >= 0; pos--) {
     const tag = candidates[pos]!
-    const threshold = candidates.length - pos
+    const branchDist = await countCommitsAhead(repoPath, stopTag, tag)
+    if (branchDist === undefined) break
     const unique = await countUniqueCommits(repoPath, tag, commit)
     if (unique === undefined) break
     if (ancestorDist !== undefined && unique > ancestorDist) return undefined
     // This tag has too many unique commits — stop ascending the chain
     // (higher tags will have even more).  Any previously found `best` from
     // a lower tag is still valid and will be returned.
-    if (unique > threshold) break
+    if (unique > branchDist) break
     const ahead = await countUniqueCommits(repoPath, commit, tag)
     if (ahead === undefined) break
     best = { tag, commitsAhead: ahead }

--- a/src/main/sources/standalone/updateOrchestrator.ts
+++ b/src/main/sources/standalone/updateOrchestrator.ts
@@ -2,8 +2,8 @@ import fs from 'fs'
 import path from 'path'
 import { spawn } from 'child_process'
 import { killProcTree } from '../../lib/process'
-import { resolveInstalledVersion, clearVersionCache } from '../../lib/version-resolve'
-import { readGitHead } from '../../lib/git'
+import { resolveInstalledVersion, clearVersionCache, type LatestTagOverride } from '../../lib/version-resolve'
+import { readGitHead, fetchTags, findLatestVersionTag, revParseRef } from '../../lib/git'
 import { PYTORCH_RE, installFilteredRequirements, getPipIndexArgs } from '../../lib/pip'
 import { formatComfyVersion } from '../../lib/version'
 import type { ComfyVersion } from '../../lib/version'
@@ -314,17 +314,30 @@ export async function runComfyUIUpdate(opts: UpdateOrchestrationOptions): Promis
     }
   }
 
-  // Re-resolve comfyVersion from git state
+  // Re-resolve comfyVersion from git state.
+  // Fetch tags so the local repo has all release tags for version resolution
+  // (the update script may only fetch master on the latest channel).
+  await fetchTags(comfyuiDir)
   clearVersionCache()
   const checkedOutTag = markers.CHECKED_OUT_TAG || undefined
   const fullPostHead = markers.POST_UPDATE_HEAD || readGitHead(comfyuiDir)
+
+  // Build a latestTagOverride so resolveInstalledVersion can use the
+  // tag's SHA directly — matches the background version sync approach.
+  let latestTagOverride: LatestTagOverride | undefined
+  const latestTag = await findLatestVersionTag(comfyuiDir)
+  if (latestTag) {
+    const sha = await revParseRef(comfyuiDir, latestTag)
+    if (sha) latestTagOverride = { name: latestTag, sha }
+  }
 
   let comfyVersion: ComfyVersion | undefined
   if (fullPostHead) {
     comfyVersion = await resolveInstalledVersion(
       comfyuiDir, fullPostHead,
       installation.comfyVersion as ComfyVersion | undefined,
-      checkedOutTag
+      checkedOutTag,
+      latestTagOverride
     )
   }
 


### PR DESCRIPTION
After updating on the **Latest on GitHub** channel, the displayed version regressed (e.g. `v0.19.5+33` to `v0.19.4+28`). Three issues combined to cause this:

### 1. Update script only fetched tags for stable channel
`update_comfyui.py` only included `+refs/tags/*:refs/tags/*` in the refspec when `--stable` was passed. Now always fetches tags.

### 2. Post-update resolution missing latestTagOverride
The post-update version resolution in `updateOrchestrator.ts` called `resolveInstalledVersion` without a `latestTagOverride` (tag name + SHA), unlike the background sync path. Now fetches tags and computes one matching the background sync approach.

### 3. Backport tag threshold too strict
`findBestBackportTag` assumed each release tag adds exactly one unique commit (the version bump). But release branches can carry additional cherry-picks with no master equivalent. For v0.19.5, there were 3 unique commits vs a threshold of 2, causing it to be rejected in favor of v0.19.4.

**Fix:** Replaced the fixed per-position threshold with the actual commit count from the ancestor tag to the candidate on the release branch.