### PR TITLE
test(lifecycle): synthetic restart + ProgressModal Reboot of errored install

### DIFF
--- a/e2e/lifecycle-progress-reboot.test.ts
+++ b/e2e/lifecycle-progress-reboot.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Lifecycle E2E: ProgressModal "Reboot" of an errored install (lifecycle
+ * audit gap #24).
+ *
+ * Distinct from the failure-then-retry path (#7) — here the install is
+ * already in `sessionStore.errorInstances` BEFORE the user interacts with
+ * the ProgressModal. We seed an errorInstance directly, then drive a
+ * retryable apiCall through `injectRetryableProgressError` so the op
+ * lands in ProgressModal's error footer; clicking Reboot must re-invoke
+ * the SAME `op.apiCall` (proven by the call-counter helper) and the op
+ * must transition back through running → finished/ok in place.
+ */
+
+import os from 'node:os'
+import path from 'node:path'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { test, expect } from '@playwright/test'
+import { launchApp, type AppContext } from './launchApp'
+import { expectChooserVisible } from './support/chooserHelpers'
+import { byTestId, TID } from './support/testIds'
+
+let ctx: AppContext
+let installPath: string
+
+const INSTALL_ID = 'inst-reboot-errored-test'
+const INSTALL_NAME = 'Errored Reboot Install'
+const MARKER_FILENAME = '.comfyui-desktop-2'
+const PRE_EXISTING_ERROR = 'Earlier crash: ComfyUI exited with code 1'
+const OP_FAILURE_MESSAGE = 'Initial op failure: simulated launch failure'
+
+test.describe.configure({ mode: 'serial' })
+
+test.beforeAll(async () => {
+  installPath = await mkdtemp(path.join(os.tmpdir(), 'comfyui-launcher-reboot-errored-e2e-'))
+  await mkdir(installPath, { recursive: true })
+  await writeFile(path.join(installPath, MARKER_FILENAME), INSTALL_ID)
+
+  ctx = await launchApp({
+    settings: { firstUseCompleted: true, telemetryEnabled: false },
+    installations: [
+      {
+        id: INSTALL_ID,
+        name: INSTALL_NAME,
+        installPath,
+        sourceId: 'standalone',
+        status: 'installed',
+      },
+    ],
+  })
+  await expectChooserVisible(ctx.panel)
+})
+
+test.afterAll(async () => {
+  await ctx?.cleanup()
+  if (installPath) await rm(installPath, { recursive: true, force: true })
+})
+
+test('ProgressModal Reboot re-runs the same apiCall to recover an errored install @lifecycle', async () => {
+  // Seed a pre-existing errorInstance to mimic the audit's #24 setup —
+  // the install was already errored before the user took any action
+  // against it (distinct from #7, where the error originates inside the
+  // op the user just launched).
+  await ctx.panel.evaluate<void>(`(() => {
+    window.__e2eRenderer.seedErrorInstance({
+      installationId: ${JSON.stringify(INSTALL_ID)},
+      installationName: ${JSON.stringify(INSTALL_NAME)},
+      message: ${JSON.stringify(PRE_EXISTING_ERROR)},
+    })
+  })()`)
+  const seeded = await ctx.panel.evaluate<boolean>(
+    `window.__e2eRenderer.hasErrorInstance(${JSON.stringify(INSTALL_ID)})`,
+  )
+  expect(seeded, 'seedErrorInstance must register the install in errorInstances').toBe(true)
+
+  // Inject a retryable failing op: first apiCall returns
+  // `{ ok: false, message }`, the next one (driven by Reboot) returns
+  // `{ ok: true }`. progressStore writes the failure into
+  // `currentOp.error` AND replaces the errorInstance entry with the
+  // op-failure message — exercising the same store path the production
+  // failure flow takes.
+  await ctx.panel.evaluate<void>(`(async () => {
+    await window.__e2eRenderer.injectRetryableProgressError({
+      installationId: ${JSON.stringify(INSTALL_ID)},
+      title: 'Launching ComfyUI',
+      errorMessage: ${JSON.stringify(OP_FAILURE_MESSAGE)},
+      failuresBeforeSuccess: 1,
+    })
+  })()`)
+
+  // Error footer appears.
+  await ctx.panel.waitForVisible(byTestId(TID.progressErrorMessage), { timeout: 10_000 })
+  await ctx.panel.waitForVisible(byTestId(TID.progressReboot), { timeout: 10_000 })
+
+  // The apiCall has been invoked exactly once at this point.
+  const beforeReboot = await ctx.panel.evaluate<number>(
+    `window.__e2eRenderer.getInjectedApiCallCount(${JSON.stringify(INSTALL_ID)})`,
+  )
+  expect(beforeReboot, 'apiCall must have run once for the seeded failure').toBe(1)
+
+  // Click Reboot. handleReboot calls `progressStore.startOperation`
+  // with `op.apiCall || (() => runAction(id, 'launch'))` — proving the
+  // re-run requires the counter to advance to 2 (NOT a fresh
+  // runAction('launch') fallback, which would leave the counter at 1).
+  expect(await ctx.panel.click(byTestId(TID.progressReboot))).toBe(true)
+
+  // Counter advances: same closure was re-invoked.
+  await expect
+    .poll(
+      () =>
+        ctx.panel.evaluate<number>(
+          `window.__e2eRenderer.getInjectedApiCallCount(${JSON.stringify(INSTALL_ID)})`,
+        ),
+      { timeout: 5_000, intervals: [100, 200] },
+    )
+    .toBeGreaterThanOrEqual(2)
+
+  // Op transitions back to in-flight (error footer disappears), then
+  // resolves with `{ ok: true }` and the auto-close watcher tears the
+  // takeover down — `.brand-progress` leaves the DOM.
+  await expect
+    .poll(
+      () =>
+        ctx.panel.evaluate<boolean>(
+          `(() => !!document.querySelector('${byTestId(TID.progressErrorMessage)}'))()`,
+        ),
+      { timeout: 10_000, intervals: [100, 200] },
+    )
+    .toBe(false)
+  await expect
+    .poll(
+      () =>
+        ctx.panel.evaluate<boolean>(
+          `(() => !!document.querySelector('.brand-progress'))()`,
+        ),
+      { timeout: 10_000, intervals: [200, 500] },
+    )
+    .toBe(false)
+})

--- a/e2e/lifecycle-progress-reboot.test.ts
+++ b/e2e/lifecycle-progress-reboot.test.ts
@@ -118,21 +118,15 @@ test('ProgressModal Reboot re-runs the same apiCall to recover an errored instal
   // resolves with `{ ok: true }` and the auto-close watcher tears the
   // takeover down — `.brand-progress` leaves the DOM.
   await expect
-    .poll(
-      () =>
-        ctx.panel.evaluate<boolean>(
-          `(() => !!document.querySelector('${byTestId(TID.progressErrorMessage)}'))()`,
-        ),
-      { timeout: 10_000, intervals: [100, 200] },
-    )
+    .poll(() => ctx.panel.exists(byTestId(TID.progressErrorMessage)), {
+      timeout: 10_000,
+      intervals: [100, 200],
+    })
     .toBe(false)
   await expect
-    .poll(
-      () =>
-        ctx.panel.evaluate<boolean>(
-          `(() => !!document.querySelector('.brand-progress'))()`,
-        ),
-      { timeout: 10_000, intervals: [200, 500] },
-    )
+    .poll(() => ctx.panel.exists('.brand-progress'), {
+      timeout: 10_000,
+      intervals: [200, 500],
+    })
     .toBe(false)
 })

--- a/e2e/lifecycle.test.ts
+++ b/e2e/lifecycle.test.ts
@@ -746,9 +746,7 @@ test('picker pin-bottom Restart drives stop+launch under one "Restarting ComfyUI
   await popup.waitForVisible(byTestId(TID.pinBottomAction('restart')), { timeout: 10_000 })
   // Cross-check: the bare `launch` item must NOT be present when the
   // install is running — the swap to `restart` is what we're testing.
-  const launchVisible = await popup.evaluate<boolean>(
-    `(() => !!document.querySelector(${JSON.stringify(byTestId(TID.pinBottomAction('launch')))}))()`,
-  )
+  const launchVisible = await popup.exists(byTestId(TID.pinBottomAction('launch')))
   expect(launchVisible, 'pin-bottom Launch must NOT render while running (Restart swap)').toBe(false)
   expect(await popup.click(byTestId(TID.pinBottomAction('restart')))).toBe(true)
 
@@ -762,9 +760,7 @@ test('picker pin-bottom Restart drives stop+launch under one "Restarting ComfyUI
   await waitForProgressTakeoverAfterPopupClose()
   await expect
     .poll(async () => {
-      const title = await ctx.panel.evaluate<string | null>(
-        `(() => { const el = document.querySelector('.brand-progress'); return el ? el.textContent : null })()`,
-      )
+      const title = await ctx.panel.textOf('.brand-progress')
       return title?.includes('Restarting ComfyUI') ?? false
     }, { timeout: 10_000, intervals: [200, 500] })
     .toBe(true)

--- a/e2e/lifecycle.test.ts
+++ b/e2e/lifecycle.test.ts
@@ -43,6 +43,7 @@ import {
 } from './support/chooserHelpers'
 import {
   getIpcInvocations,
+  getRunningSessionSnapshot,
   resetIpcInvocations,
   returnFirstInstallHostToDashboard,
 } from './support/devHooks'
@@ -697,6 +698,104 @@ test('picker compact-row Restart drives system-modal confirm + re-launch @lifecy
   const launchCalls = (await getRunActionsFor(_updateInstallId))
     .filter((c) => c.actionId === 'launch')
   expect(launchCalls.length, 'exactly one launch run-action for the restart').toBeGreaterThanOrEqual(1)
+})
+
+// ---------------------------------------------------------------------------
+// Synthetic `restart` id (stop → wait → launch) — driven through the
+// picker's pin-bottom Launch→Restart swap that fires when the install
+// is running. This is the `useComfyUISettings.runAction` path, distinct
+// from the picker compact-row Restart above which routes through main's
+// `restartInstallFromPicker` and bypasses the renderer `stop-comfyui`
+// IPC. The synthetic id wraps `stopAndWaitForExit → runAction('launch')`
+// behind a single "Restarting ComfyUI" progress title so the user sees
+// one continuous op instead of stop→idle→launch flashes.
+// ---------------------------------------------------------------------------
+
+test('picker pin-bottom Restart drives stop+launch under one "Restarting ComfyUI" progress title @lifecycle', async () => {
+  test.setTimeout(300_000)
+
+  // Sanity: prior compact-row Restart test left ComfyUI running.
+  await expect.poll(comfyFrontendIsLoaded, { timeout: 30_000, intervals: [500] }).toBe(true)
+  const beforeSnapshot = await getRunningSessionSnapshot(ctx.app, _updateInstallId)
+  expect(beforeSnapshot, 'expected a running session before pin-bottom Restart').not.toBeNull()
+
+  await resetIpcInvocations(ctx.app, 'stop-comfyui')
+  await resetIpcInvocations(ctx.app, 'run-action')
+
+  // Open the picker in expanded mode on the Settings/Config tab so the
+  // pin-bottom MoreMenu is visible. `initialTab: 'config'` matches the
+  // pin-bottom Copy test above.
+  await ctx.panel.evaluate<boolean>(
+    `(() => {
+      window.api.openInstancePicker({
+        installationId: ${JSON.stringify(_updateInstallId)},
+        mode: 'expanded',
+        initialTab: 'config',
+      })
+      return true
+    })()`,
+  )
+  await waitForWebContents(ctx.app, 'comfyTitlePopup.html')
+  const popup = titlePopupPage(ctx.app)
+
+  // Open the footer "More" overflow menu → the swap surfaces the
+  // primary Launch item as `pin-bottom-action-restart` because the
+  // install is currently running.
+  await popup.waitForVisible('[data-more-trigger]', { timeout: 15_000 })
+  expect(await popup.click('[data-more-trigger]')).toBe(true)
+  await popup.waitForVisible(byTestId(TID.pinBottomAction('restart')), { timeout: 10_000 })
+  // Cross-check: the bare `launch` item must NOT be present when the
+  // install is running — the swap to `restart` is what we're testing.
+  const launchVisible = await popup.evaluate<boolean>(
+    `(() => !!document.querySelector(${JSON.stringify(byTestId(TID.pinBottomAction('launch')))}))()`,
+  )
+  expect(launchVisible, 'pin-bottom Launch must NOT render while running (Restart swap)').toBe(false)
+  expect(await popup.click(byTestId(TID.pinBottomAction('restart')))).toBe(true)
+
+  // Restart confirm renders in the popup's own ModalDialog → BaseAlert
+  // simple confirm (title + message + confirmLabel only).
+  await popup.waitForVisible(byTestId(TID.baseAlertAction), { timeout: 10_000 })
+  expect(await popup.click(byTestId(TID.baseAlertAction))).toBe(true)
+
+  // ProgressModal mounts on the panel host with the single continuous
+  // "Restarting ComfyUI" title from `actions.restartProgressTitle`.
+  await waitForProgressTakeoverAfterPopupClose()
+  await expect
+    .poll(async () => {
+      const title = await ctx.panel.evaluate<string | null>(
+        `(() => { const el = document.querySelector('.brand-progress'); return el ? el.textContent : null })()`,
+      )
+      return title?.includes('Restarting ComfyUI') ?? false
+    }, { timeout: 10_000, intervals: [200, 500] })
+    .toBe(true)
+
+  // Wait for the launch leg + the new session to register, then for
+  // the comfy frontend to come back up.
+  await waitForRunAction(_updateInstallId, 'launch', { timeout: 180_000, intervals: [1_000, 2_000] })
+  await expect
+    .poll(async () => {
+      const after = await getRunningSessionSnapshot(ctx.app, _updateInstallId)
+      if (!after) return false
+      return after.startedAt > (beforeSnapshot?.startedAt ?? 0)
+    }, { timeout: 180_000, intervals: [1_000, 2_000] })
+    .toBe(true)
+  await expect.poll(comfyFrontendIsLoaded, { timeout: 180_000, intervals: [1_000] }).toBe(true)
+
+  // The pin-bottom Restart MUST fire the renderer-side `stop-comfyui`
+  // IPC (via `stopAndWaitForExit`) — the audit's key distinction from
+  // the compact-row Restart path tested above.
+  const stopCalls = await getStopsFor(_updateInstallId)
+  expect(stopCalls.length, 'pin-bottom Restart must fire stop-comfyui via stopAndWaitForExit').toBeGreaterThanOrEqual(1)
+
+  const launchCalls = (await getRunActionsFor(_updateInstallId))
+    .filter((c) => c.actionId === 'launch')
+  expect(launchCalls.length, 'exactly one launch run-action for the synthetic restart').toBeGreaterThanOrEqual(1)
+
+  // No bare `restart` action ever reaches main — the synthetic id is
+  // renderer-only. Main only ever sees `launch` for the restart leg.
+  const restartCalls = (await getRunActionsFor(_updateInstallId))
+    .filter((c) => c.actionId === 'restart')
+  expect(restartCalls.length, 'synthetic restart id must not leak to main as a run-action').toBe(0)
 })
 
 // ---------------------------------------------------------------------------

--- a/e2e/support/devHooks.ts
+++ b/e2e/support/devHooks.ts
@@ -189,6 +189,28 @@ export async function clearRunningSessions(app: ElectronApplication): Promise<vo
   }))
 }
 
+export interface RunningSessionSnapshotLike {
+  pid: number | null
+  startedAt: number
+  port: number
+  url: string | undefined
+}
+
+/** Snapshot the live running-session entry for `installationId` (real
+ *  or synthetic). Returns `null` when no session is registered. */
+export async function getRunningSessionSnapshot(
+  app: ElectronApplication,
+  installationId: string,
+): Promise<RunningSessionSnapshotLike | null> {
+  return await evalWithRetry(() => app.evaluate((_electron, id) => {
+    const helpers = (globalThis as unknown as {
+      __e2e?: { getRunningSessionSnapshot: (id: string) => unknown }
+    }).__e2e
+    if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
+    return helpers.getRunningSessionSnapshot(id) as RunningSessionSnapshotLike | null
+  }, installationId))
+}
+
 /** Read the `checkedAt` ms timestamp of the shared release-cache entry
  *  for `(repo, channel)`. Returns `null` when no entry exists yet. */
 export async function getReleaseCacheCheckedAt(

--- a/src/main/lib/e2eHooks.ts
+++ b/src/main/lib/e2eHooks.ts
@@ -33,7 +33,22 @@ import {
   getShellOpenExternalCalls,
   resetShellOpenExternalCalls,
 } from './e2eOverrides'
-import { _test_addRunningSession, _test_clearRunningSessions } from './ipc/shared'
+import {
+  _runningSessions,
+  _test_addRunningSession,
+  _test_clearRunningSessions,
+} from './ipc/shared'
+
+export interface RunningSessionSnapshot {
+  /** Process pid (null for synthetic seeded sessions with no real proc). */
+  pid: number | null
+  /** Wall-clock ms when the session was registered — lets the restart
+   *  cluster assert a `_runningSessions.set(...)` happened between two
+   *  snapshots without needing a real pid delta. */
+  startedAt: number
+  port: number
+  url: string | undefined
+}
 
 interface SetInstallUpdateOpts {
   /** Omit to apply the override globally (matches every installationId). */
@@ -79,6 +94,11 @@ export interface E2EHelpers {
   seedRunningSession(opts: { installationId: string; installationName: string }): void
   /** Drop every synthetic session registered via `seedRunningSession`. */
   clearRunningSessions(): void
+  /** Snapshot the live `_runningSessions` entry for `installationId`
+   *  (real or seeded). Returns `null` when no session is registered.
+   *  Used by the restart cluster to assert a stop→launch chain produced
+   *  a fresh registration (new `startedAt`, new pid). */
+  getRunningSessionSnapshot(installationId: string): RunningSessionSnapshot | null
   /** Read the `checkedAt` ms timestamp from the shared release cache
    *  entry for `(repo, channel)`. Returns `null` when no entry exists
    *  yet. Used by the periodic-poll lifecycle test to observe that the
@@ -121,6 +141,16 @@ export function registerE2EHooks(): void {
       _test_addRunningSession(opts.installationId, opts.installationName)
     },
     clearRunningSessions: _test_clearRunningSessions,
+    getRunningSessionSnapshot(installationId) {
+      const session = _runningSessions.get(installationId)
+      if (!session) return null
+      return {
+        pid: session.proc?.pid ?? null,
+        startedAt: session.startedAt,
+        port: session.port,
+        url: session.url,
+      }
+    },
     getReleaseCacheCheckedAt(repo, channel) {
       return _releaseCacheGet(repo, channel)?.checkedAt ?? null
     },

--- a/src/renderer/src/panel/e2eRendererHooks.ts
+++ b/src/renderer/src/panel/e2eRendererHooks.ts
@@ -35,6 +35,22 @@ export interface InjectProgressSuccessOpts {
   newInstallationId?: string
 }
 
+export interface InjectRetryableProgressErrorOpts {
+  installationId: string
+  title?: string
+  errorMessage: string
+  /** Number of consecutive failures before the apiCall flips to
+   *  resolving with `{ ok: true }`. Defaults to 1 — i.e. fail once,
+   *  succeed on the first Reboot. */
+  failuresBeforeSuccess?: number
+}
+
+export interface SeedErrorInstanceOpts {
+  installationId: string
+  installationName: string
+  message?: string
+}
+
 export interface StartInFlightOpOpts {
   installationId: string
   title?: string
@@ -56,6 +72,12 @@ interface PanelBindings {
 }
 
 let bindings: PanelBindings | null = null
+
+/** Per-installation invocation counter for the apiCall seeded by
+ *  `injectRetryableProgressError`. Module-scoped so the closure that
+ *  the progressStore captures and the test-side
+ *  `getInjectedApiCallCount` reader observe the same Map. */
+const injectedApiCallCounts = new Map<string, number>()
 
 /** Deferred apiCall promises for ops seeded via `startInFlightOp`,
  *  keyed by installationId so `settleInFlightOp` can resolve the right
@@ -83,13 +105,26 @@ export interface E2ERendererHelpers {
    *  `instance-stopped` message — without this poll the apiCall-time
    *  `wasRunning` capture races the broadcast). */
   isRunning(installationId: string): boolean
-  /** Seed an entry into `sessionStore.errorInstances` so the chooser
-   *  tile flips into its has-error state and the kebab grows a
-   *  `Dismiss error` item, without having to drive a real failing op
-   *  through `showProgress` first. */
-  seedErrorInstance(opts: { installationId: string; installationName: string; message?: string }): void
+  /** Drive the show-progress chain with an apiCall that fails the
+   *  first `failuresBeforeSuccess` times and then resolves with
+   *  `{ ok: true }`. Used by the ProgressModal Reboot cluster to
+   *  prove `handleReboot` re-runs the same `op.apiCall` (instead of
+   *  the legacy fresh-launch fallback) and that recovery clears the
+   *  error UI in place. */
+  injectRetryableProgressError(opts: InjectRetryableProgressErrorOpts): Promise<void>
+  /** Seed `sessionStore.errorInstances` directly so the renderer
+   *  treats an install as pre-existing errored without having to fail
+   *  a real op first. Mirrors the broadcast path the launcher uses
+   *  when a crash arrives before any UI took an action on the
+   *  install. */
+  seedErrorInstance(opts: SeedErrorInstanceOpts): void
   /** True iff `sessionStore.errorInstances` has an entry for the id. */
   hasErrorInstance(installationId: string): boolean
+  /** Read the recorded invocation count for the apiCall most recently
+   *  seeded via `injectRetryableProgressError`. Lets the test prove
+   *  `handleReboot` re-invoked the same closure (count went from 1 → 2)
+   *  rather than the fresh-launch fallback. */
+  getInjectedApiCallCount(installationId: string): number
   /** Seed an in-flight op whose `apiCall` is a controllable Promise so
    *  the op stays pending until `settleInFlightOp` resolves it. Lets
    *  tests exercise the busy-guard / Return-to-Dashboard / cancel-flow
@@ -154,14 +189,36 @@ export function registerE2ERendererHooks(): void {
     isRunning(installationId) {
       return useSessionStore().isRunning(installationId)
     },
+    async injectRetryableProgressError({ installationId, title, errorMessage, failuresBeforeSuccess }) {
+      const b = ensureBound()
+      const failsRequired = failuresBeforeSuccess ?? 1
+      // Reset any prior counter for the same id so a leaked op from a
+      // previous test can't intercept this one's call-count assertions.
+      injectedApiCallCounts.set(installationId, 0)
+      await b.showProgress({
+        installationId,
+        title: title ?? `Retryable failed op — ${installationId}`,
+        opKind: 'generic',
+        apiCall: () => {
+          const next = (injectedApiCallCounts.get(installationId) ?? 0) + 1
+          injectedApiCallCounts.set(installationId, next)
+          return next <= failsRequired
+            ? Promise.resolve({ ok: false, message: errorMessage })
+            : Promise.resolve({ ok: true })
+        },
+      })
+    },
     seedErrorInstance({ installationId, installationName, message }) {
       useSessionStore().errorInstances.set(installationId, {
         installationName,
-        message,
+        message: message ?? `Seeded error for ${installationId}`,
       })
     },
     hasErrorInstance(installationId) {
       return useSessionStore().errorInstances.has(installationId)
+    },
+    getInjectedApiCallCount(installationId) {
+      return injectedApiCallCounts.get(installationId) ?? 0
     },
     async startInFlightOp({ installationId, title, opKind, destroysInstance, triggersInstanceStart }) {
       const b = ensureBound()

--- a/src/renderer/src/views/ProgressModal.vue
+++ b/src/renderer/src/views/ProgressModal.vue
@@ -914,6 +914,7 @@ defineExpose({ startOperation, showOperation })
             v-if="!currentOp.destroysInstance"
             type="button"
             class="brand-primary brand-progress__footer-btn"
+            :data-testid="TID.progressReboot"
             @click="handleReboot"
           >
             <RefreshCcw :size="16" />

--- a/src/shared/testIds.ts
+++ b/src/shared/testIds.ts
@@ -87,6 +87,10 @@ export const TID = {
   progressErrorMessage: 'progress-error-message',
   /** The logs panel in the brand progress takeover. */
   progressLogs: 'progress-logs',
+  /** The Reboot button in the brand progress takeover's error footer.
+   *  Drives `handleReboot` (re-runs `op.apiCall` or falls back to a
+   *  fresh `launch` action). */
+  progressReboot: 'progress-reboot',
 } as const
 
 export type TestIdKey = keyof typeof TID


### PR DESCRIPTION
Covers lifecycle audit gaps #8 (synthetic `restart` id stop→launch chain) and #24 (Reboot of an errored install).

**Lifecycle #8** — added to `e2e/lifecycle.test.ts` after the existing picker compact-row Restart test. Opens the picker in expanded mode on the running install, clicks the pin-bottom MoreMenu, verifies the swap to `pin-bottom-action-restart` (asserts `pin-bottom-action-launch` is absent), confirms via BaseAlert in the popup, then asserts:
- Progress takeover renders the single continuous `Restarting ComfyUI` title.
- Renderer-side `stop-comfyui` IPC fires (vs the picker compact-row path which bypasses it via `restartInstallFromPicker`).
- `run-action` with `actionId='launch'` fires.
- `_runningSessions` entry's `startedAt` advances (proves stop+launch produced a fresh session).
- No bare `restart` action ever leaks to main.

**Lifecycle #24** — new `e2e/lifecycle-progress-reboot.test.ts`. Seeds a pre-existing `errorInstance`, injects a retryable failing op via `__e2eRenderer.injectRetryableProgressError` (counter-driven apiCall that fails once then succeeds), clicks the new `TID.progressReboot` button, and asserts:
- Same apiCall closure was re-invoked (counter goes from 1 → 2 — distinguishes from the legacy fresh-`runAction('launch')` fallback).
- Error footer and brand-progress takeover disappear (recovery in place).

**New helpers**
- `e2eHooks.getRunningSessionSnapshot(id)` — main-side snapshot of `_runningSessions` (pid + startedAt + port + url).
- `e2eRendererHooks.injectRetryableProgressError(opts)` — apiCall that fails `failuresBeforeSuccess` times then resolves with `{ ok: true }`; module-level counter Map shared with the next helper.
- `e2eRendererHooks.seedErrorInstance(opts)` / `hasErrorInstance(id)` — direct `sessionStore.errorInstances` seeding.
- `e2eRendererHooks.getInjectedApiCallCount(id)` — reads the counter the retryable apiCall increments.
- `TID.progressReboot` + `data-testid` binding on `ProgressModal`'s Reboot button.