### PR TITLE
chore: bump version to 0.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-desktop-2",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "ComfyUI Desktop 2.0",
   "author": {
     "name": "Jedrzej Kosinski",


### PR DESCRIPTION
## Summary
- bump `package.json` version from `0.6.3` to `0.6.4`
- generated by `Version Bump PR` workflow

## Details
- target branch: `main`
- bump type: `patch`
- release label requested: `true`
