### PR TITLE
fix(launcher): strip Electron's default menu globally (#502)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -494,8 +494,8 @@ function refreshComfyTabBody(installationId: string): void {
  *     have no `ipcRenderer`, can't send these IPCs, and even if a future
  *     change re-introduced a preload they wouldn't be in `comfyWindows`.
  *     The destructive Electron menu items they would otherwise inherit
- *     (Close Window / Close All Windows / Quit) are stripped globally
- *     by `installAppMenu()` — see `menu.ts`.
+ *     (Close Window / Close All Windows) are stripped globally by
+ *     `installAppMenu()` — see `menu.ts`.
  *   - The `comfyView` and `panelView` WebContentsViews of a registered
  *     entry are deliberately matched by separate predicates
  *     (`panelView?.webContents === event.sender`) — never by this helper —

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -12,6 +12,7 @@ import * as ipc from './lib/ipc'
 import { getAppVersion } from './lib/ipc'
 import * as updater from './lib/updater'
 import * as settings from './settings'
+import { installAppMenu } from './menu'
 import * as i18n from './lib/i18n'
 import { configDir, migrateXdgPaths } from './lib/paths'
 import { waitForPort, COMFY_BOOT_TIMEOUT_MS } from './lib/process'
@@ -492,6 +493,9 @@ function refreshComfyTabBody(installationId: string): void {
  *     are unregistered loose `BrowserWindow`s with `preload: undefined`. They
  *     have no `ipcRenderer`, can't send these IPCs, and even if a future
  *     change re-introduced a preload they wouldn't be in `comfyWindows`.
+ *     The destructive Electron menu items they would otherwise inherit
+ *     (Close Window / Close All Windows / Quit) are stripped globally
+ *     by `installAppMenu()` — see `menu.ts`.
  *   - The `comfyView` and `panelView` WebContentsViews of a registered
  *     entry are deliberately matched by separate predicates
  *     (`panelView?.webContents === event.sender`) — never by this helper —
@@ -3315,6 +3319,13 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
   app.whenReady().then(async () => {
     migrateXdgPaths()
     registerProcessErrorHandlers()
+
+    // Strip Electron's default menu before any BrowserWindow opens so
+    // OAuth / cloud-login popups (and every other window) can't reach
+    // destructive items like "Close All Windows" that bypass our
+    // managed shutdown. See `installAppMenu` for the per-platform
+    // template.
+    installAppMenu()
 
     // Bring up main-process telemetry as early as possible so install/migrate
     // sub-step events can fire even before the renderer mounts.

--- a/src/main/menu.test.ts
+++ b/src/main/menu.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { setApplicationMenu, buildFromTemplate } = vi.hoisted(() => ({
+  setApplicationMenu: vi.fn(),
+  buildFromTemplate: vi.fn((template: unknown) => ({ __template: template })),
+}))
+
+vi.mock('electron', () => ({
+  Menu: {
+    setApplicationMenu,
+    buildFromTemplate,
+  },
+}))
+
+import { installAppMenu } from './menu'
+
+beforeEach(() => {
+  setApplicationMenu.mockClear()
+  buildFromTemplate.mockClear()
+})
+
+describe('installAppMenu', () => {
+  it('clears the application menu on win32', () => {
+    installAppMenu('win32')
+    expect(setApplicationMenu).toHaveBeenCalledTimes(1)
+    expect(setApplicationMenu).toHaveBeenCalledWith(null)
+    expect(buildFromTemplate).not.toHaveBeenCalled()
+  })
+
+  it('clears the application menu on linux', () => {
+    installAppMenu('linux')
+    expect(setApplicationMenu).toHaveBeenCalledTimes(1)
+    expect(setApplicationMenu).toHaveBeenCalledWith(null)
+    expect(buildFromTemplate).not.toHaveBeenCalled()
+  })
+
+  it('installs a sanitized template on darwin without close / closeAllWindows', () => {
+    installAppMenu('darwin')
+    expect(buildFromTemplate).toHaveBeenCalledTimes(1)
+    expect(setApplicationMenu).toHaveBeenCalledTimes(1)
+
+    const template = buildFromTemplate.mock.calls[0]?.[0] as Array<{
+      role?: string
+      label?: string
+      submenu?: Array<{ role?: string; type?: string }>
+    }>
+    expect(template).toBeTruthy()
+
+    // Top-level: appMenu, editMenu, custom Window — File / View / Help dropped.
+    const topLevelRoles = template.map((entry) => entry.role ?? entry.label)
+    expect(topLevelRoles).toEqual(['appMenu', 'editMenu', 'Window'])
+
+    const windowEntry = template.find((entry) => entry.label === 'Window')
+    expect(windowEntry).toBeTruthy()
+    const windowRoles = (windowEntry?.submenu ?? []).map((item) => item.role)
+    expect(windowRoles).toContain('minimize')
+    expect(windowRoles).toContain('zoom')
+    expect(windowRoles).toContain('front')
+    expect(windowRoles).not.toContain('close')
+    expect(windowRoles).not.toContain('closeAllWindows')
+
+    // Recursively walk the entire template — no destructive role anywhere.
+    const collectRoles = (
+      items: Array<{ role?: string; submenu?: unknown }> | undefined,
+    ): string[] => {
+      if (!items) return []
+      const out: string[] = []
+      for (const item of items) {
+        if (item.role) out.push(item.role)
+        if (Array.isArray(item.submenu)) {
+          out.push(...collectRoles(item.submenu as Array<{ role?: string; submenu?: unknown }>))
+        }
+      }
+      return out
+    }
+    const allRoles = collectRoles(template as unknown as Array<{ role?: string; submenu?: unknown }>)
+    expect(allRoles).not.toContain('close')
+    expect(allRoles).not.toContain('closeAllWindows')
+  })
+})

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -1,0 +1,45 @@
+import { Menu } from 'electron'
+import type { MenuItemConstructorOptions } from 'electron'
+
+/**
+ * Install the global application menu used by every BrowserWindow we
+ * spawn — including OAuth / cloud-login popups created via
+ * `comfyContents.setWindowOpenHandler`. Without this, Electron's default
+ * menu is inherited and exposes destructive items (Close Window /
+ * Close All Windows / Quit) that bypass our managed shutdown:
+ *
+ *   - On Windows / Linux the menu sits in each window's title bar (or is
+ *     reachable via the system-menu icon at the top-left). We strip it
+ *     entirely with `setApplicationMenu(null)` so popups expose only the
+ *     OS frame controls (Restore / Move / Size / Minimize / Maximize /
+ *     Close — all of which route through our window `close` handlers).
+ *
+ *   - On macOS the menu is application-global and cannot be removed, so
+ *     we install a sanitized template that keeps the standard
+ *     `appMenu` (About / Hide / Hide Others / Show All / Quit) and
+ *     `editMenu` (Undo / Redo / Cut / Copy / Paste / Select All — needed
+ *     for OAuth form fields), plus a custom Window submenu containing
+ *     only `minimize` / `zoom` / `front` and explicitly omitting the
+ *     default `close` / `closeAllWindows` roles. The default File / View
+ *     / Help menus are dropped entirely.
+ */
+export function installAppMenu(platform: NodeJS.Platform = process.platform): void {
+  if (platform !== 'darwin') {
+    Menu.setApplicationMenu(null)
+    return
+  }
+  const template: MenuItemConstructorOptions[] = [
+    { role: 'appMenu' },
+    { role: 'editMenu' },
+    {
+      label: 'Window',
+      submenu: [
+        { role: 'minimize' },
+        { role: 'zoom' },
+        { type: 'separator' },
+        { role: 'front' },
+      ],
+    },
+  ]
+  Menu.setApplicationMenu(Menu.buildFromTemplate(template))
+}

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -6,7 +6,7 @@ import type { MenuItemConstructorOptions } from 'electron'
  * spawn — including OAuth / cloud-login popups created via
  * `comfyContents.setWindowOpenHandler`. Without this, Electron's default
  * menu is inherited and exposes destructive items (Close Window /
- * Close All Windows / Quit) that bypass our managed shutdown:
+ * Close All Windows) that bypass our managed shutdown:
  *
  *   - On Windows / Linux the menu sits in each window's title bar (or is
  *     reachable via the system-menu icon at the top-left). We strip it


### PR DESCRIPTION
## Summary

Fixes #502.

OAuth / cloud-login popups spawned from ComfyUI via `comfyContents.setWindowOpenHandler` inherit Electron's default application menu, exposing destructive items (**Close Window**, **Close All Windows**, **Quit**) that bypass our managed shutdown and leave the app stuck.

The pre-existing per-window `removeMenu()` in `did-create-window` is fragile:

- it's timing-dependent (the popup is interactive briefly before the handler fires),
- it only runs on Windows / Linux, and
- on Windows the system-menu icon at the top-left of the popup's title bar still surfaces destructive items.

## Fix

Install a global application menu in `app.whenReady()` **before any BrowserWindow opens**:

- **Windows / Linux** — `Menu.setApplicationMenu(null)`. Strips the menu from every window we ever spawn, including OAuth popups.
- **macOS** (where the menu is application-global and cannot be removed) — install a sanitized template:
  - `{ role: 'appMenu' }` — About / Hide / Hide Others / Show All / Quit (standard macOS, must keep).
  - `{ role: 'editMenu' }` — Undo / Redo / Cut / Copy / Paste / Select All (needed for OAuth form fields).
  - Custom `Window` submenu containing only `minimize` / `zoom` / `front`.
  - Default `File` / `View` / `Help` menus dropped entirely.
  - Destructive `close` / `closeAllWindows` roles explicitly omitted.

The pre-existing `removeMenu()` call in `did-create-window` is left in place as belt-and-suspenders.

## Files

- `src/main/menu.ts` — new `installAppMenu(platform?)` helper.
- `src/main/menu.test.ts` — covers Win/Linux (null) and darwin (template shape, recursive role check that `close` / `closeAllWindows` appear nowhere).
- `src/main/index.ts` — calls `installAppMenu()` at the start of `app.whenReady()` and updates the aux-window contract doc-block.

## Verification

- `pnpm run typecheck` ✅
- `pnpm run lint` ✅
- `pnpm run test` ✅ (67 files, 803 tests; 3 new in `menu.test.ts`)
- `pnpm run build` ✅

Manual verification still needs to happen on Windows (open a cloud-login popup, confirm clicking the top-left of the title bar exposes only the OS system menu — Restore / Move / Size / Minimize / Maximize / Close — with no Electron items) and macOS (confirm the global menu has no Close / Close All Windows reachable).

Amp-Thread-ID: https://ampcode.com/threads/T-019e00ad-788d-73be-b97f-37574a21aabe
