### PR TITLE
ci(release): pin pnpmVersion in todesktop.json to 10.28.1

### DIFF
--- a/todesktop.json
+++ b/todesktop.json
@@ -11,6 +11,7 @@
   "appId": "org.comfy.comfyui-desktop-2",
   "icon": "./assets/Comfy_Logo_x512.png",
   "packageManager": "pnpm",
+  "pnpmVersion": "10.28.1",
   "packageJson": {
     "extends": "package.json",
     "productName": "ComfyUI Desktop 2.0",


### PR DESCRIPTION
## Why

The v0.6.3 release ran on May 12 and **failed for Windows + Linux** while Mac built successfully: https://github.com/Comfy-Org/ComfyUI-Desktop-2.0-Beta/actions/runs/25714861909

ToDesktop's build server runs `npx pnpm@latest install --prod=false --no-frozen-lockfile` and **ignores the project's `packageManager` field in package.json**. Since pnpm v11 shipped on May 9-11, 2026, `pnpm@latest` now resolves to a version that requires Node v22.13+ (it imports `node:sqlite`), but ToDesktop's Windows + Linux build VMs are still on Node v20.20.2. Mac succeeds because that builder is already on a newer Node.

Resulting error from the ToDesktop builder logs:

```
warn: This version of pnpm requires at least Node.js v22.13
warn: The current version of Node.js is v20.20.2
node:internal/modules/cjs/loader:1031
      throw new ERR_UNKNOWN_BUILTIN_MODULE(request);
            ^
Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite
    at Module._load (node:internal/modules/cjs/loader:1031:13)
    ...
    at file:///C:/npm/cache/_npx/de6729f694090229/node_modules/pnpm/dist/pnpm.mjs:16044:25
Error: Command failed with exit code 1: npx pnpm@latest install --prod=false --no-frozen-lockfile
```

## Fix

ToDesktop's `todesktop.json` schema (`@todesktop/cli` v1.22.0) exposes a top-level `pnpmVersion` string field for exactly this purpose:

```json
"pnpmVersionProperty": {
  "type": "string",
  "validSemver": {},
  "minLength": 1,
  "description": "The version of pnpm that ToDesktop should use for installation.",
  "examples": ["8.10.5"]
}
```

Pin `pnpmVersion` to `10.28.1` to match the `packageManager` field in package.json (`pnpm@10.28.1`) so the ToDesktop builder stops drifting onto whatever `pnpm@latest` resolves to and stays on the same major we develop and lockfile-test against locally.

## Diff

```diff
   "packageManager": "pnpm",
+  "pnpmVersion": "10.28.1",
```

## Test Plan

- Cannot reproduce locally — the failure is exclusively on ToDesktop's hosted build VMs.
- Verified the field is recognized by ToDesktop's published schema (`https://unpkg.com/@todesktop/cli@1.22.0/schemas/schema.json`).
- `pnpm run typecheck` and `pnpm run lint` (run by husky pre-commit) pass.
- The next `ToDesktop Build & Release` workflow run will be the real verification — Windows + Linux jobs should now successfully complete the `pnpm install` step.