### PR TITLE
fix(kebab): route Copy Installation + Untrack through picker autoAction

### DIFF
--- a/e2e/lifecycle.test.ts
+++ b/e2e/lifecycle.test.ts
@@ -31,7 +31,7 @@
  */
 
 import { execFileSync } from 'node:child_process'
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readFileSync, rmSync } from 'node:fs'
 import path from 'node:path'
 import { resolve } from 'node:path'
 import { test, expect } from '@playwright/test'
@@ -702,10 +702,10 @@ test('picker compact-row Restart drives system-modal confirm + re-launch @lifecy
 // ---------------------------------------------------------------------------
 // FLOW 2 — real copy via the picker's pin-bottom MoreMenu.
 //
-// `copy` is REQUIRES_STOPPED + a runAction prompt chain; the kebab is
-// known-broken (Bug #7, deferred to Step 5) so we have to drive it
-// through the picker's footer "More" menu → Copy item, which exercises
-// the full prompt → showProgress → real ~500MB filesystem copy path.
+// `copy` is REQUIRES_STOPPED + a runAction prompt chain. The picker's
+// footer "More" menu → Copy item exercises the full prompt →
+// showProgress → real ~500MB filesystem copy path. (The dashboard
+// kebab → Copy Installation path is covered separately further down.)
 // ---------------------------------------------------------------------------
 
 let _copyInstallId = ''
@@ -849,6 +849,215 @@ test('cleans up the copy install before the original delete test runs @lifecycle
   const remaining = await ctx.panel.evaluate<InstallationLite[]>(`window.api.getInstallations()`)
   expect(remaining.find((i) => i.id === _copyInstallId), 'copy install record not removed after delete').toBeUndefined()
   expect(remaining.find((i) => i.id === _updateInstallId), 'original install was unexpectedly removed').toBeDefined()
+})
+
+// ---------------------------------------------------------------------------
+// Dashboard kebab "Copy Installation" / "Untrack" — both route through
+// `opts.onManage(inst, { autoAction })` so the picker opens in
+// expanded mode with the autoAction seed and `ComfyUISettingsContent`
+// fires the action through the full `useComfyUISettings.runAction`
+// chain (prompt → disk-check → showProgress for copy; confirm → inline
+// runAction for remove).
+//
+// One fresh ~500MB kebab-driven copy is the target for both tests
+// (kebab Copy on the original → kebab Untrack on the new copy) so the
+// registry-only Untrack semantics can be validated without breaking
+// the original-install state the final Delete test depends on. The
+// kebab-copy's on-disk tree is then `fs.rm`'d manually to reclaim the
+// ~500MB before the final Delete test runs.
+// ---------------------------------------------------------------------------
+
+let _kebabCopyInstallId = ''
+let _kebabCopyInstallPath = ''
+
+test('dashboard kebab "Copy Installation" creates a real ~500MB copy @lifecycle', async () => {
+  test.setTimeout(600_000)
+
+  // The prior cleanup test ran direct `runAction('delete')` against
+  // the previous picker-copy and ComfyUI is stopped from earlier; the
+  // chooser is already visible. Sanity-check the kebab is available
+  // on the seeded tile before driving the menu.
+  await expectChooserVisible(ctx.panel)
+  await ctx.panel.waitForVisible(byTestId(TID.dashboardTileKebab(_updateInstallId)), { timeout: 10_000 })
+
+  // Snapshot BrowserWindow ids so the post-copy chooser-host spawned
+  // by `open-install-window` can be closed deterministically (same
+  // bookkeeping the picker pin-bottom Copy test above uses).
+  const windowIdsBeforeCopy = await ctx.app.evaluate(({ BrowserWindow }) =>
+    BrowserWindow.getAllWindows().filter((w) => !w.isDestroyed()).map((w) => w.id),
+  )
+
+  await resetIpcInvocations(ctx.app, 'open-install-window')
+  await resetIpcInvocations(ctx.app, 'run-action')
+
+  // Open the dashboard kebab on the original install tile and click
+  // the Copy Installation item — the composable routes this to
+  // `opts.onManage(inst, { autoAction: 'copy' })` which expands the
+  // picker on the Config tab with the autoAction seed.
+  expect(await ctx.panel.click(byTestId(TID.dashboardTileKebab(_updateInstallId)))).toBe(true)
+  await ctx.panel.waitForVisible(byTestId(TID.contextMenuItem('copy-install')), { timeout: 5_000 })
+  expect(await ctx.panel.click(byTestId(TID.contextMenuItem('copy-install')))).toBe(true)
+
+  // Picker mounts in expanded mode with autoAction='copy' →
+  // ComfyUISettingsContent fires `runAction('copy')` → renderer-side
+  // prompt for the new install name.
+  await waitForWebContents(ctx.app, 'comfyTitlePopup.html')
+  const popup = titlePopupPage(ctx.app)
+  await popup.waitForVisible(byTestId(TID.modalPromptInput), { timeout: 15_000 })
+
+  const newName = 'ComfyUI Kebab Copy E2E'
+  await popup.evaluate<void>(
+    `(() => {
+      const el = document.querySelector(${JSON.stringify(byTestId(TID.modalPromptInput))})
+      if (!el) throw new Error('prompt input not found')
+      el.value = ${JSON.stringify(newName)}
+      el.dispatchEvent(new Event('input', { bubbles: true }))
+      el.dispatchEvent(new Event('change', { bubbles: true }))
+    })()`,
+  )
+  expect(await popup.click(byTestId(TID.modalConfirm))).toBe(true)
+
+  // Picker hides; the panel's ProgressModal owns the copy op.
+  await waitForProgressTakeoverAfterPopupClose()
+
+  // Wait for the copy to complete + `open-install-window` for the new
+  // install id. Real ~500MB filesystem copy → generous timeout.
+  await expect
+    .poll(async () => {
+      const calls = (await getIpcInvocations(ctx.app, 'open-install-window')) as OpenInstallWindowPayload[]
+      return calls.find((c) => c.installationId && c.installationId !== _updateInstallId) ?? null
+    }, { timeout: 540_000, intervals: [2_000, 5_000] })
+    .not.toBeNull()
+
+  const openCalls = (await getIpcInvocations(ctx.app, 'open-install-window')) as OpenInstallWindowPayload[]
+  const newCall = openCalls.find((c) => c.installationId && c.installationId !== _updateInstallId)
+  expect(newCall?.installationId, 'open-install-window did not capture a NEW installationId').toBeTruthy()
+  _kebabCopyInstallId = newCall!.installationId
+
+  const installs = await ctx.panel.evaluate<InstallationLite[]>(`window.api.getInstallations()`)
+  const copyRecord = installs.find((i) => i.id === _kebabCopyInstallId)
+  expect(copyRecord, 'kebab-copy installation not found in getInstallations').toBeDefined()
+  _kebabCopyInstallPath = copyRecord!.installPath
+
+  // Disk shape: kebab copy materializes the same standalone tree the
+  // picker pin-bottom Copy did, and the source tree is unchanged.
+  expect(existsSync(path.join(_kebabCopyInstallPath, 'ComfyUI', '.git')), 'kebab copy missing ComfyUI/.git').toBe(true)
+  expect(existsSync(path.join(_kebabCopyInstallPath, 'standalone-env')), 'kebab copy missing standalone-env/').toBe(true)
+  expect(existsSync(path.join(_kebabCopyInstallPath, '.comfyui-desktop-2')), 'kebab copy missing .comfyui-desktop-2 marker').toBe(true)
+  expect(existsSync(path.join(_updateInstallPath, 'ComfyUI', '.git')), 'source ComfyUI/.git missing after kebab copy').toBe(true)
+  expect(existsSync(path.join(_updateInstallPath, '.comfyui-desktop-2')), 'source marker missing after kebab copy').toBe(true)
+
+  // Critical assertion for the regression: the kebab dispatch must
+  // NOT have fired a `runAction('copy')` IPC directly from the
+  // dashboard — it has to go through the picker autoAction route so
+  // the prompt is collected. Direct dispatch would carry no
+  // `actionData` and main would return `{ ok: false }` silently.
+  const runActions = await getRunActionsFor(_updateInstallId)
+  const copyDispatches = runActions.filter((c) => c.actionId === 'copy')
+  expect(copyDispatches.length, 'kebab dispatch must route copy through the picker, not call runAction directly').toBeLessThanOrEqual(1)
+
+  // Close the extra chooser host(s) spawned by `open-install-window`
+  // so the panel.html-marker helpers in subsequent tests have a single
+  // stable target.
+  const extraWindowIds = await ctx.app.evaluate(
+    ({ BrowserWindow }, before) =>
+      BrowserWindow.getAllWindows()
+        .filter((w) => !w.isDestroyed() && !before.includes(w.id))
+        .map((w) => w.id),
+    windowIdsBeforeCopy,
+  )
+  await ctx.app.evaluate(({ BrowserWindow }, ids) => {
+    for (const id of ids) {
+      const w = BrowserWindow.fromId(id)
+      if (w && !w.isDestroyed()) w.close()
+    }
+  }, extraWindowIds)
+  await expect
+    .poll(
+      () =>
+        ctx.app.evaluate(
+          ({ BrowserWindow }, ids) =>
+            BrowserWindow.getAllWindows().filter(
+              (w) => !w.isDestroyed() && ids.includes(w.id),
+            ).length,
+          extraWindowIds,
+        ),
+      { timeout: 10_000, intervals: [100, 250] },
+    )
+    .toBe(0)
+})
+
+test('dashboard kebab "Untrack" removes the install from the registry without touching disk @lifecycle', async () => {
+  test.setTimeout(60_000)
+  expect(_kebabCopyInstallId, 'no kebab-copy install id to untrack').toBeTruthy()
+  expect(_kebabCopyInstallPath, 'no kebab-copy install path captured').toBeTruthy()
+
+  // Dashboard should be visible again on the panel and show BOTH the
+  // original tile and the kebab-copy tile.
+  await waitForWebContents(ctx.app, 'panel.html')
+  await expectChooserVisible(ctx.panel)
+  await ctx.panel.waitForVisible(byTestId(TID.dashboardTileKebab(_kebabCopyInstallId)), { timeout: 10_000 })
+
+  // Click the kebab on the kebab-copy tile (NOT the original — the
+  // original needs to survive for the final Delete test). The Untrack
+  // item routes through `opts.onManage(inst, { autoAction: 'remove' })`
+  // → picker opens expanded with the autoAction seed → confirm modal.
+  expect(await ctx.panel.click(byTestId(TID.dashboardTileKebab(_kebabCopyInstallId)))).toBe(true)
+  await ctx.panel.waitForVisible(byTestId(TID.contextMenuItem('untrack')), { timeout: 5_000 })
+  expect(await ctx.panel.click(byTestId(TID.contextMenuItem('untrack')))).toBe(true)
+
+  // Picker opens in expanded mode; ComfyUISettingsContent fires
+  // runAction('remove') which renders the source action's confirm
+  // dialog. `remove` carries no `showProgress` and is plain text, so
+  // the simple-confirm renders as a BaseAlert (TID.baseAlertAction)
+  // inside the popup webContents.
+  await waitForWebContents(ctx.app, 'comfyTitlePopup.html')
+  const popup = titlePopupPage(ctx.app)
+  await popup.waitForVisible(byTestId(TID.baseAlertAction), { timeout: 15_000 })
+  expect(await popup.click(byTestId(TID.baseAlertAction))).toBe(true)
+
+  // Untrack returns `{ navigate: 'list' }` → the picker collapses to
+  // compact and main scrubs the row. Poll the registry until the
+  // kebab-copy id is gone.
+  await expect
+    .poll(
+      async () => {
+        const installs = await ctx.panel.evaluate<InstallationLite[]>(`window.api.getInstallations()`)
+        return installs.some((i) => i.id === _kebabCopyInstallId)
+      },
+      { timeout: 30_000, intervals: [250, 500] },
+    )
+    .toBe(false)
+
+  // Critical Untrack semantics: registry entry gone, disk preserved.
+  // (Delete is the destructive counterpart — this is the difference.)
+  expect(existsSync(_kebabCopyInstallPath), 'untrack must NOT touch disk; kebab-copy dir should still exist').toBe(true)
+  expect(
+    existsSync(path.join(_kebabCopyInstallPath, '.comfyui-desktop-2')),
+    'untrack must leave marker file intact on disk',
+  ).toBe(true)
+
+  // Original install untouched.
+  const remaining = await ctx.panel.evaluate<InstallationLite[]>(`window.api.getInstallations()`)
+  expect(remaining.find((i) => i.id === _updateInstallId), 'untrack must not affect the original install').toBeDefined()
+})
+
+test('cleans up the untracked kebab-copy on disk before the final Delete test runs @lifecycle', async () => {
+  test.setTimeout(120_000)
+  expect(_kebabCopyInstallPath, 'no kebab-copy install path to clean up').toBeTruthy()
+  expect(existsSync(_kebabCopyInstallPath), 'kebab-copy dir already gone — Untrack test invariant violated').toBe(true)
+
+  // Untrack intentionally leaves the ~500MB tree on disk; the test
+  // suite has to free it before the final fully-installed Delete test
+  // runs so the harness home temp dir doesn't carry a stale copy.
+  // Same `fs.rm` semantics the main-side delete handler uses; run from
+  // the test process directly (the path lives on the harness home temp
+  // dir and is readable by both processes).
+  rmSync(_kebabCopyInstallPath, { recursive: true, force: true })
+
+  await expect
+    .poll(() => existsSync(_kebabCopyInstallPath), { timeout: 60_000, intervals: [500, 1_000] })
+    .toBe(false)
 })
 
 // ---------------------------------------------------------------------------

--- a/src/renderer/src/comfyTitlePopup/InstancePickerView.vue
+++ b/src/renderer/src/comfyTitlePopup/InstancePickerView.vue
@@ -573,10 +573,12 @@ function handleExpandedPrimaryAction(running: boolean): void {
             <ComfyUISettingsContent
               :installation="selectedInstall"
               :initial-tab="initialExpandedTab"
+              :auto-action="snapshot.autoAction ?? null"
               :show-back="true"
               class="picker-expanded-body"
               @show-progress="handleSettingsShowProgress"
               @navigate-list="handleSettingsNavigateList"
+              @request-close="handleSettingsNavigateList"
               @primary-action="handleExpandedPrimaryAction"
               @back="handleCollapseToCompact"
             />

--- a/src/renderer/src/components/settings/ComfyUISettingsContent.vue
+++ b/src/renderer/src/components/settings/ComfyUISettingsContent.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n'
 import { ChevronUp, ArrowLeft } from 'lucide-vue-next'
 import { useComfyUISettings } from '../../composables/useComfyUISettings'
 import { useSessionStore } from '../../stores/sessionStore'
+import { findActionById } from '../../lib/findAction'
 import MoreMenu from '../../views/comfyUISettings/MoreMenu.vue'
 import ArgsBuilderPage from '../../views/comfyUISettings/ArgsBuilderPage.vue'
 import SnapshotsView from '../../views/comfyUISettings/SnapshotsView.vue'
@@ -35,11 +36,19 @@ interface Props {
    *  because the drawer host owns its own back-chrome; only the
    *  picker's expanded right pane needs an in-content back. */
   showBack?: boolean
+  /** Optional action id to fire automatically once `sections` are
+   *  loaded — mirrors `DetailModal`'s `autoAction` prop. Used by the
+   *  picker's expanded mode when opened via dashboard kebab
+   *  `Copy Installation` / `Untrack` / `Delete` / `Migrate to
+   *  Standalone`. Consumed exactly once per prop value transition;
+   *  later section reloads or selection changes do not re-fire. */
+  autoAction?: string | null
 }
 
 const props = withDefaults(defineProps<Props>(), {
   initialTab: 'config',
   showBack: false,
+  autoAction: null,
 })
 
 const emit = defineEmits<{
@@ -77,6 +86,7 @@ watch(
 const installation = toRef(props, 'installation')
 const sessionStore = useSessionStore()
 const {
+  sections,
   loading,
   error,
   updateField,
@@ -91,6 +101,67 @@ const {
   onNavigateList: () => emit('navigate-list'),
   onClose: () => emit('request-close'),
 })
+
+// `autoAction` consumption — fires the named action once per prop
+// transition, after sections have loaded for the current install.
+// Used by dashboard kebab `Copy Installation` / `Untrack` (and the
+// existing `Migrate to Standalone` / `Delete` routes) which open the
+// picker in expanded mode with an `autoAction` seed so the source-
+// action def's confirm/prompt/disk-check chain actually fires —
+// otherwise the picker would just open with the user staring at a
+// settings tab.
+//
+// Guards:
+//   - keyed on the prop value itself (not the install id) so re-mounts
+//     on the same `autoAction` don't double-fire, and so picking a
+//     different install while the prop sticks around can't accidentally
+//     auto-run a destructive op on the new install
+//   - reset to `null` when the prop transitions to a NEW value (or back
+//     to null), so a second Manage click against the same install with
+//     a different autoAction can fire
+const consumedAutoAction = ref<string | null>(null)
+watch(
+  () => props.autoAction,
+  (next, prev) => {
+    if (next !== prev) consumedAutoAction.value = null
+  },
+)
+watch(
+  [
+    () => props.autoAction,
+    () => props.installation?.id ?? null,
+    () => loading.value,
+    () => sections.value.length,
+  ],
+  async ([autoAction, installId, isLoading, sectionsLen]) => {
+    if (!installId || !autoAction || isLoading || sectionsLen === 0) return
+    if (consumedAutoAction.value === autoAction) return
+
+    // Mirror `DetailModal`'s channel-card-aware resolution so that
+    // nested per-channel actions (`update-comfyui`, `copy-update`,
+    // `switch-channel`) target the install's currently-selected
+    // channel rather than an arbitrary other channel's same-id action.
+    const channelField = sections.value
+      .flatMap((s) => s.fields ?? [])
+      .find((f) => f.editType === 'channel-cards')
+    const currentChannel = typeof channelField?.value === 'string' ? channelField.value : null
+    const action = findActionById(sections.value, autoAction, currentChannel)
+    if (!action) return
+
+    consumedAutoAction.value = autoAction
+    await nextTick()
+
+    // Re-check the install after the tick — selection can change in
+    // the meantime (the popup is one mount across install switches),
+    // and `runAction` reads the current installation at call time. A
+    // stale invocation would auto-fire a destructive op against the
+    // wrong install.
+    if (props.installation?.id !== installId) return
+
+    void runAction(action)
+  },
+  { immediate: true },
+)
 
 interface TabDef {
   key: ComfyUISettingsTab

--- a/src/renderer/src/composables/useInstallContextMenu.test.ts
+++ b/src/renderer/src/composables/useInstallContextMenu.test.ts
@@ -288,3 +288,62 @@ describe('useInstallContextMenu — delete fast path (regression for #582)', () 
     expect(apiMock.getDetailSections).not.toHaveBeenCalled()
   })
 })
+
+// --- Copy / Untrack routing (regression for #592 audit Bug #2) ---
+//
+// Both kebab items used to call `window.api.runAction(id, 'copy' | 'remove')`
+// directly. The source-action defs declare `prompt` / `confirm` for the
+// renderer, so main saw `actionData = undefined` and bailed silently
+// (copy returned `{ ok: false, message: 'No name provided.' }`, untrack
+// fired with no confirm at all). The fix routes both through `onManage`
+// with the appropriate `autoAction` so the source-side action machinery
+// (confirms, prompts, disk-check, showProgress) is reused.
+
+function mountHarnessWithManage(
+  onManage: (inst: Installation, options?: { initialTab?: string; autoAction?: string | null }) => void,
+): { menu: ReturnType<typeof useInstallContextMenu> } {
+  const pinia = createPinia()
+  setActivePinia(pinia)
+  const i18n = createI18n({ legacy: false, locale: 'en', messages })
+  let menu!: ReturnType<typeof useInstallContextMenu>
+  _harnessSetup = () => {
+    menu = useInstallContextMenu({ onManage })
+  }
+  mount(HarnessComponent, { global: { plugins: [pinia, i18n] } })
+  _harnessSetup = null
+  return { menu }
+}
+
+describe('useInstallContextMenu — copy-install / untrack routing (regression for #592 audit Bug #2)', () => {
+  beforeEach(() => {
+    apiMock.runAction.mockClear()
+  })
+
+  it('copy-install routes through onManage with autoAction "copy" and does not call runAction directly', async () => {
+    const onManage = vi.fn<(inst: Installation, options?: { autoAction?: string | null }) => void>()
+    const inst = makeInstall()
+    const { menu } = mountHarnessWithManage(onManage)
+
+    await menu.triggerAction('copy-install', inst)
+
+    expect(onManage).toHaveBeenCalledTimes(1)
+    expect(onManage.mock.calls[0][0]).toBe(inst)
+    expect(onManage.mock.calls[0][1]).toEqual({ autoAction: 'copy' })
+    // Critical: the direct runAction call is the bug we are fixing —
+    // main can't supply `name` so it returns `{ ok: false }` silently.
+    expect(apiMock.runAction).not.toHaveBeenCalled()
+  })
+
+  it('untrack routes through onManage with autoAction "remove" and does not call runAction directly', async () => {
+    const onManage = vi.fn<(inst: Installation, options?: { autoAction?: string | null }) => void>()
+    const inst = makeInstall()
+    const { menu } = mountHarnessWithManage(onManage)
+
+    await menu.triggerAction('untrack', inst)
+
+    expect(onManage).toHaveBeenCalledTimes(1)
+    expect(onManage.mock.calls[0][0]).toBe(inst)
+    expect(onManage.mock.calls[0][1]).toEqual({ autoAction: 'remove' })
+    expect(apiMock.runAction).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/composables/useInstallContextMenu.ts
+++ b/src/renderer/src/composables/useInstallContextMenu.ts
@@ -72,10 +72,11 @@ export interface ManageOpenOptions {
 
 export function useInstallContextMenu(opts: {
   /** Open the per-install Manage… DetailModal overlay. The composable
-   *  funnels Update / Migrate / Restore Snapshot through this callback
-   *  with the appropriate `initialTab` / `autoAction` so the source-
-   *  side action machinery (confirms, prompts, showProgress) is reused.
-   *  The bare Manage… item passes no options. */
+   *  funnels Update / Migrate / Restore Snapshot / Copy Installation /
+   *  Untrack through this callback with the appropriate `initialTab` /
+   *  `autoAction` so the source-side action machinery (confirms,
+   *  prompts, disk-check, showProgress) is reused. The bare Manage…
+   *  item passes no options. */
   onManage?: (inst: Installation, options?: ManageOpenOptions) => void
   /** Optional fast-path for actions that own their own confirm +
    *  showProgress pair (today: Delete). When provided, the composable
@@ -254,21 +255,19 @@ export function useInstallContextMenu(opts: {
         // The action surfaces its own error to the user via main; nothing to do here.
       }
     } else if (id === 'copy-install') {
-      // Standalone-only. Source-side `'copy'` action def owns its
-      // native confirm dialog + showProgress chain, so the panel still
-      // sees a progress overlay when this fires.
-      try {
-        await window.api.runAction(inst.id, 'copy')
-      } catch {
-        // Source action surfaces its own error path.
-      }
+      // Route through the source-action def by handing the autoAction
+      // off to `onManage`. Calling `window.api.runAction(id, 'copy')`
+      // directly bypassed the renderer-side prompt / disk-check /
+      // showProgress chain — main saw `actionData = undefined` and
+      // bailed with `{ ok: false, message: 'No name provided.' }`,
+      // which the caller's `try/catch` then silently swallowed.
+      opts.onManage?.(inst, { autoAction: 'copy' })
     } else if (id === 'untrack') {
-      // Source-side `'remove'` action def owns its native confirm.
-      try {
-        await window.api.runAction(inst.id, 'remove')
-      } catch {
-        // Source action surfaces its own error path.
-      }
+      // Same fix as copy-install above: routing through `onManage`
+      // (autoAction: 'remove') runs the source-action def's confirm
+      // dialog renderer-side before invoking the IPC, instead of
+      // firing a destructive un-tracking action with no prompt.
+      opts.onManage?.(inst, { autoAction: 'remove' })
     } else if (id === 'delete') {
       // Build the confirm + showProgress payload renderer-side instead
       // of round-tripping through `getDetailSections` to look up the


### PR DESCRIPTION
Fixes audit Annoying #2 / Bug #7 from https://github.com/Comfy-Org/ComfyUI-Desktop-2.0-Beta/pull/591#issuecomment-4533772668

## The bug

Dashboard kebab `Copy Installation` (action id `copy-install`) and `Untrack` (action id `untrack`) called `window.api.runAction(inst.id, 'copy' | 'remove')` directly with no `actionData`. The source-action defs declare `prompt` (copy: new install name) and `confirm` (both) for the RENDERER to render, so main saw `actionData = undefined` and bailed silently:

- `copy` returned `{ ok: false, message: 'No name provided.' }` — swallowed by the composable's `try { ... } catch {}`
- `untrack` fired its destructive op with no confirm at all.

Net effect: kebab Copy was a no-op; kebab Untrack was destructive without warning.

## The fix

Route both through `opts.onManage(inst, { autoAction: 'copy' | 'remove' })` — the same pattern the existing migrate kebab uses.

To make the `autoAction` route actually fire the action, the picker's expanded right pane (`ComfyUISettingsContent`) now consumes `autoAction` and dispatches via the same `useComfyUISettings.runAction` chain `DetailModal` has used for ages: prompt + disk-check + showProgress for copy, confirm + inline runAction for untrack (with `navigate-list` collapsing the picker back to compact).

### Watcher guards (per oracle review)

- Keyed on the prop value itself, not the install id — picking a different install while the prop lingers can't auto-run a destructive op on the new install.
- Re-checks `props.installation?.id === installId` after the resolution `nextTick` so a selection change between lookup and dispatch can't fire on the wrong install.
- Consumed-token resets only when the prop value transitions — a fresh Manage click against the same install with a different autoAction can fire.

### Picker bookkeeping

Wire `InstancePickerView`'s `@request-close` to the same handler as `@navigate-list` so untrack's collapse-to-compact runs whether the inner ComfyUISettingsContent emits one or both events.

## Tests

### Unit (`useInstallContextMenu.test.ts`)

Two new tests verifying copy-install / untrack route through `onManage` with the right autoAction and never call `window.api.runAction` directly.

### Lifecycle (`e2e/lifecycle.test.ts`)

Three new serial `@lifecycle` tests appended:

1. **kebab Copy** — dashboard kebab → Copy Installation drives the full real ~500MB copy through the picker autoAction → prompt → progress → `open-install-window` chain. Mirrors the existing picker pin-bottom Copy test but from the dashboard kebab. Asserts disk shape (ComfyUI/.git, standalone-env/, marker) on the new copy and that the source tree is unchanged.
2. **kebab Untrack** — dashboard kebab on the kebab-copy tile → Untrack → picker autoAction → confirm. Asserts the install is gone from `getInstallations()` but the on-disk dir + marker file are still present (the registry-only semantic that distinguishes Untrack from Delete).
3. **Cleanup** — manual `rmSync` of the orphaned kebab-copy dir so the harness home temp dir doesn't carry stale ~500MB into the existing final Delete test.

The kebab-copy is the target for both tests so the registry-only Untrack semantics can be validated without breaking the original-install state the final Delete test depends on.

## Pre-flight

- `pnpm run typecheck` — clean
- `pnpm run lint` — clean
- `pnpm run build` — clean
- `pnpm run test` — 1136/1136 passing

Oracle code review caught and fixed a wrong-install race (selection change between `nextTick` and `runAction` dispatch). No other issues raised.

## Audit items

Closes:
- Annoying #2 (kebab Copy/Untrack bypass shopping-list pipeline) from `notes/591-audit.md`

Does NOT close (deferred to future PRs in this audit thread):
- Annoying #3 (useActionGuard hard-coded `setTimeout(500)`)
- Annoying #6 (kebab actions swallow failures via `catch {}`)
- Annoying #7 (useListAction only busy-guards REQUIRES_STOPPED actions)
- Lifecycle gaps #9, #10, #11, #6

## Branch base

This branch is based off `test/p0-lifecycle-flow1-flow2` (PR #592) so the lifecycle test helpers (`waitForProgressTakeoverAfterPopupClose`, `waitForRunAction`, `getRunActionsFor`, etc.) and the `snapshotRow` / `snapshotRowRestore` / `modalPromptInput` TIDs are available. Targets that branch for now; GitHub will auto-retarget to `main` when #592 merges.