### PR TITLE
fix: default to bootstrap pygit2 so the path is actually exercised in dev

### DIFF
--- a/src/main/lib/ipc/index.ts
+++ b/src/main/lib/ipc/index.ts
@@ -97,33 +97,60 @@ export function register(callbacks: RegisterCallbacks = {}): void {
     } catch {}
   })()
 
-  // Configure pygit2 fallback if system git is unavailable
-  // Set COMFY_FORCE_BOOTSTRAP_GIT=1 to skip system git and standalone checks (for testing)
+  // Configure git backend.  We default to the bundled bootstrap pygit2 so the
+  // pygit2 code path is always exercised — most developers have system git
+  // installed, which would otherwise mask bugs in the pygit2 path that real
+  // users (without system git) hit on first launch.
+  //
+  // If bootstrap pygit2 is unavailable for any reason we log loudly and fall
+  // back to standalone-install pygit2, then system git.  Set
+  // COMFY_FORCE_BOOTSTRAP_GIT=1 to disable the fallback entirely (for testing).
   void (async () => {
+    const forceBootstrap = process.env.COMFY_FORCE_BOOTSTRAP_GIT === '1'
+
+    if (tryConfigureBootstrapPygit2()) {
+      console.log('[ipc] Using bootstrap pygit2 for git operations (default)')
+      return
+    }
+
+    console.warn(
+      '[ipc] Bootstrap pygit2 not available — bootstrap-python/<platform>/ is missing. ' +
+      'Run "pnpm run bootstrap" (or "pnpm run bootstrap:fetch") to build it. ' +
+      'Falling back to standalone-install pygit2 / system git.'
+    )
+
+    if (forceBootstrap) {
+      console.warn('[ipc] COMFY_FORCE_BOOTSTRAP_GIT set but bootstrap python not found — no git backend will be configured')
+      return
+    }
+
+    // Prefer standalone installation's pygit2 (co-located with ComfyUI env).
+    // Failures listing installations must NOT short-circuit the system-git
+    // fallback below, so this lookup is isolated in its own try/catch.
     try {
-      const forceBootstrap = process.env.COMFY_FORCE_BOOTSTRAP_GIT === '1'
-      if (forceBootstrap) {
-        if (tryConfigureBootstrapPygit2()) {
-          console.log('[ipc] COMFY_FORCE_BOOTSTRAP_GIT — using bootstrap python for git')
-          return
-        }
-        console.warn('[ipc] COMFY_FORCE_BOOTSTRAP_GIT set but bootstrap python not found')
-      }
-      if (await isGitAvailable()) return
-      // Prefer standalone installation's pygit2 (co-located with ComfyUI env)
       const all = await installations.list()
       for (const inst of all) {
         if (inst.sourceId !== 'standalone' || !inst.installPath) continue
         if (tryConfigurePygit2Fallback(inst.installPath)) {
-          console.log('[ipc] System git not found — configured pygit2 fallback via', inst.installPath)
+          console.log('[ipc] Configured pygit2 fallback via standalone install at', inst.installPath)
           return
         }
       }
-      // Fall back to bootstrap python (bundled with the app, for pre-install use)
-      if (tryConfigureBootstrapPygit2()) {
-        console.log('[ipc] System git not found — configured pygit2 via bootstrap python')
+    } catch (err) {
+      console.warn('[ipc] Failed to enumerate standalone installations for pygit2 fallback:', err)
+    }
+
+    // Final fallback: system git, if installed.
+    try {
+      if (await isGitAvailable()) {
+        console.log('[ipc] Using system git (bootstrap pygit2 and standalone pygit2 both unavailable)')
+        return
       }
-    } catch {}
+    } catch (err) {
+      console.warn('[ipc] isGitAvailable() check failed:', err)
+    }
+
+    console.warn('[ipc] No git backend available (bootstrap pygit2, standalone pygit2, and system git all missing)')
   })()
 
   // Clean up partial downloads


### PR DESCRIPTION
## Summary

Most developers have system git installed, which previously masked bugs in
the pygit2 code path that real users (without git) hit on first launch.
This PR makes bundled bootstrap pygit2 the default git backend so the
pygit2 path is exercised by everyone.

## New priority order

1. **bootstrap pygit2** (default) — `bootstrap-python/<platform>/`
2. standalone-install pygit2 (co-located with a ComfyUI standalone env)
3. system `git`

If bootstrap pygit2 is unavailable for any reason, the app logs loudly
(naming the missing directory and the commands to fix it: `pnpm run bootstrap` /
`pnpm run bootstrap:fetch`) before falling back.

## `COMFY_FORCE_BOOTSTRAP_GIT=1` semantics

Now means **"do not fall back"** — if bootstrap pygit2 is missing under the
flag, no git backend is configured (matches the test-isolation intent).
`pnpm run dev:bootstrap` already sets this for you and `predev:bootstrap`
auto-builds bootstrap python if missing.

## Resilience

The standalone-install lookup and the `isGitAvailable()` check are each
wrapped in their own `try/catch` so a failure in one path can never
short-circuit the next fallback.

## Verification

```
pnpm run typecheck   ✓
pnpm run lint        ✓
pnpm run build       ✓
pnpm run test        ✓ 631/631
```

## Related

- Pairs with the documentation update in #docs-pr (catches README up
  with bootstrap + release process).
