### PR TITLE
feat(titlebar): drop browser-style back/forward chevrons

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -247,28 +247,14 @@ interface ComfyWindowEntry {
    */
   panelView: WebContentsView | null
   /**
-   * Which panel is currently rendered (== `panelHistory[panelHistoryIndex]`).
-   * Always one of the user-visible panel keys — never the internal
-   * `'comfy-lifecycle'` / `'chooser'` body modes. For install-less host
-   * windows only `'comfy'`, `'launcher-settings'`, and `'directories'`
-   * are reachable (Install Settings is hidden — the install caret menu
-   * is suppressed without an install backing the window).
+   * Which panel is currently rendered. Always one of the user-visible
+   * panel keys — never the internal `'comfy-lifecycle'` / `'chooser'`
+   * body modes. For install-less host windows only `'comfy'`,
+   * `'launcher-settings'`, and `'directories'` are reachable
+   * (Install Settings is hidden — the install caret menu is suppressed
+   * without an install backing the window).
    */
   activePanel: ComfyPanelKey
-  /**
-   * Browser-style navigation history for the title-bar Back / Forward
-   * buttons. The pill is no longer treated as a tab indicator —
-   * navigating between pages uses this stack instead.
-   *
-   * The "root" is `'comfy'` and is always at index 0. Opening a page
-   * (Settings / Directories / Install Settings / a flow) truncates any
-   * forward history and pushes the new key. Returning to the comfy
-   * body via the pill or the page's X-close button resets the stack
-   * to `['comfy']` (deliberate "I'm done with these pages" gesture
-   * — clears forward history). Back / Forward only move the index.
-   */
-  panelHistory: ComfyPanelKey[]
-  panelHistoryIndex: number
   /** Last known theme reported by the ComfyUI frontend, applied to the panel when it loads. */
   lastTheme: { bg: string; text: string }
   /** Layout function bound to this entry — updates view bounds for the current activePanel. */
@@ -499,7 +485,6 @@ function refreshComfyTabBody(installationId: string): void {
  *
  * This is the single chokepoint every title-bar IPC must funnel through —
  * see `comfy-window:open-title-menu` / `comfy-window:set-panel` /
- * `comfy-window:go-back` / `comfy-window:go-forward` /
  * `comfy-window:click-app-update-pill` / `comfy-window:click-install-update-pill`.
  *
  * Aux windows are NEVER reachable through this lookup:
@@ -1285,7 +1270,6 @@ function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowResult {
       titleBarView.webContents.send('comfy-titlebar:theme-changed', entry.lastTheme)
       titleBarView.webContents.send('comfy-titlebar:title-changed', entry.titleBarText)
       titleBarView.webContents.send('comfy-titlebar:source-category-changed', entry.sourceCategory)
-      _notifyTitleBarNavState(entry)
     }
     // Phase 3 §18 — both modes get the app-update pill and the
     // downloads tray. The install-update pill is install-backed only:
@@ -1380,8 +1364,6 @@ function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowResult {
     titleBarView,
     panelView: null,
     activePanel: 'comfy',
-    panelHistory: ['comfy'],
-    panelHistoryIndex: 0,
     lastTheme: opts.initialTheme,
     layoutViews,
     comfyUrl: '',
@@ -1523,15 +1505,14 @@ function onLaunch({ port, url, process: proc, installation, mode }: {
       void existing.comfyView.webContents.loadURL(comfyUrl).catch(() => {})
     }
     // A relaunch implicitly means "land me in the live ComfyUI view",
-    // so force the host's activePanel back to `'comfy'` and clear any
-    // breadcrumb history. Without this, a launch kicked off from a
-    // non-comfy panel (e.g. the install-settings DetailModal) would
-    // leave the body stranded on the lifecycle / settings panel —
-    // `refreshComfyTabBody` early-returns on `activePanel !== 'comfy'`.
-    // The trailing `refreshComfyTabBody` still handles the
-    // comfy-lifecycle → comfy body-mode swap when the entry was
-    // already on `'comfy'` (setActivePanel early-returns there).
-    setActivePanel(existing.windowKey, 'comfy', 'reset')
+    // so force the host's activePanel back to `'comfy'`. Without this, a
+    // launch kicked off from a non-comfy panel (e.g. the install-settings
+    // DetailModal) would leave the body stranded on the lifecycle /
+    // settings panel — `refreshComfyTabBody` early-returns on
+    // `activePanel !== 'comfy'`. The trailing `refreshComfyTabBody`
+    // still handles the comfy-lifecycle → comfy body-mode swap when the
+    // entry was already on `'comfy'` (setActivePanel early-returns there).
+    setActivePanel(existing.windowKey, 'comfy')
     refreshComfyTabBody(installationId)
     if (proc) {
       proc.on('exit', () => {
@@ -2026,11 +2007,8 @@ function _detachInstallImpl(entry: ComfyWindowEntry): void {
 
   // Reset nav state to the comfy pill (chooser body for install-less hosts).
   entry.activePanel = 'comfy'
-  entry.panelHistory = ['comfy']
-  entry.panelHistoryIndex = 0
   if (!entry.titleBarView.webContents.isDestroyed()) {
     entry.titleBarView.webContents.send('comfy-titlebar:panel-changed', 'comfy')
-    _notifyTitleBarNavState(entry)
   }
 
   // Tear down the install-backed PanelApp and remount fresh in chooser mode.
@@ -2320,47 +2298,7 @@ function focusActiveBody(entry: ComfyWindowEntry): void {
   }
 }
 
-/**
- * How a panel switch is being requested. Drives the navigation-history
- * book-keeping so the title bar's Back / Forward buttons behave like a
- * browser tab rather than a page swap:
- *   - `'navigate'`: opening a page from a menu / dropdown / chooser →
- *     truncate forward history and push the new key.
- *   - `'back'` / `'forward'`: only move the history index. The caller
- *     resolves the destination key from the stack, this function just
- *     applies it.
- *   - `'reset'`: pill click or X-close → wipe history back to `['comfy']`
- *     and land on index 0. A deliberate "I'm done with these pages"
- *     gesture, so forward history is intentionally cleared.
- */
-type PanelNavSource = 'navigate' | 'back' | 'forward' | 'reset'
-
-/** Push `key` onto the history, truncating any forward entries first.
- *  No-op when `key` is already the current panel. */
-function _pushPanelHistory(entry: ComfyWindowEntry, key: ComfyPanelKey): void {
-  // Drop everything strictly after the current index — the user is
-  // forking history from where they currently are.
-  entry.panelHistory = entry.panelHistory.slice(0, entry.panelHistoryIndex + 1)
-  if (entry.panelHistory[entry.panelHistoryIndex] === key) return
-  entry.panelHistory.push(key)
-  entry.panelHistoryIndex = entry.panelHistory.length - 1
-}
-
-/** Send the current Back/Forward enabled state to the title bar so it can
- *  enable / disable the arrow buttons. */
-function _notifyTitleBarNavState(entry: ComfyWindowEntry): void {
-  if (entry.titleBarView.webContents.isDestroyed()) return
-  entry.titleBarView.webContents.send('comfy-titlebar:nav-state-changed', {
-    canBack: entry.panelHistoryIndex > 0,
-    canForward: entry.panelHistoryIndex < entry.panelHistory.length - 1,
-  })
-}
-
-function setActivePanel(
-  windowKey: number,
-  panel: ComfyPanelKey,
-  source: PanelNavSource = 'navigate',
-): void {
+function setActivePanel(windowKey: number, panel: ComfyPanelKey): void {
   const entry = comfyWindows.get(windowKey)
   if (!entry || entry.window.isDestroyed()) return
   // Install Settings is install-scoped (the install caret menu in the
@@ -2373,27 +2311,7 @@ function setActivePanel(
   // host windows are allowed to open it.
   if (entry.installationId === null && panel === 'install-settings') return
 
-  // Update navigation history per source. The history mutation happens
-  // BEFORE the early-return for "same panel" because a `'reset'` from a
-  // page back to `'comfy'` still has work to do (clear forward) even
-  // when the panel is already comfy by some other accident.
-  if (source === 'reset') {
-    entry.panelHistory = ['comfy']
-    entry.panelHistoryIndex = 0
-    panel = 'comfy'
-  } else if (source === 'navigate') {
-    _pushPanelHistory(entry, panel)
-  }
-  // For 'back' / 'forward' the caller has already moved
-  // panelHistoryIndex; we only apply the panel switch here.
-
-  if (entry.activePanel === panel) {
-    // Even when the panel didn't change (e.g. menu re-pick of the
-    // current page), nav state may have shifted (forward truncated)
-    // — push the latest state so the title bar arrows reflect reality.
-    _notifyTitleBarNavState(entry)
-    return
-  }
+  if (entry.activePanel === panel) return
 
   entry.activePanel = panel
   // Resolve to the actual body mode (Comfy pill maps to lifecycle / chooser
@@ -2414,7 +2332,6 @@ function setActivePanel(
     // internal `'comfy-lifecycle'` body mode.
     entry.titleBarView.webContents.send('comfy-titlebar:panel-changed', panel)
   }
-  _notifyTitleBarNavState(entry)
   focusActiveBody(entry)
 }
 
@@ -2423,43 +2340,14 @@ ipcMain.on('comfy-window:set-panel', (event, payload: { panel: string }) => {
   if (!found) return
   const panel = payload?.panel as ComfyPanelKey
   if (!VALID_PANELS.has(panel)) return
-  // Pill clicks always send `'comfy'` from the title bar — treat as a
-  // history reset (the pill is no longer a tab indicator, so going
-  // home should clear the breadcrumb of pages the user was browsing).
-  // Other panel keys from the title bar come from the File / Install
-  // dropdowns and are 'navigate'.
-  setActivePanel(found.id, panel, panel === 'comfy' ? 'reset' : 'navigate')
-})
-
-/** Title bar Back arrow → step one entry backward in history. */
-ipcMain.on('comfy-window:go-back', (event) => {
-  const found = findEntryByTitleBarSender(event.sender)
-  if (!found) return
-  const { id, entry } = found
-  if (entry.panelHistoryIndex <= 0) return
-  entry.panelHistoryIndex -= 1
-  const target = entry.panelHistory[entry.panelHistoryIndex]
-  if (!target) return
-  setActivePanel(id, target, 'back')
-})
-
-/** Title bar Forward arrow → step one entry forward in history. */
-ipcMain.on('comfy-window:go-forward', (event) => {
-  const found = findEntryByTitleBarSender(event.sender)
-  if (!found) return
-  const { id, entry } = found
-  if (entry.panelHistoryIndex >= entry.panelHistory.length - 1) return
-  entry.panelHistoryIndex += 1
-  const target = entry.panelHistory[entry.panelHistoryIndex]
-  if (!target) return
-  setActivePanel(id, target, 'forward')
+  setActivePanel(found.id, panel)
 })
 
 /**
  * Page-level X close (rendered inside the panel WebContentsView, e.g.
  * Settings / Directories / Install Settings) — same effect as a pill
- * click: history is reset and the body returns to the comfy/chooser
- * root. The panel preload exposes this as `closeCurrentPanel()`.
+ * click: the body returns to the comfy/chooser root. The panel preload
+ * exposes this as `closeCurrentPanel()`.
  *
  * We resolve the host window via the panel's WebContents sender. The
  * panelView is lazily created so we walk every entry instead of caching
@@ -2468,7 +2356,7 @@ ipcMain.on('comfy-window:go-forward', (event) => {
 ipcMain.on('comfy-window:close-current-panel', (event) => {
   for (const [id, entry] of comfyWindows) {
     if (entry.panelView?.webContents === event.sender) {
-      setActivePanel(id, 'comfy', 'reset')
+      setActivePanel(id, 'comfy')
       return
     }
   }

--- a/src/preload/comfyTitleBarPreload.ts
+++ b/src/preload/comfyTitleBarPreload.ts
@@ -61,16 +61,8 @@ export interface ComfyTitleBarBridge {
   /** Pop the Install caret menu as a native OS menu. No-op for
    *  install-less host windows (main filters by sender's entry). */
   openInstallMenu(anchor: TitleMenuAnchor): void
-  /** Browser-style Back arrow — step one entry backward in the host
-   *  window's panel-history stack. No-op when at the root. */
-  goBack(): void
-  /** Browser-style Forward arrow — step one entry forward in history.
-   *  No-op when there's nothing to redo (i.e. user hasn't pressed Back). */
-  goForward(): void
   /** Subscribe to panel-active changes coming from main. */
   onPanelChanged(cb: (panel: ComfyPanelKey) => void): () => void
-  /** Subscribe to navigation-state changes (Back/Forward enabledness). */
-  onNavStateChanged(cb: (state: { canBack: boolean; canForward: boolean }) => void): () => void
   /** Subscribe to title text changes coming from main. */
   onTitleChanged(cb: (title: string) => void): () => void
   /** Track B item 4 — subscribe to install source-category pushes
@@ -185,26 +177,12 @@ const bridge: ComfyTitleBarBridge = {
   openInstallMenu: (anchor) => {
     ipcRenderer.send('comfy-window:open-title-menu', { menu: 'install', anchor })
   },
-  goBack: () => {
-    ipcRenderer.send('comfy-window:go-back')
-  },
-  goForward: () => {
-    ipcRenderer.send('comfy-window:go-forward')
-  },
   onPanelChanged: (cb) => {
     const handler = (_event: IpcRendererEvent, panel: unknown): void => {
       if (typeof panel === 'string') cb(panel as ComfyPanelKey)
     }
     ipcRenderer.on('comfy-titlebar:panel-changed', handler)
     return () => ipcRenderer.removeListener('comfy-titlebar:panel-changed', handler)
-  },
-  onNavStateChanged: (cb) => {
-    const handler = (_event: IpcRendererEvent, data: unknown): void => {
-      const { canBack, canForward } = (data || {}) as { canBack?: unknown; canForward?: unknown }
-      cb({ canBack: !!canBack, canForward: !!canForward })
-    }
-    ipcRenderer.on('comfy-titlebar:nav-state-changed', handler)
-    return () => ipcRenderer.removeListener('comfy-titlebar:nav-state-changed', handler)
   },
   onTitleChanged: (cb) => {
     const handler = (_event: IpcRendererEvent, title: unknown): void => {

--- a/src/renderer/src/comfyTitleBar/TitleBarApp.test.ts
+++ b/src/renderer/src/comfyTitleBar/TitleBarApp.test.ts
@@ -16,7 +16,6 @@ interface MockDownloadsTrayState {
 
 interface MockBridgeState {
   panelChangedCallbacks: ((panel: string) => void)[]
-  navStateChangedCallbacks: ((state: { canBack: boolean; canForward: boolean }) => void)[]
   titleChangedCallbacks: ((title: string) => void)[]
   sourceCategoryChangedCallbacks: ((category: string | null) => void)[]
   themeChangedCallbacks: ((theme: { bg: string; text: string }) => void)[]
@@ -34,8 +33,6 @@ interface MockBridgeState {
   newWindowCalls: number
   fileMenuAnchors: { x: number; y: number }[]
   installMenuAnchors: { x: number; y: number }[]
-  goBackCalls: number
-  goForwardCalls: number
   appUpdatePillClicks: number
   installUpdatePillClicks: number
   downloadsTrayClicks: number
@@ -45,7 +42,6 @@ interface MockBridgeState {
 function installMockBridge(opts: { isMac?: boolean; installationId?: string | null } = {}): MockBridgeState {
   const state: MockBridgeState = {
     panelChangedCallbacks: [],
-    navStateChangedCallbacks: [],
     titleChangedCallbacks: [],
     sourceCategoryChangedCallbacks: [],
     themeChangedCallbacks: [],
@@ -59,8 +55,6 @@ function installMockBridge(opts: { isMac?: boolean; installationId?: string | nu
     newWindowCalls: 0,
     fileMenuAnchors: [],
     installMenuAnchors: [],
-    goBackCalls: 0,
-    goForwardCalls: 0,
     appUpdatePillClicks: 0,
     installUpdatePillClicks: 0,
     downloadsTrayClicks: 0,
@@ -74,14 +68,8 @@ function installMockBridge(opts: { isMac?: boolean; installationId?: string | nu
     openNewWindow: () => { state.newWindowCalls += 1 },
     openFileMenu: (anchor: { x: number; y: number }) => { state.fileMenuAnchors.push(anchor) },
     openInstallMenu: (anchor: { x: number; y: number }) => { state.installMenuAnchors.push(anchor) },
-    goBack: () => { state.goBackCalls += 1 },
-    goForward: () => { state.goForwardCalls += 1 },
     onPanelChanged: (cb: (panel: string) => void) => {
       state.panelChangedCallbacks.push(cb)
-      return () => {}
-    },
-    onNavStateChanged: (cb: (state: { canBack: boolean; canForward: boolean }) => void) => {
-      state.navStateChangedCallbacks.push(cb)
       return () => {}
     },
     onTitleChanged: (cb: (title: string) => void) => {
@@ -260,47 +248,11 @@ describe('TitleBarApp', () => {
     expect(wrapper.find('.title-install-pill').classes()).not.toContain('active')
   })
 
-  it('renders Back and Forward buttons disabled by default and enables them via onNavStateChanged', async () => {
+  it('does not render any title-bar nav buttons (back/forward chevrons removed with the takeover layout)', async () => {
     const { default: TitleBarApp } = await import('./TitleBarApp.vue')
     const wrapper = mount(TitleBarApp)
     await flushPromises()
-    const navButtons = wrapper.findAll('.title-nav-button')
-    expect(navButtons.length).toBe(2)
-    const [backBtn, fwdBtn] = navButtons
-    expect((backBtn!.element as HTMLButtonElement).disabled).toBe(true)
-    expect((fwdBtn!.element as HTMLButtonElement).disabled).toBe(true)
-
-    bridgeState.navStateChangedCallbacks.forEach((cb) => cb({ canBack: true, canForward: false }))
-    await flushPromises()
-    expect((backBtn!.element as HTMLButtonElement).disabled).toBe(false)
-    expect((fwdBtn!.element as HTMLButtonElement).disabled).toBe(true)
-
-    bridgeState.navStateChangedCallbacks.forEach((cb) => cb({ canBack: true, canForward: true }))
-    await flushPromises()
-    expect((backBtn!.element as HTMLButtonElement).disabled).toBe(false)
-    expect((fwdBtn!.element as HTMLButtonElement).disabled).toBe(false)
-  })
-
-  it('forwards Back / Forward clicks through the bridge when enabled', async () => {
-    const { default: TitleBarApp } = await import('./TitleBarApp.vue')
-    const wrapper = mount(TitleBarApp)
-    await flushPromises()
-    const navButtons = wrapper.findAll('.title-nav-button')
-    const [backBtn, fwdBtn] = navButtons
-
-    // Disabled — clicks should be no-ops.
-    await backBtn!.trigger('click')
-    await fwdBtn!.trigger('click')
-    expect(bridgeState.goBackCalls).toBe(0)
-    expect(bridgeState.goForwardCalls).toBe(0)
-
-    // Enable both, then click each.
-    bridgeState.navStateChangedCallbacks.forEach((cb) => cb({ canBack: true, canForward: true }))
-    await flushPromises()
-    await backBtn!.trigger('click')
-    await fwdBtn!.trigger('click')
-    expect(bridgeState.goBackCalls).toBe(1)
-    expect(bridgeState.goForwardCalls).toBe(1)
+    expect(wrapper.findAll('.title-nav-button').length).toBe(0)
   })
 
   it('applies the is-mac class when running on macOS', async () => {

--- a/src/renderer/src/comfyTitleBar/TitleBarApp.vue
+++ b/src/renderer/src/comfyTitleBar/TitleBarApp.vue
@@ -3,8 +3,6 @@ import { ref, onMounted, onUnmounted, computed, useTemplateRef } from 'vue'
 import {
   ArrowDownToLine,
   ChevronDown,
-  ChevronLeft,
-  ChevronRight,
   Download,
   Menu as MenuIcon,
   RefreshCw,
@@ -63,10 +61,7 @@ interface Bridge {
   openFileMenu: (anchor: MenuAnchor) => void
   /** Pop the Install caret menu natively. No-op for install-less host windows. */
   openInstallMenu: (anchor: MenuAnchor) => void
-  goBack: () => void
-  goForward: () => void
   onPanelChanged: (cb: (panel: ComfyPanelKey) => void) => () => void
-  onNavStateChanged: (cb: (state: { canBack: boolean; canForward: boolean }) => void) => () => void
   onTitleChanged: (cb: (title: string) => void) => () => void
   /** Track B item 4 — install source-category pushes from main. The
    *  raw category string drives the install-type icon next to the
@@ -169,10 +164,6 @@ const isHoverActive = ref(true)
  *  Directories). The pill itself no longer reflects this — the pill is
  *  an identity label, not a tab indicator. */
 const activePanel = ref<ComfyPanelKey>('comfy')
-/** Browser-style Back/Forward enabledness, pushed by main after every
- *  navigation. Disabled-by-default until the first nav-state event. */
-const canBack = ref(false)
-const canForward = ref(false)
 /**
  * Modal-unification (Track M-2.3 / M-4) — first-use takeover step
  * pushed from main via `comfy-titlebar:first-use-mode-changed`. The
@@ -411,14 +402,6 @@ function handleFileMenu(): void {
   if (Date.now() - menuClosedAt.file < MENU_REOPEN_GUARD_MS) return
   bridge?.openFileMenu(anchorBelow(fileBtnRef.value))
 }
-function handleBack(): void {
-  if (!canBack.value) return
-  bridge?.goBack()
-}
-function handleForward(): void {
-  if (!canForward.value) return
-  bridge?.goForward()
-}
 /** Single click target for the install pill. On install-backed windows
  *  the whole pill opens the native install menu (Phase 3 §7 — the pill
  *  body and caret are no longer separate hit targets). Install-less
@@ -431,7 +414,6 @@ function handleInstallPillClick(): void {
 }
 
 let unsubPanel: (() => void) | undefined
-let unsubNavState: (() => void) | undefined
 let unsubTitle: (() => void) | undefined
 let unsubSourceCategory: (() => void) | undefined
 let unsubTheme: (() => void) | undefined
@@ -467,10 +449,6 @@ onMounted(() => {
   if (!bridge) return
   unsubPanel = bridge.onPanelChanged((panel) => {
     activePanel.value = panel
-  })
-  unsubNavState = bridge.onNavStateChanged(({ canBack: cb, canForward: cf }) => {
-    canBack.value = cb
-    canForward.value = cf
   })
   unsubTitle = bridge.onTitleChanged((title) => {
     installLabel.value = title || 'ComfyUI'
@@ -512,7 +490,6 @@ onMounted(() => {
 
 onUnmounted(() => {
   unsubPanel?.()
-  unsubNavState?.()
   unsubTitle?.()
   unsubSourceCategory?.()
   unsubTheme?.()
@@ -617,32 +594,11 @@ onUnmounted(() => {
       </button>
     </div>
 
-    <!-- Center: browser-style Back / Forward arrows immediately left of
-         the install pill. The pill is a single click target — clicking
-         anywhere on it opens the native install menu. The caret inside
-         is decoration, not a separate button. Install-less host windows
+    <!-- Center: install pill. Single click target — clicking anywhere
+         on it opens the native install menu. The caret inside is
+         decoration, not a separate button. Install-less host windows
          render the pill as a disabled identity label (no menu, no caret). -->
     <div class="title-center">
-      <button
-        type="button"
-        class="title-nav-button"
-        :disabled="!canBack"
-        aria-label="Back"
-        title="Back"
-        @click="handleBack"
-      >
-        <ChevronLeft :size="16" />
-      </button>
-      <button
-        type="button"
-        class="title-nav-button"
-        :disabled="!canForward"
-        aria-label="Forward"
-        title="Forward"
-        @click="handleForward"
-      >
-        <ChevronRight :size="16" />
-      </button>
       <button
         ref="pillBtn"
         type="button"
@@ -793,39 +749,10 @@ onUnmounted(() => {
   border-color: rgba(0, 0, 0, 0.18);
 }
 
-/* Icon-only variant — square padding so the hamburger sits centred
-   with the same outer height as the back/forward arrows. */
+/* Icon-only variant — square padding so the hamburger sits centred. */
 .title-menu-button--icon {
   padding: 4px 6px;
   gap: 0;
-}
-
-/* --- Back / Forward arrows (browser-style nav) --- */
-.title-nav-button {
-  -webkit-app-region: no-drag;
-  background: transparent;
-  color: inherit;
-  border: 1px solid transparent;
-  border-radius: 4px;
-  padding: 2px 6px;
-  cursor: pointer;
-  opacity: 0.85;
-  display: inline-flex;
-  align-items: center;
-  transition: background-color 0.12s, opacity 0.12s, border-color 0.12s;
-}
-.title-bar.is-hover-active .title-nav-button:not(:disabled):hover {
-  opacity: 1;
-  background: rgba(255, 255, 255, 0.08);
-  border-color: rgba(255, 255, 255, 0.18);
-}
-.title-bar.is-light.is-hover-active .title-nav-button:not(:disabled):hover {
-  background: rgba(0, 0, 0, 0.06);
-  border-color: rgba(0, 0, 0, 0.18);
-}
-.title-nav-button:disabled {
-  opacity: 0.3;
-  cursor: default;
 }
 
 /* --- Install pill (center) — single click target. The whole pill


### PR DESCRIPTION
Closes #492.

The back/forward chevrons in the title bar were a holdover from the takeover-screen era when pages stacked on the host window's body and the user navigated between them in-place. The modal-unification work moved every settings/install/track flow into self-closing centred modals, so the panel-history breadcrumb is no longer reachable.

## Removed

- The two `.title-nav-button` buttons + their handlers and CSS in [TitleBarApp.vue](https://github.com/Comfy-Org/ComfyUI-Desktop-2.0-Beta/blob/feat/unified-window-titlebar-panels/src/renderer/src/comfyTitleBar/TitleBarApp.vue) - including `ChevronLeft` / `ChevronRight` icon imports and the `canBack` / `canForward` refs.
- `goBack` / `goForward` / `onNavStateChanged` from the title-bar preload bridge and the underlying IPC channels (`comfy-window:go-back`, `comfy-window:go-forward`, `comfy-titlebar:nav-state-changed`).
- `panelHistory` / `panelHistoryIndex` on `ComfyWindowEntry`, the `PanelNavSource` type, the `_pushPanelHistory` / `_notifyTitleBarNavState` helpers, and the `source` parameter on `setActivePanel`. Pill click and page-X-close now just call `setActivePanel(id, 'comfy')`.
- The two nav-button vitest specs (replaced with an explicit absence assertion).

## Verification

- `pnpm run typecheck` ?
- `pnpm run lint` ?
- `pnpm run test` ? (798/798)
- `pnpm run build` ?

Diff: 4 files, 26 insertions / 281 deletions.