### PR TITLE
fix(install): unstrand new installs from bundled ComfyUI on first launch

### DIFF
--- a/src/main/lib/comfyui-releases.test.ts
+++ b/src/main/lib/comfyui-releases.test.ts
@@ -165,6 +165,39 @@ describe('fetchLatestRelease', () => {
       expect(result!.tag_name).toBe('v1.19.5')
       expect(mockedLsRemoteLatestTag).toHaveBeenCalledTimes(1)
     })
+
+    it('a null tag uses the short failure TTL, not the long success TTL', async () => {
+      // A null result (e.g. no git backend configured) used to be cached
+      // for SUCCESS_TTL_MS = 10 min, indistinguishable from a confirmed
+      // empty repo. The post-install update step then read that poisoned
+      // null on every subsequent call within 10 minutes and falsely showed
+      // "Already up to date", stranding new installs on the bundled
+      // ComfyUI version. Pin behavior: a null result must expire on the
+      // failure cadence so the next caller refetches.
+      vi.useFakeTimers()
+      try {
+        mockedLsRemoteLatestTag.mockResolvedValueOnce(undefined).mockResolvedValueOnce('v1.19.5')
+        const a = await getLatestStableTag()
+        // Advance past the failure TTL (30 s) but well within the success
+        // TTL (10 min) so we can tell the two apart.
+        vi.setSystemTime(Date.now() + 60_000)
+        const b = await getLatestStableTag()
+        expect(a).toBeNull()
+        expect(b).toBe('v1.19.5')
+        expect(mockedLsRemoteLatestTag).toHaveBeenCalledTimes(2)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('fetchLatestRelease forwards refresh through to the tag lookup', async () => {
+      mockedLsRemoteLatestTag.mockResolvedValueOnce('v1.19.5').mockResolvedValueOnce('v1.19.6')
+      const a = await fetchLatestRelease('stable')
+      const b = await fetchLatestRelease('stable', { refresh: true })
+      expect(a!.tag_name).toBe('v1.19.5')
+      expect(b!.tag_name).toBe('v1.19.6')
+      expect(mockedLsRemoteLatestTag).toHaveBeenCalledTimes(2)
+    })
   })
 
   describe('mirror setting', () => {

--- a/src/main/lib/comfyui-releases.ts
+++ b/src/main/lib/comfyui-releases.ts
@@ -48,7 +48,15 @@ export async function getLatestStableTag(opts?: { refresh?: boolean }): Promise<
   const promise = (async () => {
     try {
       const tag = (await lsRemoteLatestTag(url)) ?? null
-      _latestTagCache.set(url, { tag, expiresAt: Date.now() + SUCCESS_TTL_MS })
+      // A `null` tag here means the lookup resolved without throwing but
+      // produced no value — almost always because no git backend was
+      // configured at the time of the call (no bootstrap-python in the
+      // installer + no prior installs + no system git). Treat it as a
+      // failure: caching it for SUCCESS_TTL_MS (10 min) silently stranded
+      // new standalone installs on the bundled ComfyUI version because the
+      // post-install update step would read the poisoned cache and skip.
+      const ttl = tag === null ? FAILURE_TTL_MS : SUCCESS_TTL_MS
+      _latestTagCache.set(url, { tag, expiresAt: Date.now() + ttl })
       return tag
     } catch {
       _latestTagCache.set(url, { tag: null, expiresAt: Date.now() + FAILURE_TTL_MS })
@@ -68,7 +76,8 @@ export function _clearLatestStableTagCache(): void {
 }
 
 export async function fetchLatestRelease(
-  channel: string
+  channel: string,
+  opts?: { refresh?: boolean },
 ): Promise<Record<string, unknown> | null> {
   const mirrorEnabled = settings.get('useChineseMirrors') === true
   const remoteUrl = getComfyUIRemoteUrl(mirrorEnabled)
@@ -76,7 +85,7 @@ export async function fetchLatestRelease(
   if (channel === 'latest') {
     const [headSha, latestTag] = await Promise.all([
       lsRemoteRef(remoteUrl, 'refs/heads/master'),
-      getLatestStableTag(),
+      getLatestStableTag(opts),
     ])
     if (!headSha) return null
     return {
@@ -91,7 +100,7 @@ export async function fetchLatestRelease(
   }
 
   // Stable channel: build synthetic release from latest tag
-  const latestTag = await getLatestStableTag()
+  const latestTag = await getLatestStableTag(opts)
   if (!latestTag) return null
   return {
     tag_name: latestTag,

--- a/src/main/lib/fetch.ts
+++ b/src/main/lib/fetch.ts
@@ -70,9 +70,13 @@ function _headerString(value: string | string[] | undefined): string | undefined
   return Array.isArray(value) ? value[0] : value
 }
 
-export function fetchJSON(url: string): Promise<unknown> {
+export function fetchJSON(url: string, opts?: { refresh?: boolean }): Promise<unknown> {
   _ensureLoaded()
-  const cached = _cache.get(url)
+  // When `refresh` is set, ignore the persisted ETag so the response is
+  // never served from cache. Used by the install wizard for R2 manifests
+  // that decide which standalone env release a user can pick — stale
+  // values there silently strand users on old versions.
+  const cached = opts?.refresh ? undefined : _cache.get(url)
 
   return new Promise((resolve, reject) => {
     // Use cache: "no-cache" so Chromium always revalidates with the server

--- a/src/main/sources/standalone/index.ts
+++ b/src/main/sources/standalone/index.ts
@@ -183,15 +183,16 @@ export const standalone: SourcePlugin = {
       const prefix = PLATFORM_PREFIX[process.platform]
       if (!prefix) return []
 
-      // Fetch latest.json (tiny, pre-warmed on startup) to know which vendors exist
-      const latest = await fetchJSON(`${R2_BASE_URL}/latest.json`) as R2Latest
+      // Always revalidate R2 manifests when populating the install wizard —
+      // a stale persisted ETag can otherwise hide a freshly-shipped standalone
+      // release and strand new installs on whatever the previous run cached.
+      const latest = await fetchJSON(`${R2_BASE_URL}/latest.json`, { refresh: true }) as R2Latest
       const vendorIds = Object.keys(latest).filter((id) => id.startsWith(prefix))
       if (vendorIds.length === 0) return []
 
-      // Fetch per-vendor release history in parallel
       const vendorReleases = Object.fromEntries(
         await Promise.all(vendorIds.map(async (id) => {
-          const data = await fetchJSON(`${R2_BASE_URL}/${id}/releases.json`) as R2VendorReleases
+          const data = await fetchJSON(`${R2_BASE_URL}/${id}/releases.json`, { refresh: true }) as R2VendorReleases
           return [id, data.releases] as const
         }))
       )

--- a/src/main/sources/standalone/install.ts
+++ b/src/main/sources/standalone/install.ts
@@ -9,7 +9,6 @@ import { formatTime } from '../../lib/util'
 import { t } from '../../lib/i18n'
 import * as snapshots from '../../lib/snapshots'
 import { fetchLatestRelease } from '../../lib/comfyui-releases'
-import { formatComfyVersion } from '../../lib/version'
 import { repairMacBinaries, codesignBinaries } from './macRepair'
 import { runComfyUIUpdate } from './updateOrchestrator'
 import {
@@ -148,11 +147,14 @@ export async function postInstall(installation: InstallationRecord, { sendProgre
     try {
       const latestRelease = await fetchLatestRelease('stable')
       const latestTag = latestRelease?.tag_name as string | undefined
-      const currentTag = (installation.comfyVersion as ComfyVersion | undefined)
-        ? formatComfyVersion(installation.comfyVersion as ComfyVersion, 'short')
-        : (installation.version as string | undefined)
+      const current = installation.comfyVersion as ComfyVersion | undefined
+      const onLatestTag = !!latestTag && current?.baseTag === latestTag && current?.commitsAhead === 0
 
-      if (!latestTag || latestTag === currentTag) {
+      if (!latestTag) {
+        // Don't lie. A network flake here previously masqueraded as "Already up to date,"
+        // which is how first installs were stranding on the bundled v0.20.x.
+        sendProgress('update', { percent: 100, status: 'Skipped — could not verify latest version' })
+      } else if (onLatestTag) {
         sendProgress('update', { percent: 100, status: 'Already up to date' })
       } else {
         const result = await runComfyUIUpdate({

--- a/src/main/sources/standalone/install.ts
+++ b/src/main/sources/standalone/install.ts
@@ -145,7 +145,13 @@ export async function postInstall(installation: InstallationRecord, { sendProgre
     sendProgress('update', { percent: -1, status: 'Fetching latest stable version' })
 
     try {
-      const latestRelease = await fetchLatestRelease('stable')
+      // Bypass the in-memory tag cache: it can be poisoned with `null` at
+      // app startup when no git backend is configured (installer ships no
+      // bootstrap-python, no prior installs to lend pygit2, no system git
+      // on PATH). By the time post-install runs, `tryConfigurePygit2Fallback`
+      // above has configured pygit2 against the just-extracted env, so the
+      // refreshed lookup succeeds and the update step actually fires.
+      const latestRelease = await fetchLatestRelease('stable', { refresh: true })
       const latestTag = latestRelease?.tag_name as string | undefined
       const current = installation.comfyVersion as ComfyVersion | undefined
       const onLatestTag = !!latestTag && current?.baseTag === latestTag && current?.commitsAhead === 0


### PR DESCRIPTION
Stacks on #611 (the first commit on this branch is Maanil's commit from that PR). Together they fix the "Latest Stable" install landing on v0.20.1 instead of v0.22.3 that we hit while QA-ing the prerelease.

## Summary

A fresh standalone install via "Latest Stable" silently stranded users on the bundled ComfyUI version (currently v0.20.1) while showing "Already up to date" in the post-install update step. Repro confirmed on a clean state of this Windows machine — bug reproduces deterministically when no git backend is available at app startup.

## Root cause (trace)

1. App startup runs the git-backend cascade in `src/main/lib/ipc/index.ts:111–160`:
   - `tryConfigureBootstrapPygit2()` — needs `resources/bootstrap-python/<platform>/python.exe`. The 0.6.4 installer doesn't ship one (the startup log says so verbatim: `Bootstrap pygit2 not available — bootstrap-python/<platform>/ is missing. Run "pnpm run bootstrap"`).
   - Falls back to per-install pygit2 via `installations.list()` — empty on a fresh machine.
   - Falls back to system `git` — many Windows users don't have it on PATH.
   - Final branch logs `No git backend available (bootstrap pygit2, standalone pygit2, and system git all missing)`.
2. Line 167 then calls `await getLatestStableTag()` to pre-warm the install-wizard label. With no backend, `lsRemoteLatestTag` resolves `undefined` (it doesn't throw — `execFile('git', ...)` ENOENT goes to the success path). `getLatestStableTag` caches `{ tag: null, expiresAt: now + SUCCESS_TTL_MS (10 min) }`.
3. User clicks "New install → Latest Stable". `tryConfigurePygit2Fallback` in `install.ts:118–120` configures pygit2 against the just-extracted standalone-env python, so the lookup *would now work* — but `fetchLatestRelease('stable')` at line 149 reads the still-valid poisoned `null` from the in-memory cache. `latestTag = undefined` → `!latestTag` branch → "Already up to date" → install finalizes on v0.20.1.

Captured live cascade from the test run:

```
[ipc] Bootstrap pygit2 not available — bootstrap-python/<platform>/ is missing. …
[ipc] No git backend available (bootstrap pygit2, standalone pygit2, and system git all missing)
```

## Fix (layered)

**Root cause** — `comfyui-releases.ts`: cache a `null` tag with `FAILURE_TTL_MS` (30 s), not `SUCCESS_TTL_MS` (10 min). A null result means the call resolved without throwing but produced no value, which in practice only happens when no git backend was available; treating it as a brief failure lets the next caller refetch (post-install runs minutes later, by which time pygit2 is configured against the extracted env).

**Defense-in-depth** — `install.ts`: pass `{ refresh: true }` from the post-install update path so any future caller that warms the cache before post-install can't strand an install. Adds `opts?: { refresh?: boolean }` to `fetchLatestRelease` (passthrough to `getLatestStableTag`, which already supports it).

**Honesty + structural comparison** — from #611, retained on this branch: the post-install update now distinguishes "could not verify latest version" (network/git unavailable) from "already up to date" (structurally on the latest tag, via `current.baseTag === latestTag && current.commitsAhead === 0` instead of formatted-string equality).

**R2 manifest refresh** — from #611, retained: `fetchJSON({ refresh: true })` for the install-wizard's `latest.json` / `releases.json` reads so a freshly-shipped vendor build can't be hidden by a stale ETag.

## Follow-up (not in this PR)

The 0.6.4 installer is missing `resources/bootstrap-python/<platform>/python.exe`. This is a release-engineering issue — `pnpm run bootstrap` (or `bootstrap:fetch`) needs to run before the packaging step, and the directory needs to be included in the asar-unpacked output. With it present, the startup cascade succeeds at step 1 and this whole class of bug becomes much harder to hit. Worth a separate ticket.

## Test plan

- [x] Repro on a clean Windows state: clear `installations.json` / `release-cache.json` / `fetch-cache.json`, strip `git` from PATH, launch app, click "New install → Latest Stable". Without this fix the update step shows "Already up to date" and ComfyUI is v0.20.1; with this fix it updates to v0.22.3.
- [ ] Run with a real git backend (system git on PATH) and confirm Latest Stable still installs on latest and the message is "Up to date" once on latest, not "Skipped".
- [ ] Run with the network down during post-install (interface offline) and confirm the message is "Skipped — could not verify latest version" rather than a false "Already up to date".
- [x] Vitest: two new tests pin the failure-TTL behavior and the `refresh` plumbing.