### PR TITLE
test(lifecycle): P0 FLOW 1 + FLOW 2 + Restart + real copy lifecycle coverage

### DIFF
--- a/e2e/lifecycle.test.ts
+++ b/e2e/lifecycle.test.ts
@@ -41,8 +41,18 @@ import {
   expectChooserVisible,
   expectTakeoverOpen,
 } from './support/chooserHelpers'
-import { returnFirstInstallHostToDashboard } from './support/devHooks'
-import { waitForWebContents } from './support/cdpPages'
+import {
+  getIpcInvocations,
+  resetIpcInvocations,
+  returnFirstInstallHostToDashboard,
+} from './support/devHooks'
+import {
+  isPopupVisible,
+  systemModalPage,
+  titlePopupPage,
+  waitForWebContents,
+} from './support/cdpPages'
+import { byTestId, TID } from './support/testIds'
 
 let ctx: AppContext
 
@@ -401,6 +411,444 @@ test('update-comfyui drives the real updater and moves HEAD forward @lifecycle',
 test('re-launch ComfyUI after update validates the updated install runs @lifecycle', async () => {
   await clickInstallTile(ctx.panel, 'ComfyUI')
   await expect.poll(comfyFrontendIsLoaded, { timeout: 180_000, intervals: [1_000] }).toBe(true)
+})
+
+// ---------------------------------------------------------------------------
+// FLOW 1 — IN_PLACE_RELAUNCH coverage via the real picker UI.
+//
+// The existing direct-runAction update test above covers the stopped-install
+// code path. These tests cover the running-install path: the user opens the
+// picker against a live ComfyUI, clicks Update Now (or Restore Snapshot),
+// confirms in the popup's own dialog, and the panel-side apiCall wrapper
+// self-stops + runs the op + relaunches in place. Each test re-uses the
+// real ~500MB install the lifecycle suite already built and drives the
+// actions through real DOM gestures.
+// ---------------------------------------------------------------------------
+
+interface SnapshotSummaryLite {
+  filename: string
+  label: string | null
+}
+interface SnapshotListLite { snapshots: SnapshotSummaryLite[] }
+
+interface OpenInstallWindowPayload {
+  installationId: string
+}
+interface RunActionInvocation {
+  installationId?: string
+  actionId?: string
+}
+interface StopComfyInvocation {
+  installationId?: string
+}
+
+/** Polls until the title-popup webContents reports hidden (the picker
+ *  closes itself once main routes the action), then waits for the
+ *  panel-side `.brand-progress` takeover to mount. Used by every
+ *  picker-driven action whose op lands in the ProgressModal. */
+async function waitForProgressTakeoverAfterPopupClose(): Promise<void> {
+  await expect
+    .poll(() => isPopupVisible(ctx.app, 'comfyTitlePopup.html'), {
+      timeout: 10_000, intervals: [100, 200],
+    })
+    .toBe(false)
+  await ctx.panel.waitForVisible('.brand-progress', { timeout: 30_000 })
+}
+
+/** Polls until a `run-action` IPC for `installationId` with `actionId`
+ *  has been recorded. Wraps the long-budget poll the picker-driven
+ *  update / restore / restart tests need to wait for the IN_PLACE_RELAUNCH
+ *  launch leg. */
+async function waitForRunAction(
+  installationId: string, actionId: string,
+  opts: { timeout?: number; intervals?: number[] } = {},
+): Promise<void> {
+  await expect
+    .poll(async () => {
+      const calls = (await getIpcInvocations(ctx.app, 'run-action')) as RunActionInvocation[]
+      return calls.some((c) => c.installationId === installationId && c.actionId === actionId)
+    }, { timeout: opts.timeout ?? 540_000, intervals: opts.intervals ?? [2_000, 5_000] })
+    .toBe(true)
+}
+
+async function getRunActionsFor(installationId: string): Promise<RunActionInvocation[]> {
+  const calls = (await getIpcInvocations(ctx.app, 'run-action')) as RunActionInvocation[]
+  return calls.filter((c) => c.installationId === installationId)
+}
+
+async function getStopsFor(installationId: string): Promise<StopComfyInvocation[]> {
+  const calls = (await getIpcInvocations(ctx.app, 'stop-comfyui')) as StopComfyInvocation[]
+  return calls.filter((c) => c.installationId === installationId)
+}
+
+let _restoreSnapshotFilename = ''
+let _snapshotHeadAtCapture = ''
+
+test('captures a snapshot for the picker-driven restore test @lifecycle', async () => {
+  // ComfyUI is running from the prior re-launch test. `snapshot-save`
+  // is NOT in REQUIRES_STOPPED so it runs against a live install — the
+  // snapshot just records the current state. Captured label gives us a
+  // stable filename to grab in the restore test below.
+  expect(_updateInstallId, 'update install id not captured').toBeTruthy()
+  await ctx.panel.evaluate<unknown>(
+    `window.api.runAction(${JSON.stringify(_updateInstallId)}, 'snapshot-save', { label: 'lifecycle-restore-target' })`,
+  )
+  const list = await ctx.panel.evaluate<SnapshotListLite>(
+    `window.api.getSnapshots(${JSON.stringify(_updateInstallId)})`,
+  )
+  const target = list.snapshots.find((s) => s.label === 'lifecycle-restore-target')
+  expect(target, 'lifecycle-restore-target snapshot missing from getSnapshots').toBeDefined()
+  _restoreSnapshotFilename = target!.filename
+  _snapshotHeadAtCapture = execFileSync('git', ['rev-parse', 'HEAD'], {
+    cwd: _comfyUIDir, encoding: 'utf-8', windowsHide: true,
+  }).trim()
+  expect(_snapshotHeadAtCapture).toMatch(/^[a-f0-9]{40}$/)
+})
+
+test('picker-driven update-comfyui IN_PLACE_RELAUNCH while running @lifecycle', async () => {
+  // Real `update-comfyui` against github.com can spend minutes inside
+  // `uv pip install -r requirements.txt` if the rolled-back range
+  // crosses a requirements change. Mirror the stopped-install
+  // update test's 10-minute budget.
+  test.setTimeout(600_000)
+
+  // Roll HEAD back so the update has work — the prior update test
+  // already moved HEAD forward to the latest stable, so we have to
+  // un-do that for the picker click to show "Update available".
+  const headBefore = execFileSync('git', ['rev-parse', 'HEAD'], {
+    cwd: _comfyUIDir, encoding: 'utf-8', windowsHide: true,
+  }).trim()
+  execFileSync('git', ['reset', '--hard', 'HEAD~3'], {
+    cwd: _comfyUIDir, stdio: 'pipe', windowsHide: true,
+  })
+  const rolledBack = execFileSync('git', ['rev-parse', 'HEAD'], {
+    cwd: _comfyUIDir, encoding: 'utf-8', windowsHide: true,
+  }).trim()
+  expect(rolledBack, 'git reset --hard did not move HEAD').not.toBe(headBefore)
+
+  await resetIpcInvocations(ctx.app, 'stop-comfyui')
+  await resetIpcInvocations(ctx.app, 'run-action')
+
+  // Open the picker in expanded mode on the Update tab. Channel
+  // metadata loads via real `check-update` against github.com — the
+  // Update Now button appears once the stable channel reports an
+  // update available.
+  await ctx.panel.evaluate<boolean>(
+    `(() => {
+      window.api.openInstancePicker({
+        installationId: ${JSON.stringify(_updateInstallId)},
+        mode: 'expanded',
+        initialTab: 'update',
+      })
+      return true
+    })()`,
+  )
+  await waitForWebContents(ctx.app, 'comfyTitlePopup.html')
+  const popup = titlePopupPage(ctx.app)
+  await popup.waitForSelector(byTestId(TID.updateActionButton('update-comfyui')), { timeout: 60_000 })
+  expect(await popup.click(byTestId(TID.updateActionButton('update-comfyui')))).toBe(true)
+
+  // The update action carries `confirm.messageDetails` (truncated
+  // release notes), so it lands in `ModalDialog`'s rich-confirm
+  // branch — `TID.modalConfirm` is the primary CTA there.
+  await popup.waitForVisible(byTestId(TID.modalConfirm), { timeout: 15_000 })
+  expect(await popup.click(byTestId(TID.modalConfirm))).toBe(true)
+
+  // Popup hides; the panel's ProgressModal owns the long-running op.
+  await waitForProgressTakeoverAfterPopupClose()
+
+  // Wait for the relaunch leg of IN_PLACE_RELAUNCH to fire (panel-side
+  // `useDeepLinkRouter` appends `runAction('launch')` after a successful
+  // update). Then wait for the comfy frontend to be loaded again.
+  await waitForRunAction(_updateInstallId, 'launch')
+  await expect.poll(comfyFrontendIsLoaded, { timeout: 180_000, intervals: [1_000, 2_000] }).toBe(true)
+
+  // IPC chain: exactly one self-stop, then update-comfyui then launch
+  // (both scoped to our installation id).
+  const ourStops = await getStopsFor(_updateInstallId)
+  expect(ourStops.length, 'self-stop should fire exactly once for IN_PLACE_RELAUNCH').toBe(1)
+
+  const ourRunCalls = await getRunActionsFor(_updateInstallId)
+  expect(ourRunCalls.length, 'update + launch run-action calls').toBeGreaterThanOrEqual(2)
+  expect(ourRunCalls[0]?.actionId, 'first run-action should be update-comfyui').toBe('update-comfyui')
+  const launchIdx = ourRunCalls.findIndex((c) => c.actionId === 'launch')
+  expect(launchIdx, 'launch run-action should follow update-comfyui').toBeGreaterThan(0)
+
+  // HEAD moved forward off the rolled-back commit.
+  const headAfter = execFileSync('git', ['rev-parse', 'HEAD'], {
+    cwd: _comfyUIDir, encoding: 'utf-8', windowsHide: true,
+  }).trim()
+  expect(headAfter, 'update did not move HEAD').not.toBe(rolledBack)
+})
+
+test('picker-driven snapshot-restore IN_PLACE_RELAUNCH while running @lifecycle', async () => {
+  test.setTimeout(600_000)
+  expect(_restoreSnapshotFilename, 'restore-target snapshot not captured').toBeTruthy()
+
+  // Move HEAD off the snapshot commit so the restore has work to do.
+  // Use a parent of the snapshot commit so restore lands somewhere
+  // different from the current working tree.
+  execFileSync('git', ['reset', '--hard', `${_snapshotHeadAtCapture}~5`], {
+    cwd: _comfyUIDir, stdio: 'pipe', windowsHide: true,
+  })
+  const rolledBack = execFileSync('git', ['rev-parse', 'HEAD'], {
+    cwd: _comfyUIDir, encoding: 'utf-8', windowsHide: true,
+  }).trim()
+  expect(rolledBack, 'rollback did not change HEAD off the snapshot commit').not.toBe(_snapshotHeadAtCapture)
+
+  await resetIpcInvocations(ctx.app, 'stop-comfyui')
+  await resetIpcInvocations(ctx.app, 'run-action')
+
+  await ctx.panel.evaluate<boolean>(
+    `(() => {
+      window.api.openInstancePicker({
+        installationId: ${JSON.stringify(_updateInstallId)},
+        mode: 'expanded',
+        initialTab: 'snapshots',
+      })
+      return true
+    })()`,
+  )
+  await waitForWebContents(ctx.app, 'comfyTitlePopup.html')
+  const popup = titlePopupPage(ctx.app)
+  // Expand the snapshot row to reveal Restore.
+  await popup.waitForSelector(byTestId(TID.snapshotRow(_restoreSnapshotFilename)), { timeout: 30_000 })
+  expect(await popup.click(byTestId(TID.snapshotRow(_restoreSnapshotFilename)))).toBe(true)
+  await popup.waitForVisible(byTestId(TID.snapshotRowRestore(_restoreSnapshotFilename)), { timeout: 10_000 })
+  expect(await popup.click(byTestId(TID.snapshotRowRestore(_restoreSnapshotFilename)))).toBe(true)
+
+  // SnapshotsView builds a diff-preview confirm with `messageDetails` —
+  // rich confirm branch, `TID.modalConfirm` is the primary CTA.
+  await popup.waitForVisible(byTestId(TID.modalConfirm), { timeout: 30_000 })
+  expect(await popup.click(byTestId(TID.modalConfirm))).toBe(true)
+
+  await waitForProgressTakeoverAfterPopupClose()
+
+  // Wait for the IN_PLACE_RELAUNCH launch leg + frontend load.
+  await waitForRunAction(_updateInstallId, 'launch')
+  await expect.poll(comfyFrontendIsLoaded, { timeout: 180_000, intervals: [1_000, 2_000] }).toBe(true)
+
+  const ourStops = await getStopsFor(_updateInstallId)
+  expect(ourStops.length, 'self-stop should fire exactly once for IN_PLACE_RELAUNCH').toBe(1)
+
+  const ourRunCalls = await getRunActionsFor(_updateInstallId)
+  expect(ourRunCalls[0]?.actionId, 'first run-action should be snapshot-restore').toBe('snapshot-restore')
+  expect(ourRunCalls.some((c) => c.actionId === 'launch'), 'launch run-action must follow restore').toBe(true)
+
+  // Snapshot restore moves ComfyUI's HEAD to the snapshot's commit.
+  const headAfter = execFileSync('git', ['rev-parse', 'HEAD'], {
+    cwd: _comfyUIDir, encoding: 'utf-8', windowsHide: true,
+  }).trim()
+  expect(headAfter, 'snapshot-restore did not land HEAD on the snapshot commit').toBe(_snapshotHeadAtCapture)
+})
+
+// ---------------------------------------------------------------------------
+// Restart synthetic action — driven through the compact-picker row's
+// "Restart" CTA. The CTA fires `restartInstall` over the picker bridge,
+// which lives in `main/index.ts` as `restartInstallFromPicker` — confirm
+// via the shell-level system modal (migrated off `dialog.showMessageBox`),
+// then main runs `ipc.stopRunning` and routes a `picker-pick-install`
+// payload back to the panel for the re-launch.
+//
+// Note: this path intentionally bypasses the `stop-comfyui` IPC channel
+// (it goes through `ipc.stopRunning` directly), so the per-channel
+// invocation count for `stop-comfyui` stays at zero.
+// ---------------------------------------------------------------------------
+
+test('picker compact-row Restart drives system-modal confirm + re-launch @lifecycle', async () => {
+  test.setTimeout(300_000)
+
+  await resetIpcInvocations(ctx.app, 'stop-comfyui')
+  await resetIpcInvocations(ctx.app, 'run-action')
+
+  await ctx.panel.evaluate<boolean>(`(() => { window.api.openInstancePicker(); return true })()`)
+  await waitForWebContents(ctx.app, 'comfyTitlePopup.html')
+  const popup = titlePopupPage(ctx.app)
+  // PickerRow renders its primary CTA as "Restart" when the install is
+  // currently running — same test id either way.
+  await popup.waitForSelector(byTestId(TID.pickerRowOpen(_updateInstallId)), { timeout: 15_000 })
+  expect(await popup.click(byTestId(TID.pickerRowOpen(_updateInstallId)))).toBe(true)
+
+  // Popup hides as soon as main routes the restart-install IPC; the
+  // system-modal overlay mounts on the host window in its place.
+  await expect
+    .poll(() => isPopupVisible(ctx.app, 'comfyTitlePopup.html'), {
+      timeout: 10_000, intervals: [100, 200],
+    })
+    .toBe(false)
+  await waitForWebContents(ctx.app, 'comfySystemModal.html')
+  const sysModal = systemModalPage(ctx.app)
+  await sysModal.waitForVisible(byTestId(TID.baseAlertAction), { timeout: 15_000 })
+  expect(await sysModal.click(byTestId(TID.baseAlertAction))).toBe(true)
+
+  // The restart path tears down + re-launches comfy in place. Wait
+  // for the launch leg to fire on the panel side (panel handles the
+  // `picker-pick-install` overlay → `performPickerLaunch` →
+  // `runAction(id, 'launch')`), then for the frontend to be live.
+  await waitForRunAction(_updateInstallId, 'launch', { timeout: 180_000, intervals: [1_000, 2_000] })
+  await expect.poll(comfyFrontendIsLoaded, { timeout: 180_000, intervals: [1_000] }).toBe(true)
+
+  // The picker compact Restart deliberately bypasses the `stop-comfyui`
+  // renderer IPC (main uses `ipc.stopRunning` directly), so no
+  // invocations should land on that channel.
+  const stopCalls = await getStopsFor(_updateInstallId)
+  expect(stopCalls.length, 'compact picker Restart should bypass the stop-comfyui renderer IPC').toBe(0)
+
+  const launchCalls = (await getRunActionsFor(_updateInstallId))
+    .filter((c) => c.actionId === 'launch')
+  expect(launchCalls.length, 'exactly one launch run-action for the restart').toBeGreaterThanOrEqual(1)
+})
+
+// ---------------------------------------------------------------------------
+// FLOW 2 — real copy via the picker's pin-bottom MoreMenu.
+//
+// `copy` is REQUIRES_STOPPED + a runAction prompt chain; the kebab is
+// known-broken (Bug #7, deferred to Step 5) so we have to drive it
+// through the picker's footer "More" menu → Copy item, which exercises
+// the full prompt → showProgress → real ~500MB filesystem copy path.
+// ---------------------------------------------------------------------------
+
+let _copyInstallId = ''
+let _copyInstallPath = ''
+
+test('picker pin-bottom Copy creates a real ~500MB copy of the install @lifecycle', async () => {
+  test.setTimeout(600_000)
+
+  // Copy is REQUIRES_STOPPED — stop comfy via return-to-dashboard so
+  // the IPC handler doesn't bail and the picker dispatches without a
+  // self-stop preamble.
+  await returnFirstInstallHostToDashboard(ctx.app)
+  await expect.poll(comfyFrontendIsLoaded, { timeout: 30_000, intervals: [500] }).toBe(false)
+  await waitForWebContents(ctx.app, 'panel.html')
+  await expectChooserVisible(ctx.panel)
+
+  // Snapshot BrowserWindow ids before the copy fires. The copy emits
+  // `open-install-window` for the NEW install, which (because no window
+  // backs it yet) spawns a fresh chooser host. Subsequent tests use
+  // URL-marker-based helpers (`panel.html`) which would non-deterministically
+  // bind to either chooser host, so we close the extra below.
+  const windowIdsBeforeCopy = await ctx.app.evaluate(({ BrowserWindow }) =>
+    BrowserWindow.getAllWindows().filter((w) => !w.isDestroyed()).map((w) => w.id),
+  )
+
+  await resetIpcInvocations(ctx.app, 'open-install-window')
+  await resetIpcInvocations(ctx.app, 'run-action')
+
+  await ctx.panel.evaluate<boolean>(
+    `(() => {
+      window.api.openInstancePicker({
+        installationId: ${JSON.stringify(_updateInstallId)},
+        mode: 'expanded',
+        initialTab: 'config',
+      })
+      return true
+    })()`,
+  )
+  await waitForWebContents(ctx.app, 'comfyTitlePopup.html')
+  const popup = titlePopupPage(ctx.app)
+
+  // Open the footer "More" overflow menu → click Copy.
+  await popup.waitForVisible('[data-more-trigger]', { timeout: 15_000 })
+  expect(await popup.click('[data-more-trigger]')).toBe(true)
+  await popup.waitForVisible(byTestId(TID.pinBottomAction('copy')), { timeout: 10_000 })
+  expect(await popup.click(byTestId(TID.pinBottomAction('copy')))).toBe(true)
+
+  // Prompt for the copy's new name (rendered by ModalDialog's prompt
+  // branch inside the popup webContents).
+  await popup.waitForVisible(byTestId(TID.modalPromptInput), { timeout: 10_000 })
+  const newName = 'ComfyUI Copy E2E'
+  await popup.evaluate<void>(
+    `(() => {
+      const el = document.querySelector(${JSON.stringify(byTestId(TID.modalPromptInput))})
+      if (!el) throw new Error('prompt input not found')
+      el.value = ${JSON.stringify(newName)}
+      el.dispatchEvent(new Event('input', { bubbles: true }))
+      el.dispatchEvent(new Event('change', { bubbles: true }))
+    })()`,
+  )
+  expect(await popup.click(byTestId(TID.modalConfirm))).toBe(true)
+
+  await waitForProgressTakeoverAfterPopupClose()
+
+  // Wait for the copy to complete + `open-install-window` to fire for
+  // the new install. Real ~500MB filesystem copy → generous timeout.
+  await expect
+    .poll(async () => {
+      const calls = (await getIpcInvocations(ctx.app, 'open-install-window')) as OpenInstallWindowPayload[]
+      return calls.find((c) => c.installationId && c.installationId !== _updateInstallId) ?? null
+    }, { timeout: 540_000, intervals: [2_000, 5_000] })
+    .not.toBeNull()
+
+  const openCalls = (await getIpcInvocations(ctx.app, 'open-install-window')) as OpenInstallWindowPayload[]
+  const newCall = openCalls.find((c) => c.installationId && c.installationId !== _updateInstallId)
+  expect(newCall?.installationId, 'open-install-window did not capture a NEW installationId').toBeTruthy()
+  _copyInstallId = newCall!.installationId
+
+  const installs = await ctx.panel.evaluate<InstallationLite[]>(`window.api.getInstallations()`)
+  const copyRecord = installs.find((i) => i.id === _copyInstallId)
+  expect(copyRecord, 'copy installation not found in getInstallations').toBeDefined()
+  _copyInstallPath = copyRecord!.installPath
+
+  // Disk shape: copy is a full standalone tree (ComfyUI/.git +
+  // standalone-env + marker), and the source dir is untouched.
+  expect(existsSync(path.join(_copyInstallPath, 'ComfyUI', '.git')), 'copy missing ComfyUI/.git').toBe(true)
+  expect(existsSync(path.join(_copyInstallPath, 'standalone-env')), 'copy missing standalone-env/').toBe(true)
+  expect(existsSync(path.join(_copyInstallPath, '.comfyui-desktop-2')), 'copy missing .comfyui-desktop-2 marker').toBe(true)
+  expect(existsSync(path.join(_updateInstallPath, 'ComfyUI', '.git')), 'source ComfyUI/.git missing after copy').toBe(true)
+  expect(existsSync(path.join(_updateInstallPath, '.comfyui-desktop-2')), 'source marker missing after copy').toBe(true)
+
+  // Close the extra chooser host spawned by `open-install-window` so
+  // panel.html-marker helpers in subsequent tests have a single, stable
+  // target.
+  const extraWindowIds = await ctx.app.evaluate(
+    ({ BrowserWindow }, before) =>
+      BrowserWindow.getAllWindows()
+        .filter((w) => !w.isDestroyed() && !before.includes(w.id))
+        .map((w) => w.id),
+    windowIdsBeforeCopy,
+  )
+  expect(
+    extraWindowIds.length,
+    'open-install-window should have spawned a new chooser host',
+  ).toBeGreaterThan(0)
+  await ctx.app.evaluate(({ BrowserWindow }, ids) => {
+    for (const id of ids) {
+      const w = BrowserWindow.fromId(id)
+      if (w && !w.isDestroyed()) w.close()
+    }
+  }, extraWindowIds)
+  await expect
+    .poll(
+      () =>
+        ctx.app.evaluate(
+          ({ BrowserWindow }, ids) =>
+            BrowserWindow.getAllWindows().filter(
+              (w) => !w.isDestroyed() && ids.includes(w.id),
+            ).length,
+          extraWindowIds,
+        ),
+      { timeout: 10_000, intervals: [100, 250] },
+    )
+    .toBe(0)
+})
+
+test('cleans up the copy install before the original delete test runs @lifecycle', async () => {
+  test.setTimeout(300_000)
+  expect(_copyInstallId, 'no copy install id captured to clean up').toBeTruthy()
+
+  // Direct runAction('delete') bypasses the confirm chain — the copy
+  // is stopped (never launched), so no `stop-comfyui` preamble is
+  // needed. Frees disk before the existing final delete test runs
+  // against the original.
+  const result = await ctx.panel.evaluate<UpdateActionResult>(
+    `window.api.runAction(${JSON.stringify(_copyInstallId)}, 'delete')`,
+  )
+  expect(result.ok, `delete copy failed: ${result.message ?? ''}`).toBe(true)
+
+  expect(existsSync(_copyInstallPath), `copy install dir ${_copyInstallPath} still on disk after delete`).toBe(false)
+  const remaining = await ctx.panel.evaluate<InstallationLite[]>(`window.api.getInstallations()`)
+  expect(remaining.find((i) => i.id === _copyInstallId), 'copy install record not removed after delete').toBeUndefined()
+  expect(remaining.find((i) => i.id === _updateInstallId), 'original install was unexpectedly removed').toBeDefined()
 })
 
 // ---------------------------------------------------------------------------

--- a/e2e/support/cdpPages.ts
+++ b/e2e/support/cdpPages.ts
@@ -199,6 +199,13 @@ export function titlePopupPage(app: ElectronApplication): WebContentsPage {
   return new WebContentsPage(app, 'comfyTitlePopup.html')
 }
 
+/** WebContentsPage for the shell-level system-modal popup. Hosts the
+ *  app-update Download/Restart confirm, the picker Restart confirm,
+ *  the switch-instance confirm, and the Close All Windows confirm. */
+export function systemModalPage(app: ElectronApplication): WebContentsPage {
+  return new WebContentsPage(app, 'comfySystemModal.html')
+}
+
 /**
  * True iff the WebContentsView whose URL contains `marker` is currently
  * `setVisible(true)` AND has non-zero bounds — the EmbeddedPopupView

--- a/src/main/host/detach.ts
+++ b/src/main/host/detach.ts
@@ -1,8 +1,10 @@
-import { dialog, ipcMain } from 'electron'
+import { ipcMain } from 'electron'
 import type { BrowserWindow, WebContentsView } from 'electron'
 import * as ipc from '../lib/ipc'
 import { COMFY_BG } from '../lib/theme'
 import { destroyPanelView, ensurePanelView } from './panelView'
+import { openSystemModalAsync } from '../popups/systemModal'
+import type { SystemModalDetailGroup } from '../popups/systemModal'
 import { comfyWindows, isChooserHost, isInstallHost } from './registry'
 import type { ComfyWindowEntry } from './registry'
 import {
@@ -189,41 +191,48 @@ export async function confirmAndCloseAllHostWindows(
     return
   }
   const titles = entries.map((e) => e.window.getTitle() || 'Untitled window')
-  const detailLines: string[] = ['Open windows:', ...titles.map((t) => `  • ${t}`)]
+  const details: SystemModalDetailGroup[] = [
+    { label: 'Open windows', items: titles },
+  ]
   if (ipc.hasActiveOperations()) {
     try {
       const items = await ipc.getActiveDetails()
       const sessions = items.filter((i) => i.type === 'session').map((i) => i.name)
       const operations = items.filter((i) => i.type === 'operation').map((i) => i.name)
       const downloads = items.filter((i) => i.type === 'download').map((i) => i.name)
-      if (sessions.length > 0) {
-        detailLines.push('', 'Running ComfyUI:', ...sessions.map((n) => `  • ${n}`))
-      }
-      if (operations.length > 0) {
-        detailLines.push('', 'In-progress operations:', ...operations.map((n) => `  • ${n}`))
-      }
-      if (downloads.length > 0) {
-        detailLines.push('', 'Active downloads:', ...downloads.map((n) => `  • ${n}`))
-      }
+      if (sessions.length > 0) details.push({ label: 'Running ComfyUI', items: sessions })
+      if (operations.length > 0) details.push({ label: 'In-progress operations', items: operations })
+      if (downloads.length > 0) details.push({ label: 'Active downloads', items: downloads })
     } catch {
       // If active-detail collection ever throws, fall back to just the
       // window list — the user still sees what's about to close.
     }
   }
-  const opts: Electron.MessageBoxOptions = {
-    type: 'question',
-    buttons: ['Close All', 'Cancel'],
-    defaultId: 1,
-    cancelId: 1,
-    title: 'Close All Windows',
-    message: `Close ${entries.length} open windows?`,
-    detail: detailLines.join('\n'),
+  // Pick the parent for the overlay. Prefer the caller's hint (the
+  // window the user clicked Close All from); fall back to any live
+  // host so we don't drop the confirm entirely when the popup's
+  // parent has gone away mid-flight.
+  const overlayParentEntry = parentWindow && !parentWindow.isDestroyed()
+    ? entries.find((e) => e.window === parentWindow)
+    : entries[0]
+  if (!overlayParentEntry) {
+    closeAllHostWindows()
+    return
   }
-  const result = parentWindow && !parentWindow.isDestroyed()
-    ? await dialog.showMessageBox(parentWindow, opts)
-    : await dialog.showMessageBox(opts)
-  if (result.response === 0) {
-    // The global dialog already lists in-progress ops / sessions /
+  const confirmed = await openSystemModalAsync({
+    parent: overlayParentEntry.window,
+    spec: {
+      title: 'Close All Windows',
+      message: `Close ${entries.length} open windows?`,
+      details,
+      confirmLabel: 'Close All',
+      cancelLabel: 'Cancel',
+      confirmStyle: 'danger',
+      theme: overlayParentEntry.lastTheme,
+    },
+  })
+  if (confirmed) {
+    // The global confirm already lists in-progress ops / sessions /
     // downloads, so the per-window tier-aware prompt would be
     // redundant after the user confirmed the bulk close. Pre-clear
     // every entry so each window's `close` handler skips its own

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, Menu, ipcMain, net, dialog } from 'electron'
+import { app, Menu, ipcMain, net } from 'electron'
 import type { BrowserWindow, WebContentsView } from 'electron'
 import type { Tray } from 'electron'
 import path from 'path'
@@ -21,6 +21,7 @@ import {
 } from './popups/titleTooltip'
 import {
   openSystemModal,
+  openSystemModalAsync,
   registerSystemModalIpc,
 } from './popups/systemModal'
 import { registerTitlePopupIpc, type InstancePickerInstall } from './popups/titlePopup'
@@ -1039,17 +1040,27 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
         } catch {
           // Name lookup is cosmetic — fall through with the id as the label.
         }
-        const result = await dialog.showMessageBox(parentEntry.window, {
-          type: 'question',
-          buttons: ['Switch', 'Cancel'],
-          defaultId: 0,
-          cancelId: 1,
-          title: 'Switch instance?',
-          message: `Switch to ${targetName}?`,
-          detail:
-            'The current instance will be stopped and replaced in this window. Any unsaved work in the workflow will be lost.',
+        const confirmed = await openSystemModalAsync({
+          parent: parentEntry.window,
+          spec: {
+            title: 'Switch instance?',
+            message: `Switch to ${targetName}?`,
+            details: [
+              {
+                label: 'Heads up',
+                items: [
+                  'The current instance will be stopped and replaced in this window.',
+                  'Any unsaved work in the workflow will be lost.',
+                ],
+              },
+            ],
+            confirmLabel: 'Switch',
+            cancelLabel: 'Cancel',
+            confirmStyle: 'primary',
+            theme: parentEntry.lastTheme,
+          },
         })
-        if (result.response !== 0) return
+        if (!confirmed) return
         // `entry.detachInstall()` runs the full symmetric undo of
         // `attachInstall`: stops the running session, releases the
         // comfyView URL, re-navigates the title-bar back to chooser
@@ -1225,28 +1236,34 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
         // window short-circuit reloads the comfyView URL in place
         // without re-creating the BrowserWindow or the entry.
         //
-        // Confirm with a native dialog parented to the host so the
-        // prompt visually belongs to the window that initiated the
-        // restart. Reuses the same dialog idiom as
-        // `confirmAndCloseAllHostWindows` for visual consistency.
+        // Confirm via the shell-level system-modal overlay parented to
+        // the host so the prompt visually belongs to the window that
+        // initiated the restart. Same primitive `confirmAndCloseAllHostWindows`
+        // uses, so the launcher's confirm surface is consistent across
+        // shell-level prompts (and Playwright-driveable end to end).
         const parentEntry = comfyWindows.get(parentEntryId)
-        const parentWindow = parentEntry && !parentEntry.window.isDestroyed()
-          ? parentEntry.window
-          : null
-        const opts: Electron.MessageBoxOptions = {
-          type: 'question',
-          buttons: ['Restart', 'Cancel'],
-          defaultId: 1,
-          cancelId: 1,
-          title: 'Restart instance?',
-          message: 'Restart this instance?',
-          detail:
-            'Restarting will stop the running session. Any unsaved work in the workflow will be lost.',
-        }
-        const result = parentWindow
-          ? await dialog.showMessageBox(parentWindow, opts)
-          : await dialog.showMessageBox(opts)
-        if (result.response !== 0) return
+        if (!parentEntry || parentEntry.window.isDestroyed()) return
+        const confirmed = await openSystemModalAsync({
+          parent: parentEntry.window,
+          spec: {
+            title: 'Restart instance?',
+            message: 'Restart this instance?',
+            details: [
+              {
+                label: 'Heads up',
+                items: [
+                  'Restarting will stop the running session.',
+                  'Any unsaved work in the workflow will be lost.',
+                ],
+              },
+            ],
+            confirmLabel: 'Restart',
+            cancelLabel: 'Cancel',
+            confirmStyle: 'primary',
+            theme: parentEntry.lastTheme,
+          },
+        })
+        if (!confirmed) return
         // Stop is idempotent — awaiting ensures the process is fully
         // gone before the re-launch so the new session doesn't race a
         // port that's still bound.

--- a/src/main/popups/systemModal.ts
+++ b/src/main/popups/systemModal.ts
@@ -11,12 +11,25 @@ import { EmbeddedPopupView } from './embeddedPopupView'
 
 type SystemModalConfirmStyle = 'primary' | 'danger'
 
+/** Structured detail block — renders as `<label>` followed by a bulleted
+ *  list of `items` beneath the main `message`. Multiple groups stack
+ *  vertically. Mirrors the `messageDetails` shape `BaseAlert` already
+ *  exposes via the confirm modal primitive — used by the close-all
+ *  confirm to list open windows / running sessions / in-flight ops /
+ *  active downloads without packing them into a flat `message` string. */
+export interface SystemModalDetailGroup {
+  label: string
+  items: string[]
+}
+
 export interface SystemModalSpec {
   /** Unique per open. Stamped onto the action ack so a stale ack
    *  for a previously-dismissed modal can be ignored. */
   id: string
   title: string
   message: string
+  /** Optional structured detail groups rendered beneath the message. */
+  details?: SystemModalDetailGroup[]
   confirmLabel: string
   cancelLabel: string
   confirmStyle?: SystemModalConfirmStyle
@@ -40,9 +53,33 @@ export interface SystemModalEntry {
 const systemModalsByParent = new Map<number, SystemModalEntry>()
 const systemModalsByWebContents = new Map<number, SystemModalEntry>()
 
+/** Settle any in-flight (current OR pending) modal on this entry as
+ *  cancelled. Callers can rely on `openSystemModalAsync` resolving
+ *  `false` for every drop reason (supersession, parent close, popup
+ *  crash). Errors thrown by user callbacks are swallowed so a buggy
+ *  caller can't poison subsequent settlements. */
+function cancelEntry(entry: SystemModalEntry): void {
+  const current = entry.currentCallback
+  const pending = entry.pendingSpec?.callback
+  entry.currentSpec = null
+  entry.currentCallback = null
+  entry.pendingSpec = null
+  try { current?.('cancel') } catch {}
+  try { pending?.('cancel') } catch {}
+}
+
 export function ensureSystemModal(parent: BrowserWindow): SystemModalEntry {
   const existing = systemModalsByParent.get(parent.id)
   if (existing && !existing.view.isDestroyed()) return existing
+
+  // Forward-declared so the popup-crash / parent-close teardowns can
+  // detach the parent-window resize listener — without this, a
+  // crash-and-recreate cycle accumulates one resize listener per cycle
+  // on the parent BrowserWindow.
+  let layoutBelowTitleBar: () => void = () => {}
+  const detachResizeListener = (): void => {
+    if (!parent.isDestroyed()) parent.removeListener('resize', layoutBelowTitleBar)
+  }
 
   const view = new EmbeddedPopupView({
     parent,
@@ -50,15 +87,20 @@ export function ensureSystemModal(parent: BrowserWindow): SystemModalEntry {
     preloadName: 'comfySystemModalPreload.js',
     initialBounds: { x: 0, y: 0, width: 1, height: 1 },
     onParentClosed: () => {
+      detachResizeListener()
+      const cur = systemModalsByParent.get(parent.id)
+      if (cur && cur.view === view) cancelEntry(cur)
       systemModalsByParent.delete(parent.id)
       systemModalsByWebContents.delete(view.popupWebContentsId)
     },
     onDestroyed: () => {
+      detachResizeListener()
       // Identity-check so we don't drop a fresher entry that may have
       // been registered against the same parent id between the popup
       // crash and this teardown firing.
       const cur = systemModalsByParent.get(parent.id)
       if (cur && cur.view === view) {
+        cancelEntry(cur)
         systemModalsByParent.delete(parent.id)
       }
       systemModalsByWebContents.delete(view.popupWebContentsId)
@@ -78,7 +120,7 @@ export function ensureSystemModal(parent: BrowserWindow): SystemModalEntry {
   // strip uncovered keeps it visually unblurred so the user can tell
   // at a glance that the modal is a body-level overlay rather than a
   // full-window takeover.
-  const layoutBelowTitleBar = (): void => {
+  layoutBelowTitleBar = (): void => {
     if (view.popup.webContents.isDestroyed() || parent.isDestroyed()) return
     const b = parent.getContentBounds()
     const y = TITLEBAR_HEIGHT + 1
@@ -87,7 +129,6 @@ export function ensureSystemModal(parent: BrowserWindow): SystemModalEntry {
   }
   layoutBelowTitleBar()
   parent.on('resize', layoutBelowTitleBar)
-  parent.once('closed', () => parent.removeListener('resize', layoutBelowTitleBar))
 
   return entry
 }
@@ -106,7 +147,10 @@ function showSystemModalNow(entry: SystemModalEntry): void {
 export interface OpenSystemModalOpts {
   parent: BrowserWindow
   spec: Omit<SystemModalSpec, 'id'> & { id?: string }
-  callback: SystemModalCallback
+  /** Optional explicit callback. Required by the legacy `openSystemModal`
+   *  call path; the Promise-shaped `openSystemModalAsync` wrapper supplies
+   *  its own internal resolver, so callers using it can omit this. */
+  callback?: SystemModalCallback
 }
 
 /**
@@ -118,25 +162,27 @@ export interface OpenSystemModalOpts {
  */
 export function openSystemModal(opts: OpenSystemModalOpts): string {
   const entry = ensureSystemModal(opts.parent)
-  // Supersede any in-flight modal — fire its callback as cancelled
-  // so the previous flow can clean up rather than wait forever.
-  if (entry.currentCallback) {
-    try { entry.currentCallback('cancel') } catch {}
-    entry.currentCallback = null
-    entry.currentSpec = null
-  }
+  // Supersede any in-flight OR queued-but-not-yet-flushed modal — every
+  // previous-open callback resolves cancelled so awaiters never hang.
+  // Same helper the parent-close / popup-crash teardowns use, so all
+  // four drop reasons share one settlement path.
+  cancelEntry(entry)
   const id = opts.spec.id ?? `sysmodal-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
   const spec: SystemModalSpec = { ...opts.spec, id }
+  // `opts.callback` is optional on the public type so `openSystemModalAsync`
+  // (which provides its own resolver) and fire-and-forget callers can both
+  // use this entry point. Internally we always carry a callable.
+  const callback: SystemModalCallback = opts.callback ?? (() => {})
 
   if (!entry.view.rendererReady) {
     // Queue until the renderer signals ready; on `ready` we'll flush
     // and push set-modal.
-    entry.pendingSpec = { spec, callback: opts.callback }
+    entry.pendingSpec = { spec, callback }
     return id
   }
 
   entry.currentSpec = spec
-  entry.currentCallback = opts.callback
+  entry.currentCallback = callback
   if (!entry.view.popup.webContents.isDestroyed()) {
     entry.view.popup.webContents.send('comfy-systemmodal:set-modal', spec)
   }
@@ -145,6 +191,25 @@ export function openSystemModal(opts: OpenSystemModalOpts): string {
   // so the user isn't stuck without UI.
   entry.view.scheduleShowFallback(200, () => showSystemModalNow(entry))
   return id
+}
+
+/** Promise-shaped wrapper around `openSystemModal` for callers that
+ *  want to `await` a yes/no decision instead of plumbing a callback.
+ *  Resolves `true` when the user clicks the confirm button, `false`
+ *  for cancel / superseded / parent destroyed. */
+export function openSystemModalAsync(opts: OpenSystemModalOpts): Promise<boolean> {
+  return new Promise((resolve) => {
+    openSystemModal({
+      parent: opts.parent,
+      spec: opts.spec,
+      callback: (action) => {
+        if (opts.callback) {
+          try { opts.callback(action) } catch {}
+        }
+        resolve(action === 'confirm')
+      },
+    })
+  })
 }
 
 /** Wire the IPC handlers that drive the system-modal popup. Called

--- a/src/preload/comfySystemModalPreload.ts
+++ b/src/preload/comfySystemModalPreload.ts
@@ -19,12 +19,20 @@ import type { IpcRendererEvent } from 'electron'
 
 export type SystemModalConfirmStyle = 'primary' | 'danger'
 
+export interface SystemModalDetailGroup {
+  label: string
+  items: string[]
+}
+
 export interface SystemModalSpec {
   /** Unique identifier per open. Echoed back on action ack so main
    *  can route the result to the right callback. */
   id: string
   title: string
   message: string
+  /** Optional structured detail groups rendered beneath the message
+   *  (label + bulleted items). Mirrors `BaseAlert`'s `messageDetails`. */
+  details?: SystemModalDetailGroup[]
   confirmLabel: string
   cancelLabel: string
   confirmStyle?: SystemModalConfirmStyle
@@ -55,12 +63,21 @@ export interface ComfySystemModalBridge {
   onModal(cb: (spec: SystemModalSpec) => void): () => void
 }
 
+function isDetailGroup(value: unknown): value is SystemModalDetailGroup {
+  if (!value || typeof value !== 'object') return false
+  const g = value as { label?: unknown; items?: unknown }
+  if (typeof g.label !== 'string') return false
+  if (!Array.isArray(g.items)) return false
+  return g.items.every((it) => typeof it === 'string')
+}
+
 function isModalSpec(value: unknown): value is SystemModalSpec {
   if (!value || typeof value !== 'object') return false
   const v = value as {
     id?: unknown
     title?: unknown
     message?: unknown
+    details?: unknown
     confirmLabel?: unknown
     cancelLabel?: unknown
     theme?: unknown
@@ -70,6 +87,10 @@ function isModalSpec(value: unknown): value is SystemModalSpec {
   if (typeof v.message !== 'string') return false
   if (typeof v.confirmLabel !== 'string') return false
   if (typeof v.cancelLabel !== 'string') return false
+  if (v.details !== undefined) {
+    if (!Array.isArray(v.details)) return false
+    if (!v.details.every(isDetailGroup)) return false
+  }
   if (!v.theme || typeof v.theme !== 'object') return false
   const theme = v.theme as { bg?: unknown; text?: unknown }
   if (typeof theme.bg !== 'string' || typeof theme.text !== 'string') return false

--- a/src/renderer/src/comfySystemModal/SystemModalApp.vue
+++ b/src/renderer/src/comfySystemModal/SystemModalApp.vue
@@ -20,10 +20,16 @@ import BaseAlert from '../components/ui/BaseAlert.vue'
 
 type SystemModalConfirmStyle = 'primary' | 'danger'
 
+interface SystemModalDetailGroup {
+  label: string
+  items: string[]
+}
+
 interface SystemModalSpec {
   id: string
   title: string
   message: string
+  details?: SystemModalDetailGroup[]
   confirmLabel: string
   cancelLabel: string
   confirmStyle?: SystemModalConfirmStyle
@@ -87,7 +93,24 @@ onUnmounted(() => {
     show-cancel
     @close="ack('confirm')"
     @cancel="ack('cancel')"
-  />
+  >
+    <!-- Default slot replaces the bare message rendering when the spec
+         carries structured `details` — we render `message` first, then
+         each detail group as a labelled bulleted list. -->
+    <template v-if="spec?.details && spec.details.length > 0" #default>
+      <p v-if="spec.message" class="system-modal-message">{{ spec.message }}</p>
+      <div
+        v-for="(group, gi) in spec.details"
+        :key="`detail-${gi}`"
+        class="system-modal-detail-group"
+      >
+        <p class="system-modal-detail-label">{{ group.label }}</p>
+        <ul class="system-modal-detail-items">
+          <li v-for="(item, ii) in group.items" :key="`item-${ii}`">{{ item }}</li>
+        </ul>
+      </div>
+    </template>
+  </BaseAlert>
 </template>
 
 <style>
@@ -100,5 +123,33 @@ body,
   width: 100%;
   height: 100%;
   background: transparent !important;
+}
+
+.system-modal-message {
+  margin: 0 0 12px;
+}
+
+.system-modal-detail-group + .system-modal-detail-group {
+  margin-top: 10px;
+}
+
+.system-modal-detail-label {
+  margin: 0 0 4px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.system-modal-detail-items {
+  margin: 0;
+  padding-left: 18px;
+  font-size: 13px;
+  color: var(--neutral-100);
+}
+
+.system-modal-detail-items li {
+  line-height: 1.5;
 }
 </style>

--- a/src/renderer/src/components/ModalDialog.vue
+++ b/src/renderer/src/components/ModalDialog.vue
@@ -2,6 +2,7 @@
 import { ref, computed, watch, nextTick, onMounted, onUnmounted, reactive } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useModal, type ModalOption } from '../composables/useModal'
+import { TID } from '../../../shared/testIds'
 import InfoTooltip from './InfoTooltip.vue'
 import MigrateConfirmBody from './MigrateConfirmBody.vue'
 import BaseAlert from './ui/BaseAlert.vue'
@@ -408,7 +409,7 @@ onUnmounted(() => {
           </template>
         </div>
         <div class="modal-actions">
-          <button @click="close(false)">{{ $t('common.cancel') }}</button>
+          <button :data-testid="TID.modalCancel" @click="close(false)">{{ $t('common.cancel') }}</button>
           <button
             :class="confirmClass"
             :disabled="
@@ -416,6 +417,7 @@ onUnmounted(() => {
               state.variantLoading ||
               (state.variantCards.length > 0 && !state.selectedVariant)
             "
+            :data-testid="TID.modalConfirm"
             @click="close(true)"
           >
             {{ state.confirmLabel }}
@@ -470,6 +472,7 @@ onUnmounted(() => {
               v-model="inputValue"
               type="text"
               class="modal-input"
+              :data-testid="TID.modalPromptInput"
               :placeholder="state.placeholder"
               @keydown.enter="submitPrompt"
             />
@@ -477,8 +480,8 @@ onUnmounted(() => {
           <div v-if="error" class="modal-error">{{ error }}</div>
         </div>
         <div class="modal-actions">
-          <button @click="close(null)">{{ $t('common.cancel') }}</button>
-          <button class="primary" @click="submitPrompt">{{ state.confirmLabel }}</button>
+          <button :data-testid="TID.modalCancel" @click="close(null)">{{ $t('common.cancel') }}</button>
+          <button class="primary" :data-testid="TID.modalConfirm" @click="submitPrompt">{{ state.confirmLabel }}</button>
         </div>
       </div>
 

--- a/src/renderer/src/views/comfyUISettings/MoreMenu.vue
+++ b/src/renderer/src/views/comfyUISettings/MoreMenu.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref, useTemplateRef, watch } from 'vue'
+import { TID } from '../../../../shared/testIds'
 import type { ActionDef } from '../../types/ipc'
 
 /**
@@ -127,6 +128,7 @@ const visibleActions = computed(() => props.actions)
           }"
           :disabled="action.enabled === false"
           :tabindex="focusedIndex === i ? 0 : -1"
+          :data-testid="TID.pinBottomAction(action.id)"
           @click="handlePick(action)"
         >
           {{ action.label }}

--- a/src/renderer/src/views/comfyUISettings/SnapshotRow.vue
+++ b/src/renderer/src/views/comfyUISettings/SnapshotRow.vue
@@ -26,9 +26,15 @@ interface Props {
   expanded: boolean
   /** First (newest) snapshot in the timeline carries a "Current" badge. */
   isCurrent?: boolean
+  /** Optional `data-testid` for the header toggle — lets the parent
+   *  scope tests to a specific snapshot by filename. */
+  toggleTestId?: string
 }
 
-const props = withDefaults(defineProps<Props>(), { isCurrent: false })
+const props = withDefaults(defineProps<Props>(), {
+  isCurrent: false,
+  toggleTestId: undefined,
+})
 
 const emit = defineEmits<{
   toggle: []
@@ -103,6 +109,7 @@ const chips = computed<Chip[]>(() => {
       type="button"
       class="snapshot-row-head"
       :aria-expanded="expanded"
+      :data-testid="toggleTestId"
       @click="emit('toggle')"
     >
       <div class="snapshot-row-head-left">

--- a/src/renderer/src/views/comfyUISettings/SnapshotsView.vue
+++ b/src/renderer/src/views/comfyUISettings/SnapshotsView.vue
@@ -2,6 +2,7 @@
 import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { Download, RotateCcw, Trash2 } from 'lucide-vue-next'
+import { TID } from '../../../../shared/testIds'
 import { useModal } from '../../composables/useModal'
 import { emitTelemetryAction, toCountBucket } from '../../lib/telemetry'
 import {
@@ -434,6 +435,7 @@ async function handleImport(): Promise<void> {
               :snapshot="item.snapshot"
               :expanded="expanded === item.snapshot.filename"
               :is-current="i === 0"
+              :toggle-test-id="TID.snapshotRow(item.snapshot.filename)"
               @toggle="toggleExpand(item.snapshot.filename)"
             >
               <template #expanded>
@@ -458,6 +460,7 @@ async function handleImport(): Promise<void> {
                     type="button"
                     class="snapshots-view-detail-btn primary"
                     :aria-label="t('snapshots.restore', 'Restore')"
+                    :data-testid="TID.snapshotRowRestore(item.snapshot.filename)"
                     @click="handleRestore(item.snapshot.filename)"
                   >
                     <RotateCcw :size="13" />

--- a/src/shared/testIds.ts
+++ b/src/shared/testIds.ts
@@ -41,10 +41,15 @@ export const TID = {
   contextMenuItem: (id: string) => `context-menu-item-${id}`,
 
   // ---------- Confirm modals ----------
-  /** Generic confirm modal confirm button. */
+  /** Generic confirm modal confirm button. Used by the rich-confirm
+   *  (`messageDetails`, snapshot preview, etc.) variant of `ModalDialog`
+   *  AND its prompt mode (e.g. Copy Installation new-name prompt). */
   modalConfirm: 'modal-confirm-button',
   /** Generic confirm modal cancel button. */
   modalCancel: 'modal-cancel-button',
+  /** The text input inside the prompt modal (Copy Installation,
+   *  Copy & Update, snapshot save label, etc.). */
+  modalPromptInput: 'modal-prompt-input',
   /** The primary action button of a `BaseAlert` (alert OK / simple
    *  confirm primary). Hard-coded in `BaseAlert.vue` — kept here so
    *  tests reference a single source of truth. */
@@ -61,6 +66,21 @@ export const TID = {
   updateChannelCard: (channel: string) => `update-channel-card-${channel}`,
   /** The "Update Now" / "Copy & Update" CTA inside a channel card. */
   updateActionButton: (actionId: string) => `update-action-${actionId}`,
+
+  // ---------- Settings drawer / picker — pin-bottom MoreMenu ----------
+  /** An action item inside the Settings drawer / picker's footer "More"
+   *  menu. `actionId` matches the `ActionDef.id` shipped in the source's
+   *  `pinBottom: true` section (e.g. `copy`, `delete`, `open-folder`),
+   *  with the Launch→Restart swap surfacing as `restart` when the
+   *  install is running. */
+  pinBottomAction: (actionId: string) => `pin-bottom-action-${actionId}`,
+
+  // ---------- Snapshots tab ----------
+  /** A snapshot timeline row's expand toggle (header strip). `filename`
+   *  is the snapshot's on-disk filename — stable across reloads. */
+  snapshotRow: (filename: string) => `snapshot-row-${filename}`,
+  /** The Restore CTA inside an expanded snapshot row's detail panel. */
+  snapshotRowRestore: (filename: string) => `snapshot-row-restore-${filename}`,
 
   // ---------- Progress takeover ----------
   /** The red error message block in the brand progress takeover. */


### PR DESCRIPTION
Follow-up to #591. Implements the P0 items from the audit comment: https://github.com/Comfy-Org/ComfyUI-Desktop-2.0-Beta/pull/591#issuecomment-4533772668

## Scope contract

- **No mocking or faking of application logic.** Every new lifecycle test uses real button presses and real behavior against the existing real ~500MB install the suite already builds.
- **Serial dependent tests that reuse the existing install are permitted** and used here — the new tests are appended after the existing FLOW 3 (delete) test and reuse `_updateInstallId` / `_updateInstallPath`.
- Migration of all three remaining native `dialog.showMessageBox` confirms (`restartInstallFromPicker`, switch-instance, `confirmAndCloseAllHostWindows`) onto the DOM-based `openSystemModal` primitive, so they actually show under our title bar / EmbeddedPopupView contract (and so the e2e tests can drive them with real DOM clicks).

## What's covered

Six new `@lifecycle` tests:

| Test | Scope |
|---|---|
| A | Picker captures snapshot (sets up D) |
| B | Picker-driven `update-comfyui` IN_PLACE_RELAUNCH while running |
| C | Picker-driven `snapshot-restore` IN_PLACE_RELAUNCH while running |
| D | Picker compact-row Restart drives the system-modal confirm + re-launch (asserts the renderer does NOT invoke `stop-comfyui` IPC — main uses `ipc.stopRunning` directly) |
| E | Picker pin-bottom Copy creates a real ~500MB copy of the install via the MoreMenu (kebab is bug-#7-deferred), exercising the full prompt → showProgress → fs copy → `open-install-window` path |
| F | Cleans up the copy install before the original delete test runs |

## Supporting production changes

- `SystemModalSpec.details` field for structured `<label> + bulleted items` groups (mirrors `messageDetails` on `BaseAlert`).
- `openSystemModalAsync()` Promise-shaped wrapper.
- `cancelEntry` helper guarantees the callback resolves `false` for **every** drop reason: parent-close, popup crash, supersession-of-current, AND supersession-of-pending-before-ready.
- Detach the parent-window resize listener on popup crash so a crash-and-recreate cycle no longer accumulates listeners.
- New TIDs propagated through renderer + `src/shared/testIds.ts`: `pinBottomAction`, `snapshotRow`, `snapshotRowRestore`, `modalPromptInput`.
- `systemModalPage` helper in `e2e/support/cdpPages.ts`.
- Test E snapshots `BrowserWindow.getAllWindows()` ids before the copy fires and closes the extra chooser host that `open-install-window` spawns for the new copy install, so subsequent `panel.html`-marker helpers in tests F and beyond have a single stable target.

## Validation

- `pnpm run typecheck && pnpm run lint && pnpm run build && pnpm run test` — all 94 test files / 1134 unit tests passing.
- Oracle code review run before push; raised issues addressed in-commit (pending-callback supersession + resize-listener leak on crash/recreate).

Out of scope per the audit / plan: kebab MoreMenu rework (bug #7, Step 5), separate `popups/systemModal.test.ts` unit suite, and the remaining P1/P2 items.
