### PR TITLE
docs(legal): address multi-reviewer findings on #540

### DIFF
--- a/docs/legal/EULA.md
+++ b/docs/legal/EULA.md
@@ -1,8 +1,8 @@
 # End-User License Agreement (EULA)
 
 **Effective date:** 2026-05-08
-**Applies to:** ComfyUI Desktop 2.0 (the "Desktop App," "we," "us," "our")
-**Publisher:** Comfy Org
+**Applies to:** ComfyUI Desktop 2.0 (the "Desktop App")
+**Publisher:** Comfy Org ("Comfy Org," "we," "us," "our")
 
 ---
 
@@ -21,6 +21,7 @@ If you don't agree to these terms, don't install or use the Desktop App.
 
 ## 1. Definitions
 
+- **"Comfy Org"** means the publisher of the Desktop App and the party to this EULA. *[REVIEW: insert registered legal entity name, jurisdiction of incorporation, and registered office address before GA.]*
 - **"Desktop App"** means the ComfyUI Desktop 2.0 application, including all binaries, installers, signed packages, scripts, configuration, and bundled assets we distribute under the names "ComfyUI Desktop 2.0," "Comfy Desktop 2," or any successor naming.
 - **"You"** means the individual or entity installing or using the Desktop App.
 - **"Source Code"** means the open-source source code published at [github.com/Comfy-Org/ComfyUI-Desktop-2.0-Beta](https://github.com/Comfy-Org/ComfyUI-Desktop-2.0-Beta).
@@ -47,7 +48,6 @@ You may use the Desktop App for any lawful purpose. You agree **not to**:
 - Remove, alter, or obscure any copyright, trademark, or other proprietary notices in the Desktop App's user interface.
 - Use the Comfy Org name, logo, or branding to imply endorsement or affiliation that does not exist (see Section 8, Trademarks).
 - Distribute modified compiled binaries under our trademarks (you may modify and redistribute the **Source Code** under the MIT License, but the resulting binaries must not be branded as "ComfyUI Desktop," "Comfy Desktop," or any confusingly similar name).
-- Use the Desktop App to develop a competing product that is substantially derived from the proprietary (non-MIT) portions of the distributed binary, such as our signed installer wrapper or auto-update integration. *[REVIEW: tighten or remove based on competitive-protection stance; MIT-licensed core does not allow blanket non-compete restrictions.]*
 
 ## 4. Updates and auto-update
 
@@ -55,7 +55,7 @@ The Desktop App includes an automatic update mechanism that may, from time to ti
 
 - Check our update servers for new versions.
 - Download and install updates automatically or after your confirmation, depending on your settings.
-- Update bundled dependencies (Python runtime, ComfyUI core, etc.) as part of the app's normal operation.
+- Update bundled dependencies (e.g. the Python bootstrap runtime, signed installer wrapper, application frameworks) as part of the app's normal operation. Note that ComfyUI core and custom nodes are not bundled — see Section 7.2.
 
 You can disable automatic updates in Settings. If you do, you accept responsibility for keeping the Desktop App up to date and acknowledge that security fixes will not be applied automatically.
 
@@ -63,7 +63,7 @@ We may discontinue support for older versions of the Desktop App at any time wit
 
 ## 5. Data collection
 
-The Desktop App collects anonymous telemetry (usage analytics and crash reports) as described in our [Privacy Policy](./PRIVACY_POLICY.md). You can turn telemetry off at any time in Settings → Desktop panel → Telemetry. Doing so does not affect your ability to use the Desktop App.
+The Desktop App collects anonymous telemetry (usage analytics and crash reports) as described in our [Privacy Policy](./PRIVACY_POLICY.md). You can turn telemetry off at any time in Settings → Telemetry. Doing so does not affect your ability to use the Desktop App.
 
 Your workflows, models, prompts, and generated outputs are **not** transmitted to us and remain on your local machine.
 
@@ -142,7 +142,7 @@ This EULA takes effect when you install or use the Desktop App and continues unt
 
 **You may terminate** this EULA at any time by uninstalling the Desktop App. Uninstalling stops new telemetry collection. Past anonymous telemetry records remain in our systems subject to the retention terms in the [Privacy Policy](./PRIVACY_POLICY.md).
 
-**We may terminate** this EULA if you materially breach it. Upon termination, you must stop using the Desktop App and uninstall it. Sections that by their nature survive termination (Sections 6, 9, 10, 12, 13, 14) will survive.
+**We may terminate** this EULA if you materially breach it. Upon termination, you must stop using the Desktop App and uninstall it. Sections that by their nature survive termination (Sections 6, 7, 8, 9, 10, 12, 13, 14, 18, 19) will survive.
 
 ## 12. Export and sanctions compliance
 

--- a/docs/legal/PRIVACY_POLICY.md
+++ b/docs/legal/PRIVACY_POLICY.md
@@ -166,13 +166,13 @@ You have rights over your data. The specifics depend on where you live, but the 
 
 ### 9.1 Turn off data collection going forward
 
-Open the Desktop App → **Settings → Desktop panel → Telemetry** → toggle off. Future events stop immediately, including any in-flight queue (it's flushed best-effort, then halted).
+Open the Desktop App → **Settings → Telemetry** → toggle off. Future events stop immediately; any pending in-flight requests already on the wire may still complete.
 
 ### 9.2 Delete past data
 
-Email **privacy@comfy.org** with your **anonymous device ID** (Settings → About → "Copy device ID"). We'll remove records associated with that ID from our analytics, crash report, and long-term storage within 30 days.
+Email **privacy@comfy.org** with your approximate install date, platform, and version. We'll do a best-effort match against our analytics, crash report, and long-term storage and remove associated records within 30 days.
 
-If you've lost the device ID (e.g. uninstalled the app), tell us what platform/version you were on and approximately when — we'll do best-effort removal but may not be able to identify records definitively.
+*[VERIFY: replace this with the in-app device ID lookup once the "Copy device ID" affordance ships — tracked separately. Without that surface we can't ask anonymous users for an identifier they cannot retrieve.]*
 
 ### 9.3 Access, rectification, portability (GDPR/UK GDPR)
 
@@ -185,7 +185,7 @@ If you're in the EU, UK, or EEA, you have the right to:
 - **Object** to processing based on legitimate interests
 - **Data portability** — receive your data in a machine-readable format
 
-Email **privacy@comfy.org** with your device ID.
+Email **privacy@comfy.org** with your approximate install date, platform, and version (until the in-app device ID lookup ships).
 
 ### 9.4 California rights (CCPA/CPRA)
 
@@ -213,11 +213,11 @@ We'd appreciate the chance to address your concern first — email **privacy@com
 
 Uninstalling the Desktop App ends data collection. The local device ID file is removed along with the app. We don't keep tracking IDs after uninstall, so you'll be treated as a new device if you reinstall.
 
-## 9.7 How we verify identity for data requests
+### 9.7 How we verify identity for data requests
 
-Because the Desktop App doesn't require an account, you are anonymous to us by default. We identify your data through your **anonymous device ID** (Settings → About → "Copy device ID").
+Because the Desktop App doesn't require an account, you are anonymous to us by default. We identify your data through an **anonymous device ID** held locally on your machine.
 
-For deletion or access requests, please include your device ID in your email to **privacy@comfy.org**. If you can't retrieve it (e.g. you've already uninstalled), tell us your approximate install date, platform, and the type of activity you remember — we'll do a best-effort match.
+For deletion or access requests, tell us your approximate install date, platform, version, and the type of activity you remember — we'll do a best-effort match against our records. Once the in-app device ID lookup ships, include that ID for an exact match.
 
 We will **not** ask you for any additional identifying information (e.g. government ID) to process a request, because the data we hold is anonymous and we have no reliable way to match it to a real-world identity. Requests for data we don't hold will be answered with "we don't hold that data."
 

--- a/docs/legal/THIRD_PARTY_NOTICES.md
+++ b/docs/legal/THIRD_PARTY_NOTICES.md
@@ -129,9 +129,9 @@ The full text of every license listed is also available in the Desktop App's Abo
 
 ### 7zip-bin
 - **Version:** ^5.2.0
-- **License:** MIT (wrapper) + LGPL-2.1+ / Unlicense (bundled 7z binaries)
+- **License:** MIT (wrapper) + LGPL-2.1 with linking exception + BSD-3-Clause (7-Zip core) + unRAR restriction (RAR decoder component, may not be used to develop a program able to decode any RAR archive)
 - **Source:** https://github.com/develar/7zip-bin
-- **Notice:** Contains the 7-Zip binaries distributed under their respective licenses. The 7-Zip source is available at https://www.7-zip.org/.
+- **Notice:** Contains the 7-Zip binaries distributed under their respective licenses. The 7-Zip source and full license text are available at https://www.7-zip.org/license.txt.
 
 ---
 
@@ -157,12 +157,23 @@ The full text of every license listed is also available in the Desktop App's Abo
 
 ## Bundled Python runtime
 
-### bootstrap-python
-- **Source:** Python Software Foundation
-- **License:** Python Software Foundation License (PSF)
-- **Source URL:** https://www.python.org/
+The Desktop App bundles a minimal "bootstrap" Python environment as an extra resource so that the very first ComfyUI installation can proceed without the user installing Python separately. The bootstrap is built by `scripts/build-bootstrap-python.mjs` from the following components, each redistributed under its own license:
 
-The Desktop App bundles a minimal "bootstrap" Python runtime as an extra resource so that the very first ComfyUI installation can proceed without the user installing Python separately. Only this lightweight bootstrap Python is part of the Desktop App's distributed binary; full Python environments used by individual ComfyUI installs are created on-disk at runtime, are not part of our binary, and are governed by the PSF License directly.
+### python-build-standalone (CPython distribution)
+- **Source:** https://github.com/astral-sh/python-build-standalone
+- **License:** MIT (distribution build scripts and binary artifacts) + Python Software Foundation License v2 (the embedded CPython interpreter and standard library)
+
+### pygit2 (bundled into the bootstrap via pip)
+- **Source:** https://github.com/libgit2/pygit2
+- **License:** GPL v2 with a linking exception (the linking exception permits combining pygit2 with software under different licenses, including proprietary, without making the combined work GPL)
+
+### libgit2 (bundled by the pygit2 wheel)
+- **Source:** https://github.com/libgit2/libgit2
+- **License:** GPL v2 with a linking exception (same linking exception as pygit2)
+
+Only this lightweight bootstrap environment is part of the Desktop App's distributed binary; full Python environments used by individual ComfyUI installs are created on-disk at runtime, are not part of our binary, and are governed by their components' licenses directly.
+
+*[VERIFY: confirm the exact python-build-standalone release pinned in `scripts/build-bootstrap-python.mjs` and the resolved pygit2 + libgit2 versions before GA.]*
 
 ---
 
@@ -181,15 +192,15 @@ Comfy Org does not control the licensing of these components and is not a party 
 
 ## Documentation and other notices
 
-This document, the [EULA](./EULA.md), and the [Privacy Policy](./PRIVACY_POLICY.md) are © 2026 Comfy Org and are provided as starting drafts under MIT-equivalent permission (i.e., feel free to adapt them; we make no warranty about their legal sufficiency for your context).
+This document, the [EULA](./EULA.md), and the [Privacy Policy](./PRIVACY_POLICY.md) are © 2026 Comfy Org. They are AI-drafted starting points provided for internal review; we make no representation about their legal sufficiency for any other party's use, and no license is granted by their inclusion in this repository.
 
 ---
 
 ## How to generate a complete list before GA
 
-The list above covers the **direct production dependencies** declared in `package.json` plus the bundled runtimes. For a fully accurate THIRD_PARTY_NOTICES file before GA, the build pipeline should:
+The list above is hand-curated and covers the major components actually bundled into the shipped Desktop binary (renderer + main process + bootstrap Python). Note that the basis is "bundled in the shipped binary" rather than `package.json` classification — Vite bundles many `devDependencies` (Vue, Pinia, vueuse, Tailwind, etc.) into the renderer at build time. For a fully accurate THIRD_PARTY_NOTICES file before GA, the build pipeline should:
 
-1. Run a license-scanning tool against the resolved `pnpm-lock.yaml` (e.g. `license-checker`, `pnpm licenses ls`, or `npm-license-crawler`) to capture every transitive dependency.
+1. Run `pnpm licenses list --long --prod` (built-in, matches the resolved lockfile) or an equivalent license-scanning tool to capture every transitive dependency that ends up in the bundle.
 2. Filter to **runtime** dependencies that end up in the shipped binary (dev tools, test runners, linters generally don't need attribution because they're not distributed).
 3. Output a generated section appended to this document or a separate auto-generated file referenced from this one.
 4. Surface the list in the Desktop App's About panel as a scrollable view (similar to the inline privacy policy on the consent screen).
@@ -217,4 +228,4 @@ For any question about third-party components or attributions, email **legal@com
 
 ---
 
-*This document is an AI-drafted starting point. The lists above reflect the direct dependencies declared in `package.json` as of 2026-05-08 and should be expanded with a full transitive-dependency scan before GA. Items marked `[VERIFY]` flag entries that need confirmation.*
+*This document is an AI-drafted starting point. The lists above reflect the major components bundled into the shipped Desktop binary (renderer, main process, bootstrap Python) as of 2026-05-08 and should be expanded with a full transitive-dependency scan before GA. Items marked `[VERIFY]` flag entries that need confirmation.*

--- a/src/renderer/src/lib/privacyPolicy.ts
+++ b/src/renderer/src/lib/privacyPolicy.ts
@@ -139,8 +139,8 @@ export const PRIVACY_POLICY: PrivacyPolicy = {
     {
       kind: 'ul',
       items: [
-        '**Turn off analytics**: Settings → Desktop panel → toggle off the analytics opt-in. Future events stop immediately.',
-        '**Delete past data**: email **privacy@comfy.org** with your anonymous device ID (Settings → About → "Copy device ID") and we’ll remove records associated with it.',
+        '**Turn off analytics**: Settings → Telemetry → toggle off the analytics opt-in. Future events stop immediately.',
+        '**Delete past data**: email **privacy@comfy.org** with your approximate install date, platform, and version, and we’ll do a best-effort match and remove associated records.',
         "**Stop using the app**: uninstalling Desktop ends data collection. We don't keep tracking IDs after uninstall.",
       ],
     },


### PR DESCRIPTION
Stacks on #540. Branch base is `deepme987/docs/add-legal-drafts` so this PR's diff shows only the corrections — rebase onto `main` once #540 lands.

## What this fixes

Four reviewers (general, Christian-style, millermedia, deep) converged on a set of doc-only issues in #540. This PR addresses the ten blocker-tier items that are pure markdown/policy edits, plus one one-line alignment in `src/renderer/src/lib/privacyPolicy.ts` so the in-app inline policy matches the corrected Settings nav path.

### PRIVACY_POLICY.md
1. Section §9.7 header was `## 9.7` (H2) — demoted to `### 9.7` so it sits under §9 and the EULA §11 survival cross-reference resolves.
2. Replaced "Settings → Desktop panel → Telemetry" with "Settings → Telemetry" (the actual section that exists per `src/main/lib/ipc/registerSettingsHandlers.ts`).
3. Softened "Settings → About → Copy device ID" to an email-based deletion flow with a `[VERIFY]` tag — the copy-device-id button does not ship today and the previous wording was a promise we couldn't keep.

### EULA.md
4. Defined "Comfy Org" in §1 and fixed the header so `"we," "us," "our"` refer to the publisher (Comfy Org), not the Desktop App.
5. Deleted the §3 anti-compete bullet that contradicted both the MIT-licensed source code and the README's "shell only" framing.
6. Dropped "ComfyUI core" from §4's bundled-dependencies list (core is installed at runtime per §7.2 — keeping it in §4 would contradict the shell framing).
7. Fixed §5 Settings nav path to match Privacy Policy.
8. Extended the §11 survival list to include sections **7, 8, 18, 19** (third-party licenses, trademarks, severability, entire agreement) — these survive termination by their nature.

### THIRD_PARTY_NOTICES.md
9. Corrected 7zip-bin license. The actual upstream is **LGPL-2.1 + BSD-3-Clause + unRAR restriction**, not "LGPL-2.1+ / Unlicense" — see https://www.7-zip.org/license.txt .
10. Rewrote the bootstrap-python entry to disclose what `scripts/build-bootstrap-python.mjs` actually bundles: **python-build-standalone** (MIT) wrapping **CPython** (PSF v2), plus **pygit2** and **libgit2** (both GPL v2 with a linking exception). Verified against the build script.
11. Removed the accidental outbound license grant ("provided as starting drafts under MIT-equivalent permission") on the legal documents themselves — that was an unintentional permissive license on org-produced policy text.
12. Reframed the bundling basis: the basis is "what's bundled into the shipped binary," not "what's in `dependencies` vs `devDependencies`" — Vite bundles many devDependencies (Vue, Pinia, Tailwind, etc.) into the renderer at build time.

### Out of scope (tracked separately for #540's follow-ups)

- Shipping the actual "Copy device ID" affordance in Settings → About (real feature work).
- Verifying ToDesktop runtime terms, ClickHouse region, OFAC list refresh, PostHog region (US vs EU default).
- Wiring `posthogProvider.optOut() + flush()` and explicit `sessionReplaySampleRate: 0` to back the privacy-policy commitments.
- Adding a Vitest that asserts `PRIVACY_POLICY.effectiveDate` matches the markdown `Effective date:` line (sync-enforcement test).
- Cosmetic `.worktrees/**` glob consistency in `eslint.config.ts`.

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run test` (843/843 pass)
- [ ] Manual: render the in-app consent screen on the unified-titlebar branch and confirm the policy text reads correctly with the new Settings → Telemetry path.
- [ ] Counsel sanity check on the EULA §11 survival list addition and the §3 non-compete deletion.