### PR TITLE
docs(agents): forbid ending sessions with uncommitted work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,10 @@ If you encounter a flaky test during a run, investigate and fix it before contin
 - **Never reference plan steps, phases, tracks, or stage IDs** (e.g. "Phase 3 §17", "Track M-7", "Stage W-4"). Plans change; the comment becomes a lie within hours and meaningless once the feature ships. Describe what the code does, not what plan brought it here.
 - **Don't narrate history** ("This used to do X, now it does Y"). The git log carries that.
 
+## Never end a session with uncommitted work
+
+Never end a session with uncommitted changes or untracked work files. Before handing off or stopping, **commit** (or `git stash push -u -m "<descriptive name>"`) all in-progress work — including new untracked files. Workspaces get cleaned and untracked files vanish; if it isn't committed or stashed, it is lost. Prefer committing on a working branch over stashing.
+
 ## Follow instructions
 
 When the user gives explicit direction (e.g., "move away from takeovers", "use the unified primitive"), apply it everywhere — search the whole codebase for remaining offenders. **Never silently defer or skip part of an instruction without asking.** If something looks risky, ask; don't decide unilaterally to leave it for later.


### PR DESCRIPTION
Untracked files have been silently lost when workspaces are cleaned (e.g. station1's cleanup work for thread T-019e1f3a-d236-76b8-a437-97fe359dc365 disappeared). Make it explicit that agents must commit or named-stash all in-progress work before handing off.