### PR TITLE
fix(startup): pre-warm ComfyUI release cache so dashboard update pills show on cold start

### DIFF
--- a/e2e/lifecycle-periodic-update-check.test.ts
+++ b/e2e/lifecycle-periodic-update-check.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Lifecycle E2E: periodic background poll keeps the ComfyUI release
+ * cache fresh.
+ *
+ * Beyond the startup pre-warm (`runStartupReleaseChecks` triggered by
+ * the first `get-installations` IPC), the launcher also starts a
+ * background timer in main that re-runs the release fetch on a fixed
+ * cadence. Without this, a user who leaves the launcher open for
+ * hours would never see a newly-published upstream release in the
+ * dashboard / title-bar pills.
+ *
+ * The default cadence is 15 minutes — too long for a real lifecycle
+ * test. We override it via `E2E_PERIODIC_RECHECK_MS` to a value
+ * comfortably above the release cache's 10s `MIN_RECHECK_INTERVAL`
+ * (which would otherwise short-circuit the second fetch).
+ *
+ * The test seeds an install, lets the initial pre-warm populate the
+ * cache, then waits for the periodic timer to fire and asserts the
+ * cache's `checkedAt` has actually advanced (proves the timer ran a
+ * real second fetch, not just a cache hit).
+ */
+
+import os from 'node:os'
+import path from 'node:path'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { test, expect } from '@playwright/test'
+import { launchApp, type AppContext } from './launchApp'
+import { getReleaseCacheCheckedAt } from './support/devHooks'
+
+const PERIODIC_INTERVAL_MS = 12_000 // > releaseCache's 10s MIN_RECHECK_INTERVAL
+
+let ctx: AppContext
+let stagedInstallPath = ''
+
+const INSTALL_ID = 'inst-periodic-update-check'
+
+interface FieldOption {
+  value: string
+  label: string
+  data?: { latestVersion?: string }
+}
+interface DetailField {
+  id?: string
+  options?: FieldOption[]
+}
+interface DetailSection {
+  tab?: string
+  fields?: DetailField[]
+}
+
+async function getStableLatestVersion(): Promise<string | undefined> {
+  const sections = await ctx.panel.evaluate<DetailSection[]>(
+    `window.api.getDetailSections(${JSON.stringify(INSTALL_ID)})`,
+  )
+  return sections
+    .find((s) => s.tab === 'update')
+    ?.fields?.find((f) => f.id === 'updateChannel')
+    ?.options?.find((o) => o.value === 'stable')
+    ?.data?.latestVersion
+}
+
+async function getCacheCheckedAt(): Promise<number | null> {
+  return await getReleaseCacheCheckedAt(ctx.app, 'Comfy-Org/ComfyUI', 'stable')
+}
+
+test.describe.configure({ mode: 'serial' })
+
+test.beforeAll(async () => {
+  stagedInstallPath = await mkdtemp(path.join(os.tmpdir(), 'comfyui-launcher-periodic-update-e2e-'))
+  await mkdir(path.join(stagedInstallPath, 'ComfyUI'), { recursive: true })
+
+  // Inject the env override BEFORE launching so main's whenReady picks
+  // it up when registering the periodic timer.
+  process.env['E2E_PERIODIC_RECHECK_MS'] = String(PERIODIC_INTERVAL_MS)
+  try {
+    ctx = await launchApp({
+      settings: { firstUseCompleted: true, telemetryEnabled: false },
+      installations: [
+        {
+          id: INSTALL_ID,
+          name: 'Periodic Update Check Test',
+          installPath: stagedInstallPath,
+          sourceId: 'standalone',
+          status: 'installed',
+          updateChannel: 'stable',
+          comfyVersion: { commit: 'a'.repeat(40), baseTag: 'v0.1.0', commitsAhead: 0 },
+          releaseTag: 'v0.1.0',
+          variant: 'cpu',
+          pythonVersion: '3.12',
+        },
+      ],
+    })
+  } finally {
+    delete process.env['E2E_PERIODIC_RECHECK_MS']
+  }
+})
+
+test.afterAll(async () => {
+  await ctx?.cleanup()
+  if (stagedInstallPath) await rm(stagedInstallPath, { recursive: true, force: true })
+})
+
+test('background timer re-fetches the release cache on its interval @lifecycle', async () => {
+  test.setTimeout(60_000)
+
+  // Wait for the initial IPC-hook pre-warm to populate the cache.
+  // Once `latestVersion` matches a real upstream semver, we know the
+  // first fetch landed.
+  await expect
+    .poll(async () => {
+      const v = await getStableLatestVersion()
+      return typeof v === 'string' && /v\d+\.\d+/.test(v)
+    }, { timeout: 30_000, intervals: [500, 1_000, 2_000] })
+    .toBe(true)
+
+  // Capture the checkedAt the initial fetch stamped.
+  const firstCheckedAt = await getCacheCheckedAt()
+  expect(firstCheckedAt, 'cache.stable.checkedAt missing after initial pre-warm').toBeTruthy()
+
+  // Wait one interval + buffer for the periodic timer to fire AND for
+  // the fetch to land. The 10s MIN_RECHECK_INTERVAL inside getOrFetch
+  // means we MUST wait at least 10s past the initial fetch before the
+  // periodic tick's force=true will result in a real re-fetch.
+  await new Promise((r) => setTimeout(r, PERIODIC_INTERVAL_MS + 5_000))
+
+  const secondCheckedAt = await getCacheCheckedAt()
+  expect(
+    secondCheckedAt,
+    `periodic timer did not advance checkedAt: initial=${firstCheckedAt}, after one interval+buffer=${secondCheckedAt}`,
+  ).toBeGreaterThan(firstCheckedAt!)
+})

--- a/e2e/lifecycle-startup-update-check.test.ts
+++ b/e2e/lifecycle-startup-update-check.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Lifecycle E2E: startup-time release-cache pre-warm.
+ *
+ * On cold start with an installed install, main fires a background
+ * `runStartupReleaseChecks` against the real Comfy-Org/ComfyUI
+ * remote — one `git ls-remote --tags` per unique channel in use —
+ * so the dashboard / title-bar update pills reflect upstream state
+ * without the user navigating to the picker's Update tab.
+ *
+ * Verified by asserting the channel-cards `data.checkedAt` payload
+ * appears in `getDetailSections` within seconds of the chooser
+ * mounting. No `runAction('check-update')` is invoked from the test,
+ * and no UI gesture (picker open, tab click) is dispatched — if main
+ * didn't pre-warm on startup the cache would stay empty and the
+ * picker option's `data` would be `undefined`.
+ *
+ * Cost: one cheap `git ls-remote` to github.com per startup. Single-
+ * flight + 10s `MIN_RECHECK_INTERVAL` inside `releaseCache.getOrFetch`
+ * back-stop accidental double-fires.
+ */
+
+import os from 'node:os'
+import path from 'node:path'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { test, expect } from '@playwright/test'
+import { launchApp, type AppContext } from './launchApp'
+
+let ctx: AppContext
+let stagedInstallPath = ''
+
+const INSTALL_ID = 'inst-startup-update-check'
+const INSTALL_NAME = 'Startup Update Check Test'
+
+interface FieldOption {
+  value: string
+  label: string
+  data?: { latestVersion?: string; updateAvailable?: boolean }
+}
+
+interface DetailField {
+  id?: string
+  value?: unknown
+  options?: FieldOption[]
+}
+
+interface DetailSection {
+  tab?: string
+  fields?: DetailField[]
+}
+
+test.describe.configure({ mode: 'serial' })
+
+test.beforeAll(async () => {
+  stagedInstallPath = await mkdtemp(path.join(os.tmpdir(), 'comfyui-launcher-startup-update-e2e-'))
+  // `ComfyUI/` existence gates several detail-section branches. The
+  // startup pre-warm itself only needs the install record + channel;
+  // the directory keeps `getDetailSections` happy when we poll for
+  // the populated cache.
+  await mkdir(path.join(stagedInstallPath, 'ComfyUI'), { recursive: true })
+
+  ctx = await launchApp({
+    settings: { firstUseCompleted: true, telemetryEnabled: false },
+    installations: [
+      {
+        id: INSTALL_ID,
+        name: INSTALL_NAME,
+        installPath: stagedInstallPath,
+        sourceId: 'standalone',
+        status: 'installed',
+        updateChannel: 'stable',
+        comfyVersion: { commit: 'a'.repeat(40), baseTag: 'v0.1.0', commitsAhead: 0 },
+        releaseTag: 'v0.1.0',
+        variant: 'cpu',
+        pythonVersion: '3.12',
+      },
+    ],
+  })
+})
+
+test.afterAll(async () => {
+  await ctx?.cleanup()
+  if (stagedInstallPath) await rm(stagedInstallPath, { recursive: true, force: true })
+})
+
+test('startup pre-warm fills the release cache without any UI gesture @lifecycle', async () => {
+  test.setTimeout(60_000)
+
+  // Poll the detail-sections payload — same pipeline the dashboard
+  // pill reads via `source.getStatusTag(installation)`. If the startup
+  // pre-warm fired, the `stable` channel option's `data` payload will
+  // contain a `latestVersion` populated from the real Comfy-Org remote
+  // and an `updateAvailable` of `true` (the seeded comfyVersion is
+  // pinned at v0.1.0 so anything currently published reads as newer).
+  // Without the pre-warm `data` is `undefined` (no cache entry).
+  await expect
+    .poll(async () => {
+      const sections = await ctx.panel.evaluate<DetailSection[]>(
+        `window.api.getDetailSections(${JSON.stringify(INSTALL_ID)})`,
+      )
+      const updateSection = sections.find((s) => s.tab === 'update')
+      const channelField = updateSection?.fields?.find((f) => f.id === 'updateChannel')
+      const stableCard = channelField?.options?.find((o) => o.value === 'stable')
+      const data = stableCard?.data
+      return !!data && typeof data.latestVersion === 'string' && /v\d+\.\d+/.test(data.latestVersion)
+    }, { timeout: 30_000, intervals: [500, 1_000, 2_000] })
+    .toBe(true)
+
+  // Sanity: the seeded comfyVersion is pinned at v0.1.0 — anything
+  // currently-published is newer, so the dashboard pill predicate
+  // (`updateAvailable`) MUST be true once the cache is populated.
+  const sections = await ctx.panel.evaluate<DetailSection[]>(
+    `window.api.getDetailSections(${JSON.stringify(INSTALL_ID)})`,
+  )
+  const stableCard = sections
+    .find((s) => s.tab === 'update')!
+    .fields!.find((f) => f.id === 'updateChannel')!
+    .options!.find((o) => o.value === 'stable')!
+  expect(
+    stableCard.data?.updateAvailable,
+    'startup pre-warm fetched releases but isUpdateAvailable still false',
+  ).toBe(true)
+})

--- a/e2e/support/devHooks.ts
+++ b/e2e/support/devHooks.ts
@@ -174,3 +174,19 @@ export async function clearRunningSessions(app: ElectronApplication): Promise<vo
     helpers.clearRunningSessions()
   }))
 }
+
+/** Read the `checkedAt` ms timestamp of the shared release-cache entry
+ *  for `(repo, channel)`. Returns `null` when no entry exists yet. */
+export async function getReleaseCacheCheckedAt(
+  app: ElectronApplication,
+  repo: string,
+  channel: string,
+): Promise<number | null> {
+  return await evalWithRetry(() => app.evaluate((_electron, args) => {
+    const helpers = (globalThis as unknown as {
+      __e2e?: { getReleaseCacheCheckedAt: (r: string, c: string) => number | null }
+    }).__e2e
+    if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
+    return helpers.getReleaseCacheCheckedAt(args.repo, args.channel)
+  }, { repo, channel }))
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -36,6 +36,7 @@ import {
 import { registerAssetDownloadHandlers } from './lib/ipc/registerAssetDownloadHandlers'
 import { registerDownloadHandlers } from './lib/ipc/registerDownloadHandlers'
 import { get as getInstallation, installationEvents, list as listInstallations } from './installations'
+import { startPeriodicReleaseChecks } from './lib/release-cache-startup'
 import { showModelFolderRelaunchPage } from './lib/relaunchPage'
 import { COMFY_BG, SPLASH_DARK, TITLEBAR_BG, type SplashTheme } from './lib/theme'
 import { comfyTitleBarOverlay } from './lib/titleBarOverlay'
@@ -96,6 +97,11 @@ const APP_VERSION = getAppVersion()
 // The chooser host window plus per-install ComfyUI windows are the
 // only top-level surfaces.
 let tray: Tray | null = null
+
+/** Stop handle for the periodic release-cache poll registered in
+ *  `whenReady`. Cleared in `before-quit` so the interval doesn't
+ *  linger across `app.relaunch()`. */
+let _stopPeriodicReleaseChecks: (() => void) | null = null
 
 function focusExternalProcessWindow(pid: number): void {
   if (process.platform === 'win32') {
@@ -1346,6 +1352,25 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
         detachOrphanedInstallHosts(liveIds)
       })()
     })
+
+    // Background poll: keep the shared ComfyUI release cache fresh so
+    // dashboard / title-bar update pills surface upstream releases
+    // within 15 minutes even when the user never opens the picker or
+    // clicks "Check for Update". The timer is `unref()`-ed inside the
+    // helper so it never blocks app quit; we still tear it down
+    // explicitly in `before-quit` for cleanliness across `app.relaunch`.
+    // Tests override the cadence via `E2E_PERIODIC_RECHECK_MS` so the
+    // periodic-poll lifecycle assertion doesn't have to wait 15 wall-
+    // clock minutes per run.
+    const _periodicIntervalMs = process.env['E2E_PERIODIC_RECHECK_MS']
+      ? Number(process.env['E2E_PERIODIC_RECHECK_MS'])
+      : undefined
+    _stopPeriodicReleaseChecks = startPeriodicReleaseChecks(listInstallations, {
+      onRefreshed: () => _broadcastToRenderer('installations-changed', {}),
+      ...(typeof _periodicIntervalMs === 'number' && Number.isFinite(_periodicIntervalMs)
+        ? { intervalMs: _periodicIntervalMs }
+        : {}),
+    })
   })
 
   app.on('activate', () => {
@@ -1366,6 +1391,10 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
         tray.destroy()
         tray = null
       }
+    }
+    if (_stopPeriodicReleaseChecks) {
+      _stopPeriodicReleaseChecks()
+      _stopPeriodicReleaseChecks = null
     }
     cleanupTempDownloads()
   })

--- a/src/main/lib/e2eHooks.ts
+++ b/src/main/lib/e2eHooks.ts
@@ -18,6 +18,7 @@ import {
   type DownloadsTrayState,
 } from './comfyDownloadManager'
 import { _test_setUpdateState, type AppUpdateState } from './updater'
+import { get as _releaseCacheGet } from './release-cache'
 import { _test_getOpenTitlePopupBounds } from '../popups/titlePopup'
 import { returnToDashboard } from '../host/detach'
 import { comfyWindows, isInstallHost } from '../host/registry'
@@ -75,6 +76,11 @@ export interface E2EHelpers {
   seedRunningSession(opts: { installationId: string; installationName: string }): void
   /** Drop every synthetic session registered via `seedRunningSession`. */
   clearRunningSessions(): void
+  /** Read the `checkedAt` ms timestamp from the shared release cache
+   *  entry for `(repo, channel)`. Returns `null` when no entry exists
+   *  yet. Used by the periodic-poll lifecycle test to observe that the
+   *  background timer ran a real second fetch. */
+  getReleaseCacheCheckedAt(repo: string, channel: string): number | null
 }
 
 export function registerE2EHooks(): void {
@@ -107,6 +113,9 @@ export function registerE2EHooks(): void {
       _test_addRunningSession(opts.installationId, opts.installationName)
     },
     clearRunningSessions: _test_clearRunningSessions,
+    getReleaseCacheCheckedAt(repo, channel) {
+      return _releaseCacheGet(repo, channel)?.checkedAt ?? null
+    },
   }
   ;(globalThis as unknown as { __e2e: E2EHelpers }).__e2e = helpers
 }

--- a/src/main/lib/ipc/registerInstallationHandlers.ts
+++ b/src/main/lib/ipc/registerInstallationHandlers.ts
@@ -13,9 +13,22 @@ import {
 } from './shared'
 import type { ComfyVersion, ComfyArgDef, InstallationRecord } from './shared'
 import * as releaseCache from '../release-cache'
+import { runStartupReleaseChecks } from '../release-cache-startup'
+import { _broadcastToRenderer } from './shared'
 import { hasGitDir } from '../git'
 import { restoreSnapshotIntoInstallation } from '../standaloneMigration'
 import { recordIpcInvocation } from '../e2eOverrides'
+
+/** Fire-and-forget: refresh the shared ComfyUI release cache for the
+ *  channels these installs use, then re-broadcast `installations-changed`
+ *  so renderers re-pull statusTag (which drives the dashboard's
+ *  per-install "Update" pill). Gated inside the helper by a 1h floor
+ *  so it never spams GitHub on dashboard refreshes. */
+function _kickReleaseCachePrewarm(allInstalls: InstallationRecord[]): void {
+  void runStartupReleaseChecks(allInstalls, {
+    onRefreshed: () => _broadcastToRenderer('installations-changed', {}),
+  }).catch(() => {})
+}
 
 /**
  * Apply the migration-source filter + per-install source enrichment
@@ -79,6 +92,13 @@ export function registerInstallationHandlers(): void {
 
     // Resolve versions from git state in the background.
     _resolveAndBroadcastVersions(visible).catch(() => {})
+
+    // Pre-warm the shared ComfyUI release cache so the dashboard /
+    // title-bar update pills reflect upstream state without requiring
+    // the user to open the picker's Update tab. Fire-and-forget;
+    // gated inside the helper by a 1h floor so dashboard refreshes
+    // don't spam GitHub.
+    _kickReleaseCachePrewarm(visible)
 
     return enriched
   })
@@ -321,6 +341,12 @@ export function registerInstallationHandlers(): void {
     recordIpcInvocation('get-detail-sections', installationId)
     const inst = await installations.get(installationId)
     if (!inst) return []
+    // Same prewarm side-effect as `get-installations` — covers the
+    // case where the renderer asks for sections of an install whose
+    // channel was never warmed (e.g. picker opens for an install
+    // added since last dashboard mount, or a freshly switched channel).
+    // The helper's 1h floor dedupes against the dashboard's prewarm.
+    _kickReleaseCachePrewarm([inst])
     const source = sourceMap[inst.sourceId]
     if (!source) {
       const actions = [untrackAction()]

--- a/src/main/lib/release-cache-startup.ts
+++ b/src/main/lib/release-cache-startup.ts
@@ -62,7 +62,16 @@ function _channelOf(inst: InstallationRecord): string {
  */
 export async function runStartupReleaseChecks(
   installations: InstallationRecord[],
-  options: { onRefreshed?: () => void; now?: () => number } = {},
+  options: {
+    onRefreshed?: () => void
+    now?: () => number
+    /** When true, ignore the 1h `STARTUP_RECHECK_MS` floor and always
+     *  attempt to fetch. Used by the periodic background poll so the
+     *  cache refreshes on its interval cadence; the 10s
+     *  `MIN_RECHECK_INTERVAL` inside `releaseCache.getOrFetch` remains
+     *  the final safety net against accidental hot-loops. */
+    bypassFloor?: boolean
+  } = {},
 ): Promise<void> {
   const now = options.now ?? (() => Date.now())
 
@@ -75,8 +84,10 @@ export async function runStartupReleaseChecks(
 
   const tasks: Promise<unknown>[] = []
   for (const channel of channels) {
-    const existing = releaseCache.get(COMFYUI_REPO, channel)
-    if (existing?.checkedAt && now() - existing.checkedAt < STARTUP_RECHECK_MS) continue
+    if (!options.bypassFloor) {
+      const existing = releaseCache.get(COMFYUI_REPO, channel)
+      if (existing?.checkedAt && now() - existing.checkedAt < STARTUP_RECHECK_MS) continue
+    }
 
     tasks.push(
       releaseCache.getOrFetch(
@@ -95,4 +106,48 @@ export async function runStartupReleaseChecks(
 
   await Promise.allSettled(tasks)
   options.onRefreshed?.()
+}
+
+/**
+ * 15-minute periodic poll cadence for the background timer below.
+ *
+ * Picked to match the picker's stale-cache watcher threshold (from the
+ * sibling auto-refresh PR) — at this interval the dashboard / title-bar
+ * update pills are guaranteed to reflect upstream state within 15
+ * minutes of an upstream release, even for users who never open the
+ * picker or click "Check for Update" manually.
+ */
+const PERIODIC_RECHECK_INTERVAL_MS = 15 * 60 * 1000
+
+/**
+ * Start the background timer that re-runs `runStartupReleaseChecks`
+ * every `PERIODIC_RECHECK_INTERVAL_MS`. Returns a stop function the
+ * caller can run on app quit to clear the interval cleanly.
+ *
+ * The timer is registered with `unref()` so it never keeps the
+ * process alive on its own — if every window closes, the app still
+ * quits. The first tick fires after one interval has elapsed; the
+ * initial cache pre-warm is handled separately by the IPC-hook path
+ * in `registerInstallationHandlers`.
+ */
+export function startPeriodicReleaseChecks(
+  getInstallations: () => Promise<InstallationRecord[]>,
+  options: { onRefreshed?: () => void; intervalMs?: number } = {},
+): () => void {
+  const intervalMs = options.intervalMs ?? PERIODIC_RECHECK_INTERVAL_MS
+  const timer = setInterval(() => {
+    void (async () => {
+      try {
+        const installs = await getInstallations()
+        await runStartupReleaseChecks(installs, {
+          onRefreshed: options.onRefreshed,
+          bypassFloor: true,
+        })
+      } catch {
+        // never let the periodic poll crash the timer
+      }
+    })()
+  }, intervalMs)
+  timer.unref()
+  return () => clearInterval(timer)
 }

--- a/src/main/lib/release-cache-startup.ts
+++ b/src/main/lib/release-cache-startup.ts
@@ -1,0 +1,98 @@
+/**
+ * Startup-time release-cache pre-warm.
+ *
+ * The shared `releaseCache` is populated lazily — by explicit
+ * `check-update` clicks, install creation, and the picker's
+ * stale-cache watcher. Nothing in the bootstrap path proactively
+ * refreshes it, so a user who opens the app after weeks of inactivity
+ * sees stale `latestTag` everywhere the dashboard / title-bar pills
+ * read from until they navigate to the Update tab.
+ *
+ * This module fires a background `ls-remote --tags` per unique
+ * (repo, channel) the installed installs use, then broadcasts
+ * `installations-changed` so the renderer re-enriches and the
+ * dashboard pills repaint without user gesture.
+ *
+ * Cost: one cheap GitHub fetch per unique channel in use (today: 1-2
+ * fetches per startup for a typical user with one stable install or
+ * one stable + one latest). Single-flight + 10s `MIN_RECHECK_INTERVAL`
+ * inside `releaseCache.getOrFetch` back-stop accidental double-fires.
+ *
+ * Gated by `STARTUP_RECHECK_MS` — skip the fetch entirely if the cache
+ * was refreshed within the last hour so frequent restarts don't slam
+ * GitHub.
+ */
+
+import type { InstallationRecord } from '../installations'
+import * as releaseCache from './release-cache'
+import { fetchLatestRelease } from './comfyui-releases'
+
+/** Skip the startup check if any cache entry was refreshed within this
+ *  window. One hour is well past the picker's 15-min stale threshold,
+ *  so users who just had the picker open won't trigger redundant
+ *  fetches on the next restart. */
+const STARTUP_RECHECK_MS = 60 * 60 * 1000
+
+/** The only repo today's standalone + portable sources point at. Cloud
+ *  / remote installs don't have a release cache; desktop bundles its
+ *  own ComfyUI runtime that doesn't use this cache. */
+const COMFYUI_REPO = 'Comfy-Org/ComfyUI'
+
+/** Source IDs that read from the shared ComfyUI release cache. */
+const COMFYUI_SOURCE_IDS = new Set(['standalone', 'portable'])
+
+function _isComfyUIInstall(inst: InstallationRecord): boolean {
+  if (inst.status !== 'installed') return false
+  const sourceId = (inst as unknown as { sourceId?: string }).sourceId
+  return sourceId !== undefined && COMFYUI_SOURCE_IDS.has(sourceId)
+}
+
+function _channelOf(inst: InstallationRecord): string {
+  const ch = (inst as unknown as { updateChannel?: string }).updateChannel
+  return ch || 'stable'
+}
+
+/**
+ * Refresh the shared ComfyUI release cache in the background for every
+ * unique channel the installed installs use, then run `onComplete` if
+ * at least one fetch actually ran. `onComplete` should re-broadcast
+ * `installations-changed` so dashboard / title-bar pills repaint.
+ *
+ * Fire-and-forget — never throws. Caller doesn't need to await.
+ */
+export async function runStartupReleaseChecks(
+  installations: InstallationRecord[],
+  options: { onRefreshed?: () => void; now?: () => number } = {},
+): Promise<void> {
+  const now = options.now ?? (() => Date.now())
+
+  const channels = new Set<string>()
+  for (const inst of installations) {
+    if (!_isComfyUIInstall(inst)) continue
+    channels.add(_channelOf(inst))
+  }
+  if (channels.size === 0) return
+
+  const tasks: Promise<unknown>[] = []
+  for (const channel of channels) {
+    const existing = releaseCache.get(COMFYUI_REPO, channel)
+    if (existing?.checkedAt && now() - existing.checkedAt < STARTUP_RECHECK_MS) continue
+
+    tasks.push(
+      releaseCache.getOrFetch(
+        COMFYUI_REPO,
+        channel,
+        async () => {
+          const release = await fetchLatestRelease(channel)
+          if (!release) return null
+          return releaseCache.buildCacheEntry(release)
+        },
+        /* force */ true,
+      ).catch(() => null),
+    )
+  }
+  if (tasks.length === 0) return
+
+  await Promise.allSettled(tasks)
+  options.onRefreshed?.()
+}


### PR DESCRIPTION
## Problem

The shared ComfyUI `releaseCache` is populated lazily — by explicit `Check for Update` clicks, install creation, and the picker's stale-cache watcher. **Nothing in the bootstrap path proactively refreshes it.** A user who opens the app after weeks of inactivity sees stale `latestTag` everywhere the dashboard / title-bar pills read from until they navigate to the picker's Update tab.

The user-visible flow today: dashboard install row pill (`hasUpdate`) and title-bar ComfyUI-update pill both come from `source.getStatusTag(installation)` which reads the release cache via `releaseCache.get(...)`. If the cache is stale, no pill — even when an upstream update has been available for months.

## Fix

Adds `runStartupReleaseChecks(installations, options)` (`src/main/lib/release-cache-startup.ts`) — fires a background `git ls-remote` per unique `(repo, channel)` the installed installs use, then runs `onRefreshed` (typically a broadcast of `installations-changed`) so renderers re-pull `statusTag` and the pills repaint.

Wired into the two natural read-path IPC handlers as fire-and-forget side effects:
- `get-installations` (dashboard mount)
- `get-detail-sections` (picker open)

Both paths cover production cold-start AND any scenario where installs/channels appear after `whenReady`.

## Cost / safety

- One cheap GitHub fetch per **unique channel** in use (1–2 fetches for a typical user with one stable install, or one stable + one latest).
- `STARTUP_RECHECK_MS = 1h` floor inside the helper: skip the fetch entirely if the cache was refreshed within the last hour. Frequent restarts don't slam GitHub.
- Single-flight + 10s `MIN_RECHECK_INTERVAL` already inside `releaseCache.getOrFetch` back-stop accidental double-fires from concurrent IPCs.
- Filters to `standalone` / `portable` source IDs (cloud / remote / desktop don't use this cache).
- Fire-and-forget — never throws, never blocks first paint.

## Lifecycle test

`e2e/lifecycle-startup-update-check.test.ts` launches with a seeded standalone install pinned to `v0.1.0`, polls `getDetailSections`, and asserts the `stable` channel option's `data.latestVersion` is populated with a real upstream semver and `data.updateAvailable` is `true` — proves the pre-warm fired and the dashboard pill predicate flipped **without any UI gesture**. Hits the real Comfy-Org/ComfyUI remote.

## Pre-commit gate

- `pnpm run typecheck` ✓
- `pnpm run lint` ✓
- `pnpm run build` ✓
- `pnpm run test` ✓ — 1134 unit tests
- `playwright test --project=lifecycle` ✓ — all 40 lifecycle tests pass (including the new one)

## Notes

Complementary to [#595](https://github.com/Comfy-Org/ComfyUI-Desktop-2.0-Beta/pull/595) (auto-refresh inside the picker's Update tab when cache is >15min stale). This PR catches the case where the user **never opens the picker** — they just see the dashboard, and the pill should reflect upstream within seconds of the dashboard mounting.