### PR TITLE
fix(install): refresh R2 manifests and tighten post-install version c…

### DIFF
--- a/src/main/lib/fetch.ts
+++ b/src/main/lib/fetch.ts
@@ -70,9 +70,13 @@ function _headerString(value: string | string[] | undefined): string | undefined
   return Array.isArray(value) ? value[0] : value
 }
 
-export function fetchJSON(url: string): Promise<unknown> {
+export function fetchJSON(url: string, opts?: { refresh?: boolean }): Promise<unknown> {
   _ensureLoaded()
-  const cached = _cache.get(url)
+  // When `refresh` is set, ignore the persisted ETag so the response is
+  // never served from cache. Used by the install wizard for R2 manifests
+  // that decide which standalone env release a user can pick — stale
+  // values there silently strand users on old versions.
+  const cached = opts?.refresh ? undefined : _cache.get(url)
 
   return new Promise((resolve, reject) => {
     // Use cache: "no-cache" so Chromium always revalidates with the server

--- a/src/main/sources/standalone/index.ts
+++ b/src/main/sources/standalone/index.ts
@@ -183,15 +183,16 @@ export const standalone: SourcePlugin = {
       const prefix = PLATFORM_PREFIX[process.platform]
       if (!prefix) return []
 
-      // Fetch latest.json (tiny, pre-warmed on startup) to know which vendors exist
-      const latest = await fetchJSON(`${R2_BASE_URL}/latest.json`) as R2Latest
+      // Always revalidate R2 manifests when populating the install wizard —
+      // a stale persisted ETag can otherwise hide a freshly-shipped standalone
+      // release and strand new installs on whatever the previous run cached.
+      const latest = await fetchJSON(`${R2_BASE_URL}/latest.json`, { refresh: true }) as R2Latest
       const vendorIds = Object.keys(latest).filter((id) => id.startsWith(prefix))
       if (vendorIds.length === 0) return []
 
-      // Fetch per-vendor release history in parallel
       const vendorReleases = Object.fromEntries(
         await Promise.all(vendorIds.map(async (id) => {
-          const data = await fetchJSON(`${R2_BASE_URL}/${id}/releases.json`) as R2VendorReleases
+          const data = await fetchJSON(`${R2_BASE_URL}/${id}/releases.json`, { refresh: true }) as R2VendorReleases
           return [id, data.releases] as const
         }))
       )

--- a/src/main/sources/standalone/install.ts
+++ b/src/main/sources/standalone/install.ts
@@ -9,7 +9,6 @@ import { formatTime } from '../../lib/util'
 import { t } from '../../lib/i18n'
 import * as snapshots from '../../lib/snapshots'
 import { fetchLatestRelease } from '../../lib/comfyui-releases'
-import { formatComfyVersion } from '../../lib/version'
 import { repairMacBinaries, codesignBinaries } from './macRepair'
 import { runComfyUIUpdate } from './updateOrchestrator'
 import {
@@ -148,11 +147,14 @@ export async function postInstall(installation: InstallationRecord, { sendProgre
     try {
       const latestRelease = await fetchLatestRelease('stable')
       const latestTag = latestRelease?.tag_name as string | undefined
-      const currentTag = (installation.comfyVersion as ComfyVersion | undefined)
-        ? formatComfyVersion(installation.comfyVersion as ComfyVersion, 'short')
-        : (installation.version as string | undefined)
+      const current = installation.comfyVersion as ComfyVersion | undefined
+      const onLatestTag = !!latestTag && current?.baseTag === latestTag && current?.commitsAhead === 0
 
-      if (!latestTag || latestTag === currentTag) {
+      if (!latestTag) {
+        // Don't lie. A network flake here previously masqueraded as "Already up to date,"
+        // which is how first installs were stranding on the bundled v0.20.x.
+        sendProgress('update', { percent: 100, status: 'Skipped — could not verify latest version' })
+      } else if (onLatestTag) {
         sendProgress('update', { percent: 100, status: 'Already up to date' })
       } else {
         const result = await runComfyUIUpdate({


### PR DESCRIPTION
Closes https://github.com/Comfy-Org/ComfyUI-Desktop-2.0-Beta/issues/610

## Summary

Fixes standalone installs getting stuck on old ComfyUI versions.

- **Install wizard** — Always fetches fresh R2 manifest data (`latest.json` and `releases.json`) instead of using a cached copy. A stale cache could hide a new release, so new installs would only see older versions.
- **Post-install update check** — Compares the actual installed version (`ComfyVersion`) instead of formatted tag strings. If the latest version can't be fetched, it now says "Skipped — could not verify latest version" instead of wrongly showing "Already up to date".

## Test plan

- [ ] Open the install wizard after a new standalone release ships — the new version appears in the list
- [ ] Run a fresh standalone install when GitHub is unreachable during the post-install check — shows "Skipped", not "Already up to date"
- [ ] Run a fresh install when already on latest — still shows "Already up to date"
