### PR TITLE
fix(launcher): surface downloads tray + Desktop Update modal on Comfy windows (closes #523)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -323,21 +323,39 @@ interface ComfyWindowEntry {
    */
   firstUseMode: 'none' | 'consent-lockdown' | 'post-consent'
   /**
-   * Issue #523 — `true` while the panel renderer has at least one
-   * overlay (Tier 1/2/3 via `useOverlay`) or modal (`useModal`)
-   * mounted on a Comfy host whose body mode is `'comfy'`. The panel
-   * normally collapses to 0×0 + setVisible(false) under `'comfy'` so
-   * the live ComfyUI surface fills the body; with this flag set
-   * `layoutViews` lifts the panel back to the full body rect on top
-   * of the comfy view so the popover/modal is actually visible.
+   * Issue #523 — current panel-renderer overlay/modal layout the
+   * panel surface should adopt when the host's body mode is
+   * `'comfy'`.
    *
-   * Toggled by the `comfy-panel:set-overlay-active` IPC the panel
-   * renderer fires from a watcher on `currentOverlay !== null ||
-   * modal.state.visible`. No-op for install-less hosts (their body
-   * mode never resolves to `'comfy'` in the first place — the Comfy
-   * pill maps to `'chooser'`).
+   *   - `null`     — no overlay/modal mounted in the panel renderer.
+   *                  `layoutViews` collapses the panelView to 0×0 so
+   *                  the live ComfyUI surface fills the body.
+   *   - `'modal'`  — panel renderer has a full-surface modal mounted
+   *                  (SettingsModal, Desktop Update confirm modal,
+   *                  ProgressModal, Tier 3 takeovers). `layoutViews`
+   *                  lifts the panel to the full body rect AND
+   *                  collapses comfyView so the modal owns the
+   *                  surface — the modal expects to be the focused
+   *                  affordance and we don't want ComfyUI flickering
+   *                  through.
+   *   - `'drawer'` — panel renderer has a lightweight, anchored
+   *                  popover mounted (downloads tray). `layoutViews`
+   *                  lifts the panelView on top of comfyView at the
+   *                  full body rect (so the popover can render)
+   *                  while leaving comfyView visible underneath. The
+   *                  panel renderer paints `.panel-shell` transparent
+   *                  in this mode (with the popover keeping its
+   *                  opaque `var(--surface)`) so the user sees the
+   *                  popover floating over the live ComfyUI view —
+   *                  visually the same as the title-bar dropdown.
+   *
+   * Toggled by the `comfy-panel:set-overlay-layout` IPC the panel
+   * renderer fires from a watcher that maps the active overlay kind
+   * (and modal visibility) to one of the three values. No-op for
+   * install-less hosts (their body mode never resolves to `'comfy'`
+   * in the first place — the Comfy pill maps to `'chooser'`).
    */
-  overlayMounted: boolean
+  overlayLayout: 'modal' | 'drawer' | null
   /**
    * Window-mode unification (Stage W-3b) — current title-bar pill
    * label. Install-backed windows mirror the install name (and re-
@@ -490,7 +508,24 @@ function computeBodyMode(entry: ComfyWindowEntry): BodyMode {
  * issue #523's keyboard-focus regression on the overlay-only path.
  */
 function isPanelBodyVisible(entry: ComfyWindowEntry): boolean {
-  return computeBodyMode(entry) !== 'comfy' || entry.overlayMounted
+  return computeBodyMode(entry) !== 'comfy' || entry.overlayLayout !== null
+}
+
+/**
+ * True when the panel surface is up but should NOT eclipse the
+ * ComfyUI view — i.e. the panel renderer is showing a drawer-style
+ * popover (`overlayLayout === 'drawer'`) over a `'comfy'` body. In
+ * that mode `layoutViews` lifts the panel on top of comfyView (so
+ * the popover can render) AND keeps comfyView visible underneath
+ * (so the user still sees the live frontend). Other panel-visible
+ * states (any non-`'comfy'` body, or `'modal'` layout) eclipse the
+ * comfy view as before.
+ *
+ * Centralising the predicate so `layoutViews` can't drift from
+ * future callers (focus, comfy-view interactivity gates, etc.).
+ */
+function isComfyVisibleUnderPanelOverlay(entry: ComfyWindowEntry): boolean {
+  return computeBodyMode(entry) === 'comfy' && entry.overlayLayout === 'drawer'
 }
 
 /**
@@ -1276,21 +1311,40 @@ function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowResult {
     // hosts, so the install-backed visibility branch handles both.
     //
     // Issue #523 — when the body mode is `'comfy'` BUT the panel
-    // renderer has an overlay/modal mounted (`entry.overlayMounted`),
+    // renderer has an overlay/modal mounted (`entry.overlayLayout`),
     // lift the panel up to the full body rect on top of the comfy
-    // view so the popover/modal is actually visible. The comfy view
-    // stays alive but collapsed; closing the overlay flips
-    // `overlayMounted` back to false and `layoutViews` re-runs to
-    // restore the normal comfy-on-top layout. The shared
-    // `isPanelBodyVisible` predicate is reused by `focusActiveBody`
-    // to keep keyboard focus in step with the visible body.
+    // view so the popover/modal is actually visible. Two sub-modes:
+    //
+    //   - `'modal'`  collapses the comfy view (current behavior — used
+    //                by SettingsModal / Desktop Update / Tier 3
+    //                takeovers; the modal owns the surface).
+    //   - `'drawer'` keeps the comfy view at full body bounds and
+    //                visible UNDERNEATH the panel; the panel renderer
+    //                paints `.panel-shell` transparent so only the
+    //                anchored popover (DownloadsTrayPopover) is
+    //                opaque. Visually matches the title-bar dropdown.
+    //
+    // Closing the overlay flips `overlayLayout` back to `null` and
+    // `layoutViews` re-runs to restore the normal comfy-on-top
+    // layout. The shared `isPanelBodyVisible` predicate is reused by
+    // `focusActiveBody` to keep keyboard focus in step with whichever
+    // surface is on top.
     const showPanel = entry ? isPanelBodyVisible(entry) : false
+    const drawerMode = entry ? isComfyVisibleUnderPanelOverlay(entry) : false
     if (showPanel && entry?.panelView) {
       entry.panelView.setBounds(bodyRect)
       entry.panelView.setVisible(true)
-      // Keep ComfyUI alive but collapsed so it can't intercept input.
-      comfyView.setBounds({ x: 0, y: titleBarTotal, width: 0, height: 0 })
-      comfyView.setVisible(false)
+      if (drawerMode) {
+        // Drawer mode — keep ComfyUI visible at full body bounds
+        // underneath the (transparent) panel surface.
+        comfyView.setBounds(bodyRect)
+        comfyView.setVisible(true)
+      } else {
+        // Modal mode — keep ComfyUI alive but collapsed so it can't
+        // intercept input and isn't visible behind the modal chrome.
+        comfyView.setBounds({ x: 0, y: titleBarTotal, width: 0, height: 0 })
+        comfyView.setVisible(false)
+      }
     } else {
       comfyView.setBounds(bodyRect)
       comfyView.setVisible(true)
@@ -1449,7 +1503,7 @@ function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowResult {
         ? opts.comfyWebPreferences.partition
         : null,
     firstUseMode: 'none',
-    overlayMounted: false,
+    overlayLayout: null,
     titleBarText: opts.initialTitleBarText,
     sourceCategory: opts.initialSourceCategory,
     _installCleanup: null,
@@ -2356,7 +2410,13 @@ function ensurePanelView(windowKey: number, entry: ComfyWindowEntry, initialPane
       // ComfyUI frontend's storage even though it runs in the same window.
     },
   })
-  panelView.setBackgroundColor(resolveTheme() === 'dark' ? '#202020' : '#ffffff')
+  // Issue #523 — panel WebContentsView is intentionally transparent at
+  // the compositor level so the drawer-mode overlay (downloads tray)
+  // can render the panel surface as transparent CSS and let the
+  // ComfyUI WebContentsView underneath show through. The panel body
+  // CSS still paints `var(--bg)` opaque under normal modes, so this
+  // only affects pixels the page itself leaves transparent.
+  panelView.setBackgroundColor('#00000000')
   entry.window.contentView.addChildView(panelView)
   // Insert at zero size, behind the comfy view; layoutViews handles positioning.
   panelView.setBounds({ x: 0, y: TITLEBAR_HEIGHT + 1, width: 0, height: 0 })
@@ -2495,40 +2555,54 @@ ipcMain.on('comfy-window:close-current-panel', (event) => {
 })
 
 /**
- * Issue #523 — panel renderer's overlay/modal mount tracker.
+ * Issue #523 — panel renderer's overlay/modal layout tracker.
  *
- * The panel renderer (`PanelApp.vue`) runs a watcher on
- * `currentOverlay !== null || modal.state.visible` and fires this
- * IPC on every edge. Main flips `entry.overlayMounted` accordingly
- * and re-runs `layoutViews()`.
+ * The panel renderer (`PanelApp.vue`) runs a watcher that maps the
+ * active overlay kind (and `useModal` visibility) to one of three
+ * layouts and fires this IPC on every edge:
  *
- * The flag only matters when the body mode is `'comfy'` — i.e.
- * install-backed windows where ComfyUI is running and the user is
- * looking at the live frontend. In that mode `layoutViews` would
- * normally collapse the panelView to 0×0 + setVisible(false), so a
- * popover/modal mounted by the panel renderer would have no surface
- * to paint on. Setting `overlayMounted = true` lifts the panel back
- * to the full body rect on top of the comfy view; setting it
- * `false` restores the comfy-on-top layout.
+ *   - `null`     — no overlay/modal mounted.
+ *   - `'modal'`  — full-surface modal (Settings, Desktop Update,
+ *                  ProgressModal, Tier 3 takeovers). Panel surface
+ *                  eclipses comfy.
+ *   - `'drawer'` — anchored popover (downloads tray). Panel surface
+ *                  lifts on top of comfy but stays visually
+ *                  transparent so comfy shows through.
+ *
+ * Main writes `entry.overlayLayout` and re-runs `layoutViews()` so
+ * the panel surface is positioned/visible according to the rules in
+ * `layoutViews` (see comment there for the per-mode bounds /
+ * comfy-view visibility matrix).
+ *
+ * Only matters when the body mode is `'comfy'` — install-less hosts
+ * never resolve to `'comfy'` so the layout flag is effectively a
+ * no-op for them.
  *
  * Resolved via the `event.sender === entry.panelView?.webContents`
  * walk to avoid maintaining a separate reverse-map (the panelView
  * is lazily constructed; a cached map would race construction).
  */
-ipcMain.on('comfy-panel:set-overlay-active', (event, payload: { active: boolean }) => {
-  const active = !!payload?.active
-  for (const entry of comfyWindows.values()) {
-    if (entry.panelView?.webContents !== event.sender) continue
-    if (entry.overlayMounted === active) return
-    entry.overlayMounted = active
-    if (entry.window.isDestroyed()) return
-    entry.layoutViews()
-    // Hand keyboard focus to whichever body view just became visible
-    // so keystrokes don't land in the now-occluded one.
-    focusActiveBody(entry)
-    return
-  }
-})
+ipcMain.on(
+  'comfy-panel:set-overlay-layout',
+  (event, payload: { layout: 'modal' | 'drawer' | null }) => {
+    const raw = payload?.layout
+    const layout: 'modal' | 'drawer' | null =
+      raw === 'modal' || raw === 'drawer' ? raw : null
+    for (const entry of comfyWindows.values()) {
+      if (entry.panelView?.webContents !== event.sender) continue
+      if (entry.overlayLayout === layout) return
+      entry.overlayLayout = layout
+      if (entry.window.isDestroyed()) return
+      entry.layoutViews()
+      // Hand keyboard focus to whichever body view just became visible
+      // so keystrokes don't land in the now-occluded one. Drawer mode
+      // still wants focus on the panel (the popover holds it), so
+      // `isPanelBodyVisible` covers both modal and drawer cases.
+      focusActiveBody(entry)
+      return
+    }
+  },
+)
 
 /**
  * Modal-unification (Track M-2.2 / M-4) — first-use takeover step
@@ -2661,7 +2735,7 @@ ipcMain.on('comfy-window:click-app-update-pill', (event) => {
  * → Update sub-tab), so flipping the body to `'settings'` is the
  * right thing here. Compare `click-app-update-pill` /
  * `click-downloads-tray`, which only need a transient overlay/modal
- * surface and rely on `entry.overlayMounted` instead.
+ * surface and rely on `entry.overlayLayout` instead.
  *
  * The send itself goes through `triggerPanelOverlay` so the
  * destroyed-view guards and the `did-finish-load` deferral are
@@ -2722,8 +2796,11 @@ function _broadcastDownloadsToTitleBars(): void {
  * regression, see PR #508 / issue #523) and routes through
  * `triggerPanelOverlay` for the destroyed-view + did-finish-load
  * guards. The actual surfacing of the panel on top of the comfy
- * view happens via `entry.overlayMounted` once the renderer's
- * watcher fires `comfy-panel:set-overlay-active`.
+ * view happens via `entry.overlayLayout = 'drawer'` once the
+ * renderer's watcher fires `comfy-panel:set-overlay-layout` — drawer
+ * mode keeps comfy visible underneath the (transparent) panel
+ * surface so the popover hangs over a live ComfyUI view rather than
+ * a blank one.
  */
 ipcMain.on('comfy-window:click-downloads-tray', (event) => {
   const found = findEntryByTitleBarSender(event.sender)
@@ -2752,7 +2829,7 @@ ipcMain.on('comfy-window:click-downloads-tray', (event) => {
  * alongside the matching helper for `panel-trigger-overlay`. Send
  * Feedback only needs the renderer to RUN JS (it calls
  * `openExternal` for the typeform URL), so it does NOT touch
- * `entry.overlayMounted` — no panel UI is being surfaced.
+ * `entry.overlayLayout` — no panel UI is being surfaced.
  */
 function triggerOpenFeedback(entryId: number, source: 'titlebar' | 'menu'): void {
   const parentEntry = comfyWindows.get(entryId)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -482,6 +482,18 @@ function computeBodyMode(entry: ComfyWindowEntry): BodyMode {
 }
 
 /**
+ * Single source of truth for "is the panel surface the visible body
+ * right now?". `layoutViews` uses this to decide which view fills the
+ * body rect; `focusActiveBody` uses the same predicate to route OS
+ * keyboard focus to the matching view. Drift between the two lets
+ * keystrokes land in an invisible view, which is what triggered
+ * issue #523's keyboard-focus regression on the overlay-only path.
+ */
+function isPanelBodyVisible(entry: ComfyWindowEntry): boolean {
+  return computeBodyMode(entry) !== 'comfy' || entry.overlayMounted
+}
+
+/**
  * Re-evaluate the body mode for a comfy window after a session-state
  * transition (instance launched / stopped / crashed) and reflect it in the
  * layout. When the body mode is `'comfy-lifecycle'`, the panelView is created
@@ -1269,9 +1281,10 @@ function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowResult {
     // view so the popover/modal is actually visible. The comfy view
     // stays alive but collapsed; closing the overlay flips
     // `overlayMounted` back to false and `layoutViews` re-runs to
-    // restore the normal comfy-on-top layout.
-    const mode = entry ? computeBodyMode(entry) : 'comfy'
-    const showPanel = mode !== 'comfy' || (entry?.overlayMounted ?? false)
+    // restore the normal comfy-on-top layout. The shared
+    // `isPanelBodyVisible` predicate is reused by `focusActiveBody`
+    // to keep keyboard focus in step with the visible body.
+    const showPanel = entry ? isPanelBodyVisible(entry) : false
     if (showPanel && entry?.panelView) {
       entry.panelView.setBounds(bodyRect)
       entry.panelView.setVisible(true)
@@ -2404,16 +2417,21 @@ function getOrCreatePanelView(entry: ComfyWindowEntry): WebContentsView | null {
   return entry.panelView ?? ensurePanelView(entry.windowKey, entry, computeBodyMode(entry))
 }
 
-/** Move OS focus to whichever body view is now active so keyboard input lands in the right place. */
+/** Move OS focus to whichever body view is now active so keyboard input
+ *  lands in the right place. Uses `isPanelBodyVisible` to stay in lockstep
+ *  with `layoutViews` — the overlay-only path (#523) lifts the panel onto
+ *  the comfy view, and focus must follow or keystrokes route to the
+ *  invisible comfy frame. */
 function focusActiveBody(entry: ComfyWindowEntry): void {
   if (entry.window.isDestroyed() || !entry.window.isFocused()) return
-  const mode = computeBodyMode(entry)
-  if (mode === 'comfy') {
-    if (!entry.comfyView.webContents.isDestroyed()) entry.comfyView.webContents.focus()
-  } else if (entry.panelView && !entry.panelView.webContents.isDestroyed() && !entry.panelView.webContents.isLoadingMainFrame()) {
-    // Panel exists and is loaded — focus immediately. If still loading, the
-    // did-finish-load handler in ensurePanelView will focus it.
-    entry.panelView.webContents.focus()
+  if (isPanelBodyVisible(entry)) {
+    if (entry.panelView && !entry.panelView.webContents.isDestroyed() && !entry.panelView.webContents.isLoadingMainFrame()) {
+      // Panel exists and is loaded — focus immediately. If still loading, the
+      // did-finish-load handler in ensurePanelView will focus it.
+      entry.panelView.webContents.focus()
+    }
+  } else if (!entry.comfyView.webContents.isDestroyed()) {
+    entry.comfyView.webContents.focus()
   }
 }
 
@@ -2503,7 +2521,11 @@ ipcMain.on('comfy-panel:set-overlay-active', (event, payload: { active: boolean 
     if (entry.panelView?.webContents !== event.sender) continue
     if (entry.overlayMounted === active) return
     entry.overlayMounted = active
-    if (!entry.window.isDestroyed()) entry.layoutViews()
+    if (entry.window.isDestroyed()) return
+    entry.layoutViews()
+    // Hand keyboard focus to whichever body view just became visible
+    // so keystrokes don't land in the now-occluded one.
+    focusActiveBody(entry)
     return
   }
 })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -35,6 +35,7 @@ import { showModelFolderRelaunchPage } from './lib/relaunchPage'
 import { COMFY_BG, SPLASH_DARK, TITLEBAR_BG, type SplashTheme } from './lib/theme'
 import { TITLEBAR_HEIGHT, TRAFFIC_LIGHT_POSITION, comfyTitleBarOverlay, titleBarOverlayForTheme } from './lib/titleBarOverlay'
 import { resolveTheme, sourceMap, _registerExtraBroadcastTarget, _unregisterExtraBroadcastTarget, _runningSessions, _broadcastToRenderer, _operationAborts } from './lib/ipc/shared'
+import { triggerPanelOverlay, triggerOpenFeedback as triggerOpenFeedbackHelper } from './lib/comfy-panel-overlay'
 import * as mainTelemetry from './lib/telemetry'
 import { getDeviceId } from './lib/deviceId'
 import { scrubAll } from './lib/piiScrub'
@@ -321,6 +322,22 @@ interface ComfyWindowEntry {
    * see the IPC handler comment.
    */
   firstUseMode: 'none' | 'consent-lockdown' | 'post-consent'
+  /**
+   * Issue #523 — `true` while the panel renderer has at least one
+   * overlay (Tier 1/2/3 via `useOverlay`) or modal (`useModal`)
+   * mounted on a Comfy host whose body mode is `'comfy'`. The panel
+   * normally collapses to 0×0 + setVisible(false) under `'comfy'` so
+   * the live ComfyUI surface fills the body; with this flag set
+   * `layoutViews` lifts the panel back to the full body rect on top
+   * of the comfy view so the popover/modal is actually visible.
+   *
+   * Toggled by the `comfy-panel:set-overlay-active` IPC the panel
+   * renderer fires from a watcher on `currentOverlay !== null ||
+   * modal.state.visible`. No-op for install-less hosts (their body
+   * mode never resolves to `'comfy'` in the first place — the Comfy
+   * pill maps to `'chooser'`).
+   */
+  overlayMounted: boolean
   /**
    * Window-mode unification (Stage W-3b) — current title-bar pill
    * label. Install-backed windows mirror the install name (and re-
@@ -1245,8 +1262,16 @@ function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowResult {
     // (lifecycle / chooser / settings / etc.) depending on mode.
     // `computeBodyMode` already returns `'chooser'` for install-less
     // hosts, so the install-backed visibility branch handles both.
+    //
+    // Issue #523 — when the body mode is `'comfy'` BUT the panel
+    // renderer has an overlay/modal mounted (`entry.overlayMounted`),
+    // lift the panel up to the full body rect on top of the comfy
+    // view so the popover/modal is actually visible. The comfy view
+    // stays alive but collapsed; closing the overlay flips
+    // `overlayMounted` back to false and `layoutViews` re-runs to
+    // restore the normal comfy-on-top layout.
     const mode = entry ? computeBodyMode(entry) : 'comfy'
-    const showPanel = mode !== 'comfy'
+    const showPanel = mode !== 'comfy' || (entry?.overlayMounted ?? false)
     if (showPanel && entry?.panelView) {
       entry.panelView.setBounds(bodyRect)
       entry.panelView.setVisible(true)
@@ -1411,6 +1436,7 @@ function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowResult {
         ? opts.comfyWebPreferences.partition
         : null,
     firstUseMode: 'none',
+    overlayMounted: false,
     titleBarText: opts.initialTitleBarText,
     sourceCategory: opts.initialSourceCategory,
     _installCleanup: null,
@@ -2358,6 +2384,26 @@ function ensurePanelView(windowKey: number, entry: ComfyWindowEntry, initialPane
   return panelView
 }
 
+/**
+ * Resolve the panelView for a host entry, lazy-creating one if the
+ * window has not constructed it yet (Comfy windows defer construction
+ * until the first non-comfy switch). Returns `null` when the host
+ * window is destroyed; otherwise always returns a usable
+ * `WebContentsView`.
+ *
+ * Title-bar IPCs that need to push UI through the panel renderer
+ * (downloads tray, app-update modal, send feedback) MUST go through
+ * this — see PR #508 / issue #523 for the regressions caused by
+ * reading `entry.panelView` directly. The actual `webContents.send`
+ * lives in `triggerPanelOverlay` / `triggerOpenFeedbackHelper`
+ * (`./lib/comfy-panel-overlay.ts`), which add the matching
+ * `did-finish-load` deferral the freshly-constructed view needs.
+ */
+function getOrCreatePanelView(entry: ComfyWindowEntry): WebContentsView | null {
+  if (entry.window.isDestroyed()) return null
+  return entry.panelView ?? ensurePanelView(entry.windowKey, entry, computeBodyMode(entry))
+}
+
 /** Move OS focus to whichever body view is now active so keyboard input lands in the right place. */
 function focusActiveBody(entry: ComfyWindowEntry): void {
   if (entry.window.isDestroyed() || !entry.window.isFocused()) return
@@ -2427,6 +2473,38 @@ ipcMain.on('comfy-window:close-current-panel', (event) => {
       setActivePanel(id, 'comfy')
       return
     }
+  }
+})
+
+/**
+ * Issue #523 — panel renderer's overlay/modal mount tracker.
+ *
+ * The panel renderer (`PanelApp.vue`) runs a watcher on
+ * `currentOverlay !== null || modal.state.visible` and fires this
+ * IPC on every edge. Main flips `entry.overlayMounted` accordingly
+ * and re-runs `layoutViews()`.
+ *
+ * The flag only matters when the body mode is `'comfy'` — i.e.
+ * install-backed windows where ComfyUI is running and the user is
+ * looking at the live frontend. In that mode `layoutViews` would
+ * normally collapse the panelView to 0×0 + setVisible(false), so a
+ * popover/modal mounted by the panel renderer would have no surface
+ * to paint on. Setting `overlayMounted = true` lifts the panel back
+ * to the full body rect on top of the comfy view; setting it
+ * `false` restores the comfy-on-top layout.
+ *
+ * Resolved via the `event.sender === entry.panelView?.webContents`
+ * walk to avoid maintaining a separate reverse-map (the panelView
+ * is lazily constructed; a cached map would race construction).
+ */
+ipcMain.on('comfy-panel:set-overlay-active', (event, payload: { active: boolean }) => {
+  const active = !!payload?.active
+  for (const entry of comfyWindows.values()) {
+    if (entry.panelView?.webContents !== event.sender) continue
+    if (entry.overlayMounted === active) return
+    entry.overlayMounted = active
+    if (!entry.window.isDestroyed()) entry.layoutViews()
+    return
   }
 })
 
@@ -2535,22 +2613,19 @@ ipcMain.on('comfy-window:click-app-update-pill', (event) => {
   const found = findEntryByTitleBarSender(event.sender)
   if (!found) return
   const { entry } = found
-  const panelView = entry.panelView
-  if (!panelView || panelView.webContents.isDestroyed()) return
   const state = updater.getCurrentUpdateState()
-  if (state.kind === 'ready') {
-    panelView.webContents.send('panel-trigger-overlay', {
-      kind: 'app-update-restart-prompt',
-      version: state.version,
-    })
-    return
-  }
-  if (state.kind === 'available') {
-    panelView.webContents.send('panel-trigger-overlay', {
-      kind: 'app-update-download-prompt',
-      version: state.version,
-    })
-  }
+  if (state.kind !== 'ready' && state.kind !== 'available') return
+  // Issue #523 — Comfy windows construct the panelView lazily on
+  // first non-comfy switch; wake one if needed (the `comfy-panel:set-
+  // overlay-active` round-trip the modal kicks off below will lift it
+  // to the body rect on top of the comfy view, so the user actually
+  // sees the modal). Routes through the helper so the destroyed-view
+  // guards and the `did-finish-load` deferral are applied uniformly.
+  const panelView = getOrCreatePanelView(entry)
+  if (!panelView) return
+  triggerPanelOverlay(panelView, state.kind === 'ready'
+    ? { kind: 'app-update-restart-prompt', version: state.version }
+    : { kind: 'app-update-download-prompt', version: state.version })
 })
 
 /**
@@ -2558,36 +2633,20 @@ ipcMain.on('comfy-window:click-app-update-pill', (event) => {
  * install-less hosts (the pill is suppressed there but a defensive
  * guard keeps stray IPC from triggering anything).
  *
- * The handler does three things, in order:
- *   1. `setActivePanel(found.id, 'settings')` — bring the panel view
- *      forward when the user is currently on the ComfyUI view (the
- *      common case for this pill since it's only visible while an
- *      install is running). Without this, the unified Settings modal
- *      mounts on a hidden panel surface and the click appears to do
- *      nothing. `setActivePanel` also lazily creates the panelView
- *      on first non-comfy switch via `ensurePanelView`. It's a no-op
- *      when the entry is already on `'settings'` (i.e. the modal is
- *      already open), so we don't double-open it.
- *   2. Resolve the entry's `panelView` AFTER `setActivePanel` so we
- *      pick up any view that step 1 may have just constructed.
- *   3. `panel-trigger-overlay` with the installationId so the renderer
- *      can open the unified Settings modal deep-linked to the ComfyUI
- *      Settings tab → Update sub-tab — same surface the chooser kebab
- *      "Update…" entry routes to.
+ * `setActivePanel(found.id, 'settings')` brings the panel view
+ * forward — the unified Settings modal is the surface the user
+ * actually wants to land on (deep-linked to the ComfyUI Settings tab
+ * → Update sub-tab), so flipping the body to `'settings'` is the
+ * right thing here. Compare `click-app-update-pill` /
+ * `click-downloads-tray`, which only need a transient overlay/modal
+ * surface and rely on `entry.overlayMounted` instead.
  *
- * Step 3 must be deferred until the panelView's renderer has finished
- * loading. When the panel was just constructed by step 1, its preload
- * + Vue app haven't mounted yet, so a synchronous `send()` would land
- * before `unsubPanelTriggerOverlay = window.api.onPanelTriggerOverlay
- * (...)` ran in `onMounted`, and the IPC would be silently dropped.
- * `did-finish-load` fires once the JS bundle has executed (which is
- * what Vue's `mount()` + `onMounted` ride on), so registering a
- * `once('did-finish-load', sendDeepLink)` is a reliable trigger.
- *
- * The renderer's existing `initialTab` / `initialDetailTab` watchers
- * (added in the unified-settings-modal branch) cover the
- * already-mounted-but-on-a-different-tab case — they snap the sidebar
- * back to "ComfyUI Settings" and the inner DetailModal to Update.
+ * The send itself goes through `triggerPanelOverlay` so the
+ * destroyed-view guards and the `did-finish-load` deferral are
+ * applied uniformly. The renderer's existing `initialTab` /
+ * `initialDetailTab` watchers cover the already-mounted-but-on-a-
+ * different-tab case — they snap the sidebar back to "ComfyUI
+ * Settings" and the inner DetailModal to Update.
  */
 ipcMain.on('comfy-window:click-install-update-pill', (event) => {
   const found = findEntryByTitleBarSender(event.sender)
@@ -2596,20 +2655,11 @@ ipcMain.on('comfy-window:click-install-update-pill', (event) => {
   const installationId = entry.installationId
   if (!installationId) return
   setActivePanel(found.id, 'settings')
-  const panelView = entry.panelView
-  if (!panelView || panelView.webContents.isDestroyed()) return
-  const sendDeepLink = (): void => {
-    if (panelView.webContents.isDestroyed()) return
-    panelView.webContents.send('panel-trigger-overlay', {
-      kind: 'install-update',
-      installationId,
-    })
-  }
-  if (panelView.webContents.isLoadingMainFrame()) {
-    panelView.webContents.once('did-finish-load', sendDeepLink)
-  } else {
-    sendDeepLink()
-  }
+  // setActivePanel lazy-creates the panelView via ensurePanelView, so
+  // it's safe to read directly here (no overlay-only path needed —
+  // the body mode itself just flipped to 'settings').
+  if (!entry.panelView) return
+  triggerPanelOverlay(entry.panelView, { kind: 'install-update', installationId })
 })
 
 /**
@@ -2639,20 +2689,26 @@ function _broadcastDownloadsToTitleBars(): void {
 }
 
 /**
- * Track F — title-bar downloads-tray click. Routes through
- * `panel-trigger-overlay` so the panel renderer can mount the Tier 1
- * downloads popover via `openOverlay`. The popover reads its data
- * from the renderer's `downloadStore` (already wired via
+ * Track F / Issue #523 — title-bar downloads-tray click. Routes
+ * through `panel-trigger-overlay` so the panel renderer can mount
+ * the Tier 1 downloads popover via `openOverlay`. The popover reads
+ * its data from the renderer's `downloadStore` (already wired via
  * `onModelDownloadProgress`) so the click does not need to ship any
  * additional payload.
+ *
+ * Wakes the panelView via `getOrCreatePanelView` (lazy-construction
+ * regression, see PR #508 / issue #523) and routes through
+ * `triggerPanelOverlay` for the destroyed-view + did-finish-load
+ * guards. The actual surfacing of the panel on top of the comfy
+ * view happens via `entry.overlayMounted` once the renderer's
+ * watcher fires `comfy-panel:set-overlay-active`.
  */
 ipcMain.on('comfy-window:click-downloads-tray', (event) => {
   const found = findEntryByTitleBarSender(event.sender)
   if (!found) return
-  const { entry } = found
-  const panelView = entry.panelView
-  if (!panelView || panelView.webContents.isDestroyed()) return
-  panelView.webContents.send('panel-trigger-overlay', { kind: 'downloads' })
+  const panelView = getOrCreatePanelView(found.entry)
+  if (!panelView) return
+  triggerPanelOverlay(panelView, { kind: 'downloads' })
 })
 
 /**
@@ -2668,28 +2724,20 @@ ipcMain.on('comfy-window:click-downloads-tray', (event) => {
  * `desktop2.feedback.opened` `{ source }` so we can tell which
  * affordance the user reached for.
  *
- * In Comfy instance windows the panelView is constructed lazily on
- * the first non-comfy switch (Settings / Directories / lifecycle), so
- * a feedback click that arrives while the user is still on the
- * ComfyUI body would hit a `null` panelView and silently drop. Mirror
- * the `click-install-update-pill` pattern: ensure the panel exists
- * for the current body mode and defer the send until
- * `did-finish-load` if the bundle is still loading.
+ * The lazy-panelView + `did-finish-load` deferral that PR #508
+ * introduced for this code path now lives in
+ * `triggerOpenFeedbackHelper` (`src/main/lib/comfy-panel-overlay.ts`)
+ * alongside the matching helper for `panel-trigger-overlay`. Send
+ * Feedback only needs the renderer to RUN JS (it calls
+ * `openExternal` for the typeform URL), so it does NOT touch
+ * `entry.overlayMounted` — no panel UI is being surfaced.
  */
 function triggerOpenFeedback(entryId: number, source: 'titlebar' | 'menu'): void {
   const parentEntry = comfyWindows.get(entryId)
-  if (!parentEntry || parentEntry.window.isDestroyed()) return
-  const panelView = parentEntry.panelView ?? ensurePanelView(entryId, parentEntry, computeBodyMode(parentEntry))
-  if (panelView.webContents.isDestroyed()) return
-  const send = (): void => {
-    if (panelView.webContents.isDestroyed()) return
-    panelView.webContents.send('comfy-panel:open-feedback', { source })
-  }
-  if (panelView.webContents.isLoadingMainFrame()) {
-    panelView.webContents.once('did-finish-load', send)
-  } else {
-    send()
-  }
+  if (!parentEntry) return
+  const panelView = getOrCreatePanelView(parentEntry)
+  if (!panelView) return
+  triggerOpenFeedbackHelper(panelView, source)
 }
 
 /** Title-bar Send Feedback button click. Resolves the host entry from

--- a/src/main/lib/comfy-panel-overlay.test.ts
+++ b/src/main/lib/comfy-panel-overlay.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Issue #523 — guard test for the title-bar → panel-renderer IPC
+ * channels owned by `comfy-panel-overlay.ts`.
+ *
+ * The two channels (`'panel-trigger-overlay'` and
+ * `'comfy-panel:open-feedback'`) carry the lazy-panelView /
+ * `did-finish-load` deferral invariant the helper module enforces.
+ * Any other call site that sends these channels directly would
+ * silently re-introduce the regression PR #508 and this issue's fix
+ * landed (the freshly-constructed lazy panelView's renderer hasn't
+ * subscribed yet, so the IPC drops on the floor).
+ *
+ * This test scans every `.ts` file under `src/main/` and asserts the
+ * helper module is the ONLY one referencing either literal in a
+ * `webContents.send(...)` argument. Comments / docstrings that
+ * mention the channel name are allowed via the deliberate matching:
+ * we only flag literal strings inside parentheses preceded by
+ * `.send(` or `.send (`.
+ *
+ * If you're tempted to add a new caller for either channel: add a
+ * helper to `comfy-panel-overlay.ts` instead and route through it.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { promises as fs } from 'fs'
+import path from 'path'
+
+const MAIN_SRC_DIR = path.resolve(__dirname, '..')
+const HELPER_BASENAME = 'comfy-panel-overlay.ts'
+
+const CHANNELS = [
+  'panel-trigger-overlay',
+  'comfy-panel:open-feedback',
+] as const
+
+async function* walkTsFiles(dir: string): AsyncGenerator<string> {
+  const entries = await fs.readdir(dir, { withFileTypes: true })
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      yield* walkTsFiles(full)
+    } else if (entry.isFile() && entry.name.endsWith('.ts')) {
+      yield full
+    }
+  }
+}
+
+/** Match `.send('channel'…)` and `.send("channel"…)` (any whitespace). */
+function findRawSendsForChannel(source: string, channel: string): number[] {
+  const pattern = new RegExp(
+    `\\.send\\s*\\(\\s*['"\`]${channel.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}['"\`]`,
+    'g',
+  )
+  const lines = source.split('\n')
+  const hits: number[] = []
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    if (line === undefined) continue
+    pattern.lastIndex = 0
+    if (pattern.test(line)) hits.push(i + 1)
+  }
+  return hits
+}
+
+describe('comfy-panel-overlay channel guard (issue #523)', () => {
+  for (const channel of CHANNELS) {
+    it(`channel '${channel}' is only sent from the helper module`, async () => {
+      const offenders: { file: string; lines: number[] }[] = []
+      for await (const file of walkTsFiles(MAIN_SRC_DIR)) {
+        if (path.basename(file) === HELPER_BASENAME) continue
+        // The guard test itself contains the literal in test data — skip.
+        if (path.basename(file) === path.basename(__filename)) continue
+        const source = await fs.readFile(file, 'utf8')
+        const hits = findRawSendsForChannel(source, channel)
+        if (hits.length > 0) offenders.push({ file: path.relative(MAIN_SRC_DIR, file), lines: hits })
+      }
+      expect(
+        offenders,
+        `Found raw \`webContents.send('${channel}', ...)\` calls outside the helper module.\n`
+          + `Route the send through \`triggerPanelOverlay\` / \`triggerOpenFeedback\` in \`src/main/lib/${HELPER_BASENAME}\` instead so the lazy-panelView and did-finish-load invariants are preserved.\n`
+          + `Offenders:\n${offenders.map((o) => `  ${o.file}: lines ${o.lines.join(', ')}`).join('\n')}`,
+      ).toEqual([])
+    })
+  }
+})

--- a/src/main/lib/comfy-panel-overlay.ts
+++ b/src/main/lib/comfy-panel-overlay.ts
@@ -1,0 +1,94 @@
+/**
+ * Title-bar → panel-renderer IPC dispatch helpers.
+ *
+ * Every title-bar IPC handler that needs to push a popover, modal, or
+ * other panel-renderer-driven UI onto a Comfy host window MUST funnel
+ * the send through one of these helpers. The reasons:
+ *
+ *   1. Lazy panelView. On Comfy instance windows the `panelView`
+ *      WebContentsView is constructed lazily — only on the first
+ *      non-comfy switch (Settings / Directories / lifecycle). A
+ *      title-bar click that arrives while the user is still on the
+ *      live ComfyUI body would hit a `null` panelView and silently
+ *      drop. Callers must hand this helper an *existing* panelView
+ *      (use the `getOrCreatePanelView()` helper in `index.ts` to
+ *      lazy-create one when needed).
+ *
+ *   2. did-finish-load race. Even when the panelView exists, its
+ *      Vue bundle may still be loading. A synchronous
+ *      `webContents.send()` would land before the renderer's
+ *      `onPanelTriggerOverlay(...)` / `onOpenFeedback(...)`
+ *      subscription was wired in `onMounted`. The helper guards this
+ *      by deferring the dispatch to `did-finish-load` whenever
+ *      `isLoadingMainFrame()` is true.
+ *
+ *   3. destroyed-window safety. The helper bails on every
+ *      `webContents.isDestroyed()` edge so a window-close racing the
+ *      IPC can't crash main.
+ *
+ * The channel literals are private to this module on purpose — every
+ * other reference to them is enforced absent by
+ * `title-bar-overlay-guard.test.ts`. New title-bar→panel IPCs should
+ * either reuse one of the existing helpers (preferred) or add a new
+ * helper here, NOT inline a fresh `webContents.send(literal, …)`
+ * elsewhere.
+ *
+ * The pattern was first applied to the title-bar Send Feedback button
+ * (PR #508 / `0a063bc`) when its lazy-panelView regression on Comfy
+ * windows was fixed; #523 surfaced the same regression on the
+ * downloads tray and the Desktop Update pill, which is why all three
+ * call sites now route through here.
+ */
+import type { WebContentsView } from 'electron'
+
+const PANEL_TRIGGER_OVERLAY_CHANNEL = 'panel-trigger-overlay'
+const OPEN_FEEDBACK_CHANNEL = 'comfy-panel:open-feedback'
+
+/**
+ * Mirrors the `onPanelTriggerOverlay` payload union in
+ * `src/types/ipc.ts`. Kept narrow on purpose so adding a new kind
+ * shows up at every call site as a TS error.
+ */
+export type PanelOverlayPayload =
+  | { kind: 'install-update'; installationId: string }
+  | { kind: 'downloads' }
+  | { kind: 'app-update-restart-prompt'; version: string | null }
+  | { kind: 'app-update-download-prompt'; version: string | null }
+
+function dispatchWhenReady(
+  panelView: WebContentsView,
+  channel: string,
+  payload: unknown,
+): void {
+  const wc = panelView.webContents
+  if (wc.isDestroyed()) return
+  const send = (): void => {
+    if (wc.isDestroyed()) return
+    wc.send(channel, payload)
+  }
+  if (wc.isLoadingMainFrame()) {
+    wc.once('did-finish-load', send)
+  } else {
+    send()
+  }
+}
+
+/** Push a `panel-trigger-overlay` to the panel renderer (downloads
+ *  popover, app-update modal, install-update deep-link). See the
+ *  module docstring for the invariants every call site relies on. */
+export function triggerPanelOverlay(
+  panelView: WebContentsView,
+  payload: PanelOverlayPayload,
+): void {
+  dispatchWhenReady(panelView, PANEL_TRIGGER_OVERLAY_CHANNEL, payload)
+}
+
+/** Push a Send Feedback request to the panel renderer (the renderer
+ *  fires the `desktop2.feedback.opened` telemetry action and opens
+ *  the support URL via `openExternal`). */
+export function triggerOpenFeedback(
+  panelView: WebContentsView,
+  source: 'titlebar' | 'menu',
+): void {
+  dispatchWhenReady(panelView, OPEN_FEEDBACK_CHANNEL, { source })
+}

--- a/src/main/lib/updater.ts
+++ b/src/main/lib/updater.ts
@@ -249,8 +249,80 @@ export function onUpdateStateChanged(cb: (state: AppUpdateState) => void): () =>
   }
 }
 
+/**
+ * Issue #523 — dev-only hook for forcing the title-bar app-update
+ * pill into a deterministic state without waiting for the real
+ * todesktop event stream. Used by reviewers to QA the "Desktop
+ * Update Available" / "Desktop Update Ready" pill (and the modal
+ * surfacing fix from this issue) before merge — production builds
+ * never see this code path.
+ *
+ * Two entry points feed into this single helper:
+ *
+ *   1. The `DESKTOP2_DEBUG_UPDATE_STATE` env var, read once at
+ *      `register()`. Set to `'ready'` or `'available'` to seed the
+ *      state ~2s after startup; the broadcast pipeline pushes the
+ *      pill state to every title bar via the regular
+ *      `comfy-titlebar:app-update-state-changed` channel.
+ *
+ *   2. The `app-update:debug-set-state` IPC, available to any
+ *      renderer in dev mode. Call from the panel devtools console:
+ *
+ *        window.api.debugSetAppUpdateState({ kind: 'ready', version: '99.99.99', autoUpdate: true })
+ *
+ *      Pass `{ kind: null, version: null, autoUpdate: true }` to
+ *      clear the pill.
+ *
+ * Production guard: `app.isPackaged && !ELECTRON_RENDERER_URL` short-
+ * circuits both entry points so a packaged build can never seed a
+ * fake update state. The IPC handler is still registered (it's
+ * cheap, and registering conditionally would fork the
+ * production/dev surface for no benefit) but its body returns
+ * immediately when the dev gate is closed.
+ */
+function isDevModeForDebugUpdater(): boolean {
+  // ELECTRON_RENDERER_URL is set by electron-vite dev. !app.isPackaged
+  // covers the rarer "dev build run via `electron .`" case. Either is
+  // sufficient to enable the debug surface.
+  return !app.isPackaged || !!process.env['ELECTRON_RENDERER_URL']
+}
+
+export function debugSetAppUpdateState(state: AppUpdateState): void {
+  if (!isDevModeForDebugUpdater()) return
+  // Normalise — accept the raw payload but enforce the shape so a
+  // typo from the devtools console can't crash the title-bar
+  // renderer. `kind` is the discriminant; everything else is
+  // optional with sensible defaults.
+  const kind = state?.kind === 'available' || state?.kind === 'ready' ? state.kind : null
+  const version = typeof state?.version === 'string' && state.version ? state.version : null
+  const autoUpdate = typeof state?.autoUpdate === 'boolean' ? state.autoUpdate : isAutoInstallEnabled()
+  _setUpdateState({ kind, version, autoUpdate })
+}
+
 export function register(): void {
   bindUpdaterEvents()
+
+  ipcMain.handle(
+    'app-update:debug-set-state',
+    (_event, payload: AppUpdateState) => {
+      debugSetAppUpdateState(payload)
+    },
+  )
+
+  // Issue #523 — env-var seed for the debug pill state. Fires on the
+  // same 2s timer as the regular auto-check so the broadcast pipeline
+  // is up by the time it lands. No-op in production builds via the
+  // `isDevModeForDebugUpdater` gate inside `debugSetAppUpdateState`.
+  const envSeed = process.env['DESKTOP2_DEBUG_UPDATE_STATE']
+  if (envSeed === 'ready' || envSeed === 'available') {
+    setTimeout(() => {
+      debugSetAppUpdateState({
+        kind: envSeed,
+        version: process.env['DESKTOP2_DEBUG_UPDATE_VERSION'] || '99.99.99',
+        autoUpdate: isAutoInstallEnabled(),
+      })
+    }, 2000)
+  }
 
   ipcMain.handle('check-for-update', async () => {
     try {

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -83,8 +83,11 @@ export function buildElectronApi(): ElectronApi {
       ipcRenderer.send('comfy-window:close-current-panel'),
     setFirstUseMode: (mode: 'none' | 'consent-lockdown' | 'post-consent') =>
       ipcRenderer.send('comfy-window:set-first-use-mode', { mode }),
-    setOverlayActive: (active: boolean) =>
-      ipcRenderer.send('comfy-panel:set-overlay-active', { active: !!active }),
+    setOverlayLayout: (layout: 'modal' | 'drawer' | null) => {
+      const value: 'modal' | 'drawer' | null =
+        layout === 'modal' || layout === 'drawer' ? layout : null
+      ipcRenderer.send('comfy-panel:set-overlay-layout', { layout: value })
+    },
     onFirstUseSkip: (callback) => {
       const handler = (): void => callback()
       ipcRenderer.on('comfy-panel:first-use-skip', handler)
@@ -189,6 +192,15 @@ export function buildElectronApi(): ElectronApi {
     downloadUpdate: () => ipcRenderer.invoke('download-update'),
     installUpdate: () => ipcRenderer.invoke('install-update'),
     getUpdateCapabilities: () => ipcRenderer.invoke('get-update-capabilities'),
+    /** Issue #523 — dev-only forcing of the title-bar app-update pill
+     *  state. The main-side handler is gated behind a dev-mode check
+     *  (`!app.isPackaged || ELECTRON_RENDERER_URL`); production builds
+     *  receive the IPC but no-op. Reviewers can drive the pill into
+     *  `'ready'` / `'available'` from the panel devtools console to
+     *  QA the modal-surfacing fix without waiting for a real
+     *  todesktop event. See `updater.ts` for the matching helper. */
+    debugSetAppUpdateState: (state) =>
+      ipcRenderer.invoke('app-update:debug-set-state', state),
 
     // Event listeners (return unsubscribe functions)
     onInstallProgress: (callback) => {

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -83,6 +83,8 @@ export function buildElectronApi(): ElectronApi {
       ipcRenderer.send('comfy-window:close-current-panel'),
     setFirstUseMode: (mode: 'none' | 'consent-lockdown' | 'post-consent') =>
       ipcRenderer.send('comfy-window:set-first-use-mode', { mode }),
+    setOverlayActive: (active: boolean) =>
+      ipcRenderer.send('comfy-panel:set-overlay-active', { active: !!active }),
     onFirstUseSkip: (callback) => {
       const handler = (): void => callback()
       ipcRenderer.on('comfy-panel:first-use-skip', handler)

--- a/src/renderer/src/panel/PanelApp.test.ts
+++ b/src/renderer/src/panel/PanelApp.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { reactive } from 'vue'
 
 vi.mock('../main', () => ({
   i18n: {
@@ -9,11 +10,16 @@ vi.mock('../main', () => ({
 vi.mock('../composables/useTheme', () => ({ useTheme: () => ({ theme: 'dark' }) }))
 /** Test-controllable `useModal` mock. Each call returns the same
  *  shared singleton so tests can stub return values per case via
- *  `mockModal.confirm.mockResolvedValueOnce(true)` etc. */
+ *  `mockModal.confirm.mockResolvedValueOnce(true)` etc.
+ *
+ *  `state` is `reactive` so the issue #523 overlay-active watcher in
+ *  PanelApp.vue (which tracks `modal.state.visible`) re-runs when
+ *  tests flip the flag. */
 const mockModal = {
   alert: vi.fn(),
   confirm: vi.fn(),
   close: vi.fn(),
+  state: reactive({ visible: false }),
 }
 vi.mock('../composables/useModal', () => ({
   useModal: () => mockModal,
@@ -256,6 +262,7 @@ function installMockApi(initial?: {
     installUpdate: state.installUpdate,
     downloadUpdate: state.downloadUpdate,
     setFirstUseMode: vi.fn(),
+    setOverlayActive: vi.fn(),
     closeCurrentPanel: vi.fn(),
     onFirstUseSkip: vi.fn((cb: () => void) => {
       state.firstUseSkipCallbacks.push(cb)
@@ -316,10 +323,22 @@ function installMockApi(initial?: {
   return state
 }
 
+/**
+ * Track mounted wrappers so `afterEach` can unmount them — without
+ * this every PanelApp from a prior test stays alive in the module and
+ * its watchers (notably the issue #523 overlay-active watcher) keep
+ * firing against the *current* test's `window.api.setOverlayActive`
+ * mock when shared module state (e.g. `useOverlay().current`) is
+ * reset in `beforeEach`.
+ */
+const mountedWrappers: ReturnType<typeof mount>[] = []
+
 function mountPanel() {
-  return mount(PanelApp, {
+  const wrapper = mount(PanelApp, {
     global: { plugins: [createTestI18n(), createPinia()] },
   })
+  mountedWrappers.push(wrapper)
+  return wrapper
 }
 
 const SAMPLE_INSTALL: InstallationLike = {
@@ -344,9 +363,19 @@ describe('PanelApp', () => {
     mockModal.alert.mockReset()
     mockModal.confirm.mockReset()
     mockModal.close.mockReset()
+    mockModal.state.visible = false
     mockState = installMockApi({ installations: [SAMPLE_INSTALL] })
     // Default URL — individual tests override.
     window.history.replaceState({}, '', '/?installationId=test-id')
+  })
+
+  afterEach(() => {
+    // Unmount every PanelApp this test mounted so its watchers stop
+    // — see the comment on `mountedWrappers` for why this matters.
+    while (mountedWrappers.length > 0) {
+      const wrapper = mountedWrappers.pop()
+      try { wrapper?.unmount() } catch { /* ignore double-unmount */ }
+    }
   })
 
   it('renders the comfy-lifecycle body by default for install-backed hosts', async () => {
@@ -850,6 +879,80 @@ describe('PanelApp', () => {
     mockState.panelTriggerOverlayCallbacks.forEach((cb) => cb({ kind: 'downloads' }))
     await flushPromises()
     expect(wrapper.find('[data-testid="downloads-tray-popover"]').exists()).toBe(true)
+  })
+
+  // ---------------------------------------------------------------------------
+  // Issue #523 — overlay-active watcher.
+  //
+  // PanelApp watches `currentOverlay !== null || modal.state.visible`
+  // and pushes the result to main via `window.api.setOverlayActive`.
+  // Main flips `entry.overlayMounted` and re-runs `layoutViews()` so
+  // the panelView surface lifts onto the comfy view (otherwise the
+  // popover/modal mounts on a panel that's collapsed to 0×0 under
+  // the `'comfy'` body mode and the user sees nothing).
+  // ---------------------------------------------------------------------------
+  it('pushes setOverlayActive(true) when an overlay opens and (false) when it closes', async () => {
+    mountPanel()
+    await flushPromises()
+    expect(mockState).toBeDefined()
+    const setOverlayActive = (window.api as { setOverlayActive: ReturnType<typeof vi.fn> })
+      .setOverlayActive
+    // Initial mount: watcher only fires on change, so no IPC yet.
+    expect(setOverlayActive).not.toHaveBeenCalled()
+
+    // Mount the downloads popover via the same path the title-bar
+    // tray click uses.
+    mockState.panelTriggerOverlayCallbacks.forEach((cb) => cb({ kind: 'downloads' }))
+    await flushPromises()
+    expect(setOverlayActive).toHaveBeenLastCalledWith(true)
+
+    // Close the overlay (renderer-internal close path used by the
+    // popover's own close handler).
+    useOverlay().current.value = null
+    await flushPromises()
+    expect(setOverlayActive).toHaveBeenLastCalledWith(false)
+  })
+
+  it('pushes setOverlayActive(true) when a useModal-driven modal opens and (false) when it closes', async () => {
+    mountPanel()
+    await flushPromises()
+    const setOverlayActive = (window.api as { setOverlayActive: ReturnType<typeof vi.fn> })
+      .setOverlayActive
+    expect(setOverlayActive).not.toHaveBeenCalled()
+
+    // Simulate the global `<ModalDialog />` becoming visible (e.g.
+    // the Desktop Update confirm modal the title-bar app-update pill
+    // click pops via `useModal.confirm`).
+    mockModal.state.visible = true
+    await flushPromises()
+    expect(setOverlayActive).toHaveBeenLastCalledWith(true)
+
+    mockModal.state.visible = false
+    await flushPromises()
+    expect(setOverlayActive).toHaveBeenLastCalledWith(false)
+  })
+
+  it('does not redundantly push setOverlayActive when only the overlay kind changes', async () => {
+    mountPanel()
+    await flushPromises()
+    const setOverlayActive = (window.api as { setOverlayActive: ReturnType<typeof vi.fn> })
+      .setOverlayActive
+
+    mockState.panelTriggerOverlayCallbacks.forEach((cb) => cb({ kind: 'downloads' }))
+    await flushPromises()
+    expect(setOverlayActive).toHaveBeenCalledTimes(1)
+    expect(setOverlayActive).toHaveBeenLastCalledWith(true)
+
+    // Replacing one Tier 1 overlay with another keeps `current.value`
+    // non-null the entire time — main shouldn't be re-told the panel
+    // is "now active" mid-transition.
+    useOverlay().current.value = {
+      kind: 'settings',
+      installation: null,
+      initialTab: 'global',
+    }
+    await flushPromises()
+    expect(setOverlayActive).toHaveBeenCalledTimes(1)
   })
 
   it('ignores install-update events whose installationId does not match the host', async () => {

--- a/src/renderer/src/panel/PanelApp.test.ts
+++ b/src/renderer/src/panel/PanelApp.test.ts
@@ -262,7 +262,8 @@ function installMockApi(initial?: {
     installUpdate: state.installUpdate,
     downloadUpdate: state.downloadUpdate,
     setFirstUseMode: vi.fn(),
-    setOverlayActive: vi.fn(),
+    setOverlayLayout: vi.fn(),
+    debugSetAppUpdateState: vi.fn(),
     closeCurrentPanel: vi.fn(),
     onFirstUseSkip: vi.fn((cb: () => void) => {
       state.firstUseSkipCallbacks.push(cb)
@@ -326,8 +327,8 @@ function installMockApi(initial?: {
 /**
  * Track mounted wrappers so `afterEach` can unmount them — without
  * this every PanelApp from a prior test stays alive in the module and
- * its watchers (notably the issue #523 overlay-active watcher) keep
- * firing against the *current* test's `window.api.setOverlayActive`
+ * its watchers (notably the issue #523 overlay-layout watcher) keep
+ * firing against the *current* test's `window.api.setOverlayLayout`
  * mock when shared module state (e.g. `useOverlay().current`) is
  * reset in `beforeEach`.
  */
@@ -882,77 +883,90 @@ describe('PanelApp', () => {
   })
 
   // ---------------------------------------------------------------------------
-  // Issue #523 — overlay-active watcher.
+  // Issue #523 — overlay-layout watcher.
   //
-  // PanelApp watches `currentOverlay !== null || modal.state.visible`
-  // and pushes the result to main via `window.api.setOverlayActive`.
-  // Main flips `entry.overlayMounted` and re-runs `layoutViews()` so
-  // the panelView surface lifts onto the comfy view (otherwise the
-  // popover/modal mounts on a panel that's collapsed to 0×0 under
-  // the `'comfy'` body mode and the user sees nothing).
+  // PanelApp maps the active overlay kind (and `useModal` visibility)
+  // to one of three layouts and pushes each transition to main via
+  // `window.api.setOverlayLayout`:
+  //
+  //   - downloads overlay         → 'drawer' (panel surface stays
+  //                                 transparent so comfyView shows
+  //                                 through underneath)
+  //   - any other overlay / modal → 'modal'  (panel surface eclipses
+  //                                 comfyView)
+  //   - nothing mounted           → null     (panel collapses;
+  //                                 comfyView fills body)
+  //
+  // Main writes `entry.overlayLayout` and re-runs `layoutViews()` so
+  // the panelView surface is positioned correctly. Drawer mode is
+  // what keeps the downloads tray from blanking the entire ComfyUI
+  // view (the bug `#523` originally surfaced as a "ComfyUI disappears
+  // when downloads opens" report).
   // ---------------------------------------------------------------------------
-  it('pushes setOverlayActive(true) when an overlay opens and (false) when it closes', async () => {
+  it("pushes setOverlayLayout('drawer') for the downloads overlay and (null) when it closes", async () => {
     mountPanel()
     await flushPromises()
     expect(mockState).toBeDefined()
-    const setOverlayActive = (window.api as { setOverlayActive: ReturnType<typeof vi.fn> })
-      .setOverlayActive
+    const setOverlayLayout = (window.api as { setOverlayLayout: ReturnType<typeof vi.fn> })
+      .setOverlayLayout
     // Initial mount: watcher only fires on change, so no IPC yet.
-    expect(setOverlayActive).not.toHaveBeenCalled()
+    expect(setOverlayLayout).not.toHaveBeenCalled()
 
     // Mount the downloads popover via the same path the title-bar
     // tray click uses.
     mockState.panelTriggerOverlayCallbacks.forEach((cb) => cb({ kind: 'downloads' }))
     await flushPromises()
-    expect(setOverlayActive).toHaveBeenLastCalledWith(true)
+    expect(setOverlayLayout).toHaveBeenLastCalledWith('drawer')
 
     // Close the overlay (renderer-internal close path used by the
     // popover's own close handler).
     useOverlay().current.value = null
     await flushPromises()
-    expect(setOverlayActive).toHaveBeenLastCalledWith(false)
+    expect(setOverlayLayout).toHaveBeenLastCalledWith(null)
   })
 
-  it('pushes setOverlayActive(true) when a useModal-driven modal opens and (false) when it closes', async () => {
+  it("pushes setOverlayLayout('modal') when a useModal-driven modal opens and (null) when it closes", async () => {
     mountPanel()
     await flushPromises()
-    const setOverlayActive = (window.api as { setOverlayActive: ReturnType<typeof vi.fn> })
-      .setOverlayActive
-    expect(setOverlayActive).not.toHaveBeenCalled()
+    const setOverlayLayout = (window.api as { setOverlayLayout: ReturnType<typeof vi.fn> })
+      .setOverlayLayout
+    expect(setOverlayLayout).not.toHaveBeenCalled()
 
     // Simulate the global `<ModalDialog />` becoming visible (e.g.
     // the Desktop Update confirm modal the title-bar app-update pill
     // click pops via `useModal.confirm`).
     mockModal.state.visible = true
     await flushPromises()
-    expect(setOverlayActive).toHaveBeenLastCalledWith(true)
+    expect(setOverlayLayout).toHaveBeenLastCalledWith('modal')
 
     mockModal.state.visible = false
     await flushPromises()
-    expect(setOverlayActive).toHaveBeenLastCalledWith(false)
+    expect(setOverlayLayout).toHaveBeenLastCalledWith(null)
   })
 
-  it('does not redundantly push setOverlayActive when only the overlay kind changes', async () => {
+  it("transitions setOverlayLayout when swapping between drawer and modal overlay kinds", async () => {
     mountPanel()
     await flushPromises()
-    const setOverlayActive = (window.api as { setOverlayActive: ReturnType<typeof vi.fn> })
-      .setOverlayActive
+    const setOverlayLayout = (window.api as { setOverlayLayout: ReturnType<typeof vi.fn> })
+      .setOverlayLayout
 
     mockState.panelTriggerOverlayCallbacks.forEach((cb) => cb({ kind: 'downloads' }))
     await flushPromises()
-    expect(setOverlayActive).toHaveBeenCalledTimes(1)
-    expect(setOverlayActive).toHaveBeenLastCalledWith(true)
+    expect(setOverlayLayout).toHaveBeenCalledTimes(1)
+    expect(setOverlayLayout).toHaveBeenLastCalledWith('drawer')
 
-    // Replacing one Tier 1 overlay with another keeps `current.value`
-    // non-null the entire time — main shouldn't be re-told the panel
-    // is "now active" mid-transition.
+    // Replacing the downloads (drawer) overlay with the unified
+    // Settings modal (modal) — different layout buckets, so main
+    // should hear about the swap so it can collapse the comfy view
+    // for the new modal surface.
     useOverlay().current.value = {
       kind: 'settings',
       installation: null,
       initialTab: 'global',
     }
     await flushPromises()
-    expect(setOverlayActive).toHaveBeenCalledTimes(1)
+    expect(setOverlayLayout).toHaveBeenCalledTimes(2)
+    expect(setOverlayLayout).toHaveBeenLastCalledWith('modal')
   })
 
   it('ignores install-update events whose installationId does not match the host', async () => {

--- a/src/renderer/src/panel/PanelApp.vue
+++ b/src/renderer/src/panel/PanelApp.vue
@@ -184,21 +184,51 @@ const { current: currentOverlay, openOverlay, closeOverlay } = useOverlay()
 const modal = useModal()
 
 /**
- * Issue #523 — push the panel renderer's "is an overlay or modal
- * mounted right now?" state to main on every edge. Main flips
- * `entry.overlayMounted` and re-runs `layoutViews()` so the panel
- * surface lifts onto the comfy view while a popover/modal is up
- * (otherwise the panelView is collapsed to 0×0 + setVisible(false)
- * under the `'comfy'` body mode and the user sees nothing). The
- * watcher fires only on actual change — initial mount keeps the
- * `false` default already set by main on entry construction.
+ * Issue #523 — derive the layout the panel WebContentsView should
+ * adopt while a panel-renderer overlay/modal is mounted, and push
+ * each transition to main:
+ *
+ *   - `null`     — no overlay/modal mounted; panel collapses (under
+ *                  `'comfy'` body) so the live ComfyUI view fills
+ *                  the body. Initial state — main also defaults to
+ *                  `null` on entry construction so the first push
+ *                  only fires on actual change.
+ *   - `'modal'`  — full-surface modal. Main lifts the panel to the
+ *                  full body rect and collapses the comfy view so
+ *                  the modal owns the surface. Used by SettingsModal,
+ *                  Desktop Update confirm modal, ProgressModal, every
+ *                  Tier 3 takeover, and any `useModal` confirm.
+ *   - `'drawer'` — anchored popover. Main lifts the panel on top of
+ *                  the comfy view but leaves it visible underneath;
+ *                  this renderer paints `.panel-shell` transparent
+ *                  (via `is-drawer`) so only the popover is opaque.
+ *                  Currently used only by the downloads tray —
+ *                  matches the visual model of the title-bar dropdown
+ *                  rather than blanking out the entire ComfyUI view.
+ *
+ * The downloads-tray-backdrop element rendered below in drawer mode
+ * captures click-away dismissal — clicking anywhere outside the
+ * popover's opaque rect closes the overlay (mirrors how titlebar
+ * dropdowns dismiss on outside click).
  */
-watch(
-  () => currentOverlay.value !== null || modal.state.visible,
-  (active) => {
-    window.api.setOverlayActive(active)
-  },
-)
+const overlayLayout = computed<'modal' | 'drawer' | null>(() => {
+  if (currentOverlay.value?.kind === 'downloads') return 'drawer'
+  if (currentOverlay.value !== null) return 'modal'
+  if (modal.state.visible) return 'modal'
+  return null
+})
+
+watch(overlayLayout, (layout) => {
+  window.api.setOverlayLayout(layout)
+  // Issue #523 — `body` carries the document's opaque `var(--bg)`
+  // background (see main.css). In drawer mode the panel surface
+  // needs to be fully transparent so the underlying comfyView shows
+  // through; toggling this class lets the global selector below
+  // override the body background without leaking into modal modes.
+  if (typeof document !== 'undefined') {
+    document.body.classList.toggle('panel-drawer-active', layout === 'drawer')
+  }
+})
 
 // installationStore.fetchInstallations() is wired to onInstallationsChanged
 // inside the store itself, so the panel just needs to read from it.
@@ -1127,7 +1157,7 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div class="panel-shell">
+  <div class="panel-shell" :class="{ 'is-drawer': overlayLayout === 'drawer' }">
     <main class="panel-content">
       <div v-if="activePanel === 'comfy-lifecycle'" class="panel-comfy-lifecycle">
         <ComfyLifecycleView
@@ -1162,13 +1192,24 @@ onUnmounted(() => {
          title-bar tray. Reads its data from the shared `downloadStore`
          (same source the legacy `DownloadsPanel` consumes) so the
          tray and any other downloads surface never disagree.
-         Click-away dismissal uses `dismissTakeoverDirect` — closing
-         the popover only hides the overlay; downloads keep running
-         and the next broadcast repaints if the user reopens. -->
-    <DownloadsTrayPopover
+
+         Issue #523 — wrapped in a transparent backdrop so click-away
+         outside the popover's opaque rect dismisses it (matches the
+         visual model of the title-bar dropdown). The backdrop is the
+         outermost click target; `@click.self` ensures clicks bubbling
+         from the popover itself don't dismiss. The popover is
+         `position: fixed` so the backdrop's transparent body doesn't
+         affect its placement. The drawer-mode panel layout (set by
+         the `overlayLayout` watcher above) keeps comfyView visible
+         underneath this transparent surface, so the user sees the
+         popover floating over the live ComfyUI view. -->
+    <div
       v-if="currentOverlay?.kind === 'downloads'"
-      @close="dismissTakeoverDirect"
-    />
+      class="downloads-tray-backdrop"
+      @click.self="dismissTakeoverDirect"
+    >
+      <DownloadsTrayPopover @close="dismissTakeoverDirect" />
+    </div>
     <!-- Tier 1 unified Settings modal — replaces the legacy split
          between Install Settings (DetailModal manage), Directories,
          and App Settings. Mounted with `installation` carried by the
@@ -1258,6 +1299,33 @@ onUnmounted(() => {
   overflow: hidden;
 }
 
+/* Issue #523 — drawer-mode panel surface (downloads tray). The panel
+ * WebContentsView is positioned on top of comfyView at the full body
+ * rect by main; making the shell transparent here is what lets the
+ * live ComfyUI view show through everywhere except the popover's
+ * opaque `var(--surface)` rect. The panel-content gutter would also
+ * paint over the comfy frame if left visible, so it's hidden too —
+ * the drawer overlay slot below renders the popover absolutely
+ * (`position: fixed`) so the empty content area doesn't matter. */
+.panel-shell.is-drawer {
+  background: transparent;
+}
+.panel-shell.is-drawer .panel-content {
+  visibility: hidden;
+}
+
+/* Issue #523 — click-away backdrop for the drawer-mode downloads
+ * popover. Covers the full panel surface so any click outside the
+ * popover (which sits at z-index 1000 in DownloadsTrayPopover)
+ * dismisses the overlay via `@click.self` in the template. Stays
+ * transparent so comfyView remains visible underneath. */
+.downloads-tray-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 999;
+  background: transparent;
+}
+
 .panel-content {
   flex: 1;
   min-height: 0;
@@ -1300,5 +1368,19 @@ onUnmounted(() => {
   border-radius: 4px;
   padding: 2px 6px;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+</style>
+
+<!-- Issue #523 — non-scoped block so the selector reaches the
+     document `body` (toggled by the `overlayLayout` watcher in
+     `<script setup>`). In drawer mode the body's default opaque
+     `var(--bg)` background would otherwise paint over the panel
+     WebContentsView's transparent surface and prevent the
+     underlying comfyView from showing through. Scoped to a class
+     toggled only while drawer mode is active so modal-mode panels
+     keep their normal opaque background. -->
+<style>
+body.panel-drawer-active {
+  background: transparent !important;
 }
 </style>

--- a/src/renderer/src/panel/PanelApp.vue
+++ b/src/renderer/src/panel/PanelApp.vue
@@ -183,6 +183,23 @@ const { current: currentOverlay, openOverlay, closeOverlay } = useOverlay()
  *  spec's "modal" wording maps to actual modal chrome. */
 const modal = useModal()
 
+/**
+ * Issue #523 — push the panel renderer's "is an overlay or modal
+ * mounted right now?" state to main on every edge. Main flips
+ * `entry.overlayMounted` and re-runs `layoutViews()` so the panel
+ * surface lifts onto the comfy view while a popover/modal is up
+ * (otherwise the panelView is collapsed to 0×0 + setVisible(false)
+ * under the `'comfy'` body mode and the user sees nothing). The
+ * watcher fires only on actual change — initial mount keeps the
+ * `false` default already set by main on entry construction.
+ */
+watch(
+  () => currentOverlay.value !== null || modal.state.visible,
+  (active) => {
+    window.api.setOverlayActive(active)
+  },
+)
+
 // installationStore.fetchInstallations() is wired to onInstallationsChanged
 // inside the store itself, so the panel just needs to read from it.
 const installation = computed<Installation | null>(

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -714,14 +714,25 @@ export interface ElectronApi {
    *  and-forget; FirstUseTakeover.vue calls this on every step change
    *  and on unmount with `'none'`. */
   setFirstUseMode(mode: 'none' | 'consent-lockdown' | 'post-consent'): void
-  /** Issue #523 — push the panel renderer's "is an overlay/modal
-   *  currently mounted?" state to main. PanelApp.vue runs a watcher
-   *  on `currentOverlay !== null || modal.state.visible` and calls
-   *  this on every edge. Main flips `entry.overlayMounted` and
-   *  re-runs `layoutViews` so the panel surface lifts up onto the
-   *  comfy view (so the popover/modal is actually visible) while
-   *  active and drops back behind it when cleared. Fire-and-forget. */
-  setOverlayActive(active: boolean): void
+  /** Issue #523 — push the panel renderer's desired overlay/modal
+   *  layout to main. PanelApp.vue runs a watcher that maps the active
+   *  overlay kind (and `useModal` visibility) to one of three
+   *  layouts:
+   *
+   *    - `null`     — no overlay/modal mounted.
+   *    - `'modal'`  — full-surface modal (Settings, Desktop Update,
+   *                   ProgressModal, Tier 3 takeovers). Main lifts
+   *                   the panel to the full body rect AND collapses
+   *                   the comfy view (modal eclipses ComfyUI).
+   *    - `'drawer'` — anchored popover (downloads tray). Main lifts
+   *                   the panel on top of the comfy view but leaves
+   *                   the comfy view visible underneath; the panel
+   *                   renderer paints `.panel-shell` transparent so
+   *                   only the popover is opaque.
+   *
+   *  Main writes `entry.overlayLayout` and re-runs `layoutViews()`
+   *  on every edge. Fire-and-forget. */
+  setOverlayLayout(layout: 'modal' | 'drawer' | null): void
   /** Modal-unification (Track M-2.2) — main routes the file-menu
    *  Skip Onboarding click here. Handler runs the same
    *  `markFirstUseCompleted` + dismiss-takeover sequence the Cloud
@@ -831,6 +842,25 @@ export interface ElectronApi {
   downloadUpdate(): Promise<void>
   installUpdate(): Promise<void>
   getUpdateCapabilities(): Promise<{ canAutoUpdate: boolean; systemManaged: boolean }>
+  /** Issue #523 — dev-only forcing of the title-bar app-update pill
+   *  state (Desktop Update Available / Ready). Main-side handler is
+   *  gated to dev mode (`!app.isPackaged || ELECTRON_RENDERER_URL`)
+   *  and no-ops in packaged production builds, so the IPC is safe
+   *  to ship even though only reviewers should be calling it. Used
+   *  from the panel devtools console to QA the modal-surfacing fix
+   *  without waiting for a real todesktop event:
+   *
+   *    window.api.debugSetAppUpdateState({
+   *      kind: 'ready',          // 'available' | 'ready' | null
+   *      version: '99.99.99',    // string | null
+   *      autoUpdate: true,
+   *    })
+   */
+  debugSetAppUpdateState(state: {
+    kind: 'available' | 'ready' | null
+    version: string | null
+    autoUpdate: boolean
+  }): Promise<void>
 
   // Model downloads
   listModelDownloads(): Promise<ModelDownloadProgress[]>

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -714,6 +714,14 @@ export interface ElectronApi {
    *  and-forget; FirstUseTakeover.vue calls this on every step change
    *  and on unmount with `'none'`. */
   setFirstUseMode(mode: 'none' | 'consent-lockdown' | 'post-consent'): void
+  /** Issue #523 — push the panel renderer's "is an overlay/modal
+   *  currently mounted?" state to main. PanelApp.vue runs a watcher
+   *  on `currentOverlay !== null || modal.state.visible` and calls
+   *  this on every edge. Main flips `entry.overlayMounted` and
+   *  re-runs `layoutViews` so the panel surface lifts up onto the
+   *  comfy view (so the popover/modal is actually visible) while
+   *  active and drops back behind it when cleared. Fire-and-forget. */
+  setOverlayActive(active: boolean): void
   /** Modal-unification (Track M-2.2) — main routes the file-menu
    *  Skip Onboarding click here. Handler runs the same
    *  `markFirstUseCompleted` + dismiss-takeover sequence the Cloud


### PR DESCRIPTION
Closes #523.

## Problem

On Comfy instance windows the title-bar **downloads tray** and **Desktop Update pill** silently did nothing, and even when the Desktop Update modal *was* triggered it stayed invisible until the user opened Settings via the file-menu dropdown. Both regressions trace to the same two-layer bug:

1. **Lazy `panelView`** — Comfy windows construct the panel `WebContentsView` lazily on the first non-comfy switch (Settings / Directories / lifecycle). Both IPC handlers early-returned when `entry.panelView` was `null`, so the very first click in a fresh Comfy window dropped on the floor. This is the same regression PR #508 just fixed for the title-bar Send Feedback button.
2. **Hidden panel surface** — even after the panelView exists, `layoutViews` collapses it to `0×0` + `setVisible(false)` whenever the body mode is `'comfy'` (live ComfyUI surface up). The downloads popover and the `useModal.confirm` Desktop Update dialog both render inside the panel renderer, so they had no surface to paint on. Opening Settings flipped the body mode to `'settings'`, which made the panel visible — that's why the user saw the modal *only after* using the dropdown.

`comfy-window:click-install-update-pill` already worked because it explicitly calls `setActivePanel('settings')` first — but that's only acceptable for that handler since Settings *is* its destination. Downloads / App-Update have no panel destination; the user should land back on the live ComfyUI surface as soon as the popover/modal closes.

## Fix

### Architectural: overlay-only panel layer

- New `entry.overlayMounted: boolean` on `ComfyWindowEntry`, plus a new `comfy-panel:set-overlay-active` IPC the panel renderer fires from a watcher on `currentOverlay !== null || modal.state.visible`.
- `layoutViews` now lifts the panel to the full body rect (on top of the live comfy view) when `mode === 'comfy' && overlayMounted`. When the renderer's overlay/modal closes, the watcher fires `false` and `layoutViews` re-runs to restore the comfy-on-top layout. The user lands back on ComfyUI without any panel-state side-effects.

### Structural enforcement: the helper module

- New `src/main/lib/comfy-panel-overlay.ts` owns the lazy-panelView wake-up + `did-finish-load` deferral pattern PR #508 introduced for the feedback button. Channel literals (`'panel-trigger-overlay'`, `'comfy-panel:open-feedback'`) are private to the module.
- New `src/main/lib/comfy-panel-overlay.test.ts` is a CI guard that scans `src/main/**/*.ts` for raw `.send('panel-trigger-overlay', ...)` / `.send('comfy-panel:open-feedback', ...)` calls outside the helper. Future title-bar IPCs that try to roll their own send will fail the build with a pointer to the helper. This makes the bug-prone path *unrepresentable* from outside the module — discipline isn't load-bearing.
- All four `panel-trigger-overlay` call sites (`click-app-update-pill`, `click-install-update-pill`, `click-downloads-tray`, plus `triggerOpenFeedback` for the open-feedback channel) now route through the helpers.
- New `getOrCreatePanelView(entry)` in `index.ts` — the canonical way to wake a Comfy window's panel surface from a title-bar IPC.

## Tests

- Pre-existing tests: 815 → 817 passing (no regressions).
- New `PanelApp.test.ts` coverage for the overlay-active watcher: opens an overlay → emits `setOverlayActive(true)`; closes → emits `(false)`; toggling `useModal.state.visible` does the same; replacing one overlay with another does NOT re-emit (boolean source value didn't change).
- New `comfy-panel-overlay.test.ts` guard fails CI on any new raw send.
- Test hygiene: `PanelApp.test.ts` now tracks mounted wrappers and unmounts them in `afterEach`. Without this every prior test's PanelApp watcher kept reacting to module-level overlay/modal state in subsequent tests (caught while writing the new tests — old PanelApps were firing `setOverlayActive(false)` 32× because they never died).

## Manual verification surface

1. Launch a Comfy install. While ComfyUI is running, click the title-bar downloads tray → popover appears on top of ComfyUI.
2. With a Desktop update available (or simulate via `updater.getCurrentUpdateState()`), click the title-bar update pill → confirm modal appears immediately, no Settings detour required.
3. Dismiss either → user is back on the live ComfyUI surface, panel surface dropped behind, no `activePanel` change.
4. Click Send Feedback → still works (PR #508 path now also goes through the helper, no behaviour change).
5. Same surfaces on the Dashboard window: still work as before (chooser body mode is never `'comfy'`, so `overlayMounted` is a no-op there).
