### PR TITLE
fix: restore Ctrl/Cmd + =/-/0 zoom shortcuts on ComfyUI windows

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1838,16 +1838,12 @@ function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts): boolea
       reloadComfy()
       return
     }
-    // Restore Ctrl/Cmd + =/+ /- /0 zoom shortcuts on the comfy WebContentsView.
-    // Pre-#414 ComfyUI loaded directly into BrowserWindow.webContents, where
-    // Chromium handled these natively. Now ComfyUI lives in a child
-    // WebContentsView, and after `installAppMenu` strips the default menu
-    // (Windows/Linux) or omits the View > Zoom roles (macOS) there is no
-    // accelerator path left. We re-bind them explicitly, scoped to
-    // `comfyContents` so the title bar and panel views are unaffected.
-    // Step 0.5 mirrors Electron's standard zoomLevel granularity
-    // (~91%/110%/122%/...); clamp matches Chromium's 25%–500% range.
-    if (mod && (input.key === '=' || input.key === '+' || input.key === '-' || input.key === '0')) {
+    // Restore Ctrl/Cmd + =/+/-/0 zoom on the comfy WebContentsView. The default
+    // accelerators target BrowserWindow.webContents (empty since #414) and the
+    // app menu has no View > Zoom roles, so we wire it explicitly here. Step
+    // 0.5 mirrors Electron's standard zoomLevel granularity (~91% / 110% / ...).
+    // Exclude Alt to avoid AltGr / Ctrl+Alt collisions on non-US layouts.
+    if (mod && !input.alt && (input.key === '=' || input.key === '+' || input.key === '-' || input.key === '0')) {
       e.preventDefault()
       if (comfyContents.isDestroyed()) return
       if (input.key === '0') {
@@ -1855,8 +1851,7 @@ function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts): boolea
         return
       }
       const step = input.key === '-' ? -0.5 : 0.5
-      const next = Math.max(-3, Math.min(3, comfyContents.getZoomLevel() + step))
-      comfyContents.setZoomLevel(next)
+      comfyContents.setZoomLevel(comfyContents.getZoomLevel() + step)
     }
   }
   comfyContents.on('before-input-event', onBeforeInputEvent)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1843,6 +1843,15 @@ function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts): boolea
     // app menu has no View > Zoom roles, so we wire it explicitly here. Step
     // 0.5 mirrors Electron's standard zoomLevel granularity (~91% / 110% / ...).
     // Exclude Alt to avoid AltGr / Ctrl+Alt collisions on non-US layouts.
+    //
+    // NOTE on view hot-swapping: this handler closes over `comfyContents`
+    // captured at attach time. Today, comfyView swaps happen only before
+    // attachInstall runs, so the listener always lives on the active view and
+    // `_installCleanup` removes it symmetrically. If we later hot-swap
+    // entry.comfyView mid-attach (e.g. to reuse a host window without tearing
+    // down install state), this binding goes stale and zoom shortcuts will
+    // silently stop working until the next attach. The Reset Zoom menu item
+    // re-reads parentEntry.comfyView at click time, so it stays correct.
     if (mod && !input.alt && (input.key === '=' || input.key === '+' || input.key === '-' || input.key === '0')) {
       e.preventDefault()
       if (comfyContents.isDestroyed()) return

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1836,6 +1836,27 @@ function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts): boolea
     if (input.key === 'F5' || (input.key.toLowerCase() === 'r' && mod)) {
       e.preventDefault()
       reloadComfy()
+      return
+    }
+    // Restore Ctrl/Cmd + =/+ /- /0 zoom shortcuts on the comfy WebContentsView.
+    // Pre-#414 ComfyUI loaded directly into BrowserWindow.webContents, where
+    // Chromium handled these natively. Now ComfyUI lives in a child
+    // WebContentsView, and after `installAppMenu` strips the default menu
+    // (Windows/Linux) or omits the View > Zoom roles (macOS) there is no
+    // accelerator path left. We re-bind them explicitly, scoped to
+    // `comfyContents` so the title bar and panel views are unaffected.
+    // Step 0.5 mirrors Electron's standard zoomLevel granularity
+    // (~91%/110%/122%/...); clamp matches Chromium's 25%–500% range.
+    if (mod && (input.key === '=' || input.key === '+' || input.key === '-' || input.key === '0')) {
+      e.preventDefault()
+      if (comfyContents.isDestroyed()) return
+      if (input.key === '0') {
+        comfyContents.setZoomLevel(0)
+        return
+      }
+      const step = input.key === '-' ? -0.5 : 0.5
+      const next = Math.max(-3, Math.min(3, comfyContents.getZoomLevel() + step))
+      comfyContents.setZoomLevel(next)
     }
   }
   comfyContents.on('before-input-event', onBeforeInputEvent)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2853,6 +2853,18 @@ function buildTitleMenuItems(entry: ComfyWindowEntry): TitleMenuItem[] {
   if (entry.installationId !== null) {
     items.push({ id: 'return-to-dashboard', label: 'Return to Dashboard' })
   }
+  // Reset Zoom — discoverable recovery path for users who zoom the Comfy
+  // view too far to read. Only surfaced when zoom is actually non-default,
+  // and the label includes the current percent so the menu also doubles
+  // as a status indicator. The Ctrl/Cmd + 0 shortcut wired in `onLaunch`
+  // does the same thing for users who know it.
+  if (!entry.comfyView.webContents.isDestroyed()) {
+    const level = entry.comfyView.webContents.getZoomLevel()
+    if (level !== 0) {
+      const percent = Math.round(Math.pow(1.2, level) * 100)
+      items.push({ id: 'reset-zoom', label: `Reset Zoom (${percent}%)` })
+    }
+  }
   items.push({ id: 'close-all-windows', label: 'Close All Windows' })
   return items
 }
@@ -3175,6 +3187,14 @@ function activateTitleMenuItem(entry: TitleMenuPopupEntry, id: string): void {
     // via `comfy-window:click-feedback`; `source` distinguishes the
     // two entry points in the telemetry payload.
     triggerOpenFeedback(entry.parentEntryId, 'menu')
+  }
+  else if (id === 'reset-zoom') {
+    // Pair to the Ctrl/Cmd + 0 shortcut wired in `onLaunch`. The menu
+    // entry is only built when zoom is non-zero (see `buildTitleMenuItems`),
+    // so this always corresponds to a visible state change.
+    if (parentEntry && !parentEntry.comfyView.webContents.isDestroyed()) {
+      parentEntry.comfyView.webContents.setZoomLevel(0)
+    }
   }
   else if (id === 'new-install' || id === 'track' || id === 'load-snapshot' || id === 'quick-install') {
     // Install-creation / import flows are chooser-host-only.


### PR DESCRIPTION
Closes #512.

## What

Re-binds `Ctrl/Cmd + =` / `+` / `-` / `0` directly on `comfyContents` inside the existing `before-input-event` handler in `onLaunch()` so they zoom the ComfyUI canvas/UI again. Title bar and panel `WebContentsView`s are unaffected since the handler is scoped to `comfyContents` only.

## Why this regressed

Pre-#414 (custom title bar) ComfyUI loaded directly into a `BrowserWindow`'s `webContents`, where Chromium handled the standard zoom keyboard shortcuts natively. After #414 ComfyUI lives in a child `WebContentsView`, so the shortcuts no longer reach it. Then once `installAppMenu` strips the default app menu (Windows/Linux) or omits the `View > Zoom` roles (macOS), there is no accelerator path left at all — keys appear dead inside the ComfyUI window.

## Behavior

- Step `0.5` mirrors Electron's standard `zoomLevel` granularity (~91% / 110% / 122% / ...). The 91% step lines up with the 90% the reporter said they used.
- Clamp `-3..3` matches Chromium's 25%–500% range.
- Per-origin zoom persistence (session partition) is unchanged — saved zoom from previous sessions returns automatically.
- `Ctrl+0` always resets to 100%.

## Out of scope

- The hamburger `View ▸ Zoom` submenu the reporter mentioned as their first preference lives in `ComfyUI_frontend`, not in this repo. Shortcut keys alone fully address the secondary ask.
- The launcher window has been retired (Phase 3) and the legacy `ZoomBanner` / `reset-zoom` IPC are unused; this PR does not touch them.

## Test plan

**Pre-fix baseline (current `main`)**
1. Launch a ComfyUI installation.
2. Focus the canvas; press `Ctrl/Cmd + -` / `+` / `0` — nothing happens (bug).

**Post-fix**
1. Same setup.
2. `Ctrl/Cmd + -` shrinks one step (~91% then ~83% then ~75% ...), clamped near 25%.
3. `Ctrl/Cmd + =` (or `+`) enlarges one step, clamped near 500%.
4. `Ctrl/Cmd + 0` resets to 100%.
5. Custom title bar height/buttons/colors unchanged.
6. Close and re-open the same install — zoom level persists.
7. macOS: traffic-light positioning + full-screen padding still correct.
8. Windows/Linux: native title-bar overlay still painted with theme colors.

**Automated** (per `AGENTS.md`):
`pnpm run typecheck` ✅
`pnpm run lint` ✅
`pnpm run build` ✅
`pnpm run test` ✅ (802/802)