### PR TITLE
feat(title-bar): make download starts + finishes obvious in the tray (#558)

### DIFF
--- a/src/renderer/src/comfyTitleBar/TitleBarApp.test.ts
+++ b/src/renderer/src/comfyTitleBar/TitleBarApp.test.ts
@@ -648,11 +648,13 @@ describe('TitleBarApp', () => {
     expect(tray.attributes('aria-label')).toBe('2 downloads in progress')
   })
 
-  it('renders the downloads tray icon-only (no badge) when only recent entries exist', async () => {
-    // The badge counts ACTIVE downloads, not recent ones — so a tray
-    // with only completed entries should still show the icon (so the
-    // user can reopen the popover) but without a numeric badge that
-    // would otherwise read as "things still working".
+  it('treats recent entries already present on the first push as already-acknowledged', async () => {
+    // The first downloads-changed push is the initial state main
+    // hands the title bar after `ready()`. Anything `recent` there
+    // finished before this window even opened, so we suppress the
+    // unseen-finished indicator (it would otherwise misfire on every
+    // window mount). The tray collapses back to its idle label and
+    // shows neither a numeric nor an unseen badge.
     const { default: TitleBarApp } = await import('./TitleBarApp.vue')
     const wrapper = mount(TitleBarApp)
     await flushPromises()
@@ -673,10 +675,119 @@ describe('TitleBarApp', () => {
     await flushPromises()
     expect(wrapper.find('.title-downloads-tray').exists()).toBe(true)
     expect(wrapper.find('.title-downloads-badge').exists()).toBe(false)
+    expect(wrapper.find('.title-downloads-tray').classes()).not.toContain('has-unseen')
     // Idle label — no in-flight downloads, but the tray is still
     // reachable so the recent-completed row in the popover stays
     // accessible until the user dismisses it.
     expect(wrapper.find('.title-downloads-tray').attributes('title')).toBe('Downloads')
+  })
+
+  it('marks the tray as unseen when a download completes after the initial state', async () => {
+    // Simulate the real flow: the window opens with nothing in flight
+    // (initial empty push), then a download starts and finishes. The
+    // user never opened the popup, so the tray should switch to its
+    // success-coloured unseen state with a labelled badge.
+    const { default: TitleBarApp } = await import('./TitleBarApp.vue')
+    const wrapper = mount(TitleBarApp)
+    await flushPromises()
+    bridgeState.downloadsChangedCallbacks.forEach((cb) =>
+      cb({ active: [], recent: [] }),
+    )
+    await flushPromises()
+    bridgeState.downloadsChangedCallbacks.forEach((cb) =>
+      cb({
+        active: [
+          {
+            url: 'https://example.com/a.safetensors',
+            filename: 'a.safetensors',
+            progress: 0.4,
+            status: 'downloading',
+          },
+        ],
+        recent: [],
+      }),
+    )
+    await flushPromises()
+    bridgeState.downloadsChangedCallbacks.forEach((cb) =>
+      cb({
+        active: [],
+        recent: [
+          {
+            url: 'https://example.com/a.safetensors',
+            filename: 'a.safetensors',
+            progress: 1,
+            status: 'completed',
+          },
+        ],
+      }),
+    )
+    await flushPromises()
+    const tray = wrapper.find('.title-downloads-tray')
+    expect(tray.classes()).toContain('has-unseen')
+    expect(tray.classes()).not.toContain('has-active')
+    const badge = wrapper.find('.title-downloads-badge.is-unseen')
+    expect(badge.exists()).toBe(true)
+    expect(badge.text()).toBe('1')
+    expect(tray.attributes('title')).toBe('1 download finished — click to review')
+  })
+
+  it('clears the unseen indicator when the downloads popup is opened', async () => {
+    const { default: TitleBarApp } = await import('./TitleBarApp.vue')
+    const wrapper = mount(TitleBarApp)
+    await flushPromises()
+    bridgeState.downloadsChangedCallbacks.forEach((cb) =>
+      cb({ active: [], recent: [] }),
+    )
+    await flushPromises()
+    bridgeState.downloadsChangedCallbacks.forEach((cb) =>
+      cb({
+        active: [],
+        recent: [
+          {
+            url: 'https://example.com/a.safetensors',
+            filename: 'a.safetensors',
+            progress: 1,
+            status: 'completed',
+          },
+        ],
+      }),
+    )
+    await flushPromises()
+    expect(wrapper.find('.title-downloads-tray').classes()).toContain('has-unseen')
+    bridgeState.menuOpenedCallbacks.forEach((cb) =>
+      cb({ menu: 'downloads' } as { menu: 'menu' }),
+    )
+    await flushPromises()
+    const tray = wrapper.find('.title-downloads-tray')
+    expect(tray.classes()).not.toContain('has-unseen')
+    expect(wrapper.find('.title-downloads-badge.is-unseen').exists()).toBe(false)
+    expect(tray.attributes('title')).toBe('Downloads')
+  })
+
+  it('flashes the tray when a brand-new active download appears', async () => {
+    const { default: TitleBarApp } = await import('./TitleBarApp.vue')
+    const wrapper = mount(TitleBarApp)
+    await flushPromises()
+    // Initial empty state so the next push counts as a real new arrival.
+    bridgeState.downloadsChangedCallbacks.forEach((cb) =>
+      cb({ active: [], recent: [] }),
+    )
+    await flushPromises()
+    bridgeState.downloadsChangedCallbacks.forEach((cb) =>
+      cb({
+        active: [
+          {
+            url: 'https://example.com/a.safetensors',
+            filename: 'a.safetensors',
+            progress: 0.1,
+            status: 'pending',
+          },
+        ],
+        recent: [],
+      }),
+    )
+    await flushPromises()
+    expect(wrapper.find('.title-downloads-tray').classes()).toContain('is-flashing')
   })
 
   it('uses singular copy when exactly one download is in flight', async () => {

--- a/src/renderer/src/comfyTitleBar/TitleBarApp.vue
+++ b/src/renderer/src/comfyTitleBar/TitleBarApp.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted, useTemplateRef } from 'vue'
+import { ref, onMounted, onUnmounted, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import {
   ArrowDownToLine,
+  Check,
   Download,
   Loader2,
   Menu as MenuIcon,
@@ -222,7 +223,9 @@ const { isHoverActive } = useTitleBarHoverGate({ hideTip, handleTooltipPointer }
 
 const {
   downloadsActiveCount,
+  unseenFinishedCount,
   downloadsTrayLabel,
+  downloadsStartedAt,
   handleFileMenu,
   handleDownloadsTray,
 } = useTitleBarMenus({
@@ -230,6 +233,25 @@ const {
   hideTip,
   fileBtnRef,
   downloadsBtnRef,
+})
+
+/** One-shot "downloads started" attention flash. Driven by
+ *  `downloadsStartedAt` from the menus composable, which bumps each
+ *  time a brand-new active download appears. The flash is purely
+ *  decorative — it overlays the existing pulsing badge / count so the
+ *  user immediately notices the tray came alive even if they were
+ *  looking elsewhere on screen. The 1600 ms window matches one full
+ *  cycle of the underlying CSS keyframes. */
+const downloadsFlash = ref(false)
+let flashTimer: ReturnType<typeof setTimeout> | null = null
+watch(downloadsStartedAt, (next) => {
+  if (next === 0) return
+  downloadsFlash.value = true
+  if (flashTimer) clearTimeout(flashTimer)
+  flashTimer = setTimeout(() => {
+    downloadsFlash.value = false
+    flashTimer = null
+  }, 1600)
 })
 
 let unsubPanel: (() => void) | undefined
@@ -245,6 +267,10 @@ onMounted(() => {
 onUnmounted(() => {
   unsubPanel?.()
   hideTip()
+  if (flashTimer) {
+    clearTimeout(flashTimer)
+    flashTimer = null
+  }
 })
 </script>
 
@@ -333,16 +359,38 @@ onUnmounted(() => {
         ref="downloadsBtn"
         type="button"
         class="title-downloads-tray"
-        :class="{ 'has-active': downloadsActiveCount > 0 }"
+        :class="{
+          'has-active': downloadsActiveCount > 0,
+          'has-unseen': downloadsActiveCount === 0 && unseenFinishedCount > 0,
+          'is-flashing': downloadsFlash,
+        }"
         v-bind="tooltipAttrs(downloadsTrayLabel)"
         @click="handleDownloadsTray"
       >
         <ArrowDownToLine :size="14" />
+        <!-- Active queue badge: count of in-flight downloads. Pulses
+             via CSS while `.has-active`; the one-shot `.is-flashing`
+             class layers a brighter scale-bounce on top whenever a
+             brand-new download appears so the user catches the
+             "started" event even if they were looking elsewhere. -->
         <span
           v-if="downloadsActiveCount > 0"
           class="title-downloads-badge"
           aria-hidden="true"
         >{{ downloadsActiveCount }}</span>
+        <!-- Unseen-finished badge (issue #558): only shown when the
+             queue is idle AND something terminal landed since the
+             user last opened the popup. Distinct success colour +
+             check icon so it doesn't read as "still working". Cleared
+             on the next `onMenuOpened({menu:'downloads'})` push. -->
+        <span
+          v-else-if="unseenFinishedCount > 0"
+          class="title-downloads-badge is-unseen"
+          aria-hidden="true"
+        >
+          <Check :size="9" :stroke-width="3" />
+          <span class="title-downloads-badge-count">{{ unseenFinishedCount }}</span>
+        </span>
       </button>
       <!-- Center identity pill. Install-backed hosts show the install's
            name + install-type icon; install-less hosts show the static
@@ -701,6 +749,103 @@ onUnmounted(() => {
   font-size: 10px;
   font-weight: 600;
   line-height: 1;
+  gap: 2px;
+}
+
+/* Active-queue attention treatment (issue #558).
+   While downloads are in flight the tray shouldn't read as the same
+   passive surface chip it has in the steady state — slow ring pulse
+   + a subtle accent-tinted border draws the eye without being noisy
+   enough to feel like an alert. */
+.title-downloads-tray.has-active {
+  border-color: rgba(96, 165, 250, 0.55);
+  background: rgba(96, 165, 250, 0.16);
+}
+.title-bar.is-light .title-downloads-tray.has-active {
+  border-color: rgba(37, 99, 235, 0.55);
+  background: rgba(37, 99, 235, 0.12);
+}
+.title-downloads-tray.has-active .title-downloads-badge {
+  animation: title-downloads-pulse 1.6s ease-in-out infinite;
+}
+
+/* One-shot "downloads started" flash. Layered on top of `.has-active`
+   so a fresh download that arrives while others are running still
+   triggers a noticeable bump rather than blending into the existing
+   pulse. The class is owned by the renderer (set for ~1.6 s after
+   `downloadsStartedAt` bumps) so the animation re-runs cleanly each
+   time. */
+.title-downloads-tray.is-flashing .title-downloads-badge {
+  animation:
+    title-downloads-flash 0.55s cubic-bezier(0.2, 0.9, 0.3, 1.4) 1,
+    title-downloads-pulse 1.6s ease-in-out infinite 0.6s;
+}
+.title-downloads-tray.is-flashing {
+  animation: title-downloads-tray-flash 0.9s ease-out 1;
+}
+
+/* Unseen-finished treatment. Distinct success-coloured chrome so
+   "downloads completed while you weren't looking" reads as a
+   different state than "downloads in flight". Cleared the moment the
+   user opens the popup. */
+.title-downloads-tray.has-unseen {
+  border-color: rgba(34, 197, 94, 0.55);
+  background: rgba(34, 197, 94, 0.16);
+}
+.title-bar.is-light .title-downloads-tray.has-unseen {
+  border-color: rgba(22, 163, 74, 0.55);
+  background: rgba(22, 163, 74, 0.12);
+}
+.title-downloads-badge.is-unseen {
+  background: #22c55e;
+  padding: 0 4px;
+}
+.title-downloads-badge.is-unseen .title-downloads-badge-count {
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1;
+}
+
+@keyframes title-downloads-pulse {
+  0%, 100% {
+    box-shadow: 0 0 0 0 rgba(96, 165, 250, 0.55);
+  }
+  50% {
+    box-shadow: 0 0 0 4px rgba(96, 165, 250, 0);
+  }
+}
+@keyframes title-downloads-flash {
+  0% {
+    transform: scale(0.6);
+    opacity: 0;
+  }
+  60% {
+    transform: scale(1.25);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+@keyframes title-downloads-tray-flash {
+  0%, 100% {
+    box-shadow: 0 0 0 0 rgba(96, 165, 250, 0);
+  }
+  20% {
+    box-shadow: 0 0 0 4px rgba(96, 165, 250, 0.55);
+  }
+}
+
+/* Honour reduced-motion preferences — fall back to a static accent
+   border for the running state and skip the bounce / pulse loops
+   entirely. */
+@media (prefers-reduced-motion: reduce) {
+  .title-downloads-tray.has-active .title-downloads-badge,
+  .title-downloads-tray.is-flashing,
+  .title-downloads-tray.is-flashing .title-downloads-badge {
+    animation: none;
+  }
 }
 
 /* Dropdown popups are now native OS menus rendered via Menu.popup() in

--- a/src/renderer/src/comfyTitleBar/useTitleBarMenus.ts
+++ b/src/renderer/src/comfyTitleBar/useTitleBarMenus.ts
@@ -1,4 +1,4 @@
-import { computed, onMounted, onUnmounted, ref, type ComputedRef, type Ref, type ShallowRef } from 'vue'
+import { computed, onMounted, onUnmounted, reactive, ref, type ComputedRef, type Ref, type ShallowRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 interface MenuAnchor {
@@ -44,7 +44,18 @@ interface TitleBarMenusApi {
   isMenuOpen: Ref<boolean>
   downloadsState: Ref<DownloadsTrayState>
   downloadsActiveCount: ComputedRef<number>
+  /** Number of `recent` (terminal) entries the user hasn't reviewed
+   *  yet. Reset to zero whenever the downloads popup is opened. */
+  unseenFinishedCount: ComputedRef<number>
+  /** Tooltip / aria-label for the tray button — switches between an
+   *  in-progress label, an unseen-finished label, and the idle
+   *  "Downloads" label. */
   downloadsTrayLabel: ComputedRef<string>
+  /** Monotonic timestamp bumped each time a brand-new active download
+   *  appears so the title bar can play a one-shot "downloads started"
+   *  attention animation. `0` means "no pulse yet" — the renderer can
+   *  treat it as a guard for the initial mount. */
+  downloadsStartedAt: Ref<number>
   handleFileMenu: () => void
   handleDownloadsTray: () => void
 }
@@ -66,6 +77,13 @@ interface TitleBarMenusApi {
  * Tracked per-kind because the waffle and the downloads-tray live on
  * separate buttons — clicking one shouldn't suppress a fresh open of
  * the other.
+ *
+ * The composable also owns the "unseen finished" book-keeping for the
+ * downloads tray (issue #558): when downloads complete while the user
+ * isn't looking, the tray tags itself as unseen until the popup is
+ * opened. URLs already in `recent` on first sight are treated as
+ * already-acknowledged so a window opening mid-flow doesn't paint a
+ * stale indicator.
  */
 export function useTitleBarMenus(opts: UseTitleBarMenusOpts): TitleBarMenusApi {
   const { t } = useI18n()
@@ -79,12 +97,26 @@ export function useTitleBarMenus(opts: UseTitleBarMenusOpts): TitleBarMenusApi {
 
   const isMenuOpen = ref(false)
   const downloadsState = ref<DownloadsTrayState>({ active: [], recent: [] })
+  /** URLs the user has already acknowledged. Used to derive the
+   *  unseen-finished count without persisting per-entry state on the
+   *  upstream payload. */
+  const seenUrls = reactive(new Set<string>())
+  /** Last set of active URLs — diffed against the next push to detect
+   *  "a new download appeared". */
+  const previousActiveUrls = new Set<string>()
+  let firstDownloadsPush = true
+  const downloadsStartedAt = ref(0)
 
   const downloadsActiveCount = computed(() => downloadsState.value.active.length)
+  const unseenFinishedCount = computed(() =>
+    downloadsState.value.recent.filter((d) => !seenUrls.has(d.url)).length,
+  )
   const downloadsTrayLabel = computed<string>(() => {
-    const n = downloadsActiveCount.value
-    if (n === 0) return t('titleBar.downloads')
-    return t('titleBar.downloadsInProgress', { n }, n)
+    const active = downloadsActiveCount.value
+    if (active > 0) return t('titleBar.downloadsInProgress', { n: active }, active)
+    const unseen = unseenFinishedCount.value
+    if (unseen > 0) return t('titleBar.downloadsCompleteUnseen', { n: unseen }, unseen)
+    return t('titleBar.downloads')
   })
 
   /** Anchor a native menu just below `el`'s bottom-left corner.
@@ -119,22 +151,64 @@ export function useTitleBarMenus(opts: UseTitleBarMenusOpts): TitleBarMenusApi {
     opts.bridge?.clickDownloadsTray(anchorBelow(opts.downloadsBtnRef.value))
   }
 
+  /** Mark every current `recent` entry as seen. Triggered by main
+   *  pushing `menu: 'downloads'` in `onMenuOpened` so opening the
+   *  popup is what acknowledges the indicator. */
+  function acknowledgeRecent(): void {
+    for (const d of downloadsState.value.recent) seenUrls.add(d.url)
+  }
+
+  /** Diff helper — returns true if `next.active` carries a URL that
+   *  wasn't in the previous active set. Used to bump the "started"
+   *  timestamp once per new in-flight item. */
+  function hasNewActive(next: DownloadsTrayState): boolean {
+    for (const d of next.active) {
+      if (!previousActiveUrls.has(d.url)) return true
+    }
+    return false
+  }
+
+  function ingestDownloadsState(next: DownloadsTrayState): void {
+    if (firstDownloadsPush) {
+      // The first push happens after main's `ready()` and reflects
+      // whatever was in flight when the window came up. Treat all
+      // entries (active + recent) as already-known so we don't fire
+      // the "started" pulse for downloads the user already initiated
+      // and don't paint an unseen indicator for items that finished
+      // before the window opened.
+      for (const d of next.active) previousActiveUrls.add(d.url)
+      for (const d of next.recent) seenUrls.add(d.url)
+      firstDownloadsPush = false
+      downloadsState.value = next
+      return
+    }
+    if (hasNewActive(next)) downloadsStartedAt.value = Date.now()
+    previousActiveUrls.clear()
+    for (const d of next.active) previousActiveUrls.add(d.url)
+    // Drop seen URLs that no longer appear in `recent` so the set
+    // doesn't grow unbounded across the window's lifetime.
+    const stillRecent = new Set(next.recent.map((d) => d.url))
+    for (const url of [...seenUrls]) {
+      if (!stillRecent.has(url)) seenUrls.delete(url)
+    }
+    downloadsState.value = next
+  }
+
   let unsubMenuOpened: (() => void) | undefined
   let unsubMenuClosed: (() => void) | undefined
   let unsubDownloads: (() => void) | undefined
 
   onMounted(() => {
     if (!opts.bridge) return
-    unsubMenuOpened = opts.bridge.onMenuOpened(() => {
+    unsubMenuOpened = opts.bridge.onMenuOpened((info) => {
       isMenuOpen.value = true
+      if (info.menu === 'downloads') acknowledgeRecent()
     })
     unsubMenuClosed = opts.bridge.onMenuClosed(({ menu }) => {
       menuClosedAt[menu] = Date.now()
       isMenuOpen.value = false
     })
-    unsubDownloads = opts.bridge.onDownloadsChanged((next) => {
-      downloadsState.value = next
-    })
+    unsubDownloads = opts.bridge.onDownloadsChanged(ingestDownloadsState)
   })
 
   onUnmounted(() => {
@@ -147,7 +221,9 @@ export function useTitleBarMenus(opts: UseTitleBarMenusOpts): TitleBarMenusApi {
     isMenuOpen,
     downloadsState,
     downloadsActiveCount,
+    unseenFinishedCount,
     downloadsTrayLabel,
+    downloadsStartedAt,
     handleFileMenu,
     handleDownloadsTray,
   }

--- a/src/renderer/src/comfyTitlePopup/DownloadsView.vue
+++ b/src/renderer/src/comfyTitlePopup/DownloadsView.vue
@@ -86,13 +86,15 @@ function isTerminal(d: DownloadEntry): boolean {
   return TERMINAL_STATUSES.has(d.status)
 }
 
-/** Combined insertion-ordered list — active + terminal entries
- *  preserve their original slot. `createdAt` is the source of truth;
- *  the active/recent split survives only because that's the shape main
- *  pushes over the IPC. */
+/** Combined list ordered newest-first by `createdAt` — both active
+ *  and terminal entries share one slot so a download that transitions
+ *  active → cancelled / completed stays in place rather than jumping
+ *  between buckets. The active/recent split survives only because
+ *  that's the shape main pushes over the IPC; on screen the most
+ *  recently kicked-off download surfaces at the top of the list. */
 const orderedEntries = computed<DownloadEntry[]>(() =>
   [...props.state.active, ...props.state.recent].sort(
-    (a, b) => (a.createdAt ?? 0) - (b.createdAt ?? 0),
+    (a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0),
   ),
 )
 

--- a/src/renderer/src/lib/i18nMessages.ts
+++ b/src/renderer/src/lib/i18nMessages.ts
@@ -33,6 +33,11 @@ export const en = {
     /** vue-i18n plural rule: "no plural form | singular | plural". */
     downloadsInProgress:
       'no downloads in progress | {n} download in progress | {n} downloads in progress',
+    /** Tooltip used when the in-flight queue is empty but one or more
+     *  downloads have finished since the user last opened the tray.
+     *  The unseen indicator clears as soon as the popup is opened. */
+    downloadsCompleteUnseen:
+      'no recent downloads | {n} download finished — click to review | {n} downloads finished — click to review',
     desktopUpdateAvailable: 'Desktop Update Available',
     desktopUpdateDownloading: 'Downloading update…',
     desktopUpdateReady: 'Desktop Update Ready',

--- a/src/renderer/src/views/DownloadsView.vue
+++ b/src/renderer/src/views/DownloadsView.vue
@@ -43,13 +43,14 @@ onMounted(() => {
 })
 
 const ordered = computed<ModelDownloadProgress[]>(() => {
-  // Single insertion-ordered list keyed on `createdAt` so a download
-  // that transitions active → cancelled / completed stays in its
-  // original slot rather than jumping to the bottom of a separate
-  // "finished" bucket. `createdAt` is stamped by main on first sight
+  // Single list ordered newest-first by `createdAt` so the most
+  // recently kicked-off download surfaces at the top and finished
+  // ones drift down as new ones come in. A download that transitions
+  // active → cancelled / completed keeps its slot rather than jumping
+  // between buckets. `createdAt` is stamped by main on first sight
   // and preserved across status updates.
   return [...store.downloads.values()].sort(
-    (a, b) => (a.createdAt ?? 0) - (b.createdAt ?? 0),
+    (a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0),
   )
 })
 


### PR DESCRIPTION
Closes #558.

## Problem

When downloads start in the title-bar tray today the only signal is a small numeric badge appearing next to the icon. Once the queue empties the badge vanishes - even if downloads completed while the user wasn't looking and they never opened the popup. Per #558, both events should be visually obvious.

## Change

Pure title-bar renderer change layered on top of the existing onDownloadsChanged stream. Three new states + a clear acknowledgement gesture:

| State | Treatment |
|---|---|
| Active queue | Tray gets has-active: accent border tint + slow ring pulse on the badge |
| New download appeared | One-shot is-flashing class: scale-bounce on the badge + a brief glow ring on the tray (~1.6 s) |
| Finished but unseen | Tray switches to has-unseen: success-coloured chrome + Check icon + count badge |

Opening the downloads popup (onMenuOpened({menu:'downloads'})) acknowledges every current ecent URL, so the unseen indicator clears the moment the user looks at it. Already-acknowledged URLs that drop out of ecent are pruned so the seen-set doesn't grow forever.

The first downloads-changed push that arrives after eady() is treated as already-acknowledged so a window opening mid-flow doesn't paint a stale unseen indicator for downloads that finished before this window even existed.

prefers-reduced-motion short-circuits all three keyframes - the static accent / success border tints still convey the state without animation.

## Files

- `src/renderer/src/comfyTitleBar/useTitleBarMenus.ts` - owns the seen-set + `downloadsStartedAt` ref + `acknowledgeRecent()` + `ingestDownloadsState()` diff.
- `src/renderer/src/comfyTitleBar/TitleBarApp.vue` - three new `:class` bindings on the tray, separate `is-unseen` badge slot, all CSS keyframes + reduced-motion guard.
- `src/renderer/src/lib/i18nMessages.ts` - adds `titleBar.downloadsCompleteUnseen` (plural) used as the tooltip / aria-label in the unseen state.
- `src/renderer/src/comfyTitleBar/TitleBarApp.test.ts` - updates the existing `recent`-only test (now exercises the first-push acknowledgement path) and adds three new specs covering the unseen indicator, the popup-open acknowledgement, and the started flash.

## Verification

`pnpm run typecheck` ?
`pnpm run lint` ?
`pnpm run build` ?
`pnpm run test` ? (940 passing, 4 new title-bar specs)

Generated with Amp: https://ampcode.com/threads/T-019e2e09-dcf6-75eb-b31a-b9a9825fc315