### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-desktop-2",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "ComfyUI Desktop 2.0",
   "author": {
     "name": "Jedrzej Kosinski",


### PR DESCRIPTION
## Summary
- bump `package.json` version from `0.5.0` to `0.6.0`
- generated by `Version Bump PR` workflow (PR step failed due to invalid `BEN_PAT`; created manually)

## Details
- target branch: `main`
- bump type: `minor`
- release label requested: `true`
