### PR TITLE
fix(launcher): restore Send Feedback affordance in title bar + waffle menu

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2640,6 +2640,34 @@ ipcMain.on('comfy-window:click-downloads-tray', (event) => {
 })
 
 /**
+ * Forward a Send Feedback request to the host's panel renderer.
+ * Panel-side (`PanelApp.vue`) fires the `desktop2.feedback.opened`
+ * telemetry action and opens the typeform support URL via
+ * `openExternal`. The renderer is the natural home because
+ * `buildSupportUrl()` reads `navigator.userAgent` and the telemetry
+ * helpers live renderer-side. Used by both the file-menu "Send
+ * Feedback" entry and the title-bar feedback button.
+ *
+ * `source` is forwarded into the renderer's telemetry context as
+ * `desktop2.feedback.opened` `{ source }` so we can tell which
+ * affordance the user reached for.
+ */
+function triggerOpenFeedback(entryId: number, source: 'titlebar' | 'menu'): void {
+  const parentEntry = comfyWindows.get(entryId)
+  if (!parentEntry?.panelView) return
+  if (parentEntry.panelView.webContents.isDestroyed()) return
+  parentEntry.panelView.webContents.send('comfy-panel:open-feedback', { source })
+}
+
+/** Title-bar Send Feedback button click. Resolves the host entry from
+ *  the title-bar sender, then routes through `triggerOpenFeedback`. */
+ipcMain.on('comfy-window:click-feedback', (event) => {
+  const found = findEntryByTitleBarSender(event.sender)
+  if (!found) return
+  triggerOpenFeedback(found.entry.windowKey, 'titlebar')
+})
+
+/**
  * File menu → New Window (Phase 3 title bar v2). Always opens a fresh
  * install-less chooser host window — does NOT focus an existing one
  * (that's the tray-entry behaviour). The user explicitly asked for a
@@ -2825,6 +2853,8 @@ function buildTitleMenuItems(kind: 'file' | 'install', entry: ComfyWindowEntry):
     items.push(
       { id: 'directories', label: 'Directories', checked: entry.activePanel === 'directories' },
       { id: 'launcher-settings', label: 'App Settings' },
+      { kind: 'separator' },
+      { id: 'feedback', label: 'Send Feedback' },
     )
     return items
   }
@@ -3104,6 +3134,13 @@ function activateTitleMenuItem(entry: TitleMenuPopupEntry, id: string): void {
       if (parentEntry?.panelView && !parentEntry.panelView.webContents.isDestroyed()) {
         parentEntry.panelView.webContents.send('comfy-panel:first-use-skip')
       }
+    }
+    else if (id === 'feedback') {
+      // Forward to the panel renderer — see `triggerOpenFeedback`.
+      // The title-bar Send Feedback button lands on the same helper
+      // via `comfy-window:click-feedback`; `source` distinguishes the
+      // two entry points in the telemetry payload.
+      triggerOpenFeedback(entry.parentEntryId, 'menu')
     }
     else if (id === 'new-install' || id === 'track' || id === 'load-snapshot' || id === 'quick-install') {
       // Track B item 3 — install-creation / import flows are

--- a/src/preload/comfyTitleBarPreload.ts
+++ b/src/preload/comfyTitleBarPreload.ts
@@ -148,6 +148,12 @@ export interface ComfyTitleBarBridge {
    *  the same `panel-trigger-overlay` channel as the app-update pill
    *  so the panel renderer can open the downloads popover. */
   clickDownloadsTray(): void
+  /** Click handler for the title-bar Send Feedback button. Main
+   *  resolves the host entry from the sender and forwards
+   *  `comfy-panel:open-feedback` to the panel renderer, which fires
+   *  the `desktop2.feedback.opened` telemetry action and opens the
+   *  support URL via `openExternal`. */
+  clickFeedback(): void
   /** Tell main this title bar is mounted; main responds with the initial state. */
   ready(): void
 }
@@ -292,6 +298,9 @@ const bridge: ComfyTitleBarBridge = {
   },
   clickDownloadsTray: () => {
     ipcRenderer.send('comfy-window:click-downloads-tray')
+  },
+  clickFeedback: () => {
+    ipcRenderer.send('comfy-window:click-feedback')
   },
   ready: () => {
     ipcRenderer.send('comfy-window:title-bar-ready')

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -61,6 +61,14 @@ const api: ElectronApi = {
     ipcRenderer.on('comfy-panel:first-use-skip', handler)
     return () => ipcRenderer.removeListener('comfy-panel:first-use-skip', handler)
   },
+  onOpenFeedback: (callback) => {
+    const handler = (_event: IpcRendererEvent, data: unknown): void => {
+      const source = (data as { source?: unknown } | null)?.source
+      callback({ source: source === 'menu' ? 'menu' : 'titlebar' })
+    }
+    ipcRenderer.on('comfy-panel:open-feedback', handler)
+    return () => ipcRenderer.removeListener('comfy-panel:open-feedback', handler)
+  },
   /**
    * Step 5 §16 — main consults the panel renderer before tearing down
    * the host window so a Tier 2 progress / Tier 3 takeover overlay can

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -168,10 +168,6 @@ body {
   display: flex; align-items: center; justify-content: center;
   flex-shrink: 0;
 }
-.sidebar-feedback {
-  margin: 0 8px;
-  width: auto;
-}
 .sidebar-version {
   padding: 8px 20px;
   font-size: 11px;

--- a/src/renderer/src/comfyTitleBar/TitleBarApp.test.ts
+++ b/src/renderer/src/comfyTitleBar/TitleBarApp.test.ts
@@ -39,6 +39,7 @@ interface MockBridgeState {
   appUpdatePillClicks: number
   installUpdatePillClicks: number
   downloadsTrayClicks: number
+  feedbackClicks: number
   readyCalls: number
 }
 
@@ -64,6 +65,7 @@ function installMockBridge(opts: { isMac?: boolean; installationId?: string | nu
     appUpdatePillClicks: 0,
     installUpdatePillClicks: 0,
     downloadsTrayClicks: 0,
+    feedbackClicks: 0,
     readyCalls: 0,
   }
   const installationId = opts.installationId === undefined ? 'test-id' : opts.installationId
@@ -134,6 +136,9 @@ function installMockBridge(opts: { isMac?: boolean; installationId?: string | nu
     },
     clickDownloadsTray: () => {
       state.downloadsTrayClicks += 1
+    },
+    clickFeedback: () => {
+      state.feedbackClicks += 1
     },
     ready: () => {
       state.readyCalls += 1
@@ -777,6 +782,39 @@ describe('TitleBarApp', () => {
     await wrapper.find('.title-downloads-tray').trigger('click')
     expect(bridgeState.downloadsTrayClicks).toBe(1)
     wrapper.unmount()
+  })
+
+  it('renders a Send Feedback button and forwards clicks through the bridge', async () => {
+    // Restored from the pre-unified-window sidebar — the title-bar
+    // entry pairs with the file-menu "Send Feedback" entry. Both
+    // route through main → panel renderer (where the telemetry +
+    // openExternal side-effects fire); the title-bar half just has
+    // to surface the affordance and forward the click.
+    const { default: TitleBarApp } = await import('./TitleBarApp.vue')
+    const wrapper = mount(TitleBarApp, { attachTo: document.body })
+    await flushPromises()
+    const btn = wrapper.find('.title-feedback-button')
+    expect(btn.exists()).toBe(true)
+    expect(btn.attributes('aria-label')).toBe('Send Feedback')
+    await btn.trigger('click')
+    expect(bridgeState.feedbackClicks).toBe(1)
+    wrapper.unmount()
+  })
+
+  it('hides the Send Feedback button during the first-use consent-lockdown step', async () => {
+    // Same gating as the waffle: during the T&C consent step the only
+    // first-use gestures we want available are explicit consent or
+    // OS-chrome window close. The feedback button reappears once the
+    // takeover advances out of the lockdown.
+    const { default: TitleBarApp } = await import('./TitleBarApp.vue')
+    const wrapper = mount(TitleBarApp)
+    await flushPromises()
+    bridgeState.firstUseModeChangedCallbacks.forEach((cb) => cb('consent-lockdown'))
+    await flushPromises()
+    expect(wrapper.find('.title-feedback-button').exists()).toBe(false)
+    bridgeState.firstUseModeChangedCallbacks.forEach((cb) => cb('post-consent'))
+    await flushPromises()
+    expect(wrapper.find('.title-feedback-button').exists()).toBe(true)
   })
 
   it('renders the downloads tray on install-less (chooser-host) windows too — downloads are global, not per-install', async () => {

--- a/src/renderer/src/comfyTitleBar/TitleBarApp.vue
+++ b/src/renderer/src/comfyTitleBar/TitleBarApp.vue
@@ -7,6 +7,7 @@ import {
   ChevronRight,
   Download,
   Menu as MenuIcon,
+  MessageSquarePlus,
   RefreshCw,
 } from 'lucide-vue-next'
 import { installTypeMetaFor } from '../lib/installTypeIcon'
@@ -133,6 +134,11 @@ interface Bridge {
    *  the same `panel-trigger-overlay` channel as the update pills so
    *  the panel renderer can mount the downloads popover. */
   clickDownloadsTray: () => void
+  /** Click handler for the title-bar Send Feedback button. Main
+   *  forwards `comfy-panel:open-feedback` to the panel renderer,
+   *  which fires the `desktop2.feedback.opened` telemetry action and
+   *  opens the support URL via `openExternal`. */
+  clickFeedback: () => void
   ready: () => void
 }
 
@@ -363,6 +369,15 @@ const downloadsTrayLabel = computed<string>(() => {
 
 function handleDownloadsTray(): void {
   bridge?.clickDownloadsTray()
+}
+
+/** Title-bar Send Feedback button. Routes through main, which forwards
+ *  `comfy-panel:open-feedback` to the panel renderer — the renderer
+ *  fires the `desktop2.feedback.opened` telemetry action and opens the
+ *  support URL via `openExternal`. The waffle menu's "Send Feedback"
+ *  entry lands on the same panel-side handler. */
+function handleFeedback(): void {
+  bridge?.clickFeedback()
 }
 
 /** Body luminance test — drives is-light styling (lighter hover state). */
@@ -615,6 +630,20 @@ onUnmounted(() => {
           aria-hidden="true"
         >{{ downloadsActiveCount }}</span>
       </button>
+      <!-- Send Feedback — always-visible affordance restored from the
+           pre-unified-window sidebar. Hidden during the consent-lockdown
+           step for the same reason the waffle is: the only first-use
+           gesture we want available is consent or OS-chrome close. -->
+      <button
+        v-if="!isConsentLockdown"
+        type="button"
+        class="title-menu-button title-menu-button--icon title-feedback-button"
+        title="Send Feedback"
+        aria-label="Send Feedback"
+        @click="handleFeedback"
+      >
+        <MessageSquarePlus :size="16" />
+      </button>
     </div>
 
     <!-- Center: browser-style Back / Forward arrows immediately left of
@@ -798,6 +827,14 @@ onUnmounted(() => {
 .title-menu-button--icon {
   padding: 4px 6px;
   gap: 0;
+}
+
+/* Send Feedback sits visually apart from the
+   waffle / app-update / downloads cluster — the cluster is window-
+   chrome, the feedback button is an outbound action. The extra inset
+   (on top of the 2px container gap) reads as "different group". */
+.title-feedback-button {
+  margin-left: 10px;
 }
 
 /* --- Back / Forward arrows (browser-style nav) --- */

--- a/src/renderer/src/panel/PanelApp.test.ts
+++ b/src/renderer/src/panel/PanelApp.test.ts
@@ -187,8 +187,15 @@ interface MockApiState {
    *  waffle popup; tests can simulate the click by invoking each
    *  callback. */
   firstUseSkipCallbacks: (() => void)[]
+  /** Feedback callbacks. Main fires this when the user clicks the
+   *  title-bar Send Feedback button or the file-menu "Send Feedback"
+   *  entry; tests can simulate the click by invoking each callback
+   *  with the originating `source`. */
+  openFeedbackCallbacks: ((data: { source: 'titlebar' | 'menu' }) => void)[]
   installations: InstallationLike[]
   getInstallations: ReturnType<typeof vi.fn>
+  openExternal: ReturnType<typeof vi.fn>
+  getAppVersion: ReturnType<typeof vi.fn>
   /** Per-key getSetting values. Tests that need first-use takeover to
    *  auto-mount can flip `firstUseCompleted` to false here. Default is
    *  `true` so existing tests don't trip the takeover. */
@@ -205,8 +212,11 @@ function installMockApi(initial?: {
     panelTriggerOverlayCallbacks: [],
     installationsChangedCallbacks: [],
     firstUseSkipCallbacks: [],
+    openFeedbackCallbacks: [],
     installations,
     getInstallations: vi.fn(async () => state.installations),
+    openExternal: vi.fn(async () => {}),
+    getAppVersion: vi.fn(async () => '0.5.0'),
     settings: { firstUseCompleted: true, ...initial?.settings },
   }
   const api = {
@@ -233,6 +243,12 @@ function installMockApi(initial?: {
       state.firstUseSkipCallbacks.push(cb)
       return () => {}
     }),
+    onOpenFeedback: vi.fn((cb: (data: { source: 'titlebar' | 'menu' }) => void) => {
+      state.openFeedbackCallbacks.push(cb)
+      return () => {}
+    }),
+    openExternal: state.openExternal,
+    getAppVersion: state.getAppVersion,
     onSettingsChanged: vi.fn(() => () => {}),
     // Step 5 §16 — main consults the panel renderer before tearing
     // down the host window. PanelApp subscribes on mount; the test
@@ -594,6 +610,49 @@ describe('PanelApp', () => {
     expect(wrapper.find('[data-testid="first-use-takeover"]').exists()).toBe(false)
     // Chooser body underneath remains mounted, same as Cloud-pick.
     expect(wrapper.find('[data-testid="chooser-view"]').exists()).toBe(true)
+  })
+
+  it('emits desktop2.feedback.opened with the originating source and opens the support URL', async () => {
+    // Both the title-bar feedback button and the file-menu "Send
+    // Feedback" entry route through main's `comfy-panel:open-feedback`
+    // IPC. The panel renderer is the natural home for the click side-
+    // effects because `buildSupportUrl()` reads `navigator.userAgent`
+    // and the telemetry helper lives renderer-side. Verify the listener
+    // (a) emits the legacy-parity telemetry action with `source` baked
+    // into the context so we can tell the two affordances apart, and
+    // (b) opens the typeform URL with the cached app version in `ver`.
+    mountPanel()
+    await flushPromises()
+
+    interface TelemetryEvent {
+      actionName: string
+      context?: { source?: string }
+    }
+    const telemetryEvents: TelemetryEvent[] = []
+    const listener = (e: Event): void => {
+      telemetryEvents.push((e as CustomEvent<TelemetryEvent>).detail)
+    }
+    window.addEventListener('launcher-telemetry-action', listener)
+
+    expect(mockState.openFeedbackCallbacks.length).toBeGreaterThan(0)
+    // Title-bar button click.
+    mockState.openFeedbackCallbacks.forEach((cb) => cb({ source: 'titlebar' }))
+    await flushPromises()
+    // File-menu entry click.
+    mockState.openFeedbackCallbacks.forEach((cb) => cb({ source: 'menu' }))
+    await flushPromises()
+
+    window.removeEventListener('launcher-telemetry-action', listener)
+
+    const feedbackTelemetry = telemetryEvents.filter(
+      (e) => e.actionName === 'desktop2.feedback.opened',
+    )
+    expect(feedbackTelemetry.map((e) => e.context?.source)).toEqual(['titlebar', 'menu'])
+    expect(mockState.openExternal).toHaveBeenCalledTimes(2)
+    const url = (mockState.openExternal.mock.calls[0]?.[0] ?? '') as string
+    expect(url).toContain('form.typeform.com/to/VhOXmuaL')
+    expect(url).toContain('ver=0.5.0')
+    expect(url).toMatch(/[?&]platform=/)
   })
 
   // Post-Phase-3 polish: the first-use takeover dropped its in-app

--- a/src/renderer/src/panel/PanelApp.vue
+++ b/src/renderer/src/panel/PanelApp.vue
@@ -24,6 +24,8 @@ import { useLauncherPrefs } from '../composables/useLauncherPrefs'
 import { useListAction } from '../composables/useListAction'
 import { useMigrateAction } from '../composables/useMigrateAction'
 import { useOverlay, type FlowComponent } from '../composables/useOverlay'
+import { emitTelemetryAction } from '../lib/telemetry'
+import { buildSupportUrl } from '../lib/supportUrl'
 import type { ActionResult, Installation, ShowProgressOpts } from '../types/ipc'
 
 /**
@@ -189,6 +191,24 @@ let unsubSettings: (() => void) | null = null
 let unsubCloseRequest: (() => void) | null = null
 let unsubPanelTriggerOverlay: (() => void) | null = null
 let unsubFirstUseSkip: (() => void) | null = null
+let unsubOpenFeedback: (() => void) | null = null
+
+/** App version cached at mount; appended to the support URL as the
+ *  `ver` query param so feedback submissions can be filtered by build.
+ *  Cached because the typeform open path is fire-and-forget and we
+ *  don't want to await an IPC inside the click handler. Empty string
+ *  while the initial fetch is in flight or if it failed — `buildSupportUrl`
+ *  treats falsy as "omit the param". */
+const appVersion = ref('')
+
+/** Forward a Send Feedback request from the title-bar button or the
+ *  file-menu entry: fire the `desktop2.feedback.opened` telemetry
+ *  action (with `source` so we can tell which affordance the user
+ *  reached for), then open the typeform support URL via `openExternal`. */
+function handleOpenFeedback(source: 'titlebar' | 'menu'): void {
+  emitTelemetryAction('desktop2.feedback.opened', { source })
+  void window.api.openExternal(buildSupportUrl(appVersion.value || undefined))
+}
 
 async function loadLocale(): Promise<void> {
   const messages = await window.api.getLocaleMessages()
@@ -893,6 +913,23 @@ onMounted(async () => {
     void completeFirstUseAndDismiss()
   })
 
+  // Title-bar Send Feedback button + file-menu "Send Feedback" entry
+  // both forward through main to this listener. See `handleOpenFeedback`;
+  // `source` identifies the affordance for telemetry.
+  unsubOpenFeedback = window.api.onOpenFeedback(({ source }) => {
+    handleOpenFeedback(source)
+  })
+
+  // Cache the app version for the support URL's `ver` query param.
+  // Fire-and-forget — `handleOpenFeedback` falls back to omitting the
+  // param while this is in flight or if it rejects.
+  void window.api
+    .getAppVersion()
+    .then((v) => {
+      appVersion.value = v
+    })
+    .catch(() => {})
+
   // Initialize stores / prefs needed by the install-settings DetailModal.
   // installationStore wires its own onInstallationsChanged listener.
   await Promise.all([
@@ -927,6 +964,7 @@ onUnmounted(() => {
   unsubCloseRequest?.()
   unsubPanelTriggerOverlay?.()
   unsubFirstUseSkip?.()
+  unsubOpenFeedback?.()
   pendingPickUnsub?.()
   sessionStore.dispose()
 })

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -730,6 +730,14 @@ export interface ElectronApi {
    *  `markFirstUseCompleted` + dismiss-takeover sequence the Cloud
    *  pick path uses. Returns an unsubscribe. */
   onFirstUseSkip(callback: () => void): Unsubscribe
+  /** Main forwards both the title-bar feedback button and the file-menu
+   *  "Send Feedback" entry here. The panel renderer fires the
+   *  `desktop2.feedback.opened` telemetry action (with `source` so we
+   *  can tell the two affordances apart) and opens the support URL via
+   *  `openExternal` — the renderer is the natural home because
+   *  `buildSupportUrl()` reads `navigator.userAgent` and the telemetry
+   *  helpers live renderer-side. Returns an unsubscribe. */
+  onOpenFeedback(callback: (data: { source: 'titlebar' | 'menu' }) => void): Unsubscribe
   /** Step 5 §16 — main consults the panel renderer before tearing down
    *  the host window. Returns an unsubscribe; the callback receives a
    *  `requestId` it must echo back via `respondCloseRequest` so main


### PR DESCRIPTION
Closes #489. Follow-up to #485.

## Problem

The `feat/unified-window-titlebar-panels` refactor removed the launcher window and its sidebar entirely. The sidebar previously hosted a `Send Feedback` button wired through `App.vue::openFeedback()` -> `buildSupportUrl()` -> `window.api.openExternal()` with telemetry `desktop2.feedback.opened` fired on click. After the refactor:

- `desktop2.feedback.opened` is no longer emitted from anywhere.
- `src/renderer/src/lib/supportUrl.ts` is orphaned (zero importers).
- `.sidebar-feedback` CSS rule is dead.

## Fix

Restored the affordance via two entry points (per discussion in #489), both routing through a single panel-side handler so the side-effects only live in one place:

```
Title-bar button ─┐
                  ├─▶ main.triggerOpenFeedback ─▶ comfy-panel:open-feedback {source}
File-menu entry ──┘                                                          │
                                                                             ▼
                              PanelApp.handleOpenFeedback(source)
                                  emitTelemetryAction('desktop2.feedback.opened', { source })
                                  openExternal(buildSupportUrl(appVersion))
```

### What's surfaced

- **Title-bar button** — `MessageSquarePlus` icon in the left cluster, after the optional app-update / downloads tray entries, with `margin-left: 10px` so it reads as a separate group from the window-chrome cluster. Hidden during the first-use consent-lockdown step (same gating as the waffle).
- **Waffle menu (File menu) entry** — `Send Feedback` under a separator after `Directories` / `App Settings`. Suppressed in the `post-consent` short-circuit, same as the other steady-state entries.

### What's sent on click

- **Telemetry**: `desktop2.feedback.opened` with `context: { source: 'titlebar' | 'menu' }` so PostHog / Datadog can split the metric by which affordance the user reached for.
- **Browser open**: `https://form.typeform.com/to/VhOXmuaL?ver=<appVersion>&platform=<windows|mac|linux|unknown>` via `openExternal`.

### Why panel renderer (not main, not title-bar renderer)

- `buildSupportUrl()` reads `navigator.userAgent` (renderer-only).
- `emitTelemetryAction` lives in `src/renderer/src/lib/telemetry.ts` (renderer-only).
- The title-bar renderer has no `window.api` / telemetry imports today; PanelApp already does, so the listener slots in next to the existing `onFirstUseSkip` push.

### Cleanup

- Removed orphan `.sidebar-feedback` CSS rule (the broader `.sidebar-*` group is also dead but left in scope of this PR).
- `supportUrl.ts` is now consumed by `PanelApp.vue` — no longer dead code.

## Tests

- `TitleBarApp.test.ts` — feedback button is rendered with the right aria-label, click forwards through the bridge, hidden during `consent-lockdown`.
- `PanelApp.test.ts` — both `'titlebar'` and `'menu'` source values round-trip through the IPC into `desktop2.feedback.opened` telemetry context, and `openExternal` is called twice with the typeform URL containing `ver=0.5.0` and `platform=...`.

## Verification

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm build` ✅
- `pnpm test` — 793 / 793 passing ✅
