### PR TITLE
fix: restrict getAppVersion's git describe to release tags

### DIFF
--- a/src/main/lib/ipc/shared.ts
+++ b/src/main/lib/ipc/shared.ts
@@ -223,7 +223,10 @@ export function getAppVersion(): string {
   let version = app.getVersion()
   if (!app.isPackaged) {
     try {
-      version = execFileSync('git', ['describe', '--tags', '--always'], { cwd: __dirname, encoding: 'utf8' }).trim() || version
+      // Restrict to release tags (`v0.5.0`, etc.) so unrelated tags like
+      // `bootstrap-v1` from the bootstrap-python build don't bleed into the
+      // launcher's displayed version.
+      version = execFileSync('git', ['describe', '--tags', '--always', '--match', 'v[0-9]*'], { cwd: __dirname, encoding: 'utf8' }).trim() || version
     } catch {}
   }
   return version.replace(/^v/, '')


### PR DESCRIPTION
## Summary

The launcher's bottom-left version label was rendering as
`bootstrap-v1-11-g<sha>` (or, after the leading-`v` strip,
`ootstrap-1-11-g<sha>`) in dev builds, instead of the actual launcher
version like `0.5.0-22-g<sha>`.

## Root cause

`getAppVersion()` in `src/main/lib/ipc/shared.ts` runs
`git describe --tags --always` to build a dev-mode version string.  The
bootstrap-python build process ([introduced via #436](https://github.com/Comfy-Org/ComfyUI-Desktop-2.0-Beta/pull/436))
added an unrelated `bootstrap-v1` git tag, which became the closest
tag reachable from `HEAD` — so `git describe` started returning
`bootstrap-v1-…` instead of the most recent release tag (`v0.5.0`).

## Fix

Pass `--match 'v[0-9]*'` so `git describe` only considers release tags
(`v0.5.0`, `v0.4.5`, …).  Verified locally:

```
$ git describe --tags --always --match "v[0-9]*"
v0.5.0-22-ge5ee5f6
```

## Verification

```
pnpm run typecheck   ✓
pnpm run lint        ✓
pnpm run build       ✓
pnpm run test        ✓ 640/640
```

No behavior change for packaged builds (`app.isPackaged` short-circuit
still returns `app.getVersion()` from `package.json`).
