### PR TITLE
Use dashes in .comfy_environment value (local-desktop2-standalone)

### DIFF
--- a/src/main/sources/standalone/envPaths.test.ts
+++ b/src/main/sources/standalone/envPaths.test.ts
@@ -10,7 +10,7 @@ vi.mock('electron', () => ({
 import { writeComfyEnvironment } from './envPaths'
 
 const ENV_FILENAME = '.comfy_environment'
-const EXPECTED_CONTENT = 'local_desktop2_standalone\n'
+const EXPECTED_CONTENT = 'local-desktop2-standalone\n'
 
 describe('writeComfyEnvironment', () => {
   let tmpDir: string
@@ -23,7 +23,7 @@ describe('writeComfyEnvironment', () => {
     try { fs.rmSync(tmpDir, { recursive: true, force: true }) } catch {}
   })
 
-  it('writes the marker file with local_desktop2_standalone content + trailing newline', async () => {
+  it('writes the marker file with local-desktop2-standalone content + trailing newline', async () => {
     await writeComfyEnvironment(tmpDir)
     const written = fs.readFileSync(path.join(tmpDir, ENV_FILENAME), 'utf-8')
     expect(written).toBe(EXPECTED_CONTENT)

--- a/src/main/sources/standalone/envPaths.ts
+++ b/src/main/sources/standalone/envPaths.ts
@@ -56,13 +56,13 @@ export function getMasterPythonPath(installPath: string): string {
 }
 
 const COMFY_ENVIRONMENT_FILE = '.comfy_environment'
-const COMFY_ENVIRONMENT_VALUE = 'local_desktop2_standalone'
+const COMFY_ENVIRONMENT_VALUE = 'local-desktop2-standalone'
 const COMFY_ENVIRONMENT_CONTENT = COMFY_ENVIRONMENT_VALUE + '\n'
 
 /**
  * Write the `.comfy_environment` marker file consumed by ComfyUI core
  * (see Comfy-Org/ComfyUI#13425) so partner-node API requests carry the
- * `X-Comfy-Env: local_desktop2_standalone` header. Idempotent: if the file already
+ * `X-Comfy-Env: local-desktop2-standalone` header. Idempotent: if the file already
  * has the expected content, this is a no-op. Skips silently when the
  * target directory does not exist (older installs not yet migrated).
  * Errors are swallowed with a warning — this marker is non-critical and


### PR DESCRIPTION
## Summary

Renames the `.comfy_environment` marker value from `local_desktop2_standalone` to `local-desktop2-standalone` to align with the dash convention being adopted on the ComfyUI side ([Comfy-Org/ComfyUI#13425](https://github.com/Comfy-Org/ComfyUI/pull/13425)).

Dashes are easier to type than underscores and are more conventional in HTTP-header-adjacent identifiers (the value ends up in the `X-Comfy-Env` header).

## Changes

- `src/main/sources/standalone/envPaths.ts`: `COMFY_ENVIRONMENT_VALUE` updated; doc comment example updated.
- `src/main/sources/standalone/envPaths.test.ts`: test fixtures and case description updated.

## Verification

- `pnpm run typecheck` ✅
- `pnpm run lint` ✅
- `pnpm exec vitest run src/main/sources/standalone/envPaths.test.ts` — 5/5 ✅

## Related

- Comfy-Org/ComfyUI-Desktop-2.0-Beta#428 (original PR introducing the marker, already merged)
- [Comfy-Org/ComfyUI#13425](https://github.com/Comfy-Org/ComfyUI/pull/13425) (ComfyUI side, also switched to dashes — default value is now `local-git`)