### PR TITLE
fix: version display stuck on stale tag when new release appears

### DIFF
--- a/src/main/lib/ipc/shared.ts
+++ b/src/main/lib/ipc/shared.ts
@@ -9,7 +9,7 @@ import * as installations from '../../installations'
 import type { InstallationRecord } from '../../installations'
 import { formatComfyVersion } from '../version'
 import type { ComfyVersion } from '../version'
-import { resolveInstalledVersion, clearVersionCache } from '../version-resolve'
+import { resolveLocalVersion, clearVersionCache } from '../version-resolve'
 import type { LatestTagOverride } from '../version-resolve'
 import { readGitHead, readGitRemoteUrl, fetchTags, findLatestVersionTag, revParseRef, hasGitDir, isGitAvailable, tryConfigureBootstrapPygit2, tryConfigurePygit2Fallback } from '../git'
 import { ensureRemoteUrl } from '../github-mirror'
@@ -57,7 +57,7 @@ export {
   path, fs, os, app, ipcMain, dialog, shell, BrowserWindow, nativeTheme,
   execFile, spawn, execFileSync,
   sources, installations, settings, releaseCache, i18n,
-  formatComfyVersion, resolveInstalledVersion, clearVersionCache,
+  formatComfyVersion, resolveLocalVersion, clearVersionCache,
   readGitRemoteUrl, fetchTags, findLatestVersionTag, revParseRef, hasGitDir, isGitAvailable, tryConfigureBootstrapPygit2, tryConfigurePygit2Fallback,
   ensureRemoteUrl,
   defaultInstallDir, sanitizeDirName, allocateUniqueDir, download, createCache, extract, deleteDir, formatDeleteStatus, deleteAction, untrackAction,
@@ -468,7 +468,7 @@ export async function _resolveAndBroadcastVersions(list: InstallationRecord[]): 
       // made external changes (manual git pull, checkout, etc.).
       const actualHead = readGitHead(comfyuiDir) || cv.commit
 
-      const resolved = await resolveInstalledVersion(comfyuiDir, actualHead, cv, undefined, override)
+      const resolved = await resolveLocalVersion(comfyuiDir, actualHead, undefined, override)
       const resolvedStr = formatComfyVersion(resolved, 'short')
       const storedStr = formatComfyVersion(cv, 'short')
       const versionChanged = resolvedStr !== storedStr

--- a/src/main/lib/snapshots/diff.ts
+++ b/src/main/lib/snapshots/diff.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import { hasGitDir } from '../git'
-import { resolveInstalledVersion } from '../version-resolve'
+import { resolveLocalVersion } from '../version-resolve'
 import type { LatestTagOverride } from '../version-resolve'
 import { formatComfyVersion } from '../version'
 import type { ComfyVersion } from '../version'
@@ -46,7 +46,7 @@ export async function resolveSnapshotVersion(
     return formatComfyVersion(snapshotCv, style)
   }
   try {
-    const resolved = await resolveInstalledVersion(comfyuiDir, comfyui.commit, snapshotCv, undefined, options?.latestTagOverride)
+    const resolved = await resolveLocalVersion(comfyuiDir, comfyui.commit, undefined, options?.latestTagOverride)
     return formatComfyVersion(resolved, style)
   } catch {
     return formatComfyVersion(snapshotCv, style)

--- a/src/main/lib/version-resolve.test.ts
+++ b/src/main/lib/version-resolve.test.ts
@@ -11,7 +11,7 @@ vi.mock('./git', () => ({
 }))
 
 import { findNearestTag, findLatestVersionTag, countCommitsAhead, countUniqueCommits, isAncestorOf, findMergeBase } from './git'
-import { resolveLocalVersion, clearVersionCache, resolveInstalledVersion } from './version-resolve'
+import { resolveLocalVersion, clearVersionCache } from './version-resolve'
 
 const mockedFindNearestTag = vi.mocked(findNearestTag)
 const mockedFindLatestVersionTag = vi.mocked(findLatestVersionTag)
@@ -193,6 +193,37 @@ describe('resolveLocalVersion', () => {
     expect(result).toEqual({ commit: 'abc1234', baseTag: 'v0.16.4', commitsAhead: 38 })
   })
 
+  it('falls back to ancestor tag when merge-base equals commit (older commit, newer tag)', async () => {
+    // Scenario: commit is older than latestTag on the same branch.
+    // merge-base of (latestTag, commit) = commit itself.  Without the
+    // guard, countCommitsAhead(commit, commit) = 0, producing a wrong
+    // "v0.18.3+0".  With the guard, the merge-base path is skipped.
+    mockedFindNearestTag.mockImplementation(async (_repo, ref) => {
+      if (ref === 'abc1234') return 'v0.17.0'
+      if (ref === 'v0.18.3') return 'v0.18.3'
+      if (ref === 'v0.18.3~1') return 'v0.17.0'
+      return undefined
+    })
+    mockedFindLatestVersionTag.mockResolvedValue('v0.18.3')
+    mockedCountCommitsAhead.mockImplementation(async (_repo, base) => {
+      if (base === 'v0.17.0') return 12
+      return undefined
+    })
+    mockedIsAncestorOf.mockImplementation(async (_repo, ancestor, descendant) => {
+      if (ancestor === 'v0.17.0' && descendant === 'v0.18.3') return true
+      if (ancestor === 'v0.18.3' && descendant === 'abc1234') return false
+      return false
+    })
+    mockedCountUniqueCommits.mockImplementation(async (_repo, ref1) => {
+      if (ref1 === 'v0.18.3') return 50
+      return undefined
+    })
+    mockedFindMergeBase.mockResolvedValue('abc1234')
+
+    const result = await resolveLocalVersion('/repo', 'abc1234')
+    expect(result).toEqual({ commit: 'abc1234', baseTag: 'v0.17.0', commitsAhead: 12 })
+  })
+
   it('falls back to ancestor tag when merge-base fails (backport path)', async () => {
     // latestTag is NOT a direct ancestor of the commit (backport branch),
     // the backport walk returns nothing, and findMergeBase also fails
@@ -356,57 +387,4 @@ describe('resolveLocalVersion', () => {
     })
   })
 
-  describe('resolveInstalledVersion', () => {
-    it('returns stored version when commit matches and baseTag exists', async () => {
-      const stored = { commit: 'abc1234', baseTag: 'v0.17.2', commitsAhead: 12 }
-      const result = await resolveInstalledVersion('/repo', 'abc1234', stored)
-      expect(result).toBe(stored)
-      expect(mockedFindNearestTag).not.toHaveBeenCalled()
-    })
-
-    it('re-resolves when stored version has no baseTag', async () => {
-      mockedFindNearestTag.mockResolvedValue('v0.17.0')
-      mockedFindLatestVersionTag.mockResolvedValue('v0.17.0')
-      mockedCountCommitsAhead.mockResolvedValue(5)
-
-      const stored = { commit: 'abc1234' }
-      const result = await resolveInstalledVersion('/repo', 'abc1234', stored)
-      expect(result).toEqual({ commit: 'abc1234', baseTag: 'v0.17.0', commitsAhead: 5 })
-    })
-
-    it('re-resolves when commit changed', async () => {
-      mockedFindNearestTag.mockResolvedValue('v0.18.0')
-      mockedFindLatestVersionTag.mockResolvedValue('v0.18.0')
-      mockedCountCommitsAhead.mockResolvedValue(0)
-
-      const stored = { commit: 'old1234', baseTag: 'v0.17.2', commitsAhead: 12 }
-      const result = await resolveInstalledVersion('/repo', 'new5678', stored)
-      expect(result).toEqual({ commit: 'new5678', baseTag: 'v0.18.0', commitsAhead: 0 })
-    })
-
-    it('re-resolves when no stored version exists', async () => {
-      mockedFindNearestTag.mockResolvedValue('v0.17.0')
-      mockedFindLatestVersionTag.mockResolvedValue('v0.17.0')
-      mockedCountCommitsAhead.mockResolvedValue(0)
-
-      const result = await resolveInstalledVersion('/repo', 'abc1234', undefined)
-      expect(result).toEqual({ commit: 'abc1234', baseTag: 'v0.17.0', commitsAhead: 0 })
-    })
-
-    it('passes hint and latestTagOverride through to resolveLocalVersion', async () => {
-      mockedFindNearestTag.mockResolvedValue('v0.16.4')
-      mockedCountCommitsAhead.mockImplementation(async (_repo, tag) => {
-        if (tag === 'v0.16.4') return 38
-        if (tag === 'sha-of-v0.17.1') return 7
-        return undefined
-      })
-      mockedIsAncestorOf.mockResolvedValue(true)
-
-      const result = await resolveInstalledVersion('/repo', 'abc1234', undefined, 'v0.14.0', {
-        name: 'v0.17.1',
-        sha: 'sha-of-v0.17.1',
-      })
-      expect(result).toEqual({ commit: 'abc1234', baseTag: 'v0.17.1', commitsAhead: 7 })
-    })
-  })
 })

--- a/src/main/lib/version-resolve.ts
+++ b/src/main/lib/version-resolve.ts
@@ -96,9 +96,6 @@ async function findBestBackportTag(
 }
 
 /**
- * @internal Use {@link resolveInstalledVersion} instead — it guards against
- * re-resolving when stored metadata is already authoritative.
- *
  * Resolve a {@link ComfyVersion} from local git state.  Uses the nearest
  * ancestor tag as a base, upgrading to a newer version tag when possible.
  *
@@ -195,7 +192,9 @@ export async function resolveLocalVersion(
         // less precise (doesn't exclude cherry-picked commits from +N) but
         // still gives a reasonable display.
         const mergeBase = await findMergeBase(comfyuiDir, latestTagRef!, commit)
-        const dist = mergeBase ? await countCommitsAhead(comfyuiDir, mergeBase, commit) : undefined
+        const dist = mergeBase && mergeBase !== commit
+          ? await countCommitsAhead(comfyuiDir, mergeBase, commit)
+          : undefined
         if (dist !== undefined) {
           baseTag = latestTagName
           commitsAhead = dist
@@ -222,31 +221,6 @@ export async function resolveLocalVersion(
   return result
 }
 
-/**
- * Single write-gate for resolving the version to store on an installation.
- *
- * When the commit hasn't changed and the stored version already has a
- * baseTag, returns the stored version as-is — re-resolving against the
- * current git state can produce wrong results when newer tags exist
- * (e.g. a snapshot-restored v0.17.2+12 re-resolving to v0.18.3).
- *
- * Only re-resolves from git when:
- * - No stored version exists (fresh install)
- * - The commit has changed (update / restore that moved HEAD)
- * - The stored version lacks a baseTag (legacy migration)
- */
-export async function resolveInstalledVersion(
-  comfyuiDir: string,
-  commit: string,
-  storedVersion: ComfyVersion | undefined,
-  hint?: string,
-  latestTagOverride?: LatestTagOverride,
-): Promise<ComfyVersion> {
-  if (storedVersion?.baseTag && storedVersion.commit === commit) {
-    return storedVersion
-  }
-  return resolveLocalVersion(comfyuiDir, commit, hint, latestTagOverride)
-}
 
 /** Clear the version cache (e.g. after an update changes tags). */
 export function clearVersionCache(): void {

--- a/src/main/sources/standalone/actions.ts
+++ b/src/main/sources/standalone/actions.ts
@@ -4,7 +4,7 @@ import { fetchLatestRelease } from '../../lib/comfyui-releases'
 import * as releaseCache from '../../lib/release-cache'
 import { formatComfyVersion } from '../../lib/version'
 import type { ComfyVersion } from '../../lib/version'
-import { resolveInstalledVersion } from '../../lib/version-resolve'
+import { resolveLocalVersion } from '../../lib/version-resolve'
 import { readGitHead } from '../../lib/git'
 import { installFilteredRequirements } from '../../lib/pip'
 import { copyDirWithProgress } from '../../lib/copy'
@@ -128,14 +128,9 @@ export async function handleAction(
       installation.updateInfoByChannel as Record<string, Record<string, unknown>> | undefined,
       installation.comfyVersion as ComfyVersion | undefined
     )
-    // Reconcile comfyVersion through the single write-gate.
-    // resolveInstalledVersion keeps stored baseTag metadata when the commit
-    // matches, and re-resolves from git only for old snapshots that lack it.
+    // Re-resolve comfyVersion from git state after the snapshot restore.
     if (!comfyResult.error && restoredHead) {
-      const snapshotCv: ComfyVersion | undefined = targetSnapshot.comfyui.commit
-        ? { commit: targetSnapshot.comfyui.commit, baseTag: targetSnapshot.comfyui.baseTag, commitsAhead: targetSnapshot.comfyui.commitsAhead }
-        : undefined
-      const resolved = await resolveInstalledVersion(comfyuiDir, restoredHead, snapshotCv)
+      const resolved = await resolveLocalVersion(comfyuiDir, restoredHead)
       restoreState.comfyVersion = resolved
       const tag = formatComfyVersion(resolved, 'short')
       const channelInfo = restoreState.updateInfoByChannel as Record<string, Record<string, unknown>>

--- a/src/main/sources/standalone/install.ts
+++ b/src/main/sources/standalone/install.ts
@@ -4,7 +4,7 @@ import { execFile } from 'child_process'
 import { downloadAndExtract, downloadAndExtractMulti } from '../../lib/installer'
 import { copyDirWithProgress } from '../../lib/copy'
 import { readGitHead, isGitAvailable, isPygit2Configured, tryConfigurePygit2Fallback, fetchTags } from '../../lib/git'
-import { resolveInstalledVersion } from '../../lib/version-resolve'
+import { resolveLocalVersion } from '../../lib/version-resolve'
 import { formatTime } from '../../lib/util'
 import { t } from '../../lib/i18n'
 import * as snapshots from '../../lib/snapshots'
@@ -123,7 +123,7 @@ export async function postInstall(installation: InstallationRecord, { sendProgre
   const headCommit = readGitHead(comfyuiDir)
   if (headCommit) {
     const ref = installation.version as string | undefined
-    const comfyVersion = await resolveInstalledVersion(comfyuiDir, headCommit, undefined, ref)
+    const comfyVersion = await resolveLocalVersion(comfyuiDir, headCommit, ref)
     await update({ comfyVersion })
     // Use updated installation for snapshot so it captures the version
     installation = { ...installation, comfyVersion } as InstallationRecord
@@ -202,7 +202,7 @@ export async function probeInstallation(dirPath: string): Promise<Record<string,
     const commit = readGitHead(comfyuiDir)
     if (commit) {
       const manifestTag = version !== 'unknown' ? version : undefined
-      comfyVersion = await resolveInstalledVersion(comfyuiDir, commit, undefined, manifestTag)
+      comfyVersion = await resolveLocalVersion(comfyuiDir, commit, manifestTag)
     }
   }
 

--- a/src/main/sources/standalone/updateOrchestrator.ts
+++ b/src/main/sources/standalone/updateOrchestrator.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import { spawn } from 'child_process'
 import { killProcTree } from '../../lib/process'
-import { resolveInstalledVersion, clearVersionCache, type LatestTagOverride } from '../../lib/version-resolve'
+import { resolveLocalVersion, clearVersionCache, type LatestTagOverride } from '../../lib/version-resolve'
 import { readGitHead, fetchTags, findLatestVersionTag, revParseRef } from '../../lib/git'
 import { PYTORCH_RE, installFilteredRequirements, getPipIndexArgs } from '../../lib/pip'
 import { formatComfyVersion } from '../../lib/version'
@@ -322,7 +322,7 @@ export async function runComfyUIUpdate(opts: UpdateOrchestrationOptions): Promis
   const checkedOutTag = markers.CHECKED_OUT_TAG || undefined
   const fullPostHead = markers.POST_UPDATE_HEAD || readGitHead(comfyuiDir)
 
-  // Build a latestTagOverride so resolveInstalledVersion can use the
+  // Build a latestTagOverride so resolveLocalVersion can use the
   // tag's SHA directly — matches the background version sync approach.
   let latestTagOverride: LatestTagOverride | undefined
   const latestTag = await findLatestVersionTag(comfyuiDir)
@@ -333,11 +333,8 @@ export async function runComfyUIUpdate(opts: UpdateOrchestrationOptions): Promis
 
   let comfyVersion: ComfyVersion | undefined
   if (fullPostHead) {
-    comfyVersion = await resolveInstalledVersion(
-      comfyuiDir, fullPostHead,
-      installation.comfyVersion as ComfyVersion | undefined,
-      checkedOutTag,
-      latestTagOverride
+    comfyVersion = await resolveLocalVersion(
+      comfyuiDir, fullPostHead, checkedOutTag, latestTagOverride
     )
   }
 


### PR DESCRIPTION
## Problem

`resolveInstalledVersion` had a short-circuit guard (added in #374) that returned the stored version when `storedVersion.commit === commit && storedVersion.baseTag` was truthy. This guard predated the `latestTagOverride` parameter (added in #261) and never accounted for it.

When a new release tag appeared (e.g. `v1.19.5`) but HEAD stayed the same, the guard returned the stale stored version (`v1.19.4+38`) instead of re-resolving with the new tag override. This affected both:

- **Background version sync** (`_resolveAndBroadcastVersions`) — fetches fresh tags and builds a `latestTagOverride`, but the guard short-circuited before it could be used
- **Post-update resolution** — partially fixed in #437, but only for cases where HEAD changed

## Fix

Remove the guard and rely on `resolveLocalVersion`'s cache, which keys on `(repoPath, commit, latestTagOverride)`:
- **Deduplicates** when nothing has changed (same commit, same override = cache hit)
- **Re-resolves** when the tag context changes (new override = different cache key)

This eliminates the dual-layer deduplication that was prone to drift — the cache is the single source of truth for "should I re-resolve?"

### Merge-base edge case fix

Also fixes a pre-existing bug in the merge-base fallback path: when `mergeBase(latestTag, commit) === commit` (i.e. the commit is older than the latest tag on the same branch), `countCommitsAhead(commit, commit)` returns 0, mislabeling the version as `latestTag+0`. Added a guard to skip the merge-base path when merge-base equals the commit.

## Tests

- 631 unit tests pass (2 new)
- New: verifies stale baseTag is upgraded when `latestTagOverride` changes (the exact bug scenario)
- New: verifies older commit doesn't inherit newer tag via merge-base self-reference
