### PR TITLE
fix(picker): auto-refresh stale channel-cards on Update tab open

### DIFF
--- a/e2e/lifecycle-update-check.test.ts
+++ b/e2e/lifecycle-update-check.test.ts
@@ -21,12 +21,24 @@ import path from 'node:path'
 import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import { test, expect } from '@playwright/test'
 import { launchApp, type AppContext } from './launchApp'
+import { closeTitlePopupIfOpen, waitForWebContents } from './support/cdpPages'
+import { ageReleaseCache, getIpcInvocations, resetIpcInvocations } from './support/devHooks'
 
 let ctx: AppContext
 let stagedInstallPath = ''
+let stagedInstallPathB = ''
 
 const INSTALL_ID = 'inst-update-check'
 const INSTALL_NAME = 'Update Check Test'
+// A second install pointed at the same Comfy-Org/ComfyUI repo so the
+// stale-cache test can open the picker for an install whose
+// ComfyUISettingsContent has never mounted yet — that's the path that
+// fires the watcher's `immediate: true` callback against the staled
+// shared release cache. (Re-opening the picker for INSTALL_ID after
+// the fresh-cache test keeps the same ComfyUISettingsContent instance
+// mounted, so the watcher's deps don't re-fire.)
+const INSTALL_ID_B = 'inst-update-check-b'
+const INSTALL_NAME_B = 'Update Check Test B'
 // An intentionally old baseTag so any currently-published stable release
 // reads as "newer". v0.1.0 is from June 2024; anything from H2-2024 onward
 // will compare strictly greater under semver string ordering on the
@@ -68,11 +80,13 @@ test.describe.configure({ mode: 'serial' })
 
 test.beforeAll(async () => {
   stagedInstallPath = await mkdtemp(path.join(os.tmpdir(), 'comfyui-launcher-update-check-e2e-'))
+  stagedInstallPathB = await mkdtemp(path.join(os.tmpdir(), 'comfyui-launcher-update-check-e2e-b-'))
   // ComfyUI/ existence gates several detail-section branches (e.g. `hasGit`).
   // We don't need a real clone for this test — the check-update path itself
   // only requires it for `enrichCommitsAhead`, which no-ops without a .git
   // dir. The release-cache fetch + channel-card comparison both run.
   await mkdir(path.join(stagedInstallPath, 'ComfyUI'), { recursive: true })
+  await mkdir(path.join(stagedInstallPathB, 'ComfyUI'), { recursive: true })
 
   ctx = await launchApp({
     settings: { firstUseCompleted: true, telemetryEnabled: false },
@@ -91,6 +105,18 @@ test.beforeAll(async () => {
         variant: 'cpu',
         pythonVersion: '3.12',
       },
+      {
+        id: INSTALL_ID_B,
+        name: INSTALL_NAME_B,
+        installPath: stagedInstallPathB,
+        sourceId: 'standalone',
+        status: 'installed',
+        updateChannel: 'stable',
+        comfyVersion: { commit: SEEDED_COMMIT, baseTag: SEEDED_BASE_TAG, commitsAhead: 0 },
+        releaseTag: SEEDED_BASE_TAG,
+        variant: 'cpu',
+        pythonVersion: '3.12',
+      },
     ],
   })
 })
@@ -98,6 +124,7 @@ test.beforeAll(async () => {
 test.afterAll(async () => {
   await ctx?.cleanup()
   if (stagedInstallPath) await rm(stagedInstallPath, { recursive: true, force: true })
+  if (stagedInstallPathB) await rm(stagedInstallPathB, { recursive: true, force: true })
 })
 
 test('check-update hits the real Comfy-Org/ComfyUI remote and finds a newer release @lifecycle', async () => {
@@ -148,4 +175,131 @@ test('cross-channel fetch populates the latest channel card too @lifecycle', asy
   // semver. Just assert it's a non-empty version string with a SHA-ish shape
   // (7+ hex chars somewhere in the rendered version).
   expect(latestCard!.data!.latestVersion).toMatch(/[a-f0-9]{7,}/)
+})
+
+// ---------------------------------------------------------------------------
+// Auto-refresh of stale channel-cards when the Update tab opens.
+//
+// The release cache persists to disk forever (no TTL). Before this
+// watcher landed, a user who installed in January and opened the
+// picker in June would see January's "latest release" until they
+// clicked the explicit Check for Update button. The renderer now
+// fires `check-update` automatically when the Update tab activates
+// AND the currently-selected channel's `data.checkedAt` is older than
+// `STALE_CHANNEL_CARD_MS` (15 min) — gated per (install, channel) so
+// tab flips don't spam IPCs, and re-deduped main-side by the release
+// cache's 10s `MIN_RECHECK_INTERVAL`.
+// ---------------------------------------------------------------------------
+
+async function openPickerOnUpdateTab(installationId: string): Promise<void> {
+  await ctx.panel.evaluate<boolean>(
+    `(() => {
+      window.api.openInstancePicker({
+        installationId: ${JSON.stringify(installationId)},
+        mode: 'expanded',
+        initialTab: 'update',
+      })
+      return true
+    })()`,
+  )
+  await waitForWebContents(ctx.app, 'comfyTitlePopup.html')
+}
+
+function countAutoCheckUpdateCalls(calls: unknown[], installationId: string): number {
+  return (calls as { installationId?: string; actionId?: string }[])
+    .filter((c) => c.installationId === installationId && c.actionId === 'check-update')
+    .length
+}
+
+test('Update tab does NOT auto-refresh when the channel data is fresh @lifecycle', async () => {
+  // The previous tests just ran check-update — both cache entries are
+  // seconds old, well inside the 15min freshness window. Opening the
+  // picker on the Update tab must NOT fire an extra check-update IPC.
+  await resetIpcInvocations(ctx.app, 'run-action')
+
+  await openPickerOnUpdateTab(INSTALL_ID)
+
+  // Give the renderer a beat to mount + run the watcher. 1.5s is well
+  // past the watcher's synchronous fire path; if it were going to fire,
+  // it would have done so by now.
+  await new Promise((r) => setTimeout(r, 1500))
+
+  const checkUpdates = countAutoCheckUpdateCalls(
+    await getIpcInvocations(ctx.app, 'run-action'),
+    INSTALL_ID,
+  )
+  expect(
+    checkUpdates,
+    `auto-refresh fired ${checkUpdates}x against fresh cache — expected 0 (dedupe broken)`,
+  ).toBe(0)
+
+  await closeTitlePopupIfOpen(ctx.app)
+})
+
+test('Update tab auto-refreshes when channel data is stale @lifecycle', async () => {
+  test.setTimeout(120_000)
+
+  // Age every in-memory release-cache entry past the 15min staleness
+  // threshold (+ a healthy buffer) via the E2E hook. Mutating the
+  // module's private `_entries` map directly is the only way to make
+  // staleness visible without restarting the app — `getDetailSections`
+  // reads from the same in-memory state, never re-reads release-cache.json.
+  const stalenessTs = Date.now() - 30 * 60 * 1000
+  await ageReleaseCache(ctx.app, stalenessTs)
+
+  // Sanity-check via INSTALL_ID_B (the install we're about to open the
+  // picker for): the sections pipeline now reports the stale timestamp,
+  // proving the hook reached the same map `getEffectiveInfo` reads.
+  // The release cache is shared per-repo, so install A and B see the
+  // same staled entries.
+  const staleSections = await ctx.panel.evaluate<DetailSection[]>(
+    `window.api.getDetailSections(${JSON.stringify(INSTALL_ID_B)})`,
+  )
+  const staleUpdateSection = staleSections.find((s) => s.tab === 'update')!
+  const staleChannelField = staleUpdateSection.fields!.find((f) => f.id === 'updateChannel')!
+  const staleCard = staleChannelField.options!.find((o) => o.value === staleChannelField.value)
+  expect(
+    (staleCard?.data as { checkedAt?: number } | undefined)?.checkedAt,
+    'ageReleaseCache hook did not mutate the in-memory map main reads from',
+  ).toBe(stalenessTs)
+
+  await resetIpcInvocations(ctx.app, 'run-action')
+
+  // Open the picker for INSTALL_ID_B — its ComfyUISettingsContent has
+  // never been mounted before, so the watcher fires its `immediate: true`
+  // callback against the staled shared cache. (Re-opening for INSTALL_ID
+  // would keep the same Vue component instance + stale-relative-to-renderer
+  // sections.value, so the watcher's reactive deps wouldn't re-fire.)
+  await openPickerOnUpdateTab(INSTALL_ID_B)
+
+  // The watcher fires after sections load + Update tab activates; the
+  // IPC then runs the GitHub fetch (~hundreds of ms) before the
+  // run-action invocation lands in the hook tap.
+  await expect
+    .poll(
+      async () => countAutoCheckUpdateCalls(
+        await getIpcInvocations(ctx.app, 'run-action'),
+        INSTALL_ID_B,
+      ),
+      { timeout: 15_000, intervals: [250, 500, 1_000] },
+    )
+    .toBeGreaterThanOrEqual(1)
+
+  // After the auto-refresh completes, the selected channel card's
+  // `checkedAt` should advance past `stalenessTs` — proves the
+  // staleness was actually cleared, not just an IPC fire.
+  await expect
+    .poll(async () => {
+      const sections = await ctx.panel.evaluate<DetailSection[]>(
+        `window.api.getDetailSections(${JSON.stringify(INSTALL_ID_B)})`,
+      )
+      const updateSection = sections.find((s) => s.tab === 'update')!
+      const channelField = updateSection.fields!.find((f) => f.id === 'updateChannel')!
+      const card = channelField.options!.find((o) => o.value === channelField.value)
+      const checkedAt = (card?.data as { checkedAt?: number } | undefined)?.checkedAt
+      return typeof checkedAt === 'number' && checkedAt > stalenessTs
+    }, { timeout: 15_000, intervals: [250, 500, 1_000] })
+    .toBe(true)
+
+  await closeTitlePopupIfOpen(ctx.app)
 })

--- a/e2e/support/devHooks.ts
+++ b/e2e/support/devHooks.ts
@@ -166,6 +166,20 @@ export async function seedRunningSession(
   }, opts))
 }
 
+/** Force every release-cache entry's `checkedAt` to `maxCheckedAt`
+ *  (ms-since-epoch). Used to drive the renderer's stale-data
+ *  auto-refresh watcher without waiting wall-clock minutes. */
+export async function ageReleaseCache(
+  app: ElectronApplication,
+  maxCheckedAt: number,
+): Promise<void> {
+  await evalWithRetry(() => app.evaluate((_electron, ts) => {
+    const helpers = (globalThis as unknown as { __e2e?: { ageReleaseCache: (ts: number) => void } }).__e2e
+    if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
+    helpers.ageReleaseCache(ts)
+  }, maxCheckedAt))
+}
+
 /** Drop every synthetic session seeded via `seedRunningSession`. */
 export async function clearRunningSessions(app: ElectronApplication): Promise<void> {
   await evalWithRetry(() => app.evaluate(() => {

--- a/src/main/lib/channel-cards.ts
+++ b/src/main/lib/channel-cards.ts
@@ -13,7 +13,12 @@ export interface ChannelDef {
 export interface ChannelCardData {
   installedVersion: string
   latestVersion: string
+  /** Localized human string for display (e.g. "11/24/2025, 4:32 PM"). */
   lastChecked: string
+  /** Raw ms-since-epoch timestamp the release cache was populated. Used
+   *  renderer-side to gate auto-refresh of stale channel data when the
+   *  Update tab opens. `undefined` ⇒ no cache entry yet → treat as stale. */
+  checkedAt?: number
   updateAvailable: boolean
   actions?: Record<string, unknown>[]
 }
@@ -48,6 +53,7 @@ export function buildChannelCards(
         installedVersion: cv ? formatComfyVersion(cv, 'detail') : (info.installedTag || 'unknown'),
         latestVersion: latestCv ? formatComfyVersion(latestCv, 'detail') : (info.releaseName || info.latestTag || '—'),
         lastChecked: info.checkedAt ? new Date(info.checkedAt).toLocaleString() : '—',
+        checkedAt: info.checkedAt,
         updateAvailable: releaseCache.isUpdateAvailable(installation, def.value, info),
       } : undefined,
     }

--- a/src/main/lib/e2eHooks.ts
+++ b/src/main/lib/e2eHooks.ts
@@ -18,7 +18,10 @@ import {
   type DownloadsTrayState,
 } from './comfyDownloadManager'
 import { _test_setUpdateState, type AppUpdateState } from './updater'
-import { get as _releaseCacheGet } from './release-cache'
+import {
+  get as _releaseCacheGet,
+  _test_ageEntries as _test_ageReleaseCacheEntries,
+} from './release-cache'
 import { _test_getOpenTitlePopupBounds } from '../popups/titlePopup'
 import { returnToDashboard } from '../host/detach'
 import { comfyWindows, isInstallHost } from '../host/registry'
@@ -81,6 +84,11 @@ export interface E2EHelpers {
    *  yet. Used by the periodic-poll lifecycle test to observe that the
    *  background timer ran a real second fetch. */
   getReleaseCacheCheckedAt(repo: string, channel: string): number | null
+  /** Force every entry in the shared release cache to the given
+   *  `checkedAt` timestamp so the renderer-side stale-cache watcher
+   *  in `ComfyUISettingsContent` treats the data as stale and auto-
+   *  fires `check-update` on the next picker open. */
+  ageReleaseCache(maxCheckedAt: number): void
 }
 
 export function registerE2EHooks(): void {
@@ -116,6 +124,7 @@ export function registerE2EHooks(): void {
     getReleaseCacheCheckedAt(repo, channel) {
       return _releaseCacheGet(repo, channel)?.checkedAt ?? null
     },
+    ageReleaseCache: _test_ageReleaseCacheEntries,
   }
   ;(globalThis as unknown as { __e2e: E2EHelpers }).__e2e = helpers
 }

--- a/src/main/lib/release-cache.ts
+++ b/src/main/lib/release-cache.ts
@@ -59,6 +59,20 @@ function _persist(): void {
 }
 
 /**
+ * Test-only: force every cached entry's `checkedAt` to `maxCheckedAt` so the
+ * renderer-side stale-cache watcher fires on next picker open. Only invoked
+ * via `__e2e.ageReleaseCache` when `process.env['E2E'] === '1'`.
+ */
+export function _test_ageEntries(maxCheckedAt: number): void {
+  _ensureLoaded()
+  for (const key of Object.keys(_entries)) {
+    const entry = _entries[key]
+    if (entry) entry.checkedAt = maxCheckedAt
+  }
+  _persist()
+}
+
+/**
  * Build a cache key from a remote identity.
  * Today: "github:Comfy-Org/ComfyUI:stable"
  * Future: could include branch/ref overrides per installation.

--- a/src/renderer/src/components/settings/ComfyUISettingsContent.vue
+++ b/src/renderer/src/components/settings/ComfyUISettingsContent.vue
@@ -163,6 +163,72 @@ watch(
   { immediate: true },
 )
 
+// Auto-refresh stale channel-cards when the Update tab opens. The
+// release cache persists to disk forever and only refreshes on
+// explicit "Check for Update" clicks, post-update-comfyui, or install
+// creation — without this watcher, a user who opens the picker days
+// or weeks after install sees a snapshot of release data from the
+// last manual check. Fires `check-update` (cheap GitHub tag fetch,
+// deduped main-side by `MIN_RECHECK_INTERVAL = 10s` inside the release
+// cache) whenever:
+//
+//   - the active tab is `'update'`,
+//   - the sections payload has a channel-cards field,
+//   - and the currently-selected option's `data.checkedAt` is missing
+//     or older than `STALE_CHANNEL_CARD_MS`.
+//
+// Per-(install, channel) dedupe via `refreshedChannelKeys` so tab
+// flips don't spam IPCs. Main's `getOrFetch(..., force=true)` short-
+// circuits on the 10s window so even a stuck renderer can't push more
+// than 6 fetches/minute/channel.
+const STALE_CHANNEL_CARD_MS = 15 * 60 * 1000
+const refreshedChannelKeys = new Set<string>()
+watch(
+  [
+    () => activeTab.value,
+    () => props.installation?.id ?? null,
+    () => sections.value.length,
+  ],
+  ([tab, installId, sectionsLen]) => {
+    if (tab !== 'update' || !installId || sectionsLen === 0) return
+
+    const channelField = sections.value
+      .flatMap((s) => s.fields ?? [])
+      .find((f) => f.editType === 'channel-cards')
+    if (!channelField) return
+
+    const currentChannel = typeof channelField.value === 'string' ? channelField.value : null
+    if (!currentChannel) return
+
+    const selectedOption = channelField.options?.find((o) => o.value === currentChannel)
+    const data = selectedOption?.data as { checkedAt?: number } | undefined
+    const checkedAt = typeof data?.checkedAt === 'number' ? data.checkedAt : null
+    const stale = checkedAt === null || Date.now() - checkedAt > STALE_CHANNEL_CARD_MS
+    if (!stale) return
+
+    // Look up the canonical action def from sections so we inherit
+    // whatever `enabled` / disabledMessage / future fields main attaches
+    // (today: `enabled: installed`). Bail if main isn't exposing the
+    // action for this install (e.g. uninstalled / cloud).
+    const checkAction = sections.value
+      .flatMap((s) => s.actions ?? [])
+      .find((a) => a.id === 'check-update')
+    if (!checkAction || checkAction.enabled === false) return
+
+    const dedupeKey = `${installId}:${currentChannel}`
+    if (refreshedChannelKeys.has(dedupeKey)) return
+    refreshedChannelKeys.add(dedupeKey)
+
+    // `check-update` has no `showProgress` / confirm / prompt; it runs
+    // inline via `useComfyUISettings.runAction` step 10. A successful
+    // result returns `navigate: 'detail'` → section reload → fresh
+    // `checkedAt` bubbles through this watcher (dedupe set prevents
+    // re-fire on the same install+channel).
+    void runAction(checkAction)
+  },
+  { immediate: true },
+)
+
 interface TabDef {
   key: ComfyUISettingsTab
   /** The `DetailSection.tab` literal we filter for. The Figma's "Config"


### PR DESCRIPTION
## Problem

The shared release cache (`release-cache.json`) is populated by explicit `Check for Update` clicks, post-update-comfyui, and install creation — and then persists to disk **forever** with no TTL. A user who installs in January and opens the picker's Update tab in June sees January's "latest release" until they manually click `Check for Update`. Lifecycle Gap #21.

## Fix

Renderer-side watcher in `ComfyUISettingsContent` fires the existing `check-update` action whenever:
- the active tab is `update`,
- the currently-selected channel's `data.checkedAt` is missing or older than `STALE_CHANNEL_CARD_MS` (15 minutes).

Per-(install, channel) dedupe via a `Set` prevents tab flips from spamming IPCs. Main's existing 10s `MIN_RECHECK_INTERVAL` inside the release cache backs it up.

`channel-cards.ts` now exposes the raw `checkedAt` timestamp to the renderer so the watcher can gate on it.

## Test infra

`release-cache.ts` adds a `_test_ageEntries(maxCheckedAt)` helper, registered as the `__e2e.ageReleaseCache` hook, so lifecycle tests can drive staleness without waiting wall-clock minutes. (Mutating the module's private `_entries` map directly is the only way to make staleness visible without restarting the app — `getDetailSections` reads from the same in-memory state, never re-reads `release-cache.json`.)

## Lifecycle test (4 tests, all pass against real Comfy-Org/ComfyUI remote)

- `check-update hits the real remote and finds a newer release` (pre-existing)
- `cross-channel fetch populates the latest channel card too` (pre-existing)
- `Update tab does NOT auto-refresh when the channel data is fresh` — opens picker after just-fetched cache, asserts 0 `check-update` IPCs in 1.5s.
- `Update tab auto-refreshes when channel data is stale` — ages the cache via `ageReleaseCache` hook, opens the picker for a fresh install whose `ComfyUISettingsContent` has never mounted (so the watcher's `immediate: true` fires against the staled cache), asserts the `check-update` IPC fires and the on-disk `checkedAt` advances past the staleness threshold.

## Pre-commit gate

`pnpm run typecheck`, `pnpm run lint`, `pnpm run build`, `pnpm run test` (1134 unit tests) — all pass.