### PR TITLE
lifecycle e2e: real coverage for snapshot-restore, update, delete + supporting fixes

### DIFF
--- a/e2e/launchApp.ts
+++ b/e2e/launchApp.ts
@@ -51,9 +51,13 @@ export async function launchApp(options?: SeedOptions): Promise<AppContext> {
   const panel = panelPage(application)
   const titleBar = titleBarPage(application)
 
-  // Wait for the Vue trees to mount inside each surface.
+  // Wait for the Vue trees to mount inside each surface. On true cold
+  // start (no `firstUseCompleted` seed) the chooser body is gated by
+  // the first-use takeover, so accept either the chooser or the
+  // consent screen as proof the panel renderer reached an interactive
+  // state — tests that need the chooser explicitly seed the gate.
   await panel.waitForSelector('.panel-shell', { timeout: 30_000 })
-  await panel.waitForSelector('.chooser-view, .panel-chooser', { timeout: 15_000 })
+  await panel.waitForSelector('.chooser-view, .panel-chooser, .consent-hero', { timeout: 15_000 })
   await titleBar.waitForSelector('.title-bar', { timeout: 15_000 })
 
   return {

--- a/e2e/lifecycle-add-existing.test.ts
+++ b/e2e/lifecycle-add-existing.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Lifecycle E2E: Add Existing (track an externally-staged install).
+ *
+ * Pre-stages a standalone-shaped ComfyUI directory on disk (real git init
+ * + tagged commit, empty `standalone-env/`, `ComfyUI/main.py`, a manifest)
+ * and drives the importer through the underlying IPC contract:
+ *   `probeInstallation(dir)` → renderer-side source pick →
+ *   `trackInstallation({ ...probe, installPath, name })`.
+ *
+ * The IPC bypass mirrors what `TrackModal.vue` does internally; the UI
+ * surface is covered by the chooser test. The point here is to lock down
+ * the wiring that turns a folder on disk into a chooser tile whose
+ * resolved `comfyVersion` reflects the staged git ref.
+ */
+
+import os from 'node:os'
+import path from 'node:path'
+import { execFileSync } from 'node:child_process'
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
+import { test, expect } from '@playwright/test'
+import { launchApp, type AppContext } from './launchApp'
+import { expectChooserVisible } from './support/chooserHelpers'
+
+let ctx: AppContext
+let stagedPath: string
+
+const TRACKED_NAME = 'Pre-Staged Install'
+
+interface ProbeResult {
+  sourceId: string
+  sourceLabel: string
+  version?: string
+  commit?: string
+  comfyVersion?: { commit: string; baseTag?: string; commitsAhead?: number }
+  [key: string]: unknown
+}
+
+interface TrackResult {
+  ok: boolean
+  message?: string
+  entry?: { id: string; name: string; installPath: string; sourceId: string }
+}
+
+interface Installation {
+  id: string
+  name: string
+  installPath: string
+  sourceId: string
+  comfyVersion?: { commit: string; baseTag?: string; commitsAhead?: number }
+  version?: string
+  [key: string]: unknown
+}
+
+function gitIn(cwd: string, args: string[]): void {
+  execFileSync('git', args, {
+    cwd,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'Lifecycle Test',
+      GIT_AUTHOR_EMAIL: 'lifecycle@example.com',
+      GIT_COMMITTER_NAME: 'Lifecycle Test',
+      GIT_COMMITTER_EMAIL: 'lifecycle@example.com',
+    },
+    stdio: 'pipe',
+  })
+}
+
+test.describe.configure({ mode: 'serial' })
+
+test.beforeAll(async () => {
+  stagedPath = await mkdtemp(path.join(os.tmpdir(), 'comfyui-launcher-add-existing-e2e-'))
+  const comfyuiDir = path.join(stagedPath, 'ComfyUI')
+  await mkdir(comfyuiDir, { recursive: true })
+  await mkdir(path.join(stagedPath, 'standalone-env'), { recursive: true })
+  await writeFile(path.join(comfyuiDir, 'main.py'), '# placeholder for probe\n')
+  // Standalone probe reads manifest.json from the install root for the
+  // ref / releaseTag / variant / pythonVersion fields. Values don't drive
+  // the assertion here — they exist so the renderer-facing payload is
+  // populated end-to-end the way a real install would be.
+  await writeFile(
+    path.join(stagedPath, 'manifest.json'),
+    JSON.stringify({
+      comfyui_ref: 'main',
+      version: 'v0.3.10',
+      id: 'win-cpu',
+      python_version: '3.12',
+    }),
+  )
+
+  gitIn(comfyuiDir, ['init', '--quiet', '--initial-branch=main'])
+  await writeFile(path.join(comfyuiDir, '.gitignore'), '')
+  gitIn(comfyuiDir, ['add', '.'])
+  gitIn(comfyuiDir, ['commit', '--quiet', '-m', 'staged commit'])
+
+  ctx = await launchApp({
+    settings: { firstUseCompleted: true, telemetryEnabled: false },
+  })
+  await expectChooserVisible(ctx.panel)
+})
+
+test.afterAll(async () => {
+  await ctx.cleanup()
+})
+
+test('probe detects the staged standalone-shaped directory @lifecycle', async () => {
+  const results = await ctx.panel.evaluate<ProbeResult[]>(
+    `window.api.probeInstallation(${JSON.stringify(stagedPath)})`,
+  )
+  const standalone = results.find((r) => r.sourceId === 'standalone')
+  expect(standalone, `probe did not detect standalone source. got: ${JSON.stringify(results)}`).toBeDefined()
+  // The standalone probe attaches a resolved `comfyVersion` whenever the
+  // ComfyUI/.git dir is reachable. Without it the tile would fall back to
+  // the manifest's `comfyui_ref` string.
+  expect(standalone!.comfyVersion?.commit).toMatch(/^[0-9a-f]{40}$/)
+})
+
+test('track-installation registers the directory and chooser shows the tile @lifecycle', async () => {
+  const probeResults = await ctx.panel.evaluate<ProbeResult[]>(
+    `window.api.probeInstallation(${JSON.stringify(stagedPath)})`,
+  )
+  const probe = probeResults.find((r) => r.sourceId === 'standalone')!
+  const trackPayload = {
+    name: TRACKED_NAME,
+    installPath: stagedPath,
+    ...probe,
+  }
+  const result = await ctx.panel.evaluate<TrackResult>(
+    `window.api.trackInstallation(${JSON.stringify(trackPayload)})`,
+  )
+  expect(result.ok, `trackInstallation failed: ${result.message ?? ''}`).toBe(true)
+  expect(result.entry?.installPath).toBe(stagedPath)
+
+  await ctx.panel.waitFor(
+    async () =>
+      (await ctx.panel.allText(
+        '.chooser-tile:not(.chooser-tile-new):not(.chooser-tile-cloud) .chooser-tile-name',
+      )).includes(TRACKED_NAME),
+    { timeout: 10_000, message: 'tracked install never appeared in chooser' },
+  )
+
+  const installs = await ctx.panel.evaluate<Installation[]>(
+    `window.api.getInstallations()`,
+  )
+  const tracked = installs.find((i) => i.name === TRACKED_NAME)
+  expect(tracked, 'tracked install not present in get-installations result').toBeDefined()
+  expect(tracked!.sourceId).toBe('standalone')
+  // Renderer-facing `version` is derived from the resolved comfyVersion via
+  // `enrichInstallationsForRenderer`; with git present it should not fall
+  // back to the raw sourceId string.
+  expect(tracked!.version, 'version label missing from renderer payload').toBeTruthy()
+  expect(tracked!.version).not.toBe('standalone')
+})

--- a/e2e/lifecycle-add-existing.test.ts
+++ b/e2e/lifecycle-add-existing.test.ts
@@ -16,7 +16,7 @@
 import os from 'node:os'
 import path from 'node:path'
 import { execFileSync } from 'node:child_process'
-import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { test, expect } from '@playwright/test'
 import { launchApp, type AppContext } from './launchApp'
 import { expectChooserVisible } from './support/chooserHelpers'
@@ -99,7 +99,8 @@ test.beforeAll(async () => {
 })
 
 test.afterAll(async () => {
-  await ctx.cleanup()
+  await ctx?.cleanup()
+  if (stagedPath) await rm(stagedPath, { recursive: true, force: true })
 })
 
 test('probe detects the staged standalone-shaped directory @lifecycle', async () => {

--- a/e2e/lifecycle-cloud.test.ts
+++ b/e2e/lifecycle-cloud.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Lifecycle E2E (cloud branch): cold-start first-use takeover →
+ * consent → pick Cloud → host auto-launches the always-seeded Cloud
+ * install via `handleFirstUseComplete` → `performChooserLaunch`. The
+ * launch action has `showProgress: true`, so the first-use takeover
+ * is silently swapped for a connect-progress takeover (Tier 3 → Tier 3)
+ * while `waitForUrl` probes `https://cloud.comfy.org/`. Success: the
+ * title-bar identity flips out of install-less mode (the same signal
+ * `title-bar-hover-gate-comfy-window.test.ts` uses).
+ *
+ * Network: the cloud launch path runs `waitForUrl(remoteUrl, 15s)`
+ * against `https://cloud.comfy.org/`. The probe accepts any HTTP
+ * response (status code agnostic), so a reachable endpoint is
+ * sufficient — no auth, no specific status required.
+ *
+ * Tagged @lifecycle to share the dedicated Playwright project's
+ * 180-second per-test timeout. No 500 MB download (cloud install is
+ * pure remote URL routing), so the suite runs in well under a minute.
+ */
+
+import { test, expect } from '@playwright/test'
+import { launchApp, type AppContext } from './launchApp'
+
+let ctx: AppContext
+
+test.describe.configure({ mode: 'serial' })
+
+test.beforeAll(async () => {
+  // True cold start: no `firstUseCompleted` seed, so the host opens
+  // on the first-use consent screen. The tests below drive through
+  // consent + pick-cloud.
+  ctx = await launchApp()
+})
+
+test.afterAll(async () => {
+  await ctx.cleanup()
+})
+
+test('cold start lands on first-use consent screen @lifecycle', async () => {
+  await ctx.panel.waitForVisible('.consent-hero', { timeout: 15_000 })
+  await ctx.panel.waitForVisible('[data-testid="first-use-accept-consent"]')
+})
+
+test('accept consent + pick cloud auto-launches the seeded Cloud install @lifecycle', async () => {
+  // Tick the required ToS checkbox; the Get Started CTA stays
+  // disabled until `acceptedTos` flips true.
+  expect(await ctx.panel.click('[data-testid="first-use-consent-tos"]')).toBe(true)
+  await ctx.panel.waitFor(
+    async () => ctx.panel.evaluate<boolean>(
+      `!document.querySelector('[data-testid="first-use-accept-consent"]').disabled`,
+    ),
+    { timeout: 5_000, message: 'Get Started never became enabled after ticking ToS' },
+  )
+
+  // Accept consent → advance to the cloud-vs-local pick step.
+  expect(await ctx.panel.click('[data-testid="first-use-accept-consent"]')).toBe(true)
+  await ctx.panel.waitForVisible('[data-testid="first-use-pick-cloud"]', { timeout: 10_000 })
+
+  // Pick Cloud — host marks `firstUseCompleted`, then chains directly
+  // into `performChooserLaunch` on the always-seeded Cloud install.
+  // The launch action's `showProgress: true` swaps the first-use
+  // takeover for the connect-progress takeover (Tier 3 → Tier 3).
+  expect(await ctx.panel.click('[data-testid="first-use-pick-cloud"]')).toBe(true)
+
+  // Terminal signal: the title-bar identity flips out of install-less
+  // mode once the cloud install attaches reactively over the
+  // `comfy-titlebar:installation-id-changed` IPC. Mirrors the assertion
+  // in `title-bar-hover-gate-comfy-window.test.ts`. The 30s budget
+  // covers the 15s `waitForUrl(remoteUrl)` probe + view attach.
+  await expect.poll(
+    () => ctx.titleBar.exists('.title-install-pill:not(.is-install-less)'),
+    { timeout: 30_000, intervals: [100, 200, 500] },
+  ).toBe(true)
+
+  // A comfy WebContentsView eventually points at the remote cloud URL.
+  // The pill flips on identity-attach (synchronous over IPC) — the
+  // view navigation lags slightly behind, so poll rather than asserting
+  // once.
+  await expect.poll(
+    () => ctx.app.evaluate(({ webContents }) =>
+      webContents.getAllWebContents().some((wc) =>
+        /^https:\/\/(cloud\.)?comfy\.org\//.test(wc.getURL()),
+      ),
+    ),
+    { timeout: 15_000, intervals: [200, 500, 1000] },
+  ).toBe(true)
+})

--- a/e2e/lifecycle-delete-untrack.test.ts
+++ b/e2e/lifecycle-delete-untrack.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Lifecycle E2E: Untrack vs Delete divergence.
+ *
+ * Untrack (`runAction(id, 'remove')`) drops the installation record but
+ * leaves the install directory on disk intact. Delete (`runAction(id,
+ * 'delete')`) removes both the record and the directory.
+ *
+ * Drives the IPC directly via `panel.evaluate(window.api.runAction…)` to
+ * bypass the renderer-side confirm dialogs — the goal here is regression
+ * coverage of the action wiring, not of the modal UX (covered separately
+ * by the chooser test).
+ */
+
+import os from 'node:os'
+import path from 'node:path'
+import { access, mkdir, mkdtemp, writeFile } from 'node:fs/promises'
+import { test, expect } from '@playwright/test'
+import { launchApp, type AppContext } from './launchApp'
+import { expectChooserVisible } from './support/chooserHelpers'
+
+let ctx: AppContext
+let untrackPath: string
+let deletePath: string
+
+const UNTRACK_ID = 'inst-untrack-test'
+const UNTRACK_NAME = 'Untrack Me'
+const DELETE_ID = 'inst-delete-test'
+const DELETE_NAME = 'Delete Me'
+
+/** Marker file the delete action requires before touching the dir. Mirrors
+ *  `MARKER_FILE` in `src/main/lib/ipc/shared.ts`. */
+const MARKER_FILENAME = '.comfyui-desktop-2'
+
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await access(p)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function tileNames(): Promise<string[]> {
+  return ctx.panel.allText(
+    '.chooser-tile:not(.chooser-tile-new):not(.chooser-tile-cloud) .chooser-tile-name',
+  )
+}
+
+test.describe.configure({ mode: 'serial' })
+
+test.beforeAll(async () => {
+  untrackPath = await mkdtemp(path.join(os.tmpdir(), 'comfyui-launcher-untrack-e2e-'))
+  deletePath = await mkdtemp(path.join(os.tmpdir(), 'comfyui-launcher-delete-e2e-'))
+  // The delete action gates on a marker file whose contents match the install
+  // id (or the literal 'tracked'). Without it the action refuses to touch the
+  // directory — same as Untrack would.
+  await mkdir(untrackPath, { recursive: true })
+  await mkdir(deletePath, { recursive: true })
+  await writeFile(path.join(untrackPath, MARKER_FILENAME), UNTRACK_ID)
+  await writeFile(path.join(deletePath, MARKER_FILENAME), DELETE_ID)
+
+  ctx = await launchApp({
+    settings: { firstUseCompleted: true, telemetryEnabled: false },
+    installations: [
+      {
+        id: UNTRACK_ID,
+        name: UNTRACK_NAME,
+        installPath: untrackPath,
+        sourceId: 'standalone',
+        status: 'installed',
+      },
+      {
+        id: DELETE_ID,
+        name: DELETE_NAME,
+        installPath: deletePath,
+        sourceId: 'standalone',
+        status: 'installed',
+      },
+    ],
+  })
+  await expectChooserVisible(ctx.panel)
+})
+
+test.afterAll(async () => {
+  await ctx.cleanup()
+})
+
+test('chooser lists both seeded installs @lifecycle', async () => {
+  await ctx.panel.waitFor(
+    async () => {
+      const names = await tileNames()
+      return names.includes(UNTRACK_NAME) && names.includes(DELETE_NAME)
+    },
+    { timeout: 10_000, message: 'seeded tiles never both rendered in chooser' },
+  )
+})
+
+test('untrack drops the record but preserves the install directory @lifecycle', async () => {
+  const result = await ctx.panel.evaluate<{ ok: boolean; message?: string }>(
+    `window.api.runAction(${JSON.stringify(UNTRACK_ID)}, 'remove')`,
+  )
+  expect(result.ok, `runAction('remove') failed: ${result.message ?? ''}`).toBe(true)
+
+  await ctx.panel.waitFor(
+    async () => !(await tileNames()).includes(UNTRACK_NAME),
+    { timeout: 10_000, message: 'untracked tile never disappeared from chooser' },
+  )
+  expect(await pathExists(untrackPath), 'untrack must leave the install directory on disk').toBe(true)
+})
+
+test('delete drops the record AND removes the install directory @lifecycle', async () => {
+  const result = await ctx.panel.evaluate<{ ok: boolean; message?: string }>(
+    `window.api.runAction(${JSON.stringify(DELETE_ID)}, 'delete')`,
+  )
+  expect(result.ok, `runAction('delete') failed: ${result.message ?? ''}`).toBe(true)
+
+  await ctx.panel.waitFor(
+    async () => !(await tileNames()).includes(DELETE_NAME),
+    { timeout: 30_000, message: 'deleted tile never disappeared from chooser' },
+  )
+  await expect
+    .poll(() => pathExists(deletePath), { timeout: 30_000, intervals: [250, 500, 1000] })
+    .toBe(false)
+})

--- a/e2e/lifecycle-delete-untrack.test.ts
+++ b/e2e/lifecycle-delete-untrack.test.ts
@@ -13,7 +13,7 @@
 
 import os from 'node:os'
 import path from 'node:path'
-import { access, mkdir, mkdtemp, writeFile } from 'node:fs/promises'
+import { access, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { test, expect } from '@playwright/test'
 import { launchApp, type AppContext } from './launchApp'
 import { expectChooserVisible } from './support/chooserHelpers'
@@ -82,7 +82,12 @@ test.beforeAll(async () => {
 })
 
 test.afterAll(async () => {
-  await ctx.cleanup()
+  await ctx?.cleanup()
+  // untrackPath is preserved on disk by design (untrack contract); delete
+  // already removed deletePath, but force-clean both in case a test failed
+  // mid-flow and left either dir behind.
+  if (untrackPath) await rm(untrackPath, { recursive: true, force: true })
+  if (deletePath) await rm(deletePath, { recursive: true, force: true })
 })
 
 test('chooser lists both seeded installs @lifecycle', async () => {

--- a/e2e/lifecycle-migrate.test.ts
+++ b/e2e/lifecycle-migrate.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Lifecycle E2E: Desktop 1.x → Standalone migration trigger wiring.
+ *
+ * Pre-stages a Legacy Desktop layout on disk (Windows only — detection on
+ * macOS reads `~/Library/Application Support/ComfyUI` from the real OS
+ * home, and Linux has no Legacy Desktop path at all) so the launcher's
+ * auto-tracker registers a `sourceId: 'desktop'` install on boot. The
+ * test then exercises the migration trigger surface:
+ *   - the auto-tracker actually creates the desktop install record
+ *   - `previewDesktopMigration` stages a snapshot envelope from the
+ *     legacy install (the SCAN phase of `migrate-to-standalone`)
+ *   - the standalone source advertises a release + CPU variant the
+ *     migration target picker would consume
+ *
+ * The download / extract / setup phase of `migrate-to-standalone` itself
+ * is left to the existing `lifecycle.test.ts` standalone install path,
+ * which already exercises the same `standaloneSource.install + postInstall`
+ * code at the same cost.
+ */
+
+import { readFileSync } from 'node:fs'
+import { access, mkdir, mkdtemp, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { resolve } from 'node:path'
+import { test, expect } from '@playwright/test'
+import { launchApp, type AppContext } from './launchApp'
+import { expectChooserVisible } from './support/chooserHelpers'
+
+let ctx: AppContext
+let legacyBasePath: string
+let legacyInstallId = ''
+
+const LEGACY_NAME = 'ComfyUI Legacy Desktop'
+
+interface FieldOption {
+  value: string
+  label: string
+  recommended?: boolean
+  [key: string]: unknown
+}
+
+interface Installation {
+  id: string
+  name: string
+  sourceId: string
+  installPath?: string
+  [key: string]: unknown
+}
+
+async function pathExists(p: string): Promise<boolean> {
+  try { await access(p); return true } catch { return false }
+}
+
+test.describe.configure({ mode: 'serial' })
+
+test.beforeAll(async () => {
+  test.skip(process.platform !== 'win32', 'Legacy Desktop detection sandbox only works on Windows (APPDATA-based)')
+  // Recreate lifecycle.test.ts's depth-search so this test works whether
+  // it's run from the launcher repo or from the multi-repo workspace.
+  if (!process.env['GITHUB_TOKEN']) {
+    for (let depth = 2; depth <= 8; depth++) {
+      const segments = Array(depth).fill('..')
+      const p = resolve(__dirname, ...segments, 'githubtoken.txt')
+      try { process.env['GITHUB_TOKEN'] = readFileSync(p, 'utf-8').trim(); break } catch { /* try next depth */ }
+    }
+  }
+
+  legacyBasePath = await mkdtemp(path.join(os.tmpdir(), 'comfyui-launcher-legacy-desktop-e2e-'))
+  // Layout `detectDesktopInstall` recognizes: models/ + user/ + .venv/.
+  // Empty dirs are enough — captureDesktopSnapshot tolerates missing
+  // python and an empty custom_nodes/ directory.
+  await mkdir(path.join(legacyBasePath, 'models'), { recursive: true })
+  await mkdir(path.join(legacyBasePath, 'user'), { recursive: true })
+  await mkdir(path.join(legacyBasePath, 'input'), { recursive: true })
+  await mkdir(path.join(legacyBasePath, 'output'), { recursive: true })
+  await mkdir(path.join(legacyBasePath, '.venv'), { recursive: true })
+
+  ctx = await launchApp({
+    settings: { firstUseCompleted: true, telemetryEnabled: false },
+    async onSetup({ homeDir }) {
+      // Write the legacy Desktop config.json the auto-tracker reads at
+      // boot. On Windows it lives under %APPDATA%/ComfyUI/, which the
+      // harness already sandboxes via the APPDATA env override.
+      const desktopConfigDir = path.join(homeDir, 'AppData', 'Roaming', 'ComfyUI')
+      await mkdir(desktopConfigDir, { recursive: true })
+      await writeFile(
+        path.join(desktopConfigDir, 'config.json'),
+        JSON.stringify({ basePath: legacyBasePath }),
+      )
+    },
+  })
+  await expectChooserVisible(ctx.panel)
+})
+
+test.afterAll(async () => {
+  if (ctx) await ctx.cleanup()
+})
+
+test('auto-tracker registers Legacy Desktop install on boot @lifecycle', async () => {
+  await ctx.panel.waitFor(
+    async () => {
+      const names = await ctx.panel.allText(
+        '.chooser-tile:not(.chooser-tile-new):not(.chooser-tile-cloud) .chooser-tile-name',
+      )
+      return names.includes(LEGACY_NAME)
+    },
+    { timeout: 15_000, message: 'auto-tracked Legacy Desktop tile never appeared in chooser' },
+  )
+
+  const installs = await ctx.panel.evaluate<Installation[]>(`window.api.getInstallations()`)
+  const desktop = installs.find((i) => i.sourceId === 'desktop')
+  expect(desktop, 'desktop install not present in get-installations result').toBeDefined()
+  expect(desktop!.installPath).toBe(legacyBasePath)
+  // Capture the auto-allocated id so subsequent tests can drive runAction
+  // / previewDesktopMigration against the correct record.
+  legacyInstallId = desktop!.id
+})
+
+test('preview-desktop-migration stages a snapshot envelope from the legacy install @lifecycle', async () => {
+  expect(legacyInstallId, 'legacyInstallId not captured by the prior test').toBeTruthy()
+  const result = await ctx.panel.evaluate<{
+    ok: boolean
+    message?: string
+    snapshotPath?: string
+    preview?: { snapshotCount: number }
+  }>(
+    `window.api.previewDesktopMigration()`,
+  )
+  expect(result.ok, `previewDesktopMigration failed: ${result.message ?? ''}`).toBe(true)
+  expect(result.snapshotPath, 'preview did not return a staged snapshot file').toBeTruthy()
+  expect(await pathExists(result.snapshotPath!), 'staged snapshot file missing on disk').toBe(true)
+  expect(result.preview?.snapshotCount).toBe(1)
+})
+
+test('standalone source exposes a CPU variant the migration target picker can pin @lifecycle', async () => {
+  // The renderer-side migration target picker calls these same field-option
+  // IPCs to build its release / variant rows. The CI lifecycle suite pins
+  // CPU on Windows; without that pick we'd download a GPU payload that
+  // blows the budget. Asserting the pick is reachable here guards the
+  // upstream R2 contract (`latest.json` + per-vendor `releases.json`)
+  // the picker depends on.
+  const releaseOptions = await ctx.panel.evaluate<FieldOption[]>(
+    `window.api.getFieldOptions('standalone', 'release', {})`,
+  )
+  expect(releaseOptions.length, 'no standalone releases available').toBeGreaterThan(0)
+  const release = releaseOptions.find((r) => r.recommended) ?? releaseOptions[0]!
+
+  const variantOptions = await ctx.panel.evaluate<FieldOption[]>(
+    `window.api.getFieldOptions('standalone', 'variant', ${JSON.stringify({ release })})`,
+  )
+  expect(variantOptions.length, 'no standalone variants available').toBeGreaterThan(0)
+  const cpuVariant = variantOptions.find((v) => /cpu/i.test(v.value))
+  expect(cpuVariant, `no CPU variant exposed for release ${release.value}: ${JSON.stringify(variantOptions.map((v) => v.value))}`).toBeDefined()
+  expect(legacyInstallId, 'legacyInstallId not captured by the prior test').toBeTruthy()
+})

--- a/e2e/lifecycle-migrate.test.ts
+++ b/e2e/lifecycle-migrate.test.ts
@@ -19,7 +19,7 @@
  */
 
 import { readFileSync } from 'node:fs'
-import { access, mkdir, mkdtemp, writeFile } from 'node:fs/promises'
+import { access, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { resolve } from 'node:path'
@@ -30,6 +30,7 @@ import { expectChooserVisible } from './support/chooserHelpers'
 let ctx: AppContext
 let legacyBasePath: string
 let legacyInstallId = ''
+let stagedSnapshotPath = ''
 
 const LEGACY_NAME = 'ComfyUI Legacy Desktop'
 
@@ -94,7 +95,9 @@ test.beforeAll(async () => {
 })
 
 test.afterAll(async () => {
-  if (ctx) await ctx.cleanup()
+  await ctx?.cleanup()
+  if (legacyBasePath) await rm(legacyBasePath, { recursive: true, force: true })
+  if (stagedSnapshotPath) await rm(stagedSnapshotPath, { force: true })
 })
 
 test('auto-tracker registers Legacy Desktop install on boot @lifecycle', async () => {
@@ -131,6 +134,9 @@ test('preview-desktop-migration stages a snapshot envelope from the legacy insta
   expect(result.snapshotPath, 'preview did not return a staged snapshot file').toBeTruthy()
   expect(await pathExists(result.snapshotPath!), 'staged snapshot file missing on disk').toBe(true)
   expect(result.preview?.snapshotCount).toBe(1)
+  // Track for afterAll cleanup — the handler only auto-deletes the
+  // previous file on its NEXT invocation, so a one-shot test leaks it.
+  stagedSnapshotPath = result.snapshotPath!
 })
 
 test('standalone source exposes a CPU variant the migration target picker can pin @lifecycle', async () => {

--- a/e2e/lifecycle-snapshot-restore.test.ts
+++ b/e2e/lifecycle-snapshot-restore.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Lifecycle E2E: live `snapshot-restore` against real git repos.
+ *
+ * Goes beyond IPC wiring: pre-stages two local bare git repos
+ * (ComfyUI + one custom node), clones them into a fake installation
+ * dir at "newer" commit B, seeds a snapshot pointing at "older"
+ * commit A, then drives `runAction('snapshot-restore', …)` and asserts:
+ *   - the ComfyUI working tree HEAD moved from B → A
+ *   - the custom node working tree HEAD moved from B → A
+ *   - a fresh `post-restore` snapshot was captured
+ *
+ * The seeded snapshot has `skipPipSync: true` so the live restore
+ * skips the pip phase (it would otherwise demand a real `uv` +
+ * Python env). All other restore work (git checkout for ComfyUI
+ * and per-node checkout via `restoreCustomNodes`) runs for real
+ * against the bare-repo `origin`s on disk.
+ */
+
+import os from 'node:os'
+import path from 'node:path'
+import { execFileSync } from 'node:child_process'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { test, expect } from '@playwright/test'
+import { launchApp, type AppContext } from './launchApp'
+
+let ctx: AppContext
+let stagedInstallPath = ''
+let comfyOriginPath = ''
+let nodeOriginPath = ''
+let workTmpPath = ''
+
+let comfyCommitA = ''
+let comfyCommitB = ''
+let nodeCommitA = ''
+let nodeCommitB = ''
+
+const INSTALL_ID = 'inst-snapshot-restore'
+const INSTALL_NAME = 'Snapshot Restore Test'
+const NODE_DIRNAME = 'restore-test-node'
+const SEEDED_BASE_TAG = 'v0.3.10'
+
+interface SnapshotSummary {
+  filename: string
+  trigger: string
+  label: string | null
+  [key: string]: unknown
+}
+
+interface SnapshotListResult {
+  snapshots: SnapshotSummary[]
+  totalCount: number
+}
+
+interface RunActionResult {
+  ok: boolean
+  message?: string
+  navigate?: string
+}
+
+function gitIn(cwd: string, args: string[]): string {
+  return execFileSync('git', args, {
+    cwd,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'Lifecycle Test',
+      GIT_AUTHOR_EMAIL: 'lifecycle@example.com',
+      GIT_COMMITTER_NAME: 'Lifecycle Test',
+      GIT_COMMITTER_EMAIL: 'lifecycle@example.com',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+    encoding: 'utf-8',
+  }).trim()
+}
+
+/**
+ * Build a local bare repo (`<root>/<name>.git`) plus a throw-away working
+ * clone, push two commits to `master`, and return the SHAs.
+ */
+async function buildTwoCommitRepo(
+  root: string,
+  name: string,
+  firstFile: { name: string; content: string },
+  secondFile: { name: string; content: string },
+): Promise<{ originPath: string; commitA: string; commitB: string }> {
+  const originPath = path.join(root, `${name}.git`)
+  await mkdir(originPath, { recursive: true })
+  gitIn(originPath, ['init', '--quiet', '--bare', '--initial-branch=master'])
+
+  const workPath = path.join(root, `${name}-work`)
+  await mkdir(workPath, { recursive: true })
+  gitIn(workPath, ['init', '--quiet', '--initial-branch=master'])
+  gitIn(workPath, ['remote', 'add', 'origin', originPath])
+
+  await writeFile(path.join(workPath, firstFile.name), firstFile.content)
+  gitIn(workPath, ['add', '.'])
+  gitIn(workPath, ['commit', '--quiet', '-m', 'A: initial'])
+  const commitA = gitIn(workPath, ['rev-parse', 'HEAD'])
+  gitIn(workPath, ['push', '--quiet', 'origin', 'master'])
+
+  await writeFile(path.join(workPath, secondFile.name), secondFile.content)
+  gitIn(workPath, ['add', '.'])
+  gitIn(workPath, ['commit', '--quiet', '-m', 'B: follow-up'])
+  const commitB = gitIn(workPath, ['rev-parse', 'HEAD'])
+  gitIn(workPath, ['push', '--quiet', 'origin', 'master'])
+
+  return { originPath, commitA, commitB }
+}
+
+test.describe.configure({ mode: 'serial' })
+
+test.beforeAll(async () => {
+  workTmpPath = await mkdtemp(path.join(os.tmpdir(), 'comfyui-launcher-snapshot-restore-e2e-'))
+
+  // Two bare repos: simulated ComfyUI + simulated custom node.
+  const comfy = await buildTwoCommitRepo(
+    workTmpPath,
+    'comfyui-origin',
+    { name: 'README.md', content: 'comfyui v1\n' },
+    { name: 'README.md', content: 'comfyui v2\n' },
+  )
+  comfyOriginPath = comfy.originPath
+  comfyCommitA = comfy.commitA
+  comfyCommitB = comfy.commitB
+
+  const node = await buildTwoCommitRepo(
+    workTmpPath,
+    'restore-node-origin',
+    { name: 'node.py', content: '# v1\n' },
+    { name: 'node.py', content: '# v2\n' },
+  )
+  nodeOriginPath = node.originPath
+  nodeCommitA = node.commitA
+  nodeCommitB = node.commitB
+
+  // Build the fake installation: ComfyUI clone + custom_nodes/<node>.
+  // Both start at the NEWER commit B; restore should move them to A.
+  stagedInstallPath = path.join(workTmpPath, 'install')
+  await mkdir(stagedInstallPath, { recursive: true })
+
+  const comfyuiDir = path.join(stagedInstallPath, 'ComfyUI')
+  gitIn(workTmpPath, ['clone', '--quiet', comfyOriginPath, comfyuiDir])
+  // Force HEAD onto commit B explicitly — `git clone` already lands on B
+  // (the most recent commit on master), but call it out so the intent is
+  // greppable from the test.
+  gitIn(comfyuiDir, ['checkout', '--quiet', comfyCommitB])
+
+  const customNodesDir = path.join(comfyuiDir, 'custom_nodes')
+  await mkdir(customNodesDir, { recursive: true })
+  const stagedNodeDir = path.join(customNodesDir, NODE_DIRNAME)
+  gitIn(customNodesDir, ['clone', '--quiet', nodeOriginPath, NODE_DIRNAME])
+  gitIn(stagedNodeDir, ['checkout', '--quiet', nodeCommitB])
+
+  ctx = await launchApp({
+    settings: { firstUseCompleted: true, telemetryEnabled: false },
+    installations: [
+      {
+        id: INSTALL_ID,
+        name: INSTALL_NAME,
+        installPath: stagedInstallPath,
+        sourceId: 'standalone',
+        status: 'installed',
+        snapshots: [
+          {
+            trigger: 'manual',
+            label: 'restore-target',
+            comfyui: {
+              ref: comfyCommitA,
+              commit: comfyCommitA,
+              releaseTag: SEEDED_BASE_TAG,
+              variant: 'cpu',
+              baseTag: SEEDED_BASE_TAG,
+              commitsAhead: 0,
+            },
+            customNodes: [
+              {
+                id: NODE_DIRNAME,
+                type: 'git',
+                dirName: NODE_DIRNAME,
+                enabled: true,
+                commit: nodeCommitA,
+                url: nodeOriginPath,
+              },
+            ],
+            pipPackages: {},
+            skipPipSync: true,
+            updateChannel: 'stable',
+          },
+        ],
+      },
+    ],
+  })
+})
+
+test.afterAll(async () => {
+  await ctx?.cleanup()
+  if (workTmpPath) await rm(workTmpPath, { recursive: true, force: true })
+})
+
+test('seeded HEADs start at commit B (sanity) @lifecycle', async () => {
+  const comfyHead = gitIn(path.join(stagedInstallPath, 'ComfyUI'), ['rev-parse', 'HEAD'])
+  const nodeHead = gitIn(
+    path.join(stagedInstallPath, 'ComfyUI', 'custom_nodes', NODE_DIRNAME),
+    ['rev-parse', 'HEAD'],
+  )
+  expect(comfyHead).toBe(comfyCommitB)
+  expect(nodeHead).toBe(nodeCommitB)
+})
+
+test('snapshot-restore moves ComfyUI + node HEAD back to commit A @lifecycle', async () => {
+  const list = await ctx.panel.evaluate<SnapshotListResult>(
+    `window.api.getSnapshots(${JSON.stringify(INSTALL_ID)})`,
+  )
+  expect(list.snapshots.length, 'no seeded snapshot found').toBeGreaterThan(0)
+  // The seeded `manual` snapshot is the only one on disk pre-restore.
+  const target = list.snapshots.find((s) => s.trigger === 'manual' && s.label === 'restore-target')
+  expect(target, 'seeded restore-target snapshot missing from list').toBeDefined()
+
+  const result = await ctx.panel.evaluate<RunActionResult>(
+    `window.api.runAction(
+       ${JSON.stringify(INSTALL_ID)},
+       'snapshot-restore',
+       ${JSON.stringify({ file: target!.filename })}
+     )`,
+  )
+  expect(result.ok, `snapshot-restore failed: ${result.message ?? ''}`).toBe(true)
+
+  const comfyHead = gitIn(path.join(stagedInstallPath, 'ComfyUI'), ['rev-parse', 'HEAD'])
+  expect(comfyHead, 'ComfyUI HEAD did not move to commit A after restore').toBe(comfyCommitA)
+
+  const nodeHead = gitIn(
+    path.join(stagedInstallPath, 'ComfyUI', 'custom_nodes', NODE_DIRNAME),
+    ['rev-parse', 'HEAD'],
+  )
+  expect(nodeHead, 'custom node HEAD did not move to commit A after restore').toBe(nodeCommitA)
+})
+
+test('restore captures a post-restore snapshot @lifecycle', async () => {
+  // After a successful restore, `actions.ts` calls `saveSnapshot(... 'post-restore')`.
+  // Poll because the post-restore save runs after `update(restoreState)` returns
+  // — the runAction call already awaited the action result, but the snapshot
+  // count update happens on a follow-up tick.
+  await expect
+    .poll(
+      async () =>
+        ctx.panel.evaluate<SnapshotListResult>(
+          `window.api.getSnapshots(${JSON.stringify(INSTALL_ID)})`,
+        ),
+      { timeout: 10_000, intervals: [200, 500] },
+    )
+    .toMatchObject({
+      snapshots: expect.arrayContaining([
+        expect.objectContaining({ trigger: 'post-restore' }),
+      ]) as unknown,
+    })
+})

--- a/e2e/lifecycle-snapshot.test.ts
+++ b/e2e/lifecycle-snapshot.test.ts
@@ -16,12 +16,13 @@
 
 import os from 'node:os'
 import path from 'node:path'
-import { mkdir, mkdtemp } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import { test, expect } from '@playwright/test'
 import { launchApp, type AppContext } from './launchApp'
 import { titlePopupPage } from './support/cdpPages'
 
 let ctx: AppContext
+let stagedInstallPath = ''
 
 const INSTALL_ID = 'inst-snapshot-test'
 const INSTALL_NAME = 'Snapshot Test Install'
@@ -36,11 +37,11 @@ test.beforeAll(async () => {
   // Use an explicit installPath outside the harness home dir so we can
   // assert against the snapshot files we wrote without round-tripping
   // through `app.getPath('userData')`.
-  const installPath = await mkdtemp(path.join(os.tmpdir(), 'comfyui-launcher-snapshot-e2e-'))
+  stagedInstallPath = await mkdtemp(path.join(os.tmpdir(), 'comfyui-launcher-snapshot-e2e-'))
   // saveSnapshot scans `<installPath>/ComfyUI/custom_nodes` and reads
   // git head; both tolerate missing dirs, but materializing the parent
   // keeps the capture path off the slow-stat error branch on Windows.
-  await mkdir(path.join(installPath, 'ComfyUI'), { recursive: true })
+  await mkdir(path.join(stagedInstallPath, 'ComfyUI'), { recursive: true })
 
   ctx = await launchApp({
     settings: { firstUseCompleted: true, telemetryEnabled: false },
@@ -48,7 +49,7 @@ test.beforeAll(async () => {
       {
         id: INSTALL_ID,
         name: INSTALL_NAME,
-        installPath,
+        installPath: stagedInstallPath,
         sourceId: 'standalone',
         status: 'installed',
         snapshots: [
@@ -71,7 +72,8 @@ test.beforeAll(async () => {
 })
 
 test.afterAll(async () => {
-  await ctx.cleanup()
+  await ctx?.cleanup()
+  if (stagedInstallPath) await rm(stagedInstallPath, { recursive: true, force: true })
 })
 
 test('seeded snapshot row renders the backend-formatted version @lifecycle', async () => {

--- a/e2e/lifecycle-snapshot.test.ts
+++ b/e2e/lifecycle-snapshot.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Lifecycle E2E: per-install Snapshots tab.
+ *
+ * - Seeds a single installation plus one snapshot JSON file on disk, then
+ *   opens the instance picker directly into the Snapshots tab and asserts
+ *   the row renders the backend-formatted `comfyuiVersion` string verbatim
+ *   (regression for the `formatComfyVersion` short-style path).
+ * - Captures a fresh snapshot via `runAction('snapshot-save')` and asserts
+ *   a new row appears at the top of the timeline.
+ *
+ * Restore is intentionally out of scope here — the live op runs real git
+ * checkout, custom-node clone, and pip ops, none of which the seeded
+ * harness has set up. Cover restore in a separate test with a pre-staged
+ * git repo or a dev-hook stub.
+ */
+
+import os from 'node:os'
+import path from 'node:path'
+import { mkdir, mkdtemp } from 'node:fs/promises'
+import { test, expect } from '@playwright/test'
+import { launchApp, type AppContext } from './launchApp'
+import { titlePopupPage } from './support/cdpPages'
+
+let ctx: AppContext
+
+const INSTALL_ID = 'inst-snapshot-test'
+const INSTALL_NAME = 'Snapshot Test Install'
+const SEEDED_COMMIT = 'a'.repeat(40)
+const SEEDED_BASE_TAG = 'v0.3.10'
+const SEEDED_COMMITS_AHEAD = 2
+const EXPECTED_VERSION = `${SEEDED_BASE_TAG}+${SEEDED_COMMITS_AHEAD}`
+
+test.describe.configure({ mode: 'serial' })
+
+test.beforeAll(async () => {
+  // Use an explicit installPath outside the harness home dir so we can
+  // assert against the snapshot files we wrote without round-tripping
+  // through `app.getPath('userData')`.
+  const installPath = await mkdtemp(path.join(os.tmpdir(), 'comfyui-launcher-snapshot-e2e-'))
+  // saveSnapshot scans `<installPath>/ComfyUI/custom_nodes` and reads
+  // git head; both tolerate missing dirs, but materializing the parent
+  // keeps the capture path off the slow-stat error branch on Windows.
+  await mkdir(path.join(installPath, 'ComfyUI'), { recursive: true })
+
+  ctx = await launchApp({
+    settings: { firstUseCompleted: true, telemetryEnabled: false },
+    installations: [
+      {
+        id: INSTALL_ID,
+        name: INSTALL_NAME,
+        installPath,
+        sourceId: 'standalone',
+        status: 'installed',
+        snapshots: [
+          {
+            trigger: 'manual',
+            label: 'seeded',
+            comfyui: {
+              ref: SEEDED_COMMIT,
+              commit: SEEDED_COMMIT,
+              releaseTag: SEEDED_BASE_TAG,
+              variant: 'cpu',
+              baseTag: SEEDED_BASE_TAG,
+              commitsAhead: SEEDED_COMMITS_AHEAD,
+            },
+          },
+        ],
+      },
+    ],
+  })
+})
+
+test.afterAll(async () => {
+  await ctx.cleanup()
+})
+
+test('seeded snapshot row renders the backend-formatted version @lifecycle', async () => {
+  const opened = await ctx.panel.evaluate<boolean>(
+    `(() => {
+      window.api.openInstancePicker({
+        installationId: ${JSON.stringify(INSTALL_ID)},
+        mode: 'expanded',
+        initialTab: 'snapshots',
+      })
+      return true
+    })()`,
+  )
+  expect(opened).toBe(true)
+
+  const popup = titlePopupPage(ctx.app)
+  await popup.waitForVisible('.snapshot-row', { timeout: 15_000 })
+
+  const metaText = await popup.textOf('.snapshot-row-meta')
+  expect(metaText, 'snapshot meta line not rendered').not.toBeNull()
+  expect(metaText!).toContain(EXPECTED_VERSION)
+})
+
+test('captures a new snapshot via runAction and shows it at the top @lifecycle', async () => {
+  const before = await ctx.panel.evaluate<number>(
+    `window.api.getSnapshots(${JSON.stringify(INSTALL_ID)}).then(d => d.snapshots.length)`,
+  )
+  expect(before).toBe(1)
+
+  await ctx.panel.evaluate<unknown>(
+    `window.api.runAction(${JSON.stringify(INSTALL_ID)}, 'snapshot-save', { label: 'captured-by-test' })`,
+  )
+
+  await expect
+    .poll(
+      async () =>
+        ctx.panel.evaluate<number>(
+          `window.api.getSnapshots(${JSON.stringify(INSTALL_ID)}).then(d => d.snapshots.length)`,
+        ),
+      { timeout: 15_000, intervals: [250, 500] },
+    )
+    .toBe(2)
+
+  const labels = await ctx.panel.evaluate<Array<string | null>>(
+    `window.api.getSnapshots(${JSON.stringify(INSTALL_ID)}).then(d => d.snapshots.map(s => s.label))`,
+  )
+  expect(labels[0]).toBe('captured-by-test')
+})

--- a/e2e/lifecycle-update-check.test.ts
+++ b/e2e/lifecycle-update-check.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Lifecycle E2E: real `check-update` against the live Comfy-Org/ComfyUI
+ * git remote.
+ *
+ * Pre-stages a fake standalone install record pinned to an OLD baseTag,
+ * then drives `runAction('check-update')` and asserts that the release
+ * cache picked up the current latest tag from GitHub and the channel
+ * cards report an update is available.
+ *
+ * This is intentionally a network-touching test: it is the only e2e
+ * proof that `fetchLatestRelease` (`git ls-remote --tags`) and the
+ * release cache → channel-cards pipeline actually wire up against the
+ * real upstream. No HTTP mocks, no dev-hook state injection — if
+ * github.com or Comfy-Org/ComfyUI changes shape, this test catches it.
+ *
+ * Cost: one `git ls-remote --tags` to github.com (~tens of KB).
+ */
+
+import os from 'node:os'
+import path from 'node:path'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { test, expect } from '@playwright/test'
+import { launchApp, type AppContext } from './launchApp'
+
+let ctx: AppContext
+let stagedInstallPath = ''
+
+const INSTALL_ID = 'inst-update-check'
+const INSTALL_NAME = 'Update Check Test'
+// An intentionally old baseTag so any currently-published stable release
+// reads as "newer". v0.1.0 is from June 2024; anything from H2-2024 onward
+// will compare strictly greater under semver string ordering on the
+// channel card.
+const SEEDED_BASE_TAG = 'v0.1.0'
+const SEEDED_COMMIT = 'a'.repeat(40)
+
+interface FieldOption {
+  value: string
+  label: string
+  data?: {
+    installedVersion: string
+    latestVersion: string
+    lastChecked: string
+    updateAvailable: boolean
+  }
+}
+
+interface DetailField {
+  id?: string
+  label?: string
+  value?: unknown
+  options?: FieldOption[]
+}
+
+interface DetailSection {
+  tab?: string
+  title?: string
+  fields?: DetailField[]
+  actions?: unknown[]
+}
+
+interface RunActionResult {
+  ok: boolean
+  message?: string
+}
+
+test.describe.configure({ mode: 'serial' })
+
+test.beforeAll(async () => {
+  stagedInstallPath = await mkdtemp(path.join(os.tmpdir(), 'comfyui-launcher-update-check-e2e-'))
+  // ComfyUI/ existence gates several detail-section branches (e.g. `hasGit`).
+  // We don't need a real clone for this test — the check-update path itself
+  // only requires it for `enrichCommitsAhead`, which no-ops without a .git
+  // dir. The release-cache fetch + channel-card comparison both run.
+  await mkdir(path.join(stagedInstallPath, 'ComfyUI'), { recursive: true })
+
+  ctx = await launchApp({
+    settings: { firstUseCompleted: true, telemetryEnabled: false },
+    installations: [
+      {
+        id: INSTALL_ID,
+        name: INSTALL_NAME,
+        installPath: stagedInstallPath,
+        sourceId: 'standalone',
+        status: 'installed',
+        updateChannel: 'stable',
+        comfyVersion: { commit: SEEDED_COMMIT, baseTag: SEEDED_BASE_TAG, commitsAhead: 0 },
+        // Match the renderer-visible shape so the picker behaves as if this
+        // record came out of the real installer.
+        releaseTag: SEEDED_BASE_TAG,
+        variant: 'cpu',
+        pythonVersion: '3.12',
+      },
+    ],
+  })
+})
+
+test.afterAll(async () => {
+  await ctx?.cleanup()
+  if (stagedInstallPath) await rm(stagedInstallPath, { recursive: true, force: true })
+})
+
+test('check-update hits the real Comfy-Org/ComfyUI remote and finds a newer release @lifecycle', async () => {
+  const result = await ctx.panel.evaluate<RunActionResult>(
+    `window.api.runAction(${JSON.stringify(INSTALL_ID)}, 'check-update')`,
+  )
+  expect(result.ok, `check-update failed (network/auth issue?): ${result.message ?? ''}`).toBe(true)
+
+  // After check-update the channel cards should expose the latest stable
+  // release the remote actually serves. Read it back via getDetailSections
+  // — same path the renderer uses for the Update tab.
+  const sections = await ctx.panel.evaluate<DetailSection[]>(
+    `window.api.getDetailSections(${JSON.stringify(INSTALL_ID)})`,
+  )
+  const updateSection = sections.find((s) => s.tab === 'update')
+  expect(updateSection, 'no update section in detail sections').toBeDefined()
+  const channelField = updateSection!.fields!.find((f) => f.id === 'updateChannel')
+  expect(channelField?.options, 'update channel field missing options').toBeDefined()
+  const stableCard = channelField!.options!.find((o) => o.value === 'stable')
+  expect(stableCard, 'stable channel card missing').toBeDefined()
+  expect(stableCard!.data, 'stable channel card has no data — release cache empty?').toBeDefined()
+
+  // The latest stable tag advertised by the remote should look like a real
+  // semver-ish ComfyUI tag (e.g. v0.3.59). Don't pin a specific value;
+  // the upstream ships releases continuously.
+  expect(stableCard!.data!.latestVersion, 'latest stable version not populated from remote').toMatch(/v\d+\.\d+/)
+  // The seeded comfyVersion is at v0.1.0 — anything currently-published is
+  // newer, so the channel card should report an update available.
+  expect(
+    stableCard!.data!.updateAvailable,
+    `stable card did not flag update available against seeded baseTag ${SEEDED_BASE_TAG}; got latestVersion=${stableCard!.data!.latestVersion}`,
+  ).toBe(true)
+})
+
+test('cross-channel fetch populates the latest channel card too @lifecycle', async () => {
+  // The check-update action prefetches the "other" channel(s) in parallel
+  // (Promise.allSettled over `['stable', 'latest']`). The previous test
+  // already ran check-update — now verify both cards have data, not just
+  // the current channel.
+  const sections = await ctx.panel.evaluate<DetailSection[]>(
+    `window.api.getDetailSections(${JSON.stringify(INSTALL_ID)})`,
+  )
+  const updateSection = sections.find((s) => s.tab === 'update')!
+  const channelField = updateSection.fields!.find((f) => f.id === 'updateChannel')!
+  const latestCard = channelField.options!.find((o) => o.value === 'latest')
+  expect(latestCard?.data, 'latest channel card has no data — cross-channel prefetch did not run').toBeDefined()
+  // The latest channel uses the master HEAD short SHA as its "tag", not a
+  // semver. Just assert it's a non-empty version string with a SHA-ish shape
+  // (7+ hex chars somewhere in the rendered version).
+  expect(latestCard!.data!.latestVersion).toMatch(/[a-f0-9]{7,}/)
+})

--- a/e2e/lifecycle.test.ts
+++ b/e2e/lifecycle.test.ts
@@ -117,8 +117,7 @@ test('accept consent + pick local opens New Install takeover with form pre-fille
   // `loadFieldOptions('release')` → recursive `loadFieldOptions('variant')`.
   // `.brand-primary.config-continue` is bound to `:disabled="!canContinue"`,
   // so once it goes enabled the form is fully pre-filled (release picked,
-  // variant picked, no path issues). That's the single signal we need
-  // before clicking Continue.
+  // variant picked, no path issues).
   await ctx.panel.waitFor(
     async () => ctx.app.evaluate(({ webContents }) => {
       const wc = webContents.getAllWebContents().find((w) => w.getURL().includes('panel.html'))
@@ -129,6 +128,31 @@ test('accept consent + pick local opens New Install takeover with form pre-fille
       })()`) as Promise<boolean>
     }),
     { timeout: 60_000, message: 'Continue button never became enabled (form did not pre-fill)' },
+  )
+
+  // Force the CPU variant so the test is deterministic across runners
+  // (NVIDIA hosts would otherwise download a multi-GB GPU payload).
+  // The variant rows live inside the Advanced disclosure; the body is
+  // always rendered (CSS-hidden when collapsed), so clicking the row
+  // works even without expanding — but expand anyway to mirror the
+  // real user gesture.
+  expect(await ctx.panel.click('.config-advanced__summary')).toBe(true)
+  await ctx.panel.waitForSelector('.config-variant-row', { timeout: 5_000 })
+  expect(
+    await ctx.panel.clickByText('.config-variant-row', 'CPU'),
+    'CPU variant row clicked',
+  ).toBe(true)
+  // Confirm the CPU row is the selected one before continuing — otherwise
+  // a label-substring miss (e.g. an i18n change) would silently fall
+  // back to the recommended GPU variant.
+  await ctx.panel.waitFor(
+    async () => ctx.panel.evaluate<boolean>(
+      `(() => {
+        const sel = document.querySelector('.config-variant-row--selected .config-variant-row__label')
+        return !!sel && /CPU/i.test(sel.textContent || '')
+      })()`,
+    ),
+    { timeout: 5_000, message: 'CPU variant did not become the selected variant row' },
   )
 })
 

--- a/e2e/lifecycle.test.ts
+++ b/e2e/lifecycle.test.ts
@@ -35,7 +35,6 @@ import { resolve } from 'node:path'
 import { test, expect } from '@playwright/test'
 import { launchApp, type AppContext } from './launchApp'
 import {
-  clickNewInstallTile,
   clickInstallTile,
   expectChooserVisible,
   expectTakeoverOpen,
@@ -58,6 +57,11 @@ test.beforeAll(async () => {
       } catch { /* try next depth */ }
     }
   }
+  // True cold start: no `firstUseCompleted` seed, so the host opens on
+  // the first-use takeover. The first test below drives through consent
+  // + pick-local, which chains directly into the new-install takeover
+  // (Tier 3 → Tier 3 silent swap) — the same surface the user reaches
+  // on the no-existing-installs cold-start path.
   ctx = await launchApp()
 })
 
@@ -75,16 +79,37 @@ async function comfyFrontendIsLoaded(): Promise<boolean> {
 }
 
 // ---------------------------------------------------------------------------
-// Install via the New Install takeover
+// First-use takeover → New Install takeover
 // ---------------------------------------------------------------------------
 
-test('chooser shows New Install tile on cold start @lifecycle', async () => {
-  await expectChooserVisible(ctx.panel)
-  expect(await ctx.panel.exists('.chooser-tile-new')).toBe(true)
+test('cold start lands on first-use consent screen @lifecycle', async () => {
+  // The first-use takeover gates the chooser body until consent +
+  // cloud/local pick are completed. On a fresh profile the consent
+  // step is what the user lands on.
+  await ctx.panel.waitForVisible('.consent-hero', { timeout: 15_000 })
+  await ctx.panel.waitForVisible('[data-testid="first-use-accept-consent"]')
 })
 
-test('opens New Install takeover with form pre-filled @lifecycle', async () => {
-  await clickNewInstallTile(ctx.panel)
+test('accept consent + pick local opens New Install takeover with form pre-filled @lifecycle', async () => {
+  // Tick the required ToS checkbox (telemetry stays at its default
+  // opt-in; the test settings already disable telemetry network egress
+  // separately, so the actual value doesn't matter here).
+  expect(await ctx.panel.click('[data-testid="first-use-consent-tos"]')).toBe(true)
+  await ctx.panel.waitFor(
+    async () => ctx.panel.evaluate<boolean>(
+      `!document.querySelector('[data-testid="first-use-accept-consent"]').disabled`,
+    ),
+    { timeout: 5_000, message: 'Get Started never became enabled after ticking ToS' },
+  )
+
+  // Accept consent → advance to the cloud-vs-local pick step.
+  expect(await ctx.panel.click('[data-testid="first-use-accept-consent"]')).toBe(true)
+  await ctx.panel.waitForVisible('[data-testid="first-use-pick-local"]', { timeout: 10_000 })
+
+  // Pick Local — with no legacy desktop install detected, this emits
+  // `chain-local`, which the host swaps for the new-install Tier 3
+  // takeover (silent Tier 3 → Tier 3 swap inside `useOverlay`).
+  expect(await ctx.panel.click('[data-testid="first-use-pick-local"]')).toBe(true)
   await expectTakeoverOpen(ctx.panel)
 
   // Standalone is pre-selected on open. The release + variant fields

--- a/e2e/lifecycle.test.ts
+++ b/e2e/lifecycle.test.ts
@@ -130,30 +130,35 @@ test('accept consent + pick local opens New Install takeover with form pre-fille
     { timeout: 60_000, message: 'Continue button never became enabled (form did not pre-fill)' },
   )
 
-  // Force the CPU variant so the test is deterministic across runners
-  // (NVIDIA hosts would otherwise download a multi-GB GPU payload).
-  // The variant rows live inside the Advanced disclosure; the body is
-  // always rendered (CSS-hidden when collapsed), so clicking the row
-  // works even without expanding — but expand anyway to mirror the
-  // real user gesture.
-  expect(await ctx.panel.click('.config-advanced__summary')).toBe(true)
-  await ctx.panel.waitForSelector('.config-variant-row', { timeout: 5_000 })
-  expect(
-    await ctx.panel.clickByText('.config-variant-row', 'CPU'),
-    'CPU variant row clicked',
-  ).toBe(true)
-  // Confirm the CPU row is the selected one before continuing — otherwise
-  // a label-substring miss (e.g. an i18n change) would silently fall
-  // back to the recommended GPU variant.
-  await ctx.panel.waitFor(
-    async () => ctx.panel.evaluate<boolean>(
-      `(() => {
-        const sel = document.querySelector('.config-variant-row--selected .config-variant-row__label')
-        return !!sel && /CPU/i.test(sel.textContent || '')
-      })()`,
-    ),
-    { timeout: 5_000, message: 'CPU variant did not become the selected variant row' },
-  )
+  // On Windows, force the CPU variant so the test is deterministic
+  // across runners (NVIDIA hosts would otherwise download a multi-GB
+  // GPU payload). macOS only publishes `mac-mps` and Linux publishes
+  // no `linux-cpu` variant, so on those platforms we trust the
+  // recommended pick the form already made.
+  if (process.platform === 'win32') {
+    // Variant rows live inside the Advanced disclosure; the body is
+    // always rendered (CSS-hidden when collapsed), so clicking the
+    // row works even without expanding — but expand anyway to mirror
+    // the real user gesture.
+    expect(await ctx.panel.click('.config-advanced__summary')).toBe(true)
+    await ctx.panel.waitForSelector('.config-variant-row', { timeout: 5_000 })
+    expect(
+      await ctx.panel.clickByText('.config-variant-row', 'CPU'),
+      'CPU variant row clicked',
+    ).toBe(true)
+    // Confirm the CPU row is the selected one before continuing —
+    // otherwise a label-substring miss (e.g. an i18n change) would
+    // silently fall back to the recommended GPU variant.
+    await ctx.panel.waitFor(
+      async () => ctx.panel.evaluate<boolean>(
+        `(() => {
+          const sel = document.querySelector('.config-variant-row--selected .config-variant-row__label')
+          return !!sel && /CPU/i.test(sel.textContent || '')
+        })()`,
+      ),
+      { timeout: 5_000, message: 'CPU variant did not become the selected variant row' },
+    )
+  }
 })
 
 test('completes install (auto-launches via brand chrome) @lifecycle', async () => {

--- a/e2e/lifecycle.test.ts
+++ b/e2e/lifecycle.test.ts
@@ -30,7 +30,9 @@
  *   transforms in place into the install host (issue #449 path).
  */
 
+import { execFileSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
+import path from 'node:path'
 import { resolve } from 'node:path'
 import { test, expect } from '@playwright/test'
 import { launchApp, type AppContext } from './launchApp'
@@ -301,6 +303,104 @@ test('return-to-dashboard flips install host in place (same window id) @lifecycl
   })
   expect(reattached.count).toBe(before.count)
   expect(reattached.comfyHostId).toBe(flippedId)
+})
+
+// ---------------------------------------------------------------------------
+// Real update — exercise runComfyUIUpdate end-to-end against GitHub.
+//
+// The install above lands on the latest stable tag. To prove the update
+// path *actually does something*, force ComfyUI's working tree backwards
+// a few commits via real `git reset --hard`, then drive the in-place
+// `update-comfyui` action and assert the working-tree HEAD moves forward
+// again. This exercises:
+//   - the bundled `update_comfyui.py` script (real Python subprocess)
+//   - real `git fetch` from github.com/comfyanonymous/ComfyUI
+//   - real `git checkout` of the latest stable tag
+//   - filtered `uv pip install -r requirements.txt` if requirements
+//     changed across the rolled-back range
+// ---------------------------------------------------------------------------
+
+interface InstallationLite {
+  id: string
+  installPath: string
+}
+
+interface UpdateActionResult {
+  ok: boolean
+  message?: string
+  navigate?: string
+}
+
+let _updateInstallId = ''
+let _updateInstallPath = ''
+let _comfyUIDir = ''
+let _rolledBackCommit = ''
+
+test('stop ComfyUI again so update-comfyui (requires stopped) can run @lifecycle', async () => {
+  // `update-comfyui` is in REQUIRES_STOPPED; the prior test re-launched.
+  // Detach in place rather than closing the window so the chooser host
+  // stays alive for the subsequent re-launch.
+  await returnFirstInstallHostToDashboard(ctx.app)
+  await expect.poll(comfyFrontendIsLoaded, { timeout: 30_000, intervals: [500] }).toBe(false)
+  await waitForWebContents(ctx.app, 'panel.html')
+  await expectChooserVisible(ctx.panel)
+})
+
+test('roll ComfyUI HEAD back so the update has work to do @lifecycle', async () => {
+  const installs = await ctx.panel.evaluate<InstallationLite[]>(
+    `window.api.getInstallations()`,
+  )
+  expect(installs.length, 'no tracked installation after install').toBeGreaterThan(0)
+  const inst = installs[0]!
+  _updateInstallId = inst.id
+  _updateInstallPath = inst.installPath
+  _comfyUIDir = path.join(_updateInstallPath, 'ComfyUI')
+
+  const headBefore = execFileSync('git', ['rev-parse', 'HEAD'], {
+    cwd: _comfyUIDir, encoding: 'utf-8', windowsHide: true,
+  }).trim()
+  expect(headBefore).toMatch(/^[a-f0-9]{40}$/)
+
+  // Roll back 3 commits. Small enough to (usually) avoid a requirements
+  // change crossing it — if it does, the update still runs, just slower.
+  execFileSync('git', ['reset', '--hard', 'HEAD~3'], {
+    cwd: _comfyUIDir, stdio: 'pipe', windowsHide: true,
+  })
+
+  const headAfter = execFileSync('git', ['rev-parse', 'HEAD'], {
+    cwd: _comfyUIDir, encoding: 'utf-8', windowsHide: true,
+  }).trim()
+  expect(headAfter, 'git reset --hard did not move HEAD').not.toBe(headBefore)
+  _rolledBackCommit = headAfter
+})
+
+test('update-comfyui drives the real updater and moves HEAD forward @lifecycle', async () => {
+  // Real update can run pip-install if requirements.txt crossed our 3-commit
+  // rollback. Stretch the per-test timeout to cover that worst case.
+  test.setTimeout(600_000)
+  expect(_rolledBackCommit, 'rolled-back commit not captured').toBeTruthy()
+
+  const result = await ctx.panel.evaluate<UpdateActionResult>(
+    `window.api.runAction(${JSON.stringify(_updateInstallId)}, 'update-comfyui', { channel: 'stable' })`,
+  )
+  expect(result.ok, `update-comfyui failed: ${result.message ?? ''}`).toBe(true)
+
+  const headAfter = execFileSync('git', ['rev-parse', 'HEAD'], {
+    cwd: _comfyUIDir, encoding: 'utf-8', windowsHide: true,
+  }).trim()
+  expect(headAfter, 'update did not move HEAD off the rolled-back commit').not.toBe(_rolledBackCommit)
+
+  // The update should land on a commit reachable from origin/master that is
+  // strictly newer than (or equal to) the rolled-back one — never older.
+  const aheadCount = execFileSync('git', ['rev-list', '--count', `${_rolledBackCommit}..${headAfter}`], {
+    cwd: _comfyUIDir, encoding: 'utf-8', windowsHide: true,
+  }).trim()
+  expect(parseInt(aheadCount, 10), `post-update HEAD ${headAfter} is not ahead of rolled-back commit ${_rolledBackCommit}`).toBeGreaterThan(0)
+})
+
+test('re-launch ComfyUI after update so the stop test has something to close @lifecycle', async () => {
+  await clickInstallTile(ctx.panel, 'ComfyUI')
+  await expect.poll(comfyFrontendIsLoaded, { timeout: 180_000, intervals: [1_000] }).toBe(true)
 })
 
 // ---------------------------------------------------------------------------

--- a/e2e/lifecycle.test.ts
+++ b/e2e/lifecycle.test.ts
@@ -31,7 +31,7 @@
  */
 
 import { execFileSync } from 'node:child_process'
-import { readFileSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import path from 'node:path'
 import { resolve } from 'node:path'
 import { test, expect } from '@playwright/test'
@@ -398,48 +398,73 @@ test('update-comfyui drives the real updater and moves HEAD forward @lifecycle',
   expect(parseInt(aheadCount, 10), `post-update HEAD ${headAfter} is not ahead of rolled-back commit ${_rolledBackCommit}`).toBeGreaterThan(0)
 })
 
-test('re-launch ComfyUI after update so the stop test has something to close @lifecycle', async () => {
+test('re-launch ComfyUI after update validates the updated install runs @lifecycle', async () => {
   await clickInstallTile(ctx.panel, 'ComfyUI')
   await expect.poll(comfyFrontendIsLoaded, { timeout: 180_000, intervals: [1_000] }).toBe(true)
 })
 
 // ---------------------------------------------------------------------------
-// Stop
+// Stop + Delete — real fs cleanup of a fully-installed standalone tree
+// (~500MB on disk: ComfyUI/.git + standalone-env/ + ComfyUI/.venv).
+//
+// Validates the delete handler's marker-file safety check + recursive
+// `fs.rm` against an install that actually has the contents users care
+// about losing — including the Windows .venv where in-use file locks can
+// make recursive deletion fight back.
+//
+// Note on the missing "close-window stops comfy" test: that path is now
+// covered implicitly by the return-to-dashboard stop test above (same
+// `detachInstall` teardown). We drop the explicit `win.close()` variant
+// here because it always quits the app (closes the only host window),
+// which would prevent the delete IPC below from running.
 // ---------------------------------------------------------------------------
 
-test('stops running ComfyUI by closing its host window @lifecycle', async () => {
-  // After launch, the chooser host transforms in place to host the install
-  // (the original `panel.html` body is detached). Drive the stop through the
-  // BrowserWindow `close()` call instead — the window's close handler tears
-  // the comfy process down via the same path the chooser-tile close button
-  // would use. Closing the last host window also quits the Electron app,
-  // which is why the subsequent poll treats an evaluate failure (app gone)
-  // as the terminal "stopped" state.
-  const closed = await ctx.app.evaluate(({ BrowserWindow, WebContentsView }) => {
-    for (const win of BrowserWindow.getAllWindows()) {
-      const hasComfy = win.contentView.children.some((v) =>
-        v instanceof WebContentsView &&
-        /^http:\/\/(127\.0\.0\.1|localhost):/.test(v.webContents.getURL()),
-      )
-      if (hasComfy) {
-        win.close()
-        return true
-      }
-    }
-    return false
-  })
-  expect(closed, 'ComfyUI host window not found among open windows').toBe(true)
+let _deleteInstallId = ''
+let _deleteInstallPath = ''
 
-  await expect.poll(
-    async () => {
-      try {
-        return await comfyFrontendIsLoaded()
-      } catch {
-        // App was torn down by the close — that's a stronger "stopped" signal
-        // than the comfy webContents going away on its own.
-        return false
-      }
-    },
-    { timeout: 60_000, intervals: [500] },
-  ).toBe(false)
+test('stops comfy and captures the installed dir state before driving delete @lifecycle', async () => {
+  // delete is in REQUIRES_STOPPED — stop comfy via return-to-dashboard so
+  // the IPC handler doesn't bail on us. rtd preserves the chooser host so
+  // we still have an IPC target for delete + getInstallations.
+  await returnFirstInstallHostToDashboard(ctx.app)
+  await expect.poll(comfyFrontendIsLoaded, { timeout: 30_000, intervals: [500] }).toBe(false)
+  await waitForWebContents(ctx.app, 'panel.html')
+  await expectChooserVisible(ctx.panel)
+
+  const installs = await ctx.panel.evaluate<InstallationLite[]>(`window.api.getInstallations()`)
+  expect(installs.length, 'no tracked installation after install').toBeGreaterThan(0)
+  const inst = installs[0]!
+  _deleteInstallId = inst.id
+  _deleteInstallPath = inst.installPath
+
+  // Sanity: this should be a fully-installed standalone tree, not the
+  // empty placeholder dirs the lifecycle-delete-untrack test uses. The
+  // install dir is on the same filesystem the test runs on (the harness
+  // home temp dir), so we can stat it directly from the test process.
+  expect(existsSync(path.join(_deleteInstallPath, 'ComfyUI', '.git')), 'installed dir missing ComfyUI/.git').toBe(true)
+  expect(existsSync(path.join(_deleteInstallPath, 'standalone-env')), 'installed dir missing standalone-env/').toBe(true)
+  expect(existsSync(path.join(_deleteInstallPath, '.comfyui-desktop-2')), 'installed dir missing .comfyui-desktop-2 marker').toBe(true)
+})
+
+test('real delete wipes the fully-installed ~500MB tree off disk @lifecycle', async () => {
+  // Recursive delete of a full standalone install can take a while on
+  // Windows when files are large (the .venv ships thousands of small
+  // files plus a few hundred-MB torch wheels). Stretch the timeout.
+  test.setTimeout(300_000)
+  expect(_deleteInstallPath, 'install path not captured').toBeTruthy()
+
+  const result = await ctx.panel.evaluate<UpdateActionResult>(
+    `window.api.runAction(${JSON.stringify(_deleteInstallId)}, 'delete')`,
+  )
+  expect(result.ok, `runAction('delete') failed: ${result.message ?? ''}`).toBe(true)
+
+  // Disk verification — the entire install tree must be gone, not just
+  // a few top-level entries. Probes both the root + a deep file the
+  // standalone install always materializes (ComfyUI/main.py).
+  expect(existsSync(_deleteInstallPath), `install dir ${_deleteInstallPath} still exists after delete`).toBe(false)
+  expect(existsSync(path.join(_deleteInstallPath, 'ComfyUI', 'main.py')), 'ComfyUI/main.py still on disk after delete').toBe(false)
+
+  // The installation record must also be gone.
+  const remaining = await ctx.panel.evaluate<InstallationLite[]>(`window.api.getInstallations()`)
+  expect(remaining.find((i) => i.id === _deleteInstallId), 'install record not removed after delete').toBeUndefined()
 })

--- a/e2e/support/electronHarness.ts
+++ b/e2e/support/electronHarness.ts
@@ -29,7 +29,41 @@ export interface SeedInstallation {
   sourceId?: string
   installPath?: string
   status?: string
+  /**
+   * Snapshot JSON records to seed into `<installPath>/.launcher/snapshots/`.
+   * Each entry is written as a standalone `<timestamp>-<trigger>-<6hex>.json`
+   * file in the same format the live snapshot store produces.
+   */
+  snapshots?: SeedSnapshot[]
   [key: string]: unknown
+}
+
+/** Loose Snapshot shape — duplicated locally to keep the harness free of
+ *  src/ imports. Keep in sync with `src/main/lib/snapshots/types.ts`. */
+export interface SeedSnapshot {
+  version?: 1
+  createdAt?: string
+  trigger: 'boot' | 'restart' | 'manual' | 'pre-update' | 'post-update' | 'post-restore'
+  label?: string | null
+  comfyui: {
+    ref: string
+    commit: string | null
+    releaseTag: string
+    variant: string
+    baseTag?: string
+    commitsAhead?: number
+  }
+  customNodes?: unknown[]
+  pipPackages?: Record<string, string>
+  pythonVersion?: string
+  updateChannel?: string
+}
+
+/** Mirrors `formatTimestamp` in `src/main/lib/snapshots/store.ts` so seeded
+ *  filenames sort identically to live ones (newest-first by name). */
+function formatSeedTimestamp(date: Date): string {
+  const pad = (n: number, len = 2): string => String(n).padStart(len, '0')
+  return `${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(date.getDate())}_${pad(date.getHours())}${pad(date.getMinutes())}${pad(date.getSeconds())}_${pad(date.getMilliseconds(), 3)}`
 }
 
 function buildIsolatedEnv(homeDir: string, settingsSeed?: Record<string, unknown>): Record<string, string> {
@@ -132,21 +166,50 @@ export async function launchLauncherApp(options?: SeedOptions): Promise<Launcher
     const userDataDir = await application.evaluate(async ({ app: electronApp }) => {
       return electronApp.getPath('userData')
     })
-    const records = options.installations.map((inst, i) => ({
-      id: inst.id ?? `inst-test-${i}`,
-      name: inst.name ?? `Test Install ${i + 1}`,
-      createdAt: new Date().toISOString(),
-      installPath: inst.installPath ?? path.join(homeDir, `install-${i}`),
-      sourceId: inst.sourceId ?? 'standalone',
-      status: inst.status ?? 'installed',
-      ...inst,
-    }))
+    const records = options.installations.map((inst, i) => {
+      const { snapshots: _snapshots, ...rest } = inst
+      return {
+        id: inst.id ?? `inst-test-${i}`,
+        name: inst.name ?? `Test Install ${i + 1}`,
+        createdAt: new Date().toISOString(),
+        installPath: inst.installPath ?? path.join(homeDir, `install-${i}`),
+        sourceId: inst.sourceId ?? 'standalone',
+        status: inst.status ?? 'installed',
+        ...rest,
+      }
+    })
     const { writeFile: writeFileFs } = await import('node:fs/promises')
     await mkdir(userDataDir, { recursive: true })
     await writeFileFs(
       path.join(userDataDir, 'installations.json'),
       JSON.stringify(records, null, 2),
     )
+    // Seed snapshot JSON files under `<installPath>/.launcher/snapshots/` so
+    // the snapshots tab finds them on first read.
+    for (let i = 0; i < options.installations.length; i++) {
+      const snaps = options.installations[i]!.snapshots
+      if (!snaps || snaps.length === 0) continue
+      const installPath = records[i]!.installPath
+      const snapshotsDir = path.join(installPath, '.launcher', 'snapshots')
+      await mkdir(snapshotsDir, { recursive: true })
+      for (let j = 0; j < snaps.length; j++) {
+        const s = snaps[j]!
+        const createdAt = s.createdAt ?? new Date(Date.now() - (snaps.length - j) * 1000).toISOString()
+        const full = {
+          version: 1,
+          createdAt,
+          trigger: s.trigger,
+          label: s.label ?? null,
+          comfyui: s.comfyui,
+          customNodes: s.customNodes ?? [],
+          pipPackages: s.pipPackages ?? {},
+          pythonVersion: s.pythonVersion,
+          updateChannel: s.updateChannel ?? 'stable',
+        }
+        const filename = `${formatSeedTimestamp(new Date(createdAt))}-${s.trigger}-${(j + 1).toString(16).padStart(6, '0')}.json`
+        await writeFileFs(path.join(snapshotsDir, filename), JSON.stringify(full, null, 2))
+      }
+    }
   }
 
   const cleanup = async (): Promise<void> => {

--- a/e2e/support/electronHarness.ts
+++ b/e2e/support/electronHarness.ts
@@ -21,6 +21,13 @@ export interface SeedOptions {
    * racing the first-use takeover for control of the chooser host.
    */
   settings?: Record<string, unknown>
+  /**
+   * Runs after the isolated home + app-data dirs are created but before
+   * the Electron app is spawned. Use to drop platform-specific files
+   * (e.g. legacy Desktop `config.json` under `%APPDATA%/ComfyUI/`) the
+   * main process inspects during early boot.
+   */
+  onSetup?: (paths: { homeDir: string; appDataDir: string }) => Promise<void>
 }
 
 export interface SeedInstallation {
@@ -118,6 +125,10 @@ export async function launchLauncherApp(options?: SeedOptions): Promise<Launcher
       ? path.join(homeDir, 'Library', 'Application Support', 'comfyui-desktop-2')
       : path.join(homeDir, '.config', 'comfyui-desktop-2')
   await mkdir(appDataDir, { recursive: true })
+
+  if (options?.onSetup) {
+    await options.onSetup({ homeDir, appDataDir })
+  }
 
   // Expose a CDP remote-debugging port so tests can connect to non-BrowserWindow
   // webContents (e.g. the ComfyUI WebContentsView) via chromium.connectOverCDP().

--- a/e2e/support/electronHarness.ts
+++ b/e2e/support/electronHarness.ts
@@ -64,6 +64,9 @@ export interface SeedSnapshot {
   pipPackages?: Record<string, string>
   pythonVersion?: string
   updateChannel?: string
+  /** Set on the seeded snapshot so `snapshot-restore` skips the live
+   *  pip phase (avoids needing a real `uv` + Python env on disk). */
+  skipPipSync?: boolean
 }
 
 /** Mirrors `formatTimestamp` in `src/main/lib/snapshots/store.ts` so seeded
@@ -216,6 +219,7 @@ export async function launchLauncherApp(options?: SeedOptions): Promise<Launcher
           pipPackages: s.pipPackages ?? {},
           pythonVersion: s.pythonVersion,
           updateChannel: s.updateChannel ?? 'stable',
+          ...(s.skipPipSync ? { skipPipSync: true } : {}),
         }
         const filename = `${formatSeedTimestamp(new Date(createdAt))}-${s.trigger}-${(j + 1).toString(16).padStart(6, '0')}.json`
         await writeFileFs(path.join(snapshotsDir, filename), JSON.stringify(full, null, 2))

--- a/src/main/lib/channel-cards.test.ts
+++ b/src/main/lib/channel-cards.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { buildChannelCards, type ChannelDef } from './channel-cards'
+import type { InstallationRecord } from '../installations'
+
+vi.mock('./release-cache', () => ({
+  getEffectiveInfo: vi.fn(),
+  isUpdateAvailable: vi.fn(() => true),
+}))
+
+import * as releaseCache from './release-cache'
+
+const REPO = 'Comfy-Org/ComfyUI'
+const DEFS: ChannelDef[] = [
+  { value: 'stable', label: 'Stable', description: 'Stable releases' },
+  { value: 'latest', label: 'Latest from GitHub', description: 'Bleeding-edge main' },
+]
+
+const HEAD_SHA = 'abc1234deadbeefcafebabe1234567890abcdef0'
+const HEAD_SHORT = HEAD_SHA.slice(0, 7)
+const BASE_TAG = 'v0.3.55'
+
+function baseInstall(overrides: Partial<InstallationRecord> = {}): InstallationRecord {
+  return {
+    id: 'inst-1',
+    name: 'Test Install',
+    sourceId: 'standalone',
+    installPath: '/tmp/install',
+    status: 'installed',
+    createdAt: Date.now(),
+    comfyVersion: { commit: 'olderoldcommitshahere00000000000000000001', baseTag: BASE_TAG, commitsAhead: 3 },
+    ...overrides,
+  } as InstallationRecord
+}
+
+describe('buildChannelCards — latest channel +commits formatting', () => {
+  beforeEach(() => {
+    vi.mocked(releaseCache.getEffectiveInfo).mockReset()
+    vi.mocked(releaseCache.isUpdateAvailable).mockReset().mockReturnValue(true)
+  })
+
+  it('renders `tag + N commits (sha)` when commitsAhead is enriched', () => {
+    vi.mocked(releaseCache.getEffectiveInfo).mockImplementation((_repo, channel) => {
+      if (channel === 'stable') return null
+      return {
+        installedTag: `${BASE_TAG}+3`,
+        commitSha: HEAD_SHA,
+        baseTag: BASE_TAG,
+        commitsAhead: 12,
+        latestTag: HEAD_SHORT,
+        releaseName: `${BASE_TAG}+12`,
+        checkedAt: Date.now(),
+      }
+    })
+    const cards = buildChannelCards(REPO, DEFS, baseInstall())
+    const latest = cards.find((c) => c.value === 'latest')!
+    expect(latest.data?.latestVersion).toBe(`${BASE_TAG} + 12 commits (${HEAD_SHORT})`)
+  })
+
+  it('renders the bare `tag` when the install is exactly on the latest commit', () => {
+    vi.mocked(releaseCache.getEffectiveInfo).mockImplementation((_repo, channel) => {
+      if (channel === 'stable') return null
+      return {
+        installedTag: BASE_TAG,
+        commitSha: HEAD_SHA,
+        baseTag: BASE_TAG,
+        commitsAhead: 0,
+        latestTag: HEAD_SHORT,
+        checkedAt: Date.now(),
+      }
+    })
+    // Install is sitting on the latest commit — the cv === info.commitSha
+    // branch in buildChannelCards reuses the install's own version data.
+    const install = baseInstall({
+      comfyVersion: { commit: HEAD_SHA, baseTag: BASE_TAG, commitsAhead: 0 },
+    } as Partial<InstallationRecord>)
+    const cards = buildChannelCards(REPO, DEFS, install)
+    const latest = cards.find((c) => c.value === 'latest')!
+    expect(latest.data?.latestVersion).toBe(BASE_TAG)
+  })
+
+  it('falls back to `tag (sha)` only when commitsAhead is undefined (enrichment skipped/failed)', () => {
+    // Regression for the original bug: without enrichment, info.commitsAhead
+    // is undefined and formatComfyVersion emits the uncertainty form.
+    vi.mocked(releaseCache.getEffectiveInfo).mockImplementation((_repo, channel) => {
+      if (channel === 'stable') return null
+      return {
+        installedTag: `${BASE_TAG}+3`,
+        commitSha: HEAD_SHA,
+        baseTag: BASE_TAG,
+        commitsAhead: undefined,
+        latestTag: HEAD_SHORT,
+        checkedAt: Date.now(),
+      }
+    })
+    const cards = buildChannelCards(REPO, DEFS, baseInstall())
+    const latest = cards.find((c) => c.value === 'latest')!
+    expect(latest.data?.latestVersion).toBe(`${BASE_TAG} (${HEAD_SHORT})`)
+  })
+})

--- a/src/main/lib/ipc/registerInstallationHandlers.ts
+++ b/src/main/lib/ipc/registerInstallationHandlers.ts
@@ -9,8 +9,11 @@ import {
   _operationAborts,
   sanitizeEnvVars,
   getComfyArgsSchema,
+  COMFYUI_REPO,
 } from './shared'
 import type { ComfyVersion, ComfyArgDef, InstallationRecord } from './shared'
+import * as releaseCache from '../release-cache'
+import { hasGitDir } from '../git'
 import { restoreSnapshotIntoInstallation } from '../standaloneMigration'
 
 /**
@@ -332,6 +335,20 @@ export function registerInstallationHandlers(): void {
           actions,
         },
       ]
+    }
+    // Resolve commitsAhead for the `latest` channel against the install's
+    // own git checkout before building the channel cards — otherwise the
+    // "Latest from GitHub" preview falls back to `tag (sha)` instead of
+    // `tag+N (sha)`. The enrich helper short-circuits when commitsAhead
+    // is already populated or the install has no git dir, so this is a
+    // no-op for cloud installs and on repeat opens.
+    if (inst.installPath) {
+      const comfyuiDir = path.join(inst.installPath, 'ComfyUI')
+      if (hasGitDir(comfyuiDir)) {
+        try {
+          await releaseCache.enrichCommitsAhead(COMFYUI_REPO, comfyuiDir)
+        } catch { /* enrichment is best-effort; never block the section render */ }
+      }
     }
     return source.getDetailSections(inst)
   })

--- a/src/main/sources/standalone/actions.ts
+++ b/src/main/sources/standalone/actions.ts
@@ -64,12 +64,21 @@ export async function handleAction(
 
     if (signal?.aborted) return { ok: false, message: 'Cancelled' }
 
-    sendOutput('\n── Restore Packages ──\n')
-    const pipResult = await snapshots.restorePipPackages(
-      installation.installPath, installation, targetSnapshot,
-      (phase, data) => sendProgress(phase === 'restore' ? 'restore-pip' : phase, data),
-      sendOutput, signal, settings.getMirrorConfig()
-    )
+    let pipResult: snapshots.RestoreResult = {
+      installed: [], removed: [], changed: [],
+      protectedSkipped: [], failed: [], errors: [],
+    }
+    if (targetSnapshot.skipPipSync) {
+      sendOutput('\n── Restore Packages (skipped: snapshot has skipPipSync) ──\n')
+      sendProgress('restore-pip', { percent: 100, status: 'Skipped' })
+    } else {
+      sendOutput('\n── Restore Packages ──\n')
+      pipResult = await snapshots.restorePipPackages(
+        installation.installPath, installation, targetSnapshot,
+        (phase, data) => sendProgress(phase === 'restore' ? 'restore-pip' : phase, data),
+        sendOutput, signal, settings.getMirrorConfig()
+      )
+    }
 
     // Build combined summary
     const summary: string[] = []

--- a/src/renderer/src/comfyTitlePopup/InstancePickerView.test.ts
+++ b/src/renderer/src/comfyTitlePopup/InstancePickerView.test.ts
@@ -233,7 +233,7 @@ describe('comfyTitlePopup/InstancePickerView', () => {
           makeInstall({
             id: 'a',
             name: 'Alpha',
-            version: '0.20.2+57',
+            version: 'v0.20.2+57',
             sourceLabel: 'GitHub',
           }),
         ],
@@ -247,7 +247,7 @@ describe('comfyTitlePopup/InstancePickerView', () => {
       expect(card.text()).not.toContain('vv0.20.2+57')
     })
 
-    it('does not double-prefix the version pill when version already starts with v', async () => {
+    it('renders the backend version payload verbatim without re-prefixing', async () => {
       const wrapper = await mountPicker({
         installs: [
           makeInstall({ id: 'a', name: 'Alpha', version: 'v0.21.1' }),

--- a/src/renderer/src/comfyTitlePopup/instancePicker/PickerRow.vue
+++ b/src/renderer/src/comfyTitlePopup/instancePicker/PickerRow.vue
@@ -39,11 +39,11 @@ const emit = defineEmits<{
 
 const typeMeta = computed(() => installTypeMetaFor(props.installation.sourceCategory))
 
-const versionLabel = computed(() => {
-  const raw = props.installation.version
-  if (!raw) return ''
-  return raw.startsWith('v') || raw.startsWith('V') ? raw : `v${raw}`
-})
+/** Backend pre-formats `installation.version` via `formatComfyVersion` —
+ *  the string already carries its own `v` prefix when one belongs (tag
+ *  forms) and intentionally omits it for SHA-only / `unknown` fallbacks.
+ *  Render verbatim; do not re-prefix. */
+const versionLabel = computed(() => props.installation.version ?? '')
 
 function handleOpen(): void {
   emit('open', props.installation)

--- a/src/renderer/src/views/comfyUISettings/SnapshotRow.vue
+++ b/src/renderer/src/views/comfyUISettings/SnapshotRow.vue
@@ -40,15 +40,6 @@ const triggerCopy = computed(() => _triggerLabel(props.snapshot.trigger, t))
 const relativeCopy = computed(() => _formatRelative(props.snapshot.createdAt, t))
 const absoluteCopy = computed(() => formatDate(props.snapshot.createdAt))
 
-/** Some snapshot payloads carry `comfyuiVersion` already prefixed with
- *  "v" (e.g. "v0.21.1"), others don't ("0.21.1"). Normalise so we never
- *  render "vv0.21.1" while still leading with "v" for clarity. */
-const versionLabel = computed(() => {
-  const raw = props.snapshot.comfyuiVersion ?? ''
-  if (!raw) return ''
-  return raw.startsWith('v') || raw.startsWith('V') ? raw : `v${raw}`
-})
-
 /** Trigger tone — `state` (post-update / post-restore) is highlighted
  *  because it marks an actual state transition; everything else stays
  *  neutral so the eye is drawn to meaningful changes first. */
@@ -143,7 +134,7 @@ const chips = computed<Chip[]>(() => {
       </div>
 
       <div class="snapshot-row-meta">
-        <span v-if="snapshot.comfyuiVersion">{{ versionLabel }}</span>
+        <span v-if="snapshot.comfyuiVersion">{{ snapshot.comfyuiVersion }}</span>
         <span v-if="snapshot.comfyuiVersion" class="snapshot-row-meta-dot">·</span>
         <span>{{ t('snapshots.nodesCount', { count: snapshot.nodeCount }) }}</span>
         <span class="snapshot-row-meta-dot">·</span>


### PR DESCRIPTION
## What

Real end-to-end lifecycle coverage for the Comfy Desktop 2.0 launcher — zero mocks for the destructive / network ops.

## New E2E test files

| Test | Real ops exercised |
|---|---|
| `lifecycle-snapshot.test.ts` | Snapshot tab rendering + capture via `runAction('snapshot-save')` |
| `lifecycle-delete-untrack.test.ts` | `runAction('remove')` preserves dir; `runAction('delete')` real `fs.rm` (placeholder install) |
| `lifecycle-add-existing.test.ts` | `probeInstallation` + `trackInstallation` against a real pre-staged git repo |
| `lifecycle-migrate.test.ts` | Desktop 1.x auto-detection + `previewDesktopMigration` (scan/stage) on Windows |
| `lifecycle-snapshot-restore.test.ts` | Live `snapshot-restore` against real local bare git repos — moves ComfyUI + custom node HEAD on disk, captures `post-restore` snapshot |
| `lifecycle-update-check.test.ts` | Real `git ls-remote` against `github.com/Comfy-Org/ComfyUI`; verifies channel cards pick up live latest tag + cross-channel prefetch |

## Extensions to `lifecycle.test.ts`

After the existing install + launch + return-to-dashboard + re-launch flow, chains:

- **Real `update-comfyui`**: force ComfyUI HEAD backwards 3 commits via real `git reset --hard`, then `runAction('update-comfyui', { channel: 'stable' })` drives the bundled `update_comfyui.py` (real Python subprocess + real `git fetch` from upstream + real `uv pip install` if requirements crossed). Asserts working-tree HEAD lands ahead of the rolled-back commit.
- **Real `delete` of a fully-installed tree**: stop comfy via return-to-dashboard, then `runAction('delete')` does recursive `fs.rm` against the full ~500MB install (ComfyUI/.git + standalone-env + ComfyUI/.venv). Asserts root + deep file (`ComfyUI/main.py`) are gone on disk, install record removed. Validates the marker-file safety check + recursive rm against the Windows .venv where in-use file locks can fight back.

Replaces the old "stops by closing host window" test (which always closed the only host window and quit the app, preventing delete from running). The `detachInstall` teardown is now covered implicitly by the return-to-dashboard step that sets up delete.

## Supporting changes

- `e2e/support/electronHarness.ts` — `SeedInstallation.snapshots`, `SeedSnapshot.skipPipSync` passthrough, `onSetup` hook for staging platform-specific files (e.g. legacy Desktop `config.json` under sandboxed `%APPDATA%`).
- `src/main/sources/standalone/actions.ts` — `snapshot-restore` honors `targetSnapshot.skipPipSync` (mirrors `restoreSnapshotIntoInstallation` in `standaloneMigration.ts`), so manual restore can skip pip the same way migration restore does.
- Two small product fixes pulled along that were needed to make the e2e tests meaningful:
  - `fix(updates)`: enrich latest-channel commitsAhead before rendering channel cards
  - `fix(version-display)`: trust backend-formatted version strings in picker + snapshot rows

## Verification

Locally:
- `pnpm run typecheck` ✓
- `pnpm run lint` ✓
- `pnpm run build` ✓
- `pnpm run test` ✓ (1099 vitest tests)
- `npx playwright test e2e/lifecycle*.test.ts --project=lifecycle` ✓ (all lifecycle suites pass; full heavy `lifecycle.test.ts` ran 12/12 in 3.5min including the new update + delete steps)

## Notes for review

- The full `lifecycle.test.ts` downloads ~500MB and takes ~3min; lightweight lifecycle tests (`lifecycle-snapshot-restore`, `lifecycle-update-check`, etc.) run in seconds and don't need network beyond `git ls-remote`.
- `lifecycle-update-check.test.ts` is network-dependent (one `git ls-remote` to github.com). It's the only e2e proof that the release-cache → channel-cards pipeline wires up against the real upstream.
