### PR TITLE
feat: show latest stable ComfyUI tag in New Install wizard via bootstrap pygit2

### DIFF
--- a/src/main/lib/comfyui-releases.test.ts
+++ b/src/main/lib/comfyui-releases.test.ts
@@ -18,14 +18,17 @@ vi.mock('../settings', () => ({
 }))
 
 import { lsRemoteLatestTag, lsRemoteRef } from './git'
-import { fetchLatestRelease } from './comfyui-releases'
+import { fetchLatestRelease, getLatestStableTag, _clearLatestStableTagCache } from './comfyui-releases'
 import * as settings from '../settings'
 
 const mockedLsRemoteLatestTag = vi.mocked(lsRemoteLatestTag)
 const mockedLsRemoteRef = vi.mocked(lsRemoteRef)
 const mockedSettingsGet = vi.mocked(settings.get)
 
-beforeEach(() => { vi.resetAllMocks() })
+beforeEach(() => {
+  vi.resetAllMocks()
+  _clearLatestStableTagCache()
+})
 
 describe('fetchLatestRelease', () => {
   describe('latest channel', () => {
@@ -100,6 +103,67 @@ describe('fetchLatestRelease', () => {
       mockedLsRemoteLatestTag.mockResolvedValue('v0.18.3')
       const result = await fetchLatestRelease('stable')
       expect(result!.published_at).toBeUndefined()
+    })
+  })
+
+  describe('getLatestStableTag cache', () => {
+    it('caches successful lookups within the TTL', async () => {
+      mockedLsRemoteLatestTag.mockResolvedValue('v1.19.5')
+      const a = await getLatestStableTag()
+      const b = await getLatestStableTag()
+      expect(a).toBe('v1.19.5')
+      expect(b).toBe('v1.19.5')
+      expect(mockedLsRemoteLatestTag).toHaveBeenCalledTimes(1)
+    })
+
+    it('refresh: true bypasses the cache', async () => {
+      mockedLsRemoteLatestTag.mockResolvedValueOnce('v1.19.5').mockResolvedValueOnce('v1.19.6')
+      const a = await getLatestStableTag()
+      const b = await getLatestStableTag({ refresh: true })
+      expect(a).toBe('v1.19.5')
+      expect(b).toBe('v1.19.6')
+      expect(mockedLsRemoteLatestTag).toHaveBeenCalledTimes(2)
+    })
+
+    it('returns null when the lookup fails and never throws', async () => {
+      mockedLsRemoteLatestTag.mockRejectedValue(new Error('boom'))
+      await expect(getLatestStableTag()).resolves.toBeNull()
+    })
+
+    it('returns null when no tags found', async () => {
+      mockedLsRemoteLatestTag.mockResolvedValue(undefined)
+      await expect(getLatestStableTag()).resolves.toBeNull()
+    })
+
+    it('keys cache by remote URL — flipping the mirror setting refetches', async () => {
+      mockedLsRemoteLatestTag.mockResolvedValueOnce('v1.19.5').mockResolvedValueOnce('v1.19.5-mirror')
+      mockedSettingsGet.mockReturnValue(undefined as never)
+      const a = await getLatestStableTag()
+      mockedSettingsGet.mockReturnValue(true as never)
+      const b = await getLatestStableTag()
+      expect(a).toBe('v1.19.5')
+      expect(b).toBe('v1.19.5-mirror')
+      expect(mockedLsRemoteLatestTag).toHaveBeenCalledTimes(2)
+    })
+
+    it('coalesces concurrent in-flight requests', async () => {
+      let resolve: (v: string) => void = () => {}
+      mockedLsRemoteLatestTag.mockReturnValue(new Promise((r) => { resolve = r as (v: string) => void }))
+      const p1 = getLatestStableTag()
+      const p2 = getLatestStableTag()
+      resolve('v1.19.5')
+      const [a, b] = await Promise.all([p1, p2])
+      expect(a).toBe('v1.19.5')
+      expect(b).toBe('v1.19.5')
+      expect(mockedLsRemoteLatestTag).toHaveBeenCalledTimes(1)
+    })
+
+    it('fetchLatestRelease("stable") shares the cache', async () => {
+      mockedLsRemoteLatestTag.mockResolvedValue('v1.19.5')
+      await getLatestStableTag()
+      const result = await fetchLatestRelease('stable')
+      expect(result!.tag_name).toBe('v1.19.5')
+      expect(mockedLsRemoteLatestTag).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/src/main/lib/comfyui-releases.ts
+++ b/src/main/lib/comfyui-releases.ts
@@ -9,10 +9,11 @@ const REPO = 'Comfy-Org/ComfyUI'
  * Avoids repeated `git ls-remote` calls when the renderer hits the
  * release dropdown, update checks, etc. in close succession.
  */
-const LATEST_TAG_TTL_MS = 10 * 60 * 1000
+const SUCCESS_TTL_MS = 10 * 60 * 1000
+const FAILURE_TTL_MS = 30_000
 interface CacheEntry {
   tag: string | null
-  fetchedAt: number
+  expiresAt: number
 }
 const _latestTagCache = new Map<string, CacheEntry>()
 let _inflight: Map<string, Promise<string | null>> = new Map()
@@ -26,10 +27,12 @@ function _getRemoteUrl(): string {
  * `git ls-remote --tags` (Git protocol) — no GitHub REST API calls,
  * works against both github.com and gitcode.com.
  *
- * Result is cached in-memory for {@link LATEST_TAG_TTL_MS}.  Concurrent
- * callers share a single in-flight request per remote URL.  Returns
- * `null` (never throws) on failure so callers can degrade gracefully
- * when offline or pygit2 is not configured.
+ * Successful results are cached in-memory for {@link SUCCESS_TTL_MS};
+ * failures use the much shorter {@link FAILURE_TTL_MS} so a flapping
+ * remote isn't pounded on but recovers quickly.  Concurrent callers
+ * share a single in-flight request per remote URL.  Returns `null`
+ * (never throws) on failure so callers can degrade gracefully when
+ * offline or pygit2 is not configured.
  *
  * Set `refresh: true` to bypass the cache.
  */
@@ -38,19 +41,17 @@ export async function getLatestStableTag(opts?: { refresh?: boolean }): Promise<
   const now = Date.now()
   if (!opts?.refresh) {
     const hit = _latestTagCache.get(url)
-    if (hit && now - hit.fetchedAt < LATEST_TAG_TTL_MS) return hit.tag
+    if (hit && now < hit.expiresAt) return hit.tag
   }
   const existing = _inflight.get(url)
   if (existing) return existing
   const promise = (async () => {
     try {
       const tag = (await lsRemoteLatestTag(url)) ?? null
-      _latestTagCache.set(url, { tag, fetchedAt: Date.now() })
+      _latestTagCache.set(url, { tag, expiresAt: Date.now() + SUCCESS_TTL_MS })
       return tag
     } catch {
-      // Cache the failure briefly so we don't hammer a flapping remote, but
-      // use a much shorter horizon than success.
-      _latestTagCache.set(url, { tag: null, fetchedAt: Date.now() - LATEST_TAG_TTL_MS + 30_000 })
+      _latestTagCache.set(url, { tag: null, expiresAt: Date.now() + FAILURE_TTL_MS })
       return null
     } finally {
       _inflight.delete(url)

--- a/src/main/lib/comfyui-releases.ts
+++ b/src/main/lib/comfyui-releases.ts
@@ -5,16 +5,65 @@ import * as settings from '../settings'
 const REPO = 'Comfy-Org/ComfyUI'
 
 /**
- * Find the latest semver tag via `git ls-remote --tags` (Git protocol).
- * No GitHub REST API calls — works against both github.com and gitcode.com.
+ * Short-lived cache for the latest stable tag, keyed by remote URL.
+ * Avoids repeated `git ls-remote` calls when the renderer hits the
+ * release dropdown, update checks, etc. in close succession.
  */
-async function fetchLatestTag(): Promise<string | null> {
-  const url = getComfyUIRemoteUrl(settings.get('useChineseMirrors') === true)
-  try {
-    return (await lsRemoteLatestTag(url)) ?? null
-  } catch {
-    return null
+const LATEST_TAG_TTL_MS = 10 * 60 * 1000
+interface CacheEntry {
+  tag: string | null
+  fetchedAt: number
+}
+const _latestTagCache = new Map<string, CacheEntry>()
+let _inflight: Map<string, Promise<string | null>> = new Map()
+
+function _getRemoteUrl(): string {
+  return getComfyUIRemoteUrl(settings.get('useChineseMirrors') === true)
+}
+
+/**
+ * Resolve the latest stable ComfyUI tag (e.g. `v1.19.5`) via
+ * `git ls-remote --tags` (Git protocol) — no GitHub REST API calls,
+ * works against both github.com and gitcode.com.
+ *
+ * Result is cached in-memory for {@link LATEST_TAG_TTL_MS}.  Concurrent
+ * callers share a single in-flight request per remote URL.  Returns
+ * `null` (never throws) on failure so callers can degrade gracefully
+ * when offline or pygit2 is not configured.
+ *
+ * Set `refresh: true` to bypass the cache.
+ */
+export async function getLatestStableTag(opts?: { refresh?: boolean }): Promise<string | null> {
+  const url = _getRemoteUrl()
+  const now = Date.now()
+  if (!opts?.refresh) {
+    const hit = _latestTagCache.get(url)
+    if (hit && now - hit.fetchedAt < LATEST_TAG_TTL_MS) return hit.tag
   }
+  const existing = _inflight.get(url)
+  if (existing) return existing
+  const promise = (async () => {
+    try {
+      const tag = (await lsRemoteLatestTag(url)) ?? null
+      _latestTagCache.set(url, { tag, fetchedAt: Date.now() })
+      return tag
+    } catch {
+      // Cache the failure briefly so we don't hammer a flapping remote, but
+      // use a much shorter horizon than success.
+      _latestTagCache.set(url, { tag: null, fetchedAt: Date.now() - LATEST_TAG_TTL_MS + 30_000 })
+      return null
+    } finally {
+      _inflight.delete(url)
+    }
+  })()
+  _inflight.set(url, promise)
+  return promise
+}
+
+/** Test-only: clear the in-memory cache. */
+export function _clearLatestStableTagCache(): void {
+  _latestTagCache.clear()
+  _inflight = new Map()
 }
 
 export async function fetchLatestRelease(
@@ -26,7 +75,7 @@ export async function fetchLatestRelease(
   if (channel === 'latest') {
     const [headSha, latestTag] = await Promise.all([
       lsRemoteRef(remoteUrl, 'refs/heads/master'),
-      fetchLatestTag(),
+      getLatestStableTag(),
     ])
     if (!headSha) return null
     return {
@@ -41,7 +90,7 @@ export async function fetchLatestRelease(
   }
 
   // Stable channel: build synthetic release from latest tag
-  const latestTag = await fetchLatestTag()
+  const latestTag = await getLatestStableTag()
   if (!latestTag) return null
   return {
     tag_name: latestTag,

--- a/src/main/lib/ipc/index.ts
+++ b/src/main/lib/ipc/index.ts
@@ -4,7 +4,7 @@ import {
   sourceMap,
   detectDesktopInstall,
   isGitAvailable, tryConfigureBootstrapPygit2, tryConfigurePygit2Fallback,
-  createCache, fetchJSON,
+  createCache, fetchJSON, getLatestStableTag,
   setCallbacks, _broadcastToRenderer,
   migrateDefaults, checkInstallationUpdates,
   isEffectivelyEmptyInstallDir,
@@ -124,6 +124,12 @@ export function register(callbacks: RegisterCallbacks = {}): void {
         console.log('[ipc] System git not found — configured pygit2 via bootstrap python')
       }
     } catch {}
+
+    // Pre-warm the latest stable tag cache.  Once bootstrap pygit2 (or system
+    // git) is configured we can resolve the upstream ComfyUI tag without any
+    // local clone — this makes the New Install wizard's "Latest Stable" entry
+    // display the concrete version (e.g. v1.19.5) on first open.
+    try { await getLatestStableTag() } catch {}
   })()
 
   // Clean up partial downloads

--- a/src/main/lib/ipc/shared.ts
+++ b/src/main/lib/ipc/shared.ts
@@ -40,7 +40,7 @@ import * as i18n from '../i18n'
 import { syncCustomModelFolders, discoverExtraModelFolders } from '../models'
 import { copyDirWithProgress } from '../copy'
 import { fetchJSON } from '../fetch'
-import { fetchLatestRelease } from '../comfyui-releases'
+import { fetchLatestRelease, getLatestStableTag } from '../comfyui-releases'
 import { captureSnapshotIfChanged, getSnapshotCount, getSnapshotListData, getSnapshotDetailData, getSnapshotDiffVsPrevious, diffAgainstCurrent, loadSnapshot, listSnapshots, deleteSnapshot, diffSnapshots, buildExportEnvelope, validateExportEnvelope, importSnapshots, saveSnapshot, statesMatch, restoreCustomNodes, restorePipPackages, restoreComfyUIVersion, buildPostRestoreState, formatSnapshotVersion, resolveSnapshotVersion } from '../snapshots'
 import type { SnapshotExportEnvelope, Snapshot } from '../snapshots'
 import { getVariantLabel } from '../../sources/standalone'
@@ -71,7 +71,7 @@ export {
   getDiskSpace, getDirectorySize, validateInstallPath,
   syncOemSeed, formatTime, getActiveDownloads,
   syncCustomModelFolders, discoverExtraModelFolders,
-  copyDirWithProgress, fetchJSON, fetchLatestRelease,
+  copyDirWithProgress, fetchJSON, fetchLatestRelease, getLatestStableTag,
   captureSnapshotIfChanged, getSnapshotCount, getSnapshotListData, getSnapshotDetailData,
   getSnapshotDiffVsPrevious, diffAgainstCurrent, loadSnapshot, listSnapshots, diffSnapshots,
   buildExportEnvelope, validateExportEnvelope, importSnapshots, saveSnapshot, statesMatch, deleteSnapshot,

--- a/src/main/sources/standalone/index.test.ts
+++ b/src/main/sources/standalone/index.test.ts
@@ -9,12 +9,18 @@ vi.mock('../../lib/fetch', () => ({
   fetchJSON: vi.fn(),
 }))
 
+vi.mock('../../lib/comfyui-releases', () => ({
+  getLatestStableTag: vi.fn(),
+}))
+
 import { standalone } from './index'
 import { fetchJSON } from '../../lib/fetch'
+import { getLatestStableTag } from '../../lib/comfyui-releases'
 import { PLATFORM_PREFIX } from './envPaths'
 import type { FieldOption } from '../../types/sources'
 
 const mockedFetchJSON = vi.mocked(fetchJSON)
+const mockedGetLatestStableTag = vi.mocked(getLatestStableTag)
 
 // Use the running platform's vendor prefix so tests work on win32/darwin/linux CI runners.
 const VENDOR_ID = `${PLATFORM_PREFIX[process.platform] || 'win-'}nvidia`
@@ -152,5 +158,21 @@ describe('standalone.getFieldOptions release', () => {
     const latestEntry = options.find((o) => o.value === 'latest')!
     const underlyingData = latestEntry.data as Record<string, unknown>
     expect(underlyingData.tag).toBe('v0.18.3-env1')
+  })
+
+  it('"Latest Stable" entry shows the upstream ComfyUI tag in description when resolved', async () => {
+    setupMockReleases()
+    mockedGetLatestStableTag.mockResolvedValue('v1.19.5')
+    const options = await standalone.getFieldOptions!('release', {}, { includeLatestStable: true })
+    const latestEntry = options.find((o) => o.value === 'latest')!
+    expect(latestEntry.description).toBe('v1.19.5')
+  })
+
+  it('"Latest Stable" entry omits description when the tag lookup fails', async () => {
+    setupMockReleases()
+    mockedGetLatestStableTag.mockResolvedValue(null)
+    const options = await standalone.getFieldOptions!('release', {}, { includeLatestStable: true })
+    const latestEntry = options.find((o) => o.value === 'latest')!
+    expect(latestEntry.description).toBeUndefined()
   })
 })

--- a/src/main/sources/standalone/index.ts
+++ b/src/main/sources/standalone/index.ts
@@ -4,6 +4,7 @@ import { fetchJSON } from '../../lib/fetch'
 import { parseArgs, extractPort } from '../../lib/util'
 import { t } from '../../lib/i18n'
 import { launchAction } from '../../lib/actions'
+import { getLatestStableTag } from '../../lib/comfyui-releases'
 import {
   PLATFORM_PREFIX, DEFAULT_LAUNCH_ARGS,
   getVariantLabel, stripPlatform, getActivePythonPath,
@@ -203,11 +204,16 @@ export const standalone: SourcePlugin = {
 
       const options: FieldOption[] = []
 
-      // Synthetic "Latest Stable" entry
+      // Synthetic "Latest Stable" entry.  Resolve the upstream ComfyUI tag
+      // (e.g. `v1.19.5`) via bootstrap pygit2 so users can see the concrete
+      // version they'll be installing.  Falls back to no description when
+      // the lookup fails (offline, pygit2 unavailable, etc.).
       if (tags.length > 0 && context?.includeLatestStable) {
+        const latestStableTag = await getLatestStableTag()
         options.push({
           value: 'latest',
           label: t('standalone.latestVersion'),
+          ...(latestStableTag ? { description: latestStableTag } : {}),
           recommended: true,
           data: { tag: tags[0]!.tag, vendorReleases } as unknown as Record<string, unknown>,
         })


### PR DESCRIPTION
## Summary

Closes #445.

PR #436 made `pygit2` available from the very first app launch via the
bundled bootstrap python.  This PR takes advantage of that to resolve
and surface the upstream ComfyUI tag (e.g. `v1.19.5`) next to the
synthetic **Latest Stable (Recommended)** option in the standalone
release dropdown — no local clone required.

## Changes

- **New `getLatestStableTag()` helper** in `src/main/lib/comfyui-releases.ts`:
  - 10-minute in-memory TTL cache, keyed by the resolved remote URL so
    flipping the Chinese-mirror setting transparently refetches.
  - Concurrent callers share a single in-flight `git ls-remote` request.
  - Returns `null` (never throws) on failure so the wizard degrades
    gracefully when offline / pygit2 isn't configured.
  - `refresh: true` bypasses the cache.
- **`fetchLatestRelease()` now reuses the cached value**, cutting
  redundant `git ls-remote` calls during periodic update checks.
- **Pre-warmed on app startup** once pygit2 / system git is configured
  (`src/main/lib/ipc/index.ts`).  This means by the time the user opens
  the New Install wizard, the tag is already resolved.
- **Standalone source** (`src/main/sources/standalone/index.ts`)
  attaches the resolved tag as `description` on the synthetic Latest
  Stable option.  The existing renderer template
  `${label}  —  ${description}` produces e.g.
  `Latest Stable  —  v1.19.5 (Recommended)` with no Vue change.

## Tests

`src/main/lib/comfyui-releases.test.ts` — added cases for:

- cache hit within TTL
- `refresh: true` bypass
- network failure → `null` (no throw)
- mirror-setting flip → key invalidation / refetch
- concurrent in-flight coalescing (single underlying request)
- `fetchLatestRelease('stable')` shares the cache

`src/main/sources/standalone/index.test.ts` — added cases for:

- Latest Stable entry shows `description` = resolved tag when present
- `description` is omitted when `getLatestStableTag()` returns `null`

## Verification

```
pnpm run typecheck   ✓
pnpm run lint        ✓
pnpm run build       ✓
pnpm run test        ✓ 640/640
```

## Related

- #436 — bootstrap python support (the enabling change)
- #442 — version resolution fixes
- #445 — feature request being closed
