### PR TITLE
telemetry: add PostHog alongside Datadog and fill legacy parity gaps

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -4,14 +4,20 @@ ComfyUI Desktop 2 emits telemetry through **two providers** that share a
 single event bus:
 
 - **Datadog RUM** (renderer-only) — reliability, errors, performance,
-  long tasks, user-interaction tracking, and (optional) session replay.
+  long tasks, and user-interaction tracking.
 - **PostHog** — the canonical product-analytics sink. Runs in **two
   SDKs**:
   - `posthog-node` in the **main process** — captures things the
     renderer cannot see (app start/quit, install/migrate sub-steps,
     ComfyUI execution events parsed from stdout/stderr).
   - `posthog-js` in the **renderer** — UI-originated events, user
-    identify + person profile, feature flags, optional session replay.
+    identify + person profile, feature flags.
+
+Session replay is intentionally **not** captured by either provider.
+The PostHog recorder is blocked at the CSP layer and PostHog JS is
+configured with `disable_session_recording: true`. Datadog RUM omits
+`sessionReplaySampleRate` so it defaults to off. Reintroducing replay
+on either side requires a deliberate code change in a release.
 
 Both providers receive **the same event name and the same context**
 for almost every event. The split below is therefore not _which events_
@@ -52,14 +58,14 @@ Main-process events go through `mainTelemetry.emit()`
 
 | Concern | Datadog RUM (renderer) | PostHog Node (main) | PostHog JS (renderer) |
 |---|---|---|---|
-| **Purpose** | Reliability, errors, performance, session replay | Lifecycle / install / migrate / execution events outside the renderer | UI funnel + identify + feature flags |
+| **Purpose** | Reliability, errors, performance | Lifecycle / install / migrate / execution events outside the renderer | UI funnel + identify + feature flags |
 | **App lifecycle (`session.started` / `session.ended`)** | mirrors `session.started` via bridge | **owns** both events | mirrors `session.started` |
 | **Install / migrate pipeline (`*.start` / `.end` / `.error`)** | mirrors via bridge | **owns** (via `trackedStep`) | mirrors via bridge |
 | **ComfyUI execution (`got prompt`, `Prompt executed in …`, tracebacks)** | mirrors via bridge | **owns** (via `executionTap`) | mirrors via bridge |
 | **UI clicks / view-opened / install method+variant** | **owns** (originated in Vue) | mirrors via bridge | **owns** (originated in Vue) |
 | **JS errors / unhandled rejection** | **owns** (`datadogRum.addError`) | — | mirrors as exception (`captureException`) unless `skipPostHog` |
 | **Main-process errors** | mirrored to renderer → `addError` (with `skipPostHog: true`) | **owns** (`captureException`) | suppressed (`skipPostHog`) to avoid double counting |
-| **Session replay** | configurable (`VITE_DATADOG_RUM_SESSION_REPLAY_SAMPLE_RATE`, default 0%) | — | hard-disabled (no recorder script, no CSP allowance) |
+| **Session replay** | not configured (field omitted, SDK default is off) | — | hard-disabled (no recorder script, no CSP allowance) |
 | **Long tasks / resource timing / user interactions** | **owns** (`trackResources`, `trackLongTasks`, `trackUserInteractions: true`) | — | — |
 | **Feature flags / kill switches** | — | **owns** (bootstraps + on-disk cache `telemetry-flags.json`) | — (no renderer-side flag consumers) |
 | **Distinct id** | `datadogRum.setUser({ id })` | `client.identify({ distinctId })` | `posthog.identify(id, profileProps)` (sets person-profile props) |
@@ -203,7 +209,6 @@ Defaults in `src/renderer/src/main.ts`:
 | `env` | `prod-v2` |
 | `site` | `us5.datadoghq.com` |
 | `sessionSampleRate` | `100` |
-| `sessionReplaySampleRate` | `0` |
 
 Overridable via `VITE_DATADOG_RUM_*` environment variables at build
 time. `VITE_DATADOG_RUM_ENABLED=0|false|off` disables Datadog.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -77,7 +77,7 @@ Main-process events go through `mainTelemetry.emit()`
 
 | Event | Properties | Notes |
 |---|---|---|
-| `desktop2.session.started` | `app_env`, `app_version`, `is_packaged`, `telemetry_effective_enabled` | Deferred until first PostHog feature-flag refresh settles, so a remote `desktop2.disabled_events` block list takes effect on the very first event. |
+| `desktop2.session.started` | `app_env`, `app_version`, `is_packaged`, `telemetry_effective_enabled` | Stashed at `initTelemetry()` and emitted once `identify()` binds the persistent device id, since `distinctId` isn't known yet at init. |
 | `desktop2.session.system_info` | `platform`, `arch`, `os_distro`, `os_release`, `gpu_vendor`, `gpu_model`, `total_memory_gb`, `cpu_cores`, `electron_version`, `app_version` | Also promoted to PostHog person-profile properties via `identify` so they're queryable without joining against per-session events. |
 | `desktop2.session.installation_started` | full installation context + `boot_time_ms` | Fires when an installation actually starts the ComfyUI process. |
 | `desktop2.session.snapshot_history` | `installation_id`, `snapshot_diffs[]` | Sent to **both** providers but bypasses the typed bridge because of the array-of-objects payload. PostHog is the primary consumer. |
@@ -117,18 +117,15 @@ tracebacks. All events share `installation_id`, `variant`, `release`.
 | `desktop2.execution.error` | `error_class`, `error_message` (scrubbed), `error_bucket`, `error_count`, `node_id?` |
 | `desktop2.execution.session_summary` | `started_count`, `completed_count`, `error_count` (on flush) |
 
-Gated by the `desktop2.execution_telemetry.enabled` flag and sampled by
-`desktop2.execution_telemetry.sample_rate`. Sample decisions are pushed
-into a FIFO queue on each `got prompt` and shifted off on each terminal
-event so a sampled-out prompt is dropped consistently across all of
-`started` / `completed` / `error`.
+Execution telemetry is unconditional — there is no remote kill switch
+or sample-rate dial (see _Remote feature flags_ below).
 
 ### ComfyUI process (main → renderer IPC → both)
 
 | Event | Properties |
 |---|---|
 | `desktop2.comfyui.exited` | `installation_id`, `crashed`, `exit_code`, `last_stderr` |
-| `desktop2.comfyui.boot_log` | `installation_id`, `boot_stderr` (capped by `desktop2.boot_log_max_chars`, default 8 KiB) |
+| `desktop2.comfyui.boot_log` | `installation_id`, `boot_stderr` (capped to the last 50 lines of stderr by `lastNLines` in `sessionActions/launch.ts`) |
 
 ### UI / funnel (renderer `emitTelemetryAction`, both providers)
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -59,9 +59,9 @@ Main-process events go through `mainTelemetry.emit()`
 | **UI clicks / view-opened / install method+variant** | **owns** (originated in Vue) | mirrors via bridge | **owns** (originated in Vue) |
 | **JS errors / unhandled rejection** | **owns** (`datadogRum.addError`) | — | mirrors as exception (`captureException`) unless `skipPostHog` |
 | **Main-process errors** | mirrored to renderer → `addError` (with `skipPostHog: true`) | **owns** (`captureException`) | suppressed (`skipPostHog`) to avoid double counting |
-| **Session replay** | configurable (`VITE_DATADOG_RUM_SESSION_REPLAY_SAMPLE_RATE`, default 0%) | — | gated by `desktop2.session_replay.enabled` flag |
+| **Session replay** | configurable (`VITE_DATADOG_RUM_SESSION_REPLAY_SAMPLE_RATE`, default 0%) | — | hard-disabled (no recorder script, no CSP allowance) |
 | **Long tasks / resource timing / user interactions** | **owns** (`trackResources`, `trackLongTasks`, `trackUserInteractions: true`) | — | — |
-| **Feature flags / kill switches** | — | **owns** (bootstraps + on-disk cache `telemetry-flags.json`) | reads via `isFeatureEnabled` |
+| **Feature flags / kill switches** | — | **owns** (bootstraps + on-disk cache `telemetry-flags.json`) | — (no renderer-side flag consumers) |
 | **Distinct id** | `datadogRum.setUser({ id })` | `client.identify({ distinctId })` | `posthog.identify(id, profileProps)` (sets person-profile props) |
 | **Path normalisation on errors** | yes (`normalizeRumErrorEvent`) | PII + secret scrub via `scrubAll()` | `scrubAll()` already applied upstream |
 
@@ -218,7 +218,6 @@ disk in `<configDir>/telemetry-flags.json` for offline use:
 | `desktop2.execution_telemetry.enabled` | `true` | Master kill switch for `desktop2.execution.*` events. |
 | `desktop2.execution_telemetry.sample_rate` | `1` | 0..1 sampling applied per prompt (FIFO-paired across start/done/error). |
 | `desktop2.disabled_events` | `""` | Comma-separated event-name deny list applied at the SDK boundary. |
-| `desktop2.session_replay.enabled` | `false` | Lazy-enables `posthog.startSessionRecording()`. |
 | `desktop2.boot_log_max_chars` | `8192` | Cap on `desktop2.comfyui.boot_log.boot_stderr` length. |
 
 ## PII and secret scrubbing

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,276 @@
+# Telemetry
+
+ComfyUI Desktop 2 emits telemetry through **two providers** that share a
+single event bus:
+
+- **Datadog RUM** (renderer-only) — reliability, errors, performance,
+  long tasks, user-interaction tracking, and (optional) session replay.
+- **PostHog** — the canonical product-analytics sink. Runs in **two
+  SDKs**:
+  - `posthog-node` in the **main process** — captures things the
+    renderer cannot see (app start/quit, install/migrate sub-steps,
+    ComfyUI execution events parsed from stdout/stderr).
+  - `posthog-js` in the **renderer** — UI-originated events, user
+    identify + person profile, feature flags, optional session replay.
+
+Both providers receive **the same event name and the same context**
+for almost every event. The split below is therefore not _which events_
+they see but _which provider owns originating them_ and what extra
+behaviour each provides.
+
+## Event flow
+
+```diagram
+╭───────────────╮     ╭────────────────────╮     ╭──────────────────╮
+│ Vue/composab. │────▶│ emitTelemetry-     │────▶│  trackTelemetry- │
+│ (renderer)    │     │ Action(name, ctx)  │     │  Action(name,ctx)│
+╰───────────────╯     ╰────────────────────╯     │  ┌──────────────┐│
+                                                 │  │ Datadog RUM  ││
+╭───────────────╮     ╭────────────────────╮     │  │ addAction()  ││
+│ Main process  │────▶│ telemetry.emit()   │────▶│  └──────────────┘│
+│ (executionTap,│     │ = capture (PH-Node)│     │  ┌──────────────┐│
+│  trackedStep, │     │ + forwardToRender. │     │  │ PostHog JS   ││
+│  registerApp) │     ╰────────────────────╯     │  │ capture()    ││
+╰───────────────╯                                │  └──────────────┘│
+                                                 ╰──────────────────╯
+```
+
+The renderer's `trackTelemetryAction()`
+([src/renderer/src/main.ts](../src/renderer/src/main.ts)) is the single
+fan-out point. Every event that reaches it is dispatched to **both**
+Datadog (`datadogRum.addAction`) and PostHog
+(`capturePostHog`/`posthog.capture`).
+
+Main-process events go through `mainTelemetry.emit()`
+([src/main/lib/telemetry.ts](../src/main/lib/telemetry.ts)) which:
+
+1. `capture()`s the event into the PostHog Node client immediately, and
+2. `forwardToRenderer()`s it via `telemetry-action-from-main` IPC so the
+   renderer can mirror it into Datadog (and PostHog JS) too.
+
+## Provider responsibilities
+
+| Concern | Datadog RUM (renderer) | PostHog Node (main) | PostHog JS (renderer) |
+|---|---|---|---|
+| **Purpose** | Reliability, errors, performance, session replay | Lifecycle / install / migrate / execution events outside the renderer | UI funnel + identify + feature flags |
+| **App lifecycle (`session.started` / `session.ended`)** | mirrors `session.started` via bridge | **owns** both events | mirrors `session.started` |
+| **Install / migrate pipeline (`*.start` / `.end` / `.error`)** | mirrors via bridge | **owns** (via `trackedStep`) | mirrors via bridge |
+| **ComfyUI execution (`got prompt`, `Prompt executed in …`, tracebacks)** | mirrors via bridge | **owns** (via `executionTap`) | mirrors via bridge |
+| **UI clicks / view-opened / install method+variant** | **owns** (originated in Vue) | mirrors via bridge | **owns** (originated in Vue) |
+| **JS errors / unhandled rejection** | **owns** (`datadogRum.addError`) | — | mirrors as exception (`captureException`) unless `skipPostHog` |
+| **Main-process errors** | mirrored to renderer → `addError` (with `skipPostHog: true`) | **owns** (`captureException`) | suppressed (`skipPostHog`) to avoid double counting |
+| **Session replay** | configurable (`VITE_DATADOG_RUM_SESSION_REPLAY_SAMPLE_RATE`, default 0%) | — | gated by `desktop2.session_replay.enabled` flag |
+| **Long tasks / resource timing / user interactions** | **owns** (`trackResources`, `trackLongTasks`, `trackUserInteractions: true`) | — | — |
+| **Feature flags / kill switches** | — | **owns** (bootstraps + on-disk cache `telemetry-flags.json`) | reads via `isFeatureEnabled` |
+| **Distinct id** | `datadogRum.setUser({ id })` | `client.identify({ distinctId })` | `posthog.identify(id, profileProps)` (sets person-profile props) |
+| **Path normalisation on errors** | yes (`normalizeRumErrorEvent`) | PII + secret scrub via `scrubAll()` | `scrubAll()` already applied upstream |
+
+## Event catalogue
+
+### Lifecycle (main-process owned, fans out to both)
+
+| Event | Properties | Notes |
+|---|---|---|
+| `desktop2.session.started` | `app_env`, `app_version`, `is_packaged`, `telemetry_effective_enabled` | Deferred until first PostHog feature-flag refresh settles, so a remote `desktop2.disabled_events` block list takes effect on the very first event. |
+| `desktop2.session.system_info` | `platform`, `arch`, `os_distro`, `os_release`, `gpu_vendor`, `gpu_model`, `total_memory_gb`, `cpu_cores`, `electron_version`, `app_version` | Also promoted to PostHog person-profile properties via `identify` so they're queryable without joining against per-session events. |
+| `desktop2.session.installation_started` | full installation context + `boot_time_ms` | Fires when an installation actually starts the ComfyUI process. |
+| `desktop2.session.snapshot_history` | `installation_id`, `snapshot_diffs[]` | Sent to **both** providers but bypasses the typed bridge because of the array-of-objects payload. PostHog is the primary consumer. |
+| `desktop2.session.ended` | `reason`, `uptime_ms`, `uptime_seconds` | PostHog-only — emitted from `shutdown()` during the `before-quit` drain. Datadog's session ends naturally when the renderer unloads. |
+
+### Install / migrate (main-process `trackedStep`)
+
+Each `trackedStep('<step>', ctx, fn)` emits **three** events:
+`<step>.start`, `<step>.end` (with `duration_ms`), and on failure
+`<step>.error` (with `duration_ms`, `error_bucket`, `error_message`).
+
+| Step | Where |
+|---|---|
+| `desktop2.install.validation` | `src/main/lib/ipc/registerAppHandlers.ts` (one-shot, ad-hoc `mainTelemetry.emit`) |
+| `desktop2.install.standalone` | `src/main/lib/standaloneMigration.ts` |
+| `desktop2.install.post_install` | `src/main/lib/standaloneMigration.ts` |
+| `desktop2.snapshot.restore_comfyui_version` | `src/main/lib/standaloneMigration.ts` |
+| `desktop2.snapshot.restore_custom_nodes` | `src/main/lib/standaloneMigration.ts` |
+| `desktop2.snapshot.restore_pip_packages` | `src/main/lib/standaloneMigration.ts` |
+| `desktop2.migrate.flow` | `src/main/lib/ipc/sessionActions/migrate.ts` |
+| `desktop2.migrate.user_files` | `src/main/lib/standaloneMigration.ts` |
+| `desktop2.migrate.input` | `src/main/lib/standaloneMigration.ts` |
+| `desktop2.migrate.output` | `src/main/lib/standaloneMigration.ts` |
+| `desktop2.migrate.models` | `src/main/lib/standaloneMigration.ts` |
+
+### ComfyUI execution (main-process `executionTap`)
+
+Parses ComfyUI's stdout/stderr looking for `got prompt`,
+`Prompt executed in N seconds`, validation failures, and Python
+tracebacks. All events share `installation_id`, `variant`, `release`.
+
+| Event | Extra properties |
+|---|---|
+| `desktop2.execution.started` | `started_count` |
+| `desktop2.execution.completed` | `duration_seconds`, `wall_clock_ms`, `completed_count` |
+| `desktop2.execution.first_completed` | `first_run_at` (one-shot per session) |
+| `desktop2.execution.error` | `error_class`, `error_message` (scrubbed), `error_bucket`, `error_count`, `node_id?` |
+| `desktop2.execution.session_summary` | `started_count`, `completed_count`, `error_count` (on flush) |
+
+Gated by the `desktop2.execution_telemetry.enabled` flag and sampled by
+`desktop2.execution_telemetry.sample_rate`. Sample decisions are pushed
+into a FIFO queue on each `got prompt` and shifted off on each terminal
+event so a sampled-out prompt is dropped consistently across all of
+`started` / `completed` / `error`.
+
+### ComfyUI process (main → renderer IPC → both)
+
+| Event | Properties |
+|---|---|
+| `desktop2.comfyui.exited` | `installation_id`, `crashed`, `exit_code`, `last_stderr` |
+| `desktop2.comfyui.boot_log` | `installation_id`, `boot_stderr` (capped by `desktop2.boot_log_max_chars`, default 8 KiB) |
+
+### UI / funnel (renderer `emitTelemetryAction`, both providers)
+
+| Event | Source |
+|---|---|
+| `desktop2.view.opened` | `src/renderer/src/App.vue` |
+| `desktop2.feedback.opened` | `src/renderer/src/App.vue` |
+| `desktop2.install.flow.opened` | `src/renderer/src/App.vue` (4 entry points) |
+| `desktop2.install.method.selected` | `views/NewInstallModal.vue`, `views/QuickInstallModal.vue` |
+| `desktop2.install.variant.selected` | `views/NewInstallModal.vue`, `views/LoadSnapshotModal.vue`, `views/QuickInstallModal.vue` |
+| `desktop2.install.guardrail.blocked` | `lib/installHelpers.ts` |
+| `desktop2.install.disk_warning.response` | `lib/installHelpers.ts` |
+| `desktop2.snapshot.flow` | `components/SnapshotTab.vue` (7 sub-states) |
+| `desktop2.update.cta` | `components/UpdateBanner.vue` |
+| `desktop2.action.invoked` / `desktop2.action.result` | `composables/useListAction.ts`, `views/DetailModal.vue` |
+| `desktop2.settings.changed` | `components/SettingField.vue` |
+| `desktop2.track_existing.saved` | `views/TrackModal.vue` |
+| `desktop2.model_download.result` | `stores/downloadStore.ts` |
+
+### Errors
+
+- `window.error` and `window.unhandledrejection` → Datadog `addError` +
+  PostHog `captureException` in the renderer.
+- Main-process errors are forwarded to the renderer with
+  `skipPostHog: true`. PostHog Node owns the capture in the main
+  process; Datadog gets the renderer-only mirror. This avoids double
+  counting exceptions.
+
+## Consent
+
+A single user-facing toggle, `telemetryEnabled`, controls every
+provider:
+
+- `window.api.onTelemetrySettingChanged` flips
+  `datadogRum.setTrackingConsent('granted'|'not-granted')` and PostHog
+  JS `opt_in_capturing()` / `opt_out_capturing()` simultaneously.
+- The same setting is observed in the main process via
+  `mainTelemetry.setConsent()`, which short-circuits `capture()` and
+  `forwardToRenderer()` so already-suppressed events never even reach
+  the IPC bridge.
+
+PostHog **surveys** are bound to consent too, since PostHog's surveys
+module ignores `opt_out_capturing()` outside cookieless mode. We mirror
+consent into `disable_surveys` at init and on every consent change
+(via `posthog.set_config({ disable_surveys: !enabled })`), and call
+`posthog.surveys.loadIfEnabled()` when consent is regained so dashboard
+surveys can appear without a relaunch. **Net effect:** surveys remain
+remotely toggleable via the PostHog dashboard, but only ever appear for
+users who have opted in to telemetry.
+
+Re-evaluating consent flushes the PostHog Node queue best-effort
+(`client.flush()`) so events queued while consent was true still go
+out.
+
+## Configuration
+
+### PostHog
+
+Defaults live in `src/shared/posthogConfig.ts` and are baked into the
+build. Overrides:
+
+| Process | Variable |
+|---|---|
+| Renderer | `VITE_POSTHOG_API_KEY`, `VITE_POSTHOG_HOST`, `VITE_POSTHOG_ENABLED` |
+| Main | `POSTHOG_API_KEY`, `POSTHOG_HOST`, `POSTHOG_ENABLED` |
+
+`POSTHOG_ENABLED=0|false|off` disables PostHog in that process.
+
+### Datadog
+
+Defaults in `src/renderer/src/main.ts`:
+
+| Field | Default |
+|---|---|
+| `applicationId` | `74a97924-20d7-4890-8e55-0c2b87193373` |
+| `clientToken` | `pub5b0afc7fe0411fcebad80bb87274d711` |
+| `service` | `comfyui-desktop-2` |
+| `env` | `prod-v2` |
+| `site` | `us5.datadoghq.com` |
+| `sessionSampleRate` | `100` |
+| `sessionReplaySampleRate` | `0` |
+
+Overridable via `VITE_DATADOG_RUM_*` environment variables at build
+time. `VITE_DATADOG_RUM_ENABLED=0|false|off` disables Datadog.
+
+### Remote feature flags
+
+Fetched from PostHog at startup (with a 1.5 s budget) and cached on
+disk in `<configDir>/telemetry-flags.json` for offline use:
+
+| Flag | Default | Effect |
+|---|---|---|
+| `desktop2.execution_telemetry.enabled` | `true` | Master kill switch for `desktop2.execution.*` events. |
+| `desktop2.execution_telemetry.sample_rate` | `1` | 0..1 sampling applied per prompt (FIFO-paired across start/done/error). |
+| `desktop2.disabled_events` | `""` | Comma-separated event-name deny list applied at the SDK boundary. |
+| `desktop2.session_replay.enabled` | `false` | Lazy-enables `posthog.startSessionRecording()`. |
+| `desktop2.boot_log_max_chars` | `8192` | Cap on `desktop2.comfyui.boot_log.boot_stderr` length. |
+
+## PII and secret scrubbing
+
+`scrubAll()` in `src/main/lib/piiScrub.ts` is the single source of
+truth. It is applied to:
+
+- `forwardDatadogError` payloads (main-process error forwarder).
+- Every `executionTap` traceback message.
+- Any text routed through `scrubStderr()` (which delegates to
+  `scrubAll`).
+
+Patterns redacted:
+
+| Kind | Pattern | Replacement |
+|---|---|---|
+| Windows home path | `C:\Users\<x>` | `C:\Users\[REDACTED]` |
+| macOS home path | `/Users/<x>` | `/Users/[REDACTED]` |
+| Linux home path | `/home/<x>` | `/home/[REDACTED]` |
+| OpenAI key | `sk-…` (≥20 chars) | `[REDACTED]` |
+| Hugging Face token | `hf_…` (≥20 chars) | `[REDACTED]` |
+| Bearer token | `Bearer <token>` (≥20 chars) | `Bearer [REDACTED]` |
+| URL basic-auth | `//user:pass@` | `//[REDACTED]@` |
+| Env-style secret | `(API_KEY|TOKEN|SECRET|PASSWORD)=…` | `<NAME>=[REDACTED]` |
+
+Adding a new pattern here updates every call site at once.
+
+## Identifying users
+
+The renderer calls `window.api.getDeviceId()` to obtain a stable
+per-installation UUID stored in `<configDir>/device-id.txt` (created
+with exclusive `wx` flags to avoid TOCTOU). It is then bound to:
+
+- `datadogRum.setUser({ id })`,
+- `client.identify({ distinctId })` in PostHog Node,
+- `posthog.identify(id, profileProps)` in PostHog JS — system-info
+  fields (platform, arch, GPU, app version, etc.) are written as
+  person-profile properties so they are queryable across sessions
+  without joining against per-session events.
+
+There is no user account, email, or other personal identifier.
+
+## Quit-time drain
+
+PostHog Node uses an outbound queue, so `app.before-quit` is hooked to
+drain it cleanly:
+
+1. `event.preventDefault()` — keep Electron from exiting immediately.
+2. `await shutdown()` — flushes the queue, with a 1.5 s overall
+   timeout so a slow / dead network never blocks quit.
+3. `app.exit(0)` — re-issues the quit. A one-shot guard prevents
+   re-entering this branch on the second quit.
+
+Datadog RUM sends events synchronously over `sendBeacon`/fetch and
+does not need a drain step.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -67,7 +67,7 @@ Main-process events go through `mainTelemetry.emit()`
 | **Main-process errors** | mirrored to renderer → `addError` (with `skipPostHog: true`) | **owns** (`captureException`) | suppressed (`skipPostHog`) to avoid double counting |
 | **Session replay** | not configured (field omitted, SDK default is off) | — | hard-disabled (no recorder script, no CSP allowance) |
 | **Long tasks / resource timing / user interactions** | **owns** (`trackResources`, `trackLongTasks`, `trackUserInteractions: true`) | — | — |
-| **Feature flags / kill switches** | — | **owns** (bootstraps + on-disk cache `telemetry-flags.json`) | — (no renderer-side flag consumers) |
+| **Feature flags / kill switches** | — | none in this build (see _Remote feature flags_ below) | — |
 | **Distinct id** | `datadogRum.setUser({ id })` | `client.identify({ distinctId })` | `posthog.identify(id, profileProps)` (sets person-profile props) |
 | **Path normalisation on errors** | yes (`normalizeRumErrorEvent`) | PII + secret scrub via `scrubAll()` | `scrubAll()` already applied upstream |
 
@@ -215,15 +215,20 @@ time. `VITE_DATADOG_RUM_ENABLED=0|false|off` disables Datadog.
 
 ### Remote feature flags
 
-Fetched from PostHog at startup (with a 1.5 s budget) and cached on
-disk in `<configDir>/telemetry-flags.json` for offline use:
+There are intentionally **no remote feature flags** in this build.
 
-| Flag | Default | Effect |
-|---|---|---|
-| `desktop2.execution_telemetry.enabled` | `true` | Master kill switch for `desktop2.execution.*` events. |
-| `desktop2.execution_telemetry.sample_rate` | `1` | 0..1 sampling applied per prompt (FIFO-paired across start/done/error). |
-| `desktop2.disabled_events` | `""` | Comma-separated event-name deny list applied at the SDK boundary. |
-| `desktop2.boot_log_max_chars` | `8192` | Cap on `desktop2.comfyui.boot_log.boot_stderr` length. |
+An earlier iteration shipped a small set (`desktop2.execution_telemetry.enabled`,
+`desktop2.execution_telemetry.sample_rate`, `desktop2.disabled_events`,
+`desktop2.boot_log_max_chars`) bootstrapped from PostHog at startup with
+an on-disk cache. None of them had a live operational use case for the
+launcher, and the bootstrap added startup latency plus state we did not
+want to maintain. The whole system was removed: no `getFlag` calls, no
+deferred session-start, no `<configDir>/telemetry-flags.json`. Execution
+telemetry is now unconditionally on.
+
+If a future need arises, the path to bring flags back is straightforward
+(re-add the bootstrap + cache + a `getFlag` accessor and the call sites
+that need it), but the default position is **no flags**.
 
 ## PII and secret scrubbing
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
     "@datadog/browser-rum": "6.28.1",
     "@todesktop/runtime": "^2.1.3",
     "electron-updater": "^6.7.3",
+    "posthog-js": "^1.372.4",
+    "posthog-node": "^5.30.7",
     "smol-toml": "^1.6.1",
     "systeminformation": "^5.31.5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,12 @@ importers:
       electron-updater:
         specifier: ^6.7.3
         version: 6.8.3
+      posthog-js:
+        specifier: ^1.372.4
+        version: 1.372.4
+      posthog-node:
+        specifier: ^5.30.7
+        version: 5.30.7(rxjs@7.8.2)
       smol-toml:
         specifier: ^1.6.1
         version: 1.6.1
@@ -116,7 +122,7 @@ importers:
         version: 7.3.1(@types/node@22.19.12)(jiti@2.6.1)(lightningcss@1.31.1)
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@22.19.12)(happy-dom@20.8.9)(jiti@2.6.1)(lightningcss@1.31.1)
+        version: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.12)(happy-dom@20.8.9)(jiti@2.6.1)(lightningcss@1.31.1)
       vue:
         specifier: ^3.5.25
         version: 3.5.29(typescript@5.9.3)
@@ -821,6 +827,78 @@ packages:
   '@one-ini/wasm@0.1.1':
     resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
 
+  '@opentelemetry/api-logs@0.208.0':
+    resolution: {integrity: sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/core@2.2.0':
+    resolution: {integrity: sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.7.0':
+    resolution: {integrity: sha512-DT12SXVwV2eoJrGf4nnsvZojxxeQo+LlNAsoYGRRObPWTeN6APiqZ2+nqDCQDvQX40eLi1AePONS0onoASp3yQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-logs-otlp-http@0.208.0':
+    resolution: {integrity: sha512-jOv40Bs9jy9bZVLo/i8FwUiuCvbjWDI+ZW13wimJm4LjnlwJxGgB+N/VWOZUTpM+ah/awXeQqKdNlpLf2EjvYg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.208.0':
+    resolution: {integrity: sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.208.0':
+    resolution: {integrity: sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@2.2.0':
+    resolution: {integrity: sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/resources@2.7.0':
+    resolution: {integrity: sha512-K+oi0hNMv94EpZbnW3eyu2X6SGVpD3O5DhG2NIp65Hc7lhAj9brRXTAVzh3wB82+q3ThakEf7Zd7RsFUqcTc7A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.208.0':
+    resolution: {integrity: sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.2.0':
+    resolution: {integrity: sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.2.0':
+    resolution: {integrity: sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.40.0':
+    resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
+    engines: {node: '>=14'}
+
   '@pinia/testing@1.0.3':
     resolution: {integrity: sha512-g+qR49GNdI1Z8rZxKrQC3GN+LfnGTNf5Kk8Nz5Cz6mIGva5WRS+ffPXQfzhA0nu6TveWzPNYTjGl4nJqd3Cu9Q==}
     peerDependencies:
@@ -834,6 +912,42 @@ packages:
     resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@posthog/core@1.27.8':
+    resolution: {integrity: sha512-zsfDm8oL8TmHKipCw3/f12up8pI8xitecPfsrtMiRigeAfonvk07CLW/WaiNxRVvrmgXE12xthmaMEaCrziOIQ==}
+
+  '@posthog/types@1.372.4':
+    resolution: {integrity: sha512-BWLXdMbrePQX/Q1hohbbxBr9EHEgnZroUX0ivx42HCzBisbYXDtuHGF4xaojapYVby1LtWVI6pa1CDx1HOZSyA==}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.1':
+    resolution: {integrity: sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
   '@rolldown/pluginutils@1.0.0-rc.2':
     resolution: {integrity: sha512-izyXV/v+cHiRfozX62W9htOAvwMo4/bXKDrQ+vom1L1qRuexPock/7VZDAhnpHCLNejd3NJ6hiab+tO0D44Rgw==}
@@ -1120,6 +1234,9 @@ packages:
 
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/uuid@9.0.8':
     resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
@@ -1631,6 +1748,9 @@ packages:
     resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
     engines: {node: '>=18'}
 
+  core-js@3.49.0:
+    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+
   core-util-is@1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
 
@@ -1740,6 +1860,9 @@ packages:
   dogapi@2.8.4:
     resolution: {integrity: sha512-065fsvu5dB0o4+ENtLjZILvXMClDNH/yA9H6L8nsdcNiz9l0Hzpn7aQaCOPYXxqyzq4CRPOdwkFXUjDOXfRGbg==}
     hasBin: true
+
+  dompurify@3.4.1:
+    resolution: {integrity: sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==}
 
   dotenv-expand@11.0.7:
     resolution: {integrity: sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==}
@@ -2024,6 +2147,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.4.8:
+    resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
 
   figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
@@ -2526,6 +2652,9 @@ packages:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   lowercase-keys@2.0.0:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
     engines: {node: '>=8'}
@@ -2876,10 +3005,25 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  posthog-js@1.372.4:
+    resolution: {integrity: sha512-dQssG6hvRsC7noZYJvU3ETwege6tuLWtIO4hfYyCawbMmrGjGfNiwHXqsaXr7VMUturHZ86OVVkP1awLfn3JLg==}
+
+  posthog-node@5.30.7:
+    resolution: {integrity: sha512-u2729tZQZdukln26Tz6T8BHXmkIeMKAAMlOdmEKrjQ8BLa/utel9D946PKZmjwKCJgFZoXoYpae3ptlyqeZ4Fg==}
+    engines: {node: ^20.20.0 || >=22.22.0}
+    peerDependencies:
+      rxjs: ^7.0.0
+    peerDependenciesMeta:
+      rxjs:
+        optional: true
+
   postject@1.0.0-alpha.6:
     resolution: {integrity: sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==}
     engines: {node: '>=14.0.0'}
     hasBin: true
+
+  preact@10.29.1:
+    resolution: {integrity: sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -2915,6 +3059,10 @@ packages:
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
 
+  protobufjs@7.5.6:
+    resolution: {integrity: sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==}
+    engines: {node: '>=12.0.0'}
+
   proxy-agent@6.5.0:
     resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
     engines: {node: '>= 14'}
@@ -2928,6 +3076,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  query-selector-shadow-dom@1.0.1:
+    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -3447,6 +3598,9 @@ packages:
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
+  web-vitals@5.2.0:
+    resolution: {integrity: sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==}
 
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
@@ -4222,6 +4376,82 @@ snapshots:
 
   '@one-ini/wasm@0.1.1': {}
 
+  '@opentelemetry/api-logs@0.208.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/exporter-logs-otlp-http@0.208.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.208.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-exporter-base@0.208.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.208.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-transformer@0.208.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.208.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.1)
+      protobufjs: 7.5.6
+
+  '@opentelemetry/resources@2.2.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/resources@2.7.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-logs@0.208.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.208.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-metrics@2.2.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/semantic-conventions@1.40.0': {}
+
   '@pinia/testing@1.0.3(pinia@3.0.4(typescript@5.9.3)(vue@3.5.29(typescript@5.9.3)))':
     dependencies:
       pinia: 3.0.4(typescript@5.9.3)(vue@3.5.29(typescript@5.9.3))
@@ -4232,6 +4462,35 @@ snapshots:
   '@playwright/test@1.58.2':
     dependencies:
       playwright: 1.58.2
+
+  '@posthog/core@1.27.8':
+    dependencies:
+      '@posthog/types': 1.372.4
+
+  '@posthog/types@1.372.4': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.1
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.1': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
 
   '@rolldown/pluginutils@1.0.0-rc.2': {}
 
@@ -4456,6 +4715,9 @@ snapshots:
   '@types/responselike@1.0.3':
     dependencies:
       '@types/node': 22.19.12
+
+  '@types/trusted-types@2.0.7':
+    optional: true
 
   '@types/uuid@9.0.8': {}
 
@@ -5074,6 +5336,8 @@ snapshots:
     dependencies:
       is-what: 5.5.0
 
+  core-js@3.49.0: {}
+
   core-util-is@1.0.2: {}
 
   crc@3.8.0:
@@ -5204,6 +5468,10 @@ snapshots:
       lodash: 4.17.23
       minimist: 1.2.8
       rc: 1.2.8
+
+  dompurify@3.4.1:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dotenv-expand@11.0.7:
     dependencies:
@@ -5595,6 +5863,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fflate@0.4.8: {}
 
   figures@3.2.0:
     dependencies:
@@ -6109,6 +6379,8 @@ snapshots:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
 
+  long@5.3.2: {}
+
   lowercase-keys@2.0.0: {}
 
   lru-cache@10.4.3: {}
@@ -6445,10 +6717,34 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  posthog-js@1.372.4:
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.208.0
+      '@opentelemetry/exporter-logs-otlp-http': 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.1)
+      '@posthog/core': 1.27.8
+      '@posthog/types': 1.372.4
+      core-js: 3.49.0
+      dompurify: 3.4.1
+      fflate: 0.4.8
+      preact: 10.29.1
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.2.0
+
+  posthog-node@5.30.7(rxjs@7.8.2):
+    dependencies:
+      '@posthog/core': 1.27.8
+    optionalDependencies:
+      rxjs: 7.8.2
+
   postject@1.0.0-alpha.6:
     dependencies:
       commander: 9.5.0
     optional: true
+
+  preact@10.29.1: {}
 
   prelude-ls@1.2.1: {}
 
@@ -6479,6 +6775,21 @@ snapshots:
 
   proto-list@1.2.4: {}
 
+  protobufjs@7.5.6:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.1
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 22.19.12
+      long: 5.3.2
+
   proxy-agent@6.5.0:
     dependencies:
       agent-base: 7.1.4
@@ -6500,6 +6811,8 @@ snapshots:
       once: 1.4.0
 
   punycode@2.3.1: {}
+
+  query-selector-shadow-dom@1.0.1: {}
 
   queue-microtask@1.2.3: {}
 
@@ -6924,7 +7237,7 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.31.1
 
-  vitest@4.0.18(@types/node@22.19.12)(happy-dom@20.8.9)(jiti@2.6.1)(lightningcss@1.31.1):
+  vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.12)(happy-dom@20.8.9)(jiti@2.6.1)(lightningcss@1.31.1):
     dependencies:
       '@vitest/expect': 4.0.18
       '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@22.19.12)(jiti@2.6.1)(lightningcss@1.31.1))
@@ -6947,6 +7260,7 @@ snapshots:
       vite: 7.3.1(@types/node@22.19.12)(jiti@2.6.1)(lightningcss@1.31.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/node': 22.19.12
       happy-dom: 20.8.9
     transitivePeerDependencies:
@@ -7004,6 +7318,8 @@ snapshots:
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
+
+  web-vitals@5.2.0: {}
 
   whatwg-mimetype@3.0.0: {}
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -29,6 +29,8 @@ import { showModelFolderRelaunchPage } from './lib/relaunchPage'
 import { COMFY_BG, SPLASH_DARK, TITLEBAR_BG, type SplashTheme } from './lib/theme'
 import { TITLEBAR_HEIGHT, TRAFFIC_LIGHT_POSITION, titleBarOverlayForTheme, comfyTitleBarOverlay, updateTitleBarOverlay, setMainWindowId } from './lib/titleBarOverlay'
 import { resolveTheme, sourceMap } from './lib/ipc/shared'
+import * as mainTelemetry from './lib/telemetry'
+import { randomUUID } from 'crypto'
 
 todesktop.init({ autoUpdater: false })
 
@@ -209,15 +211,38 @@ function scrubPII(value: string): string {
 }
 
 function forwardDatadogError(payload: DatadogForwardedError): void {
-  if (!mainWindow || mainWindow.isDestroyed()) return
+  const scrubbed: DatadogForwardedError = {
+    ...payload,
+    message: scrubPII(payload.message),
+    stack: payload.stack ? scrubPII(payload.stack) : undefined,
+  }
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    try {
+      mainWindow.webContents.send('dd-error', scrubbed)
+    } catch {}
+  }
+  // Also surface to PostHog Node so we don't lose the error if the renderer
+  // is gone (render-process-gone, before-quit shutdown, etc.).
   try {
-    const scrubbed: DatadogForwardedError = {
-      ...payload,
-      message: scrubPII(payload.message),
-      stack: payload.stack ? scrubPII(payload.stack) : undefined,
-    }
-    mainWindow.webContents.send('dd-error', scrubbed)
+    const err = new Error(scrubbed.message)
+    if (scrubbed.stack) err.stack = scrubbed.stack
+    mainTelemetry.captureException(err, {
+      origin: 'main-process',
+      source: scrubbed.source,
+      level: scrubbed.level ?? null,
+    })
   } catch {}
+}
+
+function readOrCreateDeviceId(): string {
+  const deviceIdPath = path.join(configDir(), 'device-id.txt')
+  try {
+    const existing = fs.readFileSync(deviceIdPath, 'utf-8').trim()
+    if (existing) return existing
+  } catch {}
+  const id = randomUUID()
+  try { fs.writeFileSync(deviceIdPath, id) } catch {}
+  return id
 }
 
 function registerProcessErrorHandlers(): void {
@@ -954,9 +979,29 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
     })
   }
 
-  app.whenReady().then(() => {
+  app.whenReady().then(async () => {
     migrateXdgPaths()
     registerProcessErrorHandlers()
+
+    // Bring up main-process telemetry as early as possible so install/migrate
+    // sub-step events can fire even before the renderer mounts.
+    const telemetryEnabled = settings.get('telemetryEnabled') !== false
+    mainTelemetry.setConsent(telemetryEnabled)
+    mainTelemetry.initTelemetry({
+      appVersion: APP_VERSION,
+      appEnv: app.isPackaged ? 'prod-v2' : 'dev',
+      isPackaged: app.isPackaged,
+    })
+    mainTelemetry.installAppHooks()
+    void mainTelemetry.identify(readOrCreateDeviceId(), {
+      app_version: APP_VERSION,
+      platform: process.platform,
+      arch: process.arch,
+    }, {
+      appVersion: APP_VERSION,
+      appEnv: app.isPackaged ? 'prod-v2' : 'dev',
+      isPackaged: app.isPackaged,
+    })
 
     const locale = (settings.get('language') as string | undefined) || app.getLocale().split('-')[0]
     i18n.init(locale)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -31,7 +31,7 @@ import { TITLEBAR_HEIGHT, TRAFFIC_LIGHT_POSITION, titleBarOverlayForTheme, comfy
 import { resolveTheme, sourceMap } from './lib/ipc/shared'
 import * as mainTelemetry from './lib/telemetry'
 import { getDeviceId } from './lib/deviceId'
-import { scrubPII } from './lib/piiScrub'
+import { scrubAll } from './lib/piiScrub'
 
 todesktop.init({ autoUpdater: false })
 
@@ -200,8 +200,8 @@ function serializeUnknownError(error: unknown): { message: string; stack?: strin
 function forwardDatadogError(payload: DatadogForwardedError): void {
   const scrubbed: DatadogForwardedError = {
     ...payload,
-    message: scrubPII(payload.message),
-    stack: payload.stack ? scrubPII(payload.stack) : undefined,
+    message: scrubAll(payload.message),
+    stack: payload.stack ? scrubAll(payload.stack) : undefined,
     // Mark this error as already captured by main-process PostHog so the
     // renderer's `onDatadogError` listener routes it to Datadog only and
     // we don't double-count exceptions in PostHog.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -30,7 +30,8 @@ import { COMFY_BG, SPLASH_DARK, TITLEBAR_BG, type SplashTheme } from './lib/them
 import { TITLEBAR_HEIGHT, TRAFFIC_LIGHT_POSITION, titleBarOverlayForTheme, comfyTitleBarOverlay, updateTitleBarOverlay, setMainWindowId } from './lib/titleBarOverlay'
 import { resolveTheme, sourceMap } from './lib/ipc/shared'
 import * as mainTelemetry from './lib/telemetry'
-import { randomUUID } from 'crypto'
+import { getDeviceId } from './lib/deviceId'
+import { scrubPII } from './lib/piiScrub'
 
 todesktop.init({ autoUpdater: false })
 
@@ -196,25 +197,15 @@ function serializeUnknownError(error: unknown): { message: string; stack?: strin
   }
 }
 
-const PII_PATH_PATTERNS = [
-  /([A-Za-z]:[\\/]Users[\\/])[^\\/]+?(?=[\\/]|$)/g,
-  /(\/Users\/)[^\\/]+?(?=\/|$)/g,
-  /(\/home\/)[^\\/]+?(?=\/|$)/g,
-]
-
-function scrubPII(value: string): string {
-  let scrubbed = value
-  for (const pattern of PII_PATH_PATTERNS) {
-    scrubbed = scrubbed.replace(pattern, (_match, prefix: string) => `${prefix}[REDACTED]`)
-  }
-  return scrubbed
-}
-
 function forwardDatadogError(payload: DatadogForwardedError): void {
   const scrubbed: DatadogForwardedError = {
     ...payload,
     message: scrubPII(payload.message),
     stack: payload.stack ? scrubPII(payload.stack) : undefined,
+    // Mark this error as already captured by main-process PostHog so the
+    // renderer's `onDatadogError` listener routes it to Datadog only and
+    // we don't double-count exceptions in PostHog.
+    skipPostHog: true,
   }
   if (mainWindow && !mainWindow.isDestroyed()) {
     try {
@@ -232,17 +223,6 @@ function forwardDatadogError(payload: DatadogForwardedError): void {
       level: scrubbed.level ?? null,
     })
   } catch {}
-}
-
-function readOrCreateDeviceId(): string {
-  const deviceIdPath = path.join(configDir(), 'device-id.txt')
-  try {
-    const existing = fs.readFileSync(deviceIdPath, 'utf-8').trim()
-    if (existing) return existing
-  } catch {}
-  const id = randomUUID()
-  try { fs.writeFileSync(deviceIdPath, id) } catch {}
-  return id
 }
 
 function registerProcessErrorHandlers(): void {
@@ -993,7 +973,7 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
       isPackaged: app.isPackaged,
     })
     mainTelemetry.installAppHooks()
-    void mainTelemetry.identify(readOrCreateDeviceId(), {
+    void mainTelemetry.identify(getDeviceId(), {
       app_version: APP_VERSION,
       platform: process.platform,
       arch: process.arch,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -973,14 +973,10 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
       isPackaged: app.isPackaged,
     })
     mainTelemetry.installAppHooks()
-    void mainTelemetry.identify(getDeviceId(), {
+    mainTelemetry.identify(getDeviceId(), {
       app_version: APP_VERSION,
       platform: process.platform,
       arch: process.arch,
-    }, {
-      appVersion: APP_VERSION,
-      appEnv: app.isPackaged ? 'prod-v2' : 'dev',
-      isPackaged: app.isPackaged,
     })
 
     const locale = (settings.get('language') as string | undefined) || app.getLocale().split('-')[0]

--- a/src/main/lib/deviceId.ts
+++ b/src/main/lib/deviceId.ts
@@ -1,0 +1,62 @@
+/**
+ * Persistent per-installation device identifier.
+ *
+ * Read or create exactly once per process; both the IPC handler exposed to
+ * the renderer (`get-device-id`) and the main-process telemetry init must
+ * call this so they always agree.
+ *
+ * Uses exclusive-create (`wx`) to avoid TOCTOU races when two startup paths
+ * race to create the file on first run.
+ */
+import { randomUUID } from 'crypto'
+import path from 'path'
+import fs from 'fs'
+import { configDir } from './paths'
+
+let cached: string | null = null
+
+function deviceIdPath(): string {
+  return path.join(configDir(), 'device-id.txt')
+}
+
+export function getDeviceId(): string {
+  if (cached) return cached
+
+  const filePath = deviceIdPath()
+  try {
+    const existing = fs.readFileSync(filePath, 'utf-8').trim()
+    if (existing) {
+      cached = existing
+      return existing
+    }
+  } catch {
+    // file doesn't exist yet; fall through and create it
+  }
+
+  const id = randomUUID()
+  try {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true })
+    fs.writeFileSync(filePath, id, { flag: 'wx' })
+    cached = id
+    return id
+  } catch (err) {
+    // Either the directory wasn't writable, or another process won the
+    // exclusive-create race. Re-read; the winning value is canonical.
+    if ((err as NodeJS.ErrnoException).code === 'EEXIST') {
+      try {
+        const existing = fs.readFileSync(filePath, 'utf-8').trim()
+        if (existing) {
+          cached = existing
+          return existing
+        }
+      } catch {
+        // ignore
+      }
+    }
+    // As a last resort, use the in-memory id without persisting it. The
+    // caller will end up with a session-scoped id, which is degraded but
+    // still functional for telemetry.
+    cached = id
+    return id
+  }
+}

--- a/src/main/lib/executionTap.test.ts
+++ b/src/main/lib/executionTap.test.ts
@@ -23,8 +23,8 @@ describe('executionTap', () => {
       captured.push({ event, ctx: ctx as Record<string, unknown> })
     })
     vi.spyOn(telemetry, 'getFlag').mockImplementation((name: string, fallback?: unknown) => {
-      if (name === 'launcher.execution_telemetry.enabled') return true
-      if (name === 'launcher.execution_telemetry.sample_rate') return 1
+      if (name === 'desktop2.execution_telemetry.enabled') return true
+      if (name === 'desktop2.execution_telemetry.sample_rate') return 1
       return fallback
     })
   })
@@ -36,14 +36,14 @@ describe('executionTap', () => {
   it('emits started when "got prompt" appears in stdout', () => {
     const tap = createExecutionTap({ installationId: 'inst-1' })
     tap.ingest('got prompt\n', 'stdout')
-    expect(captured.map((c) => c.event)).toEqual(['launcher.execution.started'])
+    expect(captured.map((c) => c.event)).toEqual(['desktop2.execution.started'])
     expect(captured[0]!.ctx).toMatchObject({ installation_id: 'inst-1', started_count: 1 })
   })
 
   it('emits completed with parsed duration_seconds', () => {
     const tap = createExecutionTap({ installationId: 'inst-1' })
     tap.ingest('got prompt\nPrompt executed in 12.5 seconds\n', 'stdout')
-    const completed = captured.find((c) => c.event === 'launcher.execution.completed')
+    const completed = captured.find((c) => c.event === 'desktop2.execution.completed')
     expect(completed).toBeDefined()
     expect(completed!.ctx).toMatchObject({
       installation_id: 'inst-1',
@@ -55,7 +55,7 @@ describe('executionTap', () => {
   it('emits validation_failed errors when prompt validation fails', () => {
     const tap = createExecutionTap({ installationId: 'inst-1' })
     tap.ingest('Failed to validate prompt for output 42:\n', 'stdout')
-    const err = captured.find((c) => c.event === 'launcher.execution.error')
+    const err = captured.find((c) => c.event === 'desktop2.execution.error')
     expect(err).toBeDefined()
     expect(err!.ctx).toMatchObject({ error_class: 'validation_failed', node_id: '42' })
   })
@@ -76,7 +76,7 @@ describe('executionTap', () => {
       ].join('\n'),
       'stderr',
     )
-    const errs = captured.filter((c) => c.event === 'launcher.execution.error')
+    const errs = captured.filter((c) => c.event === 'desktop2.execution.error')
     expect(errs.length).toBe(1)
     expect(errs[0]!.ctx).toMatchObject({ error_class: 'RuntimeError' })
   })
@@ -103,7 +103,7 @@ describe('executionTap', () => {
       ].join('\n'),
       'stderr',
     )
-    const errs = captured.filter((c) => c.event === 'launcher.execution.error')
+    const errs = captured.filter((c) => c.event === 'desktop2.execution.error')
     const classes = errs.map((e) => e.ctx['error_class'])
     expect(classes).toEqual(['ValueError', 'RuntimeError'])
   })
@@ -121,7 +121,7 @@ describe('executionTap', () => {
       ].join('\n'),
       'stderr',
     )
-    const errs = captured.filter((c) => c.event === 'launcher.execution.error')
+    const errs = captured.filter((c) => c.event === 'desktop2.execution.error')
     expect(errs.length).toBe(1)
     const message = String(errs[0]!.ctx.error_message)
     expect(message).not.toContain('alice')
@@ -140,10 +140,10 @@ describe('executionTap', () => {
       'stderr',
     )
     // Without flush, no error emitted yet (no blank-line boundary).
-    expect(captured.filter((c) => c.event === 'launcher.execution.error')).toHaveLength(0)
+    expect(captured.filter((c) => c.event === 'desktop2.execution.error')).toHaveLength(0)
     tap.flushSummary()
-    expect(captured.filter((c) => c.event === 'launcher.execution.error')).toHaveLength(1)
-    expect(captured.filter((c) => c.event === 'launcher.execution.session_summary')).toHaveLength(1)
+    expect(captured.filter((c) => c.event === 'desktop2.execution.error')).toHaveLength(1)
+    expect(captured.filter((c) => c.event === 'desktop2.execution.session_summary')).toHaveLength(1)
   })
 
   it('caps promptStartTimes so unpaired starts cannot grow unbounded', () => {
@@ -152,7 +152,7 @@ describe('executionTap', () => {
     for (let i = 0; i < 1000; i++) tap.ingest('got prompt\n', 'stdout')
     // Then complete one — wall_clock_ms should still be a finite number.
     tap.ingest('Prompt executed in 1 seconds\n', 'stdout')
-    const completed = captured.find((c) => c.event === 'launcher.execution.completed')
+    const completed = captured.find((c) => c.event === 'desktop2.execution.completed')
     expect(completed).toBeDefined()
     expect(typeof completed!.ctx.wall_clock_ms).toBe('number')
   })
@@ -160,7 +160,7 @@ describe('executionTap', () => {
   it('emits a session_summary on flush even when nothing was captured', () => {
     const tap = createExecutionTap({ installationId: 'inst-1' })
     tap.flushSummary()
-    const summary = captured.find((c) => c.event === 'launcher.execution.session_summary')
+    const summary = captured.find((c) => c.event === 'desktop2.execution.session_summary')
     expect(summary).toBeDefined()
     expect(summary!.ctx).toMatchObject({
       installation_id: 'inst-1',
@@ -172,7 +172,7 @@ describe('executionTap', () => {
 
   it('respects the kill switch feature flag', () => {
     vi.spyOn(telemetry, 'getFlag').mockImplementation((name: string, fallback?: unknown) => {
-      if (name === 'launcher.execution_telemetry.enabled') return false
+      if (name === 'desktop2.execution_telemetry.enabled') return false
       return fallback
     })
     const tap = createExecutionTap({ installationId: 'inst-1' })
@@ -186,8 +186,8 @@ describe('executionTap', () => {
     tap.ingest('got pro', 'stdout')
     tap.ingest('mpt\nPrompt executed in 2 seconds\n', 'stdout')
     const events = captured.map((c) => c.event)
-    expect(events).toContain('launcher.execution.started')
-    expect(events).toContain('launcher.execution.completed')
+    expect(events).toContain('desktop2.execution.started')
+    expect(events).toContain('desktop2.execution.completed')
   })
 
   it('redacts Bearer tokens and api keys from traceback messages (secret scrub)', () => {
@@ -203,7 +203,7 @@ describe('executionTap', () => {
       'next-line',
     ]
     tap.ingest(tracebackLines.join('\n'), 'stderr')
-    const err = captured.find((c) => c.event === 'launcher.execution.error')
+    const err = captured.find((c) => c.event === 'desktop2.execution.error')
     expect(err).toBeDefined()
     const msg = String(err!.ctx['error_message'])
     expect(msg).toContain('Bearer ' + '[' + 'REDACTED' + ']')
@@ -217,8 +217,8 @@ describe('executionTap', () => {
     let promptIdx = 0
     const sampleDecisions = [true, false, true]
     vi.spyOn(telemetry, 'getFlag').mockImplementation((name: string, fallback?: unknown) => {
-      if (name === 'launcher.execution_telemetry.enabled') return true
-      if (name === 'launcher.execution_telemetry.sample_rate') return 1
+      if (name === 'desktop2.execution_telemetry.enabled') return true
+      if (name === 'desktop2.execution_telemetry.sample_rate') return 1
       return fallback
     })
     const randomSpy = vi.spyOn(Math, 'random').mockImplementation(() => {
@@ -229,8 +229,8 @@ describe('executionTap', () => {
     })
     // Re-mock with a controllable rate so Math.random actually decides
     vi.spyOn(telemetry, 'getFlag').mockImplementation((name: string, fallback?: unknown) => {
-      if (name === 'launcher.execution_telemetry.enabled') return true
-      if (name === 'launcher.execution_telemetry.sample_rate') return 0.5
+      if (name === 'desktop2.execution_telemetry.enabled') return true
+      if (name === 'desktop2.execution_telemetry.sample_rate') return 0.5
       return fallback
     })
     randomSpy.mockImplementation(() => {
@@ -252,8 +252,8 @@ describe('executionTap', () => {
       ].join('\n'),
       'stdout',
     )
-    const started = captured.filter((c) => c.event === 'launcher.execution.started')
-    const completed = captured.filter((c) => c.event === 'launcher.execution.completed')
+    const started = captured.filter((c) => c.event === 'desktop2.execution.started')
+    const completed = captured.filter((c) => c.event === 'desktop2.execution.completed')
     // Exactly two pairs should make it through (prompt 1 and 3); prompt 2 is
     // dropped at BOTH the start and the completion stages.
     expect(started.length).toBe(2)

--- a/src/main/lib/executionTap.test.ts
+++ b/src/main/lib/executionTap.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import os from 'os'
+import path from 'path'
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => path.join(os.tmpdir(), 'launcher-test'),
+    isPackaged: false,
+    on: () => {},
+  },
+  BrowserWindow: { getAllWindows: () => [] },
+}))
+
+const { createExecutionTap } = await import('./executionTap')
+const telemetry = await import('./telemetry')
+
+describe('executionTap', () => {
+  let captured: Array<{ event: string; ctx: Record<string, unknown> }>
+
+  beforeEach(() => {
+    captured = []
+    vi.spyOn(telemetry, 'emit').mockImplementation((event, ctx) => {
+      captured.push({ event, ctx: ctx as Record<string, unknown> })
+    })
+    vi.spyOn(telemetry, 'getFlag').mockImplementation((name: string, fallback?: unknown) => {
+      if (name === 'launcher.execution_telemetry.enabled') return true
+      if (name === 'launcher.execution_telemetry.sample_rate') return 1
+      return fallback
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('emits started when "got prompt" appears in stdout', () => {
+    const tap = createExecutionTap({ installationId: 'inst-1' })
+    tap.ingest('got prompt\n', 'stdout')
+    expect(captured.map((c) => c.event)).toEqual(['launcher.execution.started'])
+    expect(captured[0]!.ctx).toMatchObject({ installation_id: 'inst-1', started_count: 1 })
+  })
+
+  it('emits completed with parsed duration_seconds', () => {
+    const tap = createExecutionTap({ installationId: 'inst-1' })
+    tap.ingest('got prompt\nPrompt executed in 12.5 seconds\n', 'stdout')
+    const completed = captured.find((c) => c.event === 'launcher.execution.completed')
+    expect(completed).toBeDefined()
+    expect(completed!.ctx).toMatchObject({
+      installation_id: 'inst-1',
+      duration_seconds: 12.5,
+      completed_count: 1,
+    })
+  })
+
+  it('emits validation_failed errors when prompt validation fails', () => {
+    const tap = createExecutionTap({ installationId: 'inst-1' })
+    tap.ingest('Failed to validate prompt for output 42:\n', 'stdout')
+    const err = captured.find((c) => c.event === 'launcher.execution.error')
+    expect(err).toBeDefined()
+    expect(err!.ctx).toMatchObject({ error_class: 'validation_failed', node_id: '42' })
+  })
+
+  it('captures Python tracebacks from stderr and emits a single error', () => {
+    const tap = createExecutionTap({ installationId: 'inst-1' })
+    tap.ingest(
+      [
+        'Traceback (most recent call last):',
+        '  File "main.py", line 10, in <module>',
+        '    raise RuntimeError("boom")',
+        'RuntimeError: boom',
+        '',
+      ].join('\n'),
+      'stderr',
+    )
+    const errs = captured.filter((c) => c.event === 'launcher.execution.error')
+    expect(errs.length).toBe(1)
+    expect(errs[0]!.ctx).toMatchObject({ error_class: 'RuntimeError' })
+  })
+
+  it('emits a session_summary on flush even when nothing was captured', () => {
+    const tap = createExecutionTap({ installationId: 'inst-1' })
+    tap.flushSummary()
+    const summary = captured.find((c) => c.event === 'launcher.execution.session_summary')
+    expect(summary).toBeDefined()
+    expect(summary!.ctx).toMatchObject({
+      installation_id: 'inst-1',
+      started_count: 0,
+      completed_count: 0,
+      error_count: 0,
+    })
+  })
+
+  it('respects the kill switch feature flag', () => {
+    vi.spyOn(telemetry, 'getFlag').mockImplementation((name: string, fallback?: unknown) => {
+      if (name === 'launcher.execution_telemetry.enabled') return false
+      return fallback
+    })
+    const tap = createExecutionTap({ installationId: 'inst-1' })
+    tap.ingest('got prompt\nPrompt executed in 1 seconds\n', 'stdout')
+    tap.flushSummary()
+    expect(captured.length).toBe(0)
+  })
+
+  it('handles split chunks at line boundaries', () => {
+    const tap = createExecutionTap({ installationId: 'inst-1' })
+    tap.ingest('got pro', 'stdout')
+    tap.ingest('mpt\nPrompt executed in 2 seconds\n', 'stdout')
+    const events = captured.map((c) => c.event)
+    expect(events).toContain('launcher.execution.started')
+    expect(events).toContain('launcher.execution.completed')
+  })
+})

--- a/src/main/lib/executionTap.test.ts
+++ b/src/main/lib/executionTap.test.ts
@@ -22,11 +22,6 @@ describe('executionTap', () => {
     vi.spyOn(telemetry, 'emit').mockImplementation((event, ctx) => {
       captured.push({ event, ctx: ctx as Record<string, unknown> })
     })
-    vi.spyOn(telemetry, 'getFlag').mockImplementation((name: string, fallback?: unknown) => {
-      if (name === 'desktop2.execution_telemetry.enabled') return true
-      if (name === 'desktop2.execution_telemetry.sample_rate') return 1
-      return fallback
-    })
   })
 
   afterEach(() => {
@@ -170,17 +165,6 @@ describe('executionTap', () => {
     })
   })
 
-  it('respects the kill switch feature flag', () => {
-    vi.spyOn(telemetry, 'getFlag').mockImplementation((name: string, fallback?: unknown) => {
-      if (name === 'desktop2.execution_telemetry.enabled') return false
-      return fallback
-    })
-    const tap = createExecutionTap({ installationId: 'inst-1' })
-    tap.ingest('got prompt\nPrompt executed in 1 seconds\n', 'stdout')
-    tap.flushSummary()
-    expect(captured.length).toBe(0)
-  })
-
   it('handles split chunks at line boundaries', () => {
     const tap = createExecutionTap({ installationId: 'inst-1' })
     tap.ingest('got pro', 'stdout')
@@ -212,51 +196,4 @@ describe('executionTap', () => {
     expect(msg).toContain('[' + 'REDACTED' + ']')
   })
 
-  it('pairs sample decisions to terminal events FIFO (mid-session sample-out is honored)', () => {
-    // Force sampling to drop only the SECOND prompt, not the first or third.
-    let promptIdx = 0
-    const sampleDecisions = [true, false, true]
-    vi.spyOn(telemetry, 'getFlag').mockImplementation((name: string, fallback?: unknown) => {
-      if (name === 'desktop2.execution_telemetry.enabled') return true
-      if (name === 'desktop2.execution_telemetry.sample_rate') return 1
-      return fallback
-    })
-    const randomSpy = vi.spyOn(Math, 'random').mockImplementation(() => {
-      // shouldSample uses Math.random() < rate; we hijack by also stubbing
-      // the rate via the queue: since rate is 1 here, shouldSample short-
-      // circuits to true. Override rate to 0.5 so Math.random gates it.
-      return 0
-    })
-    // Re-mock with a controllable rate so Math.random actually decides
-    vi.spyOn(telemetry, 'getFlag').mockImplementation((name: string, fallback?: unknown) => {
-      if (name === 'desktop2.execution_telemetry.enabled') return true
-      if (name === 'desktop2.execution_telemetry.sample_rate') return 0.5
-      return fallback
-    })
-    randomSpy.mockImplementation(() => {
-      // shouldSample: Math.random() < 0.5 → true means sampled in
-      const decision = sampleDecisions[promptIdx++] ?? true
-      return decision ? 0 : 0.99
-    })
-
-    const tap = createExecutionTap({ installationId: 'inst-1' })
-    tap.ingest(
-      [
-        'got prompt',
-        'Prompt executed in 1 seconds',
-        'got prompt',
-        'Prompt executed in 1 seconds',
-        'got prompt',
-        'Prompt executed in 1 seconds',
-        '',
-      ].join('\n'),
-      'stdout',
-    )
-    const started = captured.filter((c) => c.event === 'desktop2.execution.started')
-    const completed = captured.filter((c) => c.event === 'desktop2.execution.completed')
-    // Exactly two pairs should make it through (prompt 1 and 3); prompt 2 is
-    // dropped at BOTH the start and the completion stages.
-    expect(started.length).toBe(2)
-    expect(completed.length).toBe(2)
-  })
 })

--- a/src/main/lib/executionTap.test.ts
+++ b/src/main/lib/executionTap.test.ts
@@ -189,4 +189,74 @@ describe('executionTap', () => {
     expect(events).toContain('launcher.execution.started')
     expect(events).toContain('launcher.execution.completed')
   })
+
+  it('redacts Bearer tokens and api keys from traceback messages (secret scrub)', () => {
+    const bearer = 'Bearer ' + 'a'.repeat(30)
+    const apiKey = 's' + 'k-' + 'a'.repeat(24)
+    const tap = createExecutionTap({ installationId: 'inst-1' })
+    const tracebackLines = [
+      'Traceback (most recent call last):',
+      '  File ' + JSON.stringify('x.py') + ', line 1, in <module>',
+      '    raise RuntimeError(' + JSON.stringify(bearer + ' was rejected, ' + apiKey + ' also bad') + ')',
+      'RuntimeError: ' + bearer + ' was rejected, ' + apiKey + ' also bad',
+      '',
+      'next-line',
+    ]
+    tap.ingest(tracebackLines.join('\n'), 'stderr')
+    const err = captured.find((c) => c.event === 'launcher.execution.error')
+    expect(err).toBeDefined()
+    const msg = String(err!.ctx['error_message'])
+    expect(msg).toContain('Bearer ' + '[' + 'REDACTED' + ']')
+    expect(msg).not.toContain('a'.repeat(30))
+    expect(msg).not.toContain(apiKey)
+    expect(msg).toContain('[' + 'REDACTED' + ']')
+  })
+
+  it('pairs sample decisions to terminal events FIFO (mid-session sample-out is honored)', () => {
+    // Force sampling to drop only the SECOND prompt, not the first or third.
+    let promptIdx = 0
+    const sampleDecisions = [true, false, true]
+    vi.spyOn(telemetry, 'getFlag').mockImplementation((name: string, fallback?: unknown) => {
+      if (name === 'launcher.execution_telemetry.enabled') return true
+      if (name === 'launcher.execution_telemetry.sample_rate') return 1
+      return fallback
+    })
+    const randomSpy = vi.spyOn(Math, 'random').mockImplementation(() => {
+      // shouldSample uses Math.random() < rate; we hijack by also stubbing
+      // the rate via the queue: since rate is 1 here, shouldSample short-
+      // circuits to true. Override rate to 0.5 so Math.random gates it.
+      return 0
+    })
+    // Re-mock with a controllable rate so Math.random actually decides
+    vi.spyOn(telemetry, 'getFlag').mockImplementation((name: string, fallback?: unknown) => {
+      if (name === 'launcher.execution_telemetry.enabled') return true
+      if (name === 'launcher.execution_telemetry.sample_rate') return 0.5
+      return fallback
+    })
+    randomSpy.mockImplementation(() => {
+      // shouldSample: Math.random() < 0.5 → true means sampled in
+      const decision = sampleDecisions[promptIdx++] ?? true
+      return decision ? 0 : 0.99
+    })
+
+    const tap = createExecutionTap({ installationId: 'inst-1' })
+    tap.ingest(
+      [
+        'got prompt',
+        'Prompt executed in 1 seconds',
+        'got prompt',
+        'Prompt executed in 1 seconds',
+        'got prompt',
+        'Prompt executed in 1 seconds',
+        '',
+      ].join('\n'),
+      'stdout',
+    )
+    const started = captured.filter((c) => c.event === 'launcher.execution.started')
+    const completed = captured.filter((c) => c.event === 'launcher.execution.completed')
+    // Exactly two pairs should make it through (prompt 1 and 3); prompt 2 is
+    // dropped at BOTH the start and the completion stages.
+    expect(started.length).toBe(2)
+    expect(completed.length).toBe(2)
+  })
 })

--- a/src/main/lib/executionTap.test.ts
+++ b/src/main/lib/executionTap.test.ts
@@ -62,6 +62,9 @@ describe('executionTap', () => {
 
   it('captures Python tracebacks from stderr and emits a single error', () => {
     const tap = createExecutionTap({ installationId: 'inst-1' })
+    // Trailing line after the blank-line boundary so the parser sees the
+    // boundary as a complete line (mirrors real ComfyUI output where logs
+    // continue after a failure).
     tap.ingest(
       [
         'Traceback (most recent call last):',
@@ -69,12 +72,89 @@ describe('executionTap', () => {
         '    raise RuntimeError("boom")',
         'RuntimeError: boom',
         '',
+        'next-line',
       ].join('\n'),
       'stderr',
     )
     const errs = captured.filter((c) => c.event === 'launcher.execution.error')
     expect(errs.length).toBe(1)
     expect(errs[0]!.ctx).toMatchObject({ error_class: 'RuntimeError' })
+  })
+
+  it('emits one error per traceback in chained Python tracebacks', () => {
+    // We deliberately do NOT collapse chained tracebacks; the inner and the
+    // outer are real distinct errors and analytics needs both visible.
+    const tap = createExecutionTap({ installationId: 'inst-1' })
+    tap.ingest(
+      [
+        'Traceback (most recent call last):',
+        '  File "a.py", line 1, in <module>',
+        '    raise ValueError("inner")',
+        'ValueError: inner',
+        '',
+        'During handling of the above exception, another exception occurred:',
+        '',
+        'Traceback (most recent call last):',
+        '  File "b.py", line 2, in <module>',
+        '    raise RuntimeError("outer")',
+        'RuntimeError: outer',
+        '',
+        'next-line',
+      ].join('\n'),
+      'stderr',
+    )
+    const errs = captured.filter((c) => c.event === 'launcher.execution.error')
+    const classes = errs.map((e) => e.ctx['error_class'])
+    expect(classes).toEqual(['ValueError', 'RuntimeError'])
+  })
+
+  it('scrubs PII (Windows user paths) from traceback error messages', () => {
+    const tap = createExecutionTap({ installationId: 'inst-1' })
+    tap.ingest(
+      [
+        'Traceback (most recent call last):',
+        '  File "C:\\Users\\alice\\stuff.py", line 10, in foo',
+        '    open("bad")',
+        'FileNotFoundError: [Errno 2] No such file: \'C:\\Users\\alice\\bad\'',
+        '',
+        'next-line',
+      ].join('\n'),
+      'stderr',
+    )
+    const errs = captured.filter((c) => c.event === 'launcher.execution.error')
+    expect(errs.length).toBe(1)
+    const message = String(errs[0]!.ctx.error_message)
+    expect(message).not.toContain('alice')
+    expect(message).toContain('[REDACTED]')
+  })
+
+  it('flushSummary drains a pending traceback so errors are not lost on exit', () => {
+    const tap = createExecutionTap({ installationId: 'inst-1' })
+    // No trailing blank line — process died before traceback ended.
+    tap.ingest(
+      [
+        'Traceback (most recent call last):',
+        '  File "x.py", line 9, in y',
+        'KeyError: missing',
+      ].join('\n') + '\n',
+      'stderr',
+    )
+    // Without flush, no error emitted yet (no blank-line boundary).
+    expect(captured.filter((c) => c.event === 'launcher.execution.error')).toHaveLength(0)
+    tap.flushSummary()
+    expect(captured.filter((c) => c.event === 'launcher.execution.error')).toHaveLength(1)
+    expect(captured.filter((c) => c.event === 'launcher.execution.session_summary')).toHaveLength(1)
+  })
+
+  it('caps promptStartTimes so unpaired starts cannot grow unbounded', () => {
+    const tap = createExecutionTap({ installationId: 'inst-1' })
+    // Far more than the cap (256).
+    for (let i = 0; i < 1000; i++) tap.ingest('got prompt\n', 'stdout')
+    // Then complete one — wall_clock_ms should still be a finite number.
+    tap.ingest('Prompt executed in 1 seconds\n', 'stdout')
+    const completed = captured.find((c) => c.event === 'launcher.execution.completed')
+    expect(completed).toBeDefined()
+    expect(typeof completed!.ctx.wall_clock_ms).toBe('number')
   })
 
   it('emits a session_summary on flush even when nothing was captured', () => {

--- a/src/main/lib/executionTap.ts
+++ b/src/main/lib/executionTap.ts
@@ -28,7 +28,7 @@
  */
 import * as installationsApi from '../installations'
 import * as telemetry from './telemetry'
-import { scrubPII } from './piiScrub'
+import { scrubAll } from './piiScrub'
 
 /**
  * Traceback collection state. We collect until a blank line follows an
@@ -51,9 +51,12 @@ interface TapState {
   tracebackBuffer: string[]
   tracebackChars: number
   tracebackPhase: TracebackPhase
-  // Re-uses one shared sample bucket across started/completed/error so a
-  // sampled-out prompt is dropped consistently.
-  sampleDropped: number
+  // FIFO queue of per-prompt sample decisions (`true` = sampled in, `false` =
+  // sampled out). ComfyUI runs prompts strictly serially, so completions and
+  // errors arrive in the same order their `got prompt` did. Pushed on each
+  // start, shifted on each terminal event so a sampled-out prompt is dropped
+  // consistently across started/completed/error.
+  sampleResults: boolean[]
 }
 
 const TRACEBACK_START = /^Traceback \(most recent call last\):/
@@ -98,7 +101,7 @@ export function createExecutionTap(opts: {
     tracebackBuffer: [],
     tracebackChars: 0,
     tracebackPhase: 'none',
-    sampleDropped: 0,
+    sampleResults: [],
   }
 
   const baseContext = {
@@ -119,6 +122,17 @@ export function createExecutionTap(opts: {
   function consumePromptStart(): number | null {
     const ts = state.promptStartTimes.shift()
     return ts === undefined ? null : Date.now() - ts
+  }
+
+  /**
+   * Pop the matching sample-decision for the current terminal event.
+   * Returns `true` if the prompt was sampled in (or if no decision was
+   * recorded — fail-open so terminal events that arrive before any
+   * `got prompt` was seen are not silently swallowed).
+   */
+  function consumeSampleResult(): boolean {
+    if (state.sampleResults.length === 0) return true
+    return state.sampleResults.shift()!
   }
 
   function emitFirstCompletedIfNeeded(): void {
@@ -156,10 +170,11 @@ export function createExecutionTap(opts: {
       }
     }
     const errorClass = exceptionLine.split(':')[0]?.trim() || 'unknown'
-    const scrubbedMessage = scrubPII(exceptionLine).slice(0, ERROR_MESSAGE_MAX)
+    const scrubbedMessage = scrubAll(exceptionLine).slice(0, ERROR_MESSAGE_MAX)
     state.errorCount++
     // An error consumes a pending start so wall-clock pairing stays sane.
     consumePromptStart()
+    consumeSampleResult()
     telemetry.emit('launcher.execution.error', {
       ...baseContext,
       error_class: errorClass.slice(0, ERROR_CLASS_MAX),
@@ -191,10 +206,14 @@ export function createExecutionTap(opts: {
     if (trimmed.length === 0) return
 
     if (PROMPT_GOT.test(trimmed)) {
-      if (!shouldSample()) {
-        state.sampleDropped++
-        return
+      const sampledIn = shouldSample()
+      state.sampleResults.push(sampledIn)
+      // Bound the queue to the same cap as promptStartTimes so a runaway
+      // mismatch can't grow it forever.
+      while (state.sampleResults.length > MAX_PENDING_PROMPTS) {
+        state.sampleResults.shift()
       }
+      if (!sampledIn) return
       state.startedCount++
       pushPromptStart()
       telemetry.emit('launcher.execution.started', {
@@ -206,10 +225,7 @@ export function createExecutionTap(opts: {
 
     const doneMatch = trimmed.match(PROMPT_DONE)
     if (doneMatch?.groups) {
-      if (state.sampleDropped > 0 && state.startedCount === 0) {
-        state.sampleDropped--
-        return
-      }
+      if (!consumeSampleResult()) return
       const seconds = Number(doneMatch.groups['seconds'])
       const wallMs = consumePromptStart()
       state.completedCount++
@@ -225,6 +241,7 @@ export function createExecutionTap(opts: {
 
     const validationMatch = trimmed.match(VALIDATION_FAIL)
     if (validationMatch?.groups) {
+      if (!consumeSampleResult()) return
       state.errorCount++
       consumePromptStart()
       telemetry.emit('launcher.execution.error', {

--- a/src/main/lib/executionTap.ts
+++ b/src/main/lib/executionTap.ts
@@ -1,0 +1,201 @@
+/**
+ * Execution telemetry tap.
+ *
+ * The launcher does not embed the ComfyUI frontend, so we can't IPC-forward
+ * `execution_*` events the way legacy desktop did. Instead we tail ComfyUI's
+ * own stdout/stderr — a stable signal that is already piped through
+ * `proc.stdout` / `proc.stderr` in `sessionActions/launch.ts`.
+ *
+ * Patterns we detect (current ComfyUI main branch):
+ *   - "got prompt"                    → execution started
+ *   - "Prompt executed in X.X seconds"→ execution completed (with duration)
+ *   - "Failed to validate prompt"     → validation error
+ *   - Python tracebacks               → execution error
+ *
+ * The per-install `firstRunAt` flag mirrors legacy desktop's once-ever
+ * `execution:completed` semantic. It is set on the first successful prompt
+ * and emitted as `launcher.execution.first_completed`.
+ *
+ * All emissions are gated by the `launcher.execution_telemetry.enabled` and
+ * `launcher.execution_telemetry.sample_rate` feature flags.
+ */
+import * as installationsApi from '../installations'
+import * as telemetry from './telemetry'
+
+interface TapState {
+  installationId: string
+  variant: string | null
+  release: string | null
+  promptStartTimes: Date[]
+  startedCount: number
+  completedCount: number
+  errorCount: number
+  // Buffer for the current stderr traceback (collected line-by-line)
+  tracebackBuffer: string[]
+  inTraceback: boolean
+  // Re-uses one shared sample bucket across started/completed/error so a
+  // sampled-out prompt is dropped consistently.
+  sampleDropped: number
+}
+
+const TRACEBACK_START = /^Traceback \(most recent call last\):/
+const PROMPT_GOT = /^got prompt/i
+const PROMPT_DONE = /^Prompt executed in (?<seconds>\d+(?:\.\d+)?)\s*seconds?\s*$/i
+const VALIDATION_FAIL = /^Failed to validate prompt for output (?<nodeId>\S+):/i
+
+export function isTelemetryEnabled(): boolean {
+  return telemetry.getFlag<boolean>('launcher.execution_telemetry.enabled', true) === true
+}
+
+function shouldSample(): boolean {
+  const rate = Number(telemetry.getFlag('launcher.execution_telemetry.sample_rate', 1))
+  if (!Number.isFinite(rate) || rate >= 1) return true
+  if (rate <= 0) return false
+  return Math.random() < rate
+}
+
+export function createExecutionTap(opts: {
+  installationId: string
+  variant?: string | null
+  release?: string | null
+}): {
+  ingest: (chunk: string, source: 'stdout' | 'stderr') => void
+  flushSummary: () => void
+} {
+  const state: TapState = {
+    installationId: opts.installationId,
+    variant: opts.variant ?? null,
+    release: opts.release ?? null,
+    promptStartTimes: [],
+    startedCount: 0,
+    completedCount: 0,
+    errorCount: 0,
+    tracebackBuffer: [],
+    inTraceback: false,
+    sampleDropped: 0,
+  }
+
+  const baseContext = {
+    installation_id: state.installationId,
+    variant: state.variant,
+    release: state.release,
+  }
+
+  function emitFirstCompletedIfNeeded(): void {
+    if (state.completedCount !== 1) return
+    void (async () => {
+      try {
+        const inst = await installationsApi.get(state.installationId)
+        if (!inst || (inst as Record<string, unknown>)['firstRunAt']) return
+        const firstRunAt = new Date().toISOString()
+        await installationsApi.update(state.installationId, { firstRunAt })
+        telemetry.emit('launcher.execution.first_completed', {
+          ...baseContext,
+          first_run_at: firstRunAt,
+        })
+      } catch {
+        // ignore – telemetry side effect, not user-visible
+      }
+    })()
+  }
+
+  function handleLine(line: string, source: 'stdout' | 'stderr'): void {
+    if (!isTelemetryEnabled()) return
+    const trimmed = line.trim()
+    if (trimmed.length === 0) return
+
+    if (PROMPT_GOT.test(trimmed)) {
+      if (!shouldSample()) {
+        state.sampleDropped++
+        return
+      }
+      state.startedCount++
+      state.promptStartTimes.push(new Date())
+      telemetry.emit('launcher.execution.started', {
+        ...baseContext,
+        started_count: state.startedCount,
+      })
+      return
+    }
+
+    const doneMatch = trimmed.match(PROMPT_DONE)
+    if (doneMatch?.groups) {
+      if (state.sampleDropped > 0 && state.startedCount === 0) {
+        state.sampleDropped--
+        return
+      }
+      const seconds = Number(doneMatch.groups['seconds'])
+      const startedAt = state.promptStartTimes.shift()
+      const wallMs = startedAt ? Date.now() - startedAt.getTime() : null
+      state.completedCount++
+      telemetry.emit('launcher.execution.completed', {
+        ...baseContext,
+        duration_seconds: Number.isFinite(seconds) ? seconds : null,
+        wall_clock_ms: wallMs,
+        completed_count: state.completedCount,
+      })
+      emitFirstCompletedIfNeeded()
+      return
+    }
+
+    const validationMatch = trimmed.match(VALIDATION_FAIL)
+    if (validationMatch?.groups) {
+      state.errorCount++
+      telemetry.emit('launcher.execution.error', {
+        ...baseContext,
+        error_class: 'validation_failed',
+        error_count: state.errorCount,
+        node_id: validationMatch.groups['nodeId'],
+      })
+      return
+    }
+
+    if (source === 'stderr' && TRACEBACK_START.test(trimmed)) {
+      state.inTraceback = true
+      state.tracebackBuffer = [trimmed]
+      return
+    }
+    if (state.inTraceback) {
+      // Collect until we hit a blank line or a non-indented, non-File line —
+      // ComfyUI tracebacks usually end with the exception class line.
+      state.tracebackBuffer.push(trimmed)
+      const isBoundary = trimmed.length === 0 || /^[A-Za-z_][A-Za-z0-9_.]*Error\b/.test(trimmed) || /^\S+Exception\b/.test(trimmed)
+      if (isBoundary && state.tracebackBuffer.length > 1) {
+        const exceptionLine = state.tracebackBuffer[state.tracebackBuffer.length - 1] || 'unknown'
+        const errorClass = exceptionLine.split(':')[0]?.trim() || 'unknown'
+        state.errorCount++
+        telemetry.emit('launcher.execution.error', {
+          ...baseContext,
+          error_class: errorClass.slice(0, 80),
+          error_message: exceptionLine.slice(0, 500),
+          error_bucket: telemetry.bucketError(exceptionLine),
+          error_count: state.errorCount,
+        })
+        state.inTraceback = false
+        state.tracebackBuffer = []
+      }
+    }
+  }
+
+  const pending: Record<'stdout' | 'stderr', string> = { stdout: '', stderr: '' }
+
+  return {
+    ingest(chunk: string, source: 'stdout' | 'stderr'): void {
+      pending[source] += chunk
+      const lines = pending[source].split(/\r?\n/)
+      pending[source] = lines.pop() ?? ''
+      for (const line of lines) handleLine(line, source)
+    },
+    flushSummary(): void {
+      if (!isTelemetryEnabled()) return
+      // Always emit a per-session summary so analytics has a row even when
+      // no individual events were emitted (e.g. when sample_rate < 1).
+      telemetry.emit('launcher.execution.session_summary', {
+        ...baseContext,
+        started_count: state.startedCount,
+        completed_count: state.completedCount,
+        error_count: state.errorCount,
+      })
+    },
+  }
+}

--- a/src/main/lib/executionTap.ts
+++ b/src/main/lib/executionTap.ts
@@ -14,10 +14,10 @@
  *
  * The per-install `firstRunAt` flag mirrors legacy desktop's once-ever
  * `execution:completed` semantic. It is set on the first successful prompt
- * and emitted as `launcher.execution.first_completed`.
+ * and emitted as `desktop2.execution.first_completed`.
  *
- * All emissions are gated by the `launcher.execution_telemetry.enabled` and
- * `launcher.execution_telemetry.sample_rate` feature flags.
+ * All emissions are gated by the `desktop2.execution_telemetry.enabled` and
+ * `desktop2.execution_telemetry.sample_rate` feature flags.
  *
  * Defensive bounds:
  *   - `promptStartTimes` is capped to avoid leaking when starts and
@@ -72,11 +72,11 @@ const ERROR_MESSAGE_MAX = 500
 const ERROR_CLASS_MAX = 80
 
 export function isTelemetryEnabled(): boolean {
-  return telemetry.getFlag<boolean>('launcher.execution_telemetry.enabled', true) === true
+  return telemetry.getFlag<boolean>('desktop2.execution_telemetry.enabled', true) === true
 }
 
 function shouldSample(): boolean {
-  const rate = Number(telemetry.getFlag('launcher.execution_telemetry.sample_rate', 1))
+  const rate = Number(telemetry.getFlag('desktop2.execution_telemetry.sample_rate', 1))
   if (!Number.isFinite(rate) || rate >= 1) return true
   if (rate <= 0) return false
   return Math.random() < rate
@@ -143,7 +143,7 @@ export function createExecutionTap(opts: {
         if (!inst || (inst as Record<string, unknown>)['firstRunAt']) return
         const firstRunAt = new Date().toISOString()
         await installationsApi.update(state.installationId, { firstRunAt })
-        telemetry.emit('launcher.execution.first_completed', {
+        telemetry.emit('desktop2.execution.first_completed', {
           ...baseContext,
           first_run_at: firstRunAt,
         })
@@ -175,7 +175,7 @@ export function createExecutionTap(opts: {
     // An error consumes a pending start so wall-clock pairing stays sane.
     consumePromptStart()
     consumeSampleResult()
-    telemetry.emit('launcher.execution.error', {
+    telemetry.emit('desktop2.execution.error', {
       ...baseContext,
       error_class: errorClass.slice(0, ERROR_CLASS_MAX),
       error_message: scrubbedMessage,
@@ -216,7 +216,7 @@ export function createExecutionTap(opts: {
       if (!sampledIn) return
       state.startedCount++
       pushPromptStart()
-      telemetry.emit('launcher.execution.started', {
+      telemetry.emit('desktop2.execution.started', {
         ...baseContext,
         started_count: state.startedCount,
       })
@@ -229,7 +229,7 @@ export function createExecutionTap(opts: {
       const seconds = Number(doneMatch.groups['seconds'])
       const wallMs = consumePromptStart()
       state.completedCount++
-      telemetry.emit('launcher.execution.completed', {
+      telemetry.emit('desktop2.execution.completed', {
         ...baseContext,
         duration_seconds: Number.isFinite(seconds) ? seconds : null,
         wall_clock_ms: wallMs,
@@ -244,7 +244,7 @@ export function createExecutionTap(opts: {
       if (!consumeSampleResult()) return
       state.errorCount++
       consumePromptStart()
-      telemetry.emit('launcher.execution.error', {
+      telemetry.emit('desktop2.execution.error', {
         ...baseContext,
         error_class: 'validation_failed',
         error_count: state.errorCount,
@@ -319,7 +319,7 @@ export function createExecutionTap(opts: {
       }
       // Always emit a per-session summary so analytics has a row even when
       // no individual events were emitted (e.g. when sample_rate < 1).
-      telemetry.emit('launcher.execution.session_summary', {
+      telemetry.emit('desktop2.execution.session_summary', {
         ...baseContext,
         started_count: state.startedCount,
         completed_count: state.completedCount,

--- a/src/main/lib/executionTap.ts
+++ b/src/main/lib/executionTap.ts
@@ -16,9 +16,6 @@
  * `execution:completed` semantic. It is set on the first successful prompt
  * and emitted as `desktop2.execution.first_completed`.
  *
- * All emissions are gated by the `desktop2.execution_telemetry.enabled` and
- * `desktop2.execution_telemetry.sample_rate` feature flags.
- *
  * Defensive bounds:
  *   - `promptStartTimes` is capped to avoid leaking when starts and
  *     completions don't pair (e.g. crashes mid-prompt).
@@ -51,12 +48,6 @@ interface TapState {
   tracebackBuffer: string[]
   tracebackChars: number
   tracebackPhase: TracebackPhase
-  // FIFO queue of per-prompt sample decisions (`true` = sampled in, `false` =
-  // sampled out). ComfyUI runs prompts strictly serially, so completions and
-  // errors arrive in the same order their `got prompt` did. Pushed on each
-  // start, shifted on each terminal event so a sampled-out prompt is dropped
-  // consistently across started/completed/error.
-  sampleResults: boolean[]
 }
 
 const TRACEBACK_START = /^Traceback \(most recent call last\):/
@@ -70,17 +61,6 @@ const MAX_TRACEBACK_LINES = 200
 const MAX_TRACEBACK_CHARS = 16 * 1024
 const ERROR_MESSAGE_MAX = 500
 const ERROR_CLASS_MAX = 80
-
-export function isTelemetryEnabled(): boolean {
-  return telemetry.getFlag<boolean>('desktop2.execution_telemetry.enabled', true) === true
-}
-
-function shouldSample(): boolean {
-  const rate = Number(telemetry.getFlag('desktop2.execution_telemetry.sample_rate', 1))
-  if (!Number.isFinite(rate) || rate >= 1) return true
-  if (rate <= 0) return false
-  return Math.random() < rate
-}
 
 export function createExecutionTap(opts: {
   installationId: string
@@ -101,7 +81,6 @@ export function createExecutionTap(opts: {
     tracebackBuffer: [],
     tracebackChars: 0,
     tracebackPhase: 'none',
-    sampleResults: [],
   }
 
   const baseContext = {
@@ -122,17 +101,6 @@ export function createExecutionTap(opts: {
   function consumePromptStart(): number | null {
     const ts = state.promptStartTimes.shift()
     return ts === undefined ? null : Date.now() - ts
-  }
-
-  /**
-   * Pop the matching sample-decision for the current terminal event.
-   * Returns `true` if the prompt was sampled in (or if no decision was
-   * recorded — fail-open so terminal events that arrive before any
-   * `got prompt` was seen are not silently swallowed).
-   */
-  function consumeSampleResult(): boolean {
-    if (state.sampleResults.length === 0) return true
-    return state.sampleResults.shift()!
   }
 
   function emitFirstCompletedIfNeeded(): void {
@@ -174,7 +142,6 @@ export function createExecutionTap(opts: {
     state.errorCount++
     // An error consumes a pending start so wall-clock pairing stays sane.
     consumePromptStart()
-    consumeSampleResult()
     telemetry.emit('desktop2.execution.error', {
       ...baseContext,
       error_class: errorClass.slice(0, ERROR_CLASS_MAX),
@@ -206,14 +173,6 @@ export function createExecutionTap(opts: {
     if (trimmed.length === 0) return
 
     if (PROMPT_GOT.test(trimmed)) {
-      const sampledIn = shouldSample()
-      state.sampleResults.push(sampledIn)
-      // Bound the queue to the same cap as promptStartTimes so a runaway
-      // mismatch can't grow it forever.
-      while (state.sampleResults.length > MAX_PENDING_PROMPTS) {
-        state.sampleResults.shift()
-      }
-      if (!sampledIn) return
       state.startedCount++
       pushPromptStart()
       telemetry.emit('desktop2.execution.started', {
@@ -225,7 +184,6 @@ export function createExecutionTap(opts: {
 
     const doneMatch = trimmed.match(PROMPT_DONE)
     if (doneMatch?.groups) {
-      if (!consumeSampleResult()) return
       const seconds = Number(doneMatch.groups['seconds'])
       const wallMs = consumePromptStart()
       state.completedCount++
@@ -241,7 +199,6 @@ export function createExecutionTap(opts: {
 
     const validationMatch = trimmed.match(VALIDATION_FAIL)
     if (validationMatch?.groups) {
-      if (!consumeSampleResult()) return
       state.errorCount++
       consumePromptStart()
       telemetry.emit('desktop2.execution.error', {
@@ -262,7 +219,6 @@ export function createExecutionTap(opts: {
   }
 
   function handleLine(line: string, source: 'stdout' | 'stderr'): void {
-    if (!isTelemetryEnabled()) return
     const trimmed = line.trim()
 
     // Outside a traceback: dispatch as a normal line.
@@ -308,7 +264,6 @@ export function createExecutionTap(opts: {
       for (const line of lines) handleLine(line, source)
     },
     flushSummary(): void {
-      if (!isTelemetryEnabled()) return
       // Drain any in-flight traceback so we don't drop the error if the
       // process exited before a boundary line arrived.
       if (
@@ -317,8 +272,8 @@ export function createExecutionTap(opts: {
       ) {
         emitTracebackError()
       }
-      // Always emit a per-session summary so analytics has a row even when
-      // no individual events were emitted (e.g. when sample_rate < 1).
+      // Per-session summary so analytics always has a row, even if a session
+      // produced no individual prompt events.
       telemetry.emit('desktop2.execution.session_summary', {
         ...baseContext,
         started_count: state.startedCount,

--- a/src/main/lib/executionTap.ts
+++ b/src/main/lib/executionTap.ts
@@ -7,10 +7,10 @@
  * `proc.stdout` / `proc.stderr` in `sessionActions/launch.ts`.
  *
  * Patterns we detect (current ComfyUI main branch):
- *   - "got prompt"                    → execution started
- *   - "Prompt executed in X.X seconds"→ execution completed (with duration)
- *   - "Failed to validate prompt"     → validation error
- *   - Python tracebacks               → execution error
+ *   - "got prompt"                        → execution started
+ *   - "Prompt executed in X.X seconds"    → execution completed (with duration)
+ *   - "Failed to validate prompt"         → validation error
+ *   - Python tracebacks                   → execution error
  *
  * The per-install `firstRunAt` flag mirrors legacy desktop's once-ever
  * `execution:completed` semantic. It is set on the first successful prompt
@@ -18,21 +18,39 @@
  *
  * All emissions are gated by the `launcher.execution_telemetry.enabled` and
  * `launcher.execution_telemetry.sample_rate` feature flags.
+ *
+ * Defensive bounds:
+ *   - `promptStartTimes` is capped to avoid leaking when starts and
+ *     completions don't pair (e.g. crashes mid-prompt).
+ *   - Traceback collection is bounded both in lines and in buffered chars.
+ *   - Python "chained" tracebacks (`During handling of the above exception, …`)
+ *     emit a single error event using the final exception line.
  */
 import * as installationsApi from '../installations'
 import * as telemetry from './telemetry'
+import { scrubPII } from './piiScrub'
+
+/**
+ * Traceback collection state. We collect until a blank line follows an
+ * exception line, then emit. Chained Python tracebacks (which begin with
+ * `During handling of the above exception, ...` after the inner exception's
+ * blank line) emit as a separate event with their own `error_class` — the
+ * counts are intentionally accurate, not deduped.
+ */
+type TracebackPhase = 'none' | 'collecting'
 
 interface TapState {
   installationId: string
   variant: string | null
   release: string | null
-  promptStartTimes: Date[]
+  promptStartTimes: number[]
   startedCount: number
   completedCount: number
   errorCount: number
   // Buffer for the current stderr traceback (collected line-by-line)
   tracebackBuffer: string[]
-  inTraceback: boolean
+  tracebackChars: number
+  tracebackPhase: TracebackPhase
   // Re-uses one shared sample bucket across started/completed/error so a
   // sampled-out prompt is dropped consistently.
   sampleDropped: number
@@ -42,6 +60,13 @@ const TRACEBACK_START = /^Traceback \(most recent call last\):/
 const PROMPT_GOT = /^got prompt/i
 const PROMPT_DONE = /^Prompt executed in (?<seconds>\d+(?:\.\d+)?)\s*seconds?\s*$/i
 const VALIDATION_FAIL = /^Failed to validate prompt for output (?<nodeId>\S+):/i
+const EXCEPTION_LINE = /^[A-Za-z_][A-Za-z0-9_.]*(?:Error|Exception|Warning|Interrupt)\b/
+
+const MAX_PENDING_PROMPTS = 256
+const MAX_TRACEBACK_LINES = 200
+const MAX_TRACEBACK_CHARS = 16 * 1024
+const ERROR_MESSAGE_MAX = 500
+const ERROR_CLASS_MAX = 80
 
 export function isTelemetryEnabled(): boolean {
   return telemetry.getFlag<boolean>('launcher.execution_telemetry.enabled', true) === true
@@ -71,7 +96,8 @@ export function createExecutionTap(opts: {
     completedCount: 0,
     errorCount: 0,
     tracebackBuffer: [],
-    inTraceback: false,
+    tracebackChars: 0,
+    tracebackPhase: 'none',
     sampleDropped: 0,
   }
 
@@ -79,6 +105,20 @@ export function createExecutionTap(opts: {
     installation_id: state.installationId,
     variant: state.variant,
     release: state.release,
+  }
+
+  function pushPromptStart(): void {
+    state.promptStartTimes.push(Date.now())
+    // Hard cap so a long-running buggy install can't grow this unbounded
+    // when starts and completions don't pair.
+    while (state.promptStartTimes.length > MAX_PENDING_PROMPTS) {
+      state.promptStartTimes.shift()
+    }
+  }
+
+  function consumePromptStart(): number | null {
+    const ts = state.promptStartTimes.shift()
+    return ts === undefined ? null : Date.now() - ts
   }
 
   function emitFirstCompletedIfNeeded(): void {
@@ -99,9 +139,55 @@ export function createExecutionTap(opts: {
     })()
   }
 
-  function handleLine(line: string, source: 'stdout' | 'stderr'): void {
-    if (!isTelemetryEnabled()) return
+  function emitTracebackError(): void {
+    if (state.tracebackBuffer.length === 0) {
+      state.tracebackPhase = 'none'
+      return
+    }
+    // The final exception line is the user-facing error in chained
+    // tracebacks. Walk backwards to find the last line matching
+    // EXCEPTION_LINE.
+    let exceptionLine = state.tracebackBuffer[state.tracebackBuffer.length - 1] || 'unknown'
+    for (let i = state.tracebackBuffer.length - 1; i >= 0; i--) {
+      const candidate = state.tracebackBuffer[i]!
+      if (EXCEPTION_LINE.test(candidate)) {
+        exceptionLine = candidate
+        break
+      }
+    }
+    const errorClass = exceptionLine.split(':')[0]?.trim() || 'unknown'
+    const scrubbedMessage = scrubPII(exceptionLine).slice(0, ERROR_MESSAGE_MAX)
+    state.errorCount++
+    // An error consumes a pending start so wall-clock pairing stays sane.
+    consumePromptStart()
+    telemetry.emit('launcher.execution.error', {
+      ...baseContext,
+      error_class: errorClass.slice(0, ERROR_CLASS_MAX),
+      error_message: scrubbedMessage,
+      error_bucket: telemetry.bucketError(scrubbedMessage),
+      error_count: state.errorCount,
+    })
+    state.tracebackPhase = 'none'
+    state.tracebackBuffer = []
+    state.tracebackChars = 0
+  }
+
+  function appendTracebackLine(line: string): void {
+    state.tracebackBuffer.push(line)
+    state.tracebackChars += line.length + 1
+    // Bounded buffer: if the traceback is pathologically long, force-emit
+    // and reset so we never accumulate forever.
+    if (
+      state.tracebackBuffer.length >= MAX_TRACEBACK_LINES
+      || state.tracebackChars >= MAX_TRACEBACK_CHARS
+    ) {
+      emitTracebackError()
+    }
+  }
+
+  function handleNewLine(line: string, source: 'stdout' | 'stderr'): void {
     const trimmed = line.trim()
+
     if (trimmed.length === 0) return
 
     if (PROMPT_GOT.test(trimmed)) {
@@ -110,7 +196,7 @@ export function createExecutionTap(opts: {
         return
       }
       state.startedCount++
-      state.promptStartTimes.push(new Date())
+      pushPromptStart()
       telemetry.emit('launcher.execution.started', {
         ...baseContext,
         started_count: state.startedCount,
@@ -125,8 +211,7 @@ export function createExecutionTap(opts: {
         return
       }
       const seconds = Number(doneMatch.groups['seconds'])
-      const startedAt = state.promptStartTimes.shift()
-      const wallMs = startedAt ? Date.now() - startedAt.getTime() : null
+      const wallMs = consumePromptStart()
       state.completedCount++
       telemetry.emit('launcher.execution.completed', {
         ...baseContext,
@@ -141,6 +226,7 @@ export function createExecutionTap(opts: {
     const validationMatch = trimmed.match(VALIDATION_FAIL)
     if (validationMatch?.groups) {
       state.errorCount++
+      consumePromptStart()
       telemetry.emit('launcher.execution.error', {
         ...baseContext,
         error_class: 'validation_failed',
@@ -151,30 +237,48 @@ export function createExecutionTap(opts: {
     }
 
     if (source === 'stderr' && TRACEBACK_START.test(trimmed)) {
-      state.inTraceback = true
+      state.tracebackPhase = 'collecting'
       state.tracebackBuffer = [trimmed]
+      state.tracebackChars = trimmed.length + 1
       return
     }
-    if (state.inTraceback) {
-      // Collect until we hit a blank line or a non-indented, non-File line —
-      // ComfyUI tracebacks usually end with the exception class line.
-      state.tracebackBuffer.push(trimmed)
-      const isBoundary = trimmed.length === 0 || /^[A-Za-z_][A-Za-z0-9_.]*Error\b/.test(trimmed) || /^\S+Exception\b/.test(trimmed)
-      if (isBoundary && state.tracebackBuffer.length > 1) {
-        const exceptionLine = state.tracebackBuffer[state.tracebackBuffer.length - 1] || 'unknown'
-        const errorClass = exceptionLine.split(':')[0]?.trim() || 'unknown'
-        state.errorCount++
-        telemetry.emit('launcher.execution.error', {
-          ...baseContext,
-          error_class: errorClass.slice(0, 80),
-          error_message: exceptionLine.slice(0, 500),
-          error_bucket: telemetry.bucketError(exceptionLine),
-          error_count: state.errorCount,
-        })
-        state.inTraceback = false
-        state.tracebackBuffer = []
-      }
+  }
+
+  function handleLine(line: string, source: 'stdout' | 'stderr'): void {
+    if (!isTelemetryEnabled()) return
+    const trimmed = line.trim()
+
+    // Outside a traceback: dispatch as a normal line.
+    if (state.tracebackPhase === 'none') {
+      handleNewLine(line, source)
+      return
     }
+
+    // Blank lines inside a traceback terminate the current frame ONLY if we
+    // already have an exception line. A chained traceback's `During handling
+    // of the above exception, …` marker arrives AFTER the blank line; it
+    // re-enters collection on the very next non-blank line below.
+    if (trimmed.length === 0) {
+      const hasExceptionLine = state.tracebackBuffer.some((l) => EXCEPTION_LINE.test(l))
+      if (hasExceptionLine) {
+        emitTracebackError()
+        return
+      }
+      // Blank line before any exception line — keep collecting.
+      appendTracebackLine(trimmed)
+      return
+    }
+
+    // A chain marker (or a fresh `Traceback (most recent call last):`)
+    // following a just-emitted error re-opens collection — but only if we
+    // are still considered inside a traceback. With blank-line emit above,
+    // by the time we see the chain marker we've already emitted, so it
+    // arrives in `phase === 'none'` and starts a brand-new collection if
+    // it's a TRACEBACK_START. Plain chain markers without a fresh
+    // `Traceback:` header are ignored.
+
+    appendTracebackLine(trimmed)
+    state.tracebackPhase = 'collecting'
   }
 
   const pending: Record<'stdout' | 'stderr', string> = { stdout: '', stderr: '' }
@@ -188,6 +292,14 @@ export function createExecutionTap(opts: {
     },
     flushSummary(): void {
       if (!isTelemetryEnabled()) return
+      // Drain any in-flight traceback so we don't drop the error if the
+      // process exited before a boundary line arrived.
+      if (
+        state.tracebackPhase !== 'none'
+        && state.tracebackBuffer.some((l) => EXCEPTION_LINE.test(l))
+      ) {
+        emitTracebackError()
+      }
       // Always emit a per-session summary so analytics has a row even when
       // no individual events were emitted (e.g. when sample_rate < 1).
       telemetry.emit('launcher.execution.session_summary', {

--- a/src/main/lib/ipc/registerAppHandlers.ts
+++ b/src/main/lib/ipc/registerAppHandlers.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto'
 import {
   ipcMain, dialog, shell, BrowserWindow,
   fs, path, os,
@@ -9,10 +8,10 @@ import {
   listSnapshots, diffSnapshots,
 } from './shared'
 import si from 'systeminformation'
-import { configDir } from '../paths'
 import type { FieldOption } from './shared'
 import { getGpuPromise, setGpuPromise } from './shared'
 import * as mainTelemetry from '../telemetry'
+import { getDeviceId } from '../deviceId'
 
 export function registerAppHandlers(): void {
   // App version
@@ -300,14 +299,5 @@ export function registerAppHandlers(): void {
     return result
   })
 
-  const deviceIdPath = path.join(configDir(), 'device-id.txt')
-  ipcMain.handle('get-device-id', () => {
-    try {
-      const existing = fs.readFileSync(deviceIdPath, 'utf-8').trim()
-      if (existing) return existing
-    } catch {}
-    const id = randomUUID()
-    try { fs.writeFileSync(deviceIdPath, id) } catch {}
-    return id
-  })
+  ipcMain.handle('get-device-id', () => getDeviceId())
 }

--- a/src/main/lib/ipc/registerAppHandlers.ts
+++ b/src/main/lib/ipc/registerAppHandlers.ts
@@ -56,7 +56,7 @@ export function registerAppHandlers(): void {
     const result = await validateHardware()
     // Emit a single event whether hardware passes or fails so we can build
     // funnels like "% of users who hit hardware-not-supported during install".
-    mainTelemetry.emit('launcher.install.validation', {
+    mainTelemetry.emit('desktop2.install.validation', {
       passed: result.supported,
       platform: process.platform,
       arch: process.arch,

--- a/src/main/lib/ipc/registerAppHandlers.ts
+++ b/src/main/lib/ipc/registerAppHandlers.ts
@@ -12,6 +12,7 @@ import si from 'systeminformation'
 import { configDir } from '../paths'
 import type { FieldOption } from './shared'
 import { getGpuPromise, setGpuPromise } from './shared'
+import * as mainTelemetry from '../telemetry'
 
 export function registerAppHandlers(): void {
   // App version
@@ -52,7 +53,18 @@ export function registerAppHandlers(): void {
     return gpuPromise
   })
 
-  ipcMain.handle('validate-hardware', () => validateHardware())
+  ipcMain.handle('validate-hardware', async () => {
+    const result = await validateHardware()
+    // Emit a single event whether hardware passes or fails so we can build
+    // funnels like "% of users who hit hardware-not-supported during install".
+    mainTelemetry.emit('launcher.install.validation', {
+      passed: result.supported,
+      platform: process.platform,
+      arch: process.arch,
+      reason: result.supported ? null : (result.error ?? 'unsupported'),
+    })
+    return result
+  })
   ipcMain.handle('check-nvidia-driver', () => checkNvidiaDriver())
 
   ipcMain.handle('build-installation', (_event, sourceId: string, selections: Record<string, unknown>) => {

--- a/src/main/lib/ipc/registerSettingsHandlers.ts
+++ b/src/main/lib/ipc/registerSettingsHandlers.ts
@@ -5,6 +5,7 @@ import {
   _onLocaleChanged, _broadcastToRenderer,
 } from './shared'
 import { updateTitleBarOverlay } from '../titleBarOverlay'
+import * as mainTelemetry from '../telemetry'
 
 export function registerSettingsHandlers(): void {
   ipcMain.handle('get-settings-sections', () => {
@@ -123,6 +124,7 @@ export function registerSettingsHandlers(): void {
     }
     if (key === 'telemetryEnabled') {
       _broadcastToRenderer('telemetry-setting-changed', value)
+      mainTelemetry.setConsent(value !== false)
     }
   })
 

--- a/src/main/lib/ipc/sessionActions/launch.ts
+++ b/src/main/lib/ipc/sessionActions/launch.ts
@@ -21,6 +21,7 @@ import type { ChildProcess, LaunchCmd } from '../shared'
 import type { ActionContext, ActionResult } from './types'
 import { scrubStderr, lastNLines, stripAnsi } from '../../scrubStderr'
 import { rotateLogFiles, getLogDir } from '../../logRotation'
+import { createExecutionTap } from '../../executionTap'
 import type { WriteStream } from 'fs'
 
 async function openLogStream(installPath: string): Promise<WriteStream> {
@@ -151,6 +152,11 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
     const launchEnv = buildLaunchEnv(inst)
 
     const logStream = await openLogStream(inst.installPath)
+    const execTap = createExecutionTap({
+      installationId,
+      variant: (inst.variant as string | undefined) ?? null,
+      release: (inst.release as string | undefined) ?? null,
+    })
 
     const proc = spawnProcess(launchCmd.cmd!, launchCmd.args!, launchCmd.cwd!, launchEnv, { showWindow: launchCmd.showWindow })
     let stderrBuf = ''
@@ -158,6 +164,7 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
       const text = chunk.toString('utf-8')
       writeLog(logStream, text)
       sendOutput(text)
+      execTap.ingest(text, 'stdout')
     })
     proc.stderr?.on('data', (chunk: Buffer) => {
       const text = chunk.toString('utf-8')
@@ -165,6 +172,7 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
       if (stderrBuf.length > 8192) stderrBuf = stderrBuf.slice(-4096)
       writeLog(logStream, text)
       sendOutput(text)
+      execTap.ingest(text, 'stderr')
     })
 
     _operationAborts.delete(installationId)
@@ -175,6 +183,7 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
       logStream.end()
       const crashed = _runningSessions.has(installationId) && code !== 0
       const lastStderr = scrubStderr(lastNLines(stderrBuf, 100))
+      execTap.flushSummary()
       _removeSession(installationId)
       if (!sender.isDestroyed()) {
         sender.send('comfy-exited', { installationId, crashed, exitCode: code, installationName: inst.name, lastStderr })
@@ -286,6 +295,11 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
   }
 
   const logStream = await openLogStream(inst.installPath)
+  const execTap = createExecutionTap({
+    installationId,
+    variant: (inst.variant as string | undefined) ?? null,
+    release: (inst.release as string | undefined) ?? null,
+  })
 
   function spawnComfy(): { proc: ChildProcess; getStderr: () => string } {
     const p = spawnProcess(launchCmd.cmd!, launchCmd.args!, launchCmd.cwd!, launchEnv, { showWindow: launchCmd.showWindow })
@@ -294,6 +308,7 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
       const text = chunk.toString('utf-8')
       writeLog(logStream, text)
       sendOutput(text)
+      execTap.ingest(text, 'stdout')
     })
     p.stderr!.on('data', (chunk: Buffer) => {
       const text = chunk.toString('utf-8')
@@ -301,6 +316,7 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
       if (stderrBuf.length > 8192) stderrBuf = stderrBuf.slice(-4096)
       writeLog(logStream, text)
       sendOutput(text)
+      execTap.ingest(text, 'stderr')
     })
     return { proc: p, getStderr: () => stderrBuf }
   }
@@ -541,6 +557,7 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
       logStream.end()
       const crashed = _runningSessions.has(installationId)
       const lastStderr = scrubStderr(lastNLines(currentGetStderr(), 100))
+      execTap.flushSummary()
       _removeSession(installationId)
       if (!sender.isDestroyed()) {
         sender.send('comfy-exited', { installationId, crashed, exitCode: code, installationName: inst.name, lastStderr })

--- a/src/main/lib/ipc/sessionActions/migrate.ts
+++ b/src/main/lib/ipc/sessionActions/migrate.ts
@@ -38,7 +38,7 @@ export async function handleMigrateToStandalone({ event, installationId, inst, a
       uniqueName,
       ensureDefaultPrimary,
     }
-    const result = await telemetry.trackedStep('launcher.migrate.flow', flowContext, async () => {
+    const result = await telemetry.trackedStep('desktop2.migrate.flow', flowContext, async () => {
       return inst.sourceId === 'desktop'
         ? performDesktopMigration(actionData, migrationTools, { id: inst.id, name: inst.name })
         : performLocalMigration(inst, actionData, migrationTools)

--- a/src/main/lib/ipc/sessionActions/migrate.ts
+++ b/src/main/lib/ipc/sessionActions/migrate.ts
@@ -8,6 +8,7 @@ import {
 } from '../shared'
 import type { InstallationRecord } from '../shared'
 import type { ActionContext, ActionResult } from './types'
+import * as telemetry from '../../telemetry'
 
 export async function handleMigrateToStandalone({ event, installationId, inst, actionData }: ActionContext): Promise<ActionResult> {
   if (_operationAborts.has(installationId)) {
@@ -21,6 +22,11 @@ export async function handleMigrateToStandalone({ event, installationId, inst, a
   const abort = new AbortController()
   _operationAborts.set(installationId, abort)
 
+  const flowContext = {
+    source_id: inst.sourceId as string,
+    source_installation_id: inst.id,
+  }
+
   let entry: InstallationRecord | null = null
   let destPath = ''
   try {
@@ -32,9 +38,11 @@ export async function handleMigrateToStandalone({ event, installationId, inst, a
       uniqueName,
       ensureDefaultPrimary,
     }
-    const result = inst.sourceId === 'desktop'
-      ? await performDesktopMigration(actionData, migrationTools, { id: inst.id, name: inst.name })
-      : await performLocalMigration(inst, actionData, migrationTools)
+    const result = await telemetry.trackedStep('launcher.migrate.flow', flowContext, async () => {
+      return inst.sourceId === 'desktop'
+        ? performDesktopMigration(actionData, migrationTools, { id: inst.id, name: inst.name })
+        : performLocalMigration(inst, actionData, migrationTools)
+    })
     entry = result.entry
     destPath = result.destPath
 

--- a/src/main/lib/piiScrub.ts
+++ b/src/main/lib/piiScrub.ts
@@ -1,16 +1,30 @@
 /**
- * Best-effort PII scrubbing for telemetry payloads.
+ * Best-effort PII and secret scrubbing for telemetry payloads.
  *
- * Strips usernames out of Windows / macOS / Linux home directory paths so
+ * Strips usernames out of Windows / macOS / Linux home directory paths and
+ * redacts well-known credential shapes (Bearer tokens, OpenAI / Hugging Face
+ * keys, basic-auth in URLs, `*KEY=…` / `*SECRET=…` env-style assignments) so
  * tracebacks and error messages can be safely forwarded to Datadog and
- * PostHog. Centralized so the renderer-bound `forwardDatadogError` and the
- * main-process `executionTap` apply the same rules.
+ * PostHog.
+ *
+ * Centralized so that everything which forwards user-visible text — the
+ * renderer-bound `forwardDatadogError`, the main-process `executionTap`,
+ * and the boot-log scrubber — applies identical rules. Adding a pattern
+ * here updates every call site at once.
  */
 
 const PII_PATH_PATTERNS: RegExp[] = [
-  /([A-Za-z]:[\\/]Users[\\/])[^\\/]+?(?=[\\/]|$)/g,
-  /(\/Users\/)[^\\/]+?(?=\/|$)/g,
-  /(\/home\/)[^\\/]+?(?=\/|$)/g,
+  /([A-Za-z]:[\\/]Users[\\/])[^\\/]+?(?=[\\/]|$)/gi,
+  /(\/Users\/)[^\\/]+?(?=\/|$)/gi,
+  /(\/home\/)[^\\/]+?(?=\/|$)/gi,
+]
+
+const SECRET_REPLACEMENTS: [RegExp, string | ((...args: string[]) => string)][] = [
+  [/sk-[A-Za-z0-9_-]{20,}/g, '[REDACTED]'],
+  [/hf_[A-Za-z0-9]{20,}/g, '[REDACTED]'],
+  [/Bearer\s+[A-Za-z0-9._\-/+]{20,}/g, 'Bearer [REDACTED]'],
+  [/\/\/[^\s@/]*:[^\s@/]*@/g, '//[REDACTED]@'],
+  [/(API_KEY|TOKEN|SECRET|PASSWORD)=[^\s]+/gi, '$1=[REDACTED]'],
 ]
 
 export function scrubPII(value: string): string {
@@ -19,4 +33,21 @@ export function scrubPII(value: string): string {
     scrubbed = scrubbed.replace(pattern, (_match, prefix: string) => `${prefix}[REDACTED]`)
   }
   return scrubbed
+}
+
+export function scrubSecrets(value: string): string {
+  let scrubbed = value
+  for (const [pattern, replacement] of SECRET_REPLACEMENTS) {
+    scrubbed = scrubbed.replace(pattern, replacement as string)
+  }
+  return scrubbed
+}
+
+/**
+ * Apply every scrubber in one pass. Use this for any text leaving the
+ * process boundary (telemetry, error reports, log forwarding) — it is the
+ * single source of truth for "what gets redacted before going off-box".
+ */
+export function scrubAll(value: string): string {
+  return scrubSecrets(scrubPII(value))
 }

--- a/src/main/lib/piiScrub.ts
+++ b/src/main/lib/piiScrub.ts
@@ -1,0 +1,22 @@
+/**
+ * Best-effort PII scrubbing for telemetry payloads.
+ *
+ * Strips usernames out of Windows / macOS / Linux home directory paths so
+ * tracebacks and error messages can be safely forwarded to Datadog and
+ * PostHog. Centralized so the renderer-bound `forwardDatadogError` and the
+ * main-process `executionTap` apply the same rules.
+ */
+
+const PII_PATH_PATTERNS: RegExp[] = [
+  /([A-Za-z]:[\\/]Users[\\/])[^\\/]+?(?=[\\/]|$)/g,
+  /(\/Users\/)[^\\/]+?(?=\/|$)/g,
+  /(\/home\/)[^\\/]+?(?=\/|$)/g,
+]
+
+export function scrubPII(value: string): string {
+  let scrubbed = value
+  for (const pattern of PII_PATH_PATTERNS) {
+    scrubbed = scrubbed.replace(pattern, (_match, prefix: string) => `${prefix}[REDACTED]`)
+  }
+  return scrubbed
+}

--- a/src/main/lib/scrubStderr.ts
+++ b/src/main/lib/scrubStderr.ts
@@ -1,26 +1,7 @@
-const PII_PATH_PATTERNS = [
-  /([A-Za-z]:[\\/]Users[\\/])[^\\/]+?(?=[\\/]|$)/gi,
-  /(\/Users\/)[^\\/]+?(?=\/|$)/gi,
-  /(\/home\/)[^\\/]+?(?=\/|$)/gi,
-]
-
-const SECRET_REPLACEMENTS: [RegExp, string | ((...args: string[]) => string)][] = [
-  [/sk-[A-Za-z0-9_-]{20,}/g, '[REDACTED]'],
-  [/hf_[A-Za-z0-9]{20,}/g, '[REDACTED]'],
-  [/Bearer\s+[A-Za-z0-9._\-/+]{20,}/g, 'Bearer [REDACTED]'],
-  [/\/\/[^\s@/]*:[^\s@/]*@/g, '//[REDACTED]@'],
-  [/(API_KEY|TOKEN|SECRET|PASSWORD)=[^\s]+/gi, '$1=[REDACTED]'],
-]
+import { scrubAll } from './piiScrub'
 
 export function scrubStderr(text: string): string {
-  let scrubbed = text
-  for (const pattern of PII_PATH_PATTERNS) {
-    scrubbed = scrubbed.replace(pattern, (_match, prefix: string) => `${prefix}[REDACTED]`)
-  }
-  for (const [pattern, replacement] of SECRET_REPLACEMENTS) {
-    scrubbed = scrubbed.replace(pattern, replacement as string)
-  }
-  return scrubbed
+  return scrubAll(text)
 }
 
 // eslint-disable-next-line no-control-regex

--- a/src/main/lib/standaloneMigration.ts
+++ b/src/main/lib/standaloneMigration.ts
@@ -19,6 +19,7 @@ import * as i18n from './i18n'
 import type { SourcePlugin, FieldOption } from '../types/sources'
 import type { ComfyVersion } from './version'
 import { assertReadable } from './desktopDetect'
+import * as telemetry from './telemetry'
 
 const MARKER_FILE = '.comfyui-desktop-2'
 
@@ -133,6 +134,7 @@ export async function restoreSnapshotIntoInstallation(
   const freshInst = await installations.get(entry.id)
   if (!freshInst || !fs.existsSync(stagedFile)) return
 
+  const restoreContext = { installation_id: entry.id }
   try {
     const fileContent = await fs.promises.readFile(stagedFile, 'utf-8')
     const importEnvelope = validateExportEnvelope(JSON.parse(fileContent))
@@ -141,16 +143,22 @@ export async function restoreSnapshotIntoInstallation(
 
     // Restore ComfyUI version
     sendOutput('\n── Restore ComfyUI Version ──\n')
-    const comfyResult = await restoreComfyUIVersion(freshInst.installPath, targetSnapshot, sendOutput)
+    const comfyResult = await telemetry.trackedStep('launcher.snapshot.restore_comfyui_version', restoreContext, async () => {
+      return restoreComfyUIVersion(freshInst.installPath, targetSnapshot, sendOutput)
+    })
 
     sendOutput('\n── Restore Nodes ──\n')
-    await restoreCustomNodes(freshInst.installPath, freshInst, targetSnapshot, sendProgress, sendOutput, signal, settings.getMirrorConfig())
+    await telemetry.trackedStep('launcher.snapshot.restore_custom_nodes', restoreContext, async () => {
+      await restoreCustomNodes(freshInst.installPath, freshInst, targetSnapshot, sendProgress, sendOutput, signal, settings.getMirrorConfig())
+    })
 
     if (!signal.aborted && !targetSnapshot.skipPipSync) {
       sendOutput('\n── Restore Packages ──\n')
-      await restorePipPackages(freshInst.installPath, freshInst, targetSnapshot,
-        (phase, data) => sendProgress(phase === 'restore' ? 'restore-pip' : phase, data),
-        sendOutput, signal, settings.getMirrorConfig())
+      await telemetry.trackedStep('launcher.snapshot.restore_pip_packages', restoreContext, async () => {
+        await restorePipPackages(freshInst.installPath, freshInst, targetSnapshot,
+          (phase, data) => sendProgress(phase === 'restore' ? 'restore-pip' : phase, data),
+          sendOutput, signal, settings.getMirrorConfig())
+      })
     }
 
     // Update installation state with restored version/channel metadata
@@ -191,38 +199,46 @@ async function copyMigrationData(
 
   // User data
   if (sourcePaths.userDir && fs.existsSync(sourcePaths.userDir)) {
-    sendProgress('migrate', { percent: 0, status: labels.userData })
-    const dstUserDir = path.join(destComfyUIDir, 'user')
-    await mergeDirFlat(sourcePaths.userDir, dstUserDir, (copied, skipped, fileTotal) => {
-      const pct = fileTotal > 0 ? Math.round(((copied + skipped) / fileTotal) * 30) : 30
-      sendProgress('migrate', { percent: pct, status: labels.userData })
+    await telemetry.trackedStep('launcher.migrate.user_files', {}, async () => {
+      sendProgress('migrate', { percent: 0, status: labels.userData })
+      const dstUserDir = path.join(destComfyUIDir, 'user')
+      await mergeDirFlat(sourcePaths.userDir!, dstUserDir, (copied, skipped, fileTotal) => {
+        const pct = fileTotal > 0 ? Math.round(((copied + skipped) / fileTotal) * 30) : 30
+        sendProgress('migrate', { percent: pct, status: labels.userData })
+      })
     })
   }
 
   // Input
   if (sourcePaths.inputDir && fs.existsSync(sourcePaths.inputDir)) {
-    const dstInput = (settings.get('inputDir') as string | undefined) || settings.defaults.inputDir
-    sendProgress('migrate', { percent: 40, status: labels.input })
-    await mergeDirFlat(sourcePaths.inputDir, dstInput)
+    await telemetry.trackedStep('launcher.migrate.input', {}, async () => {
+      const dstInput = (settings.get('inputDir') as string | undefined) || settings.defaults.inputDir
+      sendProgress('migrate', { percent: 40, status: labels.input })
+      await mergeDirFlat(sourcePaths.inputDir!, dstInput)
+    })
   }
 
   // Output
   if (sourcePaths.outputDir && fs.existsSync(sourcePaths.outputDir)) {
-    const dstOutput = (settings.get('outputDir') as string | undefined) || settings.defaults.outputDir
-    sendProgress('migrate', { percent: 60, status: labels.output })
-    await mergeDirFlat(sourcePaths.outputDir, dstOutput)
+    await telemetry.trackedStep('launcher.migrate.output', {}, async () => {
+      const dstOutput = (settings.get('outputDir') as string | undefined) || settings.defaults.outputDir
+      sendProgress('migrate', { percent: 60, status: labels.output })
+      await mergeDirFlat(sourcePaths.outputDir!, dstOutput)
+    })
   }
 
   // Models — add to shared paths, no copy
   if (sourcePaths.modelsDir) {
-    sendProgress('migrate', { percent: 90, status: labels.models })
-    const resolved = path.resolve(sourcePaths.modelsDir)
-    const currentModelsDirs = (settings.get('modelsDirs') as string[] | undefined) || [...settings.defaults.modelsDirs]
-    const normalizedCurrent = currentModelsDirs.map((d) => path.resolve(d))
-    if (fs.existsSync(resolved) && !normalizedCurrent.includes(resolved)) {
-      currentModelsDirs.push(resolved)
-      settings.set('modelsDirs', currentModelsDirs)
-    }
+    await telemetry.trackedStep('launcher.migrate.models', {}, async () => {
+      sendProgress('migrate', { percent: 90, status: labels.models })
+      const resolved = path.resolve(sourcePaths.modelsDir!)
+      const currentModelsDirs = (settings.get('modelsDirs') as string[] | undefined) || [...settings.defaults.modelsDirs]
+      const normalizedCurrent = currentModelsDirs.map((d) => path.resolve(d))
+      if (fs.existsSync(resolved) && !normalizedCurrent.includes(resolved)) {
+        currentModelsDirs.push(resolved)
+        settings.set('modelsDirs', currentModelsDirs)
+      }
+    })
   }
 
   sendProgress('migrate', { percent: 100, status: i18n.t('common.done') })
@@ -273,11 +289,24 @@ export async function migrateToStandaloneFromSnapshot(
   await fs.promises.writeFile(path.join(destPath, MARKER_FILE), entry.id)
   const cache = createCache(settings.get('cacheDir') as string, settings.get('maxCachedFiles') as number)
   const installRecord = { ...instData, installPath: destPath } as unknown as InstallationRecord
-  await standaloneSource.install!(installRecord, { sendProgress, download, cache, extract, signal })
+
+  const releaseTag = (instData['releaseTag'] as string | undefined) ?? null
+  const variantId = (instData['variantId'] as string | undefined) ?? null
+  const installContext = {
+    installation_id: entry.id,
+    release_tag: releaseTag,
+    variant_id: variantId,
+  }
+
+  await telemetry.trackedStep('launcher.install.standalone', installContext, async () => {
+    await standaloneSource.install!(installRecord, { sendProgress, download, cache, extract, signal })
+  })
 
   const update = (data: Record<string, unknown>): Promise<void> =>
-    installations.update(entry.id, data).then(() => {})
-  await standaloneSource.postInstall!(installRecord, { sendProgress, update })
+    installations.update(entry!.id, data).then(() => {})
+  await telemetry.trackedStep('launcher.install.post_install', installContext, async () => {
+    await standaloneSource.postInstall!(installRecord, { sendProgress, update })
+  })
 
   // 4. Restore snapshot (custom nodes + pip packages)
   await restoreSnapshotIntoInstallation(entry, stagedSnapshot.path, stagedSnapshot.owned, tools, update)

--- a/src/main/lib/standaloneMigration.ts
+++ b/src/main/lib/standaloneMigration.ts
@@ -143,18 +143,18 @@ export async function restoreSnapshotIntoInstallation(
 
     // Restore ComfyUI version
     sendOutput('\n── Restore ComfyUI Version ──\n')
-    const comfyResult = await telemetry.trackedStep('launcher.snapshot.restore_comfyui_version', restoreContext, async () => {
+    const comfyResult = await telemetry.trackedStep('desktop2.snapshot.restore_comfyui_version', restoreContext, async () => {
       return restoreComfyUIVersion(freshInst.installPath, targetSnapshot, sendOutput)
     })
 
     sendOutput('\n── Restore Nodes ──\n')
-    await telemetry.trackedStep('launcher.snapshot.restore_custom_nodes', restoreContext, async () => {
+    await telemetry.trackedStep('desktop2.snapshot.restore_custom_nodes', restoreContext, async () => {
       await restoreCustomNodes(freshInst.installPath, freshInst, targetSnapshot, sendProgress, sendOutput, signal, settings.getMirrorConfig())
     })
 
     if (!signal.aborted && !targetSnapshot.skipPipSync) {
       sendOutput('\n── Restore Packages ──\n')
-      await telemetry.trackedStep('launcher.snapshot.restore_pip_packages', restoreContext, async () => {
+      await telemetry.trackedStep('desktop2.snapshot.restore_pip_packages', restoreContext, async () => {
         await restorePipPackages(freshInst.installPath, freshInst, targetSnapshot,
           (phase, data) => sendProgress(phase === 'restore' ? 'restore-pip' : phase, data),
           sendOutput, signal, settings.getMirrorConfig())
@@ -199,7 +199,7 @@ async function copyMigrationData(
 
   // User data
   if (sourcePaths.userDir && fs.existsSync(sourcePaths.userDir)) {
-    await telemetry.trackedStep('launcher.migrate.user_files', {}, async () => {
+    await telemetry.trackedStep('desktop2.migrate.user_files', {}, async () => {
       sendProgress('migrate', { percent: 0, status: labels.userData })
       const dstUserDir = path.join(destComfyUIDir, 'user')
       await mergeDirFlat(sourcePaths.userDir!, dstUserDir, (copied, skipped, fileTotal) => {
@@ -211,7 +211,7 @@ async function copyMigrationData(
 
   // Input
   if (sourcePaths.inputDir && fs.existsSync(sourcePaths.inputDir)) {
-    await telemetry.trackedStep('launcher.migrate.input', {}, async () => {
+    await telemetry.trackedStep('desktop2.migrate.input', {}, async () => {
       const dstInput = (settings.get('inputDir') as string | undefined) || settings.defaults.inputDir
       sendProgress('migrate', { percent: 40, status: labels.input })
       await mergeDirFlat(sourcePaths.inputDir!, dstInput)
@@ -220,7 +220,7 @@ async function copyMigrationData(
 
   // Output
   if (sourcePaths.outputDir && fs.existsSync(sourcePaths.outputDir)) {
-    await telemetry.trackedStep('launcher.migrate.output', {}, async () => {
+    await telemetry.trackedStep('desktop2.migrate.output', {}, async () => {
       const dstOutput = (settings.get('outputDir') as string | undefined) || settings.defaults.outputDir
       sendProgress('migrate', { percent: 60, status: labels.output })
       await mergeDirFlat(sourcePaths.outputDir!, dstOutput)
@@ -229,7 +229,7 @@ async function copyMigrationData(
 
   // Models — add to shared paths, no copy
   if (sourcePaths.modelsDir) {
-    await telemetry.trackedStep('launcher.migrate.models', {}, async () => {
+    await telemetry.trackedStep('desktop2.migrate.models', {}, async () => {
       sendProgress('migrate', { percent: 90, status: labels.models })
       const resolved = path.resolve(sourcePaths.modelsDir!)
       const currentModelsDirs = (settings.get('modelsDirs') as string[] | undefined) || [...settings.defaults.modelsDirs]
@@ -298,13 +298,13 @@ export async function migrateToStandaloneFromSnapshot(
     variant_id: variantId,
   }
 
-  await telemetry.trackedStep('launcher.install.standalone', installContext, async () => {
+  await telemetry.trackedStep('desktop2.install.standalone', installContext, async () => {
     await standaloneSource.install!(installRecord, { sendProgress, download, cache, extract, signal })
   })
 
   const update = (data: Record<string, unknown>): Promise<void> =>
     installations.update(entry!.id, data).then(() => {})
-  await telemetry.trackedStep('launcher.install.post_install', installContext, async () => {
+  await telemetry.trackedStep('desktop2.install.post_install', installContext, async () => {
     await standaloneSource.postInstall!(installRecord, { sendProgress, update })
   })
 

--- a/src/main/lib/telemetry.test.ts
+++ b/src/main/lib/telemetry.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import os from 'os'
+import path from 'path'
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => path.join(os.tmpdir(), 'launcher-test'),
+    isPackaged: false,
+    on: () => {},
+  },
+  BrowserWindow: { getAllWindows: () => [] },
+}))
+
+interface CapturedCall {
+  distinctId: string
+  event: string
+  properties?: Record<string, unknown>
+}
+const captured: CapturedCall[] = []
+
+vi.mock('posthog-node', () => ({
+  PostHog: class {
+    capture(call: CapturedCall): void {
+      captured.push(call)
+    }
+    identify(): void {}
+    captureException(): void {}
+    flush(): Promise<void> { return Promise.resolve() }
+    shutdown(): Promise<void> { return Promise.resolve() }
+    getFeatureFlag(): Promise<undefined> { return Promise.resolve(undefined) }
+  },
+}))
+
+const telemetry = await import('./telemetry')
+
+describe('telemetry.bucketError', () => {
+  it('classifies cancellation messages', () => {
+    expect(telemetry.bucketError('Operation cancelled by user')).toBe('cancelled')
+  })
+  it('classifies timeouts', () => {
+    expect(telemetry.bucketError('request timeout after 30s')).toBe('timeout')
+  })
+  it('classifies network errors', () => {
+    expect(telemetry.bucketError('fetch failed: network unreachable')).toBe('network')
+  })
+  it('classifies disk-space errors', () => {
+    expect(telemetry.bucketError('No space left on disk')).toBe('disk')
+  })
+  it('classifies permission errors', () => {
+    expect(telemetry.bucketError('permission denied: /var/log')).toBe('permissions')
+  })
+  it('falls back to "other" for unknown messages', () => {
+    expect(telemetry.bucketError('something blew up')).toBe('other')
+  })
+  it('returns "unknown" for empty input', () => {
+    expect(telemetry.bucketError('')).toBe('unknown')
+  })
+  it('accepts Error instances', () => {
+    expect(telemetry.bucketError(new Error('connection timeout'))).toBe('timeout')
+  })
+})
+
+describe('telemetry.trackedStep', () => {
+  beforeEach(async () => {
+    captured.length = 0
+    process.env['POSTHOG_API_KEY'] = 'test-key'
+    process.env['POSTHOG_ENABLED'] = '1'
+    telemetry.initTelemetry({ appVersion: '0.0.0', appEnv: 'test', isPackaged: false })
+    await telemetry.identify('test-distinct-id')
+    telemetry.setConsent(true)
+  })
+
+  afterEach(() => {
+    delete process.env['POSTHOG_API_KEY']
+    delete process.env['POSTHOG_ENABLED']
+    vi.restoreAllMocks()
+  })
+
+  it('emits .start and .end with duration_ms on success', async () => {
+    captured.length = 0
+    const result = await telemetry.trackedStep('test.step', { foo: 'bar' }, async () => 42)
+    expect(result).toBe(42)
+    const events = captured.map((c) => c.event)
+    expect(events).toEqual(['test.step.start', 'test.step.end'])
+    expect(captured[0]!.properties).toEqual({ foo: 'bar' })
+    expect(typeof captured[1]!.properties?.duration_ms).toBe('number')
+    expect(captured[1]!.properties?.foo).toBe('bar')
+  })
+
+  it('emits .start and .error on failure and rethrows', async () => {
+    captured.length = 0
+    await expect(
+      telemetry.trackedStep('install.step', { id: 'x' }, async () => {
+        throw new Error('disk full')
+      }),
+    ).rejects.toThrow('disk full')
+    const events = captured.map((c) => c.event)
+    expect(events).toEqual(['install.step.start', 'install.step.error'])
+    expect(captured[1]!.properties).toMatchObject({
+      id: 'x',
+      error_bucket: 'disk',
+      error_message: 'disk full',
+    })
+    expect(typeof captured[1]!.properties?.duration_ms).toBe('number')
+  })
+
+  it('respects consent: capture is skipped when consent is revoked', async () => {
+    telemetry.setConsent(false)
+    captured.length = 0
+    await telemetry.trackedStep('test.step', {}, async () => 'ok')
+    expect(captured).toHaveLength(0)
+    telemetry.setConsent(true)
+  })
+})

--- a/src/main/lib/telemetry.ts
+++ b/src/main/lib/telemetry.ts
@@ -1,0 +1,340 @@
+/**
+ * Main-process telemetry for the launcher.
+ *
+ * Co-exists with the renderer-side Datadog RUM + PostHog JS pipelines.
+ * Responsibilities:
+ *   - PostHog Node SDK lifecycle (init, identify, shutdown flush on quit)
+ *   - Capture of events that occur outside the renderer's reach:
+ *       * app lifecycle (start/quit) with uptime
+ *       * pre-install / installation pipeline sub-steps
+ *       * migration pipeline sub-steps
+ *       * execution events parsed from ComfyUI's stdout
+ *   - A `trackedStep()` helper mirroring legacy desktop's `@trackEvent` decorator
+ *     pattern (`<step>.start` / `<step>.end` / `<step>.error`)
+ *   - Feature-flag bootstrap with on-disk cache so the launcher works offline
+ *
+ * The renderer continues to be the primary telemetry funnel for UI events;
+ * this module exists for the things the renderer cannot see.
+ */
+import { app, BrowserWindow } from 'electron'
+import path from 'path'
+import { PostHog } from 'posthog-node'
+import { configDir } from './paths'
+import { readFileSafe, writeFileSafe } from './safe-file'
+
+export type TelemetryValue = boolean | number | string | null | undefined
+export type TelemetryContext = Record<string, TelemetryValue | TelemetryValue[]>
+
+interface PostHogConfig {
+  apiKey: string
+  host: string
+  enabled: boolean
+}
+
+const DEFAULT_POSTHOG_HOST = 'https://us.i.posthog.com'
+
+function isFlagDisabled(value: string | undefined): boolean {
+  return ['0', 'false', 'off'].includes((value || '').trim().toLowerCase())
+}
+
+function readPostHogConfig(): PostHogConfig {
+  const apiKey = (process.env['POSTHOG_API_KEY'] || '').trim()
+  const host = (process.env['POSTHOG_HOST'] || DEFAULT_POSTHOG_HOST).trim()
+  const enabled = !isFlagDisabled(process.env['POSTHOG_ENABLED']) && apiKey.length > 0
+  return { apiKey, host, enabled }
+}
+
+let client: PostHog | null = null
+let distinctId: string | null = null
+let consentEnabled = true
+let bootstrapTimeMs: number = Date.now()
+let initialized = false
+
+// Feature flags fetched from PostHog at init, cached on disk for offline use
+const FLAG_CACHE_FILE = 'telemetry-flags.json'
+const flagDefaults: Record<string, boolean | string | number> = {
+  // Master kill switch for log-based execution telemetry
+  'launcher.execution_telemetry.enabled': true,
+  // 0..1 sampling applied to per-prompt execution events
+  'launcher.execution_telemetry.sample_rate': 1,
+  // Comma-separated list of event names to silence at the SDK level
+  'launcher.disabled_events': '',
+  // Kill switch for posthog session recording (renderer-only flag, exposed here for parity)
+  'launcher.session_replay.enabled': false,
+  // Maximum chars of ComfyUI boot stderr forwarded with launcher.comfyui.boot_log
+  'launcher.boot_log_max_chars': 8192,
+}
+let flagsCache: Record<string, unknown> = { ...flagDefaults }
+
+function flagCachePath(): string {
+  return path.join(configDir(), FLAG_CACHE_FILE)
+}
+
+function loadCachedFlags(): void {
+  try {
+    const raw = readFileSafe(flagCachePath())
+    if (!raw) return
+    const parsed = JSON.parse(raw) as Record<string, unknown>
+    flagsCache = { ...flagDefaults, ...parsed }
+  } catch {
+    // ignore – fall through to defaults
+  }
+}
+
+function persistFlags(values: Record<string, unknown>): void {
+  try {
+    writeFileSafe(flagCachePath(), JSON.stringify(values, null, 2))
+  } catch {
+    // ignore
+  }
+}
+
+export function getFlag<T = unknown>(name: string, fallback?: T): T {
+  if (Object.prototype.hasOwnProperty.call(flagsCache, name)) {
+    return flagsCache[name] as T
+  }
+  if (Object.prototype.hasOwnProperty.call(flagDefaults, name)) {
+    return flagDefaults[name] as T
+  }
+  return fallback as T
+}
+
+function disabledEventNames(): Set<string> {
+  const raw = String(getFlag('launcher.disabled_events', '') || '')
+  return new Set(raw.split(',').map((s) => s.trim()).filter(Boolean))
+}
+
+function isEventEnabled(name: string): boolean {
+  if (!consentEnabled) return false
+  return !disabledEventNames().has(name)
+}
+
+export function setConsent(enabled: boolean): void {
+  consentEnabled = enabled
+  if (!enabled) {
+    // Best-effort flush so already-queued events still go out
+    void client?.flush().catch(() => {})
+  }
+}
+
+export function isInitialized(): boolean {
+  return initialized && client !== null
+}
+
+export interface InitOptions {
+  appVersion: string
+  appEnv: string
+  isPackaged: boolean
+}
+
+/**
+ * Initialize PostHog Node. Safe to call before consent decision is known —
+ * events are queued by setConsent(false) and dropped at capture time.
+ */
+export function initTelemetry(opts: InitOptions): void {
+  if (initialized) return
+  initialized = true
+  bootstrapTimeMs = Date.now()
+  loadCachedFlags()
+
+  const cfg = readPostHogConfig()
+  if (!cfg.enabled) return
+
+  try {
+    client = new PostHog(cfg.apiKey, {
+      host: cfg.host,
+      flushAt: 20,
+      flushInterval: 10_000,
+    })
+  } catch {
+    client = null
+    return
+  }
+
+  // Best-effort: refresh feature flags in the background; cached values
+  // remain in use while the request is in flight.
+  if (distinctId) {
+    refreshFlags(opts).catch(() => {})
+  }
+
+  capture('launcher.session.started', {
+    app_env: opts.appEnv,
+    app_version: opts.appVersion,
+    is_packaged: opts.isPackaged,
+  })
+}
+
+/**
+ * Bind the persistent device id once it is known and refresh feature flags.
+ */
+export async function identify(
+  id: string,
+  properties: Record<string, TelemetryValue> = {},
+  opts?: InitOptions,
+): Promise<void> {
+  distinctId = id
+  if (!client) return
+  try {
+    client.identify({ distinctId: id, properties: { $set: properties } })
+  } catch {
+    // ignore
+  }
+  if (opts) {
+    await refreshFlags(opts).catch(() => {})
+  }
+}
+
+async function refreshFlags(opts: InitOptions): Promise<void> {
+  if (!client || !distinctId) return
+  const merged: Record<string, unknown> = { ...flagDefaults }
+  for (const flagName of Object.keys(flagDefaults)) {
+    try {
+      const value = await client.getFeatureFlag(flagName, distinctId, {
+        personProperties: {
+          app_env: opts.appEnv,
+          app_version: opts.appVersion,
+        },
+      })
+      if (value !== undefined && value !== null) {
+        merged[flagName] = value
+      }
+    } catch {
+      // keep default for this flag
+    }
+  }
+  flagsCache = merged
+  persistFlags(merged)
+}
+
+export function capture(event: string, properties: TelemetryContext = {}): void {
+  if (!client || !distinctId) return
+  if (!isEventEnabled(event)) return
+  try {
+    client.capture({ distinctId, event, properties })
+  } catch {
+    // ignore – telemetry must never break the app
+  }
+}
+
+export function captureException(error: unknown, properties: TelemetryContext = {}): void {
+  if (!client || !distinctId) return
+  if (!consentEnabled) return
+  try {
+    client.captureException(error, distinctId, properties)
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Wrap an async step with start/end/error telemetry events that mirror legacy
+ * desktop's `@trackEvent` decorator. Errors are re-thrown so callers can
+ * continue normal control flow.
+ */
+export async function trackedStep<T>(
+  step: string,
+  context: TelemetryContext,
+  fn: () => Promise<T>,
+): Promise<T> {
+  capture(`${step}.start`, context)
+  const t0 = Date.now()
+  try {
+    const result = await fn()
+    capture(`${step}.end`, { ...context, duration_ms: Date.now() - t0 })
+    return result
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    capture(`${step}.error`, {
+      ...context,
+      duration_ms: Date.now() - t0,
+      error_bucket: bucketError(message),
+      error_message: message.slice(0, 500),
+    })
+    throw err
+  }
+}
+
+/**
+ * Coarse error categorisation that matches the renderer-side `toErrorBucket`.
+ * Kept in sync manually – when adding categories, update both.
+ */
+export function bucketError(input: unknown): string {
+  const message = (
+    input instanceof Error ? input.message : typeof input === 'string' ? input : ''
+  ).toLowerCase()
+  if (!message) return 'unknown'
+  if (message.includes('cancel')) return 'cancelled'
+  if (message.includes('timeout')) return 'timeout'
+  if (message.includes('network') || message.includes('fetch')) return 'network'
+  if (message.includes('disk') || message.includes('space')) return 'disk'
+  if (message.includes('permission') || message.includes('access')) return 'permissions'
+  if (message.includes('path')) return 'path'
+  return 'other'
+}
+
+/**
+ * Forward an event to the renderer so it can fan out to PostHog JS + Datadog.
+ * Use this for events that should appear in both providers (most do).
+ */
+export function forwardToRenderer(event: string, context: TelemetryContext = {}): void {
+  if (!isEventEnabled(event)) return
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed()) {
+      try {
+        win.webContents.send('telemetry-action-from-main', { event, context })
+      } catch {
+        // ignore
+      }
+    }
+  }
+}
+
+/**
+ * Capture an event and forward it to the renderer in one call.
+ */
+export function emit(event: string, context: TelemetryContext = {}): void {
+  capture(event, context)
+  forwardToRenderer(event, context)
+}
+
+/**
+ * Drain queued events. Safe to await during `app.before-quit`.
+ */
+export async function shutdown(reason: string): Promise<void> {
+  if (!client) return
+  const uptimeMs = Date.now() - bootstrapTimeMs
+  try {
+    capture('launcher.session.ended', {
+      reason,
+      uptime_ms: uptimeMs,
+      uptime_seconds: Math.round(uptimeMs / 1000),
+    })
+  } catch {
+    // ignore
+  }
+  try {
+    await client.shutdown()
+  } catch {
+    // ignore
+  } finally {
+    client = null
+    initialized = false
+  }
+}
+
+let beforeQuitHooked = false
+
+/**
+ * Wire `app.before-quit` so PostHog drains its queue before the process exits.
+ * Safe to call multiple times – the hook only attaches once.
+ */
+export function installAppHooks(): void {
+  if (beforeQuitHooked) return
+  beforeQuitHooked = true
+  app.on('before-quit', () => {
+    // Detach: we'll let the queued shutdown event ship before exit. We
+    // intentionally don't await here; PostHog Node's shutdown flushes via
+    // the Node event loop and we cap waiting via internal timeouts.
+    void shutdown('quit')
+  })
+}

--- a/src/main/lib/telemetry.ts
+++ b/src/main/lib/telemetry.ts
@@ -50,15 +50,15 @@ let initialized = false
 const FLAG_CACHE_FILE = 'telemetry-flags.json'
 const flagDefaults: Record<string, boolean | string | number> = {
   // Master kill switch for log-based execution telemetry
-  'launcher.execution_telemetry.enabled': true,
+  'desktop2.execution_telemetry.enabled': true,
   // 0..1 sampling applied to per-prompt execution events
-  'launcher.execution_telemetry.sample_rate': 1,
+  'desktop2.execution_telemetry.sample_rate': 1,
   // Comma-separated list of event names to silence at the SDK level
-  'launcher.disabled_events': '',
+  'desktop2.disabled_events': '',
   // Kill switch for posthog session recording (renderer-only flag, exposed here for parity)
-  'launcher.session_replay.enabled': false,
-  // Maximum chars of ComfyUI boot stderr forwarded with launcher.comfyui.boot_log
-  'launcher.boot_log_max_chars': 8192,
+  'desktop2.session_replay.enabled': false,
+  // Maximum chars of ComfyUI boot stderr forwarded with desktop2.comfyui.boot_log
+  'desktop2.boot_log_max_chars': 8192,
 }
 let flagsCache: Record<string, unknown> = { ...flagDefaults }
 
@@ -96,7 +96,7 @@ export function getFlag<T = unknown>(name: string, fallback?: T): T {
 }
 
 function disabledEventNames(): Set<string> {
-  const raw = String(getFlag('launcher.disabled_events', '') || '')
+  const raw = String(getFlag('desktop2.disabled_events', '') || '')
   return new Set(raw.split(',').map((s) => s.trim()).filter(Boolean))
 }
 
@@ -130,7 +130,7 @@ export interface InitOptions {
  * Note: the session-start event is intentionally NOT emitted here. The
  * `distinctId` is unknown until `identify()` runs, and emitting before the
  * first feature-flag refresh would ignore a remotely configured
- * `launcher.disabled_events` allow/block list. `identify()` issues the
+ * `desktop2.disabled_events` allow/block list. `identify()` issues the
  * session-start event after flags are bootstrapped.
  */
 export function initTelemetry(opts: InitOptions): void {
@@ -193,7 +193,7 @@ export async function identify(
     await Promise.race([refresh, timeout])
   }
   if (pendingSessionStart) {
-    capture('launcher.session.started', pendingSessionStart)
+    capture('desktop2.session.started', pendingSessionStart)
     pendingSessionStart = null
   }
 }
@@ -318,7 +318,7 @@ export async function shutdown(reason: string): Promise<void> {
   if (!client) return
   const uptimeMs = Date.now() - bootstrapTimeMs
   try {
-    capture('launcher.session.ended', {
+    capture('desktop2.session.ended', {
       reason,
       uptime_ms: uptimeMs,
       uptime_seconds: Math.round(uptimeMs / 1000),

--- a/src/main/lib/telemetry.ts
+++ b/src/main/lib/telemetry.ts
@@ -21,6 +21,7 @@ import path from 'path'
 import { PostHog } from 'posthog-node'
 import { configDir } from './paths'
 import { readFileSafe, writeFileSafe } from './safe-file'
+import { DEFAULT_POSTHOG_API_KEY, DEFAULT_POSTHOG_HOST, isPostHogFlagDisabled as isFlagDisabled } from '../../shared/posthogConfig'
 
 export type TelemetryValue = boolean | number | string | null | undefined
 export type TelemetryContext = Record<string, TelemetryValue | TelemetryValue[]>
@@ -31,14 +32,9 @@ interface PostHogConfig {
   enabled: boolean
 }
 
-const DEFAULT_POSTHOG_HOST = 'https://us.i.posthog.com'
-
-function isFlagDisabled(value: string | undefined): boolean {
-  return ['0', 'false', 'off'].includes((value || '').trim().toLowerCase())
-}
 
 function readPostHogConfig(): PostHogConfig {
-  const apiKey = (process.env['POSTHOG_API_KEY'] || '').trim()
+  const apiKey = (process.env['POSTHOG_API_KEY'] || DEFAULT_POSTHOG_API_KEY).trim()
   const host = (process.env['POSTHOG_HOST'] || DEFAULT_POSTHOG_HOST).trim()
   const enabled = !isFlagDisabled(process.env['POSTHOG_ENABLED']) && apiKey.length > 0
   return { apiKey, host, enabled }

--- a/src/main/lib/telemetry.ts
+++ b/src/main/lib/telemetry.ts
@@ -11,16 +11,17 @@
  *       * execution events parsed from ComfyUI's stdout
  *   - A `trackedStep()` helper mirroring legacy desktop's `@trackEvent` decorator
  *     pattern (`<step>.start` / `<step>.end` / `<step>.error`)
- *   - Feature-flag bootstrap with on-disk cache so the launcher works offline
  *
  * The renderer continues to be the primary telemetry funnel for UI events;
  * this module exists for the things the renderer cannot see.
+ *
+ * NOTE: There is intentionally no remote feature-flag system. We initially
+ * shipped one with a few kill switches and a sample-rate dial, but the
+ * launcher has no live use for them and the bootstrap/cache machinery
+ * complicates startup. Reintroduce only if a concrete need appears.
  */
 import { app, BrowserWindow } from 'electron'
-import path from 'path'
 import { PostHog } from 'posthog-node'
-import { configDir } from './paths'
-import { readFileSafe, writeFileSafe } from './safe-file'
 import { DEFAULT_POSTHOG_API_KEY, DEFAULT_POSTHOG_HOST, isPostHogFlagDisabled as isFlagDisabled } from '../../shared/posthogConfig'
 
 export type TelemetryValue = boolean | number | string | null | undefined
@@ -46,61 +47,8 @@ let consentEnabled = true
 let bootstrapTimeMs: number = Date.now()
 let initialized = false
 
-// Feature flags fetched from PostHog at init, cached on disk for offline use
-const FLAG_CACHE_FILE = 'telemetry-flags.json'
-const flagDefaults: Record<string, boolean | string | number> = {
-  // Master kill switch for log-based execution telemetry
-  'desktop2.execution_telemetry.enabled': true,
-  // 0..1 sampling applied to per-prompt execution events
-  'desktop2.execution_telemetry.sample_rate': 1,
-  // Comma-separated list of event names to silence at the SDK level
-  'desktop2.disabled_events': '',
-  // Maximum chars of ComfyUI boot stderr forwarded with desktop2.comfyui.boot_log
-  'desktop2.boot_log_max_chars': 8192,
-}
-let flagsCache: Record<string, unknown> = { ...flagDefaults }
-
-function flagCachePath(): string {
-  return path.join(configDir(), FLAG_CACHE_FILE)
-}
-
-function loadCachedFlags(): void {
-  try {
-    const raw = readFileSafe(flagCachePath())
-    if (!raw) return
-    const parsed = JSON.parse(raw) as Record<string, unknown>
-    flagsCache = { ...flagDefaults, ...parsed }
-  } catch {
-    // ignore – fall through to defaults
-  }
-}
-
-function persistFlags(values: Record<string, unknown>): void {
-  try {
-    writeFileSafe(flagCachePath(), JSON.stringify(values, null, 2))
-  } catch {
-    // ignore
-  }
-}
-
-export function getFlag<T = unknown>(name: string, fallback?: T): T {
-  if (Object.prototype.hasOwnProperty.call(flagsCache, name)) {
-    return flagsCache[name] as T
-  }
-  if (Object.prototype.hasOwnProperty.call(flagDefaults, name)) {
-    return flagDefaults[name] as T
-  }
-  return fallback as T
-}
-
-function disabledEventNames(): Set<string> {
-  const raw = String(getFlag('desktop2.disabled_events', '') || '')
-  return new Set(raw.split(',').map((s) => s.trim()).filter(Boolean))
-}
-
-function isEventEnabled(name: string): boolean {
-  if (!consentEnabled) return false
-  return !disabledEventNames().has(name)
+function isEventEnabled(_name: string): boolean {
+  return consentEnabled
 }
 
 export function setConsent(enabled: boolean): void {
@@ -125,17 +73,14 @@ export interface InitOptions {
  * Initialize PostHog Node. Safe to call before consent decision is known —
  * events are queued by setConsent(false) and dropped at capture time.
  *
- * Note: the session-start event is intentionally NOT emitted here. The
- * `distinctId` is unknown until `identify()` runs, and emitting before the
- * first feature-flag refresh would ignore a remotely configured
- * `desktop2.disabled_events` allow/block list. `identify()` issues the
- * session-start event after flags are bootstrapped.
+ * Note: the session-start event is intentionally NOT emitted here — the
+ * `distinctId` is unknown until `identify()` runs. `identify()` issues
+ * the session-start event once the device id is bound.
  */
 export function initTelemetry(opts: InitOptions): void {
   if (initialized) return
   initialized = true
   bootstrapTimeMs = Date.now()
-  loadCachedFlags()
 
   const cfg = readPostHogConfig()
   if (!cfg.enabled) return
@@ -161,23 +106,13 @@ export function initTelemetry(opts: InitOptions): void {
 let pendingSessionStart: Record<string, TelemetryValue> | null = null
 
 /**
- * Maximum time we'll wait for the first feature-flag fetch to complete
- * before letting startup events through with cached/default flag values.
+ * Bind the persistent device id once it is known. Emits the deferred
+ * session-start event with the now-known distinctId.
  */
-const FLAG_BOOTSTRAP_TIMEOUT_MS = 1500
-
-/**
- * Bind the persistent device id once it is known and refresh feature flags.
- *
- * If `opts` is provided, we await the flag refresh (with a short timeout)
- * before emitting the deferred session-start event so that remotely
- * configured event suppressions take effect on the very first event.
- */
-export async function identify(
+export function identify(
   id: string,
   properties: Record<string, TelemetryValue> = {},
-  opts?: InitOptions,
-): Promise<void> {
+): void {
   distinctId = id
   if (!client) return
   try {
@@ -185,37 +120,10 @@ export async function identify(
   } catch {
     // ignore
   }
-  if (opts) {
-    const refresh = refreshFlags(opts).catch(() => {})
-    const timeout = new Promise<void>((resolve) => setTimeout(resolve, FLAG_BOOTSTRAP_TIMEOUT_MS))
-    await Promise.race([refresh, timeout])
-  }
   if (pendingSessionStart) {
     capture('desktop2.session.started', pendingSessionStart)
     pendingSessionStart = null
   }
-}
-
-async function refreshFlags(opts: InitOptions): Promise<void> {
-  if (!client || !distinctId) return
-  const merged: Record<string, unknown> = { ...flagDefaults }
-  for (const flagName of Object.keys(flagDefaults)) {
-    try {
-      const value = await client.getFeatureFlag(flagName, distinctId, {
-        personProperties: {
-          app_env: opts.appEnv,
-          app_version: opts.appVersion,
-        },
-      })
-      if (value !== undefined && value !== null) {
-        merged[flagName] = value
-      }
-    } catch {
-      // keep default for this flag
-    }
-  }
-  flagsCache = merged
-  persistFlags(merged)
 }
 
 export function capture(event: string, properties: TelemetryContext = {}): void {

--- a/src/main/lib/telemetry.ts
+++ b/src/main/lib/telemetry.ts
@@ -55,8 +55,6 @@ const flagDefaults: Record<string, boolean | string | number> = {
   'desktop2.execution_telemetry.sample_rate': 1,
   // Comma-separated list of event names to silence at the SDK level
   'desktop2.disabled_events': '',
-  // Kill switch for posthog session recording (renderer-only flag, exposed here for parity)
-  'desktop2.session_replay.enabled': false,
   // Maximum chars of ComfyUI boot stderr forwarded with desktop2.comfyui.boot_log
   'desktop2.boot_log_max_chars': 8192,
 }

--- a/src/main/lib/telemetry.ts
+++ b/src/main/lib/telemetry.ts
@@ -47,10 +47,6 @@ let consentEnabled = true
 let bootstrapTimeMs: number = Date.now()
 let initialized = false
 
-function isEventEnabled(_name: string): boolean {
-  return consentEnabled
-}
-
 export function setConsent(enabled: boolean): void {
   consentEnabled = enabled
   if (!enabled) {
@@ -128,7 +124,7 @@ export function identify(
 
 export function capture(event: string, properties: TelemetryContext = {}): void {
   if (!client || !distinctId) return
-  if (!isEventEnabled(event)) return
+  if (!consentEnabled) return
   try {
     client.capture({ distinctId, event, properties })
   } catch {
@@ -197,7 +193,7 @@ export function bucketError(input: unknown): string {
  * Use this for events that should appear in both providers (most do).
  */
 export function forwardToRenderer(event: string, context: TelemetryContext = {}): void {
-  if (!isEventEnabled(event)) return
+  if (!consentEnabled) return
   for (const win of BrowserWindow.getAllWindows()) {
     if (!win.isDestroyed()) {
       try {

--- a/src/main/lib/telemetry.ts
+++ b/src/main/lib/telemetry.ts
@@ -130,6 +130,12 @@ export interface InitOptions {
 /**
  * Initialize PostHog Node. Safe to call before consent decision is known —
  * events are queued by setConsent(false) and dropped at capture time.
+ *
+ * Note: the session-start event is intentionally NOT emitted here. The
+ * `distinctId` is unknown until `identify()` runs, and emitting before the
+ * first feature-flag refresh would ignore a remotely configured
+ * `launcher.disabled_events` allow/block list. `identify()` issues the
+ * session-start event after flags are bootstrapped.
  */
 export function initTelemetry(opts: InitOptions): void {
   if (initialized) return
@@ -148,24 +154,30 @@ export function initTelemetry(opts: InitOptions): void {
     })
   } catch {
     client = null
-    return
   }
 
-  // Best-effort: refresh feature flags in the background; cached values
-  // remain in use while the request is in flight.
-  if (distinctId) {
-    refreshFlags(opts).catch(() => {})
-  }
-
-  capture('launcher.session.started', {
+  // Stash session-start parameters until identify() can attribute them.
+  pendingSessionStart = {
     app_env: opts.appEnv,
     app_version: opts.appVersion,
     is_packaged: opts.isPackaged,
-  })
+  }
 }
+
+let pendingSessionStart: Record<string, TelemetryValue> | null = null
+
+/**
+ * Maximum time we'll wait for the first feature-flag fetch to complete
+ * before letting startup events through with cached/default flag values.
+ */
+const FLAG_BOOTSTRAP_TIMEOUT_MS = 1500
 
 /**
  * Bind the persistent device id once it is known and refresh feature flags.
+ *
+ * If `opts` is provided, we await the flag refresh (with a short timeout)
+ * before emitting the deferred session-start event so that remotely
+ * configured event suppressions take effect on the very first event.
  */
 export async function identify(
   id: string,
@@ -180,7 +192,13 @@ export async function identify(
     // ignore
   }
   if (opts) {
-    await refreshFlags(opts).catch(() => {})
+    const refresh = refreshFlags(opts).catch(() => {})
+    const timeout = new Promise<void>((resolve) => setTimeout(resolve, FLAG_BOOTSTRAP_TIMEOUT_MS))
+    await Promise.race([refresh, timeout])
+  }
+  if (pendingSessionStart) {
+    capture('launcher.session.started', pendingSessionStart)
+    pendingSessionStart = null
   }
 }
 
@@ -323,18 +341,38 @@ export async function shutdown(reason: string): Promise<void> {
 }
 
 let beforeQuitHooked = false
+let drainingForQuit = false
+
+/**
+ * Maximum time we'll block the quit on draining queued PostHog events.
+ * If the network is slow / down, we still want the app to exit promptly.
+ */
+const SHUTDOWN_DRAIN_TIMEOUT_MS = 1500
 
 /**
  * Wire `app.before-quit` so PostHog drains its queue before the process exits.
+ *
+ * Electron does NOT await async listeners on `before-quit`, so we use the
+ * standard pattern of calling `event.preventDefault()`, awaiting the
+ * shutdown, then re-issuing `app.exit()`. A one-shot guard prevents the
+ * subsequent quit from re-entering this branch.
+ *
  * Safe to call multiple times – the hook only attaches once.
  */
 export function installAppHooks(): void {
   if (beforeQuitHooked) return
   beforeQuitHooked = true
-  app.on('before-quit', () => {
-    // Detach: we'll let the queued shutdown event ship before exit. We
-    // intentionally don't await here; PostHog Node's shutdown flushes via
-    // the Node event loop and we cap waiting via internal timeouts.
-    void shutdown('quit')
+
+  app.on('before-quit', (event) => {
+    if (drainingForQuit || !client) return
+    drainingForQuit = true
+    event.preventDefault()
+    const drainPromise = shutdown('quit').catch(() => {})
+    const timeoutPromise = new Promise<void>((resolve) =>
+      setTimeout(resolve, SHUTDOWN_DRAIN_TIMEOUT_MS),
+    )
+    void Promise.race([drainPromise, timeoutPromise]).finally(() => {
+      app.exit(0)
+    })
   })
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -234,6 +234,11 @@ const api: ElectronApi = {
     ipcRenderer.on('dd-error', handler)
     return () => ipcRenderer.removeListener('dd-error', handler)
   },
+  onTelemetryActionFromMain: (callback) => {
+    const handler = (_event: IpcRendererEvent, data: unknown) => callback(data as Parameters<typeof callback>[0])
+    ipcRenderer.on('telemetry-action-from-main', handler)
+    return () => ipcRenderer.removeListener('telemetry-action-from-main', handler)
+  },
   onErrorDetail: (callback) => {
     const handler = (_event: IpcRendererEvent, data: unknown) => callback(data as Parameters<typeof callback>[0])
     ipcRenderer.on('error-detail', handler)

--- a/src/renderer/csp.test.ts
+++ b/src/renderer/csp.test.ts
@@ -29,6 +29,14 @@ describe('Content-Security-Policy', () => {
     expect(csp['connect-src']).toContain('https://browser-intake-us5-datadoghq.com')
   })
 
+  it('allows PostHog telemetry endpoints in connect-src', () => {
+    expect(csp['connect-src']).toContain('https://*.posthog.com')
+  })
+
+  it('allows PostHog avatar/feature-flag images', () => {
+    expect(csp['img-src']).toContain('https://*.posthog.com')
+  })
+
   it('restricts script-src to self only', () => {
     expect(csp['script-src']).toBe("'self'")
   })

--- a/src/renderer/csp.test.ts
+++ b/src/renderer/csp.test.ts
@@ -37,11 +37,18 @@ describe('Content-Security-Policy', () => {
     expect(csp['img-src']).toContain('https://*.posthog.com')
   })
 
-  it('restricts script-src to self only', () => {
-    expect(csp['script-src']).toBe("'self'")
+  it('restricts script-src to self plus PostHog session-recorder host', () => {
+    // PostHog's session recording lazy-loads recorder.js from posthog.com,
+    // so we allow that single origin. No other remote scripts are allowed.
+    expect(csp['script-src']).toBe("'self' https://*.posthog.com")
   })
 
   it('restricts default-src to self only', () => {
     expect(csp['default-src']).toBe("'self'")
+  })
+
+  it('allows blob and data URIs for PostHog session-recorder workers', () => {
+    expect(csp['worker-src']).toContain('blob:')
+    expect(csp['worker-src']).toContain('data:')
   })
 })

--- a/src/renderer/csp.test.ts
+++ b/src/renderer/csp.test.ts
@@ -37,18 +37,19 @@ describe('Content-Security-Policy', () => {
     expect(csp['img-src']).toContain('https://*.posthog.com')
   })
 
-  it('restricts script-src to self plus PostHog session-recorder host', () => {
-    // PostHog's session recording lazy-loads recorder.js from posthog.com,
-    // so we allow that single origin. No other remote scripts are allowed.
-    expect(csp['script-src']).toBe("'self' https://*.posthog.com")
+  it('restricts script-src to self only', () => {
+    // PostHog session recording is intentionally never loaded, so its
+    // recorder.js is blocked at the CSP layer. Only first-party scripts run.
+    expect(csp['script-src']).toBe("'self'")
   })
 
   it('restricts default-src to self only', () => {
     expect(csp['default-src']).toBe("'self'")
   })
 
-  it('allows blob and data URIs for PostHog session-recorder workers', () => {
-    expect(csp['worker-src']).toContain('blob:')
-    expect(csp['worker-src']).toContain('data:')
+  it('does not declare a worker-src directive', () => {
+    // Nothing in the app loads web workers; without session recording there
+    // is no need for blob:/data: workers, so the directive is omitted.
+    expect(csp['worker-src']).toBeUndefined()
   })
 })

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -9,7 +9,7 @@
     -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' ws: https://*.datadoghq.com https://browser-intake-us5-datadoghq.com"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.posthog.com; connect-src 'self' ws: https://*.datadoghq.com https://browser-intake-us5-datadoghq.com https://*.posthog.com; worker-src 'self' blob:"
     />
   </head>
   <body>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -9,7 +9,7 @@
     -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.posthog.com; connect-src 'self' ws: https://*.datadoghq.com https://browser-intake-us5-datadoghq.com https://*.posthog.com; worker-src 'self' blob:"
+      content="default-src 'self'; script-src 'self' https://*.posthog.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.posthog.com; connect-src 'self' ws: https://*.datadoghq.com https://browser-intake-us5-datadoghq.com https://*.posthog.com; worker-src 'self' blob: data:"
     />
   </head>
   <body>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -9,7 +9,7 @@
     -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' https://*.posthog.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.posthog.com; connect-src 'self' ws: https://*.datadoghq.com https://browser-intake-us5-datadoghq.com https://*.posthog.com; worker-src 'self' blob: data:"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.posthog.com; connect-src 'self' ws: https://*.datadoghq.com https://browser-intake-us5-datadoghq.com https://*.posthog.com"
     />
   </head>
   <body>

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -64,7 +64,7 @@ function switchView(view: TabView): void {
   const fromView = activeView.value
   nav.switchTab(view)
   if (view !== fromView) {
-    emitTelemetryAction('launcher.view.opened', {
+    emitTelemetryAction('desktop2.view.opened', {
       view,
       from_view: fromView,
     })
@@ -76,7 +76,7 @@ function switchView(view: TabView): void {
 }
 
 function openFeedback(): void {
-  emitTelemetryAction('launcher.feedback.opened')
+  emitTelemetryAction('desktop2.feedback.opened')
   window.api.openExternal(buildSupportUrl(appVersion.value || undefined))
 }
 
@@ -94,7 +94,7 @@ function openConsole(installationId: string): void {
 }
 
 async function openNewInstall(): Promise<void> {
-  emitTelemetryAction('launcher.install.flow.opened', {
+  emitTelemetryAction('desktop2.install.flow.opened', {
     flow: 'new_install',
     entrypoint: activeView.value,
   })
@@ -103,7 +103,7 @@ async function openNewInstall(): Promise<void> {
 }
 
 async function openQuickInstall(): Promise<void> {
-  emitTelemetryAction('launcher.install.flow.opened', {
+  emitTelemetryAction('desktop2.install.flow.opened', {
     flow: 'quick_install',
     entrypoint: activeView.value,
   })
@@ -112,7 +112,7 @@ async function openQuickInstall(): Promise<void> {
 }
 
 async function openTrack(): Promise<void> {
-  emitTelemetryAction('launcher.install.flow.opened', {
+  emitTelemetryAction('desktop2.install.flow.opened', {
     flow: 'track_existing',
     entrypoint: activeView.value,
   })
@@ -121,7 +121,7 @@ async function openTrack(): Promise<void> {
 }
 
 async function openLoadSnapshot(): Promise<void> {
-  emitTelemetryAction('launcher.install.flow.opened', {
+  emitTelemetryAction('desktop2.install.flow.opened', {
     flow: 'load_snapshot',
     entrypoint: activeView.value,
   })

--- a/src/renderer/src/components/SettingField.vue
+++ b/src/renderer/src/components/SettingField.vue
@@ -16,7 +16,7 @@ const localPaths = ref<string[]>(Array.isArray(props.field.value) ? [...props.fi
 
 async function updateSetting(value: string | boolean | number | string[]): Promise<void> {
   await window.api.setSetting(props.field.id, value)
-  emitTelemetryAction('launcher.settings.changed', {
+  emitTelemetryAction('desktop2.settings.changed', {
     setting_key: props.field.id,
     value_kind: props.field.type || 'text',
     bool_value: typeof value === 'boolean' ? value : undefined,

--- a/src/renderer/src/components/SnapshotTab.vue
+++ b/src/renderer/src/components/SnapshotTab.vue
@@ -218,7 +218,7 @@ async function saveSnapshot(): Promise<void> {
     await modal.alert({ title: t('snapshots.saveSnapshot'), message: (err as Error).message || String(err) })
     return
   }
-  emitTelemetryAction('launcher.snapshot.flow', {
+  emitTelemetryAction('desktop2.snapshot.flow', {
     action: 'save',
     snapshot_count_bucket: toCountBucket(snapshots.value.length),
   })
@@ -243,7 +243,7 @@ async function handleRestore(filename: string): Promise<void> {
   } finally {
     restorePreviewLoading.value = false
   }
-  emitTelemetryAction('launcher.snapshot.flow', {
+  emitTelemetryAction('desktop2.snapshot.flow', {
     action: 'restore_start',
     snapshot_count_bucket: toCountBucket(snapshots.value.length),
     has_diff: restorePreviewDiff.value ? diffHasChanges(restorePreviewDiff.value.diff) : undefined,
@@ -273,7 +273,7 @@ async function confirmRestore(): Promise<void> {
       }
       return
     }
-    emitTelemetryAction('launcher.snapshot.flow', {
+    emitTelemetryAction('desktop2.snapshot.flow', {
       action: 'import',
       snapshot_count_bucket: toCountBucket(snapshots.value.length),
       imported_bucket: toCountBucket(result.imported ?? 0),
@@ -296,7 +296,7 @@ async function confirmRestore(): Promise<void> {
     progressTitle: t('standalone.snapshotRestoringTitle'),
     cancellable: true,
   }
-  emitTelemetryAction('launcher.snapshot.flow', {
+  emitTelemetryAction('desktop2.snapshot.flow', {
     action: 'restore_complete',
     snapshot_count_bucket: toCountBucket(snapshots.value.length),
     has_diff: hasDiff,
@@ -311,7 +311,7 @@ async function handleDelete(filename: string): Promise<void> {
   })
   if (!confirmed) return
   await window.api.runAction(props.installationId, 'snapshot-delete', { file: filename })
-  emitTelemetryAction('launcher.snapshot.flow', {
+  emitTelemetryAction('desktop2.snapshot.flow', {
     action: 'delete',
     snapshot_count_bucket: toCountBucket(snapshots.value.length),
   })
@@ -327,7 +327,7 @@ async function handleDelete(filename: string): Promise<void> {
 
 async function handleExport(filename: string): Promise<void> {
   await window.api.exportSnapshot(props.installationId, filename)
-  emitTelemetryAction('launcher.snapshot.flow', {
+  emitTelemetryAction('desktop2.snapshot.flow', {
     action: 'export_one',
     snapshot_count_bucket: toCountBucket(snapshots.value.length),
   })
@@ -335,7 +335,7 @@ async function handleExport(filename: string): Promise<void> {
 
 async function handleExportAll(): Promise<void> {
   await window.api.exportAllSnapshots(props.installationId)
-  emitTelemetryAction('launcher.snapshot.flow', {
+  emitTelemetryAction('desktop2.snapshot.flow', {
     action: 'export_all',
     snapshot_count_bucket: toCountBucket(snapshots.value.length),
   })

--- a/src/renderer/src/components/UpdateBanner.vue
+++ b/src/renderer/src/components/UpdateBanner.vue
@@ -44,7 +44,7 @@ const bannerMessage = computed<string>(() => {
 })
 
 function dismiss() {
-  emitTelemetryAction('launcher.update.cta', {
+  emitTelemetryAction('desktop2.update.cta', {
     action: 'dismissed',
     state: state.value?.type || 'unknown',
     target_version: (state.value?.type === 'available' || state.value?.type === 'ready') ? state.value.version : undefined,
@@ -54,7 +54,7 @@ function dismiss() {
 }
 
 async function download() {
-  emitTelemetryAction('launcher.update.cta', {
+  emitTelemetryAction('desktop2.update.cta', {
     action: 'download_clicked',
     state: state.value?.type || 'unknown',
     target_version: state.value?.type === 'available' ? state.value.version : undefined,
@@ -64,7 +64,7 @@ async function download() {
 }
 
 async function install() {
-  emitTelemetryAction('launcher.update.cta', {
+  emitTelemetryAction('desktop2.update.cta', {
     action: 'install_clicked',
     state: state.value?.type || 'unknown',
     target_version: state.value?.type === 'ready' ? state.value.version : undefined,
@@ -73,7 +73,7 @@ async function install() {
 }
 
 function retry() {
-  emitTelemetryAction('launcher.update.cta', {
+  emitTelemetryAction('desktop2.update.cta', {
     action: 'retry_clicked',
     state: state.value?.type || 'unknown',
   })

--- a/src/renderer/src/composables/useListAction.ts
+++ b/src/renderer/src/composables/useListAction.ts
@@ -46,7 +46,7 @@ export function useListAction(uiSurface: string, callbacks: ListActionCallbacks)
         confirmStyle: action.style || 'danger',
       })
       if (!confirmed) {
-        emitTelemetryAction('launcher.action.result', { action_id: action.id, result: 'cancelled', ...telemetryContext })
+        emitTelemetryAction('desktop2.action.result', { action_id: action.id, result: 'cancelled', ...telemetryContext })
         return
       }
     }
@@ -54,13 +54,13 @@ export function useListAction(uiSurface: string, callbacks: ListActionCallbacks)
     if (action.id === 'launch') {
       const canLaunch = await localInstanceGuard.checkBeforeLaunch(inst.id)
       if (!canLaunch) {
-        emitTelemetryAction('launcher.action.result', { action_id: action.id, result: 'cancelled', ...telemetryContext })
+        emitTelemetryAction('desktop2.action.result', { action_id: action.id, result: 'cancelled', ...telemetryContext })
         return
       }
     }
 
     sessionStore.clearErrorInstance(inst.id)
-    emitTelemetryAction('launcher.action.invoked', { action_id: action.id, ...telemetryContext })
+    emitTelemetryAction('desktop2.action.invoked', { action_id: action.id, ...telemetryContext })
 
     if (action.showProgress) {
       callbacks.showProgress({
@@ -79,14 +79,14 @@ export function useListAction(uiSurface: string, callbacks: ListActionCallbacks)
         return
       }
       const resultValue = result.cancelled ? 'cancelled' : (result.ok === false ? 'failed' : 'ok')
-      emitTelemetryAction('launcher.action.result', { action_id: action.id, result: resultValue, ...telemetryContext })
+      emitTelemetryAction('desktop2.action.result', { action_id: action.id, result: resultValue, ...telemetryContext })
       if (callbacks.onNavigate) {
         await callbacks.onNavigate(result, action)
       } else if (result.message) {
         await modal.alert({ title: action.label, message: result.message })
       }
     } catch (error: unknown) {
-      emitTelemetryAction('launcher.action.result', {
+      emitTelemetryAction('desktop2.action.result', {
         action_id: action.id,
         result: 'failed',
         error_bucket: toErrorBucket(error),

--- a/src/renderer/src/lib/installHelpers.ts
+++ b/src/renderer/src/lib/installHelpers.ts
@@ -33,7 +33,7 @@ export function toPathGuardrail(issue: PathIssue): string {
 }
 
 export function trackGuardrailBlocked(guardrailType: string, flow: string, stage: string): void {
-  emitTelemetryAction('launcher.install.guardrail.blocked', {
+  emitTelemetryAction('desktop2.install.guardrail.blocked', {
     guardrail_type: guardrailType,
     flow,
     stage,
@@ -92,7 +92,7 @@ export async function checkNvidiaDriverOrWarn(
 }
 
 export function trackDiskWarningResponse(warningType: string, accepted: boolean, flow: string): void {
-  emitTelemetryAction('launcher.install.disk_warning.response', {
+  emitTelemetryAction('desktop2.install.disk_warning.response', {
     warning_type: warningType,
     accepted,
     flow,

--- a/src/renderer/src/lib/posthogProvider.test.ts
+++ b/src/renderer/src/lib/posthogProvider.test.ts
@@ -52,7 +52,6 @@ const baseOpts = {
   appVersion: '0.0.0-test',
   appEnv: 'test',
   isPackaged: false,
-  enableSessionRecording: false,
 } as const
 
 describe('posthogProvider consent ↔ disable_surveys gating', () => {

--- a/src/renderer/src/lib/posthogProvider.test.ts
+++ b/src/renderer/src/lib/posthogProvider.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Capture every option the SUT passes to `posthog.init` and every method it
+// calls on the returned client, so we can assert that consent state is
+// mirrored into `disable_surveys` (PostHog's surveys module ignores
+// `opt_out_capturing()` outside cookieless mode, so the gate has to be
+// wired by us).
+const initCalls: Array<Record<string, unknown>> = []
+const setConfigCalls: Array<Record<string, unknown>> = []
+const surveysLoadIfEnabled = vi.fn()
+let optInCalled = 0
+let optOutCalled = 0
+
+vi.mock('posthog-js', () => {
+  const fakeClient = {
+    set_config: (cfg: Record<string, unknown>) => {
+      setConfigCalls.push(cfg)
+    },
+    opt_in_capturing: () => {
+      optInCalled++
+    },
+    opt_out_capturing: () => {
+      optOutCalled++
+    },
+    surveys: {
+      loadIfEnabled: surveysLoadIfEnabled,
+    },
+    register: () => {},
+    identify: () => {},
+    capture: () => {},
+    captureException: () => {},
+    isFeatureEnabled: () => undefined,
+    reloadFeatureFlags: () => {},
+  }
+  return {
+    default: {
+      init: (_apiKey: string, opts: Record<string, unknown>) => {
+        initCalls.push(opts)
+        // PostHog's real `loaded` callback runs synchronously after init.
+        const loaded = opts['loaded'] as undefined | ((ph: unknown) => void)
+        loaded?.(fakeClient)
+        return fakeClient
+      },
+    },
+  }
+})
+
+// Stub the env Vite normally injects so `isPostHogConfigured()` returns true.
+vi.stubGlobal('import.meta', { env: { VITE_POSTHOG_API_KEY: 'phc_test_key' } })
+
+const baseOpts = {
+  appVersion: '0.0.0-test',
+  appEnv: 'test',
+  isPackaged: false,
+  enableSessionRecording: false,
+} as const
+
+describe('posthogProvider consent ↔ disable_surveys gating', () => {
+  beforeEach(() => {
+    initCalls.length = 0
+    setConfigCalls.length = 0
+    surveysLoadIfEnabled.mockClear()
+    optInCalled = 0
+    optOutCalled = 0
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('initialises with disable_surveys: true when consent is false', async () => {
+    const mod = await import('./posthogProvider')
+    mod.initPostHog({ ...baseOpts, consent: false })
+    expect(initCalls.length).toBe(1)
+    expect(initCalls[0]?.['disable_surveys']).toBe(true)
+    expect(initCalls[0]?.['opt_out_capturing_by_default']).toBe(true)
+  })
+
+  it('initialises with disable_surveys: false when consent is true', async () => {
+    const mod = await import('./posthogProvider')
+    mod.initPostHog({ ...baseOpts, consent: true })
+    expect(initCalls[0]?.['disable_surveys']).toBe(false)
+    expect(initCalls[0]?.['opt_out_capturing_by_default']).toBe(false)
+  })
+
+  it('opting out flips disable_surveys to true and opts the SDK out', async () => {
+    const mod = await import('./posthogProvider')
+    mod.initPostHog({ ...baseOpts, consent: true })
+    mod.setPostHogConsent(false)
+    expect(optOutCalled).toBe(1)
+    const lastCfg = setConfigCalls[setConfigCalls.length - 1]
+    expect(lastCfg?.['disable_surveys']).toBe(true)
+    // Re-loading surveys is not desired on opt-out — only on opt-in.
+    expect(surveysLoadIfEnabled).not.toHaveBeenCalled()
+  })
+
+  it('opting back in flips disable_surveys to false AND re-loads surveys', async () => {
+    const mod = await import('./posthogProvider')
+    mod.initPostHog({ ...baseOpts, consent: false })
+    mod.setPostHogConsent(true)
+    expect(optInCalled).toBe(1)
+    const lastCfg = setConfigCalls[setConfigCalls.length - 1]
+    expect(lastCfg?.['disable_surveys']).toBe(false)
+    expect(surveysLoadIfEnabled).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/lib/posthogProvider.ts
+++ b/src/renderer/src/lib/posthogProvider.ts
@@ -1,0 +1,135 @@
+/**
+ * Renderer-side PostHog provider.
+ *
+ * Used alongside Datadog RUM. Both providers consume events from the same
+ * `TELEMETRY_ACTION_EVENT_NAME` CustomEvent bridge, so Vue components don't
+ * need to know either SDK exists.
+ *
+ * Mirrors the shape of `datadogRum.init` / `setUser` / `setTrackingConsent`
+ * so callers in `renderer/src/main.ts` stay symmetric.
+ */
+import posthog, { type PostHog } from 'posthog-js'
+import type { TelemetryContext } from './telemetry'
+
+const DEFAULT_POSTHOG_HOST = 'https://us.i.posthog.com'
+
+interface PosthogInitOptions {
+  appVersion: string
+  appEnv: string
+  isPackaged: boolean
+  consent: boolean
+  enableSessionRecording: boolean
+}
+
+let initialized = false
+let client: PostHog | null = null
+
+function isFlagDisabled(value: string | undefined): boolean {
+  return ['0', 'false', 'off'].includes((value || '').trim().toLowerCase())
+}
+
+function readApiKey(): string {
+  return (import.meta.env.VITE_POSTHOG_API_KEY || '').trim()
+}
+
+function readHost(): string {
+  return (import.meta.env.VITE_POSTHOG_HOST || DEFAULT_POSTHOG_HOST).trim()
+}
+
+export function isPostHogConfigured(): boolean {
+  if (isFlagDisabled(import.meta.env.VITE_POSTHOG_ENABLED)) return false
+  return readApiKey().length > 0
+}
+
+export function initPostHog(opts: PosthogInitOptions): void {
+  if (initialized || !isPostHogConfigured()) return
+  initialized = true
+  try {
+    client = posthog.init(readApiKey(), {
+      api_host: readHost(),
+      opt_out_capturing_by_default: !opts.consent,
+      capture_pageview: false,
+      autocapture: false,
+      // Session recording is gated behind a remote feature flag — see main.ts
+      disable_session_recording: !opts.enableSessionRecording,
+      persistence: 'localStorage+cookie',
+      loaded: (ph) => {
+        ph.register({
+          app_env: opts.appEnv,
+          app_version: opts.appVersion,
+          is_packaged: opts.isPackaged,
+        })
+      },
+    }) as PostHog
+  } catch {
+    client = null
+  }
+}
+
+export function isInitialized(): boolean {
+  return client !== null
+}
+
+/**
+ * Bind device id + persistent profile properties (mirrors legacy desktop's
+ * Mixpanel people profile — platform, arch, gpus, app_version, etc.).
+ */
+export function identifyPostHog(id: string, properties: Record<string, unknown> = {}): void {
+  if (!client) return
+  try {
+    client.identify(id, properties)
+  } catch {
+    // ignore
+  }
+}
+
+export function capturePostHog(event: string, context: TelemetryContext = {}): void {
+  if (!client) return
+  try {
+    client.capture(event, context as Record<string, unknown>)
+  } catch {
+    // ignore
+  }
+}
+
+export function captureExceptionPostHog(error: unknown, context: Record<string, unknown> = {}): void {
+  if (!client) return
+  try {
+    if (error instanceof Error) {
+      client.captureException(error, context)
+    } else {
+      client.captureException(new Error(String(error)), context)
+    }
+  } catch {
+    // ignore
+  }
+}
+
+export function setPostHogConsent(enabled: boolean): void {
+  if (!client) return
+  try {
+    if (enabled) client.opt_in_capturing()
+    else client.opt_out_capturing()
+  } catch {
+    // ignore
+  }
+}
+
+export function isFeatureFlagEnabled(name: string, fallback = false): boolean {
+  if (!client) return fallback
+  try {
+    const value = client.isFeatureEnabled(name)
+    return value === undefined ? fallback : value
+  } catch {
+    return fallback
+  }
+}
+
+export function reloadPostHogFeatureFlags(): void {
+  if (!client) return
+  try {
+    client.reloadFeatureFlags()
+  } catch {
+    // ignore
+  }
+}

--- a/src/renderer/src/lib/posthogProvider.ts
+++ b/src/renderer/src/lib/posthogProvider.ts
@@ -47,6 +47,12 @@ export function initPostHog(opts: PosthogInitOptions): void {
       autocapture: false,
       // Session recording is gated behind a remote feature flag — see main.ts
       disable_session_recording: !opts.enableSessionRecording,
+      // Surveys are remotely toggleable via the PostHog dashboard, but only
+      // when the user has consented to telemetry. This is enforced by
+      // tracking consent in `disable_surveys` here and in setPostHogConsent
+      // below — PostHog's surveys do NOT honor `opt_out_capturing()` outside
+      // of `cookieless_mode`, so we have to wire the gate ourselves.
+      disable_surveys: !opts.consent,
       persistence: 'localStorage+cookie',
       loaded: (ph) => {
         ph.register({
@@ -107,6 +113,21 @@ export function setPostHogConsent(enabled: boolean): void {
     else client.opt_out_capturing()
   } catch {
     // ignore
+  }
+  // Keep `disable_surveys` in lock-step with consent. PostHog's surveys
+  // module ignores `opt_out_capturing()` outside cookieless mode, so the
+  // only reliable way to suppress dashboard-defined surveys for an
+  // opted-out user is to flip the config flag on every consent change.
+  // When opting back in, ask the surveys module to (re-)load so dashboard
+  // surveys can appear without requiring a relaunch.
+  try {
+    client.set_config({ disable_surveys: !enabled })
+    if (enabled) {
+      const surveys = (client as unknown as { surveys?: { loadIfEnabled?: () => void } }).surveys
+      surveys?.loadIfEnabled?.()
+    }
+  } catch {
+    // ignore – telemetry must never break the app
   }
 }
 

--- a/src/renderer/src/lib/posthogProvider.ts
+++ b/src/renderer/src/lib/posthogProvider.ts
@@ -17,7 +17,6 @@ interface PosthogInitOptions {
   appEnv: string
   isPackaged: boolean
   consent: boolean
-  enableSessionRecording: boolean
 }
 
 let initialized = false
@@ -45,8 +44,9 @@ export function initPostHog(opts: PosthogInitOptions): void {
       opt_out_capturing_by_default: !opts.consent,
       capture_pageview: false,
       autocapture: false,
-      // Session recording is gated behind a remote feature flag — see main.ts
-      disable_session_recording: !opts.enableSessionRecording,
+      // Session recording is intentionally never enabled. The recorder script
+      // is also blocked at the CSP layer.
+      disable_session_recording: true,
       // Surveys are remotely toggleable via the PostHog dashboard, but only
       // when the user has consented to telemetry. This is enforced by
       // tracking consent in `disable_surveys` here and in setPostHogConsent
@@ -131,21 +131,4 @@ export function setPostHogConsent(enabled: boolean): void {
   }
 }
 
-export function isFeatureFlagEnabled(name: string, fallback = false): boolean {
-  if (!client) return fallback
-  try {
-    const value = client.isFeatureEnabled(name)
-    return value === undefined ? fallback : value
-  } catch {
-    return fallback
-  }
-}
 
-export function reloadPostHogFeatureFlags(): void {
-  if (!client) return
-  try {
-    client.reloadFeatureFlags()
-  } catch {
-    // ignore
-  }
-}

--- a/src/renderer/src/lib/posthogProvider.ts
+++ b/src/renderer/src/lib/posthogProvider.ts
@@ -10,8 +10,7 @@
  */
 import posthog, { type PostHog } from 'posthog-js'
 import type { TelemetryContext } from './telemetry'
-
-const DEFAULT_POSTHOG_HOST = 'https://us.i.posthog.com'
+import { DEFAULT_POSTHOG_API_KEY, DEFAULT_POSTHOG_HOST, isPostHogFlagDisabled as isFlagDisabled } from '../../../shared/posthogConfig'
 
 interface PosthogInitOptions {
   appVersion: string
@@ -24,12 +23,8 @@ interface PosthogInitOptions {
 let initialized = false
 let client: PostHog | null = null
 
-function isFlagDisabled(value: string | undefined): boolean {
-  return ['0', 'false', 'off'].includes((value || '').trim().toLowerCase())
-}
-
 function readApiKey(): string {
-  return (import.meta.env.VITE_POSTHOG_API_KEY || '').trim()
+  return (import.meta.env.VITE_POSTHOG_API_KEY || DEFAULT_POSTHOG_API_KEY).trim()
 }
 
 function readHost(): string {

--- a/src/renderer/src/lib/posthogProvider.ts
+++ b/src/renderer/src/lib/posthogProvider.ts
@@ -131,4 +131,3 @@ export function setPostHogConsent(enabled: boolean): void {
   }
 }
 
-

--- a/src/renderer/src/main.ts
+++ b/src/renderer/src/main.ts
@@ -229,6 +229,12 @@ function reportRendererError(payload: {
   message: string
   stack?: string
   context?: Record<string, unknown>
+  /**
+   * If true, the error has already been captured by main-process PostHog
+   * Node and is being forwarded only so Datadog (renderer-only) sees it.
+   * Suppresses the renderer-side PostHog mirror to avoid duplicates.
+   */
+  skipPostHog?: boolean
 }): void {
   const error = new Error(payload.message || 'Unknown error')
   if (payload.stack) {
@@ -246,7 +252,7 @@ function reportRendererError(payload: {
       })
     } catch {}
   }
-  if (isPostHogInitialized()) {
+  if (!payload.skipPostHog && isPostHogInitialized()) {
     captureExceptionPostHog(error, {
       origin: 'renderer',
       forwarded_source: payload.source,
@@ -288,6 +294,7 @@ window.api.onDatadogError((data) => {
       level: data.level,
       ...(data.context || {}),
     },
+    skipPostHog: data.skipPostHog === true,
   })
 })
 

--- a/src/renderer/src/main.ts
+++ b/src/renderer/src/main.ts
@@ -17,7 +17,6 @@ import {
   captureExceptionPostHog,
   identifyPostHog,
   initPostHog,
-  isFeatureFlagEnabled,
   isInitialized as isPostHogInitialized,
   isPostHogConfigured,
   setPostHogConsent,
@@ -155,8 +154,6 @@ async function initializeProviders(): Promise<void> {
       appEnv: datadogEnv,
       isPackaged: !import.meta.env.DEV,
       consent,
-      // Default off – flip via remote feature flag at runtime.
-      enableSessionRecording: false,
     })
   }
 
@@ -197,16 +194,6 @@ async function initializeProviders(): Promise<void> {
     }).catch(() => {})
   }
 
-  // Session-replay kill switch is feature-flagged. We rely on the SDK's
-  // built-in flag fetch on init — by the time the first event is sent the
-  // flag should be available. If the user later opts in we re-check.
-  if (isPostHogInitialized() && isFeatureFlagEnabled('desktop2.session_replay.enabled')) {
-    // Lazy enable session recording. posthog-js exposes startSessionRecording.
-    try {
-      // @ts-expect-error startSessionRecording exists on PostHog runtime
-      window.posthog?.startSessionRecording?.()
-    } catch {}
-  }
 }
 
 window.api.onTelemetrySettingChanged((enabled) => {

--- a/src/renderer/src/main.ts
+++ b/src/renderer/src/main.ts
@@ -161,7 +161,7 @@ async function initializeProviders(): Promise<void> {
   }
 
   if (isDatadogInitialized || isPostHogInitialized()) {
-    trackTelemetryAction('launcher.session.started', {
+    trackTelemetryAction('desktop2.session.started', {
       app_env: datadogEnv,
       app_version: appVersion,
       is_packaged: !import.meta.env.DEV,
@@ -176,7 +176,7 @@ async function initializeProviders(): Promise<void> {
     }).catch(() => {})
     window.api.getSystemInfo().then(async (info) => {
       const ctx = info as unknown as Record<string, string | number | boolean | null | undefined>
-      trackTelemetryAction('launcher.session.system_info', ctx)
+      trackTelemetryAction('desktop2.session.system_info', ctx)
       // Promote system info to PostHog profile properties so it's queryable
       // across sessions without joining against a per-session event.
       try {
@@ -200,7 +200,7 @@ async function initializeProviders(): Promise<void> {
   // Session-replay kill switch is feature-flagged. We rely on the SDK's
   // built-in flag fetch on init — by the time the first event is sent the
   // flag should be available. If the user later opts in we re-check.
-  if (isPostHogInitialized() && isFeatureFlagEnabled('launcher.session_replay.enabled')) {
+  if (isPostHogInitialized() && isFeatureFlagEnabled('desktop2.session_replay.enabled')) {
     // Lazy enable session recording. posthog-js exposes startSessionRecording.
     try {
       // @ts-expect-error startSessionRecording exists on PostHog runtime
@@ -300,7 +300,7 @@ window.api.onDatadogError((data) => {
 })
 
 window.api.onComfyExited((data) => {
-  trackTelemetryAction('launcher.comfyui.exited', {
+  trackTelemetryAction('desktop2.comfyui.exited', {
     installation_id: data.installationId,
     crashed: data.crashed ?? false,
     exit_code: data.exitCode ?? null,
@@ -309,7 +309,7 @@ window.api.onComfyExited((data) => {
 })
 
 window.api.onComfyBootLog((data) => {
-  trackTelemetryAction('launcher.comfyui.boot_log', {
+  trackTelemetryAction('desktop2.comfyui.boot_log', {
     installation_id: data.installationId,
     boot_stderr: data.bootStderr,
   })
@@ -320,7 +320,7 @@ window.api.onInstanceStarted((data) => {
   window.api.getInstallationDdContext(data.installationId).then((ctx) => {
     if (!ctx) return
     const { snapshot_diffs, ...metadata } = ctx
-    trackTelemetryAction('launcher.session.installation_started', {
+    trackTelemetryAction('desktop2.session.installation_started', {
       ...(metadata as unknown as Record<string, string | number | boolean | null | undefined>),
       boot_time_ms: bootTimeMs ?? null,
     })
@@ -328,10 +328,10 @@ window.api.onInstanceStarted((data) => {
       // snapshot_diffs is an array of objects, which Datadog/PostHog handle
       // natively; bypass the typed bridge via a fresh call.
       if (isDatadogInitialized) {
-        try { datadogRum.addAction('launcher.session.snapshot_history', { installation_id: ctx.installation_id, snapshot_diffs }) } catch {}
+        try { datadogRum.addAction('desktop2.session.snapshot_history', { installation_id: ctx.installation_id, snapshot_diffs }) } catch {}
       }
       if (isPostHogInitialized()) {
-        capturePostHog('launcher.session.snapshot_history', { installation_id: ctx.installation_id, snapshot_diffs } as unknown as TelemetryContext)
+        capturePostHog('desktop2.session.snapshot_history', { installation_id: ctx.installation_id, snapshot_diffs } as unknown as TelemetryContext)
       }
     }
   }).catch(() => {})

--- a/src/renderer/src/main.ts
+++ b/src/renderer/src/main.ts
@@ -3,6 +3,7 @@ import './assets/main.css'
 import { datadogRum, type RumBeforeSend } from '@datadog/browser-rum'
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
+import { createI18n } from 'vue-i18n'
 import App from './App.vue'
 import { normalizeRumErrorEvent } from './lib/datadogPathNormalization'
 import {
@@ -10,6 +11,16 @@ import {
   type TelemetryActionEventDetail,
   type TelemetryContext,
 } from './lib/telemetry'
+import {
+  capturePostHog,
+  captureExceptionPostHog,
+  identifyPostHog,
+  initPostHog,
+  isFeatureFlagEnabled,
+  isInitialized as isPostHogInitialized,
+  isPostHogConfigured,
+  setPostHogConsent,
+} from './lib/posthogProvider'
 
 function serializeUnknownError(error: unknown): { message: string; stack?: string } {
   if (error instanceof Error) {
@@ -94,10 +105,12 @@ function setDatadogTrackingConsent(consent: DatadogTrackingConsent): void {
 }
 
 function trackTelemetryAction(actionName: string, context: TelemetryContext): void {
-  if (!isDatadogInitialized) return
-  try {
-    datadogRum.addAction(actionName, context)
-  } catch {}
+  if (isDatadogInitialized) {
+    try { datadogRum.addAction(actionName, context) } catch {}
+  }
+  if (isPostHogInitialized()) {
+    capturePostHog(actionName, context)
+  }
 }
 
 function handleTelemetryActionBridgeEvent(event: Event): void {
@@ -109,49 +122,107 @@ function handleTelemetryActionBridgeEvent(event: Event): void {
 }
 
 
-async function initializeDatadog(): Promise<void> {
-  if (!isDatadogConfigured) return
+async function initializeProviders(): Promise<void> {
   const telemetryEnabled = await getTelemetryEnabledSetting()
-  try {
-    datadogRum.init({
-      applicationId: datadogApplicationId,
-      clientToken: datadogClientToken,
-      site: datadogSite,
-      service: datadogService,
-      env: datadogEnv,
-      version: datadogVersion || undefined,
-      trackingConsent: toDatadogTrackingConsent(telemetryEnabled),
-      beforeSend: datadogBeforeSend,
-      sessionSampleRate: parseSampleRate(import.meta.env.VITE_DATADOG_RUM_SESSION_SAMPLE_RATE, 100),
-      sessionReplaySampleRate: parseSampleRate(import.meta.env.VITE_DATADOG_RUM_SESSION_REPLAY_SAMPLE_RATE, 0),
-      trackResources: true,
-      trackLongTasks: true,
-      trackUserInteractions: true,
+  const consent = telemetryEnabled !== false
+  const appVersion = datadogVersion || 'unknown'
+
+  if (isDatadogConfigured) {
+    try {
+      datadogRum.init({
+        applicationId: datadogApplicationId,
+        clientToken: datadogClientToken,
+        site: datadogSite,
+        service: datadogService,
+        env: datadogEnv,
+        version: datadogVersion || undefined,
+        trackingConsent: toDatadogTrackingConsent(telemetryEnabled),
+        beforeSend: datadogBeforeSend,
+        sessionSampleRate: parseSampleRate(import.meta.env.VITE_DATADOG_RUM_SESSION_SAMPLE_RATE, 100),
+        sessionReplaySampleRate: parseSampleRate(import.meta.env.VITE_DATADOG_RUM_SESSION_REPLAY_SAMPLE_RATE, 0),
+        trackResources: true,
+        trackLongTasks: true,
+        trackUserInteractions: true,
+      })
+      isDatadogInitialized = true
+    } catch {}
+  }
+
+  if (isPostHogConfigured()) {
+    initPostHog({
+      appVersion,
+      appEnv: datadogEnv,
+      isPackaged: !import.meta.env.DEV,
+      consent,
+      // Default off – flip via remote feature flag at runtime.
+      enableSessionRecording: false,
     })
-    isDatadogInitialized = true
+  }
+
+  if (isDatadogInitialized || isPostHogInitialized()) {
     trackTelemetryAction('launcher.session.started', {
       app_env: datadogEnv,
-      app_version: datadogVersion || 'unknown',
+      app_version: appVersion,
       is_packaged: !import.meta.env.DEV,
-      telemetry_effective_enabled: telemetryEnabled !== false,
+      telemetry_effective_enabled: consent,
     })
     window.api.getDeviceId().then((id) => {
-      try { datadogRum.setUser({ id }) } catch {}
+      if (isDatadogInitialized) {
+        try { datadogRum.setUser({ id }) } catch {}
+      }
+      // For PostHog we'll merge in the system_info profile properties below.
+      identifyPostHog(id)
     }).catch(() => {})
-    window.api.getSystemInfo().then((info) => {
-      trackTelemetryAction('launcher.session.system_info', info as unknown as Record<string, string | number | boolean | null | undefined>)
+    window.api.getSystemInfo().then(async (info) => {
+      const ctx = info as unknown as Record<string, string | number | boolean | null | undefined>
+      trackTelemetryAction('launcher.session.system_info', ctx)
+      // Promote system info to PostHog profile properties so it's queryable
+      // across sessions without joining against a per-session event.
+      try {
+        const id = await window.api.getDeviceId()
+        identifyPostHog(id, {
+          platform: ctx['platform'],
+          arch: ctx['arch'],
+          os_distro: ctx['os_distro'],
+          os_release: ctx['os_release'],
+          gpu_vendor: ctx['gpu_vendor'],
+          gpu_model: ctx['gpu_model'],
+          total_memory_gb: ctx['total_memory_gb'],
+          cpu_cores: ctx['cpu_cores'],
+          electron_version: ctx['electron_version'],
+          app_version: appVersion,
+        })
+      } catch {}
     }).catch(() => {})
-  } catch {}
+  }
+
+  // Session-replay kill switch is feature-flagged. We rely on the SDK's
+  // built-in flag fetch on init — by the time the first event is sent the
+  // flag should be available. If the user later opts in we re-check.
+  if (isPostHogInitialized() && isFeatureFlagEnabled('launcher.session_replay.enabled')) {
+    // Lazy enable session recording. posthog-js exposes startSessionRecording.
+    try {
+      // @ts-expect-error startSessionRecording exists on PostHog runtime
+      window.posthog?.startSessionRecording?.()
+    } catch {}
+  }
 }
 
 window.api.onTelemetrySettingChanged((enabled) => {
-  if (!isDatadogConfigured) return
-  setDatadogTrackingConsent(toDatadogTrackingConsent(enabled))
+  if (isDatadogConfigured) setDatadogTrackingConsent(toDatadogTrackingConsent(enabled))
+  setPostHogConsent(enabled !== false)
 })
 
 window.addEventListener(TELEMETRY_ACTION_EVENT_NAME, handleTelemetryActionBridgeEvent)
 
-void initializeDatadog()
+// Events emitted from the main process land here and fan out to both providers.
+window.api.onTelemetryActionFromMain((data) => {
+  if (!data || typeof data.event !== 'string' || data.event.length === 0) return
+  const ctx = (data.context && typeof data.context === 'object' ? data.context : {}) as TelemetryContext
+  trackTelemetryAction(data.event, ctx)
+})
+
+void initializeProviders()
 
 function reportRendererError(payload: {
   source: string
@@ -159,21 +230,29 @@ function reportRendererError(payload: {
   stack?: string
   context?: Record<string, unknown>
 }): void {
-  if (!isDatadogInitialized) return
   const error = new Error(payload.message || 'Unknown error')
   if (payload.stack) {
     error.stack = payload.stack
   }
-  try {
-    datadogRum.addError(error, {
-      source: 'custom',
-      context: {
-        origin: 'renderer',
-        forwarded_source: payload.source,
-        ...(payload.context || {}),
-      },
+  if (isDatadogInitialized) {
+    try {
+      datadogRum.addError(error, {
+        source: 'custom',
+        context: {
+          origin: 'renderer',
+          forwarded_source: payload.source,
+          ...(payload.context || {}),
+        },
+      })
+    } catch {}
+  }
+  if (isPostHogInitialized()) {
+    captureExceptionPostHog(error, {
+      origin: 'renderer',
+      forwarded_source: payload.source,
+      ...(payload.context || {}),
     })
-  } catch {}
+  }
 }
 
 window.addEventListener('error', (event) => {
@@ -213,7 +292,6 @@ window.api.onDatadogError((data) => {
 })
 
 window.api.onComfyExited((data) => {
-  if (!isDatadogInitialized) return
   trackTelemetryAction('launcher.comfyui.exited', {
     installation_id: data.installationId,
     crashed: data.crashed ?? false,
@@ -223,7 +301,6 @@ window.api.onComfyExited((data) => {
 })
 
 window.api.onComfyBootLog((data) => {
-  if (!isDatadogInitialized) return
   trackTelemetryAction('launcher.comfyui.boot_log', {
     installation_id: data.installationId,
     boot_stderr: data.bootStderr,
@@ -231,7 +308,6 @@ window.api.onComfyBootLog((data) => {
 })
 
 window.api.onInstanceStarted((data) => {
-  if (!isDatadogInitialized) return
   const bootTimeMs = (data as unknown as Record<string, unknown>).bootTimeMs as number | undefined
   window.api.getInstallationDdContext(data.installationId).then((ctx) => {
     if (!ctx) return
@@ -241,31 +317,30 @@ window.api.onInstanceStarted((data) => {
       boot_time_ms: bootTimeMs ?? null,
     })
     if (snapshot_diffs.length > 0) {
-      try { datadogRum.addAction('launcher.session.snapshot_history', { installation_id: ctx.installation_id, snapshot_diffs }) } catch {}
+      // snapshot_diffs is an array of objects, which Datadog/PostHog handle
+      // natively; bypass the typed bridge via a fresh call.
+      if (isDatadogInitialized) {
+        try { datadogRum.addAction('launcher.session.snapshot_history', { installation_id: ctx.installation_id, snapshot_diffs }) } catch {}
+      }
+      if (isPostHogInitialized()) {
+        capturePostHog('launcher.session.snapshot_history', { installation_id: ctx.installation_id, snapshot_diffs } as unknown as TelemetryContext)
+      }
     }
   }).catch(() => {})
 })
 
-import { i18n } from './i18n'
-import { useNavigation } from './composables/useNavigation'
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  fallbackLocale: 'en',
+  messages: { en: {} },
+  missingWarn: false,
+  fallbackWarn: false,
+})
 
 const app = createApp(App)
 app.use(createPinia())
 app.use(i18n)
 app.mount('#app')
-
-// Expose navigation bridge for E2E tests.
-// These methods only mirror what UI buttons already do (present/dismiss overlays,
-// switch tabs) — no privilege escalation. The renderer's CSP and preload sandbox
-// already restrict what scripts can execute in this context.
-{
-  const nav = useNavigation()
-  ;(window as unknown as Record<string, unknown>).__E2E_NAV__ = {
-    present: nav.present,
-    dismiss: nav.dismiss,
-    dismissAll: nav.dismissAll,
-    switchTab: nav.switchTab,
-  }
-}
 
 export { i18n }

--- a/src/renderer/src/main.ts
+++ b/src/renderer/src/main.ts
@@ -139,7 +139,9 @@ async function initializeProviders(): Promise<void> {
         trackingConsent: toDatadogTrackingConsent(telemetryEnabled),
         beforeSend: datadogBeforeSend,
         sessionSampleRate: parseSampleRate(import.meta.env.VITE_DATADOG_RUM_SESSION_SAMPLE_RATE, 100),
-        sessionReplaySampleRate: parseSampleRate(import.meta.env.VITE_DATADOG_RUM_SESSION_REPLAY_SAMPLE_RATE, 0),
+        // Session replay is intentionally not configured. Datadog defaults
+        // to off when the field is omitted; reintroduce only as a deliberate
+        // code change in a release.
         trackResources: true,
         trackLongTasks: true,
         trackUserInteractions: true,

--- a/src/renderer/src/main.ts
+++ b/src/renderer/src/main.ts
@@ -5,6 +5,7 @@ import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 import { createI18n } from 'vue-i18n'
 import App from './App.vue'
+import { useNavigation } from './composables/useNavigation'
 import { normalizeRumErrorEvent } from './lib/datadogPathNormalization'
 import {
   TELEMETRY_ACTION_EVENT_NAME,
@@ -349,5 +350,19 @@ const app = createApp(App)
 app.use(createPinia())
 app.use(i18n)
 app.mount('#app')
+
+// Expose navigation bridge for E2E tests.
+// These methods only mirror what UI buttons already do (present/dismiss overlays,
+// switch tabs) — no privilege escalation. The renderer's CSP and preload sandbox
+// already restrict what scripts can execute in this context.
+{
+  const nav = useNavigation()
+  ;(window as unknown as Record<string, unknown>).__E2E_NAV__ = {
+    present: nav.present,
+    dismiss: nav.dismiss,
+    dismissAll: nav.dismissAll,
+    switchTab: nav.switchTab,
+  }
+}
 
 export { i18n }

--- a/src/renderer/src/stores/downloadStore.ts
+++ b/src/renderer/src/stores/downloadStore.ts
@@ -20,7 +20,7 @@ export const useDownloadStore = defineStore('downloads', () => {
       isTerminalModelDownloadStatus(progress.status)
       && (!previous || previous.status !== progress.status)
     ) {
-      emitTelemetryAction('launcher.model_download.result', {
+      emitTelemetryAction('desktop2.model_download.result', {
         result: progress.status,
         directory_bucket: toModelDirectoryBucket(progress.directory),
         file_ext: toFileExtension(progress.filename),

--- a/src/renderer/src/views/DetailModal.vue
+++ b/src/renderer/src/views/DetailModal.vue
@@ -454,7 +454,7 @@ async function runAction(action: ActionDef, btn: HTMLButtonElement | null): Prom
         String((mutableAction.data as Record<string, unknown>)?.[k] ?? k)
     )
     const title = `${rawTitle} — ${instName}`
-    emitTelemetryAction('launcher.action.invoked', { action_id: mutableAction.id, ...telemetryContext })
+    emitTelemetryAction('desktop2.action.invoked', { action_id: mutableAction.id, ...telemetryContext })
     emit('show-progress', {
       installationId: instId,
       title,
@@ -473,7 +473,7 @@ async function runAction(action: ActionDef, btn: HTMLButtonElement | null): Prom
     btn.classList.add('loading')
   }
   try {
-    emitTelemetryAction('launcher.action.invoked', { action_id: mutableAction.id, ...telemetryContext })
+    emitTelemetryAction('desktop2.action.invoked', { action_id: mutableAction.id, ...telemetryContext })
     const result = await window.api.runAction(
       props.installation.id,
       mutableAction.id,
@@ -485,7 +485,7 @@ async function runAction(action: ActionDef, btn: HTMLButtonElement | null): Prom
       return
     }
     const resultValue = result.cancelled ? 'cancelled' : (result.ok === false ? 'failed' : 'ok')
-    emitTelemetryAction('launcher.action.result', { action_id: mutableAction.id, result: resultValue, ...telemetryContext })
+    emitTelemetryAction('desktop2.action.result', { action_id: mutableAction.id, result: resultValue, ...telemetryContext })
     if (result.navigate === 'list') {
       emit('close')
       emit('navigate-list')
@@ -495,7 +495,7 @@ async function runAction(action: ActionDef, btn: HTMLButtonElement | null): Prom
       await modal.alert({ title: mutableAction.label, message: result.message })
     }
   } catch (error: unknown) {
-    emitTelemetryAction('launcher.action.result', {
+    emitTelemetryAction('desktop2.action.result', {
       action_id: mutableAction.id,
       result: 'failed',
       error_bucket: toErrorBucket(error),

--- a/src/renderer/src/views/LoadSnapshotModal.vue
+++ b/src/renderer/src/views/LoadSnapshotModal.vue
@@ -200,7 +200,7 @@ function handleClearPreview(): void {
 
 function selectVariant(option: FieldOption): void {
   selectedVariant.value = option
-  emitTelemetryAction('launcher.install.variant.selected', {
+  emitTelemetryAction('desktop2.install.variant.selected', {
     variant_bucket: toVariantBucket((option.data?.variantId as string | undefined) || option.value),
     recommended: !!option.recommended,
     flow: 'snapshot',

--- a/src/renderer/src/views/NewInstallModal.vue
+++ b/src/renderer/src/views/NewInstallModal.vue
@@ -195,7 +195,7 @@ async function selectSourceCard(source: Source): Promise<void> {
   }
 
   await selectSource(source)
-  emitTelemetryAction('launcher.install.method.selected', {
+  emitTelemetryAction('desktop2.install.method.selected', {
     source_id: source.id,
     source_category: source.category || source.id,
     flow: 'wizard',
@@ -354,7 +354,7 @@ function handleFieldSelectChange(field: SourceField, fieldIndex: number, value: 
 function selectCardOption(field: SourceField, fieldIndex: number, option: FieldOption): void {
   selections.value[field.id] = option
   if (field.id === 'variant') {
-    emitTelemetryAction('launcher.install.variant.selected', {
+    emitTelemetryAction('desktop2.install.variant.selected', {
       variant_bucket: toVariantBucket((option.data?.variantId as string | undefined) || option.value),
       recommended: !!option.recommended,
       flow: 'wizard',

--- a/src/renderer/src/views/QuickInstallModal.vue
+++ b/src/renderer/src/views/QuickInstallModal.vue
@@ -128,7 +128,7 @@ async function open(): Promise<void> {
       return
     }
     source.value = standalone
-    emitTelemetryAction('launcher.install.method.selected', {
+    emitTelemetryAction('desktop2.install.method.selected', {
       source_id: standalone.id,
       source_category: standalone.category || standalone.id,
       flow: 'quick',
@@ -164,7 +164,7 @@ async function open(): Promise<void> {
 
 function selectVariant(option: FieldOption): void {
   selectedVariant.value = option
-  emitTelemetryAction('launcher.install.variant.selected', {
+  emitTelemetryAction('desktop2.install.variant.selected', {
     variant_bucket: toVariantBucket((option.data?.variantId as string | undefined) || option.value),
     recommended: !!option.recommended,
     flow: 'quick',

--- a/src/renderer/src/views/TrackModal.vue
+++ b/src/renderer/src/views/TrackModal.vue
@@ -134,7 +134,7 @@ async function handleSave(): Promise<void> {
     })
     return
   }
-  emitTelemetryAction('launcher.track_existing.saved', {
+  emitTelemetryAction('desktop2.track_existing.saved', {
     detected_source_label: selectedProbe.value.sourceLabel || 'unknown',
     probe_count_bucket: toCountBucket(probeResults.value.length),
     custom_name_used: trackName.value.trim().length > 0,

--- a/src/shared/posthogConfig.ts
+++ b/src/shared/posthogConfig.ts
@@ -1,0 +1,20 @@
+/**
+ * Cross-process PostHog defaults.
+ *
+ * Imported by both the renderer (lib/posthogProvider.ts) and the main process
+ * (lib/telemetry.ts) so the project key, host, and shared flag-disabled
+ * predicate live in exactly one place.
+ *
+ * The API key is a public, write-only ingest key for the comfyui-desktop-2
+ * PostHog project — safe to embed, same trust level as the Datadog client
+ * token. Override at build time / runtime via VITE_POSTHOG_API_KEY (renderer)
+ * or POSTHOG_API_KEY (main process).
+ */
+
+export const DEFAULT_POSTHOG_API_KEY = 'phc_iKfK86id4xVYws9LybMje0h44eGtfwFgRPIBehmy8rO'
+
+export const DEFAULT_POSTHOG_HOST = 'https://us.i.posthog.com'
+
+export function isPostHogFlagDisabled(value: string | undefined): boolean {
+  return ['0', 'false', 'off'].includes((value || '').trim().toLowerCase())
+}

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -486,6 +486,12 @@ export interface DatadogForwardedError {
   stack?: string
   level?: 'debug' | 'info' | 'warn' | 'error' | 'critical'
   context?: Record<string, unknown>
+  /**
+   * Set when the error has already been captured by main-process PostHog
+   * (via `mainTelemetry.captureException`). The renderer's listener forwards
+   * such errors to Datadog only, avoiding duplicate PostHog exceptions.
+   */
+  skipPostHog?: boolean
 }
 
 // --- Snapshot tab types ---

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -738,6 +738,7 @@ export interface ElectronApi {
   onModelDownloadProgress(callback: (progress: ModelDownloadProgress) => void): Unsubscribe
   onTelemetrySettingChanged(callback: (enabled: boolean | undefined) => void): Unsubscribe
   onDatadogError(callback: (payload: DatadogForwardedError) => void): Unsubscribe
+  onTelemetryActionFromMain(callback: (data: { event: string; context: Record<string, unknown> }) => void): Unsubscribe
   onErrorDetail(callback: (data: ErrorDetailData) => void): Unsubscribe
   onSuggestChineseMirrors(callback: () => void): Unsubscribe
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -20,6 +20,7 @@
     "electron.vite.config.*",
     "src/main/**/*",
     "src/preload/**/*",
-    "src/types/**/*"
+    "src/types/**/*",
+    "src/shared/**/*"
   ]
 }

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -25,7 +25,8 @@
     "src/renderer/src/**/*",
     "src/renderer/src/**/*.vue",
     "src/preload/*.d.ts",
-    "src/types/**/*"
+    "src/types/**/*",
+    "src/shared/**/*"
   ],
   "exclude": [
     "src/**/*.test.ts"


### PR DESCRIPTION
Closes #443.

## What this does

Adds PostHog alongside the existing Datadog RUM telemetry and fills the parity gaps with legacy desktop's Mixpanel coverage — without touching the ComfyUI frontend.

```diagram
                                       ╭──────────────────────────────╮
Vue components                         │ Datadog RUM (alerts)         │
   │                                   │ • install/migrate/rollback   │
   │ emitTelemetryAction()             │   failures                   │
   ▼                                   │ • crashes, errors            │
╭──────────────────────╮       ╭──────▶│ • boot logs, exits           │
│ CustomEvent bridge   │───────┤       ╰──────────────────────────────╯
│ (window event)       │       │       ╭──────────────────────────────╮
╰──────────────────────╯       ╰──────▶│ PostHog (product analytics)  │
            ▲                          │ • install variant chosen     │
            │ onTelemetryActionFromMain│ • migration journey funnels  │
            │                          │ • snapshot history, updates  │
╭──────────────────────╮               │ • feature usage              │
│ main process         │               ╰──────────────────────────────╯
│ (posthog-node)       │
│ • app start/quit     │ direct PostHog Node capture
│ • install sub-steps  │ for events that occur outside the
│ • migrate sub-steps  │ renderer's reach (before/after window
│ • execution tap      │ exists, before-quit drain).
╰──────────────────────╯
```

All emitted event names use the `desktop2.*` namespace.

## Architecture decision

Two PostHog SDKs:

- **`posthog-js` in renderer** — handles every UI-originated event via the existing `TELEMETRY_ACTION_EVENT_NAME` `CustomEvent` bridge. No Vue components changed; the bridge listener now fans out to both Datadog and PostHog. Identical pattern to the ComfyUI cloud frontend.
- **`posthog-node` in main** — captures events the renderer can't see: app start/quit (with `uptime_seconds`), pre-renderer events, install/migrate sub-steps, hardware validation, execution telemetry parsed from ComfyUI logs, render-process-gone, before-quit drain (`await client.shutdown()`).

Both processes share defaults from a single `src/shared/posthogConfig.ts` (project key, host, env-flag predicate) and use the same device id so events correlate in PostHog.

## Legacy desktop parity (gap fills)

| Legacy event | Launcher event | Status |
|---|---|---|
| `desktop:app_ready` | `desktop2.session.started` | ✅ existing |
| `desktop:app_quit` (uptime) | `desktop2.session.ended` (`uptime_seconds`) | ✅ new (main, before-quit) |
| `desktop:hardware_not_supported` / `validation:error_found` | `desktop2.install.validation` | ✅ new |
| `desktop:install_options_received` | `desktop2.install.method/variant.selected` | ✅ existing |
| `install_flow:create_comfy_directories` `_start/_end/_error` | (n/a — install model differs) | — |
| `install_flow:virtual_environment_create_*` `_start/_end/_error` | `desktop2.install.standalone.*` + `desktop2.install.post_install.*` | ✅ new |
| `migrate_flow:migrate_user_files / _models / _custom_nodes` | `desktop2.migrate.user_files`, `desktop2.migrate.input`, `desktop2.migrate.output`, `desktop2.migrate.models` (each `.start/.end/.error`), plus `desktop2.migrate.flow.*` overall | ✅ new |
| `comfyui:server_start` | `desktop2.session.installation_started` + `desktop2.comfyui.boot_log` + `desktop2.comfyui.exited` | ✅ existing |
| Snapshot restore phases | `desktop2.snapshot.restore_comfyui_version.*`, `desktop2.snapshot.restore_custom_nodes.*`, `desktop2.snapshot.restore_pip_packages.*` | ✅ new |
| `execution` (status from ComfyUI frontend) | `desktop2.execution.started/completed/error/session_summary` (parsed from ComfyUI stdout — see below) | ✅ new |
| once-ever `execution:completed` | `desktop2.execution.first_completed` (per-install `firstRunAt` flag) | ✅ new |
| Mixpanel people props (platform/arch/gpus/app_version) | `posthog.identify($set: {...})` with full system info | ✅ new |

## Execution telemetry without a frontend fork

The launcher embeds ComfyUI as a child process whose stdout/stderr is already piped through `proc.stdout`/`proc.stderr` in `sessionActions/launch.ts`. New `executionTap.ts` parses that stream:

- `got prompt` → `desktop2.execution.started`
- `Prompt executed in N seconds` → `desktop2.execution.completed` (with `duration_seconds`, `wall_clock_ms`)
- `Failed to validate prompt for output X:` → `desktop2.execution.error` (`error_class: validation_failed`)
- Python tracebacks → `desktop2.execution.error` (with `error_class`, `error_bucket`)
- On exit → `desktop2.execution.session_summary` (started/completed/error counts)
- First successful prompt ever for an installation → `desktop2.execution.first_completed` + `firstRunAt` persisted on the installation record

This is the live-log approach we discussed — no special frontend build, no IPC channel from inside ComfyUI, no custom node, and works with any ComfyUI version.

## Remote feature flags

There are intentionally **no** remote feature flags in this build. An earlier iteration shipped a small set (`desktop2.execution_telemetry.enabled`, `desktop2.execution_telemetry.sample_rate`, `desktop2.disabled_events`, `desktop2.boot_log_max_chars`) bootstrapped from PostHog at startup with an on-disk cache, but none had a live operational use case for the launcher and the bootstrap added startup latency plus state we did not want to maintain. The whole system was removed; execution telemetry is now unconditionally on. See `docs/telemetry.md` § "Remote feature flags" for the path back if a concrete need ever appears.

## Session replay

Session replay is intentionally **not** captured by either provider:

- PostHog JS is initialised with `disable_session_recording: true` unconditionally and the recorder script is blocked at the CSP layer.
- Datadog RUM omits `sessionReplaySampleRate` so it defaults to off.

Re-enabling on either side requires a deliberate code change in a release.

## Consent + privacy

The existing `telemetryEnabled` setting drives both providers — Datadog via `setTrackingConsent`, PostHog via `opt_in_capturing` / `opt_out_capturing` (renderer) and an in-process drop check (main). Toggle is live; no restart required.

PostHog **surveys** are bound to consent too, since PostHog's surveys module ignores `opt_out_capturing()` outside cookieless mode. Consent is mirrored into `disable_surveys` at init and on every consent change, and `posthog.surveys.loadIfEnabled()` is called when consent is regained so dashboard surveys can appear without a relaunch. **Net effect:** surveys remain remotely toggleable via the PostHog dashboard, but only ever appear for users who have opted in to telemetry.

PII path scrubbing (`scrubAll` in `src/main/lib/piiScrub.ts`) is applied to forwarded errors, every traceback message, and any text routed through `scrubStderr`.

## Configuration

Defaults (project key, host) live in `src/shared/posthogConfig.ts` and are baked into the build — the embedded PostHog project key is a public, write-only ingest key (same trust profile as the already-hardcoded Datadog client token in the renderer entry). Overrides:

| Process | Variables |
|---|---|
| Renderer | `VITE_POSTHOG_API_KEY`, `VITE_POSTHOG_HOST`, `VITE_POSTHOG_ENABLED` |
| Main | `POSTHOG_API_KEY`, `POSTHOG_HOST`, `POSTHOG_ENABLED` |

`POSTHOG_ENABLED=0|false|off` disables PostHog in that process.

## CSP

`*.posthog.com` added to `connect-src` and `img-src`. `script-src` is `'self'` only and there is no `worker-src` directive — the session-recording recorder script and its workers are blocked at the CSP layer (alongside the `disable_session_recording: true` SDK flag). Verified in `csp.test.ts`.

## Tests

- 11 new unit tests for `lib/telemetry.ts` (`bucketError` categories, `trackedStep` success/failure semantics, consent gating).
- Unit tests for `lib/executionTap.ts` covering line parsing for each pattern, traceback boundary detection, chained-traceback handling, PII scrub, `flushSummary` drain, `MAX_PENDING_PROMPTS` cap, and chunk-boundary line splitting.
- New PostHog provider tests (`lib/posthogProvider.test.ts`) for the consent ↔ `disable_surveys` gating contract.
- CSP test asserts `script-src 'self'` with no PostHog allowance and no `worker-src` directive.

```
Test Files  57 passed (57)
     Tests  679 passed (679)
```

## Verification

`pnpm run typecheck && pnpm run lint && pnpm run build && pnpm run test` all pass.

## Out of scope (follow-ups)

- WebSocket-based execution telemetry — log parsing is the v1; we can swap in a WS subscriber later if log formats churn.
- Dashboards / monitor configs — provisioned separately in PostHog and Datadog.
