### PR TITLE
Fix/context menu untrack snapshots downloads tray

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -812,6 +812,7 @@
     "pipPackages": "Pip Packages",
     "diffPrevious": "Changes from previous",
     "diffCurrent": "Differences vs. current",
+    "seeWhatChanges": "See what changes",
     "diffNoChanges": "No changes",
     "nodesCount": "{count} nodes",
     "packagesCount": "{count} packages",

--- a/src/main/popups/titlePopup.ts
+++ b/src/main/popups/titlePopup.ts
@@ -368,6 +368,16 @@ interface TitlePopupEntry {
 const titlePopupsByParent = new Map<number, TitlePopupEntry>()
 const titlePopupsByWebContents = new Map<number, TitlePopupEntry>()
 
+/** Timestamp of the most recent downloads-popup dismiss per parent
+ *  window. The downloads tray relies on blur-dismiss (no backdrop),
+ *  so a click on the tray button blurs and hides the popup BEFORE the
+ *  click IPC arrives at main — without this guard, main would see an
+ *  empty `titlePopupsByParent` slot and re-open. Any click within
+ *  `DOWNLOADS_REOPEN_SUPPRESS_MS` of the last hide is treated as the
+ *  toggle-close completion and dropped. */
+const downloadsHiddenAtByParent = new Map<number, number>()
+const DOWNLOADS_REOPEN_SUPPRESS_MS = 250
+
 /** Cached install list used to open the picker SYNCHRONOUSLY on click
  *  (no `await` on the click path → instant first frame, same as the
  *  file menu). Kept fresh by:
@@ -826,6 +836,11 @@ function ensureTitlePopup(parent: BrowserWindow): TitlePopupEntry {
       // on the trigger button is suppressed by the reopen guard.
       if (!entry.titleBarSender.isDestroyed()) {
         entry.titleBarSender.send('comfy-titlebar:menu-closed', { menu: entry.kind })
+      }
+      /** Stamp the per-parent downloads-hide time so the click IPC that
+       *  blur-dismissed us can't immediately reopen the popup. */
+      if (entry.kind === 'downloads' && !view.parentWindow.isDestroyed()) {
+        downloadsHiddenAtByParent.set(view.parentWindow.id, Date.now())
       }
       // Hide the popup backdrop on every dismiss path so the dim
       // never outlives the popup. Cheap no-op for kinds that don't
@@ -2025,6 +2040,26 @@ export function registerTitlePopupIpc(bindings: TitlePopupHostBindings): void {
       if (!found) return
       const { id: windowKey, entry } = found
       if (entry.window.isDestroyed()) return
+
+      /** Toggle: if the downloads popup is already open, close it.
+       *  Otherwise, if a downloads popup was just blur-dismissed by this
+       *  same gesture, treat the click as the close completion. */
+      const parentId = entry.window.id
+      const existingPopup = titlePopupsByParent.get(parentId)
+      if (
+        existingPopup
+        && existingPopup.kind === 'downloads'
+        && (existingPopup.view.isOpen || existingPopup.view.pendingShowTimer !== null)
+      ) {
+        hideTitlePopup(existingPopup, { releaseFocusToParent: true })
+        return
+      }
+      const hiddenAt = downloadsHiddenAtByParent.get(parentId)
+      if (hiddenAt !== undefined && Date.now() - hiddenAt < DOWNLOADS_REOPEN_SUPPRESS_MS) {
+        downloadsHiddenAtByParent.delete(parentId)
+        return
+      }
+
       const x = Math.max(0, Math.round(payload?.anchor?.x ?? 0))
       const y = Math.max(0, Math.round(payload?.anchor?.y ?? TITLEBAR_HEIGHT))
       openTitlePopup({

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -3167,6 +3167,13 @@ input[type='checkbox']:checked::after {
   cursor: default;
   opacity: 0.5;
 }
+.context-menu-item.is-danger {
+  color: var(--danger);
+}
+.context-menu-item.is-danger:hover:not(:disabled),
+.context-menu-item.is-danger:focus-visible:not(:disabled) {
+  color: var(--danger-hover);
+}
 .context-menu-separator {
   height: 1px;
   background: color-mix(in oklab, var(--neutral-100) 8%, transparent);

--- a/src/renderer/src/comfyTitleBar/useTitleBarMenus.ts
+++ b/src/renderer/src/comfyTitleBar/useTitleBarMenus.ts
@@ -177,11 +177,10 @@ export function useTitleBarMenus(opts: UseTitleBarMenusOpts): TitleBarMenusApi {
 
   function handleDownloadsTray(): void {
     opts.hideTip()
-    if (isMenuOpen.value) {
-      opts.bridge?.dismissFileMenu()
-      return
-    }
-    if (Date.now() - menuClosedAt.downloads < MENU_REOPEN_GUARD_MS) return
+    /** Toggle + reopen suppression live in main (see `click-downloads-
+     *  tray` handler in titlePopup.ts) — the renderer just dispatches.
+     *  Reading `isMenuOpen` here used to race the blur-driven close,
+     *  causing the "click closes, immediately reopens" symptom. */
     opts.bridge?.clickDownloadsTray(anchorDownloadsBelow(opts.downloadsBtnRef.value))
   }
 

--- a/src/renderer/src/components/ContextMenu.vue
+++ b/src/renderer/src/components/ContextMenu.vue
@@ -78,7 +78,7 @@ function handleClick(item: ContextMenuItem): void {
         <div v-if="item.separator && i > 0" class="context-menu-separator" />
         <button
           class="context-menu-item"
-          :class="{ disabled: item.disabled }"
+          :class="{ disabled: item.disabled, 'is-danger': item.style === 'danger' }"
           :disabled="item.disabled"
           :data-testid="TID.contextMenuItem(item.id)"
           @click="handleClick(item)"

--- a/src/renderer/src/composables/useInstallContextMenu.test.ts
+++ b/src/renderer/src/composables/useInstallContextMenu.test.ts
@@ -50,7 +50,10 @@ const messages = {
     },
     actions: {
       copyInstallation: 'Copy Install',
-      untrack: 'Untrack',
+      untrack: 'Forget',
+      untrackConfirmTitle: 'Forget Install',
+      untrackConfirmMessage:
+        'This will remove the install from the app. The files will not be deleted.',
       delete: 'Delete',
       deleteConfirmTitle: 'Delete Install',
       deleteConfirmMessage:
@@ -289,16 +292,6 @@ describe('useInstallContextMenu — delete fast path (regression for #582)', () 
   })
 })
 
-// --- Copy / Untrack routing (regression for #592 audit Bug #2) ---
-//
-// Both kebab items used to call `window.api.runAction(id, 'copy' | 'remove')`
-// directly. The source-action defs declare `prompt` / `confirm` for the
-// renderer, so main saw `actionData = undefined` and bailed silently
-// (copy returned `{ ok: false, message: 'No name provided.' }`, untrack
-// fired with no confirm at all). The fix routes both through `onManage`
-// with the appropriate `autoAction` so the source-side action machinery
-// (confirms, prompts, disk-check, showProgress) is reused.
-
 function mountHarnessWithManage(
   onManage: (inst: Installation, options?: { initialTab?: string; autoAction?: string | null }) => void,
 ): { menu: ReturnType<typeof useInstallContextMenu> } {
@@ -314,7 +307,7 @@ function mountHarnessWithManage(
   return { menu }
 }
 
-describe('useInstallContextMenu — copy-install / untrack routing (regression for #592 audit Bug #2)', () => {
+describe('useInstallContextMenu — copy-install routing', () => {
   beforeEach(() => {
     apiMock.runAction.mockClear()
   })
@@ -329,21 +322,50 @@ describe('useInstallContextMenu — copy-install / untrack routing (regression f
     expect(onManage).toHaveBeenCalledTimes(1)
     expect(onManage.mock.calls[0][0]).toBe(inst)
     expect(onManage.mock.calls[0][1]).toEqual({ autoAction: 'copy' })
-    // Critical: the direct runAction call is the bug we are fixing —
-    // main can't supply `name` so it returns `{ ok: false }` silently.
     expect(apiMock.runAction).not.toHaveBeenCalled()
   })
+})
 
-  it('untrack routes through onManage with autoAction "remove" and does not call runAction directly', async () => {
-    const onManage = vi.fn<(inst: Installation, options?: { autoAction?: string | null }) => void>()
+describe('useInstallContextMenu — untrack confirm-then-remove', () => {
+  beforeEach(() => {
+    apiMock.runAction.mockClear()
+    modalMock.confirm.mockReset()
+  })
+
+  it('shows a danger confirm and never opens the picker', async () => {
+    modalMock.confirm.mockResolvedValue(true)
+    const onManage = vi.fn()
     const inst = makeInstall()
     const { menu } = mountHarnessWithManage(onManage)
 
     await menu.triggerAction('untrack', inst)
 
-    expect(onManage).toHaveBeenCalledTimes(1)
-    expect(onManage.mock.calls[0][0]).toBe(inst)
-    expect(onManage.mock.calls[0][1]).toEqual({ autoAction: 'remove' })
+    expect(modalMock.confirm).toHaveBeenCalledTimes(1)
+    const args = modalMock.confirm.mock.calls[0]![0]
+    expect(args.title).toBe('Forget Install')
+    expect(args.confirmLabel).toBe('Forget')
+    expect(args.confirmStyle).toBe('danger')
+    expect(onManage).not.toHaveBeenCalled()
+  })
+
+  it('on confirm true, dispatches the `remove` action once', async () => {
+    modalMock.confirm.mockResolvedValue(true)
+    const inst = makeInstall()
+    const { menu } = mountHarnessWithManage(() => {})
+
+    await menu.triggerAction('untrack', inst)
+
+    expect(apiMock.runAction).toHaveBeenCalledTimes(1)
+    expect(apiMock.runAction).toHaveBeenCalledWith(inst.id, 'remove')
+  })
+
+  it('on confirm cancel, does not dispatch the action', async () => {
+    modalMock.confirm.mockResolvedValue(false)
+    const inst = makeInstall()
+    const { menu } = mountHarnessWithManage(() => {})
+
+    await menu.triggerAction('untrack', inst)
+
     expect(apiMock.runAction).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/composables/useInstallContextMenu.ts
+++ b/src/renderer/src/composables/useInstallContextMenu.ts
@@ -183,11 +183,13 @@ export function useInstallContextMenu(opts: {
         id: 'untrack',
         label: t('actions.untrack'),
         separator: items.length > 0,
+        style: 'danger',
       })
       items.push({
         id: 'delete',
         label: t('chooser.menuDelete'),
         disabled: stoppedActionGated,
+        style: 'danger',
       })
     }
 
@@ -276,11 +278,20 @@ export function useInstallContextMenu(opts: {
       // which the caller's `try/catch` then silently swallowed.
       opts.onManage?.(inst, { autoAction: 'copy' })
     } else if (id === 'untrack') {
-      // Same fix as copy-install above: routing through `onManage`
-      // (autoAction: 'remove') runs the source-action def's confirm
-      // dialog renderer-side before invoking the IPC, instead of
-      // firing a destructive un-tracking action with no prompt.
-      opts.onManage?.(inst, { autoAction: 'remove' })
+      /** Confirm + instant `remove` IPC. No picker, no progress bar —
+       *  untrack is a registry-only op. */
+      const untrackLabel = t('actions.untrack', 'Forget')
+      const confirmed = await modal.confirm({
+        title: t('actions.untrackConfirmTitle', 'Forget Install'),
+        message: t(
+          'actions.untrackConfirmMessage',
+          'This will remove the install from the app. The files will not be deleted.',
+        ),
+        confirmLabel: untrackLabel,
+        confirmStyle: 'danger',
+      })
+      if (!confirmed) return
+      await runInstantActionWithAlert(inst, 'remove', untrackLabel)
     } else if (id === 'delete') {
       // Build the confirm + showProgress payload renderer-side instead
       // of round-tripping through `getDetailSections` to look up the

--- a/src/renderer/src/types/context-menu.ts
+++ b/src/renderer/src/types/context-menu.ts
@@ -4,4 +4,8 @@ export interface ContextMenuItem {
   icon?: string
   disabled?: boolean
   separator?: boolean
+  /** Visual variant. `danger` paints the item with the `--danger` /
+   *  `--danger-hover` tokens for destructive actions. Mirrors the
+   *  picker's `MoreMenu` action shape. */
+  style?: 'default' | 'danger'
 }

--- a/src/renderer/src/views/comfyUISettings/SnapshotsView.vue
+++ b/src/renderer/src/views/comfyUISettings/SnapshotsView.vue
@@ -277,8 +277,9 @@ async function load(): Promise<void> {
 // --- Per-row expansion (change summary) ---
 
 const expandedFilenames = ref<Set<string>>(new Set())
-// Loaded "Changes from previous" diffs, keyed by snapshot filename.
-// Presence in the map = panel is open; null = loaded with no diff returned.
+/** Loaded "what changes if I restore this" diffs (current state →
+ *  target snapshot), keyed by filename. Presence in the map = panel
+ *  is open; null = loaded with no diff returned. */
 const diffByFilename = ref<Map<string, SnapshotDiffData | null>>(new Map())
 const diffLoadingFilename = ref<string | null>(null)
 
@@ -309,7 +310,7 @@ async function toggleDiff(filename: string): Promise<void> {
   }
   diffLoadingFilename.value = filename
   try {
-    const d = await window.api.getSnapshotDiff(props.installationId, filename, 'previous')
+    const d = await window.api.getSnapshotDiff(props.installationId, filename, 'current')
     const next = new Map(diffByFilename.value)
     next.set(filename, d)
     diffByFilename.value = next
@@ -820,22 +821,18 @@ async function handleImport(): Promise<void> {
                      user has expressed intent by expanding the row. -->
                 <div class="snapshots-view-detail-actions">
                   <button
+                    v-if="i !== 0"
                     type="button"
                     class="snapshots-view-detail-btn"
                     :class="{ 'is-active': isDiffOpen(item.snapshot.filename) }"
-                    :disabled="item.snapshotIndex === snapshots.length - 1"
-                    :aria-label="t('snapshots.diffPrevious', 'Changes from previous')"
-                    :title="
-                      item.snapshotIndex === snapshots.length - 1
-                        ? t('snapshots.noPrevious', 'First snapshot — no previous to compare')
-                        : t('snapshots.diffPrevious', 'Changes from previous')
-                    "
+                    :aria-label="t('snapshots.seeWhatChanges', 'See what changes')"
                     @click="toggleDiff(item.snapshot.filename)"
                   >
                     <GitCompare :size="13" />
-                    <span>{{ t('snapshots.diffPrevious', 'Changes from previous') }}</span>
+                    <span>{{ t('snapshots.seeWhatChanges', 'See what changes') }}</span>
                   </button>
                   <button
+                    v-if="i !== 0"
                     type="button"
                     class="snapshots-view-detail-btn"
                     :aria-label="t('snapshots.restore', 'Restore')"


### PR DESCRIPTION
## Summary

Three small fixes for install menus, snapshots, and the downloads tray.

- **Downloads tray** — Clicking the tray button no longer closes and immediately reopens the popup. Toggle logic now lives in the main process so it doesn't race with blur-dismiss.
- **Forget install (untrack)** — Choosing "Forget" from the install menu shows a red confirm dialog and removes the install from the app right away. It no longer opens the instance picker. Delete and Forget menu items are styled in red.
- **Snapshots** — "See what changes" now compares your current install to the snapshot you're looking at (what would change if you restored it). Restore is hidden on the newest snapshot since there's nothing to restore to.

## Test plan

- [ ] Click downloads tray twice — should open, then close, without flickering back open
- [ ] Right-click an install → Forget → confirm and cancel paths both work; picker does not open
- [ ] Right-click an install → Delete and Forget appear in red
- [ ] Open Snapshots → expand a row → "See what changes" loads a diff; Restore is not shown on the newest snapshot
