### PR TITLE
telemetry: emit desktop2.snapshot.created for every snapshot write

### DIFF
--- a/src/main/lib/ipc/registerSnapshotHandlers.ts
+++ b/src/main/lib/ipc/registerSnapshotHandlers.ts
@@ -221,7 +221,7 @@ export function registerSnapshotHandlers(): void {
       const inst = await installations.get(installationId)
       if (!inst || !inst.installPath) return { ok: false, message: 'Installation not found.' }
 
-      const result = await importSnapshots(inst.installPath, pending.envelope)
+      const result = await importSnapshots(inst.installPath, pending.envelope, installationId)
       const snapshotCount = await getSnapshotCount(inst.installPath)
       await installations.update(installationId, { snapshotCount })
       return { ok: true, imported: result.imported, restoreFile: result.filenames[0]! }

--- a/src/main/lib/snapshots.test.ts
+++ b/src/main/lib/snapshots.test.ts
@@ -17,14 +17,22 @@ vi.mock('./pip', async (importOriginal) => {
   }
 })
 
+vi.mock('./telemetry', () => ({
+  emit: vi.fn(),
+  trackedStep: vi.fn(async (_event: string, _ctx: unknown, fn: () => unknown) => fn()),
+  capture: vi.fn(),
+}))
+
 import { buildExportEnvelope, validateExportEnvelope, importSnapshots, diffSnapshots, listSnapshots, restoreComfyUIVersion, buildPostRestoreState, restorePipPackages, formatSnapshotVersion } from './snapshots'
 import type { Snapshot, SnapshotEntry, SnapshotExportEnvelope } from './snapshots'
 import type { ScannedNode } from './nodes'
 import type { InstallationRecord } from '../installations'
 import { pipFreeze, runUvPip } from './pip'
+import * as telemetry from './telemetry'
 
 const mockedPipFreeze = vi.mocked(pipFreeze)
 const mockedRunUvPip = vi.mocked(runUvPip)
+const mockedTelemetryEmit = vi.mocked(telemetry.emit)
 
 // --- Helpers ---
 
@@ -484,7 +492,7 @@ describe('importSnapshots', () => {
       makeSnapshot({ createdAt: '2026-03-01T12:00:00.000Z', trigger: 'boot' }),
       makeSnapshot({ createdAt: '2026-03-02T12:00:00.000Z', trigger: 'manual' }),
     ])
-    const result = await importSnapshots(tmpDir, envelope)
+    const result = await importSnapshots(tmpDir, envelope, 'test-install')
     expect(result.imported).toBe(2)
 
     const entries = await listSnapshots(tmpDir)
@@ -495,8 +503,8 @@ describe('importSnapshots', () => {
     const envelope = makeEnvelope([
       makeSnapshot({ createdAt: '2026-03-01T12:00:00.000Z', trigger: 'boot' }),
     ])
-    await importSnapshots(tmpDir, envelope)
-    const result = await importSnapshots(tmpDir, envelope)
+    await importSnapshots(tmpDir, envelope, 'test-install')
+    const result = await importSnapshots(tmpDir, envelope, 'test-install')
     expect(result.imported).toBe(1)
 
     const entries = await listSnapshots(tmpDir)
@@ -507,13 +515,13 @@ describe('importSnapshots', () => {
     const first = makeEnvelope([
       makeSnapshot({ createdAt: '2026-03-01T12:00:00.000Z', trigger: 'boot' }),
     ])
-    await importSnapshots(tmpDir, first)
+    await importSnapshots(tmpDir, first, 'test-install')
 
     const second = makeEnvelope([
       makeSnapshot({ createdAt: '2026-03-01T12:00:00.000Z', trigger: 'boot' }),
       makeSnapshot({ createdAt: '2026-03-02T12:00:00.000Z', trigger: 'manual' }),
     ])
-    const result = await importSnapshots(tmpDir, second)
+    const result = await importSnapshots(tmpDir, second, 'test-install')
     expect(result.imported).toBe(2)
   })
 
@@ -524,7 +532,7 @@ describe('importSnapshots', () => {
       customNodes: [makeNode({ id: 'my-node', dirName: 'my-node', version: '1.0.0' })],
       pipPackages: { numpy: '1.24.0', pillow: '10.0.0' },
     })
-    await importSnapshots(tmpDir, makeEnvelope([original]))
+    await importSnapshots(tmpDir, makeEnvelope([original]), 'test-install')
 
     const entries = await listSnapshots(tmpDir)
     expect(entries).toHaveLength(1)
@@ -544,7 +552,7 @@ describe('importSnapshots', () => {
       makeSnapshot({ createdAt: '2026-03-03T12:00:00.000Z', trigger: 'manual' }),
       makeSnapshot({ createdAt: '2026-03-02T12:00:00.000Z', trigger: 'restart' }),
     ])
-    await importSnapshots(tmpDir, envelope)
+    await importSnapshots(tmpDir, envelope, 'test-install')
 
     const entries = await listSnapshots(tmpDir)
     expect(entries).toHaveLength(3)
@@ -563,8 +571,51 @@ describe('importSnapshots', () => {
       makeSnapshot({ createdAt: '2026-03-01T12:00:00.000Z', trigger: 'boot' }),
       makeSnapshot({ createdAt: '2026-03-01T12:00:00.000Z', trigger: 'boot' }),
     ])
-    const result = await importSnapshots(tmpDir, envelope)
+    const result = await importSnapshots(tmpDir, envelope, 'test-install')
     expect(result.imported).toBe(2)
+  })
+
+  it('emits desktop2.snapshot.imported once per imported snapshot with batch context', async () => {
+    mockedTelemetryEmit.mockClear()
+    const envelope = makeEnvelope([
+      makeSnapshot({
+        createdAt: '2026-03-02T12:00:00.000Z',
+        trigger: 'manual',
+        label: 'release-cut',
+        customNodes: [makeNode({ id: 'n1', dirName: 'n1' })],
+        pipPackages: { numpy: '1.24.0', pillow: '10.0.0' },
+      }),
+      makeSnapshot({
+        createdAt: '2026-03-01T12:00:00.000Z',
+        trigger: 'boot',
+        customNodes: [],
+        pipPackages: {},
+      }),
+    ])
+
+    await importSnapshots(tmpDir, envelope, 'install-99')
+
+    expect(mockedTelemetryEmit).toHaveBeenCalledTimes(2)
+    // First (envelope index 0) — labeled manual snapshot with nodes + pip
+    expect(mockedTelemetryEmit).toHaveBeenNthCalledWith(1, 'desktop2.snapshot.imported', {
+      installation_id: 'install-99',
+      original_trigger: 'manual',
+      custom_nodes_count: 1,
+      pip_packages_count: 2,
+      has_label: true,
+      batch_size: 2,
+      batch_index: 0,
+    })
+    // Second (envelope index 1) — empty boot snapshot
+    expect(mockedTelemetryEmit).toHaveBeenNthCalledWith(2, 'desktop2.snapshot.imported', {
+      installation_id: 'install-99',
+      original_trigger: 'boot',
+      custom_nodes_count: 0,
+      pip_packages_count: 0,
+      has_label: false,
+      batch_size: 2,
+      batch_index: 1,
+    })
   })
 })
 

--- a/src/main/lib/snapshots/exportImport.ts
+++ b/src/main/lib/snapshots/exportImport.ts
@@ -2,6 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import { isSafePathComponent } from '../cnr'
 import { snapshotsDir, formatTimestamp } from './store'
+import * as telemetry from '../telemetry'
 import type { Snapshot, SnapshotEntry, SnapshotExportEnvelope } from './types'
 
 export function buildExportEnvelope(installationName: string, entries: SnapshotEntry[]): SnapshotExportEnvelope {
@@ -68,7 +69,8 @@ export function validateExportEnvelope(data: unknown): SnapshotExportEnvelope {
 
 export async function importSnapshots(
   installPath: string,
-  envelope: SnapshotExportEnvelope
+  envelope: SnapshotExportEnvelope,
+  installationId: string,
 ): Promise<{ imported: number; filenames: string[] }> {
   const dir = snapshotsDir(installPath)
   await fs.promises.mkdir(dir, { recursive: true })
@@ -99,6 +101,25 @@ export async function importSnapshots(
       throw err
     }
     filenames.push(filename)
+
+    // Per-snapshot emit (not a single batch event) so the trigger / size
+    // distribution of imported snapshots is queryable the same way as
+    // `desktop2.snapshot.created`. `batch_size` + `batch_index` let dashboards
+    // recover the import-operation grouping when they care about it.
+    //
+    // Distinct event from `desktop2.snapshot.created` because the snapshot
+    // wasn't *taken* on this install — it was copied in from an export
+    // envelope (manual import or standalone migration), and we want the
+    // "how often does an install snapshot itself" metric to stay clean.
+    telemetry.emit('desktop2.snapshot.imported', {
+      installation_id: installationId,
+      original_trigger: snapshot.trigger,
+      custom_nodes_count: snapshot.customNodes.length,
+      pip_packages_count: Object.keys(snapshot.pipPackages).length,
+      has_label: !!(snapshot.label && snapshot.label.length > 0),
+      batch_size: count,
+      batch_index: i,
+    })
   }
 
   return { imported: filenames.length, filenames }

--- a/src/main/lib/snapshots/store.test.ts
+++ b/src/main/lib/snapshots/store.test.ts
@@ -38,14 +38,18 @@ vi.mock('fs', async (importOriginal) => {
         writeFile: vi.fn(async () => {}),
         rename: vi.fn(async () => {}),
         readdir: vi.fn(async () => []),
+        readFile: vi.fn(async () => { throw new Error('not found') }),
+        unlink: vi.fn(async () => {}),
       },
     },
   }
 })
 
+import fs from 'fs'
+import path from 'path'
 import { readGitHead } from '../git'
 import { scanCustomNodes } from '../nodes'
-import { captureState, saveSnapshot } from './store'
+import { captureState, saveSnapshot, captureSnapshotIfChanged } from './store'
 import * as telemetry from '../telemetry'
 import type { InstallationRecord } from '../../installations'
 
@@ -53,6 +57,45 @@ const mockedTelemetryEmit = vi.mocked(telemetry.emit)
 
 const mockedReadGitHead = vi.mocked(readGitHead)
 const mockedScanCustomNodes = vi.mocked(scanCustomNodes)
+
+/**
+ * Stateful in-memory `fs.promises` mock — `writeFile`/`rename` route into a
+ * Map keyed by absolute path; `readdir`/`readFile`/`unlink` read from the same
+ * Map. Lets us drive `captureSnapshotIfChanged`'s `loadSnapshot` /
+ * `listSnapshots` / `deduplicateRestartSnapshot` paths without spinning up
+ * real disk I/O. Reset in each `beforeEach` via `installFsMemory()`.
+ */
+function installFsMemory(): Map<string, string> {
+  const memory = new Map<string, string>()
+  vi.mocked(fs.promises.writeFile).mockImplementation(async (p, data) => {
+    memory.set(String(p), String(data))
+  })
+  vi.mocked(fs.promises.rename).mockImplementation(async (from, to) => {
+    const data = memory.get(String(from))
+    if (data === undefined) throw new Error(`rename: missing ${String(from)}`)
+    memory.set(String(to), data)
+    memory.delete(String(from))
+  })
+  vi.mocked(fs.promises.readdir).mockImplementation(async (dir) => {
+    const prefix = String(dir).replace(/[\\/]+$/, '') + path.sep
+    const files: string[] = []
+    for (const key of memory.keys()) {
+      if (key.startsWith(prefix) && !key.slice(prefix.length).includes(path.sep)) {
+        files.push(key.slice(prefix.length))
+      }
+    }
+    return files as unknown as Awaited<ReturnType<typeof fs.promises.readdir>>
+  })
+  vi.mocked(fs.promises.readFile).mockImplementation(async (p) => {
+    const data = memory.get(String(p))
+    if (data === undefined) throw new Error(`readFile: missing ${String(p)}`)
+    return data as unknown as Awaited<ReturnType<typeof fs.promises.readFile>>
+  })
+  vi.mocked(fs.promises.unlink).mockImplementation(async (p) => {
+    memory.delete(String(p))
+  })
+  return memory
+}
 
 describe('captureState commit-matching guard', () => {
   beforeEach(() => {
@@ -199,5 +242,97 @@ describe('saveSnapshot telemetry', () => {
       'desktop2.snapshot.created',
       expect.objectContaining({ trigger: 'pre-update', has_label: false }),
     )
+  })
+})
+
+describe('captureSnapshotIfChanged telemetry', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    mockedScanCustomNodes.mockResolvedValue([])
+    mockedReadGitHead.mockReturnValue('abc1234')
+  })
+
+  it('emits no telemetry when boot state matches the last snapshot (saved: false)', async () => {
+    const memory = installFsMemory()
+    // Pre-seed `lastSnapshot` with a state that matches what `captureState`
+    // will produce (manifest read fails → ref:'unknown', commit comes from
+    // mocked readGitHead, no nodes, no pip).
+    const matching = {
+      version: 1,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      trigger: 'boot' as const,
+      label: null,
+      comfyui: { ref: 'unknown', commit: 'abc1234', releaseTag: '', variant: '' },
+      customNodes: [],
+      pipPackages: {},
+      pythonVersion: undefined,
+      updateChannel: 'stable',
+    }
+    const lastFilename = 'last.json'
+    // loadSnapshot reads through `resolveSnapshotPath` which uses
+    // `path.resolve` — on Windows that prepends the drive letter, so the
+    // memory key has to be the resolved absolute path, not a path.join
+    // form, or the readFile mock won't find it.
+    memory.set(path.resolve('/test/install', '.launcher', 'snapshots', lastFilename), JSON.stringify(matching))
+
+    const installation = {
+      id: 'install-1',
+      name: 'Test',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      installPath: '/test/install',
+      sourceId: 'test',
+      lastSnapshot: lastFilename,
+    } as unknown as InstallationRecord
+
+    const result = await captureSnapshotIfChanged('/test/install', installation, 'boot')
+
+    expect(result.saved).toBe(false)
+    expect(mockedTelemetryEmit).not.toHaveBeenCalled()
+  })
+
+  it('emits deduplicated_previous: true when restart collapses the prior intermediate snapshot', async () => {
+    const memory = installFsMemory()
+    // Pre-seed an intermediate restart snapshot (no label, same comfyui +
+    // empty nodes) that should get collapsed by `deduplicateRestartSnapshot`
+    // when the new restart snapshot lands.
+    const intermediate = {
+      version: 1,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      trigger: 'restart' as const,
+      label: null,
+      comfyui: { ref: 'unknown', commit: 'abc1234', releaseTag: '', variant: '' },
+      customNodes: [],
+      pipPackages: {},
+      pythonVersion: undefined,
+      updateChannel: 'stable',
+    }
+    // Filename uses the same `YYYYMMDD_HHMMSS_mmm-<trigger>-<suffix>.json`
+    // shape `formatTimestamp` produces; an older lexicographic key ensures
+    // it sorts AFTER the freshly-written one (newest-first sort in
+    // `listSnapshots`).
+    const intermediateFilename = '20260101_120000_000-restart-aaaaaa.json'
+    memory.set(path.join('/test/install', '.launcher', 'snapshots', intermediateFilename), JSON.stringify(intermediate))
+
+    const installation = {
+      id: 'install-9',
+      name: 'Test',
+      createdAt: '2026-02-01T00:00:00.000Z',
+      installPath: '/test/install',
+      sourceId: 'test',
+    } as InstallationRecord
+
+    const result = await captureSnapshotIfChanged('/test/install', installation, 'restart')
+
+    expect(result.saved).toBe(true)
+    expect(result.deduplicated).toBe(intermediateFilename)
+    expect(mockedTelemetryEmit).toHaveBeenCalledTimes(1)
+    expect(mockedTelemetryEmit).toHaveBeenCalledWith('desktop2.snapshot.created', {
+      installation_id: 'install-9',
+      trigger: 'restart',
+      custom_nodes_count: 0,
+      pip_packages_count: 0,
+      has_label: false,
+      deduplicated_previous: true,
+    })
   })
 })

--- a/src/main/lib/snapshots/store.test.ts
+++ b/src/main/lib/snapshots/store.test.ts
@@ -19,6 +19,10 @@ vi.mock('../pythonEnv', () => ({
   getActivePythonPath: vi.fn(() => null),
 }))
 
+vi.mock('../telemetry', () => ({
+  emit: vi.fn(),
+}))
+
 vi.mock('fs', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>
   return {
@@ -29,14 +33,23 @@ vi.mock('fs', async (importOriginal) => {
       readFileSync: vi.fn(() => {
         throw new Error('not found')
       }),
+      promises: {
+        mkdir: vi.fn(async () => {}),
+        writeFile: vi.fn(async () => {}),
+        rename: vi.fn(async () => {}),
+        readdir: vi.fn(async () => []),
+      },
     },
   }
 })
 
 import { readGitHead } from '../git'
 import { scanCustomNodes } from '../nodes'
-import { captureState } from './store'
+import { captureState, saveSnapshot } from './store'
+import * as telemetry from '../telemetry'
 import type { InstallationRecord } from '../../installations'
+
+const mockedTelemetryEmit = vi.mocked(telemetry.emit)
 
 const mockedReadGitHead = vi.mocked(readGitHead)
 const mockedScanCustomNodes = vi.mocked(scanCustomNodes)
@@ -134,5 +147,57 @@ describe('captureState commit-matching guard', () => {
     expect(state.comfyui.commit).toBeNull()
     expect(state.comfyui.baseTag).toBeUndefined()
     expect(state.comfyui.commitsAhead).toBeUndefined()
+  })
+})
+
+describe('saveSnapshot telemetry', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    mockedScanCustomNodes.mockResolvedValue([
+      { id: 'a', type: 'cnr', dirName: 'a', enabled: true, version: '1.0.0' },
+      { id: 'b', type: 'cnr', dirName: 'b', enabled: true, version: '2.0.0' },
+    ])
+    mockedReadGitHead.mockReturnValue('abc1234')
+  })
+
+  it('emits desktop2.snapshot.created with installation_id, trigger, counts, and dedup flag', async () => {
+    const installation = {
+      id: 'install-42',
+      name: 'Test',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      installPath: '/test/install',
+      sourceId: 'test',
+    } as InstallationRecord
+
+    await saveSnapshot('/test/install', installation, 'manual', 'my label')
+
+    expect(mockedTelemetryEmit).toHaveBeenCalledTimes(1)
+    expect(mockedTelemetryEmit).toHaveBeenCalledWith('desktop2.snapshot.created', {
+      installation_id: 'install-42',
+      trigger: 'manual',
+      custom_nodes_count: 2,
+      // pip freeze is short-circuited by the python-path mock returning null
+      pip_packages_count: 0,
+      has_label: true,
+      // saveSnapshot never deduplicates a previous snapshot
+      deduplicated_previous: false,
+    })
+  })
+
+  it('reports has_label: false when no label is supplied', async () => {
+    const installation = {
+      id: 'install-7',
+      name: 'Test',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      installPath: '/test/install',
+      sourceId: 'test',
+    } as InstallationRecord
+
+    await saveSnapshot('/test/install', installation, 'pre-update')
+
+    expect(mockedTelemetryEmit).toHaveBeenCalledWith(
+      'desktop2.snapshot.created',
+      expect.objectContaining({ trigger: 'pre-update', has_label: false }),
+    )
   })
 })

--- a/src/main/lib/snapshots/store.ts
+++ b/src/main/lib/snapshots/store.ts
@@ -4,6 +4,7 @@ import { readGitHead } from '../git'
 import { scanCustomNodes, nodeKey } from '../nodes'
 import { pipFreeze } from '../pip'
 import { getUvPath, getActivePythonPath } from '../pythonEnv'
+import * as telemetry from '../telemetry'
 import type { Snapshot, SnapshotEntry } from './types'
 import type { InstallationRecord } from '../../installations'
 import type { ComfyVersion } from '../version'
@@ -243,6 +244,40 @@ async function deduplicateRestartSnapshot(installPath: string, justSavedFilename
   return prev.filename
 }
 
+/**
+ * Emit `desktop2.snapshot.created` for every successful snapshot write.
+ *
+ * Centralized here (instead of inside `writeSnapshot`) because the wrapper
+ * functions own the `InstallationRecord` (for `installation_id`) and the
+ * dedup outcome (for `deduplicated_previous`). `writeSnapshot` is kept
+ * pure so it can be reused by future callers without touching telemetry.
+ *
+ * `telemetry.emit` no-ops when consent is off / SDK uninitialized, so this
+ * is safe to call unconditionally and from unit tests.
+ */
+function emitSnapshotCreated(opts: {
+  installation: InstallationRecord
+  trigger: Snapshot['trigger']
+  customNodesCount: number
+  pipPackagesCount: number
+  hasLabel: boolean
+  /**
+   * True when `captureSnapshotIfChanged` collapsed the previous restart
+   * snapshot into this one (the only path that can ever trip dedup-on-create).
+   * Direct `saveSnapshot` callers always pass `false`.
+   */
+  deduplicatedPrevious: boolean
+}): void {
+  telemetry.emit('desktop2.snapshot.created', {
+    installation_id: opts.installation.id,
+    trigger: opts.trigger,
+    custom_nodes_count: opts.customNodesCount,
+    pip_packages_count: opts.pipPackagesCount,
+    has_label: opts.hasLabel,
+    deduplicated_previous: opts.deduplicatedPrevious,
+  })
+}
+
 export async function captureSnapshotIfChanged(
   installPath: string,
   installation: InstallationRecord,
@@ -273,6 +308,15 @@ export async function captureSnapshotIfChanged(
       deduplicated = await deduplicateRestartSnapshot(installPath, filename).catch(() => undefined)
     }
 
+    emitSnapshotCreated({
+      installation,
+      trigger,
+      customNodesCount: current.customNodes.length,
+      pipPackagesCount: Object.keys(current.pipPackages).length,
+      hasLabel: false,
+      deduplicatedPrevious: deduplicated !== undefined,
+    })
+
     // Prune old auto snapshots
     await pruneAutoSnapshots(installPath, AUTO_SNAPSHOT_LIMIT).catch(() => {})
 
@@ -288,7 +332,16 @@ export async function saveSnapshot(
 ): Promise<string> {
   return withLock(installPath, async () => {
     const current = await captureState(installPath, installation)
-    return writeSnapshot(installPath, { ...current, trigger, label: label || null })
+    const filename = await writeSnapshot(installPath, { ...current, trigger, label: label || null })
+    emitSnapshotCreated({
+      installation,
+      trigger,
+      customNodesCount: current.customNodes.length,
+      pipPackagesCount: Object.keys(current.pipPackages).length,
+      hasLabel: !!(label && label.length > 0),
+      deduplicatedPrevious: false,
+    })
+    return filename
   })
 }
 

--- a/src/main/lib/standaloneMigration.ts
+++ b/src/main/lib/standaloneMigration.ts
@@ -137,7 +137,7 @@ export async function restoreSnapshotIntoInstallation(
   try {
     const fileContent = await fs.promises.readFile(stagedFile, 'utf-8')
     const importEnvelope = validateExportEnvelope(JSON.parse(fileContent))
-    await importSnapshots(freshInst.installPath, importEnvelope)
+    await importSnapshots(freshInst.installPath, importEnvelope, entry.id)
     const targetSnapshot = importEnvelope.snapshots[0]!
 
     // Restore ComfyUI version


### PR DESCRIPTION
## Summary

Adds telemetry for **every** snapshot-creating flow in the launcher so we can answer questions like "how often do auto-snapshots fire?", "what's the trigger / size distribution?", and "does the restart-snapshot dedup ever trip?". Two events:

- **`desktop2.snapshot.created`** — fresh captures via `saveSnapshot` and `captureSnapshotIfChanged` (boot, restart, manual, pre-update, post-update, post-restore).
- **`desktop2.snapshot.imported`** — files written by `importSnapshots` (manual import via the snapshots tab + standalone migration). Distinct event because the snapshot was *copied in*, not taken on this install.

Previously the snapshot subsystem only emitted `desktop2.snapshot.restore_*` (restore side) and a per-session `desktop2.session.snapshot_history` rollup. **All write paths were silent**.

## Event payloads

### `desktop2.snapshot.created`

| Field | Source |
|---|---|
| `installation_id` | `InstallationRecord.id` |
| `trigger` | `'boot'` \| `'restart'` \| `'manual'` \| `'pre-update'` \| `'post-update'` \| `'post-restore'` |
| `custom_nodes_count` | `current.customNodes.length` |
| `pip_packages_count` | `Object.keys(current.pipPackages).length` |
| `has_label` | True when `saveSnapshot` was called with a non-empty label |
| `deduplicated_previous` | True when `captureSnapshotIfChanged` collapsed the prior intermediate restart snapshot (only path that can dedup on create) |

Centralized in the wrapper layer (`saveSnapshot` + `captureSnapshotIfChanged`) — wrappers own the `InstallationRecord` and dedup outcome. `writeSnapshot` stays pure.

### `desktop2.snapshot.imported`

| Field | Source |
|---|---|
| `installation_id` | target install (threaded through `importSnapshots` as a new arg) |
| `original_trigger` | trigger preserved from the imported snapshot |
| `custom_nodes_count` | count from the snapshot's `customNodes` |
| `pip_packages_count` | count from the snapshot's `pipPackages` |
| `has_label` | True iff the imported snapshot had a non-empty label |
| `batch_size` | total snapshots in this import operation |
| `batch_index` | 0-based position within the batch |

Per-snapshot emit (matches `.created` granularity) + `batch_size` / `batch_index` so dashboards can reconstruct the import-operation grouping when needed.

## Out of scope (intentional)

- **Skipped writes** — `captureSnapshotIfChanged` short-circuits at `boot` when state matches the previous snapshot. No file written, no event.
- **`deduplicatePreUpdateSnapshot`** collapsing a just-written `pre-update` — the create event still fires; the dedup decision is separate and not tracked here.
- **Restore events** — already covered by `desktop2.snapshot.restore_*`.

## Tests

5 new tests (812 → 817 total):

- `saveSnapshot` emits `desktop2.snapshot.created` with the right payload + `has_label` reflects label presence
- `captureSnapshotIfChanged` emits **nothing** when boot state matches the previous snapshot (`saved:false`)
- `captureSnapshotIfChanged` emits `deduplicated_previous: true` when restart collapses the prior intermediate snapshot
- `importSnapshots` emits `desktop2.snapshot.imported` once per imported snapshot with correct `batch_size`/`batch_index`, mixed labeled/unlabeled

Stateful in-memory `fs.promises` mock added in `store.test.ts` so the dedup/load paths run without touching real disk. Existing 8 `importSnapshots` calls in `snapshots.test.ts` updated to pass the new `installationId` arg.

## Validation

- `pnpm run typecheck` — green
- `pnpm run lint` — green
- `pnpm run test` — 817 passed (+5)

## Branch

`telemetry/snapshot-created` off `main` at `017d9a3`.