### PR TITLE
feat(dev): keyboard shortcuts to drive title-bar pill state on dev builds

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -883,6 +883,14 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
       registerE2EHooks()
     }
 
+    // Dev-only keyboard shortcuts for driving title-bar pill state by
+    // hand on an unpackaged build. Cmd/Ctrl+Alt+U cycles the app-update
+    // pill; Cmd/Ctrl+Alt+I toggles the install-update override.
+    if (!app.isPackaged) {
+      const { registerDevShortcuts } = await import('./lib/devShortcuts')
+      registerDevShortcuts({ computeInstallUpdateAvailable })
+    }
+
     // Wire late-bound host factories before any openOrFocus* runs (the
     // tray menu, activate / second-instance handlers, and the startup
     // picker all flow through the registry).

--- a/src/main/lib/devShortcuts.test.ts
+++ b/src/main/lib/devShortcuts.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: { isPackaged: false, getPath: () => '' },
+  ipcMain: { handle: vi.fn() },
+  BrowserWindow: { getAllWindows: () => [] },
+  globalShortcut: { register: vi.fn(), unregister: vi.fn() },
+}))
+
+vi.mock('@todesktop/runtime', () => ({ default: { autoUpdater: null } }))
+vi.mock('../settings', () => ({ get: vi.fn() }))
+
+import { cycleAppUpdateState } from './devShortcuts'
+import type { AppUpdateState } from './updater'
+
+describe('cycleAppUpdateState', () => {
+  it('cycles null → available → downloading → ready → null', () => {
+    const idle: AppUpdateState = { kind: null, version: null, autoUpdate: true }
+    const a = cycleAppUpdateState(idle)
+    expect(a.kind).toBe('available')
+    expect(a.version).toBeTruthy()
+    expect(a.autoUpdate).toBe(false)
+
+    const b = cycleAppUpdateState(a)
+    expect(b.kind).toBe('downloading')
+
+    const c = cycleAppUpdateState(b)
+    expect(c.kind).toBe('ready')
+
+    const d = cycleAppUpdateState(c)
+    expect(d.kind).toBeNull()
+    expect(d.version).toBeNull()
+  })
+})

--- a/src/main/lib/devShortcuts.ts
+++ b/src/main/lib/devShortcuts.ts
@@ -1,0 +1,98 @@
+/**
+ * Dev-only keyboard shortcuts for driving title-bar pill state without
+ * a real updater event or a real install-update probe. Registered only
+ * when `!app.isPackaged` (see `index.ts whenReady`).
+ *
+ * Mirrors the state-mutation helpers `e2eHooks.ts` already wraps for
+ * Playwright, but bound to user-facing accelerators so the redesigned
+ * pill chrome can be inspected by eye on a running dev build.
+ *
+ *   - `Ctrl/Cmd+Alt+U` cycles the app-update pill through
+ *     `null → available → downloading → ready → null`.
+ *   - `Ctrl/Cmd+Alt+I` toggles the install-update override (global) on
+ *     and off, then re-broadcasts to every install-backed host so the
+ *     pill repaints immediately.
+ *
+ * Uses `globalShortcut` so the accelerator fires regardless of which
+ * window has focus inside the launcher — only registered on dev
+ * builds, so the system-wide registration is bounded to developer
+ * machines that intentionally run unpackaged.
+ */
+import { globalShortcut, type WebContentsView } from 'electron'
+import {
+  _test_setUpdateState,
+  getCurrentUpdateState,
+  type AppUpdateState,
+} from './updater'
+import {
+  installUpdateOverrides,
+  INSTALL_UPDATE_GLOBAL_KEY,
+} from './e2eOverrides'
+import { comfyWindows, isInstallHost } from '../host/registry'
+
+const APP_UPDATE_ACCELERATOR = 'CommandOrControl+Alt+U'
+const INSTALL_UPDATE_ACCELERATOR = 'CommandOrControl+Alt+I'
+
+const DEV_FAKE_VERSION = '99.0.0-dev'
+
+/**
+ * Pure cycle for the app-update pill — exported for unit tests so the
+ * sequence stays pinned even if the accelerator hookup is refactored.
+ * Mirrors the four states `useUpdatePills` knows how to render.
+ */
+export function cycleAppUpdateState(current: AppUpdateState): AppUpdateState {
+  switch (current.kind) {
+    case null:
+      return { kind: 'available', version: DEV_FAKE_VERSION, autoUpdate: false }
+    case 'available':
+      return { kind: 'downloading', version: DEV_FAKE_VERSION, autoUpdate: true }
+    case 'downloading':
+      return { kind: 'ready', version: DEV_FAKE_VERSION, autoUpdate: true }
+    case 'ready':
+      return { kind: null, version: null, autoUpdate: true }
+  }
+}
+
+interface DevShortcutsDeps {
+  /** Same install-update probe `host/createHostWindow.ts` calls when a
+   *  title-bar mounts. Passed in as a dependency to avoid pulling this
+   *  module into the `main/index.ts` import graph. */
+  computeInstallUpdateAvailable: (
+    installationId: string,
+  ) => Promise<{ available: boolean; version?: string }>
+}
+
+function broadcastInstallUpdateToAllHosts(deps: DevShortcutsDeps): void {
+  for (const entry of comfyWindows.values()) {
+    if (entry.window.isDestroyed() || !isInstallHost(entry)) continue
+    const view: WebContentsView = entry.titleBarView
+    if (view.webContents.isDestroyed()) continue
+    void deps.computeInstallUpdateAvailable(entry.installationId).then((state) => {
+      if (view.webContents.isDestroyed()) return
+      view.webContents.send('comfy-titlebar:install-update-changed', state)
+    })
+  }
+}
+
+export function registerDevShortcuts(deps: DevShortcutsDeps): void {
+  globalShortcut.register(APP_UPDATE_ACCELERATOR, () => {
+    _test_setUpdateState(cycleAppUpdateState(getCurrentUpdateState()))
+  })
+  globalShortcut.register(INSTALL_UPDATE_ACCELERATOR, () => {
+    const wasOn = installUpdateOverrides.has(INSTALL_UPDATE_GLOBAL_KEY)
+    if (wasOn) {
+      installUpdateOverrides.delete(INSTALL_UPDATE_GLOBAL_KEY)
+    } else {
+      installUpdateOverrides.set(INSTALL_UPDATE_GLOBAL_KEY, {
+        available: true,
+        version: DEV_FAKE_VERSION,
+      })
+    }
+    broadcastInstallUpdateToAllHosts(deps)
+  })
+}
+
+export function unregisterDevShortcuts(): void {
+  globalShortcut.unregister(APP_UPDATE_ACCELERATOR)
+  globalShortcut.unregister(INSTALL_UPDATE_ACCELERATOR)
+}


### PR DESCRIPTION
Adds two dev-only keyboard shortcuts (gated on `!app.isPackaged`) for inspecting the redesigned title-bar pill chrome by eye on a running dev build, without waiting for a real updater event or a real install-update probe.

## Shortcuts

| Accelerator | Action |
| --- | --- |
| `Cmd/Ctrl+Alt+U` | Cycle the app-update pill through `null ? available ? downloading ? ready ? null`. |
| `Cmd/Ctrl+Alt+I` | Toggle the install-update override on/off and re-broadcast to every install-backed host so the pill repaints immediately. |

## Implementation

- New `src/main/lib/devShortcuts.ts` registers two `globalShortcut`s. App-update cycling routes through `_test_setUpdateState` (which the E2E suite already drives via the `__e2e` bridge), so every subscribed surface - title-bar pill, Global Settings update-action panel - repaints exactly as it would for a real auto-updater event. Install-update toggling sets `installUpdateOverrides` globally, then iterates `comfyWindows` to send `comfy-titlebar:install-update-changed` on each install-backed host's title-bar view.
- Wired in `src/main/index.ts` via a dynamic `await import('./lib/devShortcuts')` right after the existing `E2E` hook gate. In packaged builds the gate is `false` so the chunk is never `require()`d and `globalShortcut.register` is never called.
- Unit test `devShortcuts.test.ts` pins the cycle sequence.

## Verification

- `pnpm run typecheck` - clean
- `pnpm run lint` - clean
- `pnpm run build` - clean; confirmed bundled `out/main/index.js` keeps the `if (!electron.app.isPackaged)` gate around both the dynamic require and the registration call.
- `pnpm run test` - 988 / 988 (new test added)
- `pnpm exec playwright test --project=windows` - 43 / 43