### PR TITLE
fix(main): bring existing install/chooser forward on app re-launch (#513)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1297,7 +1297,8 @@ function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowResult {
   // Track the most recently focused install-backed host so the
   // dock-icon / second-instance re-launch hooks can pick it over an
   // arbitrary insertion-order install when several are open. Chooser
-  // hosts are excluded — they get priority via findFirstChooserHostWindow().
+  // hosts are excluded — they have their own selection path via
+  // findPreferredChooserHostWindow().
   comfyWindow.on('focus', () => {
     const entry = comfyWindows.get(windowKey)
     if (entry && entry.installationId !== null) {
@@ -2136,24 +2137,35 @@ function _detachInstallImpl(entry: ComfyWindowEntry): void {
  * comfyView still exists (so `layoutViews` doesn't have to special-case
  * its absence) but is sized to zero and never made visible.
  */
-/**
- * Find the first install-less host window (chooser / file-menu mode) so
- * the startup picker / tray entry can focus an existing one instead of
- * stacking duplicates. Step 5's "File → New Window" entry-point will
- * always create a fresh one regardless.
- */
-function findFirstChooserHostWindow(): BrowserWindow | null {
+/** Find the first live host entry matching `pred`, preferring
+ *  non-minimised over minimised. Within each visibility bucket, returns
+ *  insertion order. Returns `null` when nothing matches. */
+function findPreferredHostByVisibility(
+  pred: (entry: ComfyWindowEntry) => boolean,
+): ComfyWindowEntry | null {
+  let minimisedFallback: ComfyWindowEntry | null = null
   for (const [, entry] of comfyWindows) {
-    if (entry.installationId === null && !entry.window.isDestroyed()) {
-      return entry.window
-    }
+    if (entry.window.isDestroyed() || !pred(entry)) continue
+    if (!entry.window.isMinimized()) return entry
+    if (minimisedFallback === null) minimisedFallback = entry
   }
-  return null
+  return minimisedFallback
 }
 
-/** Focus an existing chooser host window if one is open, otherwise create one. */
+/** Find a chooser (install-less) host window to focus, preferring a
+ *  visible one over a minimised one. Used by the tray entry, the
+ *  startup picker, and the chooser-first re-launch fallback. Step 5's
+ *  "File → New Window" entry-point still creates a fresh chooser
+ *  regardless of what this returns. */
+function findPreferredChooserHostWindow(): BrowserWindow | null {
+  const entry = findPreferredHostByVisibility((e) => e.installationId === null)
+  return entry?.window ?? null
+}
+
+/** Focus an existing chooser host window if one is open (visible
+ *  preferred over minimised), otherwise create a fresh one. */
 function openOrFocusChooserHostWindow(): BrowserWindow {
-  const existing = findFirstChooserHostWindow()
+  const existing = findPreferredChooserHostWindow()
   if (existing) {
     bringToFront(existing)
     return existing
@@ -2161,41 +2173,54 @@ function openOrFocusChooserHostWindow(): BrowserWindow {
   return openChooserHostWindow()
 }
 
-/** Find the install-backed host window the user most recently focused,
- *  falling back to the first live install-backed host in insertion
- *  order. Returns `null` when no install-backed host is open. */
+/** Find the install-backed host window to focus, prioritising in this
+ *  order:
+ *    1. The most-recently-focused install, if it is still live and
+ *       visible (not minimised).
+ *    2. Any other visible install (insertion order).
+ *    3. The most-recently-focused install if it is minimised.
+ *    4. Any other minimised install (insertion order).
+ *  Returns `null` when no install-backed host is open. */
 function findPreferredInstallHostWindow(): BrowserWindow | null {
-  if (lastFocusedInstallWindowKey !== null) {
-    const entry = comfyWindows.get(lastFocusedInstallWindowKey)
-    if (entry && entry.installationId !== null && !entry.window.isDestroyed()) {
-      return entry.window
-    }
+  const isInstall = (e: ComfyWindowEntry): boolean => e.installationId !== null
+  const lastFocused =
+    lastFocusedInstallWindowKey !== null
+      ? comfyWindows.get(lastFocusedInstallWindowKey)
+      : undefined
+  const lastFocusedAlive =
+    lastFocused && isInstall(lastFocused) && !lastFocused.window.isDestroyed()
+      ? lastFocused
+      : null
+  // Visible bucket — MRU first, then any other visible install.
+  if (lastFocusedAlive && !lastFocusedAlive.window.isMinimized()) {
+    return lastFocusedAlive.window
   }
   for (const [, entry] of comfyWindows) {
-    if (entry.installationId !== null && !entry.window.isDestroyed()) {
-      return entry.window
-    }
+    if (entry.window.isDestroyed() || !isInstall(entry)) continue
+    if (!entry.window.isMinimized()) return entry.window
   }
-  return null
+  // Minimised bucket — MRU first, then any other minimised install.
+  if (lastFocusedAlive) return lastFocusedAlive.window
+  const fallback = findPreferredHostByVisibility(isInstall)
+  return fallback?.window ?? null
 }
 
-/** Focus any live host window — chooser host preferred so the dashboard
- *  stays the entry surface, otherwise the install-backed host the user
- *  was most recently in — and only spawn a fresh chooser host when no
- *  host windows exist. Used by the platform re-launch hooks
- *  (`activate` on macOS, `second-instance` on Windows/Linux) so
- *  re-clicking the app icon brings the running install forward instead
- *  of stacking a new dashboard on top of it. */
+/** Focus any live host window for the platform re-launch hooks
+ *  (`activate` on macOS, `second-instance` on Windows/Linux). Priority:
+ *  install-backed beats chooser, with visible beating minimised inside
+ *  each type bucket; install-backed picks track the most-recently-
+ *  focused install. Spawns a fresh chooser host only when no live host
+ *  exists. */
 function openOrFocusAnyHostWindow(): BrowserWindow {
-  const chooser = findFirstChooserHostWindow()
-  if (chooser) {
-    bringToFront(chooser)
-    return chooser
-  }
   const installWin = findPreferredInstallHostWindow()
   if (installWin) {
     bringToFront(installWin)
     return installWin
+  }
+  const chooser = findPreferredChooserHostWindow()
+  if (chooser) {
+    bringToFront(chooser)
+    return chooser
   }
   return openChooserHostWindow()
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -377,15 +377,21 @@ const comfyWindows = new Map<number, ComfyWindowEntry>()
 const installationIdToWindowKey = new Map<string, number>()
 
 /**
- * Most recently focused install-backed host window's key, or `null`
- * when none has been focused yet (or the last one closed). Updated by
- * a `'focus'` listener on every host window and consulted by the
- * platform re-launch hooks (`activate` / `second-instance`) so the
- * dock-icon click brings the install the user was actually working in
- * forward, instead of an arbitrary insertion-order pick when several
- * installs are open.
+ * Most recently focused installation's id, or `null` when no install
+ * has been focused yet. Tracked by install id (not by window key) so
+ * that detach + re-launch into a different host window still resolves
+ * to the same install on the next dock-icon click.
+ *
+ * Stale ids self-invalidate: `getEntryByInstallationId(id)` returns
+ * `undefined` once the install no longer backs any window (close,
+ * detach without re-launch, uninstall) and `findPreferredInstallHostWindow`
+ * falls through to the insertion-order pick — no explicit cleanup hook
+ * required when windows close or installs detach.
+ *
+ * Updated by a `'focus'` listener on every host window and consulted
+ * by the platform re-launch hooks (`activate` / `second-instance`).
  */
-let lastFocusedInstallWindowKey: number | null = null
+let lastFocusedInstallationId: string | null = null
 
 /**
  * Window-mode unification (Stage W-4) — pending in-place attach
@@ -1294,15 +1300,16 @@ function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowResult {
   comfyWindow.on('resize', () => saveWindowBounds(opts.boundsKey, comfyWindow))
   comfyWindow.on('move', () => saveWindowBounds(opts.boundsKey, comfyWindow))
 
-  // Track the most recently focused install-backed host so the
-  // dock-icon / second-instance re-launch hooks can pick it over an
-  // arbitrary insertion-order install when several are open. Chooser
-  // hosts are excluded — they have their own selection path via
-  // findPreferredChooserHostWindow().
+  // Track the most recently focused install id so the dock-icon /
+  // second-instance re-launch hooks can pick that install over an
+  // arbitrary insertion-order pick when several are open. Tracking by
+  // id (not by windowKey) survives a detach + re-launch into a fresh
+  // host window. Chooser hosts are excluded — they have their own
+  // selection path via findPreferredChooserHostWindow().
   comfyWindow.on('focus', () => {
     const entry = comfyWindows.get(windowKey)
-    if (entry && entry.installationId !== null) {
-      lastFocusedInstallWindowKey = windowKey
+    if (entry?.installationId) {
+      lastFocusedInstallationId = entry.installationId
     }
   })
 
@@ -1398,7 +1405,6 @@ function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowResult {
 
   comfyWindow.on('closed', () => {
     ipcMain.off('comfy-window:title-bar-ready', onTitleBarReadyHandler)
-    if (lastFocusedInstallWindowKey === windowKey) lastFocusedInstallWindowKey = null
     // Window-mode unification (Stage W-1) — unregister via the
     // primary windowKey AND the secondary install-id index.
     const closedEntry = comfyWindows.get(windowKey)
@@ -1752,6 +1758,14 @@ function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts): boolea
   entry.titleBarText = installation.name
   entry.sourceCategory = sourceMap[installation.sourceId]?.category ?? null
   installationIdToWindowKey.set(installationId, entry.windowKey)
+
+  // Seed the MRU tracker if this in-place attach happens on the
+  // already-focused host: no fresh OS `'focus'` event would fire to
+  // catch it otherwise, leaving the tracker pointing at a stale (or
+  // null) install on the next dock-icon click.
+  if (comfyWindow.isFocused()) {
+    lastFocusedInstallationId = installationId
+  }
 
   // OS-level window title is rebuilt whenever the page title or the
   // install name changes. Closures over the install lifetime — reset
@@ -2123,20 +2137,6 @@ function _detachInstallImpl(entry: ComfyWindowEntry): void {
   entry.layoutViews()
 }
 
-/**
- * Open an install-less host window (Phase 3 step 2c).
- *
- * Same window shape as a comfy window — title bar pills + a body area —
- * but with no installation backing the entry. The Comfy pill resolves to
- * the chooser body via `computeBodyMode()`; the user picks an install
- * from there.
- *
- * Lean version of the install-backed `onLaunch()` flow: no comfy URL load,
- * no theme observer, no download wiring, no failure retry — those are all
- * comfy-specific and would do nothing useful in install-less mode. The
- * comfyView still exists (so `layoutViews` doesn't have to special-case
- * its absence) but is sized to zero and never made visible.
- */
 /** Find the first live host entry matching `pred`, preferring
  *  non-minimised over minimised. Within each visibility bucket, returns
  *  insertion order. Returns `null` when nothing matches. */
@@ -2154,7 +2154,7 @@ function findPreferredHostByVisibility(
 
 /** Find a chooser (install-less) host window to focus, preferring a
  *  visible one over a minimised one. Used by the tray entry, the
- *  startup picker, and the chooser-first re-launch fallback. Step 5's
+ *  startup picker, and the chooser-first re-launch fallback. The
  *  "File → New Window" entry-point still creates a fresh chooser
  *  regardless of what this returns. */
 function findPreferredChooserHostWindow(): BrowserWindow | null {
@@ -2182,26 +2182,19 @@ function openOrFocusChooserHostWindow(): BrowserWindow {
  *    4. Any other minimised install (insertion order).
  *  Returns `null` when no install-backed host is open. */
 function findPreferredInstallHostWindow(): BrowserWindow | null {
-  const isInstall = (e: ComfyWindowEntry): boolean => e.installationId !== null
-  const lastFocused =
-    lastFocusedInstallWindowKey !== null
-      ? comfyWindows.get(lastFocusedInstallWindowKey)
+  const mruEntry =
+    lastFocusedInstallationId !== null
+      ? getEntryByInstallationId(lastFocusedInstallationId)
       : undefined
-  const lastFocusedAlive =
-    lastFocused && isInstall(lastFocused) && !lastFocused.window.isDestroyed()
-      ? lastFocused
-      : null
-  // Visible bucket — MRU first, then any other visible install.
-  if (lastFocusedAlive && !lastFocusedAlive.window.isMinimized()) {
-    return lastFocusedAlive.window
-  }
-  for (const [, entry] of comfyWindows) {
-    if (entry.window.isDestroyed() || !isInstall(entry)) continue
-    if (!entry.window.isMinimized()) return entry.window
-  }
-  // Minimised bucket — MRU first, then any other minimised install.
-  if (lastFocusedAlive) return lastFocusedAlive.window
-  const fallback = findPreferredHostByVisibility(isInstall)
+  const mruAlive = mruEntry && !mruEntry.window.isDestroyed() ? mruEntry : null
+  // Helper returns the first visible install (insertion order) or, if
+  // none are visible, the first minimised install. Combined with the
+  // MRU short-circuits below, this delivers the four-tier priority
+  // (visible-MRU → any-visible → minimised-MRU → any-minimised).
+  const fallback = findPreferredHostByVisibility((e) => e.installationId !== null)
+  if (mruAlive && !mruAlive.window.isMinimized()) return mruAlive.window
+  if (fallback && !fallback.window.isMinimized()) return fallback.window
+  if (mruAlive) return mruAlive.window
   return fallback?.window ?? null
 }
 
@@ -2287,6 +2280,15 @@ function applyChooserHostThemeToAll(): void {
  */
 const CHOOSER_HOST_BOUNDS_KEY = 'chooser'
 
+/** Open a fresh install-less host window. Same shape as an install-
+ *  backed comfy window — title bar pills + body area — but with no
+ *  installation backing the entry. The Comfy pill resolves to the
+ *  chooser body via `computeBodyMode()`; the user picks an install
+ *  from there. Skips the install-backed extras (comfy URL load, theme
+ *  observer, download wiring, failure retry) since none of them apply.
+ *  The comfyView still exists so `layoutViews` doesn't have to
+ *  special-case its absence, but is sized to zero and never made
+ *  visible. */
 function openChooserHostWindow(): BrowserWindow {
   // Window-mode unification (Stage W-2) — install-less wrapper.
   // The shared `createHostWindow()` builds the BrowserWindow + 2

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -377,6 +377,17 @@ const comfyWindows = new Map<number, ComfyWindowEntry>()
 const installationIdToWindowKey = new Map<string, number>()
 
 /**
+ * Most recently focused install-backed host window's key, or `null`
+ * when none has been focused yet (or the last one closed). Updated by
+ * a `'focus'` listener on every host window and consulted by the
+ * platform re-launch hooks (`activate` / `second-instance`) so the
+ * dock-icon click brings the install the user was actually working in
+ * forward, instead of an arbitrary insertion-order pick when several
+ * installs are open.
+ */
+let lastFocusedInstallWindowKey: number | null = null
+
+/**
  * Window-mode unification (Stage W-4) — pending in-place attach
  * claims, set by the chooser-host renderer right before it kicks
  * off a launch action. `onLaunch()` consumes the claim instead of
@@ -661,8 +672,11 @@ function updateTrayMenu(): void {
 // that `onLocaleChanged: updateTrayMenu` and the `before-quit` cleanup
 // path stay valid without conditional churn for the eventual restore.
 
-/** Show a window and bring it to the front, working around Windows focus-theft prevention. */
+/** Show a window and bring it to the front, working around Windows
+ *  focus-theft prevention. Restores a minimised window first so callers
+ *  don't have to remember the two-step. */
 function bringToFront(win: BrowserWindow): void {
+  if (win.isMinimized()) win.restore()
   if (process.platform === 'win32') {
     win.setAlwaysOnTop(true)
     win.show()
@@ -1280,6 +1294,17 @@ function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowResult {
   comfyWindow.on('resize', () => saveWindowBounds(opts.boundsKey, comfyWindow))
   comfyWindow.on('move', () => saveWindowBounds(opts.boundsKey, comfyWindow))
 
+  // Track the most recently focused install-backed host so the
+  // dock-icon / second-instance re-launch hooks can pick it over an
+  // arbitrary insertion-order install when several are open. Chooser
+  // hosts are excluded — they get priority via findFirstChooserHostWindow().
+  comfyWindow.on('focus', () => {
+    const entry = comfyWindows.get(windowKey)
+    if (entry && entry.installationId !== null) {
+      lastFocusedInstallWindowKey = windowKey
+    }
+  })
+
   // Push the initial state once the title bar's preload signals readiness.
   // Filter to this title bar's WebContents to avoid cross-talk between windows.
   //
@@ -1372,6 +1397,7 @@ function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowResult {
 
   comfyWindow.on('closed', () => {
     ipcMain.off('comfy-window:title-bar-ready', onTitleBarReadyHandler)
+    if (lastFocusedInstallWindowKey === windowKey) lastFocusedInstallWindowKey = null
     // Window-mode unification (Stage W-1) — unregister via the
     // primary windowKey AND the secondary install-id index.
     const closedEntry = comfyWindows.get(windowKey)
@@ -2135,25 +2161,41 @@ function openOrFocusChooserHostWindow(): BrowserWindow {
   return openChooserHostWindow()
 }
 
+/** Find the install-backed host window the user most recently focused,
+ *  falling back to the first live install-backed host in insertion
+ *  order. Returns `null` when no install-backed host is open. */
+function findPreferredInstallHostWindow(): BrowserWindow | null {
+  if (lastFocusedInstallWindowKey !== null) {
+    const entry = comfyWindows.get(lastFocusedInstallWindowKey)
+    if (entry && entry.installationId !== null && !entry.window.isDestroyed()) {
+      return entry.window
+    }
+  }
+  for (const [, entry] of comfyWindows) {
+    if (entry.installationId !== null && !entry.window.isDestroyed()) {
+      return entry.window
+    }
+  }
+  return null
+}
+
 /** Focus any live host window — chooser host preferred so the dashboard
- *  stays the entry surface, otherwise the first install-backed host —
- *  and only spawn a fresh chooser host when no host windows exist.
- *  Restores minimised hosts before focusing. Used by the platform
- *  re-launch hooks (`activate` on macOS, `second-instance` on
- *  Windows/Linux) so re-clicking the app icon brings the running
- *  install forward instead of stacking a new dashboard on top of it. */
+ *  stays the entry surface, otherwise the install-backed host the user
+ *  was most recently in — and only spawn a fresh chooser host when no
+ *  host windows exist. Used by the platform re-launch hooks
+ *  (`activate` on macOS, `second-instance` on Windows/Linux) so
+ *  re-clicking the app icon brings the running install forward instead
+ *  of stacking a new dashboard on top of it. */
 function openOrFocusAnyHostWindow(): BrowserWindow {
   const chooser = findFirstChooserHostWindow()
   if (chooser) {
-    if (chooser.isMinimized()) chooser.restore()
     bringToFront(chooser)
     return chooser
   }
-  for (const [, entry] of comfyWindows) {
-    if (entry.window.isDestroyed()) continue
-    if (entry.window.isMinimized()) entry.window.restore()
-    bringToFront(entry.window)
-    return entry.window
+  const installWin = findPreferredInstallHostWindow()
+  if (installWin) {
+    bringToFront(installWin)
+    return installWin
   }
   return openChooserHostWindow()
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3616,14 +3616,20 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
   })
 
   app.on('activate', () => {
-    // macOS dock click. Focus an existing chooser host if open,
-    // otherwise spawn a fresh one. With the launcher window retired
-    // (Phase 3), the chooser host is the only fallback surface — any
-    // running install windows already accept their own focus events.
+    // macOS dock click. Prefer focusing an existing chooser host
+    // (so the dashboard stays the primary entry surface), then any
+    // live install-backed host, and only spawn a fresh chooser host
+    // when there are no host windows to bring forward.
     const chooser = findFirstChooserHostWindow()
     if (chooser) {
       bringToFront(chooser)
       return
+    }
+    for (const [, entry] of comfyWindows) {
+      if (!entry.window.isDestroyed()) {
+        bringToFront(entry.window)
+        return
+      }
     }
     openChooserHostWindow()
   })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2135,6 +2135,29 @@ function openOrFocusChooserHostWindow(): BrowserWindow {
   return openChooserHostWindow()
 }
 
+/** Focus any live host window — chooser host preferred so the dashboard
+ *  stays the entry surface, otherwise the first install-backed host —
+ *  and only spawn a fresh chooser host when no host windows exist.
+ *  Restores minimised hosts before focusing. Used by the platform
+ *  re-launch hooks (`activate` on macOS, `second-instance` on
+ *  Windows/Linux) so re-clicking the app icon brings the running
+ *  install forward instead of stacking a new dashboard on top of it. */
+function openOrFocusAnyHostWindow(): BrowserWindow {
+  const chooser = findFirstChooserHostWindow()
+  if (chooser) {
+    if (chooser.isMinimized()) chooser.restore()
+    bringToFront(chooser)
+    return chooser
+  }
+  for (const [, entry] of comfyWindows) {
+    if (entry.window.isDestroyed()) continue
+    if (entry.window.isMinimized()) entry.window.restore()
+    bringToFront(entry.window)
+    return entry.window
+  }
+  return openChooserHostWindow()
+}
+
 /** Resolve the title-bar / window-controls theme for install-less host
  *  windows. The chooser's panel body lives in the launcher renderer
  *  (which uses `--surface` from main.css), so the title-bar Vue header
@@ -3518,16 +3541,10 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
 } else {
   if (app.isPackaged) {
     app.on('second-instance', () => {
-      // Phase 3 — the launcher window is gone; route the OS-level
-      // "open another instance" attempt to the chooser host instead.
-      // Restores any minimised chooser host before focusing it.
-      const chooser = findFirstChooserHostWindow()
-      if (chooser) {
-        if (chooser.isMinimized()) chooser.restore()
-        bringToFront(chooser)
-        return
-      }
-      openChooserHostWindow()
+      // OS-level "open another instance" attempt — focus an existing
+      // host window (chooser or install-backed) instead of stacking
+      // a duplicate.
+      openOrFocusAnyHostWindow()
     })
   }
 
@@ -3616,22 +3633,9 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
   })
 
   app.on('activate', () => {
-    // macOS dock click. Prefer focusing an existing chooser host
-    // (so the dashboard stays the primary entry surface), then any
-    // live install-backed host, and only spawn a fresh chooser host
-    // when there are no host windows to bring forward.
-    const chooser = findFirstChooserHostWindow()
-    if (chooser) {
-      bringToFront(chooser)
-      return
-    }
-    for (const [, entry] of comfyWindows) {
-      if (!entry.window.isDestroyed()) {
-        bringToFront(entry.window)
-        return
-      }
-    }
-    openChooserHostWindow()
+    // macOS dock click — focus an existing host window before
+    // spawning a fresh chooser host.
+    openOrFocusAnyHostWindow()
   })
 
   app.on('before-quit', () => {


### PR DESCRIPTION
Fixes #513

## Problem

On macOS, clicking the dock icon while a ComfyUI install window is open spawned a fresh dashboard window stacked on top of the running install instead of bringing the existing window forward. The `second-instance` re-launch path on Windows / Linux had the same defect.

## Root cause

`app.on('activate', ...)` (and the `'second-instance'` mirror) only consulted a chooser-host lookup. Once the dashboard host flipped to install-backed mode in place via attach, no chooser host remained, so the handler fell through to spawning a new dashboard.

## Fix

The platform re-launch hooks now route through a single `openOrFocusAnyHostWindow()` helper that picks the best existing host using the priority below, and only spawns a fresh chooser host when nothing live is found.

## Priority rules

1. **Type — install beats chooser.** The install the user is working in is the surface they expect to come forward.
2. **Visibility — visible beats minimised** (tiebreaker within the same type).
3. **Recency — most-recently-focused install** (within the install bucket; tracked by install id, not window key, so detach + re-launch into a different host preserves the preference).
4. Insertion order otherwise.
5. Spawn a fresh chooser host only when no live host exists.

## Behaviour matrix

| Open windows | Action |
|---|---|
| (none) | Spawn new dashboard |
| 1 V dashboard | Focus it |
| 1 M dashboard | Restore + focus it |
| 1 V install | Focus it |
| 1 M install | Restore + focus it |
| V install + V dashboard | Focus install |
| V install + M dashboard | Focus install |
| M install + V dashboard | Restore + focus install |
| M install + M dashboard | Restore + focus install |
| 2 V installs | Focus MRU install |
| 2 M installs | Restore + focus MRU install |
| 1 V + 1 M install | Focus visible install |
| 2 V dashboards | Focus first |
| 2 M dashboards | Restore + focus first |

`V` = visible, `M` = minimised.

## Implementation notes

- New `lastFocusedInstallationId` tracker, updated by a `'focus'` listener on every host window. Tracking by id (not window key) means detach + re-launch into a fresh window still resolves to the same install on the next dock click — relevant once we rewire window flips between installs / dashboard without spawning new windows.
- `attachInstall()` seeds the tracker if the host is already focused at attach time (no fresh OS focus event would fire to catch the in-place flip otherwise).
- Stale ids self-invalidate via `getEntryByInstallationId` returning `undefined`; no explicit cleanup hook on close / detach / uninstall.
- `bringToFront()` now handles `isMinimized() → restore()` itself so all focus paths get consistent restore behaviour.
- `findPreferredHostByVisibility(pred)` is the shared visible-then-minimised scan used by both the chooser and install pickers.
- The `app.on('second-instance')` handler shares the same helper, so the same priority applies to Windows / Linux re-launches.

## Verification

- `pnpm run typecheck` ✅
- `pnpm run lint` ✅
- `pnpm run build` ✅
- `pnpm run test` — 812 passed ✅

Manual on Mac:

- Single install open → Cmd+Tab away → click dock → install comes forward.
- Install + dashboard both open → click dock → install focused.
- Install minimised, dashboard visible → click dock → install restored + focused.
- Two installs open, focused B last → click dock → B focused.
- Detach install A from window 1 (W-4 in-place), re-launch A in window 2 → click dock → window 2 focused.
- Quit to dock (no windows) → click dock → fresh chooser opens.
