### PR TITLE
fix(kebab): surface action failures + dismiss-error lifecycle test

### DIFF
--- a/e2e/lifecycle-dismiss-error.test.ts
+++ b/e2e/lifecycle-dismiss-error.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Lifecycle E2E: dismiss-error from the chooser tile kebab.
+ *
+ * Drives the `useInstallContextMenu.triggerAction('dismiss-error', inst)`
+ * path end-to-end. The kebab grows a `Dismiss error` item when
+ * `sessionStore.errorInstances` carries an entry for the install (set
+ * by `sessionStore.init`'s `onComfyExited` listener on a real crashed
+ * exit, or by a failed `apiCall` settling through `progressStore`).
+ *
+ * Asserts:
+ *   1. With an error seeded, the kebab menu surfaces a
+ *      `Dismiss error` item.
+ *   2. Clicking it clears `sessionStore.errorInstances[id]`.
+ *   3. Re-opening the kebab no longer shows the item — i.e. the
+ *      menu was rebuilt against the cleared store, not stale state.
+ */
+
+import os from 'node:os'
+import path from 'node:path'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { test, expect } from '@playwright/test'
+import { launchApp, type AppContext } from './launchApp'
+import { expectChooserVisible } from './support/chooserHelpers'
+import { byTestId, TID } from './support/testIds'
+
+let ctx: AppContext
+let installPath: string
+
+const INSTALL_ID = 'inst-dismiss-error-test'
+const INSTALL_NAME = 'Dismiss Error Me'
+const MARKER_FILENAME = '.comfyui-desktop-2'
+const ERROR_MESSAGE = 'Simulated crash for dismiss-error e2e'
+
+async function hasErrorInstance(): Promise<boolean> {
+  return ctx.panel.evaluate<boolean>(
+    `window.__e2eRenderer.hasErrorInstance(${JSON.stringify(INSTALL_ID)})`,
+  )
+}
+
+async function openKebab(): Promise<void> {
+  const clicked = await ctx.panel.click(byTestId(TID.dashboardTileKebab(INSTALL_ID)))
+  expect(clicked, 'kebab button click dispatched').toBe(true)
+}
+
+test.describe.configure({ mode: 'serial' })
+
+test.beforeAll(async () => {
+  installPath = await mkdtemp(path.join(os.tmpdir(), 'comfyui-launcher-dismiss-error-e2e-'))
+  await mkdir(installPath, { recursive: true })
+  await writeFile(path.join(installPath, MARKER_FILENAME), INSTALL_ID)
+
+  ctx = await launchApp({
+    settings: { firstUseCompleted: true, telemetryEnabled: false },
+    installations: [
+      {
+        id: INSTALL_ID,
+        name: INSTALL_NAME,
+        installPath,
+        sourceId: 'standalone',
+        status: 'installed',
+      },
+    ],
+  })
+  await expectChooserVisible(ctx.panel)
+  await ctx.panel.waitForSelector(byTestId(TID.dashboardTile(INSTALL_ID)), { timeout: 10_000 })
+})
+
+test.afterAll(async () => {
+  await ctx?.cleanup()
+  if (installPath) await rm(installPath, { recursive: true, force: true })
+})
+
+test('Dismiss error from the kebab clears the error instance @lifecycle', async () => {
+  // Seed an error directly into the renderer-side sessionStore so the
+  // kebab grows its Dismiss-error item without needing to drive a real
+  // failing op first. The kebab item visibility tracks
+  // `sessionStore.errorInstances.has(id)` (see `useInstallContextMenu`
+  // `getMenuItems`).
+  await ctx.panel.evaluate<void>(
+    `window.__e2eRenderer.seedErrorInstance({
+      installationId: ${JSON.stringify(INSTALL_ID)},
+      installationName: ${JSON.stringify(INSTALL_NAME)},
+      message: ${JSON.stringify(ERROR_MESSAGE)},
+    })`,
+  )
+  expect(await hasErrorInstance(), 'seedErrorInstance did not populate the store').toBe(true)
+
+  await openKebab()
+  await ctx.panel.waitForVisible(byTestId(TID.contextMenuItem('dismiss-error')), { timeout: 5_000 })
+
+  const dismissClicked = await ctx.panel.click(byTestId(TID.contextMenuItem('dismiss-error')))
+  expect(dismissClicked, 'dismiss-error menu item click dispatched').toBe(true)
+
+  await expect
+    .poll(hasErrorInstance, { timeout: 5_000, intervals: [100, 200] })
+    .toBe(false)
+})
+
+test('Dismiss-error item is gone from the kebab after clearing @lifecycle', async () => {
+  // The menu items are rebuilt on every open via `getMenuItems(inst)`;
+  // re-opening proves the item really disappears (not just hidden in
+  // a stale prior menu instance) once the store no longer carries an
+  // error for this install.
+  await openKebab()
+  // Wait for the menu to actually mount — Manage is unconditional.
+  await ctx.panel.waitForVisible(byTestId(TID.contextMenuItem('manage')), { timeout: 5_000 })
+  expect(
+    await ctx.panel.exists(byTestId(TID.contextMenuItem('dismiss-error'))),
+    'dismiss-error item should not appear after the error was cleared',
+  ).toBe(false)
+})

--- a/src/renderer/src/composables/useInstallContextMenu.ts
+++ b/src/renderer/src/composables/useInstallContextMenu.ts
@@ -235,6 +235,24 @@ export function useInstallContextMenu(opts: {
     return getMenuItems(inst)
   })
 
+  /** Run a fire-and-forget action (no overlay / prompt) and surface a
+   *  failure via `modal.alert` instead of swallowing it. Main returns
+   *  `{ ok: false, message }` on action-level failures (e.g. open-folder
+   *  against a missing path); the bare `try { ... } catch {}` pattern
+   *  it replaces only caught true rejections, leaving the user staring
+   *  at a no-op kebab item with no feedback. */
+  async function runInstantActionWithAlert(inst: Installation, actionId: string, actionLabel: string): Promise<void> {
+    try {
+      const result = await window.api.runAction(inst.id, actionId)
+      if (result.ok === false && result.message) {
+        await modal.alert({ title: actionLabel, message: result.message })
+      }
+    } catch (err) {
+      const message = (err as Error)?.message || String(err)
+      await modal.alert({ title: actionLabel, message })
+    }
+  }
+
   /** Single dispatch path for both the kebab/right-click menu and the
    *  chooser tile's visual pills. Pill clicks (`triggerAction('update',
    *  inst)` / `triggerAction('migrate', inst)`) and menu selections
@@ -249,11 +267,7 @@ export function useInstallContextMenu(opts: {
     } else if (id === 'restore-snapshot') {
       opts.onManage?.(inst, { initialTab: 'snapshots' })
     } else if (id === 'reveal-in-folder') {
-      try {
-        await window.api.runAction(inst.id, 'open-folder')
-      } catch {
-        // The action surfaces its own error to the user via main; nothing to do here.
-      }
+      await runInstantActionWithAlert(inst, 'open-folder', revealInFolderLabel(window.api?.platform))
     } else if (id === 'copy-install') {
       // Route through the source-action def by handing the autoAction
       // off to `onManage`. Calling `window.api.runAction(id, 'copy')`
@@ -308,11 +322,7 @@ export function useInstallContextMenu(opts: {
         // strings to the panel router which has both callbacks).
         opts.onManage(inst, { autoAction: 'delete' })
       } else {
-        try {
-          await window.api.runAction(inst.id, 'delete')
-        } catch {
-          // Source action surfaces its own error path.
-        }
+        await runInstantActionWithAlert(inst, 'delete', t('chooser.menuDelete'))
       }
     } else if (id === 'dismiss-error') {
       sessionStore.clearErrorInstance(inst.id)

--- a/src/renderer/src/panel/e2eRendererHooks.ts
+++ b/src/renderer/src/panel/e2eRendererHooks.ts
@@ -61,6 +61,13 @@ export interface E2ERendererHelpers {
    *  `instance-stopped` message — without this poll the apiCall-time
    *  `wasRunning` capture races the broadcast). */
   isRunning(installationId: string): boolean
+  /** Seed an entry into `sessionStore.errorInstances` so the chooser
+   *  tile flips into its has-error state and the kebab grows a
+   *  `Dismiss error` item, without having to drive a real failing op
+   *  through `showProgress` first. */
+  seedErrorInstance(opts: { installationId: string; installationName: string; message?: string }): void
+  /** True iff `sessionStore.errorInstances` has an entry for the id. */
+  hasErrorInstance(installationId: string): boolean
 }
 
 function ensureBound(): PanelBindings {
@@ -110,6 +117,15 @@ export function registerE2ERendererHooks(): void {
     },
     isRunning(installationId) {
       return useSessionStore().isRunning(installationId)
+    },
+    seedErrorInstance({ installationId, installationName, message }) {
+      useSessionStore().errorInstances.set(installationId, {
+        installationName,
+        message,
+      })
+    },
+    hasErrorInstance(installationId) {
+      return useSessionStore().errorInstances.has(installationId)
     },
   }
   ;(globalThis as unknown as { __e2eRenderer: E2ERendererHelpers }).__e2eRenderer = helpers


### PR DESCRIPTION
Continues the issue #591 audit follow-up — pairs one lifecycle gap with the matching `useInstallContextMenu` annoyance.

### Annoying fix #6 — kebab swallows action failures

`useInstallContextMenu.triggerAction`'s `reveal-in-folder` and the legacy `delete` fallback both ran `try { window.api.runAction(...) } catch {}` with a comment claiming the source action surfaces its own error. Main's source-side handlers actually return `{ ok: false, message }` on action errors (they never reject), so the catch only caught true rejections and the `{ ok: false }` branch was dropped on the floor — the user saw a no-op kebab item with no feedback.

Both now route through a small `runInstantActionWithAlert` helper that:
- awaits `runAction`;
- surfaces `result.ok === false && result.message` via `modal.alert({ title, message })` (the same shape `useListAction` already uses);
- still catches true rejections and alerts on those.

(`copy-install` and `untrack` no longer hit this path — #595 routed them through `onManage({ autoAction })`.)

### Lifecycle test #23 — Dismiss error from chooser kebab

New `e2e/lifecycle-dismiss-error.test.ts`:
- Seeds `sessionStore.errorInstances` directly via a new `__e2eRenderer.seedErrorInstance` helper (no need to drive a real failing op);
- Opens the kebab, asserts the `Dismiss error` item appears;
- Clicks it, asserts `sessionStore.errorInstances` no longer has the entry;
- Re-opens the kebab and asserts the item is gone (the menu was rebuilt against the cleared store).

A complementary `hasErrorInstance` helper covers the test-side read so the poll doesn't dig into Pinia internals.

### Validation

`pnpm run typecheck && pnpm run lint && pnpm run build && pnpm run test` all green; `pnpm exec playwright test e2e/lifecycle-dismiss-error.test.ts` — 2/2 pass locally.