### PR TITLE
fix(e2e): wait for named install tile before clicking in chooser helper

### DIFF
--- a/e2e/support/chooserHelpers.ts
+++ b/e2e/support/chooserHelpers.ts
@@ -23,12 +23,26 @@ export async function clickNewInstallTile(panel: WebContentsPage): Promise<void>
  * substring). Excludes the New Install and Cloud tiles — those use
  * dedicated class hooks and their descriptions can incidentally match
  * install-name substrings like "ComfyUI".
+ *
+ * The chooser PanelApp is freshly remounted whenever a host window
+ * flips back to chooser mode (e.g. Return to Dashboard). Its
+ * InstallationStore hydrates asynchronously via an IPC fetch on
+ * mount, so the tile we want may not be in the DOM yet by the time
+ * the helper is invoked. Poll for the tile's *named* presence — that
+ * is the readiness signal (rather than `.chooser-view` which is up
+ * before any tiles exist).
  */
 export async function clickInstallTile(panel: WebContentsPage, nameSubstring: string): Promise<void> {
-  const ok = await panel.clickByText(
-    '.chooser-tile:not(.chooser-tile-new):not(.chooser-tile-cloud) .chooser-tile-name',
-    nameSubstring,
+  const selector = '.chooser-tile:not(.chooser-tile-new):not(.chooser-tile-cloud) .chooser-tile-name'
+  const needle = nameSubstring.toLowerCase()
+  await panel.waitFor(
+    async () => {
+      const texts = await panel.allText(selector)
+      return texts.some((t) => t.toLowerCase().includes(needle))
+    },
+    { timeout: 15_000, message: `Install tile matching "${nameSubstring}" never appeared in chooser` },
   )
+  const ok = await panel.clickByText(selector, nameSubstring)
   expect(ok, `Install tile matching "${nameSubstring}" clicked`).toBe(true)
 }
 


### PR DESCRIPTION
Fix flaky lifecycle E2E test `return-to-dashboard flips install host in place (same window id)`.

## Root cause

After `returnToDashboard()` flips the install-backed host back to chooser mode, the panel `WebContentsView` is destroyed and recreated. The freshly-mounted `PanelApp` then mounts `ChooserView`, which calls `installationStore.fetchInstallations()` â€” an async IPC round-trip â€” and only then renders the install tiles.

`expectChooserVisible` only waits for `.chooser-view` (the always-present container), and `clickInstallTile` previously called `clickByText` exactly once with no polling. If the IPC had not resolved by the time `clickInstallTile` ran, the named tile did not exist in the DOM yet, so `clickByText` returned `false` and the assertion failed immediately with a sparse `# Page snapshot ... - list` error context (empty list).

The flake reliably reproduced on the first run after a fresh `pnpm run build` (cold filesystem cache â†’ slower hydration) and consistently passed on every subsequent run (warm cache).

## Fix

Per AGENTS.md (flaky tests: "add explicit readiness signals (e.g., IPC `ready` messages) instead of relying on timing"), poll inside `clickInstallTile` for the named tile to actually appear in the DOM before clicking. The tile's named presence is the explicit readiness signal â€” it can only render after the InstallationStore hydration IPC has resolved and Vue has reconciled.

## Verification

- `pnpm run typecheck` âœ…
- `pnpm run lint` âœ…
- `pnpm run build` âœ…
- `pnpm exec playwright test --project=lifecycle --reporter=list` â€” 7/7 passed Ã— 3 consecutive runs from a clean build. Test #6 (`return-to-dashboard ...`) timings 13.8s / 11.6s / 12.7s â€” stable.
- `pnpm run test` â€” 994/994 unit tests pass.