### PR TITLE
ci(release): pre-fetch bootstrap-python so todesktop validates extraResources

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -87,6 +87,15 @@ jobs:
       - name: Install ToDesktop CLI
         run: npm install --location=global @todesktop/cli@1.22.0
 
+      - name: Pre-fetch bootstrap-python for all platforms
+        # @todesktop/cli now eagerly validates the `extraResources` paths in
+        # todesktop.json *before* invoking the `beforeBuild` hook, so the
+        # platform-specific bootstrap-python directories must exist locally
+        # at the time `todesktop build` is invoked.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pnpm run bootstrap:fetch
+
       - name: Build with ToDesktop
         shell: bash
         run: |


### PR DESCRIPTION
## Problem

`build-release.yml` for tag `v0.6.0` failed at the `Build with ToDesktop` step:

```
ERROR
todesktop.json invalid.
FILE does not exist (.../bootstrap-python/win-x64)
FILE does not exist (.../bootstrap-python/mac-arm64)
FILE does not exist (.../bootstrap-python/linux-x64)
```

[Failed run](https://github.com/Comfy-Org/ComfyUI-Desktop-2.0-Beta/actions/runs/25480223607).

`@todesktop/cli@1.22.0` now eagerly validates the platform-specific paths in `todesktop.json` `platformOverrides.*.extraResources` **before** invoking the `beforeBuild` hook. Our `scripts/todesktop-beforeBuild.cjs` is the thing that calls `fetch-bootstrap-python.mjs` to download the bootstrap-python archive for the active platform — by the time it runs, validation has already failed.

The CLI version is unchanged from the v0.5.0 release that worked a month ago, so this is a behavior change shipped server-side or in a non-version-bumped CLI release.

## Fix

Run the existing `pnpm run bootstrap:fetch` script (which calls `scripts/fetch-bootstrap-python.mjs` for all 3 platforms) right after the ToDesktop CLI is installed, so the directories exist on disk before `todesktop build` validates the config.

The script already supports being a no-op for any platform whose directory already exists, and uses `GITHUB_TOKEN` for authenticated downloads to avoid rate limits.

## Follow-up

After this merges, the `v0.6.0` build needs to be re-triggered. Options:
- Bump to `v0.6.1` via `version-bump.yml` (cleanest).
- Or manually `workflow_dispatch` `build-release.yml` for tag `v0.6.0` after force-moving the tag to the new merge commit (avoid: tag mutation is hostile to consumers).

Recommend the bump.

Amp-Thread-ID: https://ampcode.com/threads/T-019e009a-812e-734e-b371-d5eacf9d34c2
