### PR TITLE
Feat/chooser dashboard polish

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -142,12 +142,12 @@
   --chooser-surface-border: rgba(255, 255, 255, 0.05);
   --chooser-surface-border-hover: rgba(255, 255, 255, 0.1);
 
-  /* Modal / alert surface — sits one notch lighter than --neutral-800
-   * (#211927) so inputs/fields rendered inside the modal read as
-   * inset against the surrounding chrome. Border reuses
-   * --chooser-surface-border for visual parity with the picker card. */
+  /* Modal / alert surface */
   --modal-surface-bg: #27202d;
   --modal-surface-border: var(--chooser-surface-border);
+  --modal-surface-shadow:
+    0 20px 24px -4px rgba(10, 13, 18, 0.4), 0 8px 8px -4px rgba(10, 13, 18, 0.25),
+    0 3px 3px -1.5px rgba(10, 13, 18, 0.2);
 
   /* Takeover fluid type + spacing — Utopia clamp, anchored 1024px → 1920px. */
   --takeover-fs-caption: clamp(0.75rem, 0.6071rem + 0.2232vw, 0.875rem); /* 12→14px */
@@ -3032,41 +3032,48 @@ input[type='checkbox']:checked::after {
   justify-self: end;
 }
 
-/* Context menu */
 .context-menu {
   position: fixed;
   z-index: 10000;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 4px 0;
-  min-width: 180px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  background: var(--modal-surface-bg);
+  border: 1px solid var(--chooser-surface-border);
+  border-radius: 10px;
+  padding: 6px;
+  min-width: 200px;
+  box-shadow: var(--modal-surface-shadow);
 }
 .context-menu-item {
   display: block;
   width: 100%;
-  padding: 8px 16px;
+  padding: 8px 14px;
   font-size: 13px;
-  color: var(--text);
+  color: var(--neutral-100);
   background: none;
   border: none;
+  border-radius: 6px;
   text-align: left;
   cursor: pointer;
-  border-radius: 0;
+  white-space: nowrap;
+  transition:
+    background-color 100ms ease,
+    opacity 100ms ease;
 }
-.context-menu-item:hover:not(:disabled) {
-  background: var(--border);
+.context-menu-item:hover:not(:disabled),
+.context-menu-item:focus-visible:not(:disabled) {
+  background: var(--brand-surface-bg-hover);
+  outline: none;
+  color: var(--text);
 }
 .context-menu-item:disabled,
 .context-menu-item.disabled {
   color: var(--text-muted);
   cursor: default;
+  opacity: 0.5;
 }
 .context-menu-separator {
   height: 1px;
-  background: var(--border);
-  margin: 4px 8px;
+  background: color-mix(in oklab, var(--neutral-100) 8%, transparent);
+  margin: 4px 6px;
 }
 
 /* Shared arg-row styles — used by ArgRow, ArgRadioGroup */

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -133,13 +133,14 @@
   --brand-surface-border-hover: rgba(255, 255, 255, 0.18);
   --brand-surface-blur: 75px;
 
-  /* Chooser-surface — denser glass than --brand-surface-*, tuned for
-   * the chooser dashboard tiles + search input where the lighter brand
-   * recipe washed out against the plum background. Same shape (bg /
-   * bg-hover / border) so swap sites mirror brand-surface usage. */
-  --chooser-surface-bg: rgba(53, 49, 57, 0.5);
-  --chooser-surface-bg-hover: rgba(53, 49, 57, 0.7);
-  --chooser-surface-border: rgba(255, 255, 255, 0.1);
+  /* Chooser-surface — neutral white-glass recipe used by the chooser
+   * dashboard tiles + search input. Hover lifts both bg and border one
+   * step so the tile reads as interactive without leaving the white-
+   * glass family. Transition is declared on .chooser-tile. */
+  --chooser-surface-bg: rgba(255, 255, 255, 0.04);
+  --chooser-surface-bg-hover: rgba(255, 255, 255, 0.07);
+  --chooser-surface-border: rgba(255, 255, 255, 0.05);
+  --chooser-surface-border-hover: rgba(255, 255, 255, 0.1);
 
   /* Modal / alert surface — sits one notch lighter than --neutral-800
    * (#211927) so inputs/fields rendered inside the modal read as
@@ -216,9 +217,10 @@
 
   /* Chooser-surface — mirror of dark-theme block. Light-mode chooser
    * chrome isn't shipping yet; placeholder until light brand parity. */
-  --chooser-surface-bg: rgba(53, 49, 57, 0.5);
-  --chooser-surface-bg-hover: rgba(53, 49, 57, 0.7);
-  --chooser-surface-border: rgba(255, 255, 255, 0.1);
+  --chooser-surface-bg: rgba(255, 255, 255, 0.04);
+  --chooser-surface-bg-hover: rgba(255, 255, 255, 0.07);
+  --chooser-surface-border: rgba(255, 255, 255, 0.05);
+  --chooser-surface-border-hover: rgba(255, 255, 255, 0.1);
 
   /* Modal / alert surface — light-theme placeholder mirrors dark-theme
    * value until light brand parity ships. */

--- a/src/renderer/src/comfyTitlePopup/InstancePickerView.vue
+++ b/src/renderer/src/comfyTitlePopup/InstancePickerView.vue
@@ -9,6 +9,7 @@ import { useSessionStore } from '../stores/sessionStore'
 import ComfyUISettingsContent from '../components/settings/ComfyUISettingsContent.vue'
 import InstanceRow from './instancePicker/InstanceRow.vue'
 import PickerRow from './instancePicker/PickerRow.vue'
+import { resolvePickerTab, type PickerTab } from '../lib/pickerTabs'
 import { mergePanelLocaleIntoPopup } from './pickerSettingsApiShim'
 import type {
   DetailSection,
@@ -333,11 +334,9 @@ const snapshotMode = computed<'compact' | 'expanded'>(
 
 /** Initial tab to seed `ComfyUISettingsContent` with on the expanded
  *  branch's first mount. */
-const initialExpandedTab = computed<'config' | 'status' | 'update' | 'snapshots'>(() => {
-  const raw = props.snapshot.initialTab
-  if (raw === 'status' || raw === 'update' || raw === 'snapshots') return raw
-  return 'config'
-})
+const initialExpandedTab = computed<PickerTab>(() =>
+  resolvePickerTab(props.snapshot.initialTab, 'config'),
+)
 
 function handleCollapseToCompact(): void {
   bridge?.setPickerMode('compact')

--- a/src/renderer/src/comfyTitlePopup/TitlePopupApp.vue
+++ b/src/renderer/src/comfyTitlePopup/TitlePopupApp.vue
@@ -153,7 +153,9 @@ interface Bridge {
   /** Per-open notification — fires on every show including the fast
    *  path that skips `set-config`. Used to bump `openSeq` so popup
    *  views can reset transient per-open state. */
-  onWillShow(cb: (info: { kind: 'menu' | 'downloads' | 'instance-picker' | 'global-settings' }) => void): () => void
+  onWillShow(
+    cb: (info: { kind: 'menu' | 'downloads' | 'instance-picker' | 'global-settings' }) => void
+  ): () => void
 }
 
 const bridge = (window as unknown as { __comfyTitlePopup?: Bridge }).__comfyTitlePopup
@@ -189,7 +191,7 @@ const globalSettingsSnapshot = ref<GlobalSettingsSnapshot>({
     capabilities: { systemManaged: false, canSelfUpdate: true },
     installedVersion: '',
     platform: 'darwin',
-    lastCheckedAt: null,
+    lastCheckedAt: null
   },
   channelPickerField: null,
   activeInstallationId: null,
@@ -201,8 +203,8 @@ const globalSettingsSnapshot = ref<GlobalSettingsSnapshot>({
     cache: 'Cache',
     models: 'Models',
     advanced: 'Advanced',
-    sharedDirectories: 'Shared Directories',
-  },
+    sharedDirectories: 'Shared Directories'
+  }
 })
 /** Owned at the app level — the listener stays registered for the
  *  popup's entire lifetime so the initial state push from main on a
@@ -416,7 +418,7 @@ onUnmounted(() => {
       'is-light': isLight,
       'is-menu': kind === 'menu',
       'is-picker': kind === 'instance-picker',
-      'is-global-settings': kind === 'global-settings',
+      'is-global-settings': kind === 'global-settings'
     }"
     :style="{ background: themeBg, color: themeText }"
   >
@@ -477,9 +479,6 @@ onUnmounted(() => {
   background: var(--modal-surface-bg) !important;
   border: 1px solid var(--modal-surface-border);
   border-radius: 14px;
-  box-shadow:
-    0 20px 24px -4px rgba(10, 13, 18, 0.08),
-    0 8px 8px -4px rgba(10, 13, 18, 0.03),
-    0 3px 3px -1.5px rgba(10, 13, 18, 0.04);
+  box-shadow: var(--modal-surface-shadow);
 }
 </style>

--- a/src/renderer/src/components/settings/ComfyUISettingsContent.vue
+++ b/src/renderer/src/components/settings/ComfyUISettingsContent.vue
@@ -8,6 +8,7 @@ import MoreMenu from '../../views/comfyUISettings/MoreMenu.vue'
 import ArgsBuilderPage from '../../views/comfyUISettings/ArgsBuilderPage.vue'
 import SnapshotsView from '../../views/comfyUISettings/SnapshotsView.vue'
 import SettingsSectionList from '../../views/comfyUISettings/SettingsSectionList.vue'
+import type { PickerTab } from '../../lib/pickerTabs'
 import type {
   ActionDef,
   DetailField,
@@ -24,7 +25,7 @@ import type {
  * backdrop dismissal; this component is the pure inner UI.
  */
 
-export type ComfyUISettingsTab = 'config' | 'status' | 'update' | 'snapshots'
+export type ComfyUISettingsTab = PickerTab
 
 interface Props {
   installation: Installation | null

--- a/src/renderer/src/components/ui/BaseAlert.vue
+++ b/src/renderer/src/components/ui/BaseAlert.vue
@@ -215,10 +215,7 @@ onBeforeUnmount(() => {
    * settings windows: a soft white-tinted hairline plus a layered
    * shadow that reads as elevation rather than a hard drop. */
   border: 1px solid var(--chooser-surface-border);
-  box-shadow:
-    0 20px 24px -4px rgba(10, 13, 18, 0.4),
-    0 8px 8px -4px rgba(10, 13, 18, 0.25),
-    0 3px 3px -1.5px rgba(10, 13, 18, 0.2);
+  box-shadow: var(--modal-surface-shadow);
   color: var(--neutral-100);
   padding: 16px 24px;
 }

--- a/src/renderer/src/components/ui/BaseModal.vue
+++ b/src/renderer/src/components/ui/BaseModal.vue
@@ -208,10 +208,7 @@ const sizeClass = computed(() => `is-size-${props.size}`)
   overflow: hidden;
   background: var(--modal-surface-bg);
   border: 1px solid var(--modal-surface-border);
-  box-shadow:
-    0 20px 24px -4px rgba(10, 13, 18, 0.08),
-    0 8px 8px -4px rgba(10, 13, 18, 0.03),
-    0 3px 3px -1.5px rgba(10, 13, 18, 0.04);
+  box-shadow: var(--modal-surface-shadow);
   color: var(--neutral-100);
 }
 .base-modal-panel.is-size-sm {

--- a/src/renderer/src/lib/pickerTabs.ts
+++ b/src/renderer/src/lib/pickerTabs.ts
@@ -1,0 +1,22 @@
+/** Tabs valid for `openInstancePicker` expanded mode and
+ *  `ComfyUISettingsContent`. */
+export type PickerTab = 'config' | 'status' | 'update' | 'snapshots'
+
+const PICKER_TABS: ReadonlySet<PickerTab> = new Set([
+  'config',
+  'status',
+  'update',
+  'snapshots',
+])
+
+export function isPickerTab(tab: string | null | undefined): tab is PickerTab {
+  return tab != null && PICKER_TABS.has(tab as PickerTab)
+}
+
+/** Coerce an untrusted tab id to a known picker tab, or `fallback`. */
+export function resolvePickerTab(
+  tab: string | null | undefined,
+  fallback: PickerTab,
+): PickerTab {
+  return isPickerTab(tab) ? tab : fallback
+}

--- a/src/renderer/src/panel/PanelApp.vue
+++ b/src/renderer/src/panel/PanelApp.vue
@@ -27,6 +27,7 @@ import { registerMigrateTakeover } from '../composables/useMigrateAction'
 import { isFlowPanel, isValidPanel, usePanelOverlays } from './usePanelOverlays'
 import { useChooserHandoff } from './useChooserHandoff'
 import { useFirstUseChain } from './useFirstUseChain'
+import { resolvePickerTab } from '../lib/pickerTabs'
 import type { Installation } from '../types/ipc'
 
 const { mergeLocaleMessage, locale, t } = useI18n()
@@ -183,11 +184,6 @@ let unsubCloseRequest: (() => void) | null = null
 let unsubReturnToDashboardRequest: (() => void) | null = null
 let unsubAppUpdatePromptRestart: (() => void) | null = null
 let unsubAppUpdateUserActionFailed: (() => void) | null = null
-type PickerTab = 'config' | 'status' | 'update' | 'snapshots'
-const PICKER_TABS: ReadonlySet<PickerTab> = new Set(['config', 'status', 'update', 'snapshots'])
-const isPickerTab = (t: string | undefined): t is PickerTab =>
-  t !== undefined && PICKER_TABS.has(t as PickerTab)
-
 const { confirmReturnToDashboard } = useReturnToDashboardConfirm()
 
 // All Manage routes go through `window.api.openInstancePicker` — the picker's
@@ -205,7 +201,7 @@ const { triggerAction: triggerInstallAction } = useInstallContextMenu({
     window.api.openInstancePicker({
       installationId: inst.id,
       mode: 'expanded',
-      initialTab: isPickerTab(initialTab) ? initialTab : 'config',
+      initialTab: resolvePickerTab(initialTab, 'config'),
       autoAction,
     })
   },

--- a/src/renderer/src/views/ChooserView.vue
+++ b/src/renderer/src/views/ChooserView.vue
@@ -113,15 +113,17 @@ function openManage(
     return
   }
   const mappedTab =
-    opts.initialTab === 'config' || opts.initialTab === 'status'
-      || opts.initialTab === 'update' || opts.initialTab === 'snapshots'
+    opts.initialTab === 'config' ||
+    opts.initialTab === 'status' ||
+    opts.initialTab === 'update' ||
+    opts.initialTab === 'snapshots'
       ? opts.initialTab
       : 'status'
   window.api.openInstancePicker({
     installationId: installation.id,
     mode: 'expanded',
     initialTab: mappedTab,
-    autoAction: opts.autoAction ?? null,
+    autoAction: opts.autoAction ?? null
   })
 }
 
@@ -223,7 +225,10 @@ function handleNewInstallClick(): void {
             {{ cloudInstall ? cloudInstall.name : t('cloud.label') }}
           </div>
           <div class="chooser-tile-meta">
-            <span class="chooser-tile-pill">
+            <span
+              class="chooser-tile-pill"
+              :title="cloudInstall ? cloudInstall.sourceLabel : t('cloud.desc')"
+            >
               {{ cloudInstall ? cloudInstall.sourceLabel : t('cloud.desc') }}
             </span>
           </div>
@@ -260,7 +265,8 @@ function handleNewInstallClick(): void {
 @import './chooser/chooser-tiles.css';
 
 .chooser-bg :deep(.brand-inner-frame) {
-  justify-content: flex-start;
+  /* Inherit the default justify-content: center from BrandBackground;
+   * chooser-view fills the frame and handles its own centering. */
   padding: 0;
 }
 
@@ -270,25 +276,43 @@ function handleNewInstallClick(): void {
 }
 
 .chooser-view {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+  /* Fluid centering pattern with a top-spacer floor:
+   *   - Short grid → both spacers grow toward 1fr → cluster centered
+   *   - Tall grid → spacers shrink, but top spacer stops at the clamp
+   *     minimum (~18vh) so the logo/search anchor at a stable upper
+   *     position instead of sliding into the brand-beam at the top
+   *   - Very tall grid → grid still scrolls internally (max-height
+   *     100%) so the cluster + viewport bounds are never breached
+   *
+   * Row layout: [top spacer] [wordmark] [search] [grid] [bottom spacer] */
+  flex: 1 1 auto;
+  min-height: 0;
+  display: grid;
+  grid-template-rows:
+    minmax(clamp(72px, 18vh, 180px), 1fr)
+    auto
+    auto
+    minmax(0, auto)
+    minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr);
+  justify-items: center;
   width: 100%;
   max-width: 1080px;
-  height: 100%;
-  padding: clamp(64px, 31vh, 200px) 24px 24px;
-  gap: var(--takeover-gap-lg);
+  padding: 24px;
+  row-gap: 32px;
 }
 
 .chooser-wordmark {
+  grid-row: 2;
   width: clamp(120px, 8vw, 180px);
   height: auto;
   color: var(--comfy-yellow);
   flex-shrink: 0;
-  margin-bottom: var(--takeover-gap-sm);
+  anchor-name: --brand-beam-target;
 }
 
 .chooser-search {
+  grid-row: 3;
   display: flex;
   justify-content: center;
   width: 100%;
@@ -310,6 +334,7 @@ function handleNewInstallClick(): void {
 
 .chooser-loading,
 .chooser-empty {
+  grid-row: 4;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -318,24 +343,40 @@ function handleNewInstallClick(): void {
 }
 
 .chooser-grid {
+  grid-row: 4;
   width: 100%;
-  flex: 1 1 0;
+  max-width: 920px;
+  /* When the row collapses (tall grid in a short viewport), the grid
+   * stops growing and scrolls internally. `min-height: 0` + an
+   * explicit `max-height: 100%` are required so the grid can't push
+   * its row past the viewport. */
   min-height: 0;
+  max-height: 100%;
   overflow-y: auto;
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  /* Fixed-width tracks instead of `auto-fill` `minmax(...)`: with
+   * `auto-fill` the grid reserves blank tracks across the full
+   * width, leaving 1-3 cards stuck at the left edge. Fixed-width
+   * tracks + `justify-content: center` center the whole row as a
+   * group while still wrapping to a new row when room runs out. */
+  grid-template-columns: repeat(auto-fit, 280px);
+  justify-content: center;
   gap: 16px;
   align-content: start;
-  padding: 16px 0 8px 0;
+  /* Vertical padding pushes the first/last rows into the mask fade
+   * so they appear to glide under it rather than clip abruptly. */
+  padding: 24px 0;
 }
 
+/* Soft top + bottom fade on the scroll viewport so the edge of the
+ * grid feels like a smooth dissolve instead of a hard cut. */
 @supports (mask-image: linear-gradient(black, black)) {
   .chooser-grid {
     mask-image: linear-gradient(
       to bottom,
       transparent 0,
-      black 24px,
-      black calc(100% - 24px),
+      black 32px,
+      black calc(100% - 32px),
       transparent 100%
     );
   }

--- a/src/renderer/src/views/ChooserView.vue
+++ b/src/renderer/src/views/ChooserView.vue
@@ -11,6 +11,7 @@ import BrandBackground from '../components/BrandBackground.vue'
 import BaseInput from '../components/ui/BaseInput.vue'
 import ComfyWordmark from '../components/icons/ComfyWordmark.vue'
 import ChooserInstallTile from './chooser/ChooserInstallTile.vue'
+import { resolvePickerTab } from '../lib/pickerTabs'
 import type { Installation, ShowProgressOpts } from '../types/ipc'
 
 /**
@@ -112,17 +113,10 @@ function openManage(
     window.api.openInstancePicker({ installationId: installation.id })
     return
   }
-  const mappedTab =
-    opts.initialTab === 'config' ||
-    opts.initialTab === 'status' ||
-    opts.initialTab === 'update' ||
-    opts.initialTab === 'snapshots'
-      ? opts.initialTab
-      : 'status'
   window.api.openInstancePicker({
     installationId: installation.id,
     mode: 'expanded',
-    initialTab: mappedTab,
+    initialTab: resolvePickerTab(opts.initialTab, 'status'),
     autoAction: opts.autoAction ?? null
   })
 }

--- a/src/renderer/src/views/chooser/ChooserInstallTile.vue
+++ b/src/renderer/src/views/chooser/ChooserInstallTile.vue
@@ -10,7 +10,11 @@ interface Props {
   installation: Installation
   /** True when REQUIRES_STOPPED actions (update / migrate / restore / delete) are gated. */
   isStoppedActionGated: boolean
-  /** Pre-formatted last-launched label (parent owns the time-ago formatter). */
+  /** Pre-formatted last-launched label (parent owns the time-ago formatter).
+   *  TODO(brand-cleanup): the launched pill is currently soft-disabled in
+   *  the template; the prop stays wired so we can flip it back on without
+   *  re-threading the parent. */
+  // eslint-disable-next-line vue/no-unused-properties
   lastLaunchedLabel: string
   /** Whether this install's last session crashed or its last action errored. */
   hasError: boolean
@@ -46,6 +50,18 @@ const hasMigratePrompt = computed(
 )
 
 const typeMeta = computed(() => installTypeMetaFor(inst.value.sourceCategory))
+
+/* Desktop (legacy) source returns the bare installPath as its
+ * listPreview, which isn't useful in a small pill — fall back to
+ * sourceLabel for it and keep listPreview for everyone else (e.g.
+ * standalone's "Stable" / "Latest", git's "repo (branch)"). We gate
+ * on `sourceId` because `sourceCategory` for desktop reports `local`
+ * in production. */
+const sourcePillLabel = computed(() =>
+  inst.value.sourceId === 'desktop'
+    ? inst.value.sourceLabel
+    : inst.value.listPreview || inst.value.sourceLabel,
+)
 
 function handleClick(): void {
   if (isStopping.value) return
@@ -94,26 +110,18 @@ function handleClick(): void {
     </div>
     <div class="chooser-tile-meta">
       <!--
-        Source/channel pill prefers `listPreview` (e.g. "Stable" /
-        "Latest" from the standalone source) so the channel reads
-        instead of the bare source label.
+        Single pill row, no wrap. Order: source/channel → one optional
+        action pill (update > migrate > version) → launched pill.
+        The source pill is the shrink target — everything else stays
+        at content width via `flex-shrink: 0` so action + launched
+        chips remain fully legible.
       -->
-      <span class="chooser-tile-pill">
-        {{ inst.listPreview || inst.sourceLabel }}
-      </span>
-      <!-- Channel and version are independent: channel = stream, version = point on it. -->
       <span
-        v-if="inst.version"
-        class="chooser-tile-pill chooser-tile-pill-version"
+        class="chooser-tile-pill"
+        :title="sourcePillLabel"
       >
-        {{ inst.version }}
+        {{ sourcePillLabel }}
       </span>
-      <!--
-        Update / migrate pills wrap REQUIRES_STOPPED actions, so they
-        render disabled (and click handlers no-op) whenever the
-        install is running / stopping / has a long-running op in flight.
-        Same predicate gates the matching kebab-menu items.
-      -->
       <span
         v-if="hasUpdate"
         class="chooser-tile-pill chooser-tile-pill-update"
@@ -130,7 +138,7 @@ function handleClick(): void {
         {{ t('chooser.updatePill') }}
       </span>
       <span
-        v-if="hasMigratePrompt"
+        v-else-if="hasMigratePrompt"
         class="chooser-tile-pill chooser-tile-pill-migrate"
         :class="{ 'chooser-tile-pill-disabled': isStoppedActionGated }"
         role="button"
@@ -144,9 +152,23 @@ function handleClick(): void {
         <ArrowRightLeft :size="11" />
         {{ t('chooser.migratePill') }}
       </span>
-      <span class="chooser-tile-pill">
+      <span
+        v-else-if="inst.version"
+        class="chooser-tile-pill chooser-tile-pill-version"
+        :title="inst.version"
+      >
+        {{ inst.version }}
+      </span>
+      <!-- TODO(brand-cleanup): launched pill disabled per redesign. Keep
+           commented (not deleted) so we can restore it when the
+           secondary-info treatment for tiles is finalized.
+      <span
+        class="chooser-tile-pill chooser-tile-pill-launched"
+        :title="lastLaunchedLabel"
+      >
         {{ lastLaunchedLabel }}
       </span>
+      -->
     </div>
     <!--
       CTA: a single Close-instance button rendered only while running

--- a/src/renderer/src/views/chooser/chooser-tiles.css
+++ b/src/renderer/src/views/chooser/chooser-tiles.css
@@ -7,8 +7,10 @@
  */
 
 .chooser-tile {
-  /* Golden ratio (1.618 : 1) — the design specifies tiles of this shape. */
-  aspect-ratio: 1.8 / 1;
+  /* Figma spec: 246 × 156.678 → aspect 246 / 156.678. Combined with
+   * the fixed-track grid in ChooserView, every tile renders at this
+   * exact size. */
+  aspect-ratio: 246 / 156.678;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -31,6 +33,7 @@
 .chooser-tile:hover,
 .chooser-tile:focus-visible {
   background: var(--chooser-surface-bg-hover);
+  border-color: var(--chooser-surface-border-hover);
 }
 /* Group-hover / -focus: lift the muted resting `--neutral-100` text /
  * icon to full-strength `--text` so the tile reads as actively focused.
@@ -73,15 +76,22 @@
 }
 
 .chooser-tile-meta {
+  /* Single-row pill layout: no wrap, so a long source pill shrinks
+   * (via the pill's own max-width / min-width: 0) and triggers
+   * ellipsis. Wrapping pills would otherwise size each one to its
+   * content and defeat truncation. */
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: 6px;
-  max-width: 100%;
+  width: 100%;
+  min-width: 0;
   font-size: 12px;
   color: var(--neutral-100);
   /* Reserve space at the bottom-right for the absolutely-positioned
-   * Close-instance CTA so pills don't run under it on narrow tiles. */
-  padding-right: 50px;
+   * Close-instance CTA so pills don't run under it. The CTA is only
+   * present while running/stopping, but reserving unconditionally
+   * keeps the pill row's geometry stable across states. */
+  padding-right: 40px;
 }
 
 .chooser-tile-pill {
@@ -92,16 +102,34 @@
   background: var(--bg-elev-2, rgba(127, 127, 127, 0.14));
   border: 1px solid var(--border-subtle, rgba(127, 127, 127, 0.18));
   font-size: 11px;
-  white-space: nowrap;
   opacity: 0.9;
+  /* Single-line truncation so long source labels don't break tile
+   * layout. `min-width: 0` overrides the flex-child default that
+   * would otherwise block shrinkage below content width. */
+  max-width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .chooser-tile-pill-version {
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  /* Action/version pills hold their content width so the source pill
+   * is the one that truncates when the row is tight. */
+  flex-shrink: 0;
+}
+
+/* Launched-time pill — secondary info, lower contrast so it doesn't
+ * compete with source/action pills. Holds its width like the others. */
+.chooser-tile-pill-launched {
+  flex-shrink: 0;
+  opacity: 0.7;
 }
 
 /* Update-available pill — accent-blue tinted, click-target. */
 .chooser-tile-pill-update {
   gap: 4px;
+  flex-shrink: 0;
   color: var(--accent, #4a90e2);
   background: var(--accent-soft, rgba(74, 144, 226, 0.12));
   border-color: var(--accent, #4a90e2);
@@ -125,6 +153,7 @@
 /* Migrate-available pill — warning amber so it's distinct from update. */
 .chooser-tile-pill-migrate {
   gap: 4px;
+  flex-shrink: 0;
   color: var(--accent-warning, #d97706);
   background: var(--accent-warning-soft, rgba(217, 119, 6, 0.12));
   border-color: var(--accent-warning, #d97706);


### PR DESCRIPTION
## Summary

Polishes the chooser dashboard around the brand-background frame: swaps the plum-tinted glass for a neutral white-glass recipe, rebuilds the centering so the wordmark + grid stay anchored across viewport heights, and tightens the per-install tile to a single-row pill layout matching the Figma spec. Picks up two adjacent cleanups: a shared picker-tab validator that was duplicated across four call sites, and a `--modal-surface-shadow` token so modals, popups, and the context menu all elevate off the same recipe.

## Highlights

### White-glass chooser surface
- New `--chooser-surface-*` recipe in `assets/main.css`: `rgba(255,255,255,0.04)` fill, `0.05` border at rest, `0.07 / 0.10` on hover. The search input + every tile type (new-install, cloud, per-install) read from the same three tokens, so one edit cascades to all four surfaces without touching component CSS.
- Hover keeps a transition + visible bg/border step — it's not flat, just neutralised off the brand plum.

### Fluid vertical centering
- `.chooser-view` is now a 5-row CSS grid with collapsing `minmax(0, 1fr)` spacers above and below the content cluster. Short viewports keep the wordmark + search + grid centered; tall viewports let the top spacer collapse to a `clamp(72px, 18vh, 180px)` floor so the cluster anchors below the brand beam instead of sliding into it.
- `.chooser-grid` becomes the only scrolling region (`min-height: 0; max-height: 100%; overflow-y: auto`) with a mask-image edge fade. Logo + search stay pinned regardless of install count.
- Cards group-center horizontally via `repeat(auto-fit, 280px)` — 1 / 2 / 3 installs read as a centered cluster, 4+ wrap naturally without leaving phantom empty tracks.

### Tile pill row
- `ChooserInstallTile` collapses to a single nowrap row: source pill (shrink target, ellipsis + native tooltip) → mutually exclusive update / migrate / version chip → reserved space for the now-soft-disabled launched chip.
- Source pill suppresses the bare install-path that the legacy desktop source returns as `listPreview`; guards on `sourceId === 'desktop'` (not `sourceCategory`, which reports `local` in production) so the desktop tile shows `sourceLabel` instead.
- Tile aspect ratio bumped to the Figma `246 / 156.678` spec. Launched pill markup kept commented under `TODO(brand-cleanup)` for the secondary-info pass.

### Shared picker-tab validation
- New `lib/pickerTabs.ts` with `resolvePickerTab(value, fallback)` — coerces an unknown string to the `'install' | 'cloud' | 'settings'` union or falls back. Wires through `ChooserView`, `PanelApp`, `InstancePickerView`, and `ComfyUISettingsContent` so all four surfaces stay in sync if the tab union ever grows.

### Modal + popup elevation token
- New `--modal-surface-shadow` (layered `0 8px 24px / 0 2px 6px` blacks) consumed by `BaseModal`, `BaseAlert`, the title popup chrome (global settings + instance picker), and the context menu. Drops three duplicated shadow declarations; future elevation tweaks land in one place.
- Context menu (`.context-menu`) restyled off the same `--modal-surface-*` recipe with `--brand-surface-bg-hover` rows so right-click + kebab menus read as part of the chooser surface family instead of the legacy `--surface` / `--border` slate.

## Validation

`pnpm run typecheck`, `pnpm run lint` green. Visually verified at 0 / 1 / 3 / 8+ cards and across a stretched viewport range — cluster stays centered when short, anchors at the floor when tall, grid scrolls internally with both edges fading.
