### PR TITLE
fix(release): fix bootstrap-python fetch in release pipeline + fail loudly when bootstrap-python fetch fails

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -96,6 +96,36 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm run bootstrap:fetch
 
+      - name: Verify bootstrap-python is populated for every platform
+        # Belt-and-braces check: even though fetch-bootstrap-python.mjs now
+        # exits non-zero on failure, surface the directory state in the build
+        # log and explicitly fail if any platform's Python binary is missing.
+        # The 0.6.4 installer shipped without bootstrap-python because a fetch
+        # error was swallowed and the directory was empty going into the
+        # packaging step. That class of failure must never be quiet again.
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "bootstrap-python tree:"
+          ls -la bootstrap-python/ || true
+          missing=0
+          for f in \
+            bootstrap-python/win-x64/python.exe \
+            bootstrap-python/mac-arm64/bin/python3 \
+            bootstrap-python/linux-x64/bin/python3
+          do
+            if [ ! -f "$f" ]; then
+              echo "::error::bootstrap-python verification failed: $f is missing"
+              missing=$((missing + 1))
+            else
+              echo "  OK: $f"
+            fi
+          done
+          if [ "$missing" -gt 0 ]; then
+            echo "::error::$missing bootstrap-python binar(ies) missing — refusing to build a broken installer"
+            exit 1
+          fi
+
       - name: Build with ToDesktop
         shell: bash
         run: |

--- a/scripts/fetch-bootstrap-python.mjs
+++ b/scripts/fetch-bootstrap-python.mjs
@@ -13,6 +13,12 @@
  *   --platform   Fetch only this platform (default: all platforms)
  *   --output-dir Override the output base directory (default: bootstrap-python/ in project root)
  *   --tag        Release tag to fetch from (default: bootstrap-v1)
+ *   --soft-fail  Exit 0 even when a platform fails to fetch or verify. Intended
+ *                for local dev — `predev` already prints a warning when the
+ *                directory is missing. Production builds MUST NOT pass this:
+ *                a silent fetch failure is what shipped 0.6.4 without
+ *                bootstrap-python, stranding new installs on the bundled
+ *                ComfyUI version.
  *
  * Uses GITHUB_TOKEN env var for authenticated downloads if set.
  * Skips platforms whose directory already exists.
@@ -33,11 +39,20 @@ const PLATFORMS = ['win-x64', 'mac-arm64', 'linux-x64']
 const DEFAULT_TAG = 'bootstrap-v1'
 const REPO = 'Comfy-Org/ComfyUI-Desktop-2.0-Beta'
 
+// Each platform's expected Python binary inside its bootstrap-python dir.
+// Used by verifyPlatform() so a partial / corrupt extract doesn't pass.
+const PYTHON_BINARY = {
+  'win-x64': 'python.exe',
+  'mac-arm64': path.join('bin', 'python3'),
+  'linux-x64': path.join('bin', 'python3'),
+}
+
 function parseArgs() {
   const args = process.argv.slice(2)
   let tag = DEFAULT_TAG
   let platform = null
   let outputDir = null
+  let softFail = false
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--tag' && args[i + 1]) {
       tag = args[++i]
@@ -45,9 +60,11 @@ function parseArgs() {
       platform = args[++i]
     } else if (args[i] === '--output-dir' && args[i + 1]) {
       outputDir = args[++i]
+    } else if (args[i] === '--soft-fail') {
+      softFail = true
     }
   }
-  return { tag, platform, outputDir }
+  return { tag, platform, outputDir, softFail }
 }
 
 async function fetchReleaseAssets(tag) {
@@ -98,32 +115,74 @@ async function downloadAndExtract(url, destDir) {
   }
 }
 
+function verifyPlatform(outBase, platform) {
+  const destDir = path.join(outBase, platform)
+  const binaryRel = PYTHON_BINARY[platform]
+  if (!binaryRel) {
+    // Unknown platform — nothing to verify against. Treat as caller error.
+    throw new Error(`Unknown platform ${platform}: no Python binary path configured`)
+  }
+  const binaryPath = path.join(destDir, binaryRel)
+  if (!fs.existsSync(binaryPath)) {
+    throw new Error(
+      `Expected ${binaryPath} after fetch, but it does not exist. The archive may have been partial, ` +
+      `extraction may have failed, or the directory was empty before the fetch ran. This installer ` +
+      `would ship without bootstrap pygit2 — refusing to continue.`
+    )
+  }
+}
+
 async function main() {
-  const { tag, platform: onlyPlatform, outputDir } = parseArgs()
+  const { tag, platform: onlyPlatform, outputDir, softFail } = parseArgs()
   const platforms = onlyPlatform ? [onlyPlatform] : PLATFORMS
   const outBase = outputDir || outputBase
   console.log(`Fetching bootstrap-python archives from release ${tag}`)
+  if (softFail) console.log('  --soft-fail: failures will be logged but not exit non-zero')
+
+  // Track per-platform outcome so we can fail loudly at the end if any
+  // requested platform did not end up with a usable bootstrap-python dir.
+  const failures = []
+  const recordFailure = (platform, err) => {
+    failures.push({ platform, message: err instanceof Error ? err.message : String(err) })
+    console.error(`  ${platform}: FAILED — ${err instanceof Error ? err.message : err}`)
+  }
 
   let assets
   try {
     assets = await fetchReleaseAssets(tag)
   } catch (err) {
-    console.warn(`Could not fetch release assets: ${err.message}`)
-    console.warn('Bootstrap python will not be available. Continuing without it.')
+    // Previously this just warned and returned 0. That meant any CI flake on
+    // the GitHub API (rate limit, 5xx, missing GITHUB_TOKEN on a private repo)
+    // produced an installer with no bootstrap-python, with no visible signal.
+    // Surface the failure now and treat every requested platform as failed.
+    const message = err instanceof Error ? err.message : String(err)
+    console.error(`Could not fetch release assets for tag "${tag}": ${message}`)
+    for (const platform of platforms) recordFailure(platform, new Error(`release fetch failed: ${message}`))
+    exitWithFailures(failures, softFail)
     return
   }
 
   for (const platform of platforms) {
     const destDir = path.join(outBase, platform)
+
+    // Pre-existing dir: still verify it has the binary we expect. A half-
+    // extracted dir from a previous run (e.g. cancelled tar) would otherwise
+    // be treated as "already done" and silently ship broken.
     if (fs.existsSync(destDir)) {
-      console.log(`  ${platform}: already exists, skipping`)
-      continue
+      try {
+        verifyPlatform(outBase, platform)
+        console.log(`  ${platform}: already exists and verified, skipping`)
+        continue
+      } catch (err) {
+        recordFailure(platform, err)
+        continue
+      }
     }
 
     const assetName = `bootstrap-python-${platform}.tar.gz`
     const asset = assets.find((a) => a.name === assetName)
     if (!asset) {
-      console.warn(`  ${platform}: asset ${assetName} not found in release, skipping`)
+      recordFailure(platform, new Error(`asset ${assetName} not found in release ${tag}`))
       continue
     }
 
@@ -132,13 +191,38 @@ async function main() {
       // Use asset.url (REST API endpoint) not browser_download_url to
       // support private repos and avoid auth-header issues with S3 redirects.
       await downloadAndExtract(asset.url, destDir)
+      verifyPlatform(outBase, platform)
       console.log(`  ${platform}: OK`)
     } catch (err) {
-      console.warn(`  ${platform}: failed - ${err.message}`)
+      recordFailure(platform, err)
     }
   }
 
-  console.log('Done.')
+  exitWithFailures(failures, softFail)
+}
+
+function exitWithFailures(failures, softFail) {
+  if (failures.length === 0) {
+    console.log('Done.')
+    return
+  }
+  console.error('')
+  console.error(`bootstrap-python fetch finished with ${failures.length} failure(s):`)
+  for (const { platform, message } of failures) {
+    console.error(`  - ${platform}: ${message}`)
+  }
+  if (softFail) {
+    console.error('--soft-fail was set: exiting 0 despite failures. Do not use this flag in production builds.')
+    return
+  }
+  console.error('')
+  console.error(
+    'Refusing to continue. A build that proceeds without bootstrap-python ships an installer that ' +
+    'cannot resolve "Latest Stable" on first launch (no git backend), and new installs are stranded ' +
+    'on the bundled ComfyUI version with the UI claiming "Already up to date". Fix the fetch (token / ' +
+    'network / asset name) or rerun with --soft-fail for local dev only.'
+  )
+  process.exit(1)
 }
 
 main().catch((err) => {

--- a/scripts/todesktop-beforeBuild.cjs
+++ b/scripts/todesktop-beforeBuild.cjs
@@ -1,6 +1,12 @@
+// Keys are todesktop's normalized `${platform}-${arch}` strings (matches
+// electron-builder's Platform enum: windows / mac / linux), NOT Node's
+// process.platform values (win32 / darwin / linux). Until this was fixed,
+// every Windows and Mac build silently hit the "skipping" branch below —
+// the fetch on todesktop's server never ran, which is why 0.6.4 (and every
+// earlier release with this hook) shipped without bootstrap-python.
 const PLATFORM_MAP = {
-  'win32-x64': 'win-x64',
-  'darwin-arm64': 'mac-arm64',
+  'windows-x64': 'win-x64',
+  'mac-arm64': 'mac-arm64',
   'linux-x64': 'linux-x64',
 }
 
@@ -9,10 +15,12 @@ const PLATFORM_MAP = {
 // in src/main/lib/git.ts:tryConfigureBootstrapPygit2. Kept here so a fetch
 // script that returns 0 but produces a directory without the binary still
 // fails the build instead of silently shipping a broken installer.
+// Forward slashes are fine on every platform — these strings are passed to
+// path.join() below, which normalizes separators per-OS.
 const PYTHON_BINARY = {
   'win-x64': 'python.exe',
-  'mac-arm64': require('node:path').join('bin', 'python3'),
-  'linux-x64': require('node:path').join('bin', 'python3'),
+  'mac-arm64': 'bin/python3',
+  'linux-x64': 'bin/python3',
 }
 
 module.exports = async ({ appDir, platform, arch }) => {
@@ -29,7 +37,12 @@ module.exports = async ({ appDir, platform, arch }) => {
 
   console.log(`[todesktop:beforeBuild] Fetching bootstrap python for ${bootstrapPlatform}`)
   const script = path.join(appDir, 'scripts', 'fetch-bootstrap-python.mjs')
-  const outDir = path.join(appDir, 'bootstrap-python')
+  // todesktop resolves extraResources.from against `<appDir>/extraResources/`,
+  // not against the project source root — confirmed by the build log
+  // ("file source doesn't exist  from=<appDir>\extraResources\bootstrap-python\win-x64").
+  // Writing to <appDir>/bootstrap-python (the previous behaviour) put the
+  // archive in the wrong place and todesktop's packager skipped it silently.
+  const outDir = path.join(appDir, 'extraResources', 'bootstrap-python')
   // fetch-bootstrap-python.mjs now exits non-zero on failure, which bubbles
   // up here via execSync. Don't wrap in try/catch — a failed fetch must fail
   // the build (see 0.6.4 post-mortem: a swallowed fetch error shipped an

--- a/scripts/todesktop-beforeBuild.cjs
+++ b/scripts/todesktop-beforeBuild.cjs
@@ -6,11 +6,7 @@
 // earlier release with this hook) shipped without bootstrap-python.
 const PLATFORM_MAP = {
   'windows-x64': 'win-x64',
-  // todesktop invokes the hook separately for the arm64 slice of the
-  // universal Windows installer, and todesktop.json's windows extraResources
-  // still requires bootstrap-python/win-x64 for that arch. Windows-on-ARM
-  // runs x64 binaries via emulation, so reuse the x64 bundle.
-  'windows-arm64': 'win-x64',
+  'windows-arm64': 'win-x64', // Windows-on-ARM runs x64 under emulation
   'mac-arm64': 'mac-arm64',
   'linux-x64': 'linux-x64',
 }

--- a/scripts/todesktop-beforeBuild.cjs
+++ b/scripts/todesktop-beforeBuild.cjs
@@ -6,6 +6,11 @@
 // earlier release with this hook) shipped without bootstrap-python.
 const PLATFORM_MAP = {
   'windows-x64': 'win-x64',
+  // todesktop invokes the hook separately for the arm64 slice of the
+  // universal Windows installer, and todesktop.json's windows extraResources
+  // still requires bootstrap-python/win-x64 for that arch. Windows-on-ARM
+  // runs x64 binaries via emulation, so reuse the x64 bundle.
+  'windows-arm64': 'win-x64',
   'mac-arm64': 'mac-arm64',
   'linux-x64': 'linux-x64',
 }

--- a/scripts/todesktop-beforeBuild.cjs
+++ b/scripts/todesktop-beforeBuild.cjs
@@ -4,8 +4,20 @@ const PLATFORM_MAP = {
   'linux-x64': 'linux-x64',
 }
 
+// Each platform's expected Python binary inside its bootstrap-python dir.
+// Mirrors PYTHON_BINARY in fetch-bootstrap-python.mjs and the runtime check
+// in src/main/lib/git.ts:tryConfigureBootstrapPygit2. Kept here so a fetch
+// script that returns 0 but produces a directory without the binary still
+// fails the build instead of silently shipping a broken installer.
+const PYTHON_BINARY = {
+  'win-x64': 'python.exe',
+  'mac-arm64': require('node:path').join('bin', 'python3'),
+  'linux-x64': require('node:path').join('bin', 'python3'),
+}
+
 module.exports = async ({ appDir, platform, arch }) => {
   const { execSync } = await import('node:child_process')
+  const fs = await import('node:fs')
   const path = await import('node:path')
 
   const key = `${platform}-${arch}`
@@ -18,8 +30,26 @@ module.exports = async ({ appDir, platform, arch }) => {
   console.log(`[todesktop:beforeBuild] Fetching bootstrap python for ${bootstrapPlatform}`)
   const script = path.join(appDir, 'scripts', 'fetch-bootstrap-python.mjs')
   const outDir = path.join(appDir, 'bootstrap-python')
+  // fetch-bootstrap-python.mjs now exits non-zero on failure, which bubbles
+  // up here via execSync. Don't wrap in try/catch — a failed fetch must fail
+  // the build (see 0.6.4 post-mortem: a swallowed fetch error shipped an
+  // installer with no bootstrap-python, stranding new installs).
   execSync(
     `node "${script}" --platform ${bootstrapPlatform} --output-dir "${outDir}"`,
     { stdio: 'inherit', cwd: appDir }
   )
+
+  // Defense-in-depth: even if the fetch script returns success, verify the
+  // expected binary exists before handing control back to todesktop. A
+  // divergence between the fetch script's success criteria and what the app
+  // looks for at runtime would otherwise reproduce the same silent failure.
+  const expectedBinary = path.join(outDir, bootstrapPlatform, PYTHON_BINARY[bootstrapPlatform])
+  if (!fs.existsSync(expectedBinary)) {
+    throw new Error(
+      `[todesktop:beforeBuild] fetch script returned success but ${expectedBinary} is missing. ` +
+      `Refusing to build — the installer would not provide a git backend and "Latest Stable" ` +
+      `installs would silently strand on the bundled ComfyUI version.`
+    )
+  }
+  console.log(`[todesktop:beforeBuild] Verified ${expectedBinary}`)
 }


### PR DESCRIPTION
Companion to #612 (the in-app runtime fix). This PR addresses the **other** side of the same bug: the 0.6.4 installer shipped without `resources/bootstrap-python/<platform>/python.exe`, which is the precondition for the "Latest Stable" stranding we hit in QA.

## Root cause (confirmed against todesktop build log `260527uf00qci3d`)

Two latent bugs in `scripts/todesktop-beforeBuild.cjs` meant the bootstrap-python fetch on todesktop's server has **never actually worked on Windows or Mac** since the hook was added:

1. **Platform key mismatch.** `PLATFORM_MAP` was keyed on `process.platform`-style strings (`win32-x64`, `darwin-arm64`), but todesktop passes electron-builder's `Platform` enum names (`windows-x64`, `windows-arm64`, `mac-arm64`). Every Windows and Mac build silently hit the `No bootstrap python for <key>, skipping` branch. Linux happened to match by accident.

2. **Wrong staging path.** The hook wrote to `<appDir>/bootstrap-python`, but todesktop resolves `extraResources.from` against `<appDir>/extraResources/`. The build log makes this explicit:

   ```
   • file source doesn't exist  from=<appDir>\extraResources\bootstrap-python\win-x64
   ```

   Even if bug #1 were fixed, the fetched archive would have ended up in the wrong directory.

Result: every published installer with this hook shipped without `bootstrap-python`. First launch on a fresh machine without system git therefore had no git backend, `getLatestStableTag()` returned null, the cache was poisoned with the bundled ComfyUI version, and "Latest Stable" silently stranded users on `v0.20.1`.

A third latent bug was in `scripts/fetch-bootstrap-python.mjs` itself: every error path soft-failed (`console.warn + return 0`). Even if the hook had been calling it correctly, a single GitHub API hiccup or a partial extract would have produced an empty `bootstrap-python/` dir with no signal in the build log. That class of failure has to be loud regardless.

## Changes

**1. `scripts/todesktop-beforeBuild.cjs`** — fix the actual bug + verify
   - `PLATFORM_MAP` keys corrected to `windows-x64` / `windows-arm64` / `mac-arm64` / `linux-x64` (todesktop's normalized `${platform}-${arch}`). `windows-arm64` reuses the `win-x64` bundle since Windows-on-ARM runs x64 binaries under emulation.
   - `outDir` now writes to `<appDir>/extraResources/bootstrap-python` so the staged path matches what todesktop's packager actually reads.
   - After `execSync` returns, re-checks that the platform's expected Python binary (`PYTHON_BINARY` table) exists and throws if not. Mirrors the runtime check in `src/main/lib/git.ts:tryConfigureBootstrapPygit2` — divergence between "what the build script considers complete" and "what the app looks for at runtime" produces a build failure, not a silent broken installer.

**2. `scripts/fetch-bootstrap-python.mjs`** — strict by default
   - All error paths now exit 1. Release-list fetch, individual asset download, and post-fetch binary verification all surface failures and refuse to return 0 unless every requested platform succeeded.
   - After each fetch, the script verifies the platform's Python binary actually exists. A partial archive or aborted extract that leaves a half-populated directory now fails instead of pretending success. Existing pre-populated dirs are also verified, not just trusted by existence.
   - End-of-run summary lists every failure with the platform-specific reason.
   - New `--soft-fail` flag for local dev (e.g. offline laptop). `predev` already warns when `bootstrap-python/<platform>/` is missing, so dev is not blocked. Production builds must not pass this.

**3. `.github/workflows/build-release.yml`** — explicit verification step
   - New step between the pre-fetch and `todesktop build` that lists the `bootstrap-python/` tree in the log and `::error::`s out if any platform's Python binary is missing on the GH runner. Belt-and-braces around the strict fetch script.

## Verified

- todesktop build log `260527uf00qci3d` directly confirms both bug #1 (`No bootstrap python for windows-x64, skipping`) and bug #2 (`file source doesn't exist  from=…\extraResources\bootstrap-python\win-x64`).
- Local fetch script behaviour:
  | Scenario | Expected | Actual |
  |---|---|---|
  | Valid tag + win-x64 | Fetch + verify succeeds, exit 0 | ✅ exit 0, `python.exe` present |
  | Bogus tag, no `--soft-fail` | Exit 1 with "refusing to continue" | ✅ exit 1 |
  | Bogus tag + `--soft-fail` | Exit 0, prints "do not use this flag in production builds" | ✅ exit 0 |
- `pnpm run typecheck` ✅, `pnpm run lint` ✅.

## Why ship both this and #612

The runtime fix (#612) handles future failures that strand the cache — transient pygit2 errors, broken AV scanners, etc. This release fix removes the **common-case trigger** by guaranteeing every shipped installer includes `bootstrap-python` or the build fails outright. Together they are the right defensive depth: code can't strand a user if the cascade has a backend; even if the cascade somehow has no backend, the cache fix keeps the install honest.

## Test plan

- [ ] Trigger a `workflow_dispatch` run on this branch and confirm:
  - The GH-runner verify step lists all three platform binaries.
  - The todesktop build log shows `[todesktop:beforeBuild] Fetching bootstrap python for win-x64` (not `... No bootstrap python for windows-x64, skipping`).
  - No `file source doesn't exist` warning for `bootstrap-python`.
- [ ] Inspect the produced installer: `resources/bootstrap-python/python.exe` (Windows), `resources/bootstrap-python/bin/python3` (Mac/Linux) is present.
- [ ] Local dev escape hatch: `node scripts/fetch-bootstrap-python.mjs --soft-fail --tag bootstrap-no-such-tag` exits 0 with a warning.
