### PR TITLE
chore: bump version to 0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-desktop-2",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "ComfyUI Desktop 2.0",
   "author": {
     "name": "Jedrzej Kosinski",


### PR DESCRIPTION
## Summary
- bump `package.json` version from `0.6.0` to `0.6.1`
- generated by `Version Bump PR` workflow (PR step failed: `BEN_PAT` lacks `Pull requests: write` on this repo)

## Details
- target branch: `main`
- bump type: `patch`
- release label requested: `true`

This release also includes the build-release workflow fix (#506) so the ToDesktop bootstrap-python validation no longer blocks the build.
