### PR TITLE
fix(launcher): wake the panelView so the title-bar feedback button works in Comfy windows

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2604,12 +2604,29 @@ ipcMain.on('comfy-window:click-downloads-tray', (event) => {
  * `source` is forwarded into the renderer's telemetry context as
  * `desktop2.feedback.opened` `{ source }` so we can tell which
  * affordance the user reached for.
+ *
+ * In Comfy instance windows the panelView is constructed lazily on
+ * the first non-comfy switch (Settings / Directories / lifecycle), so
+ * a feedback click that arrives while the user is still on the
+ * ComfyUI body would hit a `null` panelView and silently drop. Mirror
+ * the `click-install-update-pill` pattern: ensure the panel exists
+ * for the current body mode and defer the send until
+ * `did-finish-load` if the bundle is still loading.
  */
 function triggerOpenFeedback(entryId: number, source: 'titlebar' | 'menu'): void {
   const parentEntry = comfyWindows.get(entryId)
-  if (!parentEntry?.panelView) return
-  if (parentEntry.panelView.webContents.isDestroyed()) return
-  parentEntry.panelView.webContents.send('comfy-panel:open-feedback', { source })
+  if (!parentEntry || parentEntry.window.isDestroyed()) return
+  const panelView = parentEntry.panelView ?? ensurePanelView(entryId, parentEntry, computeBodyMode(parentEntry))
+  if (panelView.webContents.isDestroyed()) return
+  const send = (): void => {
+    if (panelView.webContents.isDestroyed()) return
+    panelView.webContents.send('comfy-panel:open-feedback', { source })
+  }
+  if (panelView.webContents.isLoadingMainFrame()) {
+    panelView.webContents.once('did-finish-load', send)
+  } else {
+    send()
+  }
 }
 
 /** Title-bar Send Feedback button click. Resolves the host entry from


### PR DESCRIPTION
## Bug

Title-bar **Send Feedback** button is silent in Comfy instance windows. The Dashboard window's button works.

## Root cause

`triggerOpenFeedback` in [src/main/index.ts](src/main/index.ts) only sends the `comfy-panel:open-feedback` IPC if `parentEntry.panelView` is non-null. The panel renderer is what fires the telemetry action and opens the typeform URL.

In **Comfy instance windows** the `panelView` starts as `null` and is constructed lazily on the first non-comfy switch (Settings / Directories / lifecycle). A user clicking Send Feedback while still on the ComfyUI body hits the early return and the click is silently dropped.

The **Dashboard** (chooser) window is unaffected because `openChooserHostWindow` calls `ensurePanelView(..., 'chooser')` eagerly during construction.

## Fix

Mirror the existing `click-install-update-pill` pattern in `triggerOpenFeedback`:

1. `ensurePanelView(...)` for the current body mode if `panelView` is null.
2. If the bundle is still loading (`isLoadingMainFrame()`), defer the IPC send until `did-finish-load` so PanelApp's `onMounted` listener has registered.
3. Otherwise send immediately.

`ensurePanelView` inserts the new panel **invisible at zero size** behind the comfyView, so the user's ComfyUI body is not disturbed visually.

## Verification

- `pnpm run typecheck` ✅
- `pnpm run lint` ✅
- `pnpm run test` ✅ (802 / 802)
- `pnpm run build` ✅

Manual repro: open a fresh Comfy instance window, click the title-bar Send Feedback button before clicking anything else — typeform should now open. Same flow from the waffle menu's Send Feedback entry.

Amp-Thread-ID: https://ampcode.com/threads/T-019e009a-812e-734e-b371-d5eacf9d34c2
