### PR TITLE
fix: Refine title-bar UI and lock handling

### DIFF
--- a/src/main/lib/file-lock-info.test.ts
+++ b/src/main/lib/file-lock-info.test.ts
@@ -47,17 +47,12 @@ describe('findLockingProcesses', { timeout: 30_000 }, () => {
     const tmpFile = path.join(os.tmpdir(), `file-lock-held-test-${Date.now()}.txt`)
     fs.writeFileSync(tmpFile, 'test')
 
-    // Spawn a child process that opens the file and holds it open
-    const child = fork(
-      '-e',
-      [
-        `const fs = require('fs');` +
-        `const fd = fs.openSync(${JSON.stringify(tmpFile)}, 'r+');` +
-        `process.send('ready');` +
-        `process.on('message', () => { fs.closeSync(fd); process.exit(); });`,
-      ],
-      { stdio: ['pipe', 'pipe', 'pipe', 'ipc'] }
+    const helper = path.join(os.tmpdir(), `file-lock-holder-${Date.now()}.cjs`)
+    fs.writeFileSync(
+      helper,
+      `const fs=require('fs');const fd=fs.openSync(${JSON.stringify(tmpFile)},'r+');process.send?.('ready');process.on('message',()=>{try{fs.closeSync(fd)}catch{}process.exit(0)});`,
     )
+    const child = fork(helper, [], { stdio: ['pipe', 'pipe', 'pipe', 'ipc'] })
 
     // Wait for the child to signal it has the file open
     await new Promise<void>((resolve) => { child.on('message', () => resolve()) })
@@ -75,6 +70,7 @@ describe('findLockingProcesses', { timeout: 30_000 }, () => {
     } finally {
       child.send('close')
       await new Promise<void>((resolve) => { child.on('exit', () => resolve()) })
+      try { fs.unlinkSync(helper) } catch {}
       try { fs.unlinkSync(tmpFile) } catch {}
     }
   })

--- a/src/main/popups/titlePopup.test.ts
+++ b/src/main/popups/titlePopup.test.ts
@@ -146,7 +146,7 @@ describe('buildTitlePopupMenuItems', () => {
     const closeAll = items.find((i) => i.id === 'close-all-windows')
     expect(closeAll?.label).toBe('Exit All Windows')
     const exitWindow = items.find((i) => i.id === 'exit-window')
-    expect(exitWindow?.label).toBe('Exit Window')
+    expect(exitWindow?.label).toBe('Close Window')
   })
 
   it('install-host menu has neither Reset Zoom nor Return to Dashboard', () => {
@@ -295,4 +295,3 @@ describe('buildInstancePickerSnapshot', () => {
     expect(snap.runningInstallationIds).toEqual([])
   })
 })
-

--- a/src/main/popups/titlePopup.ts
+++ b/src/main/popups/titlePopup.ts
@@ -652,7 +652,7 @@ export function buildTitlePopupMenuItems(entry: ComfyWindowEntry): TitlePopupMen
   items.push(
     { id: 'feedback', label: 'Send Beta Feedback', labelKey: 'fileMenu.sendFeedback' },
     { kind: 'separator' },
-    { id: 'exit-window', label: 'Exit Window', labelKey: 'fileMenu.exitWindow' },
+    { id: 'exit-window', label: 'Close Window', labelKey: 'fileMenu.exitWindow' },
     {
       id: 'close-all-windows',
       label: 'Exit All Windows',

--- a/src/main/sources/standalone/updateSections.ts
+++ b/src/main/sources/standalone/updateSections.ts
@@ -50,7 +50,7 @@ export function getDetailSections(installation: InstallationRecord): Record<stri
   const infoFields: Record<string, unknown>[] = [
     { label: t('common.installMethod'), value: installation.sourceLabel as string },
     { key: 'comfyui-version', label: t('standalone.comfyui'), value: installation.comfyVersion ? formatComfyVersion(installation.comfyVersion as ComfyVersion, 'detail') : (installation.version as string | undefined) || 'unknown' },
-    { label: t('common.release'), value: (installation.releaseTag as string | undefined) || '—' },
+    { label: t('common.initialEnvironment'), value: (installation.releaseTag as string | undefined) || '—' },
     { label: t('standalone.variant'), value: (installation.variant as string | undefined) ? getVariantLabel(installation.variant as string) : '—' },
     { label: t('standalone.python'), value: (installation.pythonVersion as string | undefined) || '—' },
     { label: t('common.location'), value: installation.installPath || '—' },

--- a/src/renderer/src/comfyTitleBar/TitleBarApp.vue
+++ b/src/renderer/src/comfyTitleBar/TitleBarApp.vue
@@ -191,7 +191,6 @@ const isInstallLess = ref((bridge?.getInstallationId() ?? '') === '')
 const {
   installLabel,
   sourceCategory,
-  themeText,
   isFullscreen,
   firstUseMode,
   isConsentLockdown,
@@ -356,10 +355,7 @@ onUnmounted(() => {
       'is-hover-active': isHoverActive,
       'is-consent-lockdown': isConsentLockdown
     }"
-    :style="{
-      color: themeText ?? undefined,
-      '--title-trailing-width': `${trailingWidthPx}px`
-    }"
+    :style="{ '--title-trailing-width': `${trailingWidthPx}px` }"
   >
     <!-- Left: app menu (hamburger). Anchors a native OS menu in main —
          HTML popups would be clipped by the title bar's WebContentsView
@@ -690,6 +686,8 @@ button.title-install-pill {
 button.title-install-pill:hover,
 button.title-install-pill:focus-visible {
   background: var(--brand-surface-bg-hover);
+  border-color: rgba(255, 255, 255, 0.32);
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.12) inset;
   outline: none;
 }
 button.title-install-pill.is-open {

--- a/src/renderer/src/lib/i18nMessages.ts
+++ b/src/renderer/src/lib/i18nMessages.ts
@@ -16,6 +16,7 @@ export const en = {
     close: 'Close',
     cancel: 'Cancel',
     back: 'Back',
+    initialEnvironment: 'Initial Environment',
     browse: 'Browse…',
     learnMore: 'Learn more'
   },

--- a/src/renderer/src/views/ProgressModal.test.ts
+++ b/src/renderer/src/views/ProgressModal.test.ts
@@ -243,7 +243,7 @@ describe('ProgressModal — brand branch state transitions', () => {
     vi.useRealTimers()
   })
 
-  it('renders in-flight state with a Return to Dashboard button and no banner', async () => {
+  it('renders in-flight state with a Cancel button and no banner', async () => {
     const { body } = await mountWithOp('inst-1', {
       flatStatus: 'Deleting installation…',
       flatPercent: 42,
@@ -254,7 +254,7 @@ describe('ProgressModal — brand branch state transitions', () => {
     expect(body.exists('.brand-progress__bar')).toBe(true)
 
     expect(body.exists('.brand-progress__footer')).toBe(true)
-    expect(body.selectorText('.brand-progress__footer')).toContain('Return to Dashboard')
+    expect(body.selectorText('.brand-progress__footer')).toContain('Cancel')
     expect(body.selectorText('.brand-progress__footer')).not.toContain('Minimize')
     expect(body.selectorText('.brand-progress__footer')).not.toContain('Reboot')
   })
@@ -444,25 +444,23 @@ describe('ProgressModal — brand branch state transitions', () => {
     expect(api.returnToDashboard).toHaveBeenCalled()
   })
 
-  it('emits close, cancels the in-flight op, and calls returnToDashboard when the in-flight Return button is clicked', async () => {
+  it('cancels the in-flight op without detaching when the in-flight Cancel button is clicked', async () => {
     const { wrapper, body } = await mountWithOp('inst-1', {
       flatStatus: 'Deleting installation…',
       flatPercent: 42,
     })
 
-    const returnBtn = body.buttonByText('Return to Dashboard')
-    expect(returnBtn).not.toBeNull()
-    returnBtn!.click()
+    const cancelBtn = body.buttonByText('Cancel')
+    expect(cancelBtn).not.toBeNull()
+    cancelBtn!.click()
     await flushPromises()
 
-    expect(wrapper.emitted('close')?.length).toBeGreaterThan(0)
-    // No installation in the store for inst-1 so the confirm is skipped
-    // and the in-flight op is cancelled.
+    expect(wrapper.emitted('close')).toBeUndefined()
     const store = useProgressStore()
     const op = store.operations.get('inst-1')
     expect(op?.cancelRequested).toBe(true)
     const api = (window as unknown as { api: MockApi }).api
-    expect(api.returnToDashboard).toHaveBeenCalled()
+    expect(api.returnToDashboard).not.toHaveBeenCalled()
   })
 
   it('uses friendlyCaption (not launchCaption) for non-launch ops', async () => {

--- a/src/renderer/src/views/ProgressModal.vue
+++ b/src/renderer/src/views/ProgressModal.vue
@@ -726,6 +726,14 @@ async function returnToDashboard(reason: ReturnToDashboardReason): Promise<void>
   await window.api.returnToDashboard()
 }
 
+function cancelInFlightOperation(): void {
+  const id = displayId.value
+  if (!id) return
+  const op = progressStore.operations.get(id)
+  if (!op || op.finished) return
+  progressStore.cancelOperation(id)
+}
+
 /** Re-run the same op that just errored. Mirrors the port-conflict
  *  retry pattern: feed the stored `apiCall` (or, for legacy launch
  *  ops without one, fall back to a fresh `runAction('launch')`) back
@@ -1065,11 +1073,11 @@ defineExpose({ startOperation, showOperation })
               <button
                 v-else
                 type="button"
-                class="brand-ghost brand-progress__footer-btn"
-                @click="returnToDashboard('in_flight')"
+                class="brand-ghost brand-progress__footer-btn brand-progress__footer-btn--danger"
+                @click="cancelInFlightOperation"
               >
-                <ArrowLeft :size="14" />
-                {{ $t('progress.returnToDashboard') }}
+                <X :size="14" />
+                {{ $t('common.cancel') }}
               </button>
             </template>
             <template v-else-if="isPortConflictOpen && currentOp.result?.portConflict">

--- a/src/shared/firstUseMode.ts
+++ b/src/shared/firstUseMode.ts
@@ -41,5 +41,5 @@ export function normaliseFirstUseMode(raw: unknown): FirstUseMode {
 
 /** True when any mode that should lock the title-bar chrome is active. */
 export function isChromeLockedMode(mode: FirstUseMode): boolean {
-  return mode !== 'none'
+  return mode === 'consent-lockdown' || mode === 'post-consent'
 }


### PR DESCRIPTION
### Motivation

- Ensure tests reliably spawn a child that holds a file open and clean up its helper file, and make the title-bar/menu labels and progress-modal behaviour clearer and consistent with UX intent.
- Replace ambiguous "Exit Window" wording with "Close Window" and surface a direct `Cancel` action for in-flight non-destructive operations instead of returning to the dashboard.
- Prevent the title-bar chrome from being locked during generic loading takeovers and make the initial environment label explicit for installation detail pages.

### Description

- Update `file-lock-info.test.ts` to write a temporary helper script and `fork` that helper instead of using an inline `-e` payload, and clean up the helper file after the test.
- Rename the install-host menu item `exit-window` label from "Exit Window" to "Close Window" in `src/main/popups/titlePopup.ts` and update the corresponding test in `titlePopup.test.ts`.
- Change the detail field label from the `common.release` key to `common.initialEnvironment` in `src/main/sources/standalone/updateSections.ts` and add the `initialEnvironment` string to the shared English catalog in `src/renderer/src/lib/i18nMessages.ts`.
- Remove the now-unused inline `themeText` style binding from `TitleBarApp.vue` and add subtle hover border/shadow styling to the install-pill for improved focus/hover visuals.
- Modify progress-modal behaviour by introducing `cancelInFlightOperation()` in `ProgressModal.vue`, wiring the in-flight non-destructive footer button to perform a cancel (and keep the host attached) with updated icon/label/styles, and update tests in `ProgressModal.test.ts` to expect the new `Cancel` semantics.
- Tighten `isChromeLockedMode` in `src/shared/firstUseMode.ts` to only lock the chrome for `'consent-lockdown'` and `'post-consent'`, excluding `'loading-lockdown'` so loading takeovers no longer collapse the title-bar chrome.

### Testing

- Ran the unit test suites covering the modified areas, including `file-lock-info.test.ts`, `titlePopup.test.ts`, and `ProgressModal.test.ts`, and the updated specs passed locally.
- Ran the renderer view tests exercising `ProgressModal.vue` transitions and the title-bar snapshots, and they succeeded against the updated behaviour.
- Performed a full test run of the project's automated unit tests and the suite completed without failures.

------