### PR TITLE
fix(#582): UX rollup — stop-confirm modal, in-place relaunch, copy/update destination, settings staleness, delete latency, cloud zip capture, progress error overflow

### DIFF
--- a/e2e/copy-update-destination.test.ts
+++ b/e2e/copy-update-destination.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Copy / copy-update destination focus (issue #582 FLOW 2).
+ *
+ * `handleCopy` / `handleCopyUpdate` / `handleReleaseUpdate` now return
+ * `{ ok: true, navigate: 'list', newInstallationId }` and
+ * `ProgressModal.handleDone` reads `newInstallationId` to call
+ * `window.api.openInstallWindow(newInstallationId)` — opening the
+ * newly-created destination install in its own window without
+ * swapping the source host.
+ *
+ * Test strategy: drive the panel's existing show-progress chain with
+ * a synthetic apiCall that resolves to a success payload carrying
+ * `newInstallationId`. The actual copy handler is bypassed (it's covered
+ * by integration tests + the field is populated unconditionally on
+ * the success path of all three handlers); this exercises the
+ * renderer-side handleDone branch + the main-side
+ * `open-install-window` IPC + the focus-existing-or-open-new
+ * behaviour.
+ */
+
+import os from 'node:os'
+import path from 'node:path'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { test, expect } from '@playwright/test'
+import { launchApp, type AppContext } from './launchApp'
+import { expectChooserVisible } from './support/chooserHelpers'
+import {
+  getIpcInvocations,
+  resetIpcInvocations,
+} from './support/devHooks'
+
+let ctx: AppContext
+let sourcePath: string
+
+const SOURCE_ID = 'inst-copy-source-test'
+const SOURCE_NAME = 'Source Install'
+const DEST_ID = 'inst-copy-destination-test'
+const MARKER_FILENAME = '.comfyui-desktop-2'
+
+test.describe.configure({ mode: 'serial' })
+
+test.beforeAll(async () => {
+  sourcePath = await mkdtemp(path.join(os.tmpdir(), 'comfyui-launcher-copy-dest-e2e-'))
+  await mkdir(sourcePath, { recursive: true })
+  await writeFile(path.join(sourcePath, MARKER_FILENAME), SOURCE_ID)
+
+  ctx = await launchApp({
+    settings: { firstUseCompleted: true, telemetryEnabled: false },
+    installations: [
+      {
+        id: SOURCE_ID,
+        name: SOURCE_NAME,
+        installPath: sourcePath,
+        sourceId: 'standalone',
+        status: 'installed',
+      },
+    ],
+  })
+  await expectChooserVisible(ctx.panel)
+})
+
+test.afterAll(async () => {
+  await ctx?.cleanup()
+  if (sourcePath) await rm(sourcePath, { recursive: true, force: true })
+})
+
+test.beforeEach(async () => {
+  await resetIpcInvocations(ctx.app, 'open-install-window')
+})
+
+test('Copy success opens the destination install in a new window @lifecycle', async () => {
+  // Drive ProgressModal with a synthetic copy result carrying the
+  // destination install id. The renderer's `handleDone` consumes
+  // `op.result.newInstallationId` and calls `openInstallWindow`.
+  await ctx.panel.evaluate<void>(
+    `window.__e2eRenderer.injectProgressSuccess({
+      installationId: ${JSON.stringify(SOURCE_ID)},
+      title: 'Copy — ' + ${JSON.stringify(SOURCE_NAME)},
+      newInstallationId: ${JSON.stringify(DEST_ID)},
+    })`,
+  )
+
+  // The brand loader auto-closes 700ms after `finished`, then
+  // handleDone fires. Poll the recorded IPC invocations.
+  await expect
+    .poll(async () => (await getIpcInvocations(ctx.app, 'open-install-window')).length, {
+      timeout: 5_000,
+      intervals: [100, 250],
+    })
+    .toBeGreaterThanOrEqual(1)
+
+  const calls = await getIpcInvocations(ctx.app, 'open-install-window') as
+    { installationId?: string }[]
+  expect(calls.length).toBe(1)
+  expect(calls[0]?.installationId).toBe(DEST_ID)
+})
+
+test('No newInstallationId → no open-install-window call @lifecycle', async () => {
+  // Same shape but no newInstallationId — should NOT trigger
+  // openInstallWindow. Guards the conditional branch in handleDone
+  // against accidentally firing for non-copy success paths.
+  await ctx.panel.evaluate<void>(
+    `window.__e2eRenderer.injectProgressSuccess({
+      installationId: ${JSON.stringify(SOURCE_ID)},
+      title: 'Other op — ' + ${JSON.stringify(SOURCE_NAME)},
+    })`,
+  )
+
+  // Wait for handleDone's auto-close window to elapse (≥700ms).
+  await new Promise((r) => setTimeout(r, 1_500))
+
+  const calls = await getIpcInvocations(ctx.app, 'open-install-window')
+  expect(calls.length).toBe(0)
+})

--- a/e2e/dashboard-delete-flow.test.ts
+++ b/e2e/dashboard-delete-flow.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Dashboard Delete fast-path E2E (regression for issue #582 fix #4).
+ *
+ * Drives the full chooser-kebab → Delete confirm → ProgressModal →
+ * directory removed flow and asserts:
+ *
+ *   1. The confirm modal renders quickly after Delete is clicked
+ *      (no perceptible stall while a `get-detail-sections` payload is
+ *      rebuilt). The bug shipped a ~2s freeze on Windows because the
+ *      composable round-tripped through `get-detail-sections` just to
+ *      look up the `deleteAction()` shape; the fast path bypasses it.
+ *   2. `get-detail-sections` is NOT invoked during the Delete dispatch
+ *      — asserted via the test-only `__e2e.getIpcInvocations()`
+ *      counter so a future regression that re-introduces the
+ *      roundtrip fails this test rather than re-introducing the
+ *      latency.
+ *   3. The install directory is gone from disk after Confirm, and the
+ *      tile disappears from the chooser.
+ */
+
+import os from 'node:os'
+import path from 'node:path'
+import { access, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { test, expect } from '@playwright/test'
+import { launchApp, type AppContext } from './launchApp'
+import { expectChooserVisible } from './support/chooserHelpers'
+import { byTestId, TID } from './support/testIds'
+import { getIpcInvocations, resetIpcInvocations } from './support/devHooks'
+
+let ctx: AppContext
+let installPath: string
+
+const INSTALL_ID = 'inst-dashboard-delete-test'
+const INSTALL_NAME = 'Delete Fast-Path Me'
+
+/** Mirrors `MARKER_FILE` in `src/main/lib/ipc/shared.ts`. The delete
+ *  action refuses to touch a directory whose marker file is missing. */
+const MARKER_FILENAME = '.comfyui-desktop-2'
+
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await access(p)
+    return true
+  } catch {
+    return false
+  }
+}
+
+test.describe.configure({ mode: 'serial' })
+
+test.beforeAll(async () => {
+  installPath = await mkdtemp(path.join(os.tmpdir(), 'comfyui-launcher-dash-delete-e2e-'))
+  await mkdir(installPath, { recursive: true })
+  await writeFile(path.join(installPath, MARKER_FILENAME), INSTALL_ID)
+
+  ctx = await launchApp({
+    settings: { firstUseCompleted: true, telemetryEnabled: false },
+    installations: [
+      {
+        id: INSTALL_ID,
+        name: INSTALL_NAME,
+        installPath,
+        sourceId: 'standalone',
+        status: 'installed',
+      },
+    ],
+  })
+  await expectChooserVisible(ctx.panel)
+})
+
+test.afterAll(async () => {
+  await ctx?.cleanup()
+  if (installPath) await rm(installPath, { recursive: true, force: true })
+})
+
+test('chooser shows the seeded tile @lifecycle', async () => {
+  await ctx.panel.waitForSelector(byTestId(TID.dashboardTile(INSTALL_ID)), { timeout: 10_000 })
+  expect(await ctx.panel.textOf(`${byTestId(TID.dashboardTile(INSTALL_ID))} .chooser-tile-name`)).toBe(INSTALL_NAME)
+})
+
+test('Delete from kebab opens confirm without invoking get-detail-sections @lifecycle', async () => {
+  // Clear any cumulative invocation history so the assertion measures
+  // only what fires during the Delete dispatch itself.
+  await resetIpcInvocations(ctx.app, 'get-detail-sections')
+
+  // Open the kebab menu on the seeded tile.
+  const kebabClicked = await ctx.panel.click(byTestId(TID.dashboardTileKebab(INSTALL_ID)))
+  expect(kebabClicked, 'kebab button click dispatched').toBe(true)
+
+  // The shared ContextMenu portals to <body>; its Delete item carries
+  // a `context-menu-item-delete` test id.
+  await ctx.panel.waitForVisible(byTestId(TID.contextMenuItem('delete')), { timeout: 5_000 })
+  const deleteClicked = await ctx.panel.click(byTestId(TID.contextMenuItem('delete')))
+  expect(deleteClicked, 'delete menu item click dispatched').toBe(true)
+
+  // The confirm modal must appear — it's a `BaseAlert` simple-confirm.
+  await ctx.panel.waitForVisible(byTestId(TID.baseAlertAction), { timeout: 5_000 })
+
+  // Fast-path assertion: the Delete dispatch must NOT have invoked the
+  // `get-detail-sections` IPC. The bug we're guarding against
+  // re-introduces a roundtrip there to look up the action's confirm
+  // payload, costing ~2s on Windows before the modal can paint.
+  const invocations = await getIpcInvocations(ctx.app, 'get-detail-sections')
+  expect(invocations, 'Delete dispatch must not call get-detail-sections').toEqual([])
+})
+
+test('Confirm removes the install directory and tile @lifecycle', async () => {
+  // Confirm the delete via the BaseAlert primary button.
+  const confirmClicked = await ctx.panel.click(byTestId(TID.baseAlertAction))
+  expect(confirmClicked, 'confirm button click dispatched').toBe(true)
+
+  // Tile disappears from the chooser once the action completes.
+  await ctx.panel.waitFor(
+    async () => !(await ctx.panel.exists(byTestId(TID.dashboardTile(INSTALL_ID)))),
+    { timeout: 30_000, message: 'deleted tile never disappeared from chooser' },
+  )
+
+  // Install directory was removed on disk.
+  await expect
+    .poll(() => pathExists(installPath), { timeout: 30_000, intervals: [250, 500, 1000] })
+    .toBe(false)
+})

--- a/e2e/global-settings-update-action.test.ts
+++ b/e2e/global-settings-update-action.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Global Settings → update-comfyui allowlist regression (issue #582
+ * fix #2).
+ *
+ * The title-bar Global Settings drawer gates install-action IPCs via
+ * `GLOBAL_SETTINGS_ALLOWED_ACTIONS` in `src/main/popups/titlePopup.ts`.
+ * Before the fix the allowlist carried a bare `'update'` id that no
+ * source produces — every click on Update Now returned
+ * `{ ok: false, message: "Action 'update' is not available." }` and
+ * the popup silently swallowed the result. The fix swapped that for
+ * the actual `'update-comfyui'` id the standalone + portable sources
+ * emit.
+ *
+ * This test drives the IPC end-to-end from inside a real Global
+ * Settings popup webContents and asserts the action surfaces SOME
+ * non-allowlist error path — i.e. it is no longer being short-
+ * circuited by the allowlist gate. We do NOT require the action to
+ * succeed (the seeded install isn't a real git checkout, so the
+ * underlying updater would fail) — only that the rejection message
+ * doesn't match the "not available" allowlist shape.
+ */
+
+import os from 'node:os'
+import path from 'node:path'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { test, expect } from '@playwright/test'
+import { launchApp, type AppContext } from './launchApp'
+import { expectChooserVisible } from './support/chooserHelpers'
+import { titlePopupPage, waitForWebContents } from './support/cdpPages'
+
+let ctx: AppContext
+let installPath: string
+
+const INSTALL_ID = 'inst-global-settings-update-test'
+const INSTALL_NAME = 'Global Settings Update Me'
+const MARKER_FILENAME = '.comfyui-desktop-2'
+
+test.describe.configure({ mode: 'serial' })
+
+test.beforeAll(async () => {
+  installPath = await mkdtemp(path.join(os.tmpdir(), 'comfyui-launcher-gs-update-e2e-'))
+  await mkdir(installPath, { recursive: true })
+  await writeFile(path.join(installPath, MARKER_FILENAME), INSTALL_ID)
+
+  ctx = await launchApp({
+    settings: { firstUseCompleted: true, telemetryEnabled: false },
+    installations: [
+      {
+        id: INSTALL_ID,
+        name: INSTALL_NAME,
+        installPath,
+        sourceId: 'standalone',
+        status: 'installed',
+      },
+    ],
+  })
+  await expectChooserVisible(ctx.panel)
+})
+
+test.afterAll(async () => {
+  await ctx?.cleanup()
+  if (installPath) await rm(installPath, { recursive: true, force: true })
+})
+
+test('update-comfyui survives the Global Settings allowlist gate @lifecycle', async () => {
+  // Open the Global Settings drawer (title popup, kind='global-settings').
+  await ctx.panel.evaluate<void>('window.api.openGlobalSettings()')
+
+  // Wait for the popup webContents to mount + the global-settings
+  // root to render. `comfyTitlePopup.html` is shared by every popup
+  // kind (instance-picker / global-settings / waffle / downloads), so
+  // the URL match alone doesn't prove which renderer is mounted —
+  // wait on the kind-specific bridge marker.
+  await waitForWebContents(ctx.app, 'comfyTitlePopup.html')
+  const popup = titlePopupPage(ctx.app)
+  await popup.waitFor(
+    async () => popup.evaluate<boolean>('typeof window.__comfyTitlePopup?.globalSettingsRunInstallAction === "function"'),
+    { timeout: 10_000, message: 'global settings popup bridge never appeared on window.__comfyTitlePopup' },
+  )
+
+  // Drive the gated IPC from inside the popup so the
+  // `popupEntry.kind === 'global-settings'` precondition is satisfied
+  // (the IPC explicitly rejects calls from any other webContents).
+  // The popup process exposes the preload bridge under
+  // `window.__comfyTitlePopup`, NOT `window.api`. Some popup UIs
+  // re-export it as `window.api` after mount, but the bridge global is
+  // the only stable hook we can reach pre-mount.
+  const result = await popup.evaluate<{ ok: boolean; message?: string }>(
+    `window.__comfyTitlePopup.globalSettingsRunInstallAction(${JSON.stringify(INSTALL_ID)}, 'update-comfyui', {})`,
+  )
+
+  // The bug we're guarding against would have produced
+  //   { ok: false, message: "Action 'update-comfyui' is not available." }
+  // exactly. The allowlist fix replaces that with whatever the action
+  // dispatcher returns — typically still `ok: false` for a non-git
+  // seeded install, but with a different message describing the real
+  // failure. Either an ok: true or any non-allowlist error proves the
+  // gate is no longer rejecting the call.
+  const allowlistRejection = `Action 'update-comfyui' is not available.`
+  expect(result.message ?? '', 'allowlist must not reject update-comfyui').not.toBe(allowlistRejection)
+})

--- a/e2e/global-settings-update-action.test.ts
+++ b/e2e/global-settings-update-action.test.ts
@@ -89,13 +89,22 @@ test('update-comfyui survives the Global Settings allowlist gate @lifecycle', as
     `window.__comfyTitlePopup.globalSettingsRunInstallAction(${JSON.stringify(INSTALL_ID)}, 'update-comfyui', {})`,
   )
 
-  // The bug we're guarding against would have produced
-  //   { ok: false, message: "Action 'update-comfyui' is not available." }
-  // exactly. The allowlist fix replaces that with whatever the action
-  // dispatcher returns — typically still `ok: false` for a non-git
-  // seeded install, but with a different message describing the real
-  // failure. Either an ok: true or any non-allowlist error proves the
-  // gate is no longer rejecting the call.
-  const allowlistRejection = `Action 'update-comfyui' is not available.`
-  expect(result.message ?? '', 'allowlist must not reject update-comfyui').not.toBe(allowlistRejection)
+  // The bug we're guarding against produced
+  //   { ok: false, message: "Action '<id>' is not available." }
+  // verbatim from the GLOBAL_SETTINGS_ALLOWED_ACTIONS gate. The
+  // allowlist fix routes `update-comfyui` past the gate into the
+  // action dispatcher; for this non-git seeded install the dispatcher
+  // typically still resolves to `ok: false`, but the message describes
+  // the underlying failure (e.g. "not a git repo", "no remote", ...),
+  // not an allowlist rejection.
+  //
+  // Match the full sentinel shape rather than the literal id so a
+  // typo elsewhere in the chain (e.g. if the action id ever flips
+  // again) doesn't silently pass: the regression we're guarding
+  // against is the gate-level reject for ANY action id, and a
+  // "not available" message at any case is the same class of bug.
+  expect(result, 'IPC must produce a structured action result').toMatchObject({
+    ok: expect.any(Boolean),
+  })
+  expect(result.message ?? '', 'allowlist must not reject the action id').not.toMatch(/not available/i)
 })

--- a/e2e/lifecycle.test.ts
+++ b/e2e/lifecycle.test.ts
@@ -143,9 +143,9 @@ test('accept consent + pick local opens New Install takeover with form pre-fille
     // row works even without expanding — but expand anyway to mirror
     // the real user gesture.
     expect(await ctx.panel.click('.config-advanced__summary')).toBe(true)
-    await ctx.panel.waitForSelector('.config-variant-row', { timeout: 5_000 })
+    await ctx.panel.waitForSelector('.brand-variant-row', { timeout: 5_000 })
     expect(
-      await ctx.panel.clickByText('.config-variant-row', 'CPU'),
+      await ctx.panel.clickByText('.brand-variant-row', 'CPU'),
       'CPU variant row clicked',
     ).toBe(true)
     // Confirm the CPU row is the selected one before continuing —
@@ -154,7 +154,7 @@ test('accept consent + pick local opens New Install takeover with form pre-fille
     await ctx.panel.waitFor(
       async () => ctx.panel.evaluate<boolean>(
         `(() => {
-          const sel = document.querySelector('.config-variant-row--selected .config-variant-row__label')
+          const sel = document.querySelector('.brand-variant-row--selected .brand-variant-row__label')
           return !!sel && /CPU/i.test(sel.textContent || '')
         })()`,
       ),

--- a/e2e/picker-settings-staleness.test.ts
+++ b/e2e/picker-settings-staleness.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Instance-picker right-pane staleness regression (issue #582 fix #1).
+ *
+ * The picker's expanded mode mounts `ComfyUISettingsContent` against
+ * the selected install. Before the fix, clicking a different row left
+ * the previous install's sections painted while the new install's
+ * `get-detail-sections` IPC was still in flight — and a slow
+ * out-of-order resolution could re-stamp install A's sections on top
+ * of B's right pane.
+ *
+ * The fix in `useComfyUISettings`:
+ *
+ *   1. Clears `sections` immediately when `installationId` changes so
+ *      the loading placeholder takes over the right pane during the
+ *      gap.
+ *   2. Stamps every in-flight `get-detail-sections` request with a
+ *      monotonic sequence number and drops any response whose
+ *      sequence has since been superseded.
+ *
+ * This test seeds two installs, opens the picker in expanded mode for
+ * A, then switches to B and asserts that the sections pane's
+ * `data-install-id` never stays on "A" once the switch is initiated
+ * — it must either render the loading placeholder or flip to B's
+ * sections.
+ */
+
+import os from 'node:os'
+import path from 'node:path'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { test, expect } from '@playwright/test'
+import { launchApp, type AppContext } from './launchApp'
+import { expectChooserVisible } from './support/chooserHelpers'
+import { titlePopupPage, waitForWebContents } from './support/cdpPages'
+import { byTestId, TID } from './support/testIds'
+
+let ctx: AppContext
+let installAPath: string
+let installBPath: string
+
+const INSTALL_A_ID = 'inst-picker-a'
+const INSTALL_A_NAME = 'Install A'
+const INSTALL_B_ID = 'inst-picker-b'
+const INSTALL_B_NAME = 'Install B'
+
+const MARKER_FILENAME = '.comfyui-desktop-2'
+
+test.describe.configure({ mode: 'serial' })
+
+test.beforeAll(async () => {
+  installAPath = await mkdtemp(path.join(os.tmpdir(), 'comfyui-launcher-picker-a-e2e-'))
+  installBPath = await mkdtemp(path.join(os.tmpdir(), 'comfyui-launcher-picker-b-e2e-'))
+  await mkdir(installAPath, { recursive: true })
+  await mkdir(installBPath, { recursive: true })
+  await writeFile(path.join(installAPath, MARKER_FILENAME), INSTALL_A_ID)
+  await writeFile(path.join(installBPath, MARKER_FILENAME), INSTALL_B_ID)
+
+  ctx = await launchApp({
+    settings: { firstUseCompleted: true, telemetryEnabled: false },
+    installations: [
+      {
+        id: INSTALL_A_ID,
+        name: INSTALL_A_NAME,
+        installPath: installAPath,
+        sourceId: 'standalone',
+        status: 'installed',
+      },
+      {
+        id: INSTALL_B_ID,
+        name: INSTALL_B_NAME,
+        installPath: installBPath,
+        sourceId: 'standalone',
+        status: 'installed',
+      },
+    ],
+  })
+  await expectChooserVisible(ctx.panel)
+})
+
+test.afterAll(async () => {
+  await ctx?.cleanup()
+  if (installAPath) await rm(installAPath, { recursive: true, force: true })
+  if (installBPath) await rm(installBPath, { recursive: true, force: true })
+})
+
+test('right pane clears stale sections when switching install A → B @lifecycle', async () => {
+  // Open the picker directly in expanded mode, pre-selected on A.
+  // `openInstancePicker` is the same renderer-facing bridge the title
+  // bar uses; we drive it from the panel so we don't have to chase
+  // the title-bar button geometry.
+  const opened = await ctx.panel.evaluate<boolean>(
+    `(() => {
+      window.api.openInstancePicker({
+        installationId: ${JSON.stringify(INSTALL_A_ID)},
+        mode: 'expanded',
+        initialTab: 'config',
+      })
+      return true
+    })()`,
+  )
+  expect(opened).toBe(true)
+
+  await waitForWebContents(ctx.app, 'comfyTitlePopup.html')
+  const popup = titlePopupPage(ctx.app)
+
+  // Wait for A's sections to render in the right pane.
+  await popup.waitForVisible(byTestId(TID.pickerSettingsSections), { timeout: 15_000 })
+  await popup.waitFor(
+    async () => (await popup.evaluate<string | null>(
+      `(() => { const el = document.querySelector('${byTestId(TID.pickerSettingsSections)}'); return el ? el.getAttribute('data-install-id') : null })()`,
+    )) === INSTALL_A_ID,
+    { timeout: 10_000, message: 'right pane never settled on Install A' },
+  )
+
+  // Click Install B's left-pane row.
+  const clickedB = await popup.click(byTestId(TID.pickerRow(INSTALL_B_ID)))
+  expect(clickedB, 'Install B row click dispatched').toBe(true)
+
+  // Staleness assertion: after switching, the sections pane must NOT
+  // still carry A's id. Either the loading placeholder takes over
+  // (sections gone), or the pane flips to B. The bug we're guarding
+  // against would leave A's data-install-id painted while B's IPC
+  // resolves.
+  await popup.waitFor(
+    async () => {
+      const state = await popup.evaluate<{ sectionsId: string | null; loadingVisible: boolean }>(
+        `(() => {
+          const sec = document.querySelector('${byTestId(TID.pickerSettingsSections)}')
+          const sectionsId = sec ? sec.getAttribute('data-install-id') : null
+          const loading = document.querySelector('${byTestId(TID.pickerSettingsLoading)}')
+          return { sectionsId, loadingVisible: !!loading }
+        })()`,
+      )
+      return state.loadingVisible || state.sectionsId === INSTALL_B_ID
+    },
+    {
+      timeout: 5_000,
+      message: 'right pane stayed on Install A after switching to B (stale-data regression)',
+    },
+  )
+
+  // And the pane should eventually settle on B (proves the new IPC
+  // response was applied, not the stale one).
+  await popup.waitFor(
+    async () => (await popup.evaluate<string | null>(
+      `(() => { const el = document.querySelector('${byTestId(TID.pickerSettingsSections)}'); return el ? el.getAttribute('data-install-id') : null })()`,
+    )) === INSTALL_B_ID,
+    { timeout: 15_000, message: 'right pane never settled on Install B after switch' },
+  )
+})

--- a/e2e/picker-stop-confirm.test.ts
+++ b/e2e/picker-stop-confirm.test.ts
@@ -1,51 +1,31 @@
 /**
- * Picker stop-confirm flow regression (issue #582 fix #6).
+ * Picker self-stopping forward flow (issue #582 fix #6 + audit).
  *
  * The instance-picker's expanded right pane (`ComfyUISettingsContent`)
- * dispatches REQUIRES_STOPPED actions (Update Now / Migrate / Restore
- * Snapshot / Delete) against an install that's currently running. The
- * bug shipped four interacting symptoms:
+ * dispatches REQUIRES_STOPPED actions (Update Now / Restore Snapshot /
+ * Copy / Delete) against an install that's currently running. Earlier
+ * the panel-side `useDeepLinkRouter` ran a separate "Stop ComfyUI?"
+ * confirm modal in the panel webContents before invoking the apiCall;
+ * that surface was the ONLY user-visible stop warning anywhere.
  *
- *   1. The stop-confirm modal disappeared mid-interaction — the popup
- *      hosted the modal in its own WebContentsView, which auto-dismisses
- *      on blur, tearing the modal down before the user could resolve it.
- *   2. The title-bar popup geometry visually obscured the panel-side
- *      modal whenever a different surface tried to host the confirm.
- *      Popups are separate OS-level WebContentsViews so CSS z-index
- *      can't lift the panel modal above them.
- *   3. ESC during the stop-confirm closed the wrong layer — the popup
- *      shell / picker view both consumed ESC even when a modal owned
- *      the foreground.
- *   4. The REQUIRES_STOPPED gate had no second guard at the panel-side
- *      forward path, so a renderer bug that fired show-progress without
- *      resolving the popup-side confirm could slip through.
+ * The audit replaced that with:
+ *   - per-action `confirm` / `prompt` copy augmented with the
+ *     `errors.willStopRunning` sentence on the popup side (so the user
+ *     sees the warning inside the action's own dialog);
+ *   - panel-side `useDeepLinkRouter` rebuilds the apiCall to self-stop
+ *     (stop-comfyui → wait → run-action) and, for IN_PLACE_RELAUNCH
+ *     ops (`update-comfyui` / `snapshot-restore`), appends a
+ *     `run-action('launch')` so the user lands back on a live ComfyUI;
+ *   - the standalone stop-confirm modal — and its TID constants — were
+ *     removed, so its visual contract is now "must never appear".
  *
- * The fix routes the stop-confirm out of the popup entirely:
- *
- *   - `useComfyUISettings.runAction` accepts `deferStoppedGuardToHost`
- *     and skips the inline `actionGuard.checkBeforeAction` for the
- *     picker, tagging the emitted `show-progress` with
- *     `requiresStopped: true`.
- *   - The picker forwards the payload through `pickerForwardShowProgress`
- *     → main `comfy-titlepopup:forward-show-progress` → panel
- *     `panel-trigger-overlay { kind: 'picker-show-progress',
- *     requiresStopped }`.
- *   - `useDeepLinkRouter` runs `actionGuard.checkBeforeAction` against
- *     the panel's own `BaseAlert` (stable, not obscured by the popup,
- *     not torn down on popup blur). Cancel aborts the whole chain —
- *     Confirm stops the session then drives the original `apiCall`.
- *   - The popup's ModalDialog + picker ESC handlers defer to a visible
- *     modal so ESC scopes to the dialog instead of collapsing the
- *     picker or closing the popup.
- *
- * Test strategy: drive the production IPC path through the popup
- * bridge, exactly the call `useComfyUISettings.runAction` emits after
- * the fix. We bypass the button click only because rendering a real
- * Update Now CTA requires seeding live release-channel metadata that
- * the standalone source pulls from network — the bridge call is the
- * single chokepoint every Update / Restore / Migrate path goes through,
- * so testing it directly covers every REQUIRES_STOPPED surface the
- * picker exposes.
+ * Test strategy: drive the picker bridge directly, exactly the IPC
+ * payload the popup-side `useComfyUISettings.runAction` emits after the
+ * user accepts the action's own confirm. The bridge call is the single
+ * chokepoint every REQUIRES_STOPPED picker surface goes through (Update
+ * / Restore / Copy / Delete), so testing it directly covers every
+ * forwarded path. We bypass the button click only because rendering a
+ * real Update Now CTA needs seeded live release-channel metadata.
  */
 
 import os from 'node:os'
@@ -60,7 +40,6 @@ import {
   titlePopupPage,
   waitForWebContents,
 } from './support/cdpPages'
-import { byTestId, TID } from './support/testIds'
 import {
   clearRunningSessions,
   getIpcInvocations,
@@ -104,8 +83,6 @@ test.afterAll(async () => {
 })
 
 test.beforeEach(async () => {
-  // Each test starts from a clean popup / IPC counter state so cancel
-  // / confirm assertions don't pick up cross-test residue.
   await closeTitlePopupIfOpen(ctx.app)
   await resetIpcInvocations(ctx.app, 'stop-comfyui')
   await resetIpcInvocations(ctx.app, 'run-action')
@@ -115,9 +92,9 @@ test.beforeEach(async () => {
 /**
  * Open the picker popup in expanded mode for INSTALL_ID and resolve
  * once the popup bridge is exposed. The picker auto-dismiss on blur is
- * benign here — every test fires `pickerForwardShowProgress` from
- * inside the popup itself, which keeps focus there until main hides
- * the popup as part of the forward.
+ * benign here — the bridge call is fired from inside the popup itself,
+ * which keeps focus there until main hides the popup as part of the
+ * forward.
  */
 async function openExpandedPicker(): Promise<void> {
   const opened = await ctx.panel.evaluate<boolean>(
@@ -142,11 +119,11 @@ async function openExpandedPicker(): Promise<void> {
 }
 
 /**
- * Simulate the picker's expanded right pane emitting the
- * `show-progress` request that `useComfyUISettings.runAction` produces
- * for a REQUIRES_STOPPED action when `deferStoppedGuardToHost` is set
- * (the picker's host prop today). Carries `requiresStopped: true` so
- * the panel-side `useDeepLinkRouter` runs the stop-confirm.
+ * Forward an `update-comfyui` show-progress request the way the
+ * popup-side `useComfyUISettings.runAction` emits it after the user
+ * accepts the augmented confirm dialog. No `requiresStopped` flag —
+ * the panel-side `useDeepLinkRouter` derives that from `actionId` plus
+ * the live session-store state.
  */
 async function forwardUpdateActionFromPicker(): Promise<void> {
   const popup = titlePopupPage(ctx.app)
@@ -158,12 +135,11 @@ async function forwardUpdateActionFromPicker(): Promise<void> {
       cancellable: false,
       triggersInstanceStart: false,
       opKind: 'update',
-      requiresStopped: true,
     })`,
   )
 }
 
-test('Cancel on stop-confirm aborts the action and leaves the session running @lifecycle', async () => {
+test('Self-stops the running session and dispatches the action @lifecycle', async () => {
   await seedRunningSession(ctx.app, {
     installationId: INSTALL_ID,
     installationName: INSTALL_NAME,
@@ -171,11 +147,7 @@ test('Cancel on stop-confirm aborts the action and leaves the session running @l
   await openExpandedPicker()
   await forwardUpdateActionFromPicker()
 
-  // Popup hides as soon as main routes the forward IPC — that's the
-  // contract that protects the panel modal from being obscured by the
-  // popup's WebContentsView geometry. Wait for it before asserting
-  // against the modal so we know we're observing the post-forward
-  // state, not a transient overlap.
+  // The popup hides as soon as main routes the forward IPC.
   await expect
     .poll(() => isPopupVisible(ctx.app, 'comfyTitlePopup.html'), {
       timeout: 5_000,
@@ -183,67 +155,13 @@ test('Cancel on stop-confirm aborts the action and leaves the session running @l
     })
     .toBe(false)
 
-  // Panel-side stop-confirm modal appears with the wired test ids —
-  // the registry pattern matches dashboardTile / contextMenuItem.
-  await ctx.panel.waitForVisible(byTestId(TID.stopInstanceConfirmModal), { timeout: 5_000 })
-  expect(await ctx.panel.isVisible(byTestId(TID.stopInstanceConfirmButton))).toBe(true)
-  expect(await ctx.panel.isVisible(byTestId(TID.baseAlertCancel))).toBe(true)
-
-  const cancelled = await ctx.panel.click(byTestId(TID.baseAlertCancel))
-  expect(cancelled, 'BaseAlert cancel button click dispatched').toBe(true)
-  await ctx.panel.waitFor(
-    async () => !(await ctx.panel.exists(byTestId(TID.stopInstanceConfirmModal))),
-    { timeout: 5_000, message: 'stop-confirm modal never closed after Cancel' },
-  )
-
-  // Bug #3 (REQUIRES_STOPPED bypass) guard: Cancel must abort the
-  // entire chain — neither stop-comfyui nor run-action may fire after
-  // the user dismisses the confirm.
-  const stopCalls = await getIpcInvocations(ctx.app, 'stop-comfyui')
-  const runCalls = await getIpcInvocations(ctx.app, 'run-action')
-  expect(stopCalls, 'stop-comfyui must not be invoked when Cancel is clicked').toEqual([])
-  expect(runCalls, 'run-action must not be invoked when Cancel is clicked').toEqual([])
-})
-
-test('Confirm stops the session and dispatches the action @lifecycle', async () => {
-  await seedRunningSession(ctx.app, {
-    installationId: INSTALL_ID,
-    installationName: INSTALL_NAME,
-  })
-  await openExpandedPicker()
-  await forwardUpdateActionFromPicker()
-
-  // Popup hides before the modal appears — same contract as the cancel
-  // test. Without this, a click on the stop-confirm primary action
-  // could race against an open popup geometry and miss.
-  await expect
-    .poll(() => isPopupVisible(ctx.app, 'comfyTitlePopup.html'), {
-      timeout: 5_000,
-      intervals: [100, 200],
-    })
-    .toBe(false)
-
-  await ctx.panel.waitForVisible(byTestId(TID.stopInstanceConfirmButton), { timeout: 5_000 })
-  const confirmed = await ctx.panel.click(byTestId(TID.stopInstanceConfirmButton))
-  expect(confirmed, 'stop-confirm primary button click dispatched').toBe(true)
-
-  // Modal must close on confirm — same lifecycle as Cancel. Without
-  // this gate the next assertion races against the in-flight resolve.
-  await ctx.panel.waitFor(
-    async () => !(await ctx.panel.exists(byTestId(TID.stopInstanceConfirmModal))),
-    { timeout: 5_000, message: 'stop-confirm modal never closed after Confirm' },
-  )
-
-  // The action chain that fires after Confirm:
-  //   1. `window.api.stopComfyUI(id)` — `actionGuard.checkBeforeAction`
-  //      sends this once the user confirms the stop-running prompt.
-  //   2. Internal 500ms settling delay (useActionGuard).
-  //   3. `window.api.runAction(id, 'update-comfyui')` — the original
-  //      `apiCall` rebuilt panel-side from the picker's forwarded
-  //      payload.
-  // Poll on both counters rather than asserting in lock-step so the
-  // intermediate 500ms wait doesn't introduce timing flake on cold
-  // CI runners.
+  // The panel rebuilds the apiCall with the self-stop wrapper:
+  //   1. `window.api.stopComfyUI(id)` (fires once)
+  //   2. wait until the session leaves the running state
+  //   3. `window.api.runAction(id, 'update-comfyui')`
+  //   4. `window.api.runAction(id, 'launch')` because `update-comfyui`
+  //      is in IN_PLACE_RELAUNCH — without this the user is left
+  //      staring at a stopped ComfyUI after an update.
   await expect
     .poll(async () => (await getIpcInvocations(ctx.app, 'stop-comfyui')).length, {
       timeout: 5_000,
@@ -255,15 +173,50 @@ test('Confirm stops the session and dispatches the action @lifecycle', async () 
       timeout: 10_000,
       intervals: [200, 500],
     })
+    .toBeGreaterThanOrEqual(2)
+
+  const runCalls = await getIpcInvocations(ctx.app, 'run-action') as
+    { installationId?: string; actionId?: string }[]
+  expect(runCalls.length).toBeGreaterThanOrEqual(2)
+  expect(runCalls[0]?.installationId).toBe(INSTALL_ID)
+  expect(runCalls[0]?.actionId).toBe('update-comfyui')
+  expect(runCalls[1]?.installationId).toBe(INSTALL_ID)
+  expect(runCalls[1]?.actionId).toBe('launch')
+
+  // stop-comfyui fires exactly once — duplicate stops would point at a
+  // regression where both useDeepLinkRouter and the (now-removed)
+  // standalone stop-confirm modal tried to stop the session.
+  const stopCalls = await getIpcInvocations(ctx.app, 'stop-comfyui')
+  expect(stopCalls.length).toBe(1)
+})
+
+test('Skips self-stop when the install is NOT running @lifecycle', async () => {
+  // Same forward, but no seeded running session. The panel must skip
+  // the stop-comfyui step (nothing to stop) AND skip the relaunch (no
+  // session was open to begin with — the user wouldn't expect a
+  // ComfyUI launch off a stopped install just because they updated it).
+  await openExpandedPicker()
+  await forwardUpdateActionFromPicker()
+
+  await expect
+    .poll(() => isPopupVisible(ctx.app, 'comfyTitlePopup.html'), {
+      timeout: 5_000,
+      intervals: [100, 200],
+    })
+    .toBe(false)
+
+  await expect
+    .poll(async () => (await getIpcInvocations(ctx.app, 'run-action')).length, {
+      timeout: 10_000,
+      intervals: [200, 500],
+    })
     .toBeGreaterThanOrEqual(1)
 
-  // Bug #4 guard: the run-action invocation must carry the original
-  // action id against the original install; the panel must not silently
-  // drop the action payload or route a different action while
-  // resolving the stop-confirm.
-  const runCalls = await getIpcInvocations(ctx.app, 'run-action')
-  const recorded = runCalls[0] as { installationId?: string; actionId?: string } | undefined
-  expect(recorded, 'run-action invocation recorded').toBeTruthy()
-  expect(recorded?.installationId).toBe(INSTALL_ID)
-  expect(recorded?.actionId).toBe('update-comfyui')
+  const stopCalls = await getIpcInvocations(ctx.app, 'stop-comfyui')
+  expect(stopCalls.length).toBe(0)
+
+  const runCalls = await getIpcInvocations(ctx.app, 'run-action') as
+    { installationId?: string; actionId?: string }[]
+  expect(runCalls.length).toBe(1)
+  expect(runCalls[0]?.actionId).toBe('update-comfyui')
 })

--- a/e2e/picker-stop-confirm.test.ts
+++ b/e2e/picker-stop-confirm.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Picker stop-confirm flow regression (issue #582 fix #6).
+ *
+ * The instance-picker's expanded right pane (`ComfyUISettingsContent`)
+ * dispatches REQUIRES_STOPPED actions (Update Now / Migrate / Restore
+ * Snapshot / Delete) against an install that's currently running. The
+ * bug shipped four interacting symptoms:
+ *
+ *   1. The stop-confirm modal disappeared mid-interaction — the popup
+ *      hosted the modal in its own WebContentsView, which auto-dismisses
+ *      on blur, tearing the modal down before the user could resolve it.
+ *   2. The title-bar popup geometry visually obscured the panel-side
+ *      modal whenever a different surface tried to host the confirm.
+ *      Popups are separate OS-level WebContentsViews so CSS z-index
+ *      can't lift the panel modal above them.
+ *   3. ESC during the stop-confirm closed the wrong layer — the popup
+ *      shell / picker view both consumed ESC even when a modal owned
+ *      the foreground.
+ *   4. The REQUIRES_STOPPED gate had no second guard at the panel-side
+ *      forward path, so a renderer bug that fired show-progress without
+ *      resolving the popup-side confirm could slip through.
+ *
+ * The fix routes the stop-confirm out of the popup entirely:
+ *
+ *   - `useComfyUISettings.runAction` accepts `deferStoppedGuardToHost`
+ *     and skips the inline `actionGuard.checkBeforeAction` for the
+ *     picker, tagging the emitted `show-progress` with
+ *     `requiresStopped: true`.
+ *   - The picker forwards the payload through `pickerForwardShowProgress`
+ *     → main `comfy-titlepopup:forward-show-progress` → panel
+ *     `panel-trigger-overlay { kind: 'picker-show-progress',
+ *     requiresStopped }`.
+ *   - `useDeepLinkRouter` runs `actionGuard.checkBeforeAction` against
+ *     the panel's own `BaseAlert` (stable, not obscured by the popup,
+ *     not torn down on popup blur). Cancel aborts the whole chain —
+ *     Confirm stops the session then drives the original `apiCall`.
+ *   - The popup's ModalDialog + picker ESC handlers defer to a visible
+ *     modal so ESC scopes to the dialog instead of collapsing the
+ *     picker or closing the popup.
+ *
+ * Test strategy: drive the production IPC path through the popup
+ * bridge, exactly the call `useComfyUISettings.runAction` emits after
+ * the fix. We bypass the button click only because rendering a real
+ * Update Now CTA requires seeding live release-channel metadata that
+ * the standalone source pulls from network — the bridge call is the
+ * single chokepoint every Update / Restore / Migrate path goes through,
+ * so testing it directly covers every REQUIRES_STOPPED surface the
+ * picker exposes.
+ */
+
+import os from 'node:os'
+import path from 'node:path'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { test, expect } from '@playwright/test'
+import { launchApp, type AppContext } from './launchApp'
+import { expectChooserVisible } from './support/chooserHelpers'
+import {
+  closeTitlePopupIfOpen,
+  isPopupVisible,
+  titlePopupPage,
+  waitForWebContents,
+} from './support/cdpPages'
+import { byTestId, TID } from './support/testIds'
+import {
+  clearRunningSessions,
+  getIpcInvocations,
+  resetIpcInvocations,
+  seedRunningSession,
+} from './support/devHooks'
+
+let ctx: AppContext
+let installPath: string
+
+const INSTALL_ID = 'inst-picker-stop-confirm-test'
+const INSTALL_NAME = 'Stop Me Before Updating'
+const MARKER_FILENAME = '.comfyui-desktop-2'
+
+test.describe.configure({ mode: 'serial' })
+
+test.beforeAll(async () => {
+  installPath = await mkdtemp(path.join(os.tmpdir(), 'comfyui-launcher-stop-confirm-e2e-'))
+  await mkdir(installPath, { recursive: true })
+  await writeFile(path.join(installPath, MARKER_FILENAME), INSTALL_ID)
+
+  ctx = await launchApp({
+    settings: { firstUseCompleted: true, telemetryEnabled: false },
+    installations: [
+      {
+        id: INSTALL_ID,
+        name: INSTALL_NAME,
+        installPath,
+        sourceId: 'standalone',
+        status: 'installed',
+      },
+    ],
+  })
+  await expectChooserVisible(ctx.panel)
+})
+
+test.afterAll(async () => {
+  await clearRunningSessions(ctx.app)
+  await ctx?.cleanup()
+  if (installPath) await rm(installPath, { recursive: true, force: true })
+})
+
+test.beforeEach(async () => {
+  // Each test starts from a clean popup / IPC counter state so cancel
+  // / confirm assertions don't pick up cross-test residue.
+  await closeTitlePopupIfOpen(ctx.app)
+  await resetIpcInvocations(ctx.app, 'stop-comfyui')
+  await resetIpcInvocations(ctx.app, 'run-action')
+  await clearRunningSessions(ctx.app)
+})
+
+/**
+ * Open the picker popup in expanded mode for INSTALL_ID and resolve
+ * once the popup bridge is exposed. The picker auto-dismiss on blur is
+ * benign here — every test fires `pickerForwardShowProgress` from
+ * inside the popup itself, which keeps focus there until main hides
+ * the popup as part of the forward.
+ */
+async function openExpandedPicker(): Promise<void> {
+  const opened = await ctx.panel.evaluate<boolean>(
+    `(() => {
+      window.api.openInstancePicker({
+        installationId: ${JSON.stringify(INSTALL_ID)},
+        mode: 'expanded',
+        initialTab: 'update',
+      })
+      return true
+    })()`,
+  )
+  expect(opened).toBe(true)
+  await waitForWebContents(ctx.app, 'comfyTitlePopup.html')
+  const popup = titlePopupPage(ctx.app)
+  await popup.waitFor(
+    async () => popup.evaluate<boolean>(
+      'typeof window.__comfyTitlePopup?.pickerForwardShowProgress === "function"',
+    ),
+    { timeout: 10_000, message: 'picker popup bridge never appeared on window.__comfyTitlePopup' },
+  )
+}
+
+/**
+ * Simulate the picker's expanded right pane emitting the
+ * `show-progress` request that `useComfyUISettings.runAction` produces
+ * for a REQUIRES_STOPPED action when `deferStoppedGuardToHost` is set
+ * (the picker's host prop today). Carries `requiresStopped: true` so
+ * the panel-side `useDeepLinkRouter` runs the stop-confirm.
+ */
+async function forwardUpdateActionFromPicker(): Promise<void> {
+  const popup = titlePopupPage(ctx.app)
+  await popup.evaluate<void>(
+    `window.__comfyTitlePopup.pickerForwardShowProgress({
+      installationId: ${JSON.stringify(INSTALL_ID)},
+      actionId: 'update-comfyui',
+      title: 'Update ComfyUI — ' + ${JSON.stringify(INSTALL_NAME)},
+      cancellable: false,
+      triggersInstanceStart: false,
+      opKind: 'update',
+      requiresStopped: true,
+    })`,
+  )
+}
+
+test('Cancel on stop-confirm aborts the action and leaves the session running @lifecycle', async () => {
+  await seedRunningSession(ctx.app, {
+    installationId: INSTALL_ID,
+    installationName: INSTALL_NAME,
+  })
+  await openExpandedPicker()
+  await forwardUpdateActionFromPicker()
+
+  // Popup hides as soon as main routes the forward IPC — that's the
+  // contract that protects the panel modal from being obscured by the
+  // popup's WebContentsView geometry. Wait for it before asserting
+  // against the modal so we know we're observing the post-forward
+  // state, not a transient overlap.
+  await expect
+    .poll(() => isPopupVisible(ctx.app, 'comfyTitlePopup.html'), {
+      timeout: 5_000,
+      intervals: [100, 200],
+    })
+    .toBe(false)
+
+  // Panel-side stop-confirm modal appears with the wired test ids —
+  // the registry pattern matches dashboardTile / contextMenuItem.
+  await ctx.panel.waitForVisible(byTestId(TID.stopInstanceConfirmModal), { timeout: 5_000 })
+  expect(await ctx.panel.isVisible(byTestId(TID.stopInstanceConfirmButton))).toBe(true)
+  expect(await ctx.panel.isVisible(byTestId(TID.baseAlertCancel))).toBe(true)
+
+  const cancelled = await ctx.panel.click(byTestId(TID.baseAlertCancel))
+  expect(cancelled, 'BaseAlert cancel button click dispatched').toBe(true)
+  await ctx.panel.waitFor(
+    async () => !(await ctx.panel.exists(byTestId(TID.stopInstanceConfirmModal))),
+    { timeout: 5_000, message: 'stop-confirm modal never closed after Cancel' },
+  )
+
+  // Bug #3 (REQUIRES_STOPPED bypass) guard: Cancel must abort the
+  // entire chain — neither stop-comfyui nor run-action may fire after
+  // the user dismisses the confirm.
+  const stopCalls = await getIpcInvocations(ctx.app, 'stop-comfyui')
+  const runCalls = await getIpcInvocations(ctx.app, 'run-action')
+  expect(stopCalls, 'stop-comfyui must not be invoked when Cancel is clicked').toEqual([])
+  expect(runCalls, 'run-action must not be invoked when Cancel is clicked').toEqual([])
+})
+
+test('Confirm stops the session and dispatches the action @lifecycle', async () => {
+  await seedRunningSession(ctx.app, {
+    installationId: INSTALL_ID,
+    installationName: INSTALL_NAME,
+  })
+  await openExpandedPicker()
+  await forwardUpdateActionFromPicker()
+
+  // Popup hides before the modal appears — same contract as the cancel
+  // test. Without this, a click on the stop-confirm primary action
+  // could race against an open popup geometry and miss.
+  await expect
+    .poll(() => isPopupVisible(ctx.app, 'comfyTitlePopup.html'), {
+      timeout: 5_000,
+      intervals: [100, 200],
+    })
+    .toBe(false)
+
+  await ctx.panel.waitForVisible(byTestId(TID.stopInstanceConfirmButton), { timeout: 5_000 })
+  const confirmed = await ctx.panel.click(byTestId(TID.stopInstanceConfirmButton))
+  expect(confirmed, 'stop-confirm primary button click dispatched').toBe(true)
+
+  // Modal must close on confirm — same lifecycle as Cancel. Without
+  // this gate the next assertion races against the in-flight resolve.
+  await ctx.panel.waitFor(
+    async () => !(await ctx.panel.exists(byTestId(TID.stopInstanceConfirmModal))),
+    { timeout: 5_000, message: 'stop-confirm modal never closed after Confirm' },
+  )
+
+  // The action chain that fires after Confirm:
+  //   1. `window.api.stopComfyUI(id)` — `actionGuard.checkBeforeAction`
+  //      sends this once the user confirms the stop-running prompt.
+  //   2. Internal 500ms settling delay (useActionGuard).
+  //   3. `window.api.runAction(id, 'update-comfyui')` — the original
+  //      `apiCall` rebuilt panel-side from the picker's forwarded
+  //      payload.
+  // Poll on both counters rather than asserting in lock-step so the
+  // intermediate 500ms wait doesn't introduce timing flake on cold
+  // CI runners.
+  await expect
+    .poll(async () => (await getIpcInvocations(ctx.app, 'stop-comfyui')).length, {
+      timeout: 5_000,
+      intervals: [100, 250],
+    })
+    .toBeGreaterThanOrEqual(1)
+  await expect
+    .poll(async () => (await getIpcInvocations(ctx.app, 'run-action')).length, {
+      timeout: 10_000,
+      intervals: [200, 500],
+    })
+    .toBeGreaterThanOrEqual(1)
+
+  // Bug #4 guard: the run-action invocation must carry the original
+  // action id against the original install; the panel must not silently
+  // drop the action payload or route a different action while
+  // resolving the stop-confirm.
+  const runCalls = await getIpcInvocations(ctx.app, 'run-action')
+  const recorded = runCalls[0] as { installationId?: string; actionId?: string } | undefined
+  expect(recorded, 'run-action invocation recorded').toBeTruthy()
+  expect(recorded?.installationId).toBe(INSTALL_ID)
+  expect(recorded?.actionId).toBe('update-comfyui')
+})

--- a/e2e/picker-stop-confirm.test.ts
+++ b/e2e/picker-stop-confirm.test.ts
@@ -87,6 +87,21 @@ test.beforeEach(async () => {
   await resetIpcInvocations(ctx.app, 'stop-comfyui')
   await resetIpcInvocations(ctx.app, 'run-action')
   await clearRunningSessions(ctx.app)
+  // `clearRunningSessions` returns when main has cleared its
+  // `_runningSessions` map, but the resulting `instance-stopped`
+  // broadcast still has to round-trip into the panel webContents
+  // before the renderer's sessionStore sees the install as stopped.
+  // useDeepLinkRouter captures `wasRunning` once at apiCall creation,
+  // so polling here is the difference between a clean test and a
+  // false-positive self-stop carried over from the previous run.
+  await expect
+    .poll(
+      async () => ctx.panel.evaluate<boolean>(
+        `(() => window.__e2eRenderer?.isRunning(${JSON.stringify(INSTALL_ID)}) ?? true)()`,
+      ),
+      { timeout: 5_000, intervals: [100, 200] },
+    )
+    .toBe(false)
 })
 
 /**
@@ -159,9 +174,13 @@ test('Self-stops the running session and dispatches the action @lifecycle', asyn
   //   1. `window.api.stopComfyUI(id)` (fires once)
   //   2. wait until the session leaves the running state
   //   3. `window.api.runAction(id, 'update-comfyui')`
-  //   4. `window.api.runAction(id, 'launch')` because `update-comfyui`
-  //      is in IN_PLACE_RELAUNCH — without this the user is left
-  //      staring at a stopped ComfyUI after an update.
+  //
+  // The IN_PLACE_RELAUNCH append (`run-action('launch')` after a
+  // successful update) is gated on `result?.ok !== false`. The test
+  // install has no real release-channel metadata so the standalone
+  // source-side update-comfyui handler returns `{ ok: false }` and
+  // the relaunch is intentionally skipped — covered by the
+  // FLOW 1 unit tests instead.
   await expect
     .poll(async () => (await getIpcInvocations(ctx.app, 'stop-comfyui')).length, {
       timeout: 5_000,
@@ -173,15 +192,13 @@ test('Self-stops the running session and dispatches the action @lifecycle', asyn
       timeout: 10_000,
       intervals: [200, 500],
     })
-    .toBeGreaterThanOrEqual(2)
+    .toBeGreaterThanOrEqual(1)
 
   const runCalls = await getIpcInvocations(ctx.app, 'run-action') as
     { installationId?: string; actionId?: string }[]
-  expect(runCalls.length).toBeGreaterThanOrEqual(2)
+  expect(runCalls.length).toBeGreaterThanOrEqual(1)
   expect(runCalls[0]?.installationId).toBe(INSTALL_ID)
   expect(runCalls[0]?.actionId).toBe('update-comfyui')
-  expect(runCalls[1]?.installationId).toBe(INSTALL_ID)
-  expect(runCalls[1]?.actionId).toBe('launch')
 
   // stop-comfyui fires exactly once — duplicate stops would point at a
   // regression where both useDeepLinkRouter and the (now-removed)

--- a/e2e/progress-error-overflow.test.ts
+++ b/e2e/progress-error-overflow.test.ts
@@ -1,0 +1,118 @@
+/**
+ * ProgressModal error-message overflow regression (issue #582 fix #7).
+ *
+ * A long failure message previously stretched the brand-progress
+ * `.brand-progress__error-message` div unbounded, blowing the modal
+ * footer off-screen on smaller heights. The fix added
+ * `max-height: clamp(120px, 22vh, 240px)` + `overflow-y: auto` so the
+ * block scrolls internally instead.
+ *
+ * This is a layout regression that jsdom can't compute, so it lives
+ * here rather than in unit tests. We seed an install, drive the
+ * renderer's `injectProgressError` dev hook with a paragraph
+ * ~5,000 chars long, and assert on the actual computed style + the
+ * scroll/client-height delta proves the cap took effect.
+ */
+
+import os from 'node:os'
+import path from 'node:path'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { test, expect } from '@playwright/test'
+import { launchApp, type AppContext } from './launchApp'
+import { expectChooserVisible } from './support/chooserHelpers'
+import { byTestId, TID } from './support/testIds'
+
+let ctx: AppContext
+let installPath: string
+
+const INSTALL_ID = 'inst-progress-error-test'
+const INSTALL_NAME = 'Progress Error Me'
+const MARKER_FILENAME = '.comfyui-desktop-2'
+
+/** Long enough that the natural rendered height comfortably exceeds
+ *  240px even at the smallest viewport widths the harness uses. Built
+ *  as repeated sentences rather than a single non-breaking token so
+ *  wrapping behaves like a real error trace. */
+const LONG_ERROR = Array.from({ length: 80 })
+  .map((_, i) => `Step ${i + 1}: simulated long failure output that would normally fill many lines of the error block and force the modal to scroll on small windows.`)
+  .join(' ')
+
+test.describe.configure({ mode: 'serial' })
+
+test.beforeAll(async () => {
+  installPath = await mkdtemp(path.join(os.tmpdir(), 'comfyui-launcher-progress-error-e2e-'))
+  await mkdir(installPath, { recursive: true })
+  await writeFile(path.join(installPath, MARKER_FILENAME), INSTALL_ID)
+
+  ctx = await launchApp({
+    settings: { firstUseCompleted: true, telemetryEnabled: false },
+    installations: [
+      {
+        id: INSTALL_ID,
+        name: INSTALL_NAME,
+        installPath,
+        sourceId: 'standalone',
+        status: 'installed',
+      },
+    ],
+  })
+  await expectChooserVisible(ctx.panel)
+})
+
+test.afterAll(async () => {
+  await ctx?.cleanup()
+  if (installPath) await rm(installPath, { recursive: true, force: true })
+})
+
+test('ProgressModal error block caps its height and scrolls @lifecycle', async () => {
+  // Drive the renderer-side dev hook: opens the ProgressModal overlay
+  // for the seeded install and resolves the apiCall immediately with
+  // `{ ok: false, message: LONG_ERROR }` so the store writes the long
+  // string into `currentOp.error`.
+  await ctx.panel.evaluate<void>(`(async () => {
+    await window.__e2eRenderer.injectProgressError({
+      installationId: ${JSON.stringify(INSTALL_ID)},
+      title: 'Test failing op',
+      errorMessage: ${JSON.stringify(LONG_ERROR)},
+    })
+  })()`)
+
+  // Wait for the error message element to mount.
+  await ctx.panel.waitForVisible(byTestId(TID.progressErrorMessage), { timeout: 10_000 })
+
+  // Read the layout state of the error block. The fix is purely CSS,
+  // so the assertion is purely on computed style + measured DOM.
+  const layout = await ctx.panel.evaluate<{
+    clientHeight: number
+    scrollHeight: number
+    maxHeightPx: number | null
+    overflowY: string
+    textLength: number
+  }>(`(() => {
+    const el = document.querySelector('${byTestId(TID.progressErrorMessage)}')
+    if (!el) return null
+    const cs = getComputedStyle(el)
+    const maxH = parseFloat(cs.maxHeight)
+    return {
+      clientHeight: el.clientHeight,
+      scrollHeight: el.scrollHeight,
+      maxHeightPx: Number.isFinite(maxH) ? maxH : null,
+      overflowY: cs.overflowY,
+      textLength: (el.textContent || '').length,
+    }
+  })()`)
+
+  expect(layout, 'progress error message element layout query returned null').not.toBeNull()
+  // Sanity-check the helper delivered the long message.
+  expect(layout.textLength).toBeGreaterThan(2_000)
+  // The fix uses `clamp(120px, 22vh, 240px)`. The upper bound is 240
+  // — assert clientHeight is strictly below that with a small fudge
+  // for browser sub-pixel rounding.
+  expect(layout.clientHeight, 'error block should not exceed the 240px clamp').toBeLessThanOrEqual(241)
+  // The content must overflow vertically — that's what proves the cap
+  // is real (otherwise the block would just grow to fit).
+  expect(layout.scrollHeight, 'error block scrollHeight must exceed clientHeight (overflow active)')
+    .toBeGreaterThan(layout.clientHeight)
+  // Style: scrolling is enabled.
+  expect(layout.overflowY).toBe('auto')
+})

--- a/e2e/support/devHooks.ts
+++ b/e2e/support/devHooks.ts
@@ -149,3 +149,28 @@ export async function resetShellOpenExternalCalls(app: ElectronApplication): Pro
     helpers.resetShellOpenExternalCalls()
   }))
 }
+
+/** Register a synthetic running session against `installationId` so the
+ *  REQUIRES_STOPPED guard fires (main side) and `sessionStore.isRunning`
+ *  flips true (renderer side) without spawning a real ComfyUI process. */
+export async function seedRunningSession(
+  app: ElectronApplication,
+  opts: { installationId: string; installationName: string },
+): Promise<void> {
+  await evalWithRetry(() => app.evaluate((_electron, o) => {
+    const helpers = (globalThis as unknown as {
+      __e2e?: { seedRunningSession: (o: unknown) => void }
+    }).__e2e
+    if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
+    helpers.seedRunningSession(o)
+  }, opts))
+}
+
+/** Drop every synthetic session seeded via `seedRunningSession`. */
+export async function clearRunningSessions(app: ElectronApplication): Promise<void> {
+  await evalWithRetry(() => app.evaluate(() => {
+    const helpers = (globalThis as unknown as { __e2e?: { clearRunningSessions: () => void } }).__e2e
+    if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
+    helpers.clearRunningSessions()
+  }))
+}

--- a/e2e/support/devHooks.ts
+++ b/e2e/support/devHooks.ts
@@ -103,3 +103,49 @@ export async function returnFirstInstallHostToDashboard(
     return helpers.returnFirstInstallHostToDashboard()
   }))
 }
+
+/** Recorded arguments for an instrumented IPC channel since the last
+ *  reset. Lets tests assert that a fast-path code path skipped a
+ *  costly handler invocation. */
+export async function getIpcInvocations(
+  app: ElectronApplication,
+  channel: string,
+): Promise<unknown[]> {
+  return await evalWithRetry(() => app.evaluate((_electron, c) => {
+    const helpers = (globalThis as unknown as { __e2e?: { getIpcInvocations: (c: string) => unknown[] } }).__e2e
+    if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
+    return helpers.getIpcInvocations(c)
+  }, channel))
+}
+
+export async function resetIpcInvocations(
+  app: ElectronApplication,
+  channel?: string,
+): Promise<void> {
+  await evalWithRetry(() => app.evaluate((_electron, c) => {
+    const helpers = (globalThis as unknown as { __e2e?: { resetIpcInvocations: (c?: string) => void } }).__e2e
+    if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
+    helpers.resetIpcInvocations(c)
+  }, channel))
+}
+
+/** URLs captured by the launcher's `shell.openExternal` wrapper while
+ *  E2E mode is active. Used by the cloud-zip test to assert a download
+ *  was captured locally instead of bouncing out to the OS browser. */
+export async function getShellOpenExternalCalls(
+  app: ElectronApplication,
+): Promise<string[]> {
+  return await evalWithRetry(() => app.evaluate(() => {
+    const helpers = (globalThis as unknown as { __e2e?: { getShellOpenExternalCalls: () => string[] } }).__e2e
+    if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
+    return helpers.getShellOpenExternalCalls()
+  }))
+}
+
+export async function resetShellOpenExternalCalls(app: ElectronApplication): Promise<void> {
+  await evalWithRetry(() => app.evaluate(() => {
+    const helpers = (globalThis as unknown as { __e2e?: { resetShellOpenExternalCalls: () => void } }).__e2e
+    if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
+    helpers.resetShellOpenExternalCalls()
+  }))
+}

--- a/e2e/support/testIds.ts
+++ b/e2e/support/testIds.ts
@@ -1,0 +1,19 @@
+/**
+ * Re-export the production `TID` registry so e2e selectors are
+ * type-checked against the same constants the Vue components render.
+ *
+ * Tests should `import { TID, byTestId } from './support/testIds'` and
+ * never type a raw `data-testid` literal. Renaming a production id
+ * becomes a typecheck error here instead of a silent runtime miss.
+ */
+
+export { TID } from '../../src/shared/testIds'
+export type { TestIdKey } from '../../src/shared/testIds'
+
+/** CSS selector for a given test id. Use inside `WebContentsPage`
+ *  helpers: `page.click(byTestId(TID.modalConfirm))`. */
+export function byTestId(id: string): string {
+  // CSS attribute selector — values from `TID` are kebab-case ascii
+  // so no escaping is needed.
+  return `[data-testid="${id}"]`
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -707,7 +707,7 @@
     "updateNoGit": "No .git directory found in ComfyUI/. Commit-based updating requires a git repository.",
     "copyAndUpdate": "Copy & Update",
     "copyAndUpdateTitle": "Copy & Update",
-    "copyAndUpdateMessage": "Create a copy of this install and update the copy from {installed} to {latest}.\n\nThe original install will not be modified.",
+    "copyAndUpdateMessage": "Create a copy of this install and update the copy from {installed} to {latest}.\n\nThe original install will be preserved.",
     "copyAndUpdatePlaceholder": "Enter a name for the copy",
     "copyAndUpdateConfirm": "Copy & Update",
     "releaseNotesLabel": "Release Notes",
@@ -922,6 +922,7 @@
     "stopRequired": "This installation is currently running and must be stopped first.",
     "stopRequiredConfirm": "This installation is currently running. Would you like to stop it to continue?",
     "stopRunning": "Stop Running",
+    "willStopRunning": "ComfyUI is currently running and will be stopped to proceed.",
     "folderPermissionDenied": "macOS denied access to \"{path}\". Please open System Settings → Privacy & Security → Files and Folders, grant access to ComfyUI Desktop 2.0, then retry."
   },
 
@@ -945,7 +946,7 @@
     "customNodes": "Third-party extensions that add new node types and functionality to ComfyUI.",
     "pipPackages": "Python packages installed in the environment. Custom nodes often install their own pip dependencies.",
     "updateNow": "Update this installation in-place.",
-    "copyAndUpdate": "Create a copy of this installation and update the copy. The original will not be modified.",
+    "copyAndUpdate": "Create a copy of this installation and update the copy. The original will be preserved.",
     "envVars": "Custom environment variables passed to ComfyUI when it starts. Warning: values are stored unencrypted in the configuration file — do not add API keys, tokens, or other sensitive information."
   },
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -920,8 +920,6 @@
     "operationInProgressGeneric": "Another operation is currently in progress for this installation. Would you like to cancel it?",
     "cancelOperation": "Cancel Operation",
     "stopRequired": "This installation is currently running and must be stopped first.",
-    "stopRequiredConfirm": "This installation is currently running. Would you like to stop it to continue?",
-    "stopRunning": "Stop Running",
     "willStopRunning": "ComfyUI is currently running and will be stopped to proceed.",
     "folderPermissionDenied": "macOS denied access to \"{path}\". Please open System Settings → Privacy & Security → Files and Folders, grant access to ComfyUI Desktop 2.0, then retry."
   },

--- a/src/main/host/createHostWindow.ts
+++ b/src/main/host/createHostWindow.ts
@@ -3,8 +3,12 @@ import path from 'path'
 import type { InstallationRecord } from '../installations'
 import { getAppVersion } from '../lib/ipc'
 import { attachContextMenu } from '../lib/contextMenu'
-import { detachWindowDownloads, getDownloadsTrayState } from '../lib/comfyDownloadManager'
-import { shouldOpenInPopup } from '../lib/allowedPopups'
+import {
+  attachSessionDownloadHandler,
+  detachWindowDownloads,
+  getDownloadsTrayState,
+} from '../lib/comfyDownloadManager'
+import { isLikelyDownloadUrl, shouldOpenInPopup } from '../lib/allowedPopups'
 import { COMFY_BG, TITLEBAR_BG } from '../lib/theme'
 import {
   TITLEBAR_HEIGHT,
@@ -748,6 +752,13 @@ export function buildComfyView(
   comfyView.setBackgroundColor(COMFY_BG)
 
   const comfyContents = comfyView.webContents
+  // Eagerly attach the will-download handler to the comfy view's
+  // session so any `session.downloadURL(...)` call below — or a server-
+  // initiated `Content-Disposition: attachment` response — flows
+  // through the launcher's downloads tray instead of falling back to
+  // the browser. `attachSessionDownloadHandler` is idempotent.
+  attachSessionDownloadHandler(comfyContents.session)
+
   comfyContents.on('did-create-window', (childWindow) => {
     childWindow.setIcon(APP_ICON)
     if (process.platform !== 'darwin') childWindow.removeMenu()
@@ -758,6 +769,20 @@ export function buildComfyView(
       // preload: undefined strips our title-bar bridge so OAuth/cloud-login
       // popups can't reach the file menu IPCs.
       return { action: 'allow', overrideBrowserWindowOptions: { webPreferences: { preload: undefined } } }
+    }
+    // Capture downloads that the previous unconditional
+    // `shell.openExternal` branch was leaking to the system browser.
+    // The cloud "Download zip" button renders as a `window.open(zipUrl)`
+    // (no `<a download>` attribute), so Electron reports disposition
+    // `'foreground-tab'` — indistinguishable from a normal external
+    // link by disposition alone. We match on the URL's pathname
+    // extension via `isLikelyDownloadUrl` (archive / installer / model
+    // weights) and route the request through `session.downloadURL`,
+    // which fires the `will-download` listener attached above and
+    // surfaces the download in the launcher's downloads tray.
+    if (isLikelyDownloadUrl(childUrl)) {
+      comfyContents.session.downloadURL(childUrl)
+      return { action: 'deny' }
     }
     shell.openExternal(childUrl)
     return { action: 'deny' }

--- a/src/main/host/panelView.ts
+++ b/src/main/host/panelView.ts
@@ -89,10 +89,18 @@ export function ensurePanelView(
   // numeric windowKey that PanelApp.vue must not see.
   const panelInstallationId = entry.installationId ?? ''
   const firstUseCompleted = getSetting('firstUseCompleted') === true
-  const panelQuery = {
+  const panelQuery: Record<string, string> = {
     installationId: panelInstallationId,
     panel: initialPanel,
     firstUseCompleted: String(firstUseCompleted),
+  }
+  // Propagate the E2E env flag to the renderer via the URL query so the
+  // panel's renderer-side test hooks (`__e2eRenderer`) only register
+  // when the runner explicitly opted in. Mirrors the main-side `E2E === '1'`
+  // gating used by `registerE2EHooks()` and the `e2eOverrides.ts`
+  // counters; the renderer can't see `process.env` directly.
+  if (process.env['E2E'] === '1') {
+    panelQuery['e2e'] = '1'
   }
   const isDev = !!process.env['ELECTRON_RENDERER_URL']
   const loadPromise = isDev

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -43,7 +43,7 @@ import { sourceMap, _broadcastToRenderer, _runningSessions } from './lib/ipc/sha
 import { enrichInstallationsForRenderer } from './lib/ipc/registerInstallationHandlers'
 import { getSnapshotListData } from './lib/snapshots'
 import { update as updateInstallation } from './installations'
-import { lookupInstallUpdateOverride } from './lib/e2eOverrides'
+import { lookupInstallUpdateOverride, recordIpcInvocation } from './lib/e2eOverrides'
 import * as mainTelemetry from './lib/telemetry'
 import { getDeviceId } from './lib/deviceId'
 
@@ -741,6 +741,30 @@ ipcMain.handle('focus-comfy-window', (_event, installationId: string) => {
   }
 
   return false
+})
+
+/**
+ * Open a new window showing the install backing `installationId`.
+ * Used by ProgressModal after copy / copy-update / release-update so
+ * the newly-created destination install gets focus without swapping
+ * the source host out from under the user.
+ *
+ * If a window already backs the install (e.g. previous launch),
+ * focuses it. Otherwise opens a fresh chooser host — A' renders in
+ * the dashboard alongside other installs and the user picks it from
+ * there. Future enhancement: auto-pick A' via a URL param on the
+ * fresh chooser host so launch fires on its own.
+ */
+ipcMain.handle('open-install-window', (_event, installationId: string) => {
+  recordIpcInvocation('open-install-window', { installationId })
+  const existing = getEntryByInstallationId(installationId)
+  if (existing && !existing.window.isDestroyed()) {
+    existing.window.show()
+    existing.window.focus()
+    return true
+  }
+  openChooserHostWindow()
+  return true
 })
 
 ipcMain.handle('close-comfy-window', (_event, installationId: string) => {

--- a/src/main/lib/allowedPopups.test.ts
+++ b/src/main/lib/allowedPopups.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest'
-import { POPUP_ALLOWED_PREFIXES, shouldOpenInPopup } from './allowedPopups'
+import {
+  isLikelyDownloadUrl,
+  POPUP_ALLOWED_PREFIXES,
+  shouldOpenInPopup,
+} from './allowedPopups'
 
 describe('POPUP_ALLOWED_PREFIXES', () => {
   it('includes the Firebase auth domain', () => {
@@ -42,5 +46,58 @@ describe('shouldOpenInPopup', () => {
 
   it('returns false for partial prefix matches', () => {
     expect(shouldOpenInPopup('https://dreamboothy.firebaseapp.com.evil.com/')).toBe(false)
+  })
+})
+
+describe('isLikelyDownloadUrl (regression for #582 cloud zip handoff)', () => {
+  it('returns true for a cloud zip export URL', () => {
+    expect(
+      isLikelyDownloadUrl('https://app.comfy.org/api/exports/abc123/workflow.zip'),
+    ).toBe(true)
+  })
+
+  it('returns true for common archive extensions', () => {
+    for (const url of [
+      'https://example.com/file.zip',
+      'https://example.com/dir/file.7z',
+      'https://example.com/file.tar.gz',
+      'https://example.com/file.tgz',
+      'https://example.com/build/installer.exe',
+      'https://example.com/installer.msi',
+      'https://example.com/model.safetensors',
+      'https://example.com/model.gguf',
+    ]) {
+      expect(isLikelyDownloadUrl(url)).toBe(true)
+    }
+  })
+
+  it('ignores query strings and fragments when matching the extension', () => {
+    expect(
+      isLikelyDownloadUrl('https://example.com/file.zip?token=abc'),
+    ).toBe(true)
+    expect(
+      isLikelyDownloadUrl('https://example.com/file.zip#section'),
+    ).toBe(true)
+  })
+
+  it('returns false for plain web pages and docs URLs', () => {
+    for (const url of [
+      'https://example.com/',
+      'https://example.com/some/page',
+      'https://docs.example.com/getting-started.html',
+      'https://example.com/file.json',
+      'https://example.com/image.png',
+    ]) {
+      expect(isLikelyDownloadUrl(url)).toBe(false)
+    }
+  })
+
+  it('returns false for unparseable URLs', () => {
+    expect(isLikelyDownloadUrl('not a url')).toBe(false)
+    expect(isLikelyDownloadUrl('')).toBe(false)
+  })
+
+  it('matching is case-insensitive (.ZIP works too)', () => {
+    expect(isLikelyDownloadUrl('https://example.com/FILE.ZIP')).toBe(true)
   })
 })

--- a/src/main/lib/allowedPopups.ts
+++ b/src/main/lib/allowedPopups.ts
@@ -41,6 +41,7 @@ const DOWNLOAD_FILE_EXTENSIONS = [
   '.rpm',
   '.appimage',
   '.safetensors',
+  '.sft',
   '.ckpt',
   '.bin',
   '.gguf',

--- a/src/main/lib/allowedPopups.ts
+++ b/src/main/lib/allowedPopups.ts
@@ -12,3 +12,59 @@ export const POPUP_ALLOWED_PREFIXES = [
 export function shouldOpenInPopup(url: string): boolean {
   return POPUP_ALLOWED_PREFIXES.some((prefix) => url.startsWith(prefix))
 }
+
+/**
+ * File extensions on a URL's pathname that strongly indicate the
+ * target is a download rather than something the user wants to open
+ * in the system browser. Used as a fallback when the
+ * `setWindowOpenHandler` `disposition` arg is not `'save-to-disk'`
+ * (e.g. the cloud renders a `window.open(zipUrl)` without an `<a
+ * download>` attribute). Archive + bundled-asset extensions only —
+ * deliberately omits `.json`, `.html`, etc. that the user may
+ * legitimately want to open in a browser.
+ */
+const DOWNLOAD_FILE_EXTENSIONS = [
+  '.zip',
+  '.7z',
+  '.tar',
+  '.tar.gz',
+  '.tgz',
+  '.gz',
+  '.bz2',
+  '.xz',
+  '.rar',
+  '.dmg',
+  '.exe',
+  '.msi',
+  '.pkg',
+  '.deb',
+  '.rpm',
+  '.appimage',
+  '.safetensors',
+  '.ckpt',
+  '.bin',
+  '.gguf',
+  '.pt',
+  '.pth',
+]
+
+/**
+ * Heuristic: does the URL's pathname end in a known archive / binary
+ * extension? Used to capture the "Download zip" link on the cloud
+ * comfy page when the cloud frontend uses a plain `window.open(url)`
+ * (no `<a download>`) — Electron's `setWindowOpenHandler` reports
+ * `disposition: 'foreground-tab'` in that case, indistinguishable
+ * from a normal external link by disposition alone.
+ *
+ * Returns false for unparseable URLs so the caller can safely fall
+ * through to its default branch.
+ */
+export function isLikelyDownloadUrl(url: string): boolean {
+  let pathname: string
+  try {
+    pathname = new URL(url).pathname.toLowerCase()
+  } catch {
+    return false
+  }
+  return DOWNLOAD_FILE_EXTENSIONS.some((ext) => pathname.endsWith(ext))
+}

--- a/src/main/lib/e2eHooks.ts
+++ b/src/main/lib/e2eHooks.ts
@@ -29,6 +29,7 @@ import {
   getShellOpenExternalCalls,
   resetShellOpenExternalCalls,
 } from './e2eOverrides'
+import { _test_addRunningSession, _test_clearRunningSessions } from './ipc/shared'
 
 interface SetInstallUpdateOpts {
   /** Omit to apply the override globally (matches every installationId). */
@@ -67,6 +68,13 @@ export interface E2EHelpers {
   getShellOpenExternalCalls(): string[]
   /** Reset the captured `shell.openExternal` URL list. */
   resetShellOpenExternalCalls(): void
+  /** Register a synthetic running session against `installationId`
+   *  without spawning a real ComfyUI process. Main's REQUIRES_STOPPED
+   *  guard sees the install as running; renderer `sessionStore.isRunning`
+   *  flips true via the `instance-started` broadcast. */
+  seedRunningSession(opts: { installationId: string; installationName: string }): void
+  /** Drop every synthetic session registered via `seedRunningSession`. */
+  clearRunningSessions(): void
 }
 
 export function registerE2EHooks(): void {
@@ -95,6 +103,10 @@ export function registerE2EHooks(): void {
     resetIpcInvocations,
     getShellOpenExternalCalls,
     resetShellOpenExternalCalls,
+    seedRunningSession(opts) {
+      _test_addRunningSession(opts.installationId, opts.installationName)
+    },
+    clearRunningSessions: _test_clearRunningSessions,
   }
   ;(globalThis as unknown as { __e2e: E2EHelpers }).__e2e = helpers
 }

--- a/src/main/lib/e2eHooks.ts
+++ b/src/main/lib/e2eHooks.ts
@@ -24,6 +24,10 @@ import { comfyWindows, isInstallHost } from '../host/registry'
 import {
   installUpdateOverrides,
   INSTALL_UPDATE_GLOBAL_KEY,
+  getIpcInvocations,
+  resetIpcInvocations,
+  getShellOpenExternalCalls,
+  resetShellOpenExternalCalls,
 } from './e2eOverrides'
 
 interface SetInstallUpdateOpts {
@@ -48,6 +52,21 @@ export interface E2EHelpers {
    *  mode without going through the popup. Resolves to the BrowserWindow
    *  id that was flipped (or null if no install-backed host exists). */
   returnFirstInstallHostToDashboard(): Promise<number | null>
+  /** Read the list of recorded invocations for an instrumented IPC
+   *  channel (e.g. `'get-detail-sections'`). Each entry is the first
+   *  argument the handler received. */
+  getIpcInvocations(channel: string): unknown[]
+  /** Clear the recorded invocations for one channel, or all channels
+   *  when called with no argument. Tests call this in `beforeAll` /
+   *  `beforeEach` to assert against deltas rather than cumulative
+   *  state across suites. */
+  resetIpcInvocations(channel?: string): void
+  /** URLs Electron's `shell.openExternal(...)` was called with via
+   *  the launcher's wrapper. Empty unless the production code recorded
+   *  an external open while `E2E === '1'`. */
+  getShellOpenExternalCalls(): string[]
+  /** Reset the captured `shell.openExternal` URL list. */
+  resetShellOpenExternalCalls(): void
 }
 
 export function registerE2EHooks(): void {
@@ -72,6 +91,10 @@ export function registerE2EHooks(): void {
       }
       return null
     },
+    getIpcInvocations,
+    resetIpcInvocations,
+    getShellOpenExternalCalls,
+    resetShellOpenExternalCalls,
   }
   ;(globalThis as unknown as { __e2e: E2EHelpers }).__e2e = helpers
 }

--- a/src/main/lib/e2eOverrides.ts
+++ b/src/main/lib/e2eOverrides.ts
@@ -23,3 +23,53 @@ export const installUpdateOverrides = new Map<string, InstallUpdateOverride>()
 export function lookupInstallUpdateOverride(installationId: string): InstallUpdateOverride | undefined {
   return installUpdateOverrides.get(installationId) ?? installUpdateOverrides.get(INSTALL_UPDATE_GLOBAL_KEY)
 }
+
+/**
+ * IPC invocation counters. Production code increments these via
+ * `recordIpcInvocation('channel-name', arg)` when `process.env['E2E']
+ * === '1'`; tests read via the `__e2e.getIpcInvocations(channel)`
+ * helper. Lets tests assert that a fast-path skipped a costly IPC
+ * (e.g. Delete should not call `get-detail-sections`).
+ */
+const ipcInvocations = new Map<string, unknown[]>()
+
+export function recordIpcInvocation(channel: string, arg?: unknown): void {
+  if (process.env['E2E'] !== '1') return
+  const arr = ipcInvocations.get(channel)
+  if (arr) {
+    arr.push(arg)
+  } else {
+    ipcInvocations.set(channel, [arg])
+  }
+}
+
+export function getIpcInvocations(channel: string): unknown[] {
+  return ipcInvocations.get(channel)?.slice() ?? []
+}
+
+export function resetIpcInvocations(channel?: string): void {
+  if (channel) ipcInvocations.delete(channel)
+  else ipcInvocations.clear()
+}
+
+/**
+ * URLs passed to Electron's `shell.openExternal(...)` while E2E mode
+ * is on. Production code calls `recordShellOpenExternal(url)` from the
+ * single launcher-side `openExternal` wrapper. Tests assert this stays
+ * empty to prove a download was captured by the session handler
+ * instead of bouncing out to the OS browser.
+ */
+const shellOpenExternalCalls: string[] = []
+
+export function recordShellOpenExternal(url: string): void {
+  if (process.env['E2E'] !== '1') return
+  shellOpenExternalCalls.push(url)
+}
+
+export function getShellOpenExternalCalls(): string[] {
+  return shellOpenExternalCalls.slice()
+}
+
+export function resetShellOpenExternalCalls(): void {
+  shellOpenExternalCalls.length = 0
+}

--- a/src/main/lib/ipc/registerInstallationHandlers.ts
+++ b/src/main/lib/ipc/registerInstallationHandlers.ts
@@ -15,6 +15,7 @@ import type { ComfyVersion, ComfyArgDef, InstallationRecord } from './shared'
 import * as releaseCache from '../release-cache'
 import { hasGitDir } from '../git'
 import { restoreSnapshotIntoInstallation } from '../standaloneMigration'
+import { recordIpcInvocation } from '../e2eOverrides'
 
 /**
  * Apply the migration-source filter + per-install source enrichment
@@ -317,6 +318,7 @@ export function registerInstallationHandlers(): void {
   })
 
   ipcMain.handle('get-detail-sections', async (_event, installationId: string) => {
+    recordIpcInvocation('get-detail-sections', installationId)
     const inst = await installations.get(installationId)
     if (!inst) return []
     const source = sourceMap[inst.sourceId]

--- a/src/main/lib/ipc/registerSessionHandlers.ts
+++ b/src/main/lib/ipc/registerSessionHandlers.ts
@@ -18,9 +18,11 @@ import {
   handleLaunch,
   handleDelegateToSource,
 } from './sessionActions'
+import { recordIpcInvocation } from '../e2eOverrides'
 
 export function registerSessionHandlers(): void {
   ipcMain.handle('stop-comfyui', async (_event, installationId?: string) => {
+    recordIpcInvocation('stop-comfyui', installationId)
     if (installationId) {
       await stopRunning(installationId)
     } else {
@@ -55,6 +57,7 @@ export function registerSessionHandlers(): void {
   })
 
   ipcMain.handle('run-action', async (_event, installationId: string, actionId: string, actionData?: Record<string, unknown>) => {
+    recordIpcInvocation('run-action', { installationId, actionId })
     const maybeInst = await installations.get(installationId)
     if (!maybeInst) return { ok: false, message: 'Installation not found.' }
     const inst = maybeInst

--- a/src/main/lib/ipc/sessionActions/copy.ts
+++ b/src/main/lib/ipc/sessionActions/copy.ts
@@ -29,10 +29,10 @@ export async function handleCopy({ event, installationId, inst, actionData }: Ac
   _operationAborts.set(installationId, abort)
 
   try {
-    await performCopy(inst, name, sendProgress, abort.signal)
+    const { entry } = await performCopy(inst, name, sendProgress, abort.signal)
     _operationAborts.delete(installationId)
     sendProgress('done', { percent: 100, status: 'Complete' })
-    return { ok: true, navigate: 'list' }
+    return { ok: true, navigate: 'list', newInstallationId: entry.id }
   } catch (err) {
     _operationAborts.delete(installationId)
     if (abort.signal.aborted) return { ok: true, navigate: 'detail' }
@@ -97,7 +97,7 @@ export async function handleCopyUpdate({ event, installationId, inst, actionData
     }
 
     _operationAborts.delete(installationId)
-    return { ok: true, navigate: 'list' }
+    return { ok: true, navigate: 'list', newInstallationId: entry.id }
   } catch (err) {
     _operationAborts.delete(installationId)
     if (abort.signal.aborted) return { ok: true, navigate: 'detail' }
@@ -221,7 +221,7 @@ export async function handleReleaseUpdate({ event, installationId, inst, actionD
       return { ok: false, message: migrateError }
     }
     sendProgress('done', { percent: 100, status: 'Complete' })
-    return { ok: true, navigate: 'list' }
+    return { ok: true, navigate: 'list', newInstallationId: entry.id }
   } catch (err) {
     _operationAborts.delete(installationId)
     if (!installComplete) {

--- a/src/main/lib/ipc/sessionActions/types.ts
+++ b/src/main/lib/ipc/sessionActions/types.ts
@@ -17,4 +17,8 @@ export interface ActionResult {
   port?: number
   url?: string
   portConflict?: Record<string, unknown>
+  /** Set by actions that produce a new install record (copy /
+   *  copy-update / release-update) so the renderer can open A' in its
+   *  own window. The source install's host stays put — never swapped. */
+  newInstallationId?: string
 }

--- a/src/main/lib/ipc/shared.ts
+++ b/src/main/lib/ipc/shared.ts
@@ -689,6 +689,46 @@ export async function getActiveDetails(): Promise<QuitActiveItem[]> {
   return items
 }
 
+/** Test-only: register a synthetic running session for an install
+ *  without spawning a real ComfyUI process. Mirrors the side effects
+ *  of `_addSession` (renderer `instance-started` broadcast →
+ *  `sessionStore.isRunning(id)` flips true; main `_runningSessions`
+ *  populated so the REQUIRES_STOPPED guard in `registerSessionHandlers`
+ *  fires). `stopRunning` handles the null `proc` case cleanly so the
+ *  panel's stop-confirm chain resolves end-to-end. Only called via
+ *  `__e2e.seedRunningSession` and gated behind `process.env.E2E === '1'`. */
+export function _test_addRunningSession(
+  installationId: string,
+  installationName: string,
+): void {
+  _runningSessions.set(installationId, {
+    proc: null,
+    port: 0,
+    url: undefined,
+    mode: 'window',
+    installationName,
+    startedAt: Date.now(),
+  })
+  _broadcastToRenderer('instance-started', {
+    installationId,
+    port: 0,
+    url: undefined,
+    mode: 'window',
+    installationName,
+  })
+}
+
+/** Test-only: drop every synthetic session registered via
+ *  `_test_addRunningSession`. Broadcasts `instance-stopped` per entry
+ *  so renderer sessionStore mirrors main. */
+export function _test_clearRunningSessions(): void {
+  const ids = Array.from(_runningSessions.keys())
+  _runningSessions.clear()
+  for (const id of ids) {
+    _broadcastToRenderer('instance-stopped', { installationId: id })
+  }
+}
+
 export function cancelAll(): void {
   for (const [_id, abort] of _operationAborts) {
     abort.abort()

--- a/src/main/popups/titlePopup.test.ts
+++ b/src/main/popups/titlePopup.test.ts
@@ -25,6 +25,7 @@ import {
   buildInstancePickerSnapshot,
   buildTitlePopupMenuItems,
   computePopupHeight,
+  GLOBAL_SETTINGS_ALLOWED_ACTIONS,
   type InstancePickerInstall,
 } from './titlePopup'
 import { nextWindowKey, type ComfyWindowEntry } from '../host/registry'
@@ -235,5 +236,36 @@ describe('buildInstancePickerSnapshot', () => {
       runningInstallationIds: [],
     })
     expect(snap.runningInstallationIds).toEqual([])
+  })
+})
+
+describe('GLOBAL_SETTINGS_ALLOWED_ACTIONS', () => {
+  // Drift between the allowlist and the actual action ids emitted by the
+  // sources surfaces as silent no-ops in the title-popup Global Settings
+  // drawer (clicks return { ok: false, message: "Action 'X' is not
+  // available." } and the popup swallows the result). This test fails
+  // loudly when an id is renamed without updating the allowlist.
+
+  it('includes every channel-card action emitted by standalone/portable sources', () => {
+    // Channel-card action ids — must stay aligned with
+    // standalone/updateSections.ts and sources/portable.ts.
+    const channelCardActionIds = ['update-comfyui', 'copy-update', 'switch-channel']
+    for (const id of channelCardActionIds) {
+      expect(GLOBAL_SETTINGS_ALLOWED_ACTIONS.has(id)).toBe(true)
+    }
+  })
+
+  it('includes the session-level release-update action', () => {
+    // `release-update` is dispatched from `sessionActions/copy.ts` as the
+    // continuation of a copy-then-update flow. It is allowed through the
+    // popup so the Global Settings drawer can drive the full chain.
+    expect(GLOBAL_SETTINGS_ALLOWED_ACTIONS.has('release-update')).toBe(true)
+  })
+
+  it('does not contain the legacy "update" id (regression for #582)', () => {
+    // The bare `update` id had no producer; clicks against it returned
+    // "Action 'update' is not available." and the user saw nothing
+    // happen. This guard keeps it from sneaking back in.
+    expect(GLOBAL_SETTINGS_ALLOWED_ACTIONS.has('update')).toBe(false)
   })
 })

--- a/src/main/popups/titlePopup.ts
+++ b/src/main/popups/titlePopup.ts
@@ -1670,11 +1670,21 @@ function activateTitlePopupMenuItem(
 const GLOBAL_SETTINGS_GITHUB_URL =
   'https://github.com/Comfy-Org/ComfyUI-Desktop-2.0-Beta'
 
-const GLOBAL_SETTINGS_ALLOWED_ACTIONS = new Set([
+/**
+ * Action ids the title-popup Global Settings drawer may invoke
+ * against an install. MUST stay in sync with what the standalone +
+ * portable sources actually emit from their channel-card action rows
+ * (`update-comfyui`, `copy-update`, `switch-channel`) plus the
+ * session-level `release-update` chain. Drift here = silent no-op
+ * because [runChannelPickerAction] returns `{ ok: false, message:
+ * "Action 'X' is not available." }` and the popup swallows the
+ * result. Parity is enforced by [titlePopup.test.ts].
+ */
+export const GLOBAL_SETTINGS_ALLOWED_ACTIONS = new Set([
   'copy-update',
   'release-update',
   'switch-channel',
-  'update',
+  'update-comfyui',
 ])
 
 /** Last seen `app-update:download-progress` payload, cached so a fresh

--- a/src/main/popups/titlePopup.ts
+++ b/src/main/popups/titlePopup.ts
@@ -2497,6 +2497,7 @@ export function registerTitlePopupIpc(bindings: TitlePopupHostBindings): void {
         triggersInstanceStart: payload?.triggersInstanceStart,
         opKind: payload?.opKind,
         isRestart: payload?.isRestart,
+        requiresStopped: payload?.requiresStopped,
       })
     },
   )

--- a/src/main/popups/titlePopup.ts
+++ b/src/main/popups/titlePopup.ts
@@ -2497,7 +2497,6 @@ export function registerTitlePopupIpc(bindings: TitlePopupHostBindings): void {
         triggersInstanceStart: payload?.triggersInstanceStart,
         opKind: payload?.opKind,
         isRestart: payload?.isRestart,
-        requiresStopped: payload?.requiresStopped,
       })
     },
   )

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -78,6 +78,8 @@ export function buildElectronApi(): ElectronApi {
     stopComfyUI: (installationId) => ipcRenderer.invoke('stop-comfyui', installationId),
     focusComfyWindow: (installationId) =>
       ipcRenderer.invoke('focus-comfy-window', installationId),
+    openInstallWindow: (installationId) =>
+      ipcRenderer.invoke('open-install-window', installationId),
     closeComfyWindow: (installationId) =>
       ipcRenderer.invoke('close-comfy-window', installationId),
     closeHostWindow: () =>

--- a/src/preload/comfyTitlePopupPreload.ts
+++ b/src/preload/comfyTitlePopupPreload.ts
@@ -448,6 +448,10 @@ export interface ComfyTitlePopupBridge {
     triggersInstanceStart?: boolean
     opKind?: 'launch' | 'install' | 'update' | 'destructive' | 'snapshot' | 'generic'
     isRestart?: boolean
+    /** Tags REQUIRES_STOPPED actions whose stop-confirm the panel must
+     *  run before invoking the action — the picker popup defers the
+     *  guard to the host so the BaseAlert survives popup teardown. */
+    requiresStopped?: boolean
   }): void
 }
 

--- a/src/preload/comfyTitlePopupPreload.ts
+++ b/src/preload/comfyTitlePopupPreload.ts
@@ -448,10 +448,6 @@ export interface ComfyTitlePopupBridge {
     triggersInstanceStart?: boolean
     opKind?: 'launch' | 'install' | 'update' | 'destructive' | 'snapshot' | 'generic'
     isRestart?: boolean
-    /** Tags REQUIRES_STOPPED actions whose stop-confirm the panel must
-     *  run before invoking the action — the picker popup defers the
-     *  guard to the host so the BaseAlert survives popup teardown. */
-    requiresStopped?: boolean
   }): void
 }
 

--- a/src/renderer/src/comfyTitlePopup/InstancePickerView.vue
+++ b/src/renderer/src/comfyTitlePopup/InstancePickerView.vue
@@ -157,7 +157,6 @@ interface PickerBridge {
     triggersInstanceStart?: boolean
     opKind?: 'launch' | 'install' | 'update' | 'destructive' | 'snapshot' | 'generic'
     isRestart?: boolean
-    requiresStopped?: boolean
   }) => void
 }
 const bridge = (window as unknown as { __comfyTitlePopup?: PickerBridge }).__comfyTitlePopup
@@ -417,7 +416,6 @@ function handleSettingsShowProgress(opts: ShowProgressOpts): void {
     triggersInstanceStart: opts.triggersInstanceStart,
     opKind: opts.opKind,
     isRestart: opts.actionId === 'restart',
-    requiresStopped: opts.requiresStopped,
   })
 }
 function handleSettingsNavigateList(): void {
@@ -576,7 +574,6 @@ function handleExpandedPrimaryAction(running: boolean): void {
               :installation="selectedInstall"
               :initial-tab="initialExpandedTab"
               :show-back="true"
-              :defer-stopped-guard-to-host="true"
               class="picker-expanded-body"
               @show-progress="handleSettingsShowProgress"
               @navigate-list="handleSettingsNavigateList"

--- a/src/renderer/src/comfyTitlePopup/InstancePickerView.vue
+++ b/src/renderer/src/comfyTitlePopup/InstancePickerView.vue
@@ -11,6 +11,7 @@ import InstanceRow from './instancePicker/InstanceRow.vue'
 import PickerRow from './instancePicker/PickerRow.vue'
 import { resolvePickerTab, type PickerTab } from '../lib/pickerTabs'
 import { mergePanelLocaleIntoPopup } from './pickerSettingsApiShim'
+import { useModal } from '../composables/useModal'
 import type {
   DetailSection,
   Installation,
@@ -156,6 +157,7 @@ interface PickerBridge {
     triggersInstanceStart?: boolean
     opKind?: 'launch' | 'install' | 'update' | 'destructive' | 'snapshot' | 'generic'
     isRestart?: boolean
+    requiresStopped?: boolean
   }) => void
 }
 const bridge = (window as unknown as { __comfyTitlePopup?: PickerBridge }).__comfyTitlePopup
@@ -381,9 +383,12 @@ watch(
 // ESC: collapse to compact when expanded, otherwise let the popup's
 // existing close-on-ESC behaviour close the popup. Capture-phase
 // listener so we win against any nested handlers inside the settings
-// UI.
+// UI — but defer to ModalDialog when a confirm/alert is open so ESC
+// resolves the dialog instead of tearing down the surface that owns it.
+const { state: pickerModalState } = useModal()
 function handleEsc(event: KeyboardEvent): void {
   if (event.key !== 'Escape') return
+  if (pickerModalState.visible) return
   if (snapshotMode.value === 'expanded') {
     event.preventDefault()
     event.stopPropagation()
@@ -412,6 +417,7 @@ function handleSettingsShowProgress(opts: ShowProgressOpts): void {
     triggersInstanceStart: opts.triggersInstanceStart,
     opKind: opts.opKind,
     isRestart: opts.actionId === 'restart',
+    requiresStopped: opts.requiresStopped,
   })
 }
 function handleSettingsNavigateList(): void {
@@ -570,6 +576,7 @@ function handleExpandedPrimaryAction(running: boolean): void {
               :installation="selectedInstall"
               :initial-tab="initialExpandedTab"
               :show-back="true"
+              :defer-stopped-guard-to-host="true"
               class="picker-expanded-body"
               @show-progress="handleSettingsShowProgress"
               @navigate-list="handleSettingsNavigateList"

--- a/src/renderer/src/comfyTitlePopup/TitlePopupApp.vue
+++ b/src/renderer/src/comfyTitlePopup/TitlePopupApp.vue
@@ -5,6 +5,7 @@ import DownloadsView from './DownloadsView.vue'
 import InstancePickerView from './InstancePickerView.vue'
 import GlobalSettingsView from './GlobalSettingsView.vue'
 import ModalDialog from '../components/ModalDialog.vue'
+import { useModal } from '../composables/useModal'
 import type { DetailSection, SnapshotListData } from '../types/ipc'
 
 /**
@@ -233,11 +234,16 @@ function handleActivate(id: string): void {
   bridge?.activate(id)
 }
 
+const { state: modalState } = useModal()
+
 function handleKeydown(event: KeyboardEvent): void {
-  if (event.key === 'Escape') {
-    event.preventDefault()
-    bridge?.close()
-  }
+  if (event.key !== 'Escape') return
+  // Defer to the popup's own ModalDialog when a confirm/alert is open —
+  // otherwise ESC would close the popup and tear the modal down with it,
+  // dropping the in-flight action promise without a user-visible cancel.
+  if (modalState.visible) return
+  event.preventDefault()
+  bridge?.close()
 }
 
 let unsubConfig: (() => void) | undefined

--- a/src/renderer/src/comfyTitlePopup/instancePicker/InstanceRow.vue
+++ b/src/renderer/src/comfyTitlePopup/instancePicker/InstanceRow.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { installTypeMetaFor } from '../../lib/installTypeIcon'
+import { TID } from '../../../../shared/testIds'
 import type { Installation } from '../../types/ipc'
 
 /**
@@ -48,6 +49,7 @@ function handleClick(): void {
       tabindex="0"
       class="picker-row"
       :class="{ 'is-active': active, 'is-running': running }"
+      :data-testid="TID.pickerRow(installation.id)"
       @click="handleClick"
       @keydown.enter="handleClick"
       @keydown.space.prevent="handleClick"

--- a/src/renderer/src/comfyTitlePopup/instancePicker/PickerRow.vue
+++ b/src/renderer/src/comfyTitlePopup/instancePicker/PickerRow.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { installTypeMetaFor } from '../../lib/installTypeIcon'
+import { TID } from '../../../../shared/testIds'
 import type { Installation } from '../../types/ipc'
 
 /**
@@ -57,6 +58,7 @@ function handleManage(): void {
   <article
     class="picker-row-card"
     :class="{ 'is-active': active, 'is-running': running }"
+    :data-testid="TID.pickerRow(installation.id)"
   >
     <div class="picker-row-card-identity">
       <span class="picker-row-card-icon-wrap">
@@ -89,10 +91,20 @@ function handleManage(): void {
     </div>
 
     <div class="picker-row-card-cta">
-      <button type="button" class="picker-row-card-open" @click="handleOpen">
+      <button
+        type="button"
+        class="picker-row-card-open"
+        :data-testid="TID.pickerRowOpen(installation.id)"
+        @click="handleOpen"
+      >
         {{ openLabel }}
       </button>
-      <button type="button" class="picker-row-card-manage" @click="handleManage">
+      <button
+        type="button"
+        class="picker-row-card-manage"
+        :data-testid="TID.pickerRowManage(installation.id)"
+        @click="handleManage"
+      >
         {{ manageLabel }}
       </button>
     </div>

--- a/src/renderer/src/components/ContextMenu.vue
+++ b/src/renderer/src/components/ContextMenu.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, watch, onBeforeUnmount, nextTick } from 'vue'
+import { TID } from '../../../shared/testIds'
 import type { ContextMenuItem } from '../types/context-menu'
 
 const props = defineProps<{
@@ -79,7 +80,7 @@ function handleClick(item: ContextMenuItem): void {
           class="context-menu-item"
           :class="{ disabled: item.disabled }"
           :disabled="item.disabled"
-          :data-testid="`context-menu-item-${item.id}`"
+          :data-testid="TID.contextMenuItem(item.id)"
           @click="handleClick(item)"
         >
           {{ item.label }}

--- a/src/renderer/src/components/ContextMenu.vue
+++ b/src/renderer/src/components/ContextMenu.vue
@@ -79,6 +79,7 @@ function handleClick(item: ContextMenuItem): void {
           class="context-menu-item"
           :class="{ disabled: item.disabled }"
           :disabled="item.disabled"
+          :data-testid="`context-menu-item-${item.id}`"
           @click="handleClick(item)"
         >
           {{ item.label }}

--- a/src/renderer/src/components/ModalDialog.vue
+++ b/src/renderer/src/components/ModalDialog.vue
@@ -241,6 +241,9 @@ onUnmounted(() => {
     :show-cancel="isSimpleConfirm"
     :button-label="baseAlertButtonLabel"
     :tone="baseAlertTone"
+    :test-id-root="state.testIds.root"
+    :test-id-action="state.testIds.action"
+    :test-id-cancel="state.testIds.cancel"
     @close="onBaseAlertClose"
     @cancel="onBaseAlertCancel"
   />

--- a/src/renderer/src/components/settings/ComfyUISettingsContent.vue
+++ b/src/renderer/src/components/settings/ComfyUISettingsContent.vue
@@ -16,6 +16,7 @@ import type {
   Installation,
   ShowProgressOpts,
 } from '../../types/ipc'
+import { TID } from '../../../../shared/testIds'
 
 /**
  * Per-install settings body (tab strip + scrollable body + footer).
@@ -338,7 +339,11 @@ defineExpose({
       <p v-if="!installation" class="empty">
         {{ t('comfyUISettings.emptyInstallLess', 'Open a ComfyUI install to view its settings.') }}
       </p>
-      <p v-else-if="loading && !visibleSections.length" class="empty">
+      <p
+        v-else-if="loading && !visibleSections.length"
+        class="empty"
+        :data-testid="TID.pickerSettingsLoading"
+      >
         {{ t('common.loading', 'Loading…') }}
       </p>
       <p v-else-if="error" class="empty error">{{ error }}</p>

--- a/src/renderer/src/components/settings/ComfyUISettingsContent.vue
+++ b/src/renderer/src/components/settings/ComfyUISettingsContent.vue
@@ -35,11 +35,17 @@ interface Props {
    *  because the drawer host owns its own back-chrome; only the
    *  picker's expanded right pane needs an in-content back. */
   showBack?: boolean
+  /** Forward to `useComfyUISettings.deferStoppedGuardToHost`. The
+   *  picker's expanded pane sets this so the REQUIRES_STOPPED
+   *  stop-confirm runs in the panel (which owns ProgressModal) rather
+   *  than in the popup webContents that auto-dismisses on blur. */
+  deferStoppedGuardToHost?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
   initialTab: 'config',
   showBack: false,
+  deferStoppedGuardToHost: false,
 })
 
 const emit = defineEmits<{
@@ -90,6 +96,7 @@ const {
   onShowProgress: (opts) => emit('show-progress', opts),
   onNavigateList: () => emit('navigate-list'),
   onClose: () => emit('request-close'),
+  deferStoppedGuardToHost: props.deferStoppedGuardToHost,
 })
 
 interface TabDef {

--- a/src/renderer/src/components/settings/ComfyUISettingsContent.vue
+++ b/src/renderer/src/components/settings/ComfyUISettingsContent.vue
@@ -35,17 +35,11 @@ interface Props {
    *  because the drawer host owns its own back-chrome; only the
    *  picker's expanded right pane needs an in-content back. */
   showBack?: boolean
-  /** Forward to `useComfyUISettings.deferStoppedGuardToHost`. The
-   *  picker's expanded pane sets this so the REQUIRES_STOPPED
-   *  stop-confirm runs in the panel (which owns ProgressModal) rather
-   *  than in the popup webContents that auto-dismisses on blur. */
-  deferStoppedGuardToHost?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
   initialTab: 'config',
   showBack: false,
-  deferStoppedGuardToHost: false,
 })
 
 const emit = defineEmits<{
@@ -96,7 +90,6 @@ const {
   onShowProgress: (opts) => emit('show-progress', opts),
   onNavigateList: () => emit('navigate-list'),
   onClose: () => emit('request-close'),
-  deferStoppedGuardToHost: props.deferStoppedGuardToHost,
 })
 
 interface TabDef {

--- a/src/renderer/src/components/settings/ComfyUISettingsContent.vue
+++ b/src/renderer/src/components/settings/ComfyUISettingsContent.vue
@@ -382,6 +382,8 @@ defineExpose({
               v-else
               :key="`tab-${activeTab}`"
               class="settings-v2-tab-pane"
+              :data-testid="TID.pickerSettingsSections"
+              :data-install-id="installation?.id"
             >
               <SettingsSectionList
                 :sections="visibleSections"

--- a/src/renderer/src/components/ui/BaseAlert.vue
+++ b/src/renderer/src/components/ui/BaseAlert.vue
@@ -37,6 +37,16 @@ interface Props {
   dismissOnOutside?: boolean
   /** Lock body scroll while open. Default true. */
   preventScroll?: boolean
+  /** Optional `data-testid` for the overlay root. Lets singleton hosts
+   *  (ModalDialog) tag a specific dialog (e.g. stop-instance confirm)
+   *  without renaming the default selectors. */
+  testIdRoot?: string
+  /** Optional `data-testid` override for the primary action button.
+   *  Defaults to `'base-alert-action'`. */
+  testIdAction?: string
+  /** Optional `data-testid` override for the cancel button.
+   *  Defaults to `'base-alert-cancel'`. */
+  testIdCancel?: string
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -49,7 +59,10 @@ const props = withDefaults(defineProps<Props>(), {
   ariaLabelledby: undefined,
   dismissOnEscape: true,
   dismissOnOutside: true,
-  preventScroll: true
+  preventScroll: true,
+  testIdRoot: undefined,
+  testIdAction: undefined,
+  testIdCancel: undefined
 })
 
 const emit = defineEmits<{ close: []; cancel: [] }>()
@@ -148,6 +161,7 @@ onBeforeUnmount(() => {
         aria-modal="true"
         :aria-label="dialogAriaLabel"
         :aria-labelledby="dialogAriaLabelledby"
+        :data-testid="testIdRoot"
         @mousedown="onOverlayMouseDown"
         @click="onOverlayClick"
       >
@@ -161,7 +175,7 @@ onBeforeUnmount(() => {
               <button
                 v-if="showCancel"
                 type="button"
-                data-testid="base-alert-cancel"
+                :data-testid="testIdCancel ?? 'base-alert-cancel'"
                 @click="onCancelClick"
               >
                 {{ cancelLabel ?? $t('common.cancel') }}
@@ -170,7 +184,7 @@ onBeforeUnmount(() => {
                 ref="actionBtnRef"
                 type="button"
                 :class="tone === 'danger' ? 'danger-solid' : 'primary'"
-                data-testid="base-alert-action"
+                :data-testid="testIdAction ?? 'base-alert-action'"
                 @click="onActionClick"
               >
                 {{ buttonLabel ?? $t('modal.ok') }}

--- a/src/renderer/src/composables/useActionGuard.ts
+++ b/src/renderer/src/composables/useActionGuard.ts
@@ -1,6 +1,7 @@
 import { useI18n } from 'vue-i18n'
 import { useSessionStore } from '../stores/sessionStore'
 import { useModal } from './useModal'
+import { TID } from '../../../shared/testIds'
 
 /**
  * Guard that checks whether an installation is busy (launching, in-progress operation)
@@ -39,6 +40,10 @@ export function useActionGuard() {
         message: t('errors.stopRequiredConfirm'),
         confirmLabel: t('errors.stopRunning'),
         confirmStyle: 'primary',
+        testIds: {
+          root: TID.stopInstanceConfirmModal,
+          action: TID.stopInstanceConfirmButton,
+        },
       })
       if (!confirmed) return false
       await window.api.stopComfyUI(installationId)

--- a/src/renderer/src/composables/useActionGuard.ts
+++ b/src/renderer/src/composables/useActionGuard.ts
@@ -1,23 +1,20 @@
 import { useI18n } from 'vue-i18n'
 import { useSessionStore } from '../stores/sessionStore'
 import { useModal } from './useModal'
-import { TID } from '../../../shared/testIds'
 
 /**
- * Guard that checks whether an installation is busy (launching, in-progress operation)
- * or running before allowing a mutating action, and prompts the user to cancel/stop.
+ * Guard for in-progress operations. Returns true if the action should
+ * proceed, false if the user cancelled. The stop-running concern is
+ * handled inside each action's own confirm/prompt copy (augmented with
+ * `errors.willStopRunning` when relevant) and the apiCall wrapper that
+ * stops ComfyUI before running the op — no separate stop-confirm modal.
  */
 export function useActionGuard() {
   const { t } = useI18n()
   const sessionStore = useSessionStore()
   const modal = useModal()
 
-  /**
-   * Check if the installation is busy or running and prompt the user.
-   * Returns true if the action should proceed, false if cancelled.
-   */
   async function checkBeforeAction(installationId: string, actionLabel: string): Promise<boolean> {
-    // Check if an operation (launch/install) is already in progress
     const activeSession = sessionStore.activeSessions.get(installationId)
     const isBusy = sessionStore.isLaunching(installationId) || (activeSession && !sessionStore.isRunning(installationId))
     if (isBusy) {
@@ -30,23 +27,6 @@ export function useActionGuard() {
       })
       if (!confirmed) return false
       await window.api.cancelOperation(installationId)
-      await new Promise((r) => setTimeout(r, 500))
-    }
-
-    // Check if the installation is running
-    if (sessionStore.isRunning(installationId)) {
-      const confirmed = await modal.confirm({
-        title: t('errors.stopRunning'),
-        message: t('errors.stopRequiredConfirm'),
-        confirmLabel: t('errors.stopRunning'),
-        confirmStyle: 'primary',
-        testIds: {
-          root: TID.stopInstanceConfirmModal,
-          action: TID.stopInstanceConfirmButton,
-        },
-      })
-      if (!confirmed) return false
-      await window.api.stopComfyUI(installationId)
       await new Promise((r) => setTimeout(r, 500))
     }
 

--- a/src/renderer/src/composables/useComfyUISettings.test.ts
+++ b/src/renderer/src/composables/useComfyUISettings.test.ts
@@ -165,4 +165,92 @@ describe('useComfyUISettings — staleness clearing (regression for #582)', () =
     expect(composable.diskSpace.value).toBeNull()
     scope.stop()
   })
+
+  it('does NOT clear sections on a same-install reload (only on install switches)', async () => {
+    // Same-install reloads happen after `updateField` / action completion.
+    // Blanking the pane in that case would be a regression — the user
+    // would see Loading… flash for an edit they didn't expect to clear
+    // the view. Switching installs is the only trigger for the clear.
+    let getCallCount = 0
+    installMockApi({
+      getDetailSections: vi.fn(() => {
+        getCallCount++
+        return Promise.resolve([makeSection(`A-call-${getCallCount}`)])
+      }),
+    })
+    const installation = ref<Installation | null>(makeInstall('a', 'A'))
+    const onShowProgress = vi.fn()
+
+    const scope = effectScope()
+    let composable!: ReturnType<typeof useComfyUISettings>
+    scope.run(() => {
+      composable = useComfyUISettings({ installation, onShowProgress })
+    })
+
+    await nextTick()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(composable.sections.value.map((s) => s.title)).toEqual(['Sections for A-call-1'])
+
+    // Second reload for the SAME install. Should NOT blank the pane
+    // mid-flight; sections.value stays at the previous payload until
+    // the new one arrives.
+    await composable.reload()
+    expect(composable.sections.value.length).toBeGreaterThan(0)
+    expect(composable.sections.value.map((s) => s.title)).toEqual(['Sections for A-call-2'])
+
+    scope.stop()
+  })
+
+  it('discards an out-of-order older response (A → B → A returning B late)', async () => {
+    // Three resolvers — A1 resolves immediately, then we switch to B
+    // (resolveB held open), then back to A2 (immediate). When B finally
+    // resolves AFTER A2, its sections must NOT overwrite A2's payload.
+    let resolveB: ((value: DetailSection[]) => void) | null = null
+    const sectionsB = new Promise<DetailSection[]>((resolve) => {
+      resolveB = resolve
+    })
+    const api = installMockApi({
+      getDetailSections: vi.fn((id: string) => {
+        if (id === 'a') return Promise.resolve([makeSection('A')])
+        if (id === 'b') return sectionsB
+        return Promise.resolve([])
+      }),
+    })
+
+    const installation = ref<Installation | null>(makeInstall('a', 'A'))
+    const scope = effectScope()
+    let composable!: ReturnType<typeof useComfyUISettings>
+    scope.run(() => {
+      composable = useComfyUISettings({ installation, onShowProgress: vi.fn() })
+    })
+
+    await nextTick()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // Switch to B — fetch held open.
+    installation.value = makeInstall('b', 'B')
+    await nextTick()
+
+    // Switch back to A — A's IPC resolves immediately, sections=A.
+    installation.value = makeInstall('a', 'A')
+    await nextTick()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(composable.sections.value.map((s) => s.title)).toEqual(['Sections for A'])
+    expect(composable.loading.value).toBe(false)
+
+    // Now resolve B late. The request-sequence guard must drop the
+    // result so it never overwrites A's payload or flips loading.
+    resolveB!([makeSection('B')])
+    await Promise.resolve()
+    await Promise.resolve()
+    await nextTick()
+
+    expect(composable.sections.value.map((s) => s.title)).toEqual(['Sections for A'])
+    expect(composable.loading.value).toBe(false)
+    expect(api.getDetailSections).toHaveBeenCalledTimes(3)
+    scope.stop()
+  })
 })

--- a/src/renderer/src/composables/useComfyUISettings.test.ts
+++ b/src/renderer/src/composables/useComfyUISettings.test.ts
@@ -1,0 +1,168 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { effectScope, nextTick, ref } from 'vue'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}))
+
+vi.mock('./useModal', () => ({
+  useModal: () => ({
+    confirm: vi.fn(),
+    prompt: vi.fn(),
+    select: vi.fn(),
+    confirmWithOptions: vi.fn(),
+    alert: vi.fn(),
+  }),
+}))
+
+vi.mock('./useActionGuard', () => ({
+  useActionGuard: () => ({
+    checkBeforeAction: vi.fn().mockResolvedValue('proceed'),
+  }),
+}))
+
+vi.mock('./useMigrateAction', () => ({
+  useMigrateAction: () => ({
+    confirmMigration: vi.fn(),
+  }),
+}))
+
+vi.mock('../lib/telemetry', () => ({
+  emitTelemetryAction: vi.fn(),
+  toErrorBucket: () => 'other',
+}))
+
+import { useComfyUISettings } from './useComfyUISettings'
+import type { DetailSection, Installation } from '../types/ipc'
+
+function makeInstall(id: string, name: string): Installation {
+  return {
+    id,
+    name,
+    sourceLabel: 'standalone',
+    sourceCategory: 'local',
+    status: 'installed',
+    installPath: `/tmp/${id}`,
+  } as Installation
+}
+
+function makeSection(installName: string): DetailSection {
+  // Stamp the section title with the install name so test assertions
+  // can distinguish "install A's payload" from "install B's payload".
+  return {
+    tab: 'status',
+    title: `Sections for ${installName}`,
+    fields: [],
+  } as DetailSection
+}
+
+interface MockApi {
+  getDetailSections: ReturnType<typeof vi.fn>
+  getDiskSpace: ReturnType<typeof vi.fn>
+}
+
+function installMockApi(overrides: Partial<MockApi> = {}): MockApi {
+  const api: MockApi = {
+    getDetailSections: vi.fn().mockResolvedValue([]),
+    getDiskSpace: vi.fn().mockResolvedValue(null),
+    ...overrides,
+  }
+  ;(window as unknown as { api: MockApi }).api = api
+  return api
+}
+
+describe('useComfyUISettings — staleness clearing (regression for #582)', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  it('clears sections + diskSpace synchronously when the install id changes so the old install\'s data does not flash', async () => {
+    // Two installs with distinct section payloads. The IPC for install B
+    // is held open until we explicitly resolve it — this models the
+    // real disk-bound delay in `getDetailSections` for an install with
+    // many snapshots.
+    let resolveB: ((value: DetailSection[]) => void) | null = null
+    const sectionsB = new Promise<DetailSection[]>((resolve) => {
+      resolveB = resolve
+    })
+
+    const api = installMockApi({
+      getDetailSections: vi.fn((id: string) => {
+        if (id === 'a') return Promise.resolve([makeSection('A')])
+        if (id === 'b') return sectionsB
+        return Promise.resolve([])
+      }),
+    })
+
+    const installation = ref<Installation | null>(makeInstall('a', 'A'))
+    const onShowProgress = vi.fn()
+
+    const scope = effectScope()
+    let composable!: ReturnType<typeof useComfyUISettings>
+    scope.run(() => {
+      composable = useComfyUISettings({ installation, onShowProgress })
+    })
+
+    // Initial load (install A) resolves immediately.
+    await nextTick()
+    await Promise.resolve() // flush microtasks for the await chain in loadAll
+    await Promise.resolve()
+    expect(composable.sections.value.map((s) => s.title)).toEqual([
+      'Sections for A',
+    ])
+
+    // Now switch to install B. The watcher fires `reload(B)` which
+    // calls `loadAll('b', ...)`. The fix clears `sections.value`
+    // BEFORE awaiting, so the next microtask should already see an
+    // empty sections array (and `loading: true`).
+    installation.value = makeInstall('b', 'B')
+    await nextTick()
+
+    expect(composable.loading.value).toBe(true)
+    expect(composable.sections.value).toEqual([])
+    expect(composable.diskSpace.value).toBeNull()
+
+    // Resolve install B's IPC; sections + loading flip to the new
+    // payload.
+    resolveB!([makeSection('B')])
+    await Promise.resolve()
+    await Promise.resolve()
+    await nextTick()
+
+    expect(composable.loading.value).toBe(false)
+    expect(composable.sections.value.map((s) => s.title)).toEqual([
+      'Sections for B',
+    ])
+    expect(api.getDetailSections).toHaveBeenCalledTimes(2)
+    scope.stop()
+  })
+
+  it('clears sections when the installation prop is set to null', async () => {
+    installMockApi({
+      getDetailSections: vi.fn().mockResolvedValue([makeSection('A')]),
+    })
+    const installation = ref<Installation | null>(makeInstall('a', 'A'))
+    const onShowProgress = vi.fn()
+
+    const scope = effectScope()
+    let composable!: ReturnType<typeof useComfyUISettings>
+    scope.run(() => {
+      composable = useComfyUISettings({ installation, onShowProgress })
+    })
+
+    await nextTick()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(composable.sections.value.length).toBeGreaterThan(0)
+
+    installation.value = null
+    await nextTick()
+    expect(composable.sections.value).toEqual([])
+    expect(composable.diskSpace.value).toBeNull()
+    scope.stop()
+  })
+})

--- a/src/renderer/src/composables/useComfyUISettings.test.ts
+++ b/src/renderer/src/composables/useComfyUISettings.test.ts
@@ -9,20 +9,27 @@ vi.mock('vue-i18n', () => ({
   }),
 }))
 
+// Shared spies so tests can assert on the modal/actionGuard calls. The
+// composable invokes `useModal()` / `useActionGuard()` once at setup, so
+// we can't reach into a fresh-per-call factory — hoisted spies are the
+// only way to capture the messages passed to `modal.confirm`, etc.
+const modalSpies = vi.hoisted(() => ({
+  confirm: vi.fn(),
+  prompt: vi.fn(),
+  select: vi.fn(),
+  confirmWithOptions: vi.fn(),
+  alert: vi.fn(),
+}))
+const actionGuardSpies = vi.hoisted(() => ({
+  checkBeforeAction: vi.fn(),
+}))
+
 vi.mock('./useModal', () => ({
-  useModal: () => ({
-    confirm: vi.fn(),
-    prompt: vi.fn(),
-    select: vi.fn(),
-    confirmWithOptions: vi.fn(),
-    alert: vi.fn(),
-  }),
+  useModal: () => modalSpies,
 }))
 
 vi.mock('./useActionGuard', () => ({
-  useActionGuard: () => ({
-    checkBeforeAction: vi.fn().mockResolvedValue('proceed'),
-  }),
+  useActionGuard: () => actionGuardSpies,
 }))
 
 vi.mock('./useMigrateAction', () => ({
@@ -37,7 +44,8 @@ vi.mock('../lib/telemetry', () => ({
 }))
 
 import { useComfyUISettings } from './useComfyUISettings'
-import type { DetailSection, Installation } from '../types/ipc'
+import { useSessionStore } from '../stores/sessionStore'
+import type { ActionDef, ActionResult, DetailSection, Installation, ShowProgressOpts } from '../types/ipc'
 
 function makeInstall(id: string, name: string): Installation {
   return {
@@ -63,12 +71,16 @@ function makeSection(installName: string): DetailSection {
 interface MockApi {
   getDetailSections: ReturnType<typeof vi.fn>
   getDiskSpace: ReturnType<typeof vi.fn>
+  stopComfyUI: ReturnType<typeof vi.fn>
+  runAction: ReturnType<typeof vi.fn>
 }
 
 function installMockApi(overrides: Partial<MockApi> = {}): MockApi {
   const api: MockApi = {
     getDetailSections: vi.fn().mockResolvedValue([]),
     getDiskSpace: vi.fn().mockResolvedValue(null),
+    stopComfyUI: vi.fn().mockResolvedValue(undefined),
+    runAction: vi.fn().mockResolvedValue({ ok: true }),
     ...overrides,
   }
   ;(window as unknown as { api: MockApi }).api = api
@@ -251,6 +263,261 @@ describe('useComfyUISettings — staleness clearing (regression for #582)', () =
     expect(composable.sections.value.map((s) => s.title)).toEqual(['Sections for A'])
     expect(composable.loading.value).toBe(false)
     expect(api.getDetailSections).toHaveBeenCalledTimes(3)
+    scope.stop()
+  })
+})
+
+describe('useComfyUISettings.runAction — stop-warning augment + self-stopping apiCall (FLOW 1 + FLOW 3)', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    modalSpies.confirm.mockReset()
+    modalSpies.prompt.mockReset()
+    modalSpies.select.mockReset()
+    modalSpies.confirmWithOptions.mockReset()
+    modalSpies.alert.mockReset()
+    actionGuardSpies.checkBeforeAction.mockReset()
+    actionGuardSpies.checkBeforeAction.mockResolvedValue('proceed')
+  })
+
+  /** Mark an install as running in the session store so `runAction`'s
+   *  `wasRunning = sessionStore.isRunning(...)` capture flips to true.
+   *  The runningInstances map is plain reactive state, so we can poke
+   *  it directly under `stubActions: false`. */
+  function markRunning(id: string, name = id): void {
+    const sessionStore = useSessionStore()
+    sessionStore.runningInstances.set(id, {
+      installationId: id,
+      installationName: name,
+      mode: 'standalone',
+    })
+  }
+
+  function mountComposable(installation: Installation | null, onShowProgress = vi.fn()): {
+    composable: ReturnType<typeof useComfyUISettings>
+    onShowProgress: ReturnType<typeof vi.fn>
+    scope: ReturnType<typeof effectScope>
+  } {
+    const installationRef = ref<Installation | null>(installation)
+    const scope = effectScope()
+    let composable!: ReturnType<typeof useComfyUISettings>
+    scope.run(() => {
+      composable = useComfyUISettings({ installation: installationRef, onShowProgress })
+    })
+    return { composable, onShowProgress, scope }
+  }
+
+  it('prepends the willStopRunning warning to the action confirm message when the install is running', async () => {
+    installMockApi()
+    markRunning('a', 'A')
+    modalSpies.confirm.mockResolvedValue(false) // user cancels — composable returns early
+    const { composable, scope } = mountComposable(makeInstall('a', 'A'))
+
+    await composable.runAction({
+      id: 'update-comfyui',
+      label: 'Update ComfyUI',
+      confirm: { title: 'Update?', message: 'This will pull the latest ComfyUI.' },
+    } as ActionDef)
+
+    expect(modalSpies.confirm).toHaveBeenCalledTimes(1)
+    const callArg = modalSpies.confirm.mock.calls[0][0] as { message: string }
+    // The shared `augmentMessageWithStopWarning` helper joins with `\n\n`
+    // so the warning visually owns its own paragraph above the action's
+    // own copy.
+    expect(callArg.message).toBe('errors.willStopRunning\n\nThis will pull the latest ComfyUI.')
+    scope.stop()
+  })
+
+  it('synthesizes a confirm dialog carrying just the warning when the action has neither confirm nor prompt', async () => {
+    installMockApi()
+    markRunning('a', 'A')
+    modalSpies.confirm.mockResolvedValue(false)
+    const { composable, scope } = mountComposable(makeInstall('a', 'A'))
+
+    await composable.runAction({
+      id: 'snapshot-restore',
+      label: 'Restore Snapshot',
+    } as ActionDef)
+
+    expect(modalSpies.confirm).toHaveBeenCalledTimes(1)
+    const callArg = modalSpies.confirm.mock.calls[0][0] as { message: string; title: string }
+    expect(callArg.message).toBe('errors.willStopRunning')
+    expect(callArg.title).toBe('Restore Snapshot')
+    scope.stop()
+  })
+
+  it('does NOT prepend the warning when the install is not running', async () => {
+    installMockApi()
+    // No markRunning — sessionStore.isRunning('a') === false.
+    modalSpies.confirm.mockResolvedValue(false)
+    const { composable, scope } = mountComposable(makeInstall('a', 'A'))
+
+    await composable.runAction({
+      id: 'update-comfyui',
+      label: 'Update ComfyUI',
+      confirm: { title: 'Update?', message: 'This will pull the latest ComfyUI.' },
+    } as ActionDef)
+
+    expect(modalSpies.confirm).toHaveBeenCalledTimes(1)
+    const callArg = modalSpies.confirm.mock.calls[0][0] as { message: string }
+    expect(callArg.message).toBe('This will pull the latest ComfyUI.')
+    scope.stop()
+  })
+
+  it('IN_PLACE_RELAUNCH apiCall stops the session, runs the op, and relaunches when the op succeeds', async () => {
+    // stopComfyUI fires → flip runningInstances → polling loop in
+    // stopAndWaitForExit exits → runAction(update-comfyui) → runAction(launch).
+    const api = installMockApi({
+      stopComfyUI: vi.fn().mockImplementation(async (id: string) => {
+        useSessionStore().runningInstances.delete(id)
+      }),
+      runAction: vi.fn().mockResolvedValue({ ok: true }),
+    })
+    markRunning('a', 'A')
+    modalSpies.confirm.mockResolvedValue(true)
+
+    const onShowProgress = vi.fn()
+    const { composable, scope } = mountComposable(makeInstall('a', 'A'), onShowProgress)
+
+    await composable.runAction({
+      id: 'update-comfyui',
+      label: 'Update ComfyUI',
+      showProgress: true,
+      confirm: { message: 'Update?' },
+    } as ActionDef)
+
+    expect(onShowProgress).toHaveBeenCalledTimes(1)
+    const opts = onShowProgress.mock.calls[0][0] as ShowProgressOpts
+    // triggersInstanceStart reflects the relaunch that the apiCall will
+    // append — ProgressModal needs it to wire up the instance-started
+    // listener that closes the chooser host.
+    expect(opts.triggersInstanceStart).toBe(true)
+
+    // Invoke the closure-bound apiCall the way ProgressModal would.
+    const result = await opts.apiCall() as ActionResult
+
+    expect(api.stopComfyUI).toHaveBeenCalledTimes(1)
+    expect(api.stopComfyUI).toHaveBeenCalledWith('a')
+    // Two run-action calls: the actual op, then the auto-relaunch.
+    expect(api.runAction).toHaveBeenCalledTimes(2)
+    expect(api.runAction).toHaveBeenNthCalledWith(1, 'a', 'update-comfyui', undefined)
+    expect(api.runAction).toHaveBeenNthCalledWith(2, 'a', 'launch')
+    expect(result).toEqual({ ok: true })
+    scope.stop()
+  })
+
+  it('IN_PLACE_RELAUNCH apiCall skips the relaunch when the op result reports ok: false', async () => {
+    // Mirrors the e2e test install where the standalone source's
+    // update-comfyui has no release metadata so it returns { ok: false } —
+    // we must NOT relaunch on a failed update.
+    const api = installMockApi({
+      stopComfyUI: vi.fn().mockImplementation(async (id: string) => {
+        useSessionStore().runningInstances.delete(id)
+      }),
+      runAction: vi.fn().mockResolvedValue({ ok: false, message: 'no update available' }),
+    })
+    markRunning('a', 'A')
+    modalSpies.confirm.mockResolvedValue(true)
+    const onShowProgress = vi.fn()
+    const { composable, scope } = mountComposable(makeInstall('a', 'A'), onShowProgress)
+
+    await composable.runAction({
+      id: 'update-comfyui',
+      label: 'Update ComfyUI',
+      showProgress: true,
+      confirm: { message: 'Update?' },
+    } as ActionDef)
+
+    const opts = onShowProgress.mock.calls[0][0] as ShowProgressOpts
+    await opts.apiCall()
+
+    expect(api.stopComfyUI).toHaveBeenCalledTimes(1)
+    expect(api.runAction).toHaveBeenCalledTimes(1)
+    expect(api.runAction).toHaveBeenCalledWith('a', 'update-comfyui', undefined)
+    scope.stop()
+  })
+
+  it('REQUIRES_STOPPED-but-not-IN_PLACE_RELAUNCH apiCall stops and runs the op without an auto-relaunch (e.g. copy-update)', async () => {
+    // copy / copy-update / release-update return a newInstallationId
+    // that opens in its own window (FLOW 2) — the source install is
+    // intentionally left stopped, so no relaunch.
+    const api = installMockApi({
+      stopComfyUI: vi.fn().mockImplementation(async (id: string) => {
+        useSessionStore().runningInstances.delete(id)
+      }),
+      runAction: vi.fn().mockResolvedValue({ ok: true, newInstallationId: 'a-prime' }),
+    })
+    markRunning('a', 'A')
+    modalSpies.confirm.mockResolvedValue(true)
+    const onShowProgress = vi.fn()
+    const { composable, scope } = mountComposable(makeInstall('a', 'A'), onShowProgress)
+
+    await composable.runAction({
+      id: 'copy-update',
+      label: 'Copy & Update',
+      showProgress: true,
+      confirm: { message: 'Copy & update?' },
+    } as ActionDef)
+
+    const opts = onShowProgress.mock.calls[0][0] as ShowProgressOpts
+    // No auto-relaunch wired in → triggersInstanceStart stays false; the
+    // new install opens in its own chooser-host window instead.
+    expect(opts.triggersInstanceStart).toBe(false)
+    await opts.apiCall()
+
+    expect(api.stopComfyUI).toHaveBeenCalledTimes(1)
+    expect(api.runAction).toHaveBeenCalledTimes(1)
+    expect(api.runAction).toHaveBeenCalledWith('a', 'copy-update', undefined)
+    scope.stop()
+  })
+
+  it('apiCall does not stop or relaunch when the install is not running', async () => {
+    // Wasn't running → nothing to stop, nothing to relaunch even for
+    // IN_PLACE_RELAUNCH actions. Just invoke the op directly.
+    const api = installMockApi({
+      runAction: vi.fn().mockResolvedValue({ ok: true }),
+    })
+    modalSpies.confirm.mockResolvedValue(true)
+    const onShowProgress = vi.fn()
+    const { composable, scope } = mountComposable(makeInstall('a', 'A'), onShowProgress)
+
+    await composable.runAction({
+      id: 'update-comfyui',
+      label: 'Update ComfyUI',
+      showProgress: true,
+      confirm: { message: 'Update?' },
+    } as ActionDef)
+
+    const opts = onShowProgress.mock.calls[0][0] as ShowProgressOpts
+    expect(opts.triggersInstanceStart).toBe(false)
+    await opts.apiCall()
+
+    expect(api.stopComfyUI).not.toHaveBeenCalled()
+    expect(api.runAction).toHaveBeenCalledTimes(1)
+    expect(api.runAction).toHaveBeenCalledWith('a', 'update-comfyui', undefined)
+    scope.stop()
+  })
+
+  it('inline (no showProgress) REQUIRES_STOPPED action self-stops before invoking the backend', async () => {
+    // Inline path mirrors the showProgress path's self-stop so the
+    // backend's running-check doesn't race the stop on a running install.
+    const api = installMockApi({
+      stopComfyUI: vi.fn().mockImplementation(async (id: string) => {
+        useSessionStore().runningInstances.delete(id)
+      }),
+      runAction: vi.fn().mockResolvedValue({ ok: true }),
+    })
+    markRunning('a', 'A')
+    modalSpies.confirm.mockResolvedValue(true)
+    const { composable, scope } = mountComposable(makeInstall('a', 'A'))
+
+    await composable.runAction({
+      id: 'update-comfyui',
+      label: 'Update ComfyUI',
+      confirm: { message: 'Update?' },
+    } as ActionDef)
+
+    expect(api.stopComfyUI).toHaveBeenCalledTimes(1)
+    expect(api.runAction).toHaveBeenCalledWith('a', 'update-comfyui', undefined)
     scope.stop()
   })
 })

--- a/src/renderer/src/composables/useComfyUISettings.ts
+++ b/src/renderer/src/composables/useComfyUISettings.ts
@@ -277,14 +277,10 @@ export function useComfyUISettings(opts: UseComfyUISettingsOpts): UseComfyUISett
     //    forwards to the panel) skip the inline confirm and tag the
     //    showProgress payload with `requiresStopped` so the host runs
     //    the guard against its own BaseAlert.
-    const deferStoppedGuard = !!opts.deferStoppedGuardToHost
-      && action.id !== 'migrate-to-standalone'
+    const requiresStoppedGuard = action.id !== 'migrate-to-standalone'
       && REQUIRES_STOPPED.has(action.id)
-    if (
-      !deferStoppedGuard
-      && action.id !== 'migrate-to-standalone'
-      && REQUIRES_STOPPED.has(action.id)
-    ) {
+    const deferStoppedGuard = !!opts.deferStoppedGuardToHost && requiresStoppedGuard
+    if (requiresStoppedGuard && !deferStoppedGuard) {
       const proceed = await actionGuard.checkBeforeAction(inst.id, action.label)
       if (!proceed) return
     }

--- a/src/renderer/src/composables/useComfyUISettings.ts
+++ b/src/renderer/src/composables/useComfyUISettings.ts
@@ -17,6 +17,7 @@ import {
   type Installation,
   type ShowProgressOpts,
 } from '../types/ipc'
+import { IN_PLACE_RELAUNCH, augmentActionWithStopWarning, stopAndWaitForExit } from '../lib/stopWarning'
 
 /**
  * Backing state + IPC plumbing for the brand-redesigned Settings drawer
@@ -30,15 +31,19 @@ import {
  * into the Status tab as a synthetic row.
  *
  * Action handling mirrors `DetailModal.runAction` exactly:
- *   1. REQUIRES_STOPPED guard via useActionGuard
+ *   1. Busy-only guard via useActionGuard (in-progress op cancel-confirm)
  *   2. `migrate-to-standalone` special case → useMigrateAction
- *   3. fieldSelects chain → modal.select per fieldSelect
- *   4. select chain → modal.select (e.g. installations)
- *   5. prompt chain → modal.prompt
- *   6. confirm chain → modal.confirm or modal.confirmWithOptions
- *   7. disk-space check for copy / copy-update / release-update
- *   8. showProgress → opts.onShowProgress with synthetic-restart support
- *   9. inline → window.api.runAction with result navigation
+ *   3. willStopRunning augment for REQUIRES_STOPPED while running —
+ *      prepends the stop-warning sentence to confirm / prompt messages
+ *      so the user knows the running ComfyUI will be stopped to proceed
+ *   4. fieldSelects chain → modal.select per fieldSelect
+ *   5. select chain → modal.select (e.g. installations)
+ *   6. prompt chain → modal.prompt
+ *   7. confirm chain → modal.confirm or modal.confirmWithOptions
+ *   8. disk-space check for copy / copy-update / release-update
+ *   9. showProgress → opts.onShowProgress with self-stopping apiCall +
+ *      in-place relaunch for update-comfyui / snapshot-restore
+ *  10. inline → window.api.runAction (also self-stops when needed)
  */
 
 export interface UseComfyUISettingsOpts {
@@ -58,14 +63,6 @@ export interface UseComfyUISettingsOpts {
    *  own dismissal before the host completes the navigation — mirrors
    *  DetailModal's `emit('close')`. */
   onClose?: () => void
-  /** Skip the inline `actionGuard.checkBeforeAction` for REQUIRES_STOPPED
-   *  actions and tag the emitted `show-progress` payload with
-   *  `requiresStopped: true` so the host runs the stop-confirm instead.
-   *  Set by hosts whose surface tears down when `show-progress` fires
-   *  (the picker popup auto-dismisses on blur and the modal would die
-   *  with it); the panel surface owns a stable BaseAlert that handles
-   *  the stop-confirm without the popup-teardown race. */
-  deferStoppedGuardToHost?: boolean
 }
 
 export interface UseComfyUISettingsApi {
@@ -270,17 +267,16 @@ export function useComfyUISettings(opts: UseComfyUISettingsOpts): UseComfyUISett
 
     const telemetryContext = { action_id: action.id }
 
-    // 1. REQUIRES_STOPPED guard — actions that need ComfyUI stopped
-    //    first (snapshot restore, release-update, …). migrate-to-
-    //    standalone manages its own guard via useMigrateAction below.
-    //    Hosts that defer to a downstream surface (the picker popup
-    //    forwards to the panel) skip the inline confirm and tag the
-    //    showProgress payload with `requiresStopped` so the host runs
-    //    the guard against its own BaseAlert.
-    const requiresStoppedGuard = action.id !== 'migrate-to-standalone'
-      && REQUIRES_STOPPED.has(action.id)
-    const deferStoppedGuard = !!opts.deferStoppedGuardToHost && requiresStoppedGuard
-    if (requiresStoppedGuard && !deferStoppedGuard) {
+    // 1. Busy-only guard. migrate-to-standalone manages its own busy
+    //    check + UI via useMigrateAction below, so skip both this
+    //    pre-flight and the step-3 message augment for it. The apiCall
+    //    self-stop still applies — migrate is REQUIRES_STOPPED and the
+    //    source session must be torn down before the backend handler
+    //    runs.
+    const ownsPreflight = action.id === 'migrate-to-standalone'
+    const requiresStoppedGuard = REQUIRES_STOPPED.has(action.id)
+    const wasRunning = sessionStore.isRunning(inst.id)
+    if (requiresStoppedGuard && !ownsPreflight) {
       const proceed = await actionGuard.checkBeforeAction(inst.id, action.label)
       if (!proceed) return
     }
@@ -299,7 +295,17 @@ export function useComfyUISettings(opts: UseComfyUISettingsOpts): UseComfyUISett
       }
     }
 
-    // 3. fieldSelects chain — each step prompts the user to pick from a
+    // 3. Stop-warning augment. No per-action confirm/prompt copy
+    //    mentions the stop today, and the standalone stop-confirm modal
+    //    was removed, so prepend the sentence to whatever the action
+    //    already says (or use it standalone if the action has neither).
+    //    Skipped for migrate-to-standalone — useMigrateAction handles
+    //    its own confirm surface (modal OR brand takeover).
+    if (requiresStoppedGuard && wasRunning && !ownsPreflight) {
+      mutableAction = augmentActionWithStopWarning(mutableAction, t('errors.willStopRunning'))
+    }
+
+    // 4. fieldSelects chain — each step prompts the user to pick from a
     //    main-side source via `getFieldOptions`. Selections feed the
     //    next step + accumulate on `mutableAction.data`.
     if (mutableAction.fieldSelects) {
@@ -342,7 +348,7 @@ export function useComfyUISettings(opts: UseComfyUISettingsOpts): UseComfyUISett
       }
     }
 
-    // 4. select chain — single-shot select against a named source
+    // 5. select chain — single-shot select against a named source
     //    (e.g. `'installations'` for "copy from which install").
     if (mutableAction.select) {
       let items: { value: string; label: string; description?: string }[] | undefined
@@ -377,7 +383,7 @@ export function useComfyUISettings(opts: UseComfyUISettingsOpts): UseComfyUISett
       }
     }
 
-    // 5. prompt chain — free-form text input (e.g. Copy Installation
+    // 6. prompt chain — free-form text input (e.g. Copy Installation
     //    new-name prompt).
     if (mutableAction.prompt) {
       const value = await modal.prompt({
@@ -396,7 +402,7 @@ export function useComfyUISettings(opts: UseComfyUISettingsOpts): UseComfyUISett
       }
     }
 
-    // 6. confirm chain — skip for migrate-to-standalone (handled in #2).
+    // 7. confirm chain — skip for migrate-to-standalone (handled in #2).
     //    `confirm.options` flips us to `confirmWithOptions` (checkbox
     //    confirm — e.g. Delete Installation's "Also delete files" toggle).
     if (mutableAction.confirm && mutableAction.id !== 'migrate-to-standalone') {
@@ -422,7 +428,7 @@ export function useComfyUISettings(opts: UseComfyUISettingsOpts): UseComfyUISett
       }
     }
 
-    // 7. Disk-space sanity check for actions that write significant
+    // 8. Disk-space sanity check for actions that write significant
     //    data. Estimate via `getInstallationSize` for copy / copy-update;
     //    fall back to a generic 1 GiB threshold otherwise.
     const diskCheckActions = new Set(['copy', 'copy-update', 'release-update'])
@@ -457,9 +463,12 @@ export function useComfyUISettings(opts: UseComfyUISettingsOpts): UseComfyUISett
       }
     }
 
-    // 8. showProgress — emit show-progress for the host's ProgressModal.
+    // 9. showProgress — emit show-progress for the host's ProgressModal.
     //    The synthetic `restart` id maps to stop → wait → launch so the
     //    user sees one continuous "Restarting ComfyUI" progress view.
+    //    REQUIRES_STOPPED ops against a running install wrap the
+    //    apiCall to stop ComfyUI → wait → run the op, and append a
+    //    relaunch when the action is in IN_PLACE_RELAUNCH.
     if (mutableAction.showProgress) {
       const rawTitle = (mutableAction.progressTitle || mutableAction.label).replace(
         /\{(\w+)\}/g,
@@ -467,17 +476,25 @@ export function useComfyUISettings(opts: UseComfyUISettingsOpts): UseComfyUISett
       )
       const title = `${rawTitle} — ${inst.name}`
       const isRestart = mutableAction.id === 'restart'
+      const needsSelfStop = wasRunning && requiresStoppedGuard && !isRestart
+      const wantsRelaunch = needsSelfStop && IN_PLACE_RELAUNCH.has(mutableAction.id)
+      const isRunning = (): boolean => sessionStore.isRunning(inst.id)
       const apiCall = isRestart
         ? async (): Promise<ReturnType<typeof window.api.runAction>> => {
-          await window.api.stopComfyUI(inst.id)
-          const deadline = Date.now() + 10_000
-          while (sessionStore.isRunning(inst.id) && Date.now() < deadline) {
-            await new Promise((r) => setTimeout(r, 100))
-          }
+          await stopAndWaitForExit(inst.id, isRunning)
           return window.api.runAction(inst.id, 'launch')
         }
-        : (): ReturnType<typeof window.api.runAction> =>
-          window.api.runAction(inst.id, mutableAction.id, mutableAction.data)
+        : needsSelfStop
+          ? async (): Promise<ReturnType<typeof window.api.runAction>> => {
+            await stopAndWaitForExit(inst.id, isRunning)
+            const result = await window.api.runAction(inst.id, mutableAction.id, mutableAction.data)
+            if (wantsRelaunch && result?.ok !== false) {
+              await window.api.runAction(inst.id, 'launch')
+            }
+            return result
+          }
+          : (): ReturnType<typeof window.api.runAction> =>
+            window.api.runAction(inst.id, mutableAction.id, mutableAction.data)
       emitTelemetryAction('desktop2.action.invoked', telemetryContext)
       opts.onShowProgress({
         installationId: inst.id,
@@ -485,7 +502,7 @@ export function useComfyUISettings(opts: UseComfyUISettingsOpts): UseComfyUISett
         apiCall,
         cancellable: !!mutableAction.cancellable,
         returnTo: 'detail',
-        triggersInstanceStart: mutableAction.id === 'launch' || isRestart,
+        triggersInstanceStart: mutableAction.id === 'launch' || isRestart || wantsRelaunch,
         // Synthetic `restart` id (stop → wait → launch) reads as a launch
         // op to the brand caption pipeline, mirroring its
         // triggersInstanceStart flag.
@@ -493,18 +510,23 @@ export function useComfyUISettings(opts: UseComfyUISettingsOpts): UseComfyUISett
         destroysInstance: destroysInstanceForActionId(mutableAction.id),
         actionId: mutableAction.id,
         actionData: mutableAction.data,
-        requiresStopped: deferStoppedGuard,
       })
       return
     }
 
-    // 9. Inline invoke + result navigation.
+    // 10. Inline invoke + result navigation. Self-stop wrap mirrors the
+    //     showProgress path so inline REQUIRES_STOPPED actions don't
+    //     race the backend's running-check on a running install.
     try {
       emitTelemetryAction('desktop2.action.invoked', telemetryContext)
+      if (wasRunning && requiresStoppedGuard) {
+        await stopAndWaitForExit(inst.id, () => sessionStore.isRunning(inst.id))
+      }
       const result = await window.api.runAction(inst.id, mutableAction.id, mutableAction.data)
       if (result.running) {
-        // Backend detected a race — surface the action guard so the
-        // user can stop ComfyUI and retry.
+        // Backend race — apiCall self-stop should have prevented this,
+        // but if a launch slipped in between the stop and the action
+        // invocation, surface the busy guard so the user can retry.
         await actionGuard.checkBeforeAction(inst.id, mutableAction.label)
         return
       }

--- a/src/renderer/src/composables/useComfyUISettings.ts
+++ b/src/renderer/src/composables/useComfyUISettings.ts
@@ -58,6 +58,14 @@ export interface UseComfyUISettingsOpts {
    *  own dismissal before the host completes the navigation — mirrors
    *  DetailModal's `emit('close')`. */
   onClose?: () => void
+  /** Skip the inline `actionGuard.checkBeforeAction` for REQUIRES_STOPPED
+   *  actions and tag the emitted `show-progress` payload with
+   *  `requiresStopped: true` so the host runs the stop-confirm instead.
+   *  Set by hosts whose surface tears down when `show-progress` fires
+   *  (the picker popup auto-dismisses on blur and the modal would die
+   *  with it); the panel surface owns a stable BaseAlert that handles
+   *  the stop-confirm without the popup-teardown race. */
+  deferStoppedGuardToHost?: boolean
 }
 
 export interface UseComfyUISettingsApi {
@@ -265,7 +273,18 @@ export function useComfyUISettings(opts: UseComfyUISettingsOpts): UseComfyUISett
     // 1. REQUIRES_STOPPED guard — actions that need ComfyUI stopped
     //    first (snapshot restore, release-update, …). migrate-to-
     //    standalone manages its own guard via useMigrateAction below.
-    if (action.id !== 'migrate-to-standalone' && REQUIRES_STOPPED.has(action.id)) {
+    //    Hosts that defer to a downstream surface (the picker popup
+    //    forwards to the panel) skip the inline confirm and tag the
+    //    showProgress payload with `requiresStopped` so the host runs
+    //    the guard against its own BaseAlert.
+    const deferStoppedGuard = !!opts.deferStoppedGuardToHost
+      && action.id !== 'migrate-to-standalone'
+      && REQUIRES_STOPPED.has(action.id)
+    if (
+      !deferStoppedGuard
+      && action.id !== 'migrate-to-standalone'
+      && REQUIRES_STOPPED.has(action.id)
+    ) {
       const proceed = await actionGuard.checkBeforeAction(inst.id, action.label)
       if (!proceed) return
     }
@@ -478,6 +497,7 @@ export function useComfyUISettings(opts: UseComfyUISettingsOpts): UseComfyUISett
         destroysInstance: destroysInstanceForActionId(mutableAction.id),
         actionId: mutableAction.id,
         actionData: mutableAction.data,
+        requiresStopped: deferStoppedGuard,
       })
       return
     }

--- a/src/renderer/src/composables/useComfyUISettings.ts
+++ b/src/renderer/src/composables/useComfyUISettings.ts
@@ -124,30 +124,45 @@ export function useComfyUISettings(opts: UseComfyUISettingsOpts): UseComfyUISett
   const diskSpace = ref<DiskSpaceInfo | null>(null)
   const loading = ref(false)
   const error = ref<string | null>(null)
+  /** Last install id `loadAll` was called with — drives the
+   *  clear-before-await decision so same-install reloads (field edits,
+   *  action completions) don't blank the pane, only row switches do. */
+  let lastLoadedId: string | null = null
+  /** Monotonically increasing request id. Each `loadAll` /
+   *  `refreshSection` call captures the next value and only writes
+   *  results back into the refs if it is still the latest in-flight
+   *  request. Prevents A→B→A clicks from letting B's late response
+   *  overwrite A's pane. */
+  let requestSeq = 0
 
   async function loadAll(installationId: string, installPath: string): Promise<void> {
-    // Clear the previous install's data BEFORE awaiting so a switch to a
-    // different install row in the title-popup picker doesn't briefly
-    // render the prior install's sections / disk reading while the new
-    // IPC is in flight (visible as "right pane is frozen" — regression
-    // for #582). `loading` flips to true alongside, so
-    // `ComfyUISettingsContent` shows its Loading… placeholder instead of
-    // stale rows.
-    sections.value = []
-    diskSpace.value = null
+    // Only clear the visible state on an actual install switch so a
+    // same-install reload (after `updateField` / action completion)
+    // doesn't flash "Loading…" — that flicker would be a regression on
+    // its own. Row switches inside the picker DO clear, which is the
+    // bug we wanted to fix (#582).
+    const isInstallSwitch = installationId !== lastLoadedId
+    if (isInstallSwitch) {
+      sections.value = []
+      diskSpace.value = null
+    }
+    lastLoadedId = installationId
     loading.value = true
     error.value = null
+    const seq = ++requestSeq
     try {
       const [secs, disk] = await Promise.all([
         window.api.getDetailSections(installationId),
         installPath ? window.api.getDiskSpace(installPath).catch(() => null) : Promise.resolve(null),
       ])
+      if (seq !== requestSeq) return
       sections.value = secs
       diskSpace.value = disk
     } catch (e) {
+      if (seq !== requestSeq) return
       error.value = e instanceof Error ? e.message : String(e)
     } finally {
-      loading.value = false
+      if (seq === requestSeq) loading.value = false
     }
   }
 
@@ -156,6 +171,10 @@ export function useComfyUISettings(opts: UseComfyUISettingsOpts): UseComfyUISett
     if (!inst) {
       sections.value = []
       diskSpace.value = null
+      lastLoadedId = null
+      // Bump the sequence so any in-flight loadAll for a previous
+      // install can't write into our now-cleared refs.
+      requestSeq++
       return
     }
     await loadAll(inst.id, inst.installPath ?? '')
@@ -172,8 +191,14 @@ export function useComfyUISettings(opts: UseComfyUISettingsOpts): UseComfyUISett
     }
     const inst = toValue(opts.installation)
     if (!inst) return
+    const targetId = inst.id
+    const seq = ++requestSeq
     try {
-      const fresh = await window.api.getDetailSections(inst.id)
+      const fresh = await window.api.getDetailSections(targetId)
+      // Drop the result if the install changed or a newer request
+      // beat us in flight — prevents A→B→A from letting B's late
+      // response splice into A's pane.
+      if (seq !== requestSeq || lastLoadedId !== targetId) return
       const updated = fresh.find((s) => s.title === sectionTitle)
       if (!updated) {
         // Title disappeared from the new payload — main mutated the
@@ -188,6 +213,7 @@ export function useComfyUISettings(opts: UseComfyUISettingsOpts): UseComfyUISett
         sections.value = fresh
       }
     } catch (e) {
+      if (seq !== requestSeq) return
       error.value = e instanceof Error ? e.message : String(e)
     }
   }
@@ -216,10 +242,10 @@ export function useComfyUISettings(opts: UseComfyUISettingsOpts): UseComfyUISett
         })
       }
     }
-    // Parity with legacy DetailSection (PARITY-G): when a field opts
-    // into `refreshSection`, splice only that section instead of
-    // replacing the whole array — preserves Vue subtrees and collapse
-    // state for sections the user wasn't touching.
+    // When a field opts into `refreshSection`, splice only that
+    // section instead of replacing the whole array — preserves Vue
+    // subtrees and collapse state for sections the user wasn't
+    // touching.
     if (field.refreshSection) {
       const owningSection = sections.value.find(
         (s) => s.fields?.some((f) => f.id === field.id),

--- a/src/renderer/src/composables/useComfyUISettings.ts
+++ b/src/renderer/src/composables/useComfyUISettings.ts
@@ -126,6 +126,15 @@ export function useComfyUISettings(opts: UseComfyUISettingsOpts): UseComfyUISett
   const error = ref<string | null>(null)
 
   async function loadAll(installationId: string, installPath: string): Promise<void> {
+    // Clear the previous install's data BEFORE awaiting so a switch to a
+    // different install row in the title-popup picker doesn't briefly
+    // render the prior install's sections / disk reading while the new
+    // IPC is in flight (visible as "right pane is frozen" — regression
+    // for #582). `loading` flips to true alongside, so
+    // `ComfyUISettingsContent` shows its Loading… placeholder instead of
+    // stale rows.
+    sections.value = []
+    diskSpace.value = null
     loading.value = true
     error.value = null
     try {

--- a/src/renderer/src/composables/useDeepLinkRouter.ts
+++ b/src/renderer/src/composables/useDeepLinkRouter.ts
@@ -1,5 +1,6 @@
 import { onMounted, onUnmounted } from 'vue'
 import { useInstallationStore } from '../stores/installationStore'
+import { useActionGuard } from './useActionGuard'
 import type { Installation, ShowProgressOpts } from '../types/ipc'
 
 import type { Overlay } from './useOverlay'
@@ -45,6 +46,7 @@ interface DeepLinkRouterOpts {
  */
 export function useDeepLinkRouter(opts: DeepLinkRouterOpts): void {
   const installationStore = useInstallationStore()
+  const actionGuard = useActionGuard()
   let unsubPanelTriggerOverlay: (() => void) | null = null
 
   onMounted(() => {
@@ -130,6 +132,16 @@ export function useDeepLinkRouter(opts: DeepLinkRouterOpts): void {
           if (!id || !actionId || !title) return
           const inst = installationStore.getById(id)
           if (!inst) return
+          // Picker deferred the REQUIRES_STOPPED guard to us so the
+          // stop-confirm runs in the panel's stable BaseAlert rather
+          // than the popup webContents that auto-dismisses on blur and
+          // gets visually obscured by the popup's own geometry. Cancel
+          // aborts the whole chain — the picker has already hidden, so
+          // no progress modal appears.
+          if (payload.requiresStopped) {
+            const proceed = await actionGuard.checkBeforeAction(id, title)
+            if (!proceed) return
+          }
           const isRestart = !!payload.isRestart
           const actionData = (payload.actionData ?? undefined) as
             | Record<string, unknown>

--- a/src/renderer/src/composables/useDeepLinkRouter.ts
+++ b/src/renderer/src/composables/useDeepLinkRouter.ts
@@ -1,7 +1,8 @@
 import { onMounted, onUnmounted } from 'vue'
 import { useInstallationStore } from '../stores/installationStore'
-import { useActionGuard } from './useActionGuard'
-import type { Installation, ShowProgressOpts } from '../types/ipc'
+import { useSessionStore } from '../stores/sessionStore'
+import { IN_PLACE_RELAUNCH, stopAndWaitForExit } from '../lib/stopWarning'
+import { REQUIRES_STOPPED, type Installation, type ShowProgressOpts } from '../types/ipc'
 
 import type { Overlay } from './useOverlay'
 
@@ -46,7 +47,7 @@ interface DeepLinkRouterOpts {
  */
 export function useDeepLinkRouter(opts: DeepLinkRouterOpts): void {
   const installationStore = useInstallationStore()
-  const actionGuard = useActionGuard()
+  const sessionStore = useSessionStore()
   let unsubPanelTriggerOverlay: (() => void) | null = null
 
   onMounted(() => {
@@ -132,44 +133,44 @@ export function useDeepLinkRouter(opts: DeepLinkRouterOpts): void {
           if (!id || !actionId || !title) return
           const inst = installationStore.getById(id)
           if (!inst) return
-          // Picker deferred the REQUIRES_STOPPED guard to us so the
-          // stop-confirm runs in the panel's stable BaseAlert rather
-          // than the popup webContents that auto-dismisses on blur and
-          // gets visually obscured by the popup's own geometry. Cancel
-          // aborts the whole chain — the picker has already hidden, so
-          // no progress modal appears.
-          if (payload.requiresStopped) {
-            const proceed = await actionGuard.checkBeforeAction(id, title)
-            if (!proceed) return
-          }
+          // Picker-driven apiCall: rebuild from actionId/actionData on
+          // this side because closures don't cross IPC. Mirrors
+          // `useComfyUISettings.runAction`'s showProgress branch —
+          // self-stops on a running install for REQUIRES_STOPPED and
+          // appends a relaunch for IN_PLACE_RELAUNCH ops.
           const isRestart = !!payload.isRestart
           const actionData = (payload.actionData ?? undefined) as
             | Record<string, unknown>
             | undefined
+          const wasRunning = sessionStore.isRunning(id)
+          const requiresStoppedGuard = !isRestart
+            && actionId !== 'migrate-to-standalone'
+            && REQUIRES_STOPPED.has(actionId)
+          const needsSelfStop = wasRunning && requiresStoppedGuard
+          const wantsRelaunch = needsSelfStop && IN_PLACE_RELAUNCH.has(actionId)
+          const isRunning = (): boolean => sessionStore.isRunning(id)
           const apiCall = isRestart
             ? async () => {
-              await window.api.stopComfyUI(id)
-              const deadline = Date.now() + 10_000
-              while (Date.now() < deadline) {
-                try {
-                  const installs = await window.api.getInstallations()
-                  const stillRunning = installs.find((i) => i.id === id)?.status === 'running'
-                  if (!stillRunning) break
-                } catch {
-                  break
-                }
-                await new Promise((r) => setTimeout(r, 100))
-              }
+              await stopAndWaitForExit(id, isRunning)
               return window.api.runAction(id, 'launch')
             }
-            : () => window.api.runAction(id, actionId, actionData)
+            : needsSelfStop
+              ? async () => {
+                await stopAndWaitForExit(id, isRunning)
+                const result = await window.api.runAction(id, actionId, actionData)
+                if (wantsRelaunch && result?.ok !== false) {
+                  await window.api.runAction(id, 'launch')
+                }
+                return result
+              }
+              : () => window.api.runAction(id, actionId, actionData)
           opts.showProgressFromPicker?.({
             installationId: id,
             title,
             apiCall,
             cancellable: !!payload.cancellable,
             returnTo: 'detail',
-            triggersInstanceStart: !!payload.triggersInstanceStart,
+            triggersInstanceStart: !!payload.triggersInstanceStart || wantsRelaunch,
             opKind: payload.opKind,
             actionId,
             actionData,

--- a/src/renderer/src/composables/useInstallContextMenu.test.ts
+++ b/src/renderer/src/composables/useInstallContextMenu.test.ts
@@ -4,19 +4,38 @@ import { createI18n } from 'vue-i18n'
 import { defineComponent, h } from 'vue'
 import { mount } from '@vue/test-utils'
 
+// `useModal` is a singleton with module-level state. The composable
+// awaits `modal.confirm(...)` which never resolves on its own — mock
+// the composable so tests can drive the confirm response synchronously.
+const modalMock = {
+  confirm: vi.fn(),
+  alert: vi.fn(),
+  prompt: vi.fn(),
+  select: vi.fn(),
+  confirmWithOptions: vi.fn(),
+}
+vi.mock('./useModal', () => ({
+  useModal: () => modalMock,
+}))
+
 import { useInstallContextMenu } from './useInstallContextMenu'
 import { useSessionStore } from '../stores/sessionStore'
 import { useProgressStore } from '../stores/progressStore'
-import type { Installation } from '../types/ipc'
+import type { Installation, ShowProgressOpts } from '../types/ipc'
 import type { ContextMenuItem } from '../types/context-menu'
 
+// Mock api on `window`. `getDetailSections` is spied so tests can
+// assert it is NOT called by the delete fast path (regression for the
+// ~2s confirm-modal latency on the dashboard kebab → Delete click).
+const apiMock = {
+  platform: 'darwin',
+  runAction: vi.fn().mockResolvedValue({ ok: true }),
+  getDetailSections: vi.fn().mockResolvedValue([]),
+  onErrorDetail: vi.fn(() => () => {}),
+}
 vi.stubGlobal('window', {
   ...window,
-  api: {
-    platform: 'darwin',
-    runAction: vi.fn().mockResolvedValue({ ok: true }),
-    onErrorDetail: vi.fn(() => () => {}),
-  },
+  api: apiMock,
 })
 
 const messages = {
@@ -32,6 +51,10 @@ const messages = {
     actions: {
       copyInstallation: 'Copy Install',
       untrack: 'Untrack',
+      delete: 'Delete',
+      deleteConfirmTitle: 'Delete Install',
+      deleteConfirmMessage:
+        'This will permanently delete the install and all its files. This cannot be undone.',
     },
     progress: { working: 'Working…' },
     running: { dismiss: 'Dismiss' },
@@ -58,33 +81,41 @@ interface HarnessHandles {
 }
 
 /**
- * `useInstallContextMenu` calls Pinia stores + `useI18n()` so the
- * composable (and the stores it depends on) can only be invoked from
- * inside a real component setup scope. Build a tiny harness component
- * that exposes the composable's computed `ctxMenuItems` for assertion,
- * along with the store handles so individual tests can pre-seed
- * running / stopping / in-progress state.
+ * Common harness component used by every spec. `useInstallContextMenu`
+ * calls Pinia stores + `useI18n()` so the composable can only run from
+ * inside a real component setup scope; this single `defineComponent`
+ * is reused across all `mountHarness*` factories so the file stays
+ * compliant with `vue/one-component-per-file`.
+ *
+ * The factory hands `setup` a closure that runs once per mount and
+ * captures handles back into the caller-supplied refs.
  */
+let _harnessSetup: (() => void) | null = null
+const HarnessComponent = defineComponent({
+  setup() {
+    _harnessSetup?.()
+    return () => h('div')
+  },
+})
+
 function mountHarness(inst: Installation, mutate?: (h: HarnessHandles) => void) {
   const pinia = createPinia()
   setActivePinia(pinia)
   const i18n = createI18n({ legacy: false, locale: 'en', messages })
   let handles!: HarnessHandles
-  const Harness = defineComponent({
-    setup() {
-      const menu = useInstallContextMenu({ onManage: () => {} })
-      const session = useSessionStore()
-      const progress = useProgressStore()
-      handles = { menu, session, progress }
-      mutate?.(handles)
-      menu.openCardMenu(
-        new MouseEvent('contextmenu', { clientX: 0, clientY: 0 }),
-        inst
-      )
-      return () => h('div')
-    },
-  })
-  const wrapper = mount(Harness, { global: { plugins: [pinia, i18n] } })
+  _harnessSetup = () => {
+    const menu = useInstallContextMenu({ onManage: () => {} })
+    const session = useSessionStore()
+    const progress = useProgressStore()
+    handles = { menu, session, progress }
+    mutate?.(handles)
+    menu.openCardMenu(
+      new MouseEvent('contextmenu', { clientX: 0, clientY: 0 }),
+      inst,
+    )
+  }
+  const wrapper = mount(HarnessComponent, { global: { plugins: [pinia, i18n] } })
+  _harnessSetup = null
   return { wrapper, ...handles }
 }
 
@@ -166,5 +197,94 @@ describe('useInstallContextMenu — gated REQUIRES_STOPPED items', () => {
     })
     expect(menu.isStoppedActionGated(inst)).toBe(true)
     expect(findItem(menu.ctxMenuItems.value, 'delete')?.disabled).toBe(true)
+  })
+})
+
+// --- Delete fast path (regression for #582) ---
+//
+// Old delete branch called `fetchActionDef` → `getDetailSections` →
+// rebuilds the entire detail tree just to pluck the 12-line
+// `deleteAction()` constant; on Windows this stalled the confirm modal
+// by ~2s. The fast path builds the confirm + showProgress payload
+// entirely renderer-side.
+
+function mountHarnessWithProgress(
+  _inst: Installation,
+  onShowProgress: (opts: ShowProgressOpts) => void,
+): { menu: ReturnType<typeof useInstallContextMenu> } {
+  // Reuses the shared `HarnessComponent` defined above; tests drive
+  // `menu.triggerAction(...)` directly so the inst arg is just a
+  // documented call-site hint.
+  const pinia = createPinia()
+  setActivePinia(pinia)
+  const i18n = createI18n({ legacy: false, locale: 'en', messages })
+  let menu!: ReturnType<typeof useInstallContextMenu>
+  _harnessSetup = () => {
+    menu = useInstallContextMenu({
+      onManage: () => {},
+      onShowProgress,
+    })
+  }
+  mount(HarnessComponent, { global: { plugins: [pinia, i18n] } })
+  _harnessSetup = null
+  return { menu }
+}
+
+describe('useInstallContextMenu — delete fast path (regression for #582)', () => {
+  beforeEach(() => {
+    apiMock.getDetailSections.mockClear()
+    apiMock.runAction.mockClear()
+    modalMock.confirm.mockReset()
+  })
+
+  it('shows the confirm modal without calling getDetailSections', async () => {
+    modalMock.confirm.mockResolvedValue(true)
+    const onShowProgress = vi.fn<(opts: ShowProgressOpts) => void>()
+    const inst = makeInstall({ name: 'My Install', installPath: '/tmp/my' })
+    const { menu } = mountHarnessWithProgress(inst, onShowProgress)
+
+    await menu.triggerAction('delete', inst)
+
+    expect(apiMock.getDetailSections).not.toHaveBeenCalled()
+    expect(modalMock.confirm).toHaveBeenCalledTimes(1)
+    const confirmArgs = modalMock.confirm.mock.calls[0][0]
+    expect(confirmArgs.title).toBe('Delete Install')
+    expect(confirmArgs.message).toContain('permanently delete')
+    expect(confirmArgs.message).toContain('/tmp/my')
+    expect(confirmArgs.confirmLabel).toBe('Delete')
+    expect(confirmArgs.confirmStyle).toBe('danger')
+  })
+
+  it('on confirm true, emits showProgress with the correct shape and does not pre-run the action', async () => {
+    modalMock.confirm.mockResolvedValue(true)
+    const onShowProgress = vi.fn<(opts: ShowProgressOpts) => void>()
+    const inst = makeInstall({ name: 'My Install', installPath: '/tmp/my' })
+    const { menu } = mountHarnessWithProgress(inst, onShowProgress)
+
+    await menu.triggerAction('delete', inst)
+
+    expect(onShowProgress).toHaveBeenCalledTimes(1)
+    const opts = onShowProgress.mock.calls[0][0]
+    expect(opts.installationId).toBe(inst.id)
+    expect(opts.title).toBe('Delete — My Install')
+    expect(opts.cancellable).toBe(true)
+    expect(opts.returnTo).toBe('list')
+    expect(opts.destroysInstance).toBe(true)
+
+    // The actual destructive call runs inside ProgressModal, not here.
+    expect(apiMock.runAction).not.toHaveBeenCalled()
+  })
+
+  it('on confirm cancel, does not emit showProgress and does not call runAction', async () => {
+    modalMock.confirm.mockResolvedValue(false)
+    const onShowProgress = vi.fn<(opts: ShowProgressOpts) => void>()
+    const inst = makeInstall()
+    const { menu } = mountHarnessWithProgress(inst, onShowProgress)
+
+    await menu.triggerAction('delete', inst)
+
+    expect(onShowProgress).not.toHaveBeenCalled()
+    expect(apiMock.runAction).not.toHaveBeenCalled()
+    expect(apiMock.getDetailSections).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/composables/useInstallContextMenu.ts
+++ b/src/renderer/src/composables/useInstallContextMenu.ts
@@ -270,33 +270,31 @@ export function useInstallContextMenu(opts: {
         // Source action surfaces its own error path.
       }
     } else if (id === 'delete') {
-      // Fast path (preferred): build the confirm + showProgress payload
-      // entirely renderer-side. The old code called fetchActionDef →
-      // `window.api.getDetailSections(inst.id)` which rebuilds the whole
-      // Status/Update/Snapshots/Settings/Actions tree (cold release-cache
-      // read, ~50 t() lookups, full structured-clone over IPC) JUST to
-      // pluck the 12-line `deleteAction()` constant — easily ~2s on
-      // Windows when main is busy with the periodic update probe.
-      // Regression for #582.
-      //
-      // Every value `deleteAction()` produces is reproducible in the
-      // renderer: install name + installPath come off the `Installation`
-      // prop, the strings live under `actions.*` in the renderer's
-      // merged `locales/en.json`, and the apiCall is the same
-      // `runAction(inst.id, 'delete')` either way. Cloud installs hit
-      // an earlier menu-item gate (`isLocalLikeInstall` + `isInstalled`
-      // in `ctxMenuItems`) so we never see them here.
+      // Build the confirm + showProgress payload renderer-side instead
+      // of round-tripping through `getDetailSections` to look up the
+      // source-side `deleteAction()` shape — the full payload rebuild
+      // was the ~2s confirm-modal stall on Windows. Cloud installs are
+      // already filtered out of the menu via `isLocalLikeInstall` +
+      // `isInstalled` gates in `ctxMenuItems`, so this path only sees
+      // local installs whose delete behaviour matches `actions.ts`.
       if (opts.onShowProgress) {
+        // English fallbacks: PanelApp merges `locales/en.json`
+        // asynchronously after mount, so a very fast first click could
+        // otherwise render raw dotted keys.
+        const deleteLabel = t('actions.delete', 'Delete')
         const confirmed = await modal.confirm({
-          title: t('actions.deleteConfirmTitle'),
-          message: `${t('actions.deleteConfirmMessage')}\n${inst.installPath ?? ''}`,
-          confirmLabel: t('actions.delete'),
+          title: t('actions.deleteConfirmTitle', 'Delete Install'),
+          message: `${t(
+            'actions.deleteConfirmMessage',
+            'This will permanently delete the install and all its files. This cannot be undone.',
+          )}\n${inst.installPath ?? ''}`,
+          confirmLabel: deleteLabel,
           confirmStyle: 'danger',
         })
         if (!confirmed) return
         opts.onShowProgress({
           installationId: inst.id,
-          title: `${t('actions.delete')} — ${inst.name}`,
+          title: `${deleteLabel} — ${inst.name}`,
           apiCall: () => window.api.runAction(inst.id, 'delete'),
           cancellable: true,
           returnTo: 'list',

--- a/src/renderer/src/composables/useInstallContextMenu.ts
+++ b/src/renderer/src/composables/useInstallContextMenu.ts
@@ -6,7 +6,7 @@ import { useModal } from './useModal'
 import { revealInFolderLabel } from './usePlatform'
 import { progressOpKindForActionId, destroysInstanceForActionId } from '../lib/progressOpKind'
 import type { ContextMenuItem } from '../types/context-menu'
-import type { ActionDef, Installation, ShowProgressOpts } from '../types/ipc'
+import type { Installation, ShowProgressOpts } from '../types/ipc'
 
 /**
  * Action / context menu for chooser tiles. Powers two surfaces:
@@ -91,71 +91,6 @@ export function useInstallContextMenu(opts: {
   const modal = useModal()
   const sessionStore = useSessionStore()
   const progressStore = useProgressStore()
-
-  /** Fetch a single ActionDef from main by walking the install's detail
-   *  sections. Used by the fast-path branches in `triggerAction` so we
-   *  can run the action's confirm + showProgress without mounting
-   *  ManageInstallModal first. Returns `null` when the source has no
-   *  matching action (e.g. cloud install + delete). */
-  async function fetchActionDef(inst: Installation, actionId: string): Promise<ActionDef | null> {
-    try {
-      const sections = await window.api.getDetailSections(inst.id)
-      for (const section of sections) {
-        const match = section.actions?.find((a) => a.id === actionId)
-        if (match) return match
-      }
-    } catch {
-      // Falls through to caller's old onManage path.
-    }
-    return null
-  }
-
-  /** Run an action that only needs confirm + showProgress (no
-   *  fieldSelects / select / prompt / disk-space prelude). Today: the
-   *  Delete action def shape. Kept narrow on purpose — the full action
-   *  chain lives in useComfyUISettings / DetailModal and we don't want
-   *  to duplicate that machinery here. Returns true when the show-
-   *  progress branch fired, false otherwise (declined, no def, or the
-   *  action wasn't a confirm+showProgress shape). */
-  async function tryRunSimpleProgressAction(inst: Installation, actionId: string): Promise<boolean> {
-    if (!opts.onShowProgress) return false
-    const action = await fetchActionDef(inst, actionId)
-    if (!action || !action.showProgress) return false
-
-    if (action.confirm) {
-      // Mirror useComfyUISettings step 6: confirmWithOptions when the
-      // action def carries checkbox options, plain confirm otherwise.
-      if (action.confirm.options) {
-        // Confirm-with-options carries data the apiCall needs, so route
-        // through the legacy modal path until we generalise the fast-
-        // path. Caller will hit the onManage fallback below.
-        return false
-      }
-      const confirmed = await modal.confirm({
-        title: action.confirm.title || 'Confirm',
-        message: action.confirm.message || 'Are you sure?',
-        messageDetails: action.confirm.messageDetails,
-        confirmLabel: action.label,
-        confirmStyle: action.style || 'danger',
-      })
-      if (!confirmed) return true
-    }
-
-    const rawTitle = (action.progressTitle || action.label).replace(
-      /\{(\w+)\}/g,
-      (_, k: string) => String((action.data as Record<string, unknown>)?.[k] ?? k),
-    )
-    opts.onShowProgress({
-      installationId: inst.id,
-      title: `${rawTitle} — ${inst.name}`,
-      apiCall: () => window.api.runAction(inst.id, action.id, action.data),
-      cancellable: !!action.cancellable,
-      returnTo: 'list',
-      opKind: progressOpKindForActionId(action.id),
-      destroysInstance: destroysInstanceForActionId(action.id),
-    })
-    return true
-  }
 
   const ctxMenu = ref({
     open: false,
@@ -335,16 +270,41 @@ export function useInstallContextMenu(opts: {
         // Source action surfaces its own error path.
       }
     } else if (id === 'delete') {
-      // Fast path (preferred): when the caller provided `onShowProgress`,
-      // fetch the source-side `delete` action def, run its confirm
-      // directly via the global modal, and emit `show-progress` so
-      // ProgressModal takes over. This avoids the brief ManageInstallModal
-      // mount + sectionsLoading spinner flash that the old `onManage`
-      // path produced. Returns `false` when the source has no matching
-      // delete action (e.g. cloud install) or the action shape is
-      // unexpectedly complex — then we fall through to the legacy paths.
-      const ran = await tryRunSimpleProgressAction(inst, 'delete')
-      if (ran) return
+      // Fast path (preferred): build the confirm + showProgress payload
+      // entirely renderer-side. The old code called fetchActionDef →
+      // `window.api.getDetailSections(inst.id)` which rebuilds the whole
+      // Status/Update/Snapshots/Settings/Actions tree (cold release-cache
+      // read, ~50 t() lookups, full structured-clone over IPC) JUST to
+      // pluck the 12-line `deleteAction()` constant — easily ~2s on
+      // Windows when main is busy with the periodic update probe.
+      // Regression for #582.
+      //
+      // Every value `deleteAction()` produces is reproducible in the
+      // renderer: install name + installPath come off the `Installation`
+      // prop, the strings live under `actions.*` in the renderer's
+      // merged `locales/en.json`, and the apiCall is the same
+      // `runAction(inst.id, 'delete')` either way. Cloud installs hit
+      // an earlier menu-item gate (`isLocalLikeInstall` + `isInstalled`
+      // in `ctxMenuItems`) so we never see them here.
+      if (opts.onShowProgress) {
+        const confirmed = await modal.confirm({
+          title: t('actions.deleteConfirmTitle'),
+          message: `${t('actions.deleteConfirmMessage')}\n${inst.installPath ?? ''}`,
+          confirmLabel: t('actions.delete'),
+          confirmStyle: 'danger',
+        })
+        if (!confirmed) return
+        opts.onShowProgress({
+          installationId: inst.id,
+          title: `${t('actions.delete')} — ${inst.name}`,
+          apiCall: () => window.api.runAction(inst.id, 'delete'),
+          cancellable: true,
+          returnTo: 'list',
+          opKind: progressOpKindForActionId('delete'),
+          destroysInstance: destroysInstanceForActionId('delete'),
+        })
+        return
+      }
       if (opts.onManage) {
         // Legacy path — DetailModal autoAction chain. Used when the
         // host doesn't expose `onShowProgress` (rare; picker forwards

--- a/src/renderer/src/composables/useListAction.ts
+++ b/src/renderer/src/composables/useListAction.ts
@@ -1,9 +1,11 @@
+import { useI18n } from 'vue-i18n'
 import { useModal } from './useModal'
 import { useActionGuard } from './useActionGuard'
 import { useLocalInstanceGuard } from './useLocalInstanceGuard'
 import { useSessionStore } from '../stores/sessionStore'
 import { emitTelemetryAction, toErrorBucket } from '../lib/telemetry'
 import { progressOpKindForActionId, destroysInstanceForActionId } from '../lib/progressOpKind'
+import { IN_PLACE_RELAUNCH, augmentMessageWithStopWarning, stopAndWaitForExit } from '../lib/stopWarning'
 import { REQUIRES_STOPPED } from '../types/ipc'
 import type { Installation, ListAction, ActionResult, ShowProgressOpts } from '../types/ipc'
 
@@ -13,6 +15,7 @@ export interface ListActionCallbacks {
 }
 
 export function useListAction(uiSurface: string, callbacks: ListActionCallbacks) {
+  const { t } = useI18n()
   const modal = useModal()
   const actionGuard = useActionGuard()
   const localInstanceGuard = useLocalInstanceGuard()
@@ -29,15 +32,23 @@ export function useListAction(uiSurface: string, callbacks: ListActionCallbacks)
       return
     }
 
-    // Pre-flight: check if the installation is busy or running
-    if (REQUIRES_STOPPED.has(action.id)) {
+    const requiresStoppedGuard = REQUIRES_STOPPED.has(action.id)
+      && action.id !== 'migrate-to-standalone'
+    const wasRunning = sessionStore.isRunning(inst.id)
+
+    if (requiresStoppedGuard) {
       if (!await actionGuard.checkBeforeAction(inst.id, action.label)) return
     }
 
-    if (action.confirm) {
+    if (action.confirm || (requiresStoppedGuard && wasRunning)) {
+      const willStopMsg = requiresStoppedGuard && wasRunning ? t('errors.willStopRunning') : ''
+      const baseMessage = action.confirm?.message
+      const message = willStopMsg
+        ? augmentMessageWithStopWarning(baseMessage, willStopMsg)
+        : (baseMessage || 'Are you sure?')
       const confirmed = await modal.confirm({
-        title: action.confirm.title || 'Confirm',
-        message: action.confirm.message || 'Are you sure?',
+        title: action.confirm?.title || action.label,
+        message,
         confirmLabel: action.label,
         confirmStyle: action.style || 'danger',
       })
@@ -58,16 +69,32 @@ export function useListAction(uiSurface: string, callbacks: ListActionCallbacks)
     sessionStore.clearErrorInstance(inst.id)
     emitTelemetryAction('desktop2.action.invoked', { action_id: action.id, ...telemetryContext })
 
+    const needsSelfStop = wasRunning && requiresStoppedGuard
+    const wantsRelaunch = needsSelfStop && IN_PLACE_RELAUNCH.has(action.id)
+    const isRunning = (): boolean => sessionStore.isRunning(inst.id)
+
     if (action.showProgress) {
       // Tag launch / restart so PanelApp's `handleShowProgress` installs
       // the chooser-host close-on-instance-started subscription AND
       // routes through the brand-chrome takeover when the source is an
       // install-less chooser host. Mirrors DetailModal's flag.
-      const triggersInstanceStart = action.id === 'launch' || action.id === 'restart'
+      const triggersInstanceStart = action.id === 'launch'
+        || action.id === 'restart'
+        || wantsRelaunch
+      const apiCall = needsSelfStop
+        ? async () => {
+          await stopAndWaitForExit(inst.id, isRunning)
+          const result = await window.api.runAction(inst.id, action.id)
+          if (wantsRelaunch && result?.ok !== false) {
+            await window.api.runAction(inst.id, 'launch')
+          }
+          return result
+        }
+        : () => window.api.runAction(inst.id, action.id)
       callbacks.showProgress({
         installationId: inst.id,
         title: `${action.progressTitle || action.label} — ${inst.name}`,
-        apiCall: () => window.api.runAction(inst.id, action.id),
+        apiCall,
         cancellable: !!action.cancellable,
         triggersInstanceStart,
         opKind: progressOpKindForActionId(action.id),
@@ -77,10 +104,16 @@ export function useListAction(uiSurface: string, callbacks: ListActionCallbacks)
     }
 
     try {
+      if (needsSelfStop) {
+        await stopAndWaitForExit(inst.id, isRunning)
+      }
       const result = await window.api.runAction(inst.id, action.id)
       if (result.running) {
         await actionGuard.checkBeforeAction(inst.id, action.label)
         return
+      }
+      if (wantsRelaunch && result?.ok !== false) {
+        await window.api.runAction(inst.id, 'launch')
       }
       const resultValue = result.cancelled ? 'cancelled' : (result.ok === false ? 'failed' : 'ok')
       emitTelemetryAction('desktop2.action.result', { action_id: action.id, result: resultValue, ...telemetryContext })

--- a/src/renderer/src/composables/useMigrateAction.ts
+++ b/src/renderer/src/composables/useMigrateAction.ts
@@ -2,6 +2,8 @@ import { toRaw } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useModal } from './useModal'
 import { useActionGuard } from './useActionGuard'
+import { useSessionStore } from '../stores/sessionStore'
+import { augmentMessageWithStopWarning } from '../lib/stopWarning'
 import { findBestVariant } from '../lib/variants'
 import type { Installation, FieldOption, SnapshotDetailData } from '../types/ipc'
 
@@ -55,6 +57,7 @@ export function useMigrateAction() {
   const { t } = useI18n()
   const modal = useModal()
   const actionGuard = useActionGuard()
+  const sessionStore = useSessionStore()
 
   /**
    * Run the migration confirmation flow for an installation.
@@ -65,13 +68,14 @@ export function useMigrateAction() {
     confirm?: MigrateConfirmOptions,
     opts?: { surface?: 'modal' | 'takeover' },
   ): Promise<MigrateActionResult | null> {
-    // Pre-flight: check if the installation is busy or running
+    // Pre-flight busy check.
     if (!await actionGuard.checkBeforeAction(installation.id, t('migrate.migrateToStandalone'))) {
       return null
     }
 
     const useTakeover = opts?.surface === 'takeover' && registeredTakeover !== null
     const takeover = useTakeover ? registeredTakeover! : null
+    const wasRunning = sessionStore.isRunning(installation.id)
 
     const isDesktop = installation.sourceId === 'desktop'
     const migrateItems = isDesktop
@@ -90,6 +94,9 @@ export function useMigrateAction() {
 
     const dialogTitle = confirm?.title || t('migrate.migrateToStandaloneConfirmTitle')
     const dialogConfirmLabel = confirm?.confirmLabel || t('migrate.migrateToStandaloneConfirm')
+    const dialogMessage = wasRunning
+      ? augmentMessageWithStopWarning(confirm?.message, t('errors.willStopRunning'))
+      : confirm?.message || ''
 
     // Show the surface (Modal OR brand takeover) with a loading state.
     // Both paths return the same { confirmed, checkboxValues } shape so
@@ -100,7 +107,7 @@ export function useMigrateAction() {
     } else {
       const modalConfirmPromise = modal.confirm({
         title: dialogTitle,
-        message: confirm?.message || '',
+        message: dialogMessage,
         loading: true,
         confirmLabel: dialogConfirmLabel,
         confirmStyle: 'primary',
@@ -135,7 +142,11 @@ export function useMigrateAction() {
       return null
     }
 
-    const detailsPayload = [{ label: t('migrate.migrationWill'), items: migrateItems }]
+    const detailsPayload = wasRunning
+      ? [
+        { label: t('migrate.migrationWill'), items: [t('errors.willStopRunning'), ...migrateItems] },
+      ]
+      : [{ label: t('migrate.migrationWill'), items: migrateItems }]
     const checkboxesPayload = isDesktop
       ? []
       : [{ id: 'enablePipSync', label: t('migrate.enablePipSync'), checked: false }]

--- a/src/renderer/src/composables/useModal.ts
+++ b/src/renderer/src/composables/useModal.ts
@@ -24,6 +24,16 @@ export interface ModalCheckbox {
   checked: boolean
 }
 
+/** Optional per-modal test-id overrides forwarded to ModalDialog →
+ *  BaseAlert. Lets call sites tag a specific dialog (e.g. the
+ *  stop-instance confirm) without changing the singleton modal
+ *  primitive's default selectors. */
+export interface ModalTestIds {
+  root?: string
+  action?: string
+  cancel?: string
+}
+
 export interface ModalState {
   visible: boolean
   type: ModalType
@@ -44,6 +54,7 @@ export interface ModalState {
   required: boolean | string
   items: ModalSelectItem[]
   options: ModalOption[]
+  testIds: ModalTestIds
   resolve: ((value: unknown) => void) | null
 }
 
@@ -67,6 +78,7 @@ const state = reactive<ModalState>({
   required: false,
   items: [],
   options: [],
+  testIds: {},
   resolve: null,
 })
 
@@ -90,6 +102,7 @@ function reset(): void {
   state.required = false
   state.items = []
   state.options = []
+  state.testIds = {}
   state.resolve = null
 }
 
@@ -132,6 +145,7 @@ export function useModal() {
     checkboxes?: ModalCheckbox[]
     confirmLabel?: string
     confirmStyle?: string
+    testIds?: ModalTestIds
   }): Promise<boolean> {
     return new Promise((resolve) => {
       reset()
@@ -145,6 +159,7 @@ export function useModal() {
       state.checkboxes = (opts.checkboxes ?? []).map((c) => ({ ...c }))
       state.confirmLabel = opts.confirmLabel ?? i18n.global.t('modal.confirm')
       state.confirmStyle = opts.confirmStyle ?? 'danger'
+      state.testIds = opts.testIds ? { ...opts.testIds } : {}
       state.resolve = resolve as (value: unknown) => void
     })
   }

--- a/src/renderer/src/lib/findAction.test.ts
+++ b/src/renderer/src/lib/findAction.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest'
+import { findActionById } from './findAction'
+import type { ActionDef, DetailSection } from '../types/ipc'
+
+function action(id: string, label = id): ActionDef {
+  return { id, label, style: 'primary', enabled: true } as ActionDef
+}
+
+describe('findActionById', () => {
+  it('returns null when nothing matches', () => {
+    const sections: DetailSection[] = [{ tab: 'status', actions: [action('check-update')] }]
+    expect(findActionById(sections, 'nonexistent')).toBeNull()
+  })
+
+  it('finds a top-level section action by id', () => {
+    const sections: DetailSection[] = [
+      { tab: 'status', actions: [action('launch'), action('delete')] },
+      { tab: 'update', actions: [action('check-update')] },
+    ]
+    const result = findActionById(sections, 'delete')
+    expect(result?.id).toBe('delete')
+  })
+
+  it('finds an action nested inside a channel-card field option (regression for #582)', () => {
+    // The standalone source emits `update-comfyui` inside
+    // `field.options[].data.actions[]` rather than at the section level.
+    // A search of only `section.actions` would silently miss it — which
+    // was the install-update pill autoAction bug.
+    const sections: DetailSection[] = [
+      {
+        tab: 'update',
+        fields: [
+          {
+            id: 'updateChannel',
+            label: 'Update channel',
+            value: 'stable',
+            editType: 'channel-cards',
+            options: [
+              {
+                value: 'stable',
+                label: 'Stable',
+                data: { actions: [action('update-comfyui'), action('copy-update')] },
+              },
+              {
+                value: 'latest',
+                label: 'Latest',
+                data: { actions: [action('switch-channel')] },
+              },
+            ],
+          },
+        ],
+        actions: [action('check-update')],
+      },
+    ]
+    const result = findActionById(sections, 'update-comfyui')
+    expect(result?.id).toBe('update-comfyui')
+  })
+
+  it('prefers the action on the install\'s currently-selected channel when the same id appears across channels', () => {
+    // Both stable and latest expose `update-comfyui`; given the install
+    // is on 'latest', the latest-channel action wins.
+    const sections: DetailSection[] = [
+      {
+        tab: 'update',
+        fields: [
+          {
+            id: 'updateChannel',
+            label: 'Update channel',
+            value: 'latest',
+            editType: 'channel-cards',
+            options: [
+              {
+                value: 'stable',
+                label: 'Stable',
+                data: { actions: [{ ...action('update-comfyui'), label: 'stable-update' }] },
+              },
+              {
+                value: 'latest',
+                label: 'Latest',
+                data: { actions: [{ ...action('update-comfyui'), label: 'latest-update' }] },
+              },
+            ],
+          },
+        ],
+      },
+    ]
+    const result = findActionById(sections, 'update-comfyui', 'latest')
+    expect(result?.label).toBe('latest-update')
+  })
+
+  it('falls back to the first nested match when no channel preference is given', () => {
+    const sections: DetailSection[] = [
+      {
+        tab: 'update',
+        fields: [
+          {
+            id: 'updateChannel',
+            label: 'Update channel',
+            value: 'stable',
+            editType: 'channel-cards',
+            options: [
+              {
+                value: 'stable',
+                label: 'Stable',
+                data: { actions: [{ ...action('update-comfyui'), label: 'stable-update' }] },
+              },
+              {
+                value: 'latest',
+                label: 'Latest',
+                data: { actions: [{ ...action('update-comfyui'), label: 'latest-update' }] },
+              },
+            ],
+          },
+        ],
+      },
+    ]
+    const result = findActionById(sections, 'update-comfyui')
+    expect(result?.label).toBe('stable-update')
+  })
+
+  it('top-level section actions win over nested ones with the same id', () => {
+    // `check-update` is a top-level action; if a channel card ever
+    // accidentally also defines one, the top-level wins because section
+    // actions are the canonical surface.
+    const sections: DetailSection[] = [
+      {
+        tab: 'update',
+        actions: [{ ...action('check-update'), label: 'top-level' }],
+        fields: [
+          {
+            id: 'updateChannel',
+            label: 'Update channel',
+            value: 'stable',
+            editType: 'channel-cards',
+            options: [
+              {
+                value: 'stable',
+                label: 'Stable',
+                data: { actions: [{ ...action('check-update'), label: 'nested' }] },
+              },
+            ],
+          },
+        ],
+      },
+    ]
+    const result = findActionById(sections, 'check-update', 'stable')
+    expect(result?.label).toBe('top-level')
+  })
+})

--- a/src/renderer/src/lib/findAction.ts
+++ b/src/renderer/src/lib/findAction.ts
@@ -1,0 +1,54 @@
+import type { ActionDef, DetailFieldOption, DetailSection } from '../types/ipc'
+
+/**
+ * Locate an action by id inside a `DetailSection[]` payload.
+ *
+ * Walks two surfaces because actions live in two distinct places:
+ *
+ *   1. `section.actions[]` — top-level section action rows (e.g.
+ *      `check-update`, `launch`, `delete`).
+ *   2. `section.fields[].options[].data.actions[]` — actions nested
+ *      INSIDE channel-card field options (the per-channel `Update Now`,
+ *      `Copy & Update`, `Switch Channel` buttons produced by
+ *      `standalone/updateSections.ts`).
+ *
+ * Both shapes carry real, dispatchable `ActionDef` payloads. Callers
+ * that only check `section.actions` will silently fail to resolve any
+ * channel-card action — that was the regression that made the
+ * title-bar install-update pill's deep-link autoAction a no-op
+ * (issue #582). Returns `null` when no match is found.
+ *
+ * When a `currentChannelValue` is given AND a match is found inside a
+ * channel-card option, prefer the option matching that channel value
+ * (so e.g. the Update Now for the currently-selected channel wins
+ * over a different channel's same-id action).
+ */
+export function findActionById(
+  sections: DetailSection[],
+  actionId: string,
+  currentChannelValue?: string | null,
+): ActionDef | null {
+  // 1. Top-level section actions.
+  for (const section of sections) {
+    const match = section.actions?.find((a) => a.id === actionId)
+    if (match) return match
+  }
+
+  // 2. Nested per-option actions (channel-cards today; the loop is
+  // general so any future option-nested action surface is covered).
+  let firstMatch: ActionDef | null = null
+  for (const section of sections) {
+    for (const field of section.fields ?? []) {
+      for (const option of (field.options ?? []) as DetailFieldOption[]) {
+        const nestedActions = (option.data?.actions ?? []) as ActionDef[]
+        const match = nestedActions.find((a) => a?.id === actionId)
+        if (!match) continue
+        if (currentChannelValue != null && option.value === currentChannelValue) {
+          return match
+        }
+        if (!firstMatch) firstMatch = match
+      }
+    }
+  }
+  return firstMatch
+}

--- a/src/renderer/src/lib/stopWarning.ts
+++ b/src/renderer/src/lib/stopWarning.ts
@@ -1,0 +1,80 @@
+/** REQUIRES_STOPPED actions whose self-stopping apiCall wrapper should
+ *  auto-launch the same install after the op succeeds — picks up an
+ *  in-place update / restore so the user isn't left staring at a stopped
+ *  ComfyUI. Copy / copy-update / release-update intentionally excluded:
+ *  focus moves to the newly-created destination install
+ *  (`ActionResult.newInstallationId` opens A' in a new window). Delete
+ *  excluded: nothing to relaunch. Migrate-to-standalone excluded: same
+ *  reason as copy. */
+export const IN_PLACE_RELAUNCH = new Set(['update-comfyui', 'snapshot-restore'])
+
+/** Prepend the `errors.willStopRunning` sentence to an existing message
+ *  body. Used by every renderer surface that runs a REQUIRES_STOPPED
+ *  action against a currently-running install — the per-action confirm /
+ *  prompt copy doesn't mention the stop, and the standalone
+ *  stop-confirm modal was removed, so this sentence is the only
+ *  surfaced warning the user gets before the apiCall stops the session. */
+export function augmentMessageWithStopWarning(
+  existing: string | undefined,
+  willStopRunning: string,
+): string {
+  if (!existing) return willStopRunning
+  return `${willStopRunning}\n\n${existing}`
+}
+
+interface ActionLike {
+  label: string
+  confirm?: { message?: string; title?: string }
+  prompt?: { message?: string }
+}
+
+/** Apply the willStopRunning warning to an action's confirm + prompt
+ *  copy, returning a new ActionDef-shaped object. Synthesizes a
+ *  bare-bones confirm when the action has neither so the warning is
+ *  never silent. Used by every surface that runs a REQUIRES_STOPPED
+ *  action through its own confirm/prompt chain. The generic preserves
+ *  the caller's full ActionDef shape so downstream `.id` / `.data` /
+ *  etc. stay accessible after augmentation. */
+export function augmentActionWithStopWarning<T extends ActionLike>(action: T, willStopRunning: string): T {
+  let mut: T = action
+  if (mut.confirm) {
+    mut = {
+      ...mut,
+      confirm: {
+        ...mut.confirm,
+        message: augmentMessageWithStopWarning(mut.confirm.message, willStopRunning),
+      },
+    }
+  }
+  if (mut.prompt) {
+    mut = {
+      ...mut,
+      prompt: {
+        ...mut.prompt,
+        message: augmentMessageWithStopWarning(mut.prompt.message, willStopRunning),
+      },
+    }
+  }
+  if (!mut.confirm && !mut.prompt) {
+    mut = {
+      ...mut,
+      confirm: { title: mut.label, message: willStopRunning },
+    }
+  }
+  return mut
+}
+
+/** Stop the install's running ComfyUI and poll until the session store
+ *  reports it as stopped, with a 10s deadline. Shared by every apiCall
+ *  wrapper that needs to drop a running session before invoking a
+ *  REQUIRES_STOPPED action. */
+export async function stopAndWaitForExit(
+  installationId: string,
+  isRunning: () => boolean,
+): Promise<void> {
+  await window.api.stopComfyUI(installationId)
+  const deadline = Date.now() + 10_000
+  while (isRunning() && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 100))
+  }
+}

--- a/src/renderer/src/panel/PanelApp.vue
+++ b/src/renderer/src/panel/PanelApp.vue
@@ -29,6 +29,7 @@ import { registerMigrateTakeover } from '../composables/useMigrateAction'
 import { isFlowPanel, isValidPanel, usePanelOverlays } from './usePanelOverlays'
 import { useChooserHandoff } from './useChooserHandoff'
 import { useFirstUseChain } from './useFirstUseChain'
+import { bindE2EPanelHooks } from './e2eRendererHooks'
 import { resolvePickerTab } from '../lib/pickerTabs'
 import type { Installation } from '../types/ipc'
 
@@ -144,6 +145,12 @@ const {
   dismissTakeoverDirect,
   switchPanel,
 } = overlays
+
+// E2E surface: tests drive UI-level flows (e.g. inject a finished
+// failed op to render ProgressModal's error state) by calling into
+// `handleShowProgress` from outside the Vue tree. Production code
+// never reads `__e2eRenderer`.
+bindE2EPanelHooks({ showProgress: handleShowProgress })
 
 const firstUseTakeoverActive = computed(
   () =>

--- a/src/renderer/src/panel/PanelApp.vue
+++ b/src/renderer/src/panel/PanelApp.vue
@@ -148,9 +148,13 @@ const {
 
 // E2E surface: tests drive UI-level flows (e.g. inject a finished
 // failed op to render ProgressModal's error state) by calling into
-// `handleShowProgress` from outside the Vue tree. Production code
-// never reads `__e2eRenderer`.
-bindE2EPanelHooks({ showProgress: handleShowProgress })
+// `handleShowProgress` from outside the Vue tree. Gated on the
+// `e2e=1` URL flag main propagates only when `process.env.E2E === '1'`,
+// matching the registration gate in `panel/main.ts`; `__e2eRenderer`
+// is never present in production.
+if (params.get('e2e') === '1') {
+  bindE2EPanelHooks({ showProgress: handleShowProgress })
+}
 
 const firstUseTakeoverActive = computed(
   () =>
@@ -471,6 +475,9 @@ onUnmounted(() => {
   // while the drawer is open doesn't leak transparency past unmount.
   document.body.classList.remove('panel-overlay-mode')
   sessionStore.dispose()
+  // Release the E2E binding so a stale closure can't keep driving the
+  // progress chain on a detached PanelApp instance after a panel swap.
+  if (params.get('e2e') === '1') bindE2EPanelHooks(null)
 })
 </script>
 

--- a/src/renderer/src/panel/e2eRendererHooks.ts
+++ b/src/renderer/src/panel/e2eRendererHooks.ts
@@ -22,6 +22,18 @@ export interface InjectProgressErrorOpts {
   errorMessage: string
 }
 
+export interface InjectProgressSuccessOpts {
+  /** Install id the operation runs against (the source of a copy /
+   *  copy-update / release-update). */
+  installationId: string
+  title?: string
+  /** Drives ProgressModal's handleDone — when set, the modal calls
+   *  `window.api.openInstallWindow(newInstallationId)` after the op
+   *  finishes. Used by the FLOW 2 e2e to exercise the destination-open
+   *  path without running a real copy. */
+  newInstallationId?: string
+}
+
 interface PanelBindings {
   showProgress: (opts: ShowProgressOpts) => Promise<void> | void
 }
@@ -36,6 +48,11 @@ export interface E2ERendererHelpers {
    *  reliably reaches the DOM without provoking a real failing
    *  install. */
   injectProgressError(opts: InjectProgressErrorOpts): Promise<void>
+  /** Drive the PanelApp's show-progress chain with a synthetic
+   *  successful copy-style result. Used by the FLOW 2 e2e to verify
+   *  `ProgressModal.handleDone` calls `openInstallWindow` with
+   *  `newInstallationId` without running an actual copy. */
+  injectProgressSuccess(opts: InjectProgressSuccessOpts): Promise<void>
 }
 
 function ensureBound(): PanelBindings {
@@ -68,6 +85,19 @@ export function registerE2ERendererHooks(): void {
         // error message. The store routes that through the same code
         // path a real action failure takes.
         apiCall: () => Promise.resolve({ ok: false, message: errorMessage }),
+      })
+    },
+    async injectProgressSuccess({ installationId, title, newInstallationId }) {
+      const b = ensureBound()
+      await b.showProgress({
+        installationId,
+        title: title ?? `Copy — ${installationId}`,
+        opKind: 'generic',
+        apiCall: () => Promise.resolve({
+          ok: true,
+          navigate: 'list',
+          newInstallationId,
+        }),
       })
     },
   }

--- a/src/renderer/src/panel/e2eRendererHooks.ts
+++ b/src/renderer/src/panel/e2eRendererHooks.ts
@@ -48,9 +48,11 @@ function ensureBound(): PanelBindings {
 /**
  * Called from `PanelApp.vue` once `handleShowProgress` is in scope.
  * Re-binding (e.g. PanelApp re-mount after panel switch) replaces the
- * previous reference.
+ * previous reference; passing `null` clears it so a stale closure
+ * captured by a detached component instance can't keep driving the
+ * progress chain after unmount.
  */
-export function bindE2EPanelHooks(next: PanelBindings): void {
+export function bindE2EPanelHooks(next: PanelBindings | null): void {
   bindings = next
 }
 

--- a/src/renderer/src/panel/e2eRendererHooks.ts
+++ b/src/renderer/src/panel/e2eRendererHooks.ts
@@ -1,0 +1,73 @@
+/**
+ * Renderer-side test-only helpers exposed on `globalThis.__e2eRenderer`
+ * so Playwright's `panel.evaluate(...)` bridge can drive UI state that
+ * is normally produced by long-running production code paths (action
+ * runs, IPC settlement, error injection).
+ *
+ * `PanelApp` registers the binding callbacks during setup once it has
+ * its overlay + progress wires available. Test code calls the helpers
+ * via `panel.evaluate('window.__e2eRenderer.foo(...)')`.
+ *
+ * Production code never references `__e2eRenderer`, so the global is a
+ * no-op outside the test runner.
+ */
+import type { ShowProgressOpts } from '../types/ipc'
+
+export interface InjectProgressErrorOpts {
+  installationId: string
+  /** Title shown in the ProgressModal header. */
+  title?: string
+  /** Body of the error block (`currentOp.error`). Long strings exercise
+   *  the overflow / clamp rules on `.brand-progress__error-message`. */
+  errorMessage: string
+}
+
+interface PanelBindings {
+  showProgress: (opts: ShowProgressOpts) => Promise<void> | void
+}
+
+let bindings: PanelBindings | null = null
+
+export interface E2ERendererHelpers {
+  /** Drive the PanelApp's normal show-progress chain with an `apiCall`
+   *  that resolves to `{ ok: false, message }` so `ProgressModal`
+   *  mounts and paints its post-failure state with the supplied error.
+   *  Used by the progress-error-overflow e2e to guarantee a long error
+   *  reliably reaches the DOM without provoking a real failing
+   *  install. */
+  injectProgressError(opts: InjectProgressErrorOpts): Promise<void>
+}
+
+function ensureBound(): PanelBindings {
+  if (!bindings) {
+    throw new Error('__e2eRenderer not bound yet — PanelApp has not mounted')
+  }
+  return bindings
+}
+
+/**
+ * Called from `PanelApp.vue` once `handleShowProgress` is in scope.
+ * Re-binding (e.g. PanelApp re-mount after panel switch) replaces the
+ * previous reference.
+ */
+export function bindE2EPanelHooks(next: PanelBindings): void {
+  bindings = next
+}
+
+export function registerE2ERendererHooks(): void {
+  const helpers: E2ERendererHelpers = {
+    async injectProgressError({ installationId, title, errorMessage }) {
+      const b = ensureBound()
+      await b.showProgress({
+        installationId,
+        title: title ?? `Failed op — ${installationId}`,
+        opKind: 'generic',
+        // Resolves immediately with `{ ok: false }` carrying the long
+        // error message. The store routes that through the same code
+        // path a real action failure takes.
+        apiCall: () => Promise.resolve({ ok: false, message: errorMessage }),
+      })
+    },
+  }
+  ;(globalThis as unknown as { __e2eRenderer: E2ERendererHelpers }).__e2eRenderer = helpers
+}

--- a/src/renderer/src/panel/e2eRendererHooks.ts
+++ b/src/renderer/src/panel/e2eRendererHooks.ts
@@ -11,6 +11,7 @@
  * Production code never references `__e2eRenderer`, so the global is a
  * no-op outside the test runner.
  */
+import { useSessionStore } from '../stores/sessionStore'
 import type { ShowProgressOpts } from '../types/ipc'
 
 export interface InjectProgressErrorOpts {
@@ -53,6 +54,13 @@ export interface E2ERendererHelpers {
    *  `ProgressModal.handleDone` calls `openInstallWindow` with
    *  `newInstallationId` without running an actual copy. */
   injectProgressSuccess(opts: InjectProgressSuccessOpts): Promise<void>
+  /** Read the renderer-side `sessionStore.isRunning(id)` so tests can
+   *  poll on the broadcast having actually propagated into the panel's
+   *  Pinia store (main's `_test_clearRunningSessions` fires the IPC but
+   *  resolves before the renderer applies the resulting
+   *  `instance-stopped` message — without this poll the apiCall-time
+   *  `wasRunning` capture races the broadcast). */
+  isRunning(installationId: string): boolean
 }
 
 function ensureBound(): PanelBindings {
@@ -99,6 +107,9 @@ export function registerE2ERendererHooks(): void {
           newInstallationId,
         }),
       })
+    },
+    isRunning(installationId) {
+      return useSessionStore().isRunning(installationId)
     },
   }
   ;(globalThis as unknown as { __e2eRenderer: E2ERendererHelpers }).__e2eRenderer = helpers

--- a/src/renderer/src/panel/main.ts
+++ b/src/renderer/src/panel/main.ts
@@ -5,6 +5,16 @@ import { createPinia } from 'pinia'
 import PanelApp from './PanelApp.vue'
 import { i18n } from '../i18n'
 import { initializeRendererBootstrap } from '../lib/rendererBootstrap'
+import { registerE2ERendererHooks } from './e2eRendererHooks'
+
+// Renderer-side E2E hooks. The helpers expose UI-driving primitives
+// (inject a finished failed op, etc.) test code can call via
+// `panel.evaluate('window.__e2eRenderer.foo(...)')`. The surface is
+// opt-in — production code never references __e2eRenderer, so leaving
+// it on the global is a no-op outside the test runner. PanelApp wires
+// the helpers to its overlay + progress chain during setup via
+// `bindE2EPanelHooks(...)`.
+registerE2ERendererHooks()
 
 const app = createApp(PanelApp)
 app.use(createPinia())

--- a/src/renderer/src/panel/main.ts
+++ b/src/renderer/src/panel/main.ts
@@ -7,14 +7,13 @@ import { i18n } from '../i18n'
 import { initializeRendererBootstrap } from '../lib/rendererBootstrap'
 import { registerE2ERendererHooks } from './e2eRendererHooks'
 
-// Renderer-side E2E hooks. The helpers expose UI-driving primitives
-// (inject a finished failed op, etc.) test code can call via
-// `panel.evaluate('window.__e2eRenderer.foo(...)')`. The surface is
-// opt-in — production code never references __e2eRenderer, so leaving
-// it on the global is a no-op outside the test runner. PanelApp wires
-// the helpers to its overlay + progress chain during setup via
-// `bindE2EPanelHooks(...)`.
-registerE2ERendererHooks()
+// Renderer-side E2E hooks. Only register when main propagated the
+// `e2e=1` URL flag (mirrors the main-side `process.env.E2E === '1'`
+// gate). PanelApp's `bindE2EPanelHooks` is the matching opt-in on the
+// component side.
+if (new URLSearchParams(window.location.search).get('e2e') === '1') {
+  registerE2ERendererHooks()
+}
 
 const app = createApp(PanelApp)
 app.use(createPinia())

--- a/src/renderer/src/stores/progressStore.test.ts
+++ b/src/renderer/src/stores/progressStore.test.ts
@@ -329,6 +329,31 @@ describe('useProgressStore', () => {
     it('is safe to cancel a nonexistent operation', () => {
       expect(() => store.cancelOperation('nonexistent')).not.toThrow()
     })
+
+    it('does NOT stop ComfyUI when the op has already finished', async () => {
+      // Silent takeover→takeover overlay swaps fire `onCancel`
+      // indiscriminately. Stopping ComfyUI for a finished op would tear
+      // down the relaunched session (or the next op's session).
+      let resolve: ((value: ActionResult) => void) | null = null
+      store.startOperation({
+        installationId: 'inst-1',
+        title: 'Install',
+        apiCall: () => new Promise<ActionResult>((r) => { resolve = r }),
+      })
+      resolve!({ ok: true })
+      await Promise.resolve()
+      await Promise.resolve()
+      const op = store.operations.get('inst-1')!
+      expect(op.finished).toBe(true)
+
+      vi.mocked(window.api.stopComfyUI).mockClear()
+      vi.mocked(window.api.cancelOperation).mockClear()
+      store.cancelOperation('inst-1')
+
+      expect(window.api.stopComfyUI).not.toHaveBeenCalled()
+      expect(window.api.cancelOperation).not.toHaveBeenCalled()
+      expect(op.cancelRequested).toBe(false)
+    })
   })
 
   describe('cleanupOperation', () => {

--- a/src/renderer/src/stores/progressStore.ts
+++ b/src/renderer/src/stores/progressStore.ts
@@ -218,6 +218,11 @@ export const useProgressStore = defineStore('progress', () => {
   function cancelOperation(installationId: string): void {
     const op = operations.get(installationId)
     if (!op) return
+    // A finished op has nothing to cancel: the silent takeover→takeover
+    // overlay swap fires `onCancel` indiscriminately, but stopping
+    // ComfyUI here would punish the next op (or a relaunched session)
+    // for the previous one having completed.
+    if (op.finished) return
     op.cancelRequested = true
     op.flatStatus = t('progress.cancelling')
     window.api.cancelOperation(installationId)

--- a/src/renderer/src/views/DetailModal.vue
+++ b/src/renderer/src/views/DetailModal.vue
@@ -18,6 +18,7 @@ import { useInstallationStore } from '../stores/installationStore'
 import { useSessionStore } from '../stores/sessionStore'
 import { emitTelemetryAction, toErrorBucket } from '../lib/telemetry'
 import { formatBytes } from '../lib/formatting'
+import { findActionById } from '../lib/findAction'
 import { progressOpKindForActionId, destroysInstanceForActionId } from '../lib/progressOpKind'
 import { useMigrateAction } from '../composables/useMigrateAction'
 import { REQUIRES_STOPPED } from '../types/ipc'
@@ -225,17 +226,26 @@ watch(
         window.api.cancelInstallationSize()
       }
 
-      // Auto-trigger an action if requested (e.g. from migrate pill click)
+      // Auto-trigger an action if requested (e.g. from migrate pill or
+      // title-bar install-update pill click). Walks both
+      // `section.actions[]` AND nested `field.options[].data.actions[]`
+      // — the latter is where channel-card actions (`update-comfyui`,
+      // `copy-update`, `switch-channel`) live, so a search of only
+      // `section.actions` would silently no-op the install-update pill
+      // (regression for #582). Prefers the action on the install's
+      // currently-selected channel when present.
       if (props.autoAction && !autoActionRun.value) {
         autoActionRun.value = true
         const actionId = props.autoAction
-        for (const section of sections.value) {
-          const action = section.actions?.find((a: ActionDef) => a.id === actionId)
-          if (action) {
-            await nextTick()
-            runAction(action, null)
-            break
-          }
+        const channelField = sections.value
+          .flatMap((s) => s.fields ?? [])
+          .find((f) => f.editType === 'channel-cards')
+        const currentChannel =
+          typeof channelField?.value === 'string' ? channelField.value : null
+        const action = findActionById(sections.value, actionId, currentChannel)
+        if (action) {
+          await nextTick()
+          runAction(action, null)
         }
       }
     }

--- a/src/renderer/src/views/DetailModal.vue
+++ b/src/renderer/src/views/DetailModal.vue
@@ -20,6 +20,7 @@ import { emitTelemetryAction, toErrorBucket } from '../lib/telemetry'
 import { formatBytes } from '../lib/formatting'
 import { findActionById } from '../lib/findAction'
 import { progressOpKindForActionId, destroysInstanceForActionId } from '../lib/progressOpKind'
+import { IN_PLACE_RELAUNCH, augmentActionWithStopWarning, stopAndWaitForExit } from '../lib/stopWarning'
 import { useMigrateAction } from '../composables/useMigrateAction'
 import { REQUIRES_STOPPED } from '../types/ipc'
 import { Pencil } from 'lucide-vue-next'
@@ -329,18 +330,30 @@ function handleActionClick(action: ActionDef, event: MouseEvent): void {
 
 async function runAction(action: ActionDef, btn: HTMLButtonElement | null): Promise<void> {
   if (!props.installation) return
+  const instId = props.installation.id
   const telemetryContext = {
     source_category: props.installation.sourceCategory || 'unknown',
     ui_surface: 'detail',
   }
 
-  // Pre-flight: check if the installation is busy or running
-  // Skip for migrate-to-standalone — the useMigrateAction composable handles its own guard
-  if (action.id !== 'migrate-to-standalone' && REQUIRES_STOPPED.has(action.id)) {
-    if (!await actionGuard.checkBeforeAction(props.installation.id, action.label)) return
+  // Busy-only guard. migrate-to-standalone manages its own busy check
+  // + confirm UI via useMigrateAction below, so skip both pre-flights
+  // for it. The apiCall self-stop still applies — migrate is
+  // REQUIRES_STOPPED and the session must be torn down before the
+  // backend handler runs.
+  const ownsPreflight = action.id === 'migrate-to-standalone'
+  const requiresStoppedGuard = REQUIRES_STOPPED.has(action.id)
+  const wasRunning = sessionStore.isRunning(instId)
+  if (requiresStoppedGuard && !ownsPreflight) {
+    if (!await actionGuard.checkBeforeAction(instId, action.label)) return
   }
 
   let mutableAction = { ...action }
+
+  // Stop-warning augment for REQUIRES_STOPPED while running.
+  if (requiresStoppedGuard && wasRunning && !ownsPreflight) {
+    mutableAction = augmentActionWithStopWarning(mutableAction, t('errors.willStopRunning'))
+  }
 
   // fieldSelects chain
   if (mutableAction.fieldSelects) {
@@ -516,7 +529,6 @@ async function runAction(action: ActionDef, btn: HTMLButtonElement | null): Prom
 
   // showProgress
   if (mutableAction.showProgress) {
-    const instId = props.installation.id
     const instName = props.installation.name
     const rawTitle = (mutableAction.progressTitle || mutableAction.label).replace(
       /\{(\w+)\}/g,
@@ -525,29 +537,33 @@ async function runAction(action: ActionDef, btn: HTMLButtonElement | null): Prom
     )
     const title = `${rawTitle} — ${instName}`
     emitTelemetryAction('desktop2.action.invoked', { action_id: mutableAction.id, ...telemetryContext })
-    // Phase 3 §9 — synthetic 'restart' action: chain stopComfyUI →
-    // launch in a single ProgressModal so the user sees one
-    // continuous "Restarting ComfyUI" view rather than two flashes.
-    // The action's confirm dialog has already run above.
+    // Synthetic 'restart' action: chain stopComfyUI → launch in a
+    // single ProgressModal so the user sees one continuous
+    // "Restarting ComfyUI" view rather than two flashes.
     const isRestart = mutableAction.id === 'restart'
+    const needsSelfStop = wasRunning && requiresStoppedGuard && !isRestart
+    const wantsRelaunch = needsSelfStop && IN_PLACE_RELAUNCH.has(mutableAction.id)
+    const isRunning = (): boolean => sessionStore.isRunning(instId)
     const apiCall = isRestart
       ? async () => {
-          await window.api.stopComfyUI(instId)
-          // Wait for the session to actually leave the running state
-          // before kicking off the new launch. The session store is
-          // updated by main via 'session-status' broadcasts.
-          const deadline = Date.now() + 10_000
-          while (sessionStore.isRunning(instId) && Date.now() < deadline) {
-            await new Promise((r) => setTimeout(r, 100))
-          }
+          await stopAndWaitForExit(instId, isRunning)
           return window.api.runAction(instId, 'launch')
         }
-      : () => window.api.runAction(instId, mutableAction.id, mutableAction.data ? toRaw(mutableAction.data) : undefined)
+      : needsSelfStop
+        ? async () => {
+            await stopAndWaitForExit(instId, isRunning)
+            const result = await window.api.runAction(instId, mutableAction.id, mutableAction.data ? toRaw(mutableAction.data) : undefined)
+            if (wantsRelaunch && result?.ok !== false) {
+              await window.api.runAction(instId, 'launch')
+            }
+            return result
+          }
+        : () => window.api.runAction(instId, mutableAction.id, mutableAction.data ? toRaw(mutableAction.data) : undefined)
     // Tag launch / restart so PanelApp's handleShowProgress installs
     // the chooser-host close-on-instance-started subscription. Without
     // this, launches kicked off from this Tier-1 modal would leave the
     // dashboard window open next to the new comfy window.
-    const triggersInstanceStart = mutableAction.id === 'launch' || isRestart
+    const triggersInstanceStart = mutableAction.id === 'launch' || isRestart || wantsRelaunch
     emit('show-progress', {
       installationId: instId,
       title,
@@ -570,15 +586,21 @@ async function runAction(action: ActionDef, btn: HTMLButtonElement | null): Prom
   }
   try {
     emitTelemetryAction('desktop2.action.invoked', { action_id: mutableAction.id, ...telemetryContext })
+    if (wasRunning && requiresStoppedGuard) {
+      await stopAndWaitForExit(instId, () => sessionStore.isRunning(instId))
+    }
     const result = await window.api.runAction(
-      props.installation.id,
+      instId,
       mutableAction.id,
       mutableAction.data ? toRaw(mutableAction.data) : undefined
     )
     // Fallback: backend detected running instance (race condition)
     if (result.running && props.installation) {
-      await actionGuard.checkBeforeAction(props.installation.id, mutableAction.label)
+      await actionGuard.checkBeforeAction(instId, mutableAction.label)
       return
+    }
+    if (wasRunning && requiresStoppedGuard && IN_PLACE_RELAUNCH.has(mutableAction.id) && result?.ok !== false) {
+      await window.api.runAction(instId, 'launch')
     }
     const resultValue = result.cancelled ? 'cancelled' : (result.ok === false ? 'failed' : 'ok')
     emitTelemetryAction('desktop2.action.result', { action_id: mutableAction.id, result: resultValue, ...telemetryContext })

--- a/src/renderer/src/views/ProgressModal.test.ts
+++ b/src/renderer/src/views/ProgressModal.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
 import { createPinia, setActivePinia } from 'pinia'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
 
 import ProgressModal from './ProgressModal.vue'
 import { useProgressStore } from '../stores/progressStore'
@@ -307,6 +309,10 @@ describe('ProgressModal — brand branch state transitions', () => {
     expect(body.selectorText('.brand-progress__error-message')).toContain(
       'Disk write failed: ENOSPC',
     )
+    // Test-id exposes the element for e2e selectors that need to assert
+    // overflow / scrollability against the real layout (jsdom can't
+    // compute scroll height).
+    expect(body.exists('[data-testid="progress-error-message"]')).toBe(true)
 
     // Inline Copy button rides alongside the message body.
     expect(body.exists('.brand-progress__error-copy')).toBe(true)
@@ -495,5 +501,42 @@ describe('ProgressModal — brand branch state transitions', () => {
     expect(subText).toContain('1050 / 2100 MB')
     expect(subText).toContain('22 MB/s')
     expect(subText).toContain('~1m remaining')
+  })
+})
+
+describe('ProgressModal — error message styling (regression for #582)', () => {
+  // jsdom doesn't compute layout, so we can't assert via
+  // `getComputedStyle().maxHeight` against the rendered element. Instead
+  // we parse the .vue file's `<style>` block directly and assert the
+  // `.brand-progress__error-message` rule still carries the `max-height`
+  // + `overflow-y` declarations introduced to stop long tracebacks from
+  // stretching the takeover.
+  //
+  // Without this guard the only signal a future refactor would have is a
+  // visual e2e diff — too easy to miss in a CSS-only PR.
+
+  // Resolved against the workspace root (cwd at test time) so this
+  // doesn't depend on import.meta.url (vitest jsdom mode can hand back
+  // a non-file URL there).
+  const vueSource = readFileSync(
+    path.resolve('src/renderer/src/views/ProgressModal.vue'),
+    'utf8',
+  )
+
+  function extractRule(selector: string): string {
+    // Anchor on a line start so we match the base rule rather than a
+    // descendant override (e.g. `.foo .bar { ... }` would otherwise win
+    // over `.bar { ... }` because it appears first in the file).
+    const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const re = new RegExp(`(?:^|\\n)${escaped}\\s*\\{([^}]*)\\}`)
+    const match = vueSource.match(re)
+    if (!match) throw new Error(`CSS rule for "${selector}" not found in ProgressModal.vue`)
+    return match[1]
+  }
+
+  it('bounds .brand-progress__error-message height so long errors do not stretch the takeover', () => {
+    const body = extractRule('.brand-progress__error-message')
+    expect(body).toMatch(/max-height:/)
+    expect(body).toMatch(/overflow-y:\s*auto/)
   })
 })

--- a/src/renderer/src/views/ProgressModal.vue
+++ b/src/renderer/src/views/ProgressModal.vue
@@ -15,6 +15,7 @@ import ComfyWordmark from '../components/icons/ComfyWordmark.vue'
 import BrandProgressGlyph from '../components/icons/BrandProgressGlyph.vue'
 import BaseAccordion from '../components/ui/BaseAccordion.vue'
 import BaseCopyButton from '../components/ui/BaseCopyButton.vue'
+import { TID } from '../../../shared/testIds'
 
 interface Props {
   installationId: string | null
@@ -775,7 +776,10 @@ defineExpose({ startOperation, showOperation })
           v-if="finishedErrorMessage"
           class="brand-progress__error-row"
         >
-          <div class="brand-progress__error-message">
+          <div
+            class="brand-progress__error-message"
+            :data-testid="TID.progressErrorMessage"
+          >
             {{ finishedErrorMessage }}
           </div>
           <BaseCopyButton
@@ -817,6 +821,7 @@ defineExpose({ startOperation, showOperation })
               id="brand-progress-logs"
               ref="brandTerminalRef"
               class="brand-progress__logs"
+              :data-testid="TID.progressLogs"
               @scroll="handleBrandTerminalScroll"
             >
               {{ displayedTerminalOutput }}
@@ -1161,10 +1166,17 @@ defineExpose({ startOperation, showOperation })
 }
 
 /* Error detail line beneath the banner. Selectable so users can copy
-   manually (Copy-button affordance lands in Phase 2.5). */
+   manually. Bounded so a long Python traceback / `uv pip` failure
+   doesn't stretch the takeover past the viewport — chosen slightly
+   shorter than the sibling `.brand-progress__logs` panel so the error
+   reads as visually subordinate to the (more verbose) logs when both
+   are open. */
 .brand-progress__error-message {
   width: 100%;
   max-width: 640px;
+  max-height: clamp(120px, 22vh, 240px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
   margin-top: -4px;
   padding: 12px 14px;
   border-radius: 8px;

--- a/src/renderer/src/views/ProgressModal.vue
+++ b/src/renderer/src/views/ProgressModal.vue
@@ -480,6 +480,14 @@ function handleDone(): void {
     void window.api.returnToDashboard()
   }
   emit('close')
+  // Copy / copy-update / release-update produced a new install — open
+  // it in its own window. The source host stays where it is so the
+  // user keeps the running session / panel state they had.
+  const newInstallationId = op.result.newInstallationId
+  if (newInstallationId) {
+    void window.api.openInstallWindow(newInstallationId)
+    return
+  }
   // Guard show-detail against a stale install id — destroy ops (or any
   // op whose success removes the install from the registry) would
   // otherwise route to a now-missing detail view.

--- a/src/renderer/src/views/chooser/ChooserInstallTile.vue
+++ b/src/renderer/src/views/chooser/ChooserInstallTile.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n'
 import { AlertCircle, ArrowDownToLine, ArrowRightLeft, MoreVertical, X } from 'lucide-vue-next'
 import { useSessionStore } from '../../stores/sessionStore'
 import { installTypeMetaFor } from '../../lib/installTypeIcon'
+import { TID } from '../../../../shared/testIds'
 import type { Installation } from '../../types/ipc'
 
 interface Props {
@@ -75,6 +76,7 @@ function handleClick(): void {
     tabindex="0"
     class="chooser-tile"
     :class="statusClasses"
+    :data-testid="TID.dashboardTile(inst.id)"
     @click="handleClick"
     @keydown.enter="handleClick"
     @keydown.space.prevent="handleClick"
@@ -99,6 +101,7 @@ function handleClick(): void {
         class="chooser-tile-kebab"
         :title="t('chooser.moreActions')"
         :aria-label="t('chooser.moreActions')"
+        :data-testid="TID.dashboardTileKebab(inst.id)"
         @click.stop="emit('open-kebab-menu', $event, inst)"
         @contextmenu.stop="emit('open-kebab-menu', $event, inst)"
       >

--- a/src/renderer/src/views/comfyUISettings/ChannelPicker.vue
+++ b/src/renderer/src/views/comfyUISettings/ChannelPicker.vue
@@ -3,6 +3,7 @@ import { computed, reactive, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import BaseSelect, { type BaseSelectOption } from '../../components/ui/BaseSelect.vue'
 import type { ActionDef, DetailField, DetailFieldOption } from '../../types/ipc'
+import { TID } from '../../../../shared/testIds'
 
 /**
  * Update Channel picker for the brand-redesigned Settings drawer (v2).
@@ -166,6 +167,7 @@ const selectOptions = computed<BaseSelectOption[]>(() =>
             ]"
             :disabled="action.enabled === false"
             :title="action.tooltip"
+            :data-testid="TID.updateActionButton(action.id)"
             @click="emit('action', action)"
           >
             {{ action.label }}
@@ -198,6 +200,7 @@ const selectOptions = computed<BaseSelectOption[]>(() =>
           ]"
           :disabled="action.enabled === false"
           :title="action.tooltip"
+          :data-testid="TID.updateActionButton(action.id)"
           @click="emit('action', action)"
         >
           {{ action.label }}

--- a/src/shared/testIds.ts
+++ b/src/shared/testIds.ts
@@ -33,11 +33,24 @@ export const TID = {
   /** The kebab / more-actions button on a dashboard tile. */
   dashboardTileKebab: (installId: string) => `dashboard-tile-kebab-${installId}`,
 
+  // ---------- Context menu ----------
+  /** A single item in the shared `ContextMenu` (the kebab + right-click
+   *  menu). `id` matches the `ContextMenuItem.id` the composable emits
+   *  — see `InstallMenuActionId` in `useInstallContextMenu.ts` for the
+   *  install-menu variants. */
+  contextMenuItem: (id: string) => `context-menu-item-${id}`,
+
   // ---------- Confirm modals ----------
   /** Generic confirm modal confirm button. */
   modalConfirm: 'modal-confirm-button',
   /** Generic confirm modal cancel button. */
   modalCancel: 'modal-cancel-button',
+  /** The primary action button of a `BaseAlert` (alert OK / simple
+   *  confirm primary). Hard-coded in `BaseAlert.vue` — kept here so
+   *  tests reference a single source of truth. */
+  baseAlertAction: 'base-alert-action',
+  /** The cancel button of a simple-confirm `BaseAlert`. */
+  baseAlertCancel: 'base-alert-cancel',
   /** Delete-install confirmation modal (the whole modal, for visibility waits). */
   deleteConfirmModal: 'delete-confirm-modal',
   /** Delete-install confirmation confirm button. */

--- a/src/shared/testIds.ts
+++ b/src/shared/testIds.ts
@@ -55,10 +55,6 @@ export const TID = {
   deleteConfirmModal: 'delete-confirm-modal',
   /** Delete-install confirmation confirm button. */
   deleteConfirmButton: 'delete-confirm-button',
-  /** Stop-running-instance confirm modal (shown before destructive actions when the install is running). */
-  stopInstanceConfirmModal: 'stop-instance-confirm-modal',
-  /** Stop-running-instance confirm button. */
-  stopInstanceConfirmButton: 'stop-instance-confirm-button',
 
   // ---------- Update flow ----------
   /** A single channel card inside the Update tab (one per release channel). */

--- a/src/shared/testIds.ts
+++ b/src/shared/testIds.ts
@@ -1,0 +1,63 @@
+/**
+ * Single source of truth for `data-testid` values used by e2e tests.
+ *
+ * Production Vue components import from this module instead of typing
+ * literal strings, and e2e tests import the SAME constants via
+ * `e2e/support/testIds.ts`. Renaming an id is a typecheck failure in
+ * tests, not a silent selector miss.
+ *
+ * Naming convention: kebab-case, scoped by surface (e.g.
+ * `picker-row-<id>`, `progress-error-message`). Per-instance variants
+ * are functions that take the install id so the id stays a literal
+ * type at the call site.
+ */
+
+export const TID = {
+  // ---------- Title-popup instance picker ----------
+  /** A row in the picker's instance list. One per install + cloud. */
+  pickerRow: (installId: string) => `picker-row-${installId}`,
+  /** The picker's compact-mode per-row Open button. */
+  pickerRowOpen: (installId: string) => `picker-row-open-${installId}`,
+  /** The picker's compact-mode per-row Manage button (expands the popup). */
+  pickerRowManage: (installId: string) => `picker-row-manage-${installId}`,
+  /** New-window CTA (compact + expanded). */
+  pickerNewWindow: 'picker-new-window',
+  /** Embedded ComfyUISettingsContent's loading placeholder. */
+  pickerSettingsLoading: 'picker-settings-loading',
+  /** Embedded ComfyUISettingsContent's settings sections root. */
+  pickerSettingsSections: 'picker-settings-sections',
+
+  // ---------- Dashboard / chooser ----------
+  /** A dashboard install tile. */
+  dashboardTile: (installId: string) => `dashboard-tile-${installId}`,
+  /** The kebab / more-actions button on a dashboard tile. */
+  dashboardTileKebab: (installId: string) => `dashboard-tile-kebab-${installId}`,
+
+  // ---------- Confirm modals ----------
+  /** Generic confirm modal confirm button. */
+  modalConfirm: 'modal-confirm-button',
+  /** Generic confirm modal cancel button. */
+  modalCancel: 'modal-cancel-button',
+  /** Delete-install confirmation modal (the whole modal, for visibility waits). */
+  deleteConfirmModal: 'delete-confirm-modal',
+  /** Delete-install confirmation confirm button. */
+  deleteConfirmButton: 'delete-confirm-button',
+  /** Stop-running-instance confirm modal (shown before destructive actions when the install is running). */
+  stopInstanceConfirmModal: 'stop-instance-confirm-modal',
+  /** Stop-running-instance confirm button. */
+  stopInstanceConfirmButton: 'stop-instance-confirm-button',
+
+  // ---------- Update flow ----------
+  /** A single channel card inside the Update tab (one per release channel). */
+  updateChannelCard: (channel: string) => `update-channel-card-${channel}`,
+  /** The "Update Now" / "Copy & Update" CTA inside a channel card. */
+  updateActionButton: (actionId: string) => `update-action-${actionId}`,
+
+  // ---------- Progress takeover ----------
+  /** The red error message block in the brand progress takeover. */
+  progressErrorMessage: 'progress-error-message',
+  /** The logs panel in the brand progress takeover. */
+  progressLogs: 'progress-logs',
+} as const
+
+export type TestIdKey = keyof typeof TID

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -272,6 +272,10 @@ export interface ActionResult {
   portConflict?: PortConflictInfo
   cancelled?: boolean
   running?: boolean
+  /** Set by actions that produce a new install record (copy /
+   *  copy-update / release-update). ProgressModal.handleDone opens
+   *  the new install in its own window — the source host stays put. */
+  newInstallationId?: string
 }
 
 export interface PortConflictInfo {
@@ -834,6 +838,13 @@ export interface ElectronApi {
   // Running
   stopComfyUI(installationId: string): Promise<void>
   focusComfyWindow(installationId: string): Promise<void>
+  /** Open a window for the install backing `installationId`. Focuses
+   *  any existing install-backed window; otherwise opens a fresh
+   *  chooser host so the user can pick the install from the dashboard.
+   *  Used by ProgressModal's `handleDone` after copy / copy-update /
+   *  release-update so the newly-created destination install gets
+   *  focus without swapping the source host. */
+  openInstallWindow(installationId: string): Promise<boolean>
   /** Close the BrowserWindow that hosts the given installation's ComfyUI
    *  view (and its title-bar / panel WebContentsViews). Returns true if a
    *  window was found and closed. Used by the embedded install-settings

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -261,15 +261,6 @@ export interface ShowProgressOpts {
    *  ignore these and use `apiCall` directly. */
   actionId?: string
   actionData?: Record<string, unknown>
-  /** REQUIRES_STOPPED action whose stop-instance guard was deferred to
-   *  the host. Set by the picker's `useComfyUISettings` when it skipped
-   *  the inline `actionGuard.checkBeforeAction` so the host (panel) can
-   *  run it instead — the picker popup is a separate WebContentsView
-   *  that auto-dismisses on blur, so a stop-confirm modal mounted there
-   *  vanishes whenever the popup loses focus. The panel surface owns a
-   *  stable BaseAlert that survives popup teardown and isn't obscured
-   *  by the popup's own geometry. */
-  requiresStopped?: boolean
 }
 
 // --- Action results ---
@@ -1172,9 +1163,6 @@ export interface ElectronApi {
       triggersInstanceStart?: boolean
       opKind?: 'launch' | 'install' | 'update' | 'destructive' | 'snapshot' | 'generic'
       isRestart?: boolean
-      /** Picker's REQUIRES_STOPPED action whose stop-confirm was
-       *  deferred to the panel. See `ShowProgressOpts.requiresStopped`. */
-      requiresStopped?: boolean
     }) => void,
   ): Unsubscribe
 }

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -261,6 +261,15 @@ export interface ShowProgressOpts {
    *  ignore these and use `apiCall` directly. */
   actionId?: string
   actionData?: Record<string, unknown>
+  /** REQUIRES_STOPPED action whose stop-instance guard was deferred to
+   *  the host. Set by the picker's `useComfyUISettings` when it skipped
+   *  the inline `actionGuard.checkBeforeAction` so the host (panel) can
+   *  run it instead — the picker popup is a separate WebContentsView
+   *  that auto-dismisses on blur, so a stop-confirm modal mounted there
+   *  vanishes whenever the popup loses focus. The panel surface owns a
+   *  stable BaseAlert that survives popup teardown and isn't obscured
+   *  by the popup's own geometry. */
+  requiresStopped?: boolean
 }
 
 // --- Action results ---
@@ -1163,6 +1172,9 @@ export interface ElectronApi {
       triggersInstanceStart?: boolean
       opKind?: 'launch' | 'install' | 'update' | 'destructive' | 'snapshot' | 'generic'
       isRestart?: boolean
+      /** Picker's REQUIRES_STOPPED action whose stop-confirm was
+       *  deferred to the panel. See `ShowProgressOpts.requiresStopped`. */
+      requiresStopped?: boolean
     }) => void,
   ): Unsubscribe
 }


### PR DESCRIPTION
Fixes #582.

Rolls up the seven sub-fixes called out in #582 plus the supporting test-infra (`@lifecycle` Playwright suite, renderer e2e hooks) and an audit-driven refactor of the REQUIRES_STOPPED action flow.

## Fixes

| # | Issue body bullet | Fix commit(s) |
|---|------|------|
| 1 | Right pane shows stale sections when clicking tabs / switching installs ("UI freezes" after the first `Loading…`) | `5bc681c` `47a8564` `fb63a96` |
| 2 | Cross-channel `update-comfyui` was a no-op (Global Settings allowlist typo) | `5bc681c` `70f2b04` |
| 3 | Cloud zip download bounces out to the OS browser | `e95f12f` |
| 4 | Dashboard Delete ~2s latency before the confirm appears (`get-detail-sections` was running on the kebab path) | `e95f12f` `a819b82` |
| 5 | Update modal disappears mid-interaction when the install is running; no clear feedback | `d1881a7` `7d0f55e` `02fbd10` |
| 6 | Stop-confirm modal closes itself when the picker dispatches the action (popup blur tore down the modal) | `7fae0f4` `5f8643c` `d1881a7` `7d0f55e` |
| 7 | ProgressModal error block has no max-height — long stderr stretched the page | `5bc681c` `ad8f0d7` |

## Audit-driven refactor (FLOW 1 / 2 / 3)

The audit found that no REQUIRES_STOPPED action's `confirm` / `prompt` copy mentioned stopping ComfyUI; the standalone "Stop ComfyUI?" modal in `useActionGuard.checkBeforeAction` was the only user-visible warning, and it was the same one fix #6 routed around.

* **FLOW 1 — Self-stopping `apiCall` + in-place relaunch (`7d0f55e` `9944fe6`)**
  REQUIRES_STOPPED actions on a running install now wrap the `apiCall` to `stopComfyUI → wait → run-action`, and `IN_PLACE_RELAUNCH` (`update-comfyui`, `snapshot-restore`) appends `run-action('launch')` on success so the user lands back on a live ComfyUI. Centralised in `src/renderer/src/lib/stopWarning.ts`. The `cancelOperation` no-op for finished ops (`9944fe6`) closes the silent takeover→takeover swap race that otherwise tore down the relaunched session.
* **FLOW 2 — Copy & Update destination (`02fbd10`)**
  `copy` / `copy-update` / `release-update` now populate `ActionResult.newInstallationId`; `ProgressModal.handleDone` consumes it via a new `open-install-window` IPC so the destination install opens in its own window instead of swapping the source host. Misleading `copyAndUpdateMessage` copy fixed in the same change.
* **FLOW 3 — Modal stack collapse (`d1881a7`)**
  Removed the standalone Stop ComfyUI? modal from `useActionGuard`; added `errors.willStopRunning` i18n string and use `augmentActionWithStopWarning` to prepend the warning to the action's own confirm/prompt dialog (synthesising one if needed). The picker fix #6 bridge (`requiresStopped` flag in IPC payload) is dropped — the panel derives the need to stop from `actionId` + session state.

## Tests

* Unit tests for `useComfyUISettings.runAction` covering FLOW 1 + FLOW 3 behaviour (message augment, IN_PLACE_RELAUNCH stop+run+launch, no-relaunch on `ok:false`, no-op when not running, inline self-stop path).
* `progressStore.cancelOperation` regression test for the finished-op no-op.
* `@lifecycle` Playwright suite:
  * `picker-stop-confirm.test.ts` — picker forwards a REQUIRES_STOPPED action; panel-side apiCall self-stops + dispatches the original action; skip-self-stop branch covered.
  * `copy-update-destination.test.ts` — `ProgressModal.handleDone` consumes `newInstallationId` and fires `open-install-window`.
  * Plus per-fix coverage: `picker-settings-staleness` (fix #1), `global-settings-update-action` (fix #2), `dashboard-delete-flow` (fix #4), `progress-error-overflow` (fix #7).

## Pre-merge checks

* `pnpm run typecheck` — green
* `pnpm run lint` — green
* `pnpm run build` — green
* `pnpm run test` — 1133 tests pass
* `pnpm playwright test --project=lifecycle` — 39 tests pass
* `pnpm playwright test --project=windows` — 36 tests pass
