### PR TITLE
test(deep-links): cover comfy:// URL routing for open-settings + install-update

### DIFF
--- a/e2e/lifecycle-deep-links.test.ts
+++ b/e2e/lifecycle-deep-links.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Lifecycle E2E: `comfy://` deep links.
+ *
+ * Main forwards `comfy://` URL clicks into the host's panel webContents
+ * as `panel-trigger-overlay` IPCs (see `index.ts` / `titlePopup.ts`).
+ * The renderer-side dispatcher is `useDeepLinkRouter`, which fans out
+ * to either the instance-picker popup or the global-settings popup
+ * depending on the payload kind.
+ *
+ * This test replays the IPC directly into the chooser host's panel
+ * webContents and asserts the corresponding main-side popup IPC fires.
+ * The install-backed expansion of these deep links is covered at the
+ * unit level by `PanelApp.test.ts` (mountPanel runs with
+ * `installationId=test-id` in the URL), which is the same callback
+ * the IPC dispatches into here.
+ */
+import os from 'node:os'
+import path from 'node:path'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { test, expect } from '@playwright/test'
+import { launchApp, type AppContext } from './launchApp'
+import { expectChooserVisible } from './support/chooserHelpers'
+import { getIpcInvocations, resetIpcInvocations } from './support/devHooks'
+
+let ctx: AppContext
+let installPath: string
+
+const INSTALL_ID = 'inst-deep-link-test'
+const INSTALL_NAME = 'Deep Link Target'
+const MARKER_FILENAME = '.comfyui-desktop-2'
+
+interface OpenInstancePickerCall {
+  installationId: string | null
+  mode: 'compact' | 'expanded'
+  initialTab: string | null
+  autoAction: string | null
+}
+
+test.describe.configure({ mode: 'serial' })
+
+test.beforeAll(async () => {
+  installPath = await mkdtemp(path.join(os.tmpdir(), 'comfyui-launcher-deep-links-e2e-'))
+  await mkdir(installPath, { recursive: true })
+  await writeFile(path.join(installPath, MARKER_FILENAME), INSTALL_ID)
+
+  ctx = await launchApp({
+    settings: { firstUseCompleted: true, telemetryEnabled: false },
+    installations: [
+      {
+        id: INSTALL_ID,
+        name: INSTALL_NAME,
+        installPath,
+        sourceId: 'standalone',
+        status: 'installed',
+      },
+    ],
+  })
+  await expectChooserVisible(ctx.panel)
+})
+
+test.afterAll(async () => {
+  await ctx?.cleanup()
+  if (installPath) await rm(installPath, { recursive: true, force: true })
+})
+
+const PICKER_CHANNEL = 'comfy-window:open-instance-picker-for-install'
+const GLOBAL_SETTINGS_CHANNEL = 'comfy-titlepopup:open-global-settings'
+
+test.beforeEach(async () => {
+  await resetIpcInvocations(ctx.app, PICKER_CHANNEL)
+  await resetIpcInvocations(ctx.app, GLOBAL_SETTINGS_CHANNEL)
+})
+
+/** Replay a `panel-trigger-overlay` payload into the chooser host's
+ *  panel webContents — the same IPC main fires when a `comfy://` URL
+ *  is dispatched. */
+async function fireDeepLink(payload: Record<string, unknown>): Promise<void> {
+  await ctx.app.evaluate(({ webContents }, p) => {
+    const wc = webContents.getAllWebContents().find((w) => w.getURL().includes('panel.html'))
+    if (!wc) throw new Error('panel webContents not found')
+    wc.send('panel-trigger-overlay', p)
+  }, payload)
+}
+
+test('comfy://open-settings?tab=global opens Global Settings @lifecycle', async () => {
+  await fireDeepLink({ kind: 'open-settings', settingsTab: 'global' })
+
+  await expect
+    .poll(
+      async () => (await getIpcInvocations(ctx.app, GLOBAL_SETTINGS_CHANNEL)).length,
+      { timeout: 5_000, intervals: [100, 200] },
+    )
+    .toBe(1)
+
+  // The picker popup must NOT have opened — `tab=global` is a
+  // dedicated branch in `useDeepLinkRouter` that never falls through
+  // to `openInstancePicker`.
+  const pickerCalls = await getIpcInvocations(ctx.app, PICKER_CHANNEL)
+  expect(pickerCalls.length).toBe(0)
+})
+
+test('comfy://open-settings?tab=comfy on chooser host opens the picker (compact fallback) @lifecycle', async () => {
+  // Chooser host has no install backing it, so `useDeepLinkRouter`
+  // falls through to the compact picker so the user can pick an
+  // install before landing on its Config tab. Install-backed hosts
+  // get expanded mode + Config tab — that variant is covered by
+  // `PanelApp.test.ts` (mounted with `installationId=test-id`).
+  await fireDeepLink({ kind: 'open-settings', settingsTab: 'comfy' })
+
+  await expect
+    .poll(
+      async () => (await getIpcInvocations(ctx.app, PICKER_CHANNEL)).length,
+      { timeout: 5_000, intervals: [100, 200] },
+    )
+    .toBe(1)
+
+  const calls = await getIpcInvocations(ctx.app, PICKER_CHANNEL) as OpenInstancePickerCall[]
+  // Chooser fallback fires `openInstancePicker()` with no args; the
+  // preload bridge normalises that into a payload with `installationId`
+  // null and `mode: 'compact'` so the picker opens unanchored to any install.
+  expect(calls[0]).toMatchObject({
+    installationId: null,
+    mode: 'compact',
+    initialTab: null,
+  })
+
+  const globalCalls = await getIpcInvocations(ctx.app, GLOBAL_SETTINGS_CHANNEL)
+  expect(globalCalls.length).toBe(0)
+})
+
+test('comfy://install-update with a non-matching installationId is ignored on chooser host @lifecycle', async () => {
+  // The chooser host's `opts.installationId` is the empty string. The
+  // `install-update` branch guards on `!id || id !== opts.installationId`
+  // so a payload for an unrelated install must NOT open any popup
+  // — protects the dispatch from firing on the wrong window. The
+  // matching-id case is covered at the unit level by `PanelApp.test.ts`.
+  await fireDeepLink({ kind: 'install-update', installationId: INSTALL_ID })
+
+  // Round-trip a follow-up `open-settings tab=global` payload so the
+  // panel renderer drains the install-update payload before we assert.
+  // If install-update had (wrongly) fired the picker IPC, the picker
+  // count would already be >= 1 by the time the global-settings handler
+  // ran on main.
+  await fireDeepLink({ kind: 'open-settings', settingsTab: 'global' })
+  await expect
+    .poll(
+      async () => (await getIpcInvocations(ctx.app, GLOBAL_SETTINGS_CHANNEL)).length,
+      { timeout: 5_000, intervals: [100, 200] },
+    )
+    .toBe(1)
+
+  const pickerCalls = await getIpcInvocations(ctx.app, PICKER_CHANNEL)
+  expect(pickerCalls.length).toBe(0)
+})

--- a/src/main/popups/titlePopup.ts
+++ b/src/main/popups/titlePopup.ts
@@ -2218,12 +2218,6 @@ export function registerTitlePopupIpc(bindings: TitlePopupHostBindings): void {
         typeof payload?.initialTab === 'string' ? payload.initialTab : null
       const autoAction =
         typeof payload?.autoAction === 'string' ? payload.autoAction : null
-      recordIpcInvocation('open-instance-picker', {
-        installationId: selectedInstallationId,
-        mode,
-        initialTab,
-        autoAction,
-      })
       openInstancePickerForHost(
         parentEntry,
         parentEntryId,
@@ -2565,7 +2559,6 @@ export function registerTitlePopupIpc(bindings: TitlePopupHostBindings): void {
       }
     }
     if (parentEntryId === undefined || !parentEntry) return
-    recordIpcInvocation('open-global-settings', { windowId: win.id })
     openGlobalSettingsForHost(
       parentEntry,
       parentEntryId,

--- a/src/main/popups/titlePopup.ts
+++ b/src/main/popups/titlePopup.ts
@@ -35,6 +35,7 @@ import {
   hideTitleTooltipPopup,
 } from './titleTooltip'
 import { EmbeddedPopupView } from './embeddedPopupView'
+import { recordIpcInvocation } from '../lib/e2eOverrides'
 
 /**
  * Title-bar dropdown popups (waffle menu, downloads tray). All title-bar
@@ -2195,6 +2196,7 @@ export function registerTitlePopupIpc(bindings: TitlePopupHostBindings): void {
         }
         | undefined,
     ) => {
+      recordIpcInvocation('comfy-window:open-instance-picker-for-install', payload)
       const win = BrowserWindow.fromWebContents(event.sender)
       if (!win || win.isDestroyed()) return
       let parentEntryId: number | undefined
@@ -2216,6 +2218,12 @@ export function registerTitlePopupIpc(bindings: TitlePopupHostBindings): void {
         typeof payload?.initialTab === 'string' ? payload.initialTab : null
       const autoAction =
         typeof payload?.autoAction === 'string' ? payload.autoAction : null
+      recordIpcInvocation('open-instance-picker', {
+        installationId: selectedInstallationId,
+        mode,
+        initialTab,
+        autoAction,
+      })
       openInstancePickerForHost(
         parentEntry,
         parentEntryId,
@@ -2544,6 +2552,7 @@ export function registerTitlePopupIpc(bindings: TitlePopupHostBindings): void {
   // the `comfy://open-settings?tab=global` deep link, both of which
   // previously opened the legacy SettingsModal overlay.
   ipcMain.on('comfy-titlepopup:open-global-settings', (event) => {
+    recordIpcInvocation('comfy-titlepopup:open-global-settings')
     const win = BrowserWindow.fromWebContents(event.sender)
     if (!win || win.isDestroyed()) return
     let parentEntryId: number | undefined
@@ -2556,6 +2565,7 @@ export function registerTitlePopupIpc(bindings: TitlePopupHostBindings): void {
       }
     }
     if (parentEntryId === undefined || !parentEntry) return
+    recordIpcInvocation('open-global-settings', { windowId: win.id })
     openGlobalSettingsForHost(
       parentEntry,
       parentEntryId,

--- a/src/renderer/src/panel/PanelApp.test.ts
+++ b/src/renderer/src/panel/PanelApp.test.ts
@@ -744,6 +744,54 @@ it('opens the new-install takeover above the chooser body when show-new-install 
     })
   })
 
+  it('opens the instance picker (expanded, Config tab) when a panel-trigger-overlay open-settings event arrives with tab=comfy', async () => {
+    // `comfy://open-settings?tab=comfy` on an install-backed host
+    // opens the picker in expanded mode on the Config tab — the same
+    // surface the title-bar Settings entry routes to.
+    mountPanel()
+    await flushPromises()
+    const api = (
+      window as unknown as { api: {
+        openInstancePicker: ReturnType<typeof vi.fn>
+        openGlobalSettings: ReturnType<typeof vi.fn>
+      } }
+    ).api
+
+    mockState.panelTriggerOverlayCallbacks.forEach((cb) =>
+      cb({ kind: 'open-settings', settingsTab: 'comfy' }),
+    )
+    await flushPromises()
+
+    expect(api.openInstancePicker).toHaveBeenCalledTimes(1)
+    expect(api.openInstancePicker).toHaveBeenCalledWith({
+      installationId: 'test-id',
+      mode: 'expanded',
+      initialTab: 'config',
+    })
+    expect(api.openGlobalSettings).not.toHaveBeenCalled()
+  })
+
+  it('opens global settings when a panel-trigger-overlay open-settings event arrives with tab=global', async () => {
+    // `comfy://open-settings?tab=global` routes to the dedicated
+    // Global Settings popup regardless of which host received it.
+    mountPanel()
+    await flushPromises()
+    const api = (
+      window as unknown as { api: {
+        openInstancePicker: ReturnType<typeof vi.fn>
+        openGlobalSettings: ReturnType<typeof vi.fn>
+      } }
+    ).api
+
+    mockState.panelTriggerOverlayCallbacks.forEach((cb) =>
+      cb({ kind: 'open-settings', settingsTab: 'global' }),
+    )
+    await flushPromises()
+
+    expect(api.openGlobalSettings).toHaveBeenCalledTimes(1)
+    expect(api.openInstancePicker).not.toHaveBeenCalled()
+  })
+
   it('shows the "Desktop Update Ready" confirm modal when a restart-prompt event arrives, and installs on confirm', async () => {
     // Issue #488 — auto-on click on the 'ready' pill (or the auto
     // restart-prompt that fires on user-initiated download


### PR DESCRIPTION
Lifecycle #14 from the #591 audit — coverage for useDeepLinkRouter's panel-trigger-overlay dispatch.

## E2E (e2e/lifecycle-deep-links.test.ts)

Replays the panel-trigger-overlay IPC into the chooser host's panel webContents via webContents.send and asserts the corresponding main-side popup IPC fires:

- comfy://open-settings?tab=global → comfy-titlepopup:open-global-settings
- comfy://open-settings?tab=comfy on chooser host → comfy-window:open-instance-picker-for-install (compact fallback, installationId: null)
- comfy://install-update with a non-matching installationId → ignored (guarded out)

## Unit (PanelApp.test.ts)

Two new tests cover the install-backed expansion of open-settings (the chooser host fallback in the e2e doesn't reach this branch):

- open-settings tab=comfy on install-backed panel → openInstancePicker({ mode: 'expanded', initialTab: 'config' })
- open-settings tab=global → openGlobalSettings() only

The matching install-update case is already covered by the existing test at line 721.

## Main

Adds recordIpcInvocation to the two downstream popup IPCs (comfy-window:open-instance-picker-for-install and comfy-titlepopup:open-global-settings) so e2e can assert delivery without UI-level scraping.

## Validation

- pnpm typecheck ✓
- pnpm lint ✓
- pnpm build ✓
- pnpm test ✓ (1138/1138 vitest)
- pnpm exec playwright test e2e/lifecycle-deep-links.test.ts --repeat-each=3 ✓ (9/9)