### PR TITLE
fix(useActionGuard): poll for op cleared instead of fixed 500ms sleep

### DIFF
--- a/e2e/lifecycle-cancel-flow.test.ts
+++ b/e2e/lifecycle-cancel-flow.test.ts
@@ -65,12 +65,7 @@ test.beforeEach(async () => {
   await clearRunningSessions(ctx.app)
   // Drop any pending in-flight op left over from a previous test so its
   // settler can't intercept this test's seed.
-  await ctx.panel.evaluate<boolean>(
-    `window.__e2eRenderer.settleInFlightOp({
-      installationId: ${JSON.stringify(INSTALL_ID)},
-      result: { ok: false, cancelled: true },
-    })`,
-  )
+  await settleInFlightOp({ ok: false, cancelled: true })
 })
 
 /** Seed an in-flight op whose apiCall stays pending until the test
@@ -99,21 +94,27 @@ async function settleInFlightOp(result: { ok: boolean; cancelled?: boolean }): P
   )
 }
 
-test('useActionGuard fires cancel-operation when the user confirms cancelling the busy op @lifecycle', async () => {
-  // Active session + in-flight op makes the guard's busy check fire.
-  await startInFlightOp()
-
-  // Run the guard in the background; the confirm modal appears and the
-  // poll waits on the op to clear. Captured on a window-scoped promise
-  // so we can await the verdict after settling.
+/** Kick off `runActionGuard` and stash the verdict promise on `window`
+ *  so the test can await it later (after driving the confirm modal). */
+async function runGuardInBackground(actionLabel: string): Promise<void> {
   await ctx.panel.evaluate<void>(
     `(() => {
       window.__guardPromise = window.__e2eRenderer.runActionGuard({
         installationId: ${JSON.stringify(INSTALL_ID)},
-        actionLabel: 'Restart ComfyUI',
+        actionLabel: ${JSON.stringify(actionLabel)},
       })
     })()`,
   )
+}
+
+function readGuardVerdict(): Promise<boolean> {
+  return ctx.panel.evaluate<boolean>('window.__guardPromise')
+}
+
+test('useActionGuard fires cancel-operation when the user confirms cancelling the busy op @lifecycle', async () => {
+  // Active session + in-flight op makes the guard's busy check fire.
+  await startInFlightOp()
+  await runGuardInBackground('Restart ComfyUI')
 
   // useActionGuard fires a plain confirm (no details / checkboxes), so
   // ModalDialog routes it through `BaseAlert` — its action button uses
@@ -136,26 +137,16 @@ test('useActionGuard fires cancel-operation when the user confirms cancelling th
   // getProgressInfo flips to null and the guard's poll exits, returning
   // true so the action would proceed.
   await settleInFlightOp({ ok: false, cancelled: true })
-  const verdict = await ctx.panel.evaluate<boolean>('window.__guardPromise')
-  expect(verdict).toBe(true)
+  expect(await readGuardVerdict()).toBe(true)
 })
 
 test('useActionGuard returns false without cancelling when the user dismisses the confirm @lifecycle', async () => {
   await startInFlightOp()
-  await ctx.panel.evaluate<void>(
-    `(() => {
-      window.__guardPromise = window.__e2eRenderer.runActionGuard({
-        installationId: ${JSON.stringify(INSTALL_ID)},
-        actionLabel: 'Restart ComfyUI',
-      })
-    })()`,
-  )
+  await runGuardInBackground('Restart ComfyUI')
 
   await ctx.panel.waitForVisible(byTestId(TID.baseAlertCancel), { timeout: 10_000 })
   expect(await ctx.panel.click(byTestId(TID.baseAlertCancel))).toBe(true)
-
-  const verdict = await ctx.panel.evaluate<boolean>('window.__guardPromise')
-  expect(verdict).toBe(false)
+  expect(await readGuardVerdict()).toBe(false)
 
   // Cancel-operation must NOT fire when the user backs out of the
   // confirm — that would punish them for accidentally hitting an

--- a/e2e/lifecycle-cancel-flow.test.ts
+++ b/e2e/lifecycle-cancel-flow.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Cancel-flow coverage: ProgressModal Return-to-Dashboard against an
+ * in-flight cancellable op, and `useActionGuard.checkBeforeAction`
+ * surfacing the "Operation in progress" confirm + driving its cancel
+ * branch end-to-end.
+ *
+ * Both branches share a controllable in-flight op seeded via
+ * `__e2eRenderer.startInFlightOp` — the apiCall is a Promise the test
+ * resolves with `settleInFlightOp` so the op stays mid-air until the
+ * cancel paths fire their teardown IPCs.
+ */
+
+import os from 'node:os'
+import path from 'node:path'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { test, expect } from '@playwright/test'
+import { launchApp, type AppContext } from './launchApp'
+import { expectChooserVisible } from './support/chooserHelpers'
+import { byTestId, TID } from './support/testIds'
+import {
+  clearRunningSessions,
+  getIpcInvocations,
+  resetIpcInvocations,
+  seedRunningSession,
+} from './support/devHooks'
+
+let ctx: AppContext
+let installPath: string
+
+const INSTALL_ID = 'inst-cancel-flow-test'
+const INSTALL_NAME = 'Cancel Me'
+const MARKER_FILENAME = '.comfyui-desktop-2'
+
+test.describe.configure({ mode: 'serial' })
+
+test.beforeAll(async () => {
+  installPath = await mkdtemp(path.join(os.tmpdir(), 'comfyui-launcher-cancel-flow-e2e-'))
+  await mkdir(installPath, { recursive: true })
+  await writeFile(path.join(installPath, MARKER_FILENAME), INSTALL_ID)
+
+  ctx = await launchApp({
+    settings: { firstUseCompleted: true, telemetryEnabled: false },
+    installations: [
+      {
+        id: INSTALL_ID,
+        name: INSTALL_NAME,
+        installPath,
+        sourceId: 'standalone',
+        status: 'installed',
+      },
+    ],
+  })
+  await expectChooserVisible(ctx.panel)
+})
+
+test.afterAll(async () => {
+  await clearRunningSessions(ctx.app)
+  await ctx?.cleanup()
+  if (installPath) await rm(installPath, { recursive: true, force: true })
+})
+
+test.beforeEach(async () => {
+  await resetIpcInvocations(ctx.app, 'cancel-operation')
+  await resetIpcInvocations(ctx.app, 'stop-comfyui')
+  await clearRunningSessions(ctx.app)
+  // Drop any pending in-flight op left over from a previous test so its
+  // settler can't intercept this test's seed.
+  await ctx.panel.evaluate<boolean>(
+    `window.__e2eRenderer.settleInFlightOp({
+      installationId: ${JSON.stringify(INSTALL_ID)},
+      result: { ok: false, cancelled: true },
+    })`,
+  )
+})
+
+/** Seed an in-flight op whose apiCall stays pending until the test
+ *  resolves it. ProgressModal mounts on the chooser host's takeover
+ *  slot exactly the way a real long-running action would render. */
+async function startInFlightOp(opts: { destroysInstance?: boolean } = {}): Promise<void> {
+  await ctx.panel.evaluate<void>(
+    `(async () => {
+      await window.__e2eRenderer.startInFlightOp({
+        installationId: ${JSON.stringify(INSTALL_ID)},
+        title: 'Updating ComfyUI — ' + ${JSON.stringify(INSTALL_NAME)},
+        opKind: 'update',
+        destroysInstance: ${opts.destroysInstance ? 'true' : 'false'},
+      })
+    })()`,
+  )
+  await ctx.panel.waitForVisible('.brand-progress', { timeout: 10_000 })
+}
+
+async function settleInFlightOp(result: { ok: boolean; cancelled?: boolean }): Promise<void> {
+  await ctx.panel.evaluate<boolean>(
+    `window.__e2eRenderer.settleInFlightOp({
+      installationId: ${JSON.stringify(INSTALL_ID)},
+      result: ${JSON.stringify(result)},
+    })`,
+  )
+}
+
+test('useActionGuard fires cancel-operation when the user confirms cancelling the busy op @lifecycle', async () => {
+  // Active session + in-flight op makes the guard's busy check fire.
+  await startInFlightOp()
+
+  // Run the guard in the background; the confirm modal appears and the
+  // poll waits on the op to clear. Captured on a window-scoped promise
+  // so we can await the verdict after settling.
+  await ctx.panel.evaluate<void>(
+    `(() => {
+      window.__guardPromise = window.__e2eRenderer.runActionGuard({
+        installationId: ${JSON.stringify(INSTALL_ID)},
+        actionLabel: 'Restart ComfyUI',
+      })
+    })()`,
+  )
+
+  // useActionGuard fires a plain confirm (no details / checkboxes), so
+  // ModalDialog routes it through `BaseAlert` — its action button uses
+  // the `baseAlertAction` test id, not `modalConfirm`.
+  await ctx.panel.waitForVisible(byTestId(TID.baseAlertAction), { timeout: 10_000 })
+  expect(await ctx.panel.click(byTestId(TID.baseAlertAction))).toBe(true)
+
+  // The guard fires window.api.cancelOperation immediately after the
+  // user confirms. main records the invocation before the poll starts.
+  await expect
+    .poll(async () => (await getIpcInvocations(ctx.app, 'cancel-operation')).length, {
+      timeout: 5_000,
+      intervals: [100, 200],
+    })
+    .toBeGreaterThanOrEqual(1)
+  const cancelCalls = await getIpcInvocations(ctx.app, 'cancel-operation') as string[]
+  expect(cancelCalls[0]).toBe(INSTALL_ID)
+
+  // Settle the apiCall so progressStore marks the op finished —
+  // getProgressInfo flips to null and the guard's poll exits, returning
+  // true so the action would proceed.
+  await settleInFlightOp({ ok: false, cancelled: true })
+  const verdict = await ctx.panel.evaluate<boolean>('window.__guardPromise')
+  expect(verdict).toBe(true)
+})
+
+test('useActionGuard returns false without cancelling when the user dismisses the confirm @lifecycle', async () => {
+  await startInFlightOp()
+  await ctx.panel.evaluate<void>(
+    `(() => {
+      window.__guardPromise = window.__e2eRenderer.runActionGuard({
+        installationId: ${JSON.stringify(INSTALL_ID)},
+        actionLabel: 'Restart ComfyUI',
+      })
+    })()`,
+  )
+
+  await ctx.panel.waitForVisible(byTestId(TID.baseAlertCancel), { timeout: 10_000 })
+  expect(await ctx.panel.click(byTestId(TID.baseAlertCancel))).toBe(true)
+
+  const verdict = await ctx.panel.evaluate<boolean>('window.__guardPromise')
+  expect(verdict).toBe(false)
+
+  // Cancel-operation must NOT fire when the user backs out of the
+  // confirm — that would punish them for accidentally hitting an
+  // action against a busy install.
+  const cancelCalls = await getIpcInvocations(ctx.app, 'cancel-operation')
+  expect(cancelCalls.length).toBe(0)
+
+  // Clean up the seeded op so the next test starts fresh.
+  await settleInFlightOp({ ok: false, cancelled: true })
+})
+
+test('Return-to-Dashboard from in-flight op cancels and closes the takeover @lifecycle', async () => {
+  // Seed a real running session so the local-install confirm prompt
+  // appears (cloud / remote skip the prompt).
+  await seedRunningSession(ctx.app, {
+    installationId: INSTALL_ID,
+    installationName: INSTALL_NAME,
+  })
+  // Wait for the renderer to see the install as running — without this
+  // the operation would resolve too fast and the user's perception of
+  // running state would race the broadcast.
+  await expect
+    .poll(
+      async () => ctx.panel.evaluate<boolean>(
+        `window.__e2eRenderer.isRunning(${JSON.stringify(INSTALL_ID)})`,
+      ),
+      { timeout: 5_000, intervals: [100, 200] },
+    )
+    .toBe(true)
+
+  await startInFlightOp()
+  // The footer renders the Return-to-Dashboard button only when the op
+  // is non-destroying (otherwise Cancel takes its place).
+  expect(await ctx.panel.clickByText('button', 'Return to Dashboard')).toBe(true)
+
+  // Local-install in-flight: ModalDialog confirm appears as a simple
+  // confirm (no details / checkboxes), so it routes through BaseAlert.
+  await ctx.panel.waitForVisible(byTestId(TID.baseAlertAction), { timeout: 10_000 })
+  expect(await ctx.panel.click(byTestId(TID.baseAlertAction))).toBe(true)
+
+  // progressStore.cancelOperation fires both cancel-operation and
+  // stop-comfyui — the latter is what actually drops the running
+  // session so the install isn't orphaned.
+  await expect
+    .poll(async () => (await getIpcInvocations(ctx.app, 'cancel-operation')).length, {
+      timeout: 5_000,
+      intervals: [100, 200],
+    })
+    .toBeGreaterThanOrEqual(1)
+  await expect
+    .poll(async () => (await getIpcInvocations(ctx.app, 'stop-comfyui')).length, {
+      timeout: 5_000,
+      intervals: [100, 200],
+    })
+    .toBeGreaterThanOrEqual(1)
+
+  const cancelCalls = await getIpcInvocations(ctx.app, 'cancel-operation') as string[]
+  expect(cancelCalls[0]).toBe(INSTALL_ID)
+
+  // Takeover closes — `.brand-progress` is unmounted.
+  await expect
+    .poll(async () => ctx.panel.exists('.brand-progress'), {
+      timeout: 5_000,
+      intervals: [100, 200],
+    })
+    .toBe(false)
+
+  // Resolve the apiCall so the op cleans up. cancelOperation does not
+  // mark op.finished — the promise has to settle for the store to
+  // clear the op.
+  await settleInFlightOp({ ok: false, cancelled: true })
+})

--- a/src/main/lib/ipc/registerSessionHandlers.ts
+++ b/src/main/lib/ipc/registerSessionHandlers.ts
@@ -41,6 +41,7 @@ export function registerSessionHandlers(): void {
   })
 
   ipcMain.handle('cancel-operation', (_event, installationId: string) => {
+    recordIpcInvocation('cancel-operation', installationId)
     const abort = _operationAborts.get(installationId)
     if (abort) {
       abort.abort()

--- a/src/renderer/src/composables/useActionGuard.test.ts
+++ b/src/renderer/src/composables/useActionGuard.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string, params?: Record<string, unknown>) =>
+      params ? `${key}:${JSON.stringify(params)}` : key,
+  }),
+}))
+
+const mockConfirm = vi.hoisted(() => vi.fn())
+vi.mock('./useModal', () => ({
+  useModal: () => ({ confirm: mockConfirm }),
+}))
+
+const sessionState = vi.hoisted(() => ({
+  activeSessions: new Map<string, { label: string }>(),
+  launching: new Set<string>(),
+  stopping: new Set<string>(),
+  running: new Set<string>(),
+}))
+vi.mock('../stores/sessionStore', () => ({
+  useSessionStore: () => ({
+    activeSessions: sessionState.activeSessions,
+    isLaunching: (id: string) => sessionState.launching.has(id),
+    isStopping: (id: string) => sessionState.stopping.has(id),
+    isRunning: (id: string) => sessionState.running.has(id),
+  }),
+}))
+
+const progressState = vi.hoisted(() => ({
+  info: new Map<string, { status: string; percent: number } | null>(),
+}))
+vi.mock('../stores/progressStore', () => ({
+  useProgressStore: () => ({
+    getProgressInfo: (id: string) => progressState.info.get(id) ?? null,
+  }),
+}))
+
+const mockCancelOperation = vi.hoisted(() => vi.fn())
+;(globalThis as unknown as { window: { api: { cancelOperation: typeof mockCancelOperation } } })
+  .window = { api: { cancelOperation: mockCancelOperation } }
+
+import { useActionGuard } from './useActionGuard'
+
+const INSTALL_ID = 'inst-guard-test'
+
+describe('useActionGuard.checkBeforeAction', () => {
+  beforeEach(() => {
+    sessionState.activeSessions.clear()
+    sessionState.launching.clear()
+    sessionState.stopping.clear()
+    sessionState.running.clear()
+    progressState.info.clear()
+    mockConfirm.mockReset()
+    mockCancelOperation.mockReset()
+  })
+
+  it('proceeds immediately when the install is idle', async () => {
+    const { checkBeforeAction } = useActionGuard()
+    const ok = await checkBeforeAction(INSTALL_ID, 'Restart')
+    expect(ok).toBe(true)
+    expect(mockConfirm).not.toHaveBeenCalled()
+    expect(mockCancelOperation).not.toHaveBeenCalled()
+  })
+
+  it('returns false without cancelling when the user dismisses the confirm', async () => {
+    sessionState.launching.add(INSTALL_ID)
+    mockConfirm.mockResolvedValue(false)
+
+    const ok = await useActionGuard().checkBeforeAction(INSTALL_ID, 'Restart')
+
+    expect(ok).toBe(false)
+    expect(mockConfirm).toHaveBeenCalledOnce()
+    expect(mockCancelOperation).not.toHaveBeenCalled()
+  })
+
+  it('cancels then polls until the in-flight op clears', async () => {
+    sessionState.activeSessions.set(INSTALL_ID, { label: 'Updating ComfyUI' })
+    progressState.info.set(INSTALL_ID, { status: 's', percent: -1 })
+    mockConfirm.mockResolvedValue(true)
+
+    const pending = useActionGuard().checkBeforeAction(INSTALL_ID, 'Restart')
+    // Let the poll iterate a couple of times before the op clears.
+    await new Promise((r) => setTimeout(r, 250))
+    expect(mockCancelOperation).toHaveBeenCalledWith(INSTALL_ID)
+    progressState.info.set(INSTALL_ID, null)
+
+    expect(await pending).toBe(true)
+  })
+
+  it('exits the poll on the 10s deadline even if the op never clears', async () => {
+    sessionState.activeSessions.set(INSTALL_ID, { label: 'Stuck' })
+    progressState.info.set(INSTALL_ID, { status: 's', percent: -1 })
+    mockConfirm.mockResolvedValue(true)
+
+    vi.useFakeTimers()
+    try {
+      const pending = useActionGuard().checkBeforeAction(INSTALL_ID, 'Restart')
+      await vi.advanceTimersByTimeAsync(10_500)
+      expect(await pending).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/src/renderer/src/composables/useActionGuard.ts
+++ b/src/renderer/src/composables/useActionGuard.ts
@@ -1,5 +1,6 @@
 import { useI18n } from 'vue-i18n'
 import { useSessionStore } from '../stores/sessionStore'
+import { useProgressStore } from '../stores/progressStore'
 import { useModal } from './useModal'
 
 /**
@@ -12,6 +13,7 @@ import { useModal } from './useModal'
 export function useActionGuard() {
   const { t } = useI18n()
   const sessionStore = useSessionStore()
+  const progressStore = useProgressStore()
   const modal = useModal()
 
   async function checkBeforeAction(installationId: string, actionLabel: string): Promise<boolean> {
@@ -27,7 +29,17 @@ export function useActionGuard() {
       })
       if (!confirmed) return false
       await window.api.cancelOperation(installationId)
-      await new Promise((r) => setTimeout(r, 500))
+      // Wait for the cancelled op to clear instead of guessing how long
+      // teardown takes — mirrors `stopAndWaitForExit`. The deadline is
+      // generous because Windows taskkill / Restart Manager can be slow;
+      // the next action would race the cancel without it.
+      const deadline = Date.now() + 10_000
+      while (
+        (progressStore.getProgressInfo(installationId) !== null || sessionStore.isStopping(installationId)) &&
+        Date.now() < deadline
+      ) {
+        await new Promise((r) => setTimeout(r, 100))
+      }
     }
 
     return true

--- a/src/renderer/src/panel/PanelApp.vue
+++ b/src/renderer/src/panel/PanelApp.vue
@@ -25,6 +25,7 @@ import { useSendFeedback } from '../composables/useSendFeedback'
 import { emitTelemetryAction } from '../lib/telemetry'
 import { useDeepLinkRouter } from '../composables/useDeepLinkRouter'
 import { useInstallContextMenu } from '../composables/useInstallContextMenu'
+import { useActionGuard } from '../composables/useActionGuard'
 import { registerMigrateTakeover } from '../composables/useMigrateAction'
 import { isFlowPanel, isValidPanel, usePanelOverlays } from './usePanelOverlays'
 import { useChooserHandoff } from './useChooserHandoff'
@@ -153,7 +154,10 @@ const {
 // matching the registration gate in `panel/main.ts`; `__e2eRenderer`
 // is never present in production.
 if (params.get('e2e') === '1') {
-  bindE2EPanelHooks({ showProgress: handleShowProgress })
+  bindE2EPanelHooks({
+    showProgress: handleShowProgress,
+    actionGuard: useActionGuard(),
+  })
 }
 
 const firstUseTakeoverActive = computed(

--- a/src/renderer/src/panel/e2eRendererHooks.ts
+++ b/src/renderer/src/panel/e2eRendererHooks.ts
@@ -12,7 +12,7 @@
  * no-op outside the test runner.
  */
 import { useSessionStore } from '../stores/sessionStore'
-import type { ShowProgressOpts } from '../types/ipc'
+import type { ActionResult, ShowProgressOpts } from '../types/ipc'
 
 export interface InjectProgressErrorOpts {
   installationId: string
@@ -35,11 +35,33 @@ export interface InjectProgressSuccessOpts {
   newInstallationId?: string
 }
 
+export interface StartInFlightOpOpts {
+  installationId: string
+  title?: string
+  opKind?: ShowProgressOpts['opKind']
+  /** Marks the op as non-destroying (default) so ProgressModal renders
+   *  the Return-to-Dashboard footer button rather than Cancel. */
+  destroysInstance?: boolean
+  triggersInstanceStart?: boolean
+}
+
+export interface SettleInFlightOpOpts {
+  installationId: string
+  result: ActionResult
+}
+
 interface PanelBindings {
   showProgress: (opts: ShowProgressOpts) => Promise<void> | void
+  actionGuard: { checkBeforeAction: (id: string, label: string) => Promise<boolean> }
 }
 
 let bindings: PanelBindings | null = null
+
+/** Deferred apiCall promises for ops seeded via `startInFlightOp`,
+ *  keyed by installationId so `settleInFlightOp` can resolve the right
+ *  one. Module-level so the renderer's progressStore captures the same
+ *  promise reference its `then` chain awaits. */
+const inFlightSettlers = new Map<string, (result: ActionResult) => void>()
 
 export interface E2ERendererHelpers {
   /** Drive the PanelApp's normal show-progress chain with an `apiCall`
@@ -68,6 +90,20 @@ export interface E2ERendererHelpers {
   seedErrorInstance(opts: { installationId: string; installationName: string; message?: string }): void
   /** True iff `sessionStore.errorInstances` has an entry for the id. */
   hasErrorInstance(installationId: string): boolean
+  /** Seed an in-flight op whose `apiCall` is a controllable Promise so
+   *  the op stays pending until `settleInFlightOp` resolves it. Lets
+   *  tests exercise the busy-guard / Return-to-Dashboard / cancel-flow
+   *  branches without driving a real long-running action. */
+  startInFlightOp(opts: StartInFlightOpOpts): Promise<void>
+  /** Resolve the deferred `apiCall` for a pending in-flight op. Returns
+   *  `false` if no settler exists (op was never seeded, or already
+   *  resolved). */
+  settleInFlightOp(opts: SettleInFlightOpOpts): boolean
+  /** Run `useActionGuard.checkBeforeAction(installationId, label)`
+   *  directly so the test can drive the busy-guard surface without
+   *  going through a real action runner. Returns the guard's verdict
+   *  (true = proceed, false = user cancelled the confirm). */
+  runActionGuard(opts: { installationId: string; actionLabel: string }): Promise<boolean>
 }
 
 function ensureBound(): PanelBindings {
@@ -126,6 +162,33 @@ export function registerE2ERendererHooks(): void {
     },
     hasErrorInstance(installationId) {
       return useSessionStore().errorInstances.has(installationId)
+    },
+    async startInFlightOp({ installationId, title, opKind, destroysInstance, triggersInstanceStart }) {
+      const b = ensureBound()
+      // Replace any prior settler for the same id so a leaked op from a
+      // previous test can't intercept this one's resolve.
+      inFlightSettlers.get(installationId)?.({ ok: false, cancelled: true })
+      const pending = new Promise<ActionResult>((resolve) => {
+        inFlightSettlers.set(installationId, resolve)
+      })
+      await b.showProgress({
+        installationId,
+        title: title ?? `In-flight — ${installationId}`,
+        opKind: opKind ?? 'generic',
+        destroysInstance: destroysInstance ?? false,
+        triggersInstanceStart: triggersInstanceStart ?? false,
+        apiCall: () => pending,
+      })
+    },
+    settleInFlightOp({ installationId, result }) {
+      const settle = inFlightSettlers.get(installationId)
+      if (!settle) return false
+      inFlightSettlers.delete(installationId)
+      settle(result)
+      return true
+    },
+    runActionGuard({ installationId, actionLabel }) {
+      return ensureBound().actionGuard.checkBeforeAction(installationId, actionLabel)
     },
   }
   ;(globalThis as unknown as { __e2eRenderer: E2ERendererHelpers }).__e2eRenderer = helpers


### PR DESCRIPTION
Issue #591 audit follow-up — cancel-flow cluster.

## Lifecycle gap #25 — useActionGuard confirm-cancel flow

No test previously drove the `Operation in progress` confirm
+ `cancelOperation` IPC path. New `e2e/lifecycle-cancel-flow.test.ts` seeds
an in-flight op via the new `__e2eRenderer.startInFlightOp` helper, runs
`useActionGuard.checkBeforeAction` directly through `runActionGuard`, asserts
the BaseAlert confirm appears, clicks confirm, asserts `cancel-operation`
IPC fires, settles the deferred apiCall, and asserts the guard resolves to
`true`. A second test covers the dismiss branch (modal cancel → guard
returns `false`, no IPC fires).

## Lifecycle gap #20 — ProgressModal Return-to-Dashboard from in-flight op

Same in-flight-op helper + a seeded running session feeds ProgressModal's
`returnToDashboard('in_flight')` path. Asserts both `cancel-operation`
and `stop-comfyui` IPCs fire and the `.brand-progress` takeover unmounts.

## Annoying #3 — useActionGuard 500ms sleep

Replaces the unconditional `setTimeout(500)` after `window.api.cancelOperation`
with a poll on `!progressStore.getProgressInfo(id) && !sessionStore.isStopping(id)`
(10s deadline, 100ms interval). Mirrors `stopAndWaitForExit`'s shape — the
fixed sleep raced Windows taskkill / Restart Manager teardown on slow paths
and was needless friction on fast ones. New unit test covers the idle / cancel
/ poll-clears / deadline branches.

## Test infra

- `__e2eRenderer.startInFlightOp({ installationId, ... })` — seeds a
  progressStore op whose `apiCall` is a controllable Promise kept pending
  in a module-level settler Map.
- `__e2eRenderer.settleInFlightOp({ installationId, result })` — resolves
  the pending Promise so the op finishes and progressStore cleans up.
- `__e2eRenderer.runActionGuard({ installationId, actionLabel })` —
  exposes `useActionGuard.checkBeforeAction` (bound from `PanelApp.vue`'s
  setup) so tests drive the busy-guard surface without a real action runner.
- `recordIpcInvocation('cancel-operation', ...)` added to the main-side
  handler so tests can observe the cancel IPC.

Base: main @ fd69bf3. Independent of the two open audit PRs
(#597 / #598).