### PR TITLE
docs: fix incorrect header name in writeComfyEnvironment comment

### DIFF
--- a/src/main/sources/standalone/envPaths.ts
+++ b/src/main/sources/standalone/envPaths.ts
@@ -62,7 +62,7 @@ const COMFY_ENVIRONMENT_CONTENT = COMFY_ENVIRONMENT_VALUE + '\n'
 /**
  * Write the `.comfy_environment` marker file consumed by ComfyUI core
  * (see Comfy-Org/ComfyUI#13425) so partner-node API requests carry the
- * `X-Comfy-Env: local-desktop2-standalone` header. Idempotent: if the file already
+ * `Comfy-Env: local-desktop2-standalone` header. Idempotent: if the file already
  * has the expected content, this is a no-op. Skips silently when the
  * target directory does not exist (older installs not yet migrated).
  * Errors are swallowed with a warning — this marker is non-critical and


### PR DESCRIPTION
The doc comment for `writeComfyEnvironment` incorrectly stated that the header sent to partner-node API requests is `X-Comfy-Env`. The actual header (set in ComfyUI core's `comfy_api_nodes/util/client.py`) is `Comfy-Env`. Comment-only fix.