### PR TITLE
Add reset-{mac,linux,windows} scripts for support: wipe leftover beta data

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/README.md
+++ b/README.md
@@ -274,3 +274,29 @@ On **Linux**, the app follows the [XDG Base Directory Specification](https://wik
 | Default install dir | `~/ComfyUI-Installs` |
 
 Existing files at the old `~/.config/comfyui-desktop-2` location are automatically migrated on first launch.
+
+### Reset / clean install
+
+If a manual update leaves the app in a broken state (no styling, no i18n, dead dropdowns, etc. — usually caused by a stale Chromium profile from a prior beta version), the [`scripts/reset-*`](scripts/) helpers wipe every known data location for the current build **and** the older beta names (`ComfyUI Launcher`, `comfyui-launcher`, `com.kosinkadink.comfyui-launcher`, `org.comfy.comfyui-launcher`). They prompt before deleting anything and **do not touch** `~/ComfyUI-Installs` (Windows: `%USERPROFILE%\ComfyUI-Installs`).
+
+Quit the app first, then:
+
+**macOS:**
+```sh
+curl -fsSLO https://raw.githubusercontent.com/Comfy-Org/ComfyUI-Desktop-2.0-Beta/main/scripts/reset-mac.sh
+bash reset-mac.sh
+```
+
+**Linux:**
+```sh
+curl -fsSLO https://raw.githubusercontent.com/Comfy-Org/ComfyUI-Desktop-2.0-Beta/main/scripts/reset-linux.sh
+bash reset-linux.sh
+```
+
+**Windows (PowerShell):**
+```powershell
+iwr -useb https://raw.githubusercontent.com/Comfy-Org/ComfyUI-Desktop-2.0-Beta/main/scripts/reset-windows.ps1 -OutFile reset-windows.ps1
+powershell -ExecutionPolicy Bypass -File .\reset-windows.ps1
+```
+
+Pass `--yes` (or `-Yes` on Windows) to skip the confirmation prompt. After cleanup, reinstall from the latest release and launch — the app should come up with a clean profile. You may need to re-add existing installations via **"Add existing installation"** since `installations.json` is wiped too.

--- a/scripts/reset-linux.sh
+++ b/scripts/reset-linux.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# ComfyUI Desktop 2.0 -- Linux reset script
+#
+# Wipes app settings, caches, and the Chromium profile for the current build
+# AND for the older beta names (ComfyUI Launcher / comfyui-launcher), in case
+# leftovers from a previous version are breaking the UI (no styles, no i18n,
+# dropdowns not working, etc.) after a manual update.
+#
+# Does NOT touch your actual ComfyUI installs at ~/ComfyUI-Installs. The
+# script DOES remove installations.json (the registry), so you may need to
+# re-add existing installs via "Add existing installation" on first launch.
+#
+# Usage:
+#   bash reset-linux.sh         # asks for confirmation
+#   bash reset-linux.sh --yes   # skip confirmation
+
+set -u
+
+YES=0
+for arg in "$@"; do
+  case "$arg" in
+    -y|--yes) YES=1 ;;
+    -h|--help)
+      sed -n '2,17p' "$0"
+      exit 0
+      ;;
+  esac
+done
+
+if [ "$(uname -s)" != "Linux" ]; then
+  echo "This script is for Linux only." >&2
+  exit 1
+fi
+
+# Refuse to run while the app is open
+if pgrep -f "comfyui-desktop-2|ComfyUI Desktop 2.0|comfyui-launcher|ComfyUI Launcher" >/dev/null 2>&1; then
+  echo "ComfyUI Desktop 2.0 / Launcher is running. Please quit it first,"
+  echo "then re-run this script."
+  exit 1
+fi
+
+# XDG base directories (with fallbacks per the XDG Base Directory Spec)
+XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
+XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+XDG_STATE_HOME="${XDG_STATE_HOME:-$HOME/.local/state}"
+
+# Every historical app/package name. The userData folder on Linux is named
+# after the package.json "name" field (NOT productName).
+APP_NAMES=(
+  "comfyui-desktop-2"
+  "comfyui-launcher"
+  "ComfyUI Desktop 2.0"
+  "ComfyUI Launcher"
+)
+
+TARGETS=()
+
+for name in "${APP_NAMES[@]}"; do
+  TARGETS+=(
+    "$XDG_CONFIG_HOME/$name"     # userData / settings.json / Chromium profile
+    "$XDG_CACHE_HOME/$name"      # download-cache (after XDG migration)
+    "$XDG_DATA_HOME/$name"       # installations.json, shared_model_paths.yaml
+    "$XDG_STATE_HOME/$name"      # port-locks
+  )
+done
+
+EXISTING=()
+for t in "${TARGETS[@]}"; do
+  if [ -e "$t" ]; then
+    EXISTING+=("$t")
+  fi
+done
+
+if [ ${#EXISTING[@]} -eq 0 ]; then
+  echo "Nothing to remove. No ComfyUI Desktop 2.0 / Launcher data found."
+  exit 0
+fi
+
+echo "The following will be permanently deleted:"
+echo
+for t in "${EXISTING[@]}"; do
+  echo "  $t"
+done
+echo
+echo "Your ComfyUI installs at ~/ComfyUI-Installs will NOT be touched."
+echo "(You may need to re-add them via 'Add existing installation' on first launch.)"
+echo
+
+if [ "$YES" -ne 1 ]; then
+  printf "Proceed? [y/N] "
+  read -r reply
+  case "$reply" in
+    y|Y|yes|YES) ;;
+    *) echo "Aborted."; exit 1 ;;
+  esac
+fi
+
+for t in "${EXISTING[@]}"; do
+  echo "Removing: $t"
+  rm -rf -- "$t"
+done
+
+echo
+echo "Done. Reinstall ComfyUI Desktop 2.0 from the latest .AppImage or .deb"
+echo "if you haven't already, then launch it. The app should come up with a"
+echo "clean profile."

--- a/scripts/reset-mac.sh
+++ b/scripts/reset-mac.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# ComfyUI Desktop 2.0 -- macOS reset script
+#
+# Wipes app settings, caches, and the Chromium profile for the current build
+# AND for the older beta names (ComfyUI Launcher / com.kosinkadink.* /
+# org.comfy.comfyui-launcher), in case leftovers from a previous version are
+# breaking the UI (no styles, no i18n, dropdowns not working, etc.) after a
+# manual update.
+#
+# Does NOT touch your actual ComfyUI installs at ~/ComfyUI-Installs. The
+# script DOES remove installations.json (the registry), so you may need to
+# re-add existing installs via "Add existing installation" on first launch.
+#
+# Usage:
+#   bash reset-mac.sh           # asks for confirmation
+#   bash reset-mac.sh --yes     # skip confirmation
+
+set -u
+
+YES=0
+for arg in "$@"; do
+  case "$arg" in
+    -y|--yes) YES=1 ;;
+    -h|--help)
+      sed -n '2,17p' "$0"
+      exit 0
+      ;;
+  esac
+done
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "This script is for macOS only." >&2
+  exit 1
+fi
+
+# Refuse to run while the app is open
+if pgrep -x "ComfyUI Desktop 2.0" >/dev/null 2>&1 \
+   || pgrep -x "ComfyUI Launcher"  >/dev/null 2>&1; then
+  echo "ComfyUI Desktop 2.0 / Launcher is running. Please quit it first (Cmd+Q),"
+  echo "then re-run this script."
+  exit 1
+fi
+
+PRODUCT_NAMES=(
+  "ComfyUI Desktop 2.0"
+  "ComfyUI Launcher"
+)
+
+BUNDLE_IDS=(
+  "org.comfy.comfyui-desktop-2"
+  "org.comfy.comfyui-launcher"
+  "com.kosinkadink.comfyui-launcher"
+)
+
+TARGETS=()
+
+for name in "${PRODUCT_NAMES[@]}"; do
+  TARGETS+=(
+    "$HOME/Library/Application Support/$name"
+    "$HOME/Library/Logs/$name"
+  )
+done
+
+for id in "${BUNDLE_IDS[@]}"; do
+  TARGETS+=(
+    "$HOME/Library/Preferences/${id}.plist"
+    "$HOME/Library/Caches/${id}"
+    "$HOME/Library/Saved Application State/${id}.savedState"
+    "$HOME/Library/WebKit/${id}"
+  )
+  # HTTPStorages has both bare and ".binarycookies" variants
+  for p in "$HOME/Library/HTTPStorages/${id}" \
+           "$HOME/Library/HTTPStorages/${id}.binarycookies"; do
+    TARGETS+=("$p")
+  done
+done
+
+EXISTING=()
+for t in "${TARGETS[@]}"; do
+  if [ -e "$t" ]; then
+    EXISTING+=("$t")
+  fi
+done
+
+if [ ${#EXISTING[@]} -eq 0 ]; then
+  echo "Nothing to remove. No ComfyUI Desktop 2.0 / Launcher data found."
+  exit 0
+fi
+
+echo "The following will be permanently deleted:"
+echo
+for t in "${EXISTING[@]}"; do
+  echo "  $t"
+done
+echo
+echo "Your ComfyUI installs at ~/ComfyUI-Installs will NOT be touched."
+echo "(You may need to re-add them via 'Add existing installation' on first launch.)"
+echo
+
+if [ "$YES" -ne 1 ]; then
+  printf "Proceed? [y/N] "
+  read -r reply
+  case "$reply" in
+    y|Y|yes|YES) ;;
+    *) echo "Aborted."; exit 1 ;;
+  esac
+fi
+
+for t in "${EXISTING[@]}"; do
+  echo "Removing: $t"
+  rm -rf -- "$t"
+done
+
+echo
+echo "Done. Reinstall ComfyUI Desktop 2.0 from the latest .dmg if you haven't already,"
+echo "then launch it. The app should come up with a clean profile."

--- a/scripts/reset-windows.ps1
+++ b/scripts/reset-windows.ps1
@@ -1,0 +1,92 @@
+# ComfyUI Desktop 2.0 -- Windows reset script
+#
+# Wipes app settings, caches, and the Chromium profile for the current build
+# AND for the older beta names (ComfyUI Launcher / comfyui-launcher), in case
+# leftovers from a previous version are breaking the UI (no styles, no i18n,
+# dropdowns not working, etc.) after a manual update.
+#
+# Does NOT touch your actual ComfyUI installs at %USERPROFILE%\ComfyUI-Installs.
+# The script DOES remove installations.json (the registry), so you may need to
+# re-add existing installs via "Add existing installation" on first launch.
+#
+# Usage (from PowerShell):
+#   powershell -ExecutionPolicy Bypass -File .\reset-windows.ps1
+#   powershell -ExecutionPolicy Bypass -File .\reset-windows.ps1 -Yes
+
+[CmdletBinding()]
+param(
+  [switch]$Yes
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Refuse to run while the app is open
+$runningNames = @(
+  'ComfyUI Desktop 2.0',
+  'ComfyUI Launcher',
+  'comfyui-desktop-2',
+  'comfyui-launcher'
+)
+$running = Get-Process -Name $runningNames -ErrorAction SilentlyContinue
+if ($running) {
+  Write-Host "ComfyUI Desktop 2.0 / Launcher is running. Please quit it first,"
+  Write-Host "then re-run this script."
+  exit 1
+}
+
+# Every historical app/package name. The userData folder on Windows is named
+# after the productName (or package.json "name") field.
+$appNames = @(
+  'ComfyUI Desktop 2.0',
+  'ComfyUI Launcher',
+  'comfyui-desktop-2',
+  'comfyui-launcher'
+)
+
+$roots = @(
+  $env:APPDATA,        # Roaming -- main userData + Chromium profile
+  $env:LOCALAPPDATA    # Local   -- caches, electron-updater, Crashpad
+)
+
+$targets = New-Object System.Collections.Generic.List[string]
+foreach ($root in $roots) {
+  if (-not $root) { continue }
+  foreach ($name in $appNames) {
+    $targets.Add((Join-Path $root $name))
+  }
+}
+
+$existing = @($targets | Where-Object { Test-Path -LiteralPath $_ })
+
+if ($existing.Count -eq 0) {
+  Write-Host "Nothing to remove. No ComfyUI Desktop 2.0 / Launcher data found."
+  exit 0
+}
+
+Write-Host "The following will be permanently deleted:"
+Write-Host ""
+foreach ($t in $existing) {
+  Write-Host "  $t"
+}
+Write-Host ""
+Write-Host "Your ComfyUI installs at $env:USERPROFILE\ComfyUI-Installs will NOT be touched."
+Write-Host "(You may need to re-add them via 'Add existing installation' on first launch.)"
+Write-Host ""
+
+if (-not $Yes) {
+  $reply = Read-Host "Proceed? [y/N]"
+  if ($reply -notmatch '^(y|Y|yes|YES)$') {
+    Write-Host "Aborted."
+    exit 1
+  }
+}
+
+foreach ($t in $existing) {
+  Write-Host "Removing: $t"
+  Remove-Item -LiteralPath $t -Recurse -Force -ErrorAction Continue
+}
+
+Write-Host ""
+Write-Host "Done. Reinstall ComfyUI Desktop 2.0 from the latest installer if you"
+Write-Host "haven't already, then launch it. The app should come up with a clean"
+Write-Host "profile."


### PR DESCRIPTION
Adds self-contained reset scripts for **macOS**, **Linux**, and **Windows** that wipe ComfyUI Desktop 2.0 user data, including leftovers from the older beta names (`ComfyUI Launcher` / `comfyui-launcher` / `com.kosinkadink.comfyui-launcher` / `org.comfy.comfyui-launcher`).

Useful when a beta user updates in-place (e.g. by drag-overwriting the .app on Mac) and ends up with a broken Chromium profile (no CSS, no i18n, dead dropdowns) because stale Cache / IndexedDB / Service Worker state from a prior version is still being read.

All three scripts:
- Refuse to run if the app is currently open
- Only list / remove paths that actually exist
- Ask for `y/N` confirmation (skippable with `--yes` / `-Yes`)
- Do **not** touch `~/ComfyUI-Installs` (or the Windows equivalent)

### Coverage

**macOS** (`reset-mac.sh`):
`Application Support`, `Preferences`, `Caches`, `Logs`, `Saved Application State`, `HTTPStorages`, `WebKit` for every historical `appId` / `productName`.

**Linux** (`reset-linux.sh`):
XDG `config` / `cache` / `data` / `state` dirs for every historical package `name`, honouring `XDG_*_HOME` env vars per [paths.ts](src/main/lib/paths.ts).

**Windows** (`reset-windows.ps1`):
`%APPDATA%` (Roaming) and `%LOCALAPPDATA%` (Local) folders for every historical `productName` / `name`.