### PR TITLE
fix(panel): restore desktop2.view.opened + desktop2.install.flow.opened telemetry

### DIFF
--- a/src/main/installations.test.ts
+++ b/src/main/installations.test.ts
@@ -166,6 +166,35 @@ describe('installations.markLaunched', () => {
   })
 })
 
+describe('installations.add (id uniqueness)', () => {
+  // Regression — `inst-${Date.now()}` collided whenever two `add()` calls
+  // landed in the same millisecond (CI / fast hardware), aliasing distinct
+  // records under the same id and breaking everything keyed by id
+  // (`getRecent`, `update`, `markLaunched`, …). The fix uses a per-process
+  // counter when the wall clock hasn't ticked between calls.
+  it('produces a distinct id for each add(), even back-to-back inside the same millisecond', async () => {
+    const installations = await loadInstallations()
+    // Pin Date.now to the same value across all 5 add() calls so we
+    // exercise the same-ms collision path deterministically rather than
+    // relying on a fast machine to repro it.
+    const fixed = 1_700_000_000_000
+    vi.spyOn(Date, 'now').mockReturnValue(fixed)
+    const records = []
+    for (let i = 0; i < 5; i++) {
+      records.push(
+        await installations.add({
+          name: `Same-ms ${i}`,
+          installPath: path.join(tmpRoot, `same-ms-${i}`),
+          sourceId: 'standalone',
+          status: 'installed',
+        }),
+      )
+    }
+    const ids = records.map((r) => r.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+})
+
 describe('installations.getRecent', () => {
   it('returns null when no installs have been launched', async () => {
     const installations = await loadInstallations()

--- a/src/main/installations.ts
+++ b/src/main/installations.ts
@@ -38,6 +38,33 @@ export interface InstallationRecord {
 
 const dataPath = path.join(dataDir(), "installations.json")
 
+/**
+ * Monotonic install-id generator. The naive `inst-${Date.now()}` form
+ * collides whenever two `add()` / `seedDefaults()` calls land in the
+ * same millisecond — common on fast hardware (CI runners) and trivially
+ * reproducible in tests that issue several `add()` calls back-to-back.
+ * The collision yielded duplicate IDs which then aliased records in
+ * `getRecent()` / `getRecentByCategory()` (see the flake on installations.test.ts
+ * `returns the install with the largest global lastLaunchedAt`).
+ *
+ * Fix: keep the existing `inst-${ms}` shape for the normal case (so all
+ * persisted IDs stay readable and existing data on disk is unchanged)
+ * and append an in-process counter only for repeat calls inside the same
+ * millisecond. Counter resets on the next millisecond tick.
+ */
+let _lastIdMs = 0
+let _idSeq = 0
+function nextInstallId(): string {
+  const now = Date.now()
+  if (now === _lastIdMs) {
+    _idSeq += 1
+    return `inst-${now}-${_idSeq}`
+  }
+  _lastIdMs = now
+  _idSeq = 0
+  return `inst-${now}`
+}
+
 // Serialize all load/save operations to prevent concurrent read-modify-write races
 let _queue: Promise<void> = Promise.resolve()
 function enqueue<T>(fn: () => Promise<T>): Promise<T> {
@@ -78,7 +105,7 @@ export async function add(installation: Record<string, unknown>): Promise<Instal
     const installations = await load()
     installation.name = uniqueName(installation.name as string, installations)
     const entry = {
-      id: `inst-${Date.now()}`,
+      id: nextInstallId(),
       createdAt: new Date().toISOString(),
       ...installation,
     } as InstallationRecord
@@ -140,7 +167,7 @@ export async function ensureExists(sourceId: string, data: Record<string, unknow
     const existing = await load()
     if (existing.some((i) => i.sourceId === sourceId)) return false
     existing.push({
-      id: `inst-${Date.now()}`,
+      id: nextInstallId(),
       createdAt: new Date().toISOString(),
       ...data,
     } as InstallationRecord)
@@ -258,7 +285,7 @@ export async function seedDefaults(defaults: Record<string, unknown>[]): Promise
     if (installations.length > 0) return false
     for (const entry of defaults) {
       installations.push({
-        id: `inst-${Date.now()}`,
+        id: nextInstallId(),
         createdAt: new Date().toISOString(),
         status: "installed",
         ...entry,

--- a/src/renderer/src/panel/PanelApp.test.ts
+++ b/src/renderer/src/panel/PanelApp.test.ts
@@ -148,6 +148,10 @@ import { createPinia, setActivePinia } from 'pinia'
 import PanelApp from './PanelApp.vue'
 import { __resetLauncherPrefsForTest } from '../composables/useLauncherPrefs'
 import { useOverlay } from '../composables/useOverlay'
+import {
+  TELEMETRY_ACTION_EVENT_NAME,
+  type TelemetryActionEventDetail,
+} from '../lib/telemetry'
 
 const messages = {
   en: {
@@ -673,5 +677,166 @@ describe('PanelApp', () => {
     )
     await flushPromises()
     expect(wrapper.find('[data-testid="detail-modal"]').exists()).toBe(false)
+  })
+
+  // ---------------------------------------------------------------------------
+  // Telemetry parity (issue #485) — verify the renderer-side telemetry
+  // events the pre-Phase-3 `App.vue` fired (`desktop2.install.flow.opened`
+  // and `desktop2.view.opened`) still fire from the equivalent code paths
+  // in PanelApp's `openFlowTakeover` / `switchPanel`.
+  //
+  // Captures CustomEvents on the `window` (the same channel
+  // `emitTelemetryAction` uses to bridge into the providers) so the test
+  // doesn't have to mock the Datadog / PostHog modules.
+  // ---------------------------------------------------------------------------
+  describe('telemetry', () => {
+    function captureTelemetry(): TelemetryActionEventDetail[] {
+      const events: TelemetryActionEventDetail[] = []
+      window.addEventListener(TELEMETRY_ACTION_EVENT_NAME, (event) => {
+        events.push((event as CustomEvent<TelemetryActionEventDetail>).detail)
+      })
+      return events
+    }
+
+    it('fires desktop2.install.flow.opened with entrypoint=chooser when chooser empty-state CTA fires', async () => {
+      window.history.replaceState({}, '', '/?panel=chooser')
+      const wrapper = mountPanel()
+      await flushPromises()
+      const events = captureTelemetry()
+      await wrapper.find('[data-testid="chooser-new-install"]').trigger('click')
+      await flushPromises()
+      const flowEvents = events.filter((e) => e.actionName === 'desktop2.install.flow.opened')
+      expect(flowEvents).toHaveLength(1)
+      expect(flowEvents[0].context).toMatchObject({
+        flow: 'new_install',
+        entrypoint: 'chooser',
+      })
+    })
+
+    it('fires desktop2.install.flow.opened with entrypoint=titlebar for a panel-switch IPC', async () => {
+      window.history.replaceState({}, '', '/?panel=chooser')
+      mountPanel()
+      await flushPromises()
+      const events = captureTelemetry()
+      mockState.panelSwitchCallbacks.forEach((cb) => cb({ panel: 'quick-install' }))
+      await flushPromises()
+      const flowEvents = events.filter((e) => e.actionName === 'desktop2.install.flow.opened')
+      expect(flowEvents).toHaveLength(1)
+      expect(flowEvents[0].context).toMatchObject({
+        flow: 'quick_install',
+        entrypoint: 'titlebar',
+      })
+    })
+
+    it('maps each FlowComponent to its legacy flow string', async () => {
+      window.history.replaceState({}, '', '/?panel=chooser')
+      mountPanel()
+      await flushPromises()
+      const events = captureTelemetry()
+      const cases: { panel: string; flow: string }[] = [
+        { panel: 'new-install', flow: 'new_install' },
+        { panel: 'track', flow: 'track_existing' },
+        { panel: 'load-snapshot', flow: 'load_snapshot' },
+        { panel: 'quick-install', flow: 'quick_install' },
+      ]
+      for (const { panel } of cases) {
+        mockState.panelSwitchCallbacks.forEach((cb) => cb({ panel }))
+        await flushPromises()
+        // The takeover slot only holds one component; emit close so the
+        // next case can open. Each *Modal stub emits 'close'.
+        const open = events.filter((e) => e.actionName === 'desktop2.install.flow.opened').pop()
+        // Dismiss whatever takeover is currently mounted.
+        useOverlay().current.value = null
+        await flushPromises()
+        expect(open?.context?.flow, `panel=${panel}`).toBe(
+          cases.find((c) => c.panel === panel)?.flow,
+        )
+      }
+    })
+
+    it('fires desktop2.install.flow.opened with entrypoint=url when the URL initial panel is a flow', async () => {
+      // Captures must be installed BEFORE mount because the URL-driven
+      // initial-panel branch fires from inside `onMounted`.
+      const events = captureTelemetry()
+      window.history.replaceState({}, '', '/?panel=load-snapshot')
+      mountPanel()
+      await flushPromises()
+      const flowEvents = events.filter((e) => e.actionName === 'desktop2.install.flow.opened')
+      expect(flowEvents).toHaveLength(1)
+      expect(flowEvents[0].context).toMatchObject({
+        flow: 'load_snapshot',
+        entrypoint: 'url',
+      })
+    })
+
+    it('fires desktop2.install.flow.opened with entrypoint=first_use on the first-use Local-branch chain', async () => {
+      mockState.settings.firstUseCompleted = false
+      window.history.replaceState({}, '', '/?panel=chooser')
+      const wrapper = mountPanel()
+      await flushPromises()
+      const events = captureTelemetry()
+      await wrapper.find('[data-testid="first-use-local"]').trigger('click')
+      await flushPromises()
+      const flowEvents = events.filter((e) => e.actionName === 'desktop2.install.flow.opened')
+      expect(flowEvents).toHaveLength(1)
+      expect(flowEvents[0].context).toMatchObject({
+        flow: 'new_install',
+        entrypoint: 'first_use',
+      })
+    })
+
+    it('fires desktop2.view.opened with the previous panel as from_view when opening directories', async () => {
+      // Default install-backed host → comfy-lifecycle is the underlying body.
+      mountPanel()
+      await flushPromises()
+      const events = captureTelemetry()
+      mockState.panelSwitchCallbacks.forEach((cb) => cb({ panel: 'directories' }))
+      await flushPromises()
+      const viewEvents = events.filter((e) => e.actionName === 'desktop2.view.opened')
+      expect(viewEvents).toHaveLength(1)
+      expect(viewEvents[0].context).toMatchObject({
+        view: 'directories',
+        from_view: 'comfy-lifecycle',
+      })
+    })
+
+    it('does NOT fire desktop2.view.opened when a panel-switch IPC re-confirms the active body panel', async () => {
+      mountPanel()
+      await flushPromises()
+      const events = captureTelemetry()
+      // Default body is comfy-lifecycle; re-confirming it is a no-op.
+      mockState.panelSwitchCallbacks.forEach((cb) => cb({ panel: 'comfy-lifecycle' }))
+      await flushPromises()
+      expect(events.filter((e) => e.actionName === 'desktop2.view.opened')).toHaveLength(0)
+    })
+
+    it('does NOT fire desktop2.install.flow.opened when openFlowTakeover is rejected by an in-flight Tier 2 op', async () => {
+      // useOverlay's tier-collision rules can reject a Tier 3 open if a
+      // Tier 2 progress op is in flight and the user cancels the
+      // confirm-prompt. The renderer must not fire the telemetry event
+      // when the takeover never actually mounted. Simulate by pre-
+      // populating the overlay slot with a progress op (Tier 2) and
+      // routing a flow open through panel-switch — useOverlay will
+      // request confirmation via window.api which our mock leaves
+      // unresolved, so openOverlay returns false.
+      window.history.replaceState({}, '', '/?panel=chooser')
+      mountPanel()
+      await flushPromises()
+      // Pre-populate Tier 2 progress overlay.
+      useOverlay().current.value = {
+        kind: 'progress',
+        installationId: 'test-id',
+        operationName: 'install',
+        onCancel: () => {},
+      }
+      const events = captureTelemetry()
+      // Trigger the flow open. The collision logic in useOverlay will
+      // either prompt (default-deny in tests since no confirm handler is
+      // wired) or silently reject — either way openFlowTakeover should
+      // bail before emitting telemetry.
+      mockState.panelSwitchCallbacks.forEach((cb) => cb({ panel: 'new-install' }))
+      await flushPromises()
+      expect(events.filter((e) => e.actionName === 'desktop2.install.flow.opened')).toHaveLength(0)
+    })
   })
 })

--- a/src/renderer/src/panel/PanelApp.vue
+++ b/src/renderer/src/panel/PanelApp.vue
@@ -24,6 +24,7 @@ import { useLauncherPrefs } from '../composables/useLauncherPrefs'
 import { useListAction } from '../composables/useListAction'
 import { useMigrateAction } from '../composables/useMigrateAction'
 import { useOverlay, type FlowComponent } from '../composables/useOverlay'
+import { emitTelemetryAction } from '../lib/telemetry'
 import type { ActionResult, Installation, ShowProgressOpts } from '../types/ipc'
 
 /**
@@ -77,6 +78,19 @@ const FLOW_PANELS: ReadonlySet<PanelKey> = new Set([
   'load-snapshot',
   'quick-install',
 ])
+
+/**
+ * Telemetry — mirrors the `flow:` strings the pre-Phase-3 `App.vue`
+ * sent with `desktop2.install.flow.opened`. Keeping the same values
+ * means the existing PostHog / Datadog dashboards keyed off `flow`
+ * keep working post-refactor.
+ */
+const FLOW_TELEMETRY_NAMES: Record<FlowComponent, string> = {
+  'new-install': 'new_install',
+  'quick-install': 'quick_install',
+  track: 'track_existing',
+  'load-snapshot': 'load_snapshot',
+}
 
 /** Panels that mount as Tier 1 page modals (waffle / install dropdown
  *  items). Like FLOW_PANELS they never sit in `activePanel` — they
@@ -315,7 +329,7 @@ function handleProgressClose(): void {
  * the cancel-prompt that fires when an in-flight Tier 2 progress op
  * is being pre-empted — see `useOverlay`'s tier-collision rules).
  */
-async function openFlowTakeover(component: FlowComponent): Promise<void> {
+async function openFlowTakeover(component: FlowComponent, entrypoint: string): Promise<void> {
   // Modal-unification (Track M-6) — opt the install-flow wizards into
   // the dedicated "Discard install setup?" cancel-prompt copy so a
   // window-close consult during the wizard reads correctly. The
@@ -327,6 +341,17 @@ async function openFlowTakeover(component: FlowComponent): Promise<void> {
   // just a wizard to dismiss.
   const ok = await openOverlay({ kind: 'takeover', component, cancelCopyKey: 'discard-setup' })
   if (!ok) return
+  // Telemetry parity (issue #485) — pre-Phase-3 the four `App.vue`
+  // openers (`openNewInstall` / `openQuickInstall` / `openTrack` /
+  // `openLoadSnapshot`) each fired `desktop2.install.flow.opened`
+  // before presenting the wizard. The single chokepoint here covers
+  // all four post-refactor; the `entrypoint` is supplied by the
+  // caller so the dashboard can still tell title-bar opens from
+  // chooser-empty-state opens etc.
+  emitTelemetryAction('desktop2.install.flow.opened', {
+    flow: FLOW_TELEMETRY_NAMES[component],
+    entrypoint,
+  })
   // Wait for the v-if branch in the takeover slot to mount the
   // component before reaching for its ref.
   await nextTick()
@@ -490,7 +515,7 @@ async function handleFirstUseComplete(): Promise<void> {
 async function handleFirstUseChainLocal(): Promise<void> {
   chainingFirstUseToNewInstall.value = true
   pendingFirstUseAutoLaunchId.value = null
-  await switchPanel('new-install')
+  await switchPanel('new-install', 'first_use')
   // FirstUseTakeover.onUnmounted just pushed `'none'` as the chain
   // swap unmounted it. Re-assert `'post-consent'` so the file-menu
   // builder keeps the chain locked down to Skip Onboarding while
@@ -691,23 +716,38 @@ watch(
  * (the title-bar pill click is just "go to this page", with no reset
  * semantics needed for tab-style views like Settings / Directories).
  */
-async function switchPanel(panel: PanelKey): Promise<void> {
+async function switchPanel(panel: PanelKey, entrypoint: string = 'titlebar'): Promise<void> {
+  // Capture the underlying body BEFORE any mutation so the
+  // `desktop2.view.opened` event reports the same `from_view` the
+  // pre-Phase-3 `App.vue::switchView` did (it captured `activeView`
+  // before calling `nav.switchTab`).
+  const fromView = activePanel.value
   if (FLOW_PANELS.has(panel)) {
-    await openFlowTakeover(panel as FlowComponent)
+    await openFlowTakeover(panel as FlowComponent, entrypoint)
     return
   }
   // Waffle / install dropdown items render as Tier 1 modals on top of
   // the underlying chooser / comfy-lifecycle body — never as a body
   // swap that hides the home view.
   if (panel === 'directories' || panel === 'launcher-settings') {
-    await openOverlay({ kind: 'page', page: panel })
+    const ok = await openOverlay({ kind: 'page', page: panel })
+    if (!ok) return
+    emitTelemetryAction('desktop2.view.opened', { view: panel, from_view: fromView })
     return
   }
   if (panel === 'install-settings' && installation.value) {
-    await openOverlay({ kind: 'manage', installation: installation.value })
+    const ok = await openOverlay({ kind: 'manage', installation: installation.value })
+    if (!ok) return
+    emitTelemetryAction('desktop2.view.opened', { view: panel, from_view: fromView })
     return
   }
+  // Body-swap branch — preserve the pre-Phase-3 `if (view !== fromView)`
+  // no-op guard so a redundant `panel-switch` IPC (e.g. main re-confirms
+  // `'comfy-lifecycle'` after an instance stop while we're already there)
+  // doesn't generate a noise event.
+  if (panel === fromView) return
   activePanel.value = panel
+  emitTelemetryAction('desktop2.view.opened', { view: panel, from_view: fromView })
 }
 
 function handleUpdateInstallation(inst: Installation): void {
@@ -774,7 +814,7 @@ async function handleChooserPick(installation: Installation): Promise<void> {
   // semantics for the missing-launch-action case: bounce into the
   // new-install flow inside this same host so the user can resolve
   // the missing setup step without bouncing to a separate window.
-  await performChooserLaunch(installation, () => { void switchPanel('new-install') })
+  await performChooserLaunch(installation, () => { void switchPanel('new-install', 'chooser_pick') })
 }
 
 function handleChooserShowNewInstall(): void {
@@ -783,7 +823,7 @@ function handleChooserShowNewInstall(): void {
   // window; the user perceives a wizard step rather than a navigation
   // jump, and dismissing the takeover drops them right back into the
   // chooser tile they came from.
-  void switchPanel('new-install')
+  void switchPanel('new-install', 'chooser')
 }
 
 function handleNavigateList(): void {
@@ -905,7 +945,7 @@ onMounted(async () => {
   // or page modal), kick that open now — script-setup couldn't because
   // the template hadn't rendered yet.
   if (FLOW_PANELS.has(initialPanel) || PAGE_PANELS.has(initialPanel)) {
-    void switchPanel(initialPanel)
+    void switchPanel(initialPanel, 'url')
   }
 
   // Phase 3 §17 Step 4 — first-use takeover auto-mounts when the


### PR DESCRIPTION
Closes #485 (telemetry parity); follow-up #489 tracks the feedback link.

## Investigation

Diff of `emitTelemetryAction(...)` call sets between `main` and `feat/unified-window-titlebar-panels` revealed three renderer-side action events that the pre-Phase-3 `App.vue` fired and that went missing in the unified-window refactor:

| Event | Old call site (`App.vue`) | Status on this branch |
|---|---|---|
| `desktop2.view.opened` | `switchView()` (sidebar tab change) | Restored â€” see `switchPanel` |
| `desktop2.install.flow.opened` (Ã—4: `new_install` / `quick_install` / `track_existing` / `load_snapshot`) | `openNewInstall` / `openQuickInstall` / `openTrack` / `openLoadSnapshot` | Restored â€” see `openFlowTakeover` |
| `desktop2.feedback.opened` | `openFeedback()` (sidebar feedback link) | UI gone; tracked in #489 |

Main-process telemetry (`telemetry.emit(â€¦)`, `trackedStep(â€¦)`, `executionTap` events) is **completely unchanged** between the two branches â€” the loss was renderer-side only. The bootstrap (Datadog + PostHog providers, the `TELEMETRY_ACTION_EVENT_NAME` bridge, `onTelemetryActionFromMain` fan-out, `onTelemetrySettingChanged` consent toggle) is intact in `rendererBootstrap.ts`, so any newly-emitted action flows to both providers without further wiring.

## Changes

**`PanelApp.vue`** â€” single chokepoint for each event:

- `openFlowTakeover(component, entrypoint)` â€” added `entrypoint` parameter; emits `desktop2.install.flow.opened` once `openOverlay` succeeds, with `flow:` mapped via the new `FLOW_TELEMETRY_NAMES` table to the same legacy strings (`new_install` / `quick_install` / `track_existing` / `load_snapshot`) so existing dashboards keep working.
- `switchPanel(panel, entrypoint='titlebar')` â€” emits `desktop2.view.opened` for every successful non-flow switch (page overlays + body swaps), preserving the legacy `if (view !== fromView)` no-op guard so a redundant `panel-switch` IPC (e.g. main re-confirming `comfy-lifecycle` after an instance stop) doesn't generate noise events.
- Each `switchPanel` caller passes its own entrypoint:
  - `handleChooserShowNewInstall` â†’ `'chooser'`
  - `handleChooserPick` missing-launch-action bounce â†’ `'chooser_pick'`
  - `handleFirstUseChainLocal` â†’ `'first_use'`
  - URL-driven initial mount â†’ `'url'`
  - `onPanelSwitch` IPC handler â†’ default `'titlebar'`

**`PanelApp.test.ts`** â€” 8 new tests covering:
- Each entrypoint (`chooser`, `titlebar`, `url`, `first_use`)
- The `FlowComponent â†’ flow` string map
- The no-op guard (no event on same-panel re-confirm)
- The `openOverlay`-rejection path (no event when the takeover never mounted)

## Verification

```
pnpm run typecheck   # passes
pnpm run lint        # passes
pnpm run test        # 797 passed (32 in PanelApp.test.ts, +8 new)
pnpm run build       # passes
```
