### PR TITLE
feat(auth): system-browser sign-in for embedded cloud workspace

### DIFF
--- a/src/main/auth/firebaseBridge/bridgeHtml.ts
+++ b/src/main/auth/firebaseBridge/bridgeHtml.ts
@@ -1,0 +1,446 @@
+/**
+ * Bridge-page HTML rendered to the user's system browser. Two flows
+ * share these helpers depending on provider:
+ *
+ *  - Google: server-driven raw OAuth (`createAuthUri` → HTTP 302 →
+ *    provider → 302 back to `signInWithIdp`). The user's browser only
+ *    sees a terminal state — "Signed in" or "Sign-in failed".
+ *
+ *  - GitHub: client-driven popup bridge — the page initialises Firebase
+ *    JS SDK and calls `signInWithPopup` (gated behind a button click so
+ *    popup-blockers can't fire). Used because GitHub OAuth Apps only
+ *    permit a single Authorization Callback URL (reserved for web
+ *    sign-in), so the loopback raw-OAuth flow can't be used.
+ */
+
+import type { FirebaseProjectConfig } from './config'
+import type { SupportedProvider } from './intercept'
+
+const FIREBASE_SDK_VERSION = '10.14.1'
+
+const PROVIDER_LABEL: Record<SupportedProvider, string> = {
+  'google.com': 'Google',
+  'github.com': 'GitHub',
+}
+
+const PROVIDER_ICON: Record<SupportedProvider, string> = {
+  'google.com': `<svg viewBox="0 0 18 18" width="18" height="18" aria-hidden="true">
+    <path fill="#4285F4" d="M17.64 9.2c0-.64-.06-1.25-.16-1.84H9v3.48h4.84a4.14 4.14 0 0 1-1.8 2.71v2.26h2.92a8.78 8.78 0 0 0 2.68-6.6z"/>
+    <path fill="#34A853" d="M9 18c2.43 0 4.47-.8 5.96-2.18l-2.92-2.26c-.8.54-1.84.86-3.04.86-2.34 0-4.32-1.58-5.03-3.7H.95v2.33A9 9 0 0 0 9 18z"/>
+    <path fill="#FBBC05" d="M3.97 10.72A5.41 5.41 0 0 1 3.69 9c0-.6.1-1.18.28-1.72V4.95H.95A9 9 0 0 0 0 9c0 1.45.35 2.83.95 4.05l3.02-2.33z"/>
+    <path fill="#EA4335" d="M9 3.58c1.32 0 2.5.45 3.44 1.35l2.58-2.58A9 9 0 0 0 9 0a9 9 0 0 0-8.05 4.95L3.97 7.28C4.68 5.16 6.66 3.58 9 3.58z"/>
+  </svg>`,
+  'github.com': `<svg viewBox="0 0 18 18" width="18" height="18" aria-hidden="true">
+    <path fill="currentColor" d="M9 0a9 9 0 0 0-2.85 17.54c.45.08.62-.2.62-.43v-1.5c-2.5.55-3.03-1.21-3.03-1.21-.41-1.04-1-1.32-1-1.32-.82-.56.06-.55.06-.55.9.06 1.38.93 1.38.93.8 1.38 2.11.98 2.62.75.08-.59.32-.99.57-1.22-1.99-.23-4.09-1-4.09-4.43 0-.98.35-1.78.93-2.41-.09-.23-.4-1.14.09-2.37 0 0 .75-.24 2.48.92a8.5 8.5 0 0 1 4.5 0c1.72-1.16 2.48-.92 2.48-.92.49 1.23.18 2.14.09 2.37.58.63.93 1.43.93 2.41 0 3.44-2.1 4.2-4.1 4.42.33.28.62.83.62 1.67v2.47c0 .24.16.52.62.43A9 9 0 0 0 9 0z"/>
+  </svg>`,
+}
+
+const COMFY_MARK = `<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAYAAABccqhmAAAACXBIWXMAAE69AABOvQFzamgUAAAVWUlEQVR42u2dC3RdVZnHv31u3snNq0nz6CsNbZIWkAJC3wUq6ACCzhpm4QxFURGXiDPKDFLHxYDKmnEhD5cKo8x0Ris4KgsVkK5BpEBfUByhPCbtDbVJWppH82iaV5P23rtnn9tQS2mTk9zk3nvO+f3Wuuuem9znd/b339+3v332VuJ+1KxZtRXWUalVStWYx7VKdLW5L9AiQSWSb46DI7dcARibAXPrs2+mDfWqY8eHtKg95j6ktW6Ipkto375Qq3msXe08bvvCC0sX5g0EwistS602pl9l/8nc8mizkAT6za3eeNGmaFRvzI2kba7vqO9HACb5O1aVLVisrOiVRmpXmy98oflbGm0PUpCwaaOvmDa6UUetp5vad25P9QghZQVg9vT51aaXX2O+4PWi1DzaFrgOrXcbF1sf1fJIc3uoEQEYg6qqqix1JPM6o5mfMg9X0oLAQ2w23vYTnTH8aFNT0xACcAJlZR/IzbWGPq9F3WYeltNWwLMoaVVa3zsQzfpRe/sbA74WgOqi6gKdlfFFEyt9xTwsoXWAj+hUou63hsMP7u7e3ZusLxFIxodeLBenSWXmLZIWeMI8vNLccmgP4DPsNv8hnWZ9oSi/dHBR31mvNklT1PMRwJwZdUutqH7IHC6iDQAcZ0fUUjc379/1kicFYF75vNKwBL6tlHyGcw1warSW/8xQ+vaG1oZOzwjA3Mq6q8wv+7E5LOYUA4xJtyh1Q2PLrqdcPQawcOHCjLy0afcYXfueeZjNeQVwhO0rf1MULM2vnD39hY6OjojrIoCq8roqpfQv5NjMPQCYkIeq7aLVtY2tO5un4u2tqXjT6vKaK4zzv4bzA8Q9KLBYJLrD9ilXpADVlbWf1qL+WyjtAUwWWSYS+ERhXunenv7OHakqAKq6omatcf7vT1VkAeBjLKXk44X5JUM9fV3bUk0ArOqK2geM83+d8wQwhUMCIpcWB0sKDvZ3PSuTcKXhZAiANbei7r/M/ec5PQAJYUlRsHSuSQeejFcE4hUAZff8OD9AwjlnJBL4XdIEYCTnJ+wHSFIkUJhfcrinr2trwgVgZLT/+5wDgCSPCeSX7D3Y17Vjgq+fgPOX11yhlXpSknQ1IQC8h4jS+uo9bQ0bplwARmb42ZN8CrE7QMrQo7U6t6ltV9N4XjSuer09t39kei/OD5BaFCpLfm776JSNARy7sEeuwdYAKcnM8HA0p6fPeWXAcQowt7L2atHyBDYGSHGUutrppcSOBMBezCOiAruE6/kB3EB3uuhaJ4uKOBoDsFfywfkBXEPxUVHfnpQI4IzKumVRrbdiUwB3EbXUsrHWGBw1ArBX7zXO/xCmBHAf9uK7sRW4R2H0KkBl5i0mRLgBUwK4kvJD+QOdPX2dr4w7BTi2aUd6k1DzB3AzPYHhyJzTbT5y+hQgK+NmnB/A9RRGM62bxxUB2Hv15VjDdu/Pdl0A7qdzMJpZdaq9CE8ZAdgbdeL8AJ6hxPj0TY4igNgW3cOZ9l7m7NIL4BWUtOqM4eqTtyZ/XwSgjmReh/MDeAwtFSO+PUYKoOVTWAvAiyKgPjlqCjB7+vzqQMD6E5YC8CbRqFQ3t4caTxkBWJZag4kAvIulZM3pUgBlwoHrMRGAh1ExH1fvE4CqsgWLjQTMw0IAnmZ+zNdPFgBlRa/ENgA+CAIC0SveJwBaZDWmAfAB+s++HssFaktqg0fSpdscpmEdAM8Tzg4Hiuo76vtjEcBQml6B8wP4hrTBtMiK4ymAZSnCfwA/jQOoY2mANZITrMIkAL4aB7joXQGwxwEWYhEAX7EgFgjMmlVbmRaW/dgDwF9Ej1qVlnVUajEFgA/HAdJ0raWUqsEUAH5UAKmxxwCIAAB86f9iIgDR1ZgCwI8CoKvtCKAAUwD4UgEKLC0SxBIA/kNrCZoUQPIxBYAvybdTACIAAH+mAEEEAMC3OYAE7SsAc7GEj2PAgoB8cGlQLlgelAVnZ8u00nQpnpYmefkB1/+2w4NROdB2VHb8oV9+99RB2bKxlxP+XvLU3IpajR38x6IL8mTN56bL6ssLJBBQvvjNr/9xQO66tVn2vD1EA3g3C0AA/MUZNdlyxz2z5NwL83z5+wf6InLrjY3y8maiAQTAR9i9/Ge/VCY3faVC0tOVr21hi8B1V4akcTeRgIVreJ+sLEvuX1ctX/xqpe+d3yY3GJB//s5sGgYC4H2C+Wny8C/ny8UfZsLniZy3OE+WrKIAhgB4POy/99+r5JwPUug5FR+5uggBoBl4l1vvmCFLVjLRc7QoAAEAT2I7/pqbpmOIUSgrz0AAaAbeDP1v+8ZMDDEG4UgUAaAZeI+PXTtN5tVlYYgx2L/vCAJAM/Aen/hMKUZwQGPDMAJAM/AWtQuzYzcYm60vMBsQAfAYH71mGkZwgNZGAJ5HABAAj7HqMsp+Ttj5xqB0dx5FAGgK3mHG7EypOoPBPydseu4QRkAAvMWK1fT+jvN/wn8EwHMCcAkC4ISe7rC89doghkAAvENGhpILVyAATtj2Qq9Eo1wFjwB4iPOW5ElWNpf6OmEzS4MhAF5j5Wou93WC3fNvI/9HALzGcgYAHWHn/j0HwxgCAfAOlbMyZO48yn9OYPQfAfAcKwj/HUP9HwHwoAAQ/juhqyMcmwEICIBniJX/lrO2nRO2vXAodg0AIACe4bzFQcnO4TQ6Yctz5P8IgOfCf3p/J0QiWra9iAAgAB4iLV3JpVeysq0T3nx1QHoPRTAEAuANlBK57a6ZUjGThS2dsJnw/9SdCCZIDvbgXdG0dCkqTpOMLOdTeO1nVs7OkL++vkTOX0L4T/6PALiCaaVpsurSQlm8IijnL8uT6WXpGCVBHGg/Krv+j/IfApAEzlyUI2tunC6XXVXEvnzJCv9/z+QfBCDBFJrQfu23Zsnlf8kgXbLZ8KtujIAAJI5LPlIod903OyYCkFza9h+VP77cjyEQgMRw7Q2lsvbumWJZhPupwGM/7WD2HwKQGD739+Vyy+2VGCJVev+WI/LIwwcwxCgwD2CSuPxjxTh/ivG9f22RoSH2/0MAppi6M3PkrgdmY4gU4pknD8rTjzP4hwBMtQFNrn/nvbMlKwtTpgq7dw3Jnbc2YwgEYOqxd+JdeE4OhkgR3mkalr+74U9yeJDQHwGYYuyLccj7Uwd7sY/rr26Q/XvZ9RcBSAAXXVogJdMppKQCv/l5l3z6rxrY72+8nRgmiCP8/wQ78Sab1neOyDe/uje22QcgAAkjNxiQFZewGGeyqH99UNY/3C7P/rZHwkeZ6YMAJJilq4ISwHoJwa7lH+wMx67oe2VLn2w3tz+FhjAMApA83LwS78b/6ZHH1nfGwud3p8nqk+bLnvjwPccnv9npnjfq+530Llqd8nn2g96+iBweYEQfAUgxlrk0/H/4u23y4D0tnECIQRVgAsxfkC1l5e5b0GNv47D88L5WTiAgAHGF/5e4M/y3B8zs1XEBEIA4WO7Srbi2bGRlHEAA4iInLyDnXpDruu/d3xuR1//IwhiAAMTF0pXB2BRgt/HSpj6JsCs2IADxhv/uzP83sysuIADx48b6v11bZ6osIABxMq8uS8oq3LcTT6h+UDrauUgGEIA4e393jv5v3djHyQMEIO7836X1f8p/gADESXauJeddmOe67035DxCASWDJinzKf4AA+Db8X034DwiAb1npwgFAu/y39XnKf4AAxMUZNdlSPsN9V/9R/gMEYFLC/6ArvzflP0AAJoEVXP0HCIA/iZX/FlP+AwTAlyxeHpR0yn+AAPg1/yf8BwTAt6x0af2f8h8gAHFSPT9LKma67+o/e/18yn+AAPg0/Kf8BwjAJLDCpfV/8n9AAOIkO8cu/7lPACj/AQIwCVywPCgZGZT/AAHwZ/jP4h+AAPg5/6f8BwiAL6k6I0tmzM503fem/AcIgJ97f8p/gABMhgAw/RcQAF+Sla3k/KVc/QcIgC+5YHk+5T9AAHwb/lP+AwTAz/m/OwVgG+U/QADiY051psyc477yX6j+sByg/AcIQLy9v0tH/5+j9wcEIG7Y+w8QAJ+SlWXJB5dR/gMEwJfYzp+Z6T5zvPX6AOU/QAD8mv/bkQsAAhC3ALgz/689Mye2eAkAAjBBZlVlxm5uxHb+f7xrJicRJkQaJnBv7/8u16wpkell6bLuB+3SsPOwDA9FUvfLaiWRiKbRIQDk/5PJqssKYjc3cHggKq0tR+SlF3vlqce6ZOebh2mESULNraj1tRzbI/+bdn6AwbRkBQSm9T3zxEG5e+0+6eulnMEYQIKxy384fxJ7ICXyFx8vkkeerpHyGekYBAFILG6d/ec17GXYvveTeVQ0EIDEsuDsHFpBilC7MFtu+nI5hkAAEseMOZm0ghTib2+cLoVFjE0jAAmiqJjGlkrY4zEXfbgAQyAAiaG7g5HnVOP8JXkYAQFIDA31g7SCFKNkOtUABCBBPP8M19KnGuEwMwURgASx4dddLKeVYuxrHMYICEBiGDqs5d4736ElpBC7Q0MYAQFIHM88eVAe/m4bhkgRtr3AGocIQIJ58J4W+Zd/2idHjpB/JrX33zUk7a1HMAQCkHh+8eMOuWr5W/L4o51yqCeCQZLAZhY4TSi+vxrwdATSRObVZEtJWbrk5DrXybR0JTULs+Wqa6ZJaRnlrPFy4zUN8odtLHKKALic/IKA3L/uDLlgGZNanDLYH5GVZ74h4aM0SVIAl9N7KCJf/1KTHB6MYgyHvLS5D+dHALyDPZj15qsDGMIhWzcy+o8AeIx9zUxqccoWBAAB8Brz6rIxggMo/yEAnsMeCDxrEQuOOOv9Kf8hAB5j2UX5EggoDOEk/3+e8B8B8BjLV7OwhRPs8t+rr1D7RwA8hL3aLQuOOuPlLZT/EACPUXd2jkwrZbkxR+E/o/8IgNdYuZre3ymbn0MAEACPsYL83xGU/xAAzxEr/51L+c8JlP8QAM9B+W8c+T/lPwTAa1D+cwblPwTAc1D+cw7lPwTAc9SdlU35zyEv/o78HwHwGCs/RPjvhOHhqPx+Qw+GQAC8xdKLCP+d8MIzh6S/l3UXEQCPweW/zvjZug6MgAB4C7v+b99gdJ79bY/s+AOj/wiAx8jIpPbvJPd/4O79GAIB8B4HuyISiVDWGo27b98r+/eyTBoC4EFs53/9f1kEdLS8/8lfdmMIBMC72PsMwvt56rEuufcb+zAEAuBtfv2zLmlr4eq2E1n/wwNyx5ebJRLGFgiAx7EHue78yl7GAgw9B8PytVua5L5vviMacyAAfuHlzb1y1z80+3aeezSq5enHu+Xjq+plw6/I+VMZ9gacQs5bnCd33DNbqudn+eL32lf3/eYX3fLofxyQd9gQBQEAia0LcNmVhbL6ikI585wcKS1Pl8zMPwdeJ4fG+qQ/nDJ01mr015z89PF+xljvb3p4e/v07s6wdHUclbd2DMorW/vkzdcGuLrPhQJgT8nKxRQAvqPf7or6sAOAH7t/6UMAAPyKNgJgMjYWZQPwJ72WIgIA8GcGMJICsC4TgD9TgEMmBVB7sASAH/1f7bEjgBCmAPCjAEjI0lo3YAoAXypAgxVNJwIA8KX/h1XInvNpzwa0S4F5mATAN/Q1toYKrGOpgNRjDwBfsdP2/WNXpSjZhD0AfISSF+27mABEo3ojFgHwUf6vZeNxAcgKqy3mjgWbAPxBOCcc2HJcAEKdoT4t8gp2AfAF2+s76vuPC8CxlEBIAwD8kf8f9/XjAqCj1tNYBsAH+X/E2nBCx/9nXZhbXtMgSs3DRACe5e3G1lCtjKwcd+KqwPbKbz/FPgBe7v5jPq7flwLYRKP6ESwE4F2iWt7j4+8RgL0H3rYvDd6MmQC8iNrU3B5qPK0AjIwK/ARDAXjR//X6k//0PgHQGcOPmrs2rAXgJeeX1hHfHl0AmpqahpTo72AxAC91/vo7tm+PKQA2A9GsH5m7TswG4Ak6jE8/fKp/nFIA2tvfGFCi7sduAF6I/vX9tk87FoDYP4bDD5q7HswH4Gp6rOHoQ6f7Z+B0/+g+3D1cmF9yWIlcjg0B3Nr9q6/uOdBw2tK+Ndprq1oqbOXYgRUBXMmOOS3l/zZ6ejAGc2bULbWiehu2BHAXUUsta96/66XRnhMY600O9XW+U5hXMlspOReTAriGdU0toYfGepLl5J3SJLLWHhbApgCuoDtd9FonT3QkALvbdneIUjdgVwAXYHy1obXB0TyegNP37OnrbCgKluabw6VYGCBVnV/f19gS+oHTp1vjee/sIutrwtqBAKna828vbgl+bVwvGe9nVJXXVSmlXzOHhVgcIGXoMf35osbWnc3jeZE13k9patvVpLS+zhxGsDlAShCxfXK8zj+uMYATOdjf9XZxfsk+c/gxbA+QXLRWn21sCz02kdcGJvqhB/u6dhQHpw2bLOJSTgFAkpxfydqm1tCDE319IJ4PN5HA1uJgSYE5XMKpAEiw84t6wDj/nfG8RyDeL2FE4NmiYOlcc3gOpwQgUaj1Ta27vignrPCbFAGwv0BPf+eTJhIoJBIASIDri3y3sTV0szmMxvtegUn6TtpEAs+MXD7MmADA1OX8tzceC/v1ZLxfYDK/XE9f19bi/JK95vCjMoESIwCclog92h/PgN9poonJp7q85gqtlL0CKZOFACahb7Xr/HvaGjZMQToxNcRmDFryc9F6MecPYKIeqrabuP/aiUzyccKUhen2jMHsQmuVfXECZxFgIs6v77N9aKqcf0ojgBOZW1l3lYkEfmwOizmrAGPSbV/S29iy66mp/qCEDNTZPyRdtL0l8TrOLcCorLN9JRHOn7AI4ERG1hi0lypaxLkGOO6Kr+mourmpfefLCf3UZPzUi+XitObKti+YtOCbQqUA/E2PCffvMD2+vXpvwq+wVcn85dVF1QWSlXGzFn2reVhCWwAf0alE32dv2rG7e3dv0uKOVLBEWdkHcnOtoZu0UreJlgraBng30pdWe6NOe6++023X5TsBeJeqqqosdSTzOtHqkyJ6Fa0FPOT5m0Tp9fYW3afapRcBOIk5ZbVzLSVrzDe83jycTwMCF/K2ua2PRuXR5vZQY2oGJC6QzqqyBYtVIHqFSQ9Wm8f2zMI02hakIGFz2268aqOOWBua2ndul0m6aMfPAvAeFpYuzBtMi6xQyoiBlovsP5lbHm0PkkC/udUbL3pRa9mYEw5sqe+o73fXkIQHkqs5JQvKVZquNb+mxvygWiW62hwXmJMSNP/PN8dBOXaMUIAzx1bSZ9pMnznuVceOD2lRe0x3HjLHDTqsQs2dO9tSvYcfi/8HcgaQRnQSd/kAAAAASUVORK5CYII=" width="56" height="56" alt="ComfyUI" style="display:block;border-radius:12px" />`
+
+const CHECK_ICON = `<svg viewBox="0 0 24 24" width="44" height="44" aria-hidden="true">
+  <circle cx="12" cy="12" r="11" fill="none" stroke="currentColor" stroke-width="2"/>
+  <path d="M7 12.5l3.2 3.2 6.8-6.8" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>`
+
+const ERROR_ICON = `<svg viewBox="0 0 24 24" width="44" height="44" aria-hidden="true">
+  <circle cx="12" cy="12" r="11" fill="none" stroke="currentColor" stroke-width="2"/>
+  <path d="M9 9l6 6M15 9l-6 6" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"/>
+</svg>`
+
+const STYLES = `
+:root {
+  color-scheme: light dark;
+  --bg: #f5f5f7;
+  --surface: #ffffff;
+  --text: #111;
+  --muted: #6b6b73;
+  --border: #e6e6ea;
+  --success: #16a34a;
+  --error: #c1272d;
+  --error-bg: #fdecec;
+  --shadow: 0 1px 2px rgba(0,0,0,0.04), 0 8px 32px rgba(0,0,0,0.06);
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0e0e10;
+    --surface: #18181b;
+    --text: #ededf0;
+    --muted: #9b9ba3;
+    --border: #2a2a2f;
+    --success: #4ade80;
+    --error: #ff6b6b;
+    --error-bg: #2b1414;
+    --shadow: 0 1px 2px rgba(0,0,0,0.3), 0 8px 32px rgba(0,0,0,0.4);
+  }
+}
+* { box-sizing: border-box; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, Inter, system-ui, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  -webkit-font-smoothing: antialiased;
+}
+.card {
+  width: 100%;
+  max-width: 420px;
+  padding: 36px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  box-shadow: var(--shadow);
+  text-align: center;
+}
+.brand { display: flex; justify-content: center; margin-bottom: 24px; }
+.status-icon { margin: 0 auto 20px; }
+.status-icon.success { color: var(--success); }
+.status-icon.error { color: var(--error); }
+h1 {
+  font-size: 22px;
+  font-weight: 600;
+  margin: 0 0 10px;
+  letter-spacing: -0.2px;
+}
+p { color: var(--muted); margin: 0; line-height: 1.55; font-size: 14px; }
+.hint {
+  margin-top: 24px;
+  padding-top: 20px;
+  border-top: 1px solid var(--border);
+  font-size: 12px;
+  color: var(--muted);
+  line-height: 1.5;
+}
+.error-block {
+  margin-top: 18px;
+  padding: 12px 14px;
+  background: var(--error-bg);
+  color: var(--error);
+  border-radius: 8px;
+  font-size: 13px;
+  text-align: left;
+  word-break: break-word;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  width: 100%;
+  margin-top: 24px;
+  padding: 12px 20px;
+  background: var(--text);
+  color: var(--surface);
+  border: 0;
+  border-radius: 10px;
+  font-size: 15px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 120ms ease, transform 80ms ease;
+}
+.btn:hover { filter: brightness(1.1); }
+.btn:active { transform: scale(0.99); }
+.btn:focus-visible { outline: 2px solid #3b82f6; outline-offset: 2px; }
+.btn[disabled] { opacity: 0.65; cursor: not-allowed; }
+.btn-spinner {
+  width: 14px; height: 14px;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+}
+.hint {
+  margin-top: 22px;
+  padding-top: 18px;
+  border-top: 1px solid var(--border);
+  font-size: 12px;
+  color: var(--muted);
+  line-height: 1.5;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+`
+
+function escapeHtml(s: string): string {
+  return s
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;')
+}
+
+function shell(title: string, body: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>${escapeHtml(title)}</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex">
+  <style>${STYLES}</style>
+</head>
+<body>
+  <div class="card">
+    <div class="brand">${COMFY_MARK}</div>
+    ${body}
+  </div>
+</body>
+</html>`
+}
+
+/**
+ * Terminal success page shown when the OAuth callback completes and
+ * the user has been injected into the Desktop view. Renders a
+ * countdown synchronised with the server-side `POST_SIGNIN_HOLD_MS`
+ * delay so the page doesn't disappear out from under the user the
+ * instant Google completes — focus only shifts after the counter
+ * reaches zero.
+ */
+export function renderDoneHtml(): string {
+  return shell(
+    "You're signed in — ComfyUI Desktop",
+    `<div class="status-icon success">${CHECK_ICON}</div>
+    <h1>You're signed in</h1>
+    <p id="countdown">Returning to ComfyUI Desktop in 3…</p>
+    <div class="hint">You can close this tab when you're back in the app.</div>
+    <script>
+      (function(){
+        var n = 3;
+        var el = document.getElementById('countdown');
+        function tick(){
+          n -= 1;
+          if (n <= 0) {
+            el.textContent = 'Returning to ComfyUI Desktop…';
+            // Best-effort tab close. Browsers block window.close on tabs
+            // that weren't opened by window.open() — but Chrome / Safari
+            // increasingly allow it when the tab originated from an
+            // external-app deep link (shell.openExternal). If blocked,
+            // the user just keeps seeing this page until they close it.
+            setTimeout(function(){ try { window.close() } catch (_) {} }, 250);
+            return;
+          }
+          el.textContent = 'Returning to ComfyUI Desktop in ' + n + '…';
+          setTimeout(tick, 1000);
+        }
+        setTimeout(tick, 1000);
+      })();
+    </script>`,
+  )
+}
+
+/**
+ * Terminal error page for IdP-denied or Firebase-exchange failures.
+ * The user can retry by returning to ComfyUI Desktop and clicking
+ * Sign in again.
+ */
+export function renderErrorHtml(message: string): string {
+  return shell(
+    'Sign-in failed — ComfyUI Desktop',
+    `<div class="status-icon error">${ERROR_ICON}</div>
+    <h1>Sign-in failed</h1>
+    <p>We weren't able to complete sign-in. Return to ComfyUI Desktop and click Sign in again to retry.</p>
+    <div class="error-block">${escapeHtml(message)}</div>`,
+  )
+}
+
+/**
+ * Provider-bridge page used for IdPs that can't use the raw OAuth
+ * loopback flow (today: GitHub — its OAuth Apps allow only a single
+ * Authorization Callback URL, reserved for web). The page initialises
+ * Firebase JS SDK and runs `signInWithPopup` from a user gesture (the
+ * "Continue with X" button — gated so popup-blockers don't fire).
+ * Auto-attempt on load handles browsers that allow external-app-opened
+ * tabs to popup once without explicit interaction.
+ *
+ * On success the page POSTs `auth.currentUser.toJSON()` to `/callback`
+ * — same payload shape the IndexedDB injection script expects.
+ */
+export function renderPopupBridgeHtml(
+  firebaseConfig: FirebaseProjectConfig,
+  providerId: SupportedProvider,
+): string {
+  const configJson = JSON.stringify(firebaseConfig)
+  const providerJson = JSON.stringify(providerId)
+  const providerLabelJson = JSON.stringify(PROVIDER_LABEL[providerId])
+  const providerIconJson = JSON.stringify(PROVIDER_ICON[providerId])
+  const sdkBase = `https://www.gstatic.com/firebasejs/${FIREBASE_SDK_VERSION}`
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Sign in to ComfyUI Desktop</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex">
+  <style>${STYLES}</style>
+</head>
+<body>
+  <div class="card">
+    <div class="brand">${COMFY_MARK}</div>
+    <div id="content"></div>
+  </div>
+  <script type="module">
+    import { initializeApp } from '${sdkBase}/firebase-app.js'
+    import {
+      getAuth,
+      GoogleAuthProvider,
+      GithubAuthProvider,
+      signInWithPopup,
+      getRedirectResult,
+    } from '${sdkBase}/firebase-auth.js'
+
+    const firebaseConfig = ${configJson}
+    const providerId = ${providerJson}
+    const providerLabel = ${providerLabelJson}
+    const providerIcon = ${providerIconJson}
+
+    const contentEl = document.getElementById('content')
+
+    function escapeHtml(s) {
+      return String(s)
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;')
+        .replaceAll("'", '&#39;')
+    }
+
+    function renderIdle(errorMessage) {
+      const err = errorMessage ? '<div class="error-block">' + escapeHtml(errorMessage) + '</div>' : ''
+      contentEl.innerHTML = \`
+        <h1>\${errorMessage ? 'Try sign-in again' : 'Sign in to continue'}</h1>
+        <p>Your browser keeps the passkeys, saved passwords, and provider sessions that the embedded popup can't.</p>
+        <button class="btn" id="signinBtn" type="button">
+          \${providerIcon}
+          <span>Continue with \${providerLabel}</span>
+        </button>
+        \${err}
+        <div class="hint">You'll be returned to ComfyUI Desktop automatically once sign-in completes.</div>
+      \`
+      document.getElementById('signinBtn').addEventListener('click', onClick)
+    }
+
+    function renderWorking() {
+      contentEl.innerHTML = \`
+        <h1>Finish in the popup</h1>
+        <p>Complete sign-in with \${providerLabel} in the window that just opened.</p>
+        <button class="btn" type="button" disabled>
+          <span class="btn-spinner"></span>
+          <span>Waiting for \${providerLabel}...</span>
+        </button>
+      \`
+    }
+
+    function renderDone() {
+      contentEl.innerHTML = \`
+        <div class="status-icon success">${CHECK_ICON}</div>
+        <h1>You're signed in</h1>
+        <p id="countdown">Returning to ComfyUI Desktop in 3…</p>
+        <div class="hint">You can close this tab when you're back in the app.</div>
+      \`
+      var n = 3
+      var el = document.getElementById('countdown')
+      function tick(){
+        n -= 1
+        if (n <= 0) {
+          el.textContent = 'Returning to ComfyUI Desktop…'
+          setTimeout(function(){ try { window.close() } catch (_) {} }, 250)
+          return
+        }
+        el.textContent = 'Returning to ComfyUI Desktop in ' + n + '…'
+        setTimeout(tick, 1000)
+      }
+      setTimeout(tick, 1000)
+    }
+
+    function buildProvider() {
+      if (providerId === 'github.com') {
+        const p = new GithubAuthProvider()
+        p.addScope('read:user')
+        p.addScope('user:email')
+        return p
+      }
+      const p = new GoogleAuthProvider()
+      p.addScope('profile')
+      p.addScope('email')
+      return p
+    }
+
+    let auth
+    try {
+      const app = initializeApp(firebaseConfig)
+      auth = getAuth(app)
+    } catch (err) {
+      contentEl.innerHTML = '<h1>Sign-in unavailable</h1><p>The Firebase SDK failed to load. Please reopen sign-in from ComfyUI Desktop.</p>'
+      throw err
+    }
+
+    async function runSignIn() {
+      const result = await signInWithPopup(auth, buildProvider())
+      if (!result || !result.user) throw new Error('Sign-in completed without a user')
+      const resp = await fetch('/callback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ user: result.user.toJSON() }),
+      })
+      if (!resp.ok) throw new Error('Callback responded ' + resp.status)
+    }
+
+    async function onClick() {
+      renderWorking()
+      try {
+        await runSignIn()
+        renderDone()
+      } catch (err) {
+        renderIdle((err && err.message) || String(err))
+      }
+    }
+
+    async function postUserAndFinish(user) {
+      const resp = await fetch('/callback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ user: user.toJSON() }),
+      })
+      if (!resp.ok) throw new Error('Callback responded ' + resp.status)
+    }
+
+    // Auto-attempt on load: a tab opened by shell.openExternal often
+    // has transient activation in Chrome and allows one popup. Falls
+    // back to the manual button when the browser blocks it. We also
+    // handle Firebase's internal popup-to-redirect fallback by first
+    // checking for a redirect result — when the URL has code+state
+    // from an in-flight Firebase redirect, getRedirectResult resolves
+    // with the user even though we never explicitly called signInWithRedirect.
+    async function autoAttempt() {
+      renderWorking()
+      try {
+        const redirectResult = await getRedirectResult(auth)
+        if (redirectResult && redirectResult.user) {
+          await postUserAndFinish(redirectResult.user)
+          renderDone()
+          return
+        }
+        await runSignIn()
+        renderDone()
+      } catch (err) {
+        const code = err && err.code
+        if (code === 'auth/popup-blocked' || code === 'auth/cancelled-popup-request') {
+          renderIdle(null)
+        } else {
+          renderIdle((err && err.message) || String(err))
+        }
+      }
+    }
+
+    autoAttempt()
+  </script>
+</body>
+</html>`
+}

--- a/src/main/auth/firebaseBridge/config.test.ts
+++ b/src/main/auth/firebaseBridge/config.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import { detectFirebaseEnv, getFirebaseConfig } from './config'
+
+describe('detectFirebaseEnv', () => {
+  it('returns dev for the dev Firebase host', () => {
+    expect(
+      detectFirebaseEnv('https://dreamboothy-dev.firebaseapp.com/__/auth/handler'),
+    ).toBe('dev')
+  })
+
+  it('returns prod for the prod Firebase host', () => {
+    expect(detectFirebaseEnv('https://dreamboothy.firebaseapp.com/__/auth/handler')).toBe(
+      'prod',
+    )
+  })
+
+  it('defaults to prod for unparseable URLs', () => {
+    expect(detectFirebaseEnv('not a url')).toBe('prod')
+  })
+})
+
+describe('getFirebaseConfig', () => {
+  it('returns the dev project config when env is dev', () => {
+    const config = getFirebaseConfig('dev')
+    expect(config.projectId).toBe('dreamboothy-dev')
+    expect(config.authDomain).toBe('dreamboothy-dev.firebaseapp.com')
+    // apiKey must be set — initializeApp throws without it.
+    expect(config.apiKey).toMatch(/^AIza/)
+  })
+
+  it('returns the prod project config when env is prod', () => {
+    const config = getFirebaseConfig('prod')
+    expect(config.projectId).toBe('dreamboothy')
+    expect(config.authDomain).toBe('dreamboothy.firebaseapp.com')
+    expect(config.apiKey).toMatch(/^AIza/)
+  })
+})

--- a/src/main/auth/firebaseBridge/config.ts
+++ b/src/main/auth/firebaseBridge/config.ts
@@ -1,0 +1,59 @@
+/**
+ * Firebase project configs mirroring the cloud frontend's
+ * `src/config/firebase.ts`. The values are public (apiKey is a
+ * project identifier, not a secret) so hardcoding them here is fine.
+ *
+ * `prod` is used when the embedded cloud-workspace view opens a
+ * popup whose host is `dreamboothy.firebaseapp.com`; `dev` for
+ * `dreamboothy-dev.firebaseapp.com`.
+ */
+export interface FirebaseProjectConfig {
+  apiKey: string
+  authDomain: string
+  databaseURL: string
+  projectId: string
+  storageBucket: string
+  messagingSenderId: string
+  appId: string
+}
+
+export type FirebaseEnv = 'prod' | 'dev'
+
+const PROD_CONFIG: FirebaseProjectConfig = {
+  apiKey: 'AIzaSyC2-fomLqgCjb7ELwta1I9cEarPK8ziTGs',
+  authDomain: 'dreamboothy.firebaseapp.com',
+  databaseURL: 'https://dreamboothy-default-rtdb.firebaseio.com',
+  projectId: 'dreamboothy',
+  storageBucket: 'dreamboothy.appspot.com',
+  messagingSenderId: '357148958219',
+  appId: '1:357148958219:web:f5917f72e5f36a2015310e',
+}
+
+const DEV_CONFIG: FirebaseProjectConfig = {
+  apiKey: 'AIzaSyDa_YMeyzV0SkVe92vBZ1tVikWBmOU5KVE',
+  authDomain: 'dreamboothy-dev.firebaseapp.com',
+  databaseURL: 'https://dreamboothy-dev-default-rtdb.firebaseio.com',
+  projectId: 'dreamboothy-dev',
+  storageBucket: 'dreamboothy-dev.appspot.com',
+  messagingSenderId: '313257147182',
+  appId: '1:313257147182:web:be38f6ebf74345fc7618bf',
+}
+
+export function getFirebaseConfig(env: FirebaseEnv): FirebaseProjectConfig {
+  return env === 'dev' ? DEV_CONFIG : PROD_CONFIG
+}
+
+/**
+ * Decide which Firebase project the intercepted popup URL points at.
+ * The URL is always one of the auth-handler URLs we already match in
+ * `isFirebaseAuthHandlerUrl`, so the host check is the source of truth.
+ */
+export function detectFirebaseEnv(url: string): FirebaseEnv {
+  try {
+    const host = new URL(url).host
+    if (host === DEV_CONFIG.authDomain) return 'dev'
+    return 'prod'
+  } catch {
+    return 'prod'
+  }
+}

--- a/src/main/auth/firebaseBridge/index.ts
+++ b/src/main/auth/firebaseBridge/index.ts
@@ -1,0 +1,130 @@
+import { shell, type BrowserWindow, type WebContents } from 'electron'
+
+import { detectFirebaseEnv } from './config'
+import { buildIndexedDbInjectScript } from './inject'
+import { extractProviderId, type SupportedProvider } from './intercept'
+import { startBridgeServer } from './server'
+
+export { extractProviderId, isFirebaseAuthHandlerUrl } from './intercept'
+
+export interface HandleFirebasePopupOpts {
+  /**
+   * Optional handle to the BrowserWindow that owns `comfyContents`.
+   * When provided, we restore + focus it after the bridge completes so
+   * the user returns to ComfyUI Desktop instead of staying parked on
+   * the now-finished browser tab.
+   */
+  parentWindow?: BrowserWindow
+  onError?: (err: Error) => void
+}
+
+/**
+ * Orchestrate the system-browser sign-in for a Firebase auth-handler
+ * URL that the embedded cloud-workspace view tried to open via
+ * `window.open()`.
+ *
+ * Flow:
+ *   1. Detect prod/dev project + IdP from the intercepted URL.
+ *   2. Spin up a loopback HTTP server with a bridge page that runs
+ *      `signInWithPopup` in the user's system browser (passkeys +
+ *      saved-passwords + existing IdP sessions all work there).
+ *   3. Await the bridge's `/callback` carrying `auth.currentUser.toJSON()`.
+ *   4. Inject the serialized user into the embedded view's
+ *      `firebaseLocalStorageDb` IndexedDB and reload — Firebase's SDK
+ *      rehydrates from persistence on init, fires `onAuthStateChanged`,
+ *      and the existing `/auth/session` post handles the rest.
+ *   5. Focus the Desktop window so the user is yanked back into the
+ *      app without needing to alt-tab from their browser.
+ *
+ * Errors are reported via the optional `onError` callback (the caller
+ * forwards them to Datadog without taking down the embedded view).
+ * On error we deliberately do NOT try to fall back to opening the
+ * Firebase popup as an Electron window — the user has already lost
+ * trust at that point, and silently restoring the old (passkey-less)
+ * popup flow is more confusing than asking them to retry sign-in.
+ */
+/**
+ * Singleton handle for the in-flight bridge. We bind to a fixed loopback
+ * port (so the Google OAuth client's exact-match `redirect_uri`
+ * allowlist works), which means only ONE bridge can run at a time. If
+ * the user clicks Sign in while a previous attempt is still parked on
+ * an open browser tab, we close the stale bridge (freeing the port)
+ * before spinning up the new one.
+ */
+let activeBridge: Awaited<ReturnType<typeof startBridgeServer>> | null = null
+
+/**
+ * Time we hold on the "You're signed in" browser page before injecting
+ * the user into the embedded view and pulling focus to Desktop. The
+ * bridge HTML renders a synchronised countdown — keep these in lockstep.
+ */
+const POST_SIGNIN_HOLD_MS = 3000
+
+export async function handleFirebasePopup(
+  url: string,
+  comfyContents: WebContents,
+  opts: HandleFirebasePopupOpts = {},
+): Promise<void> {
+  const providerId = extractProviderId(url)
+  if (!providerId) {
+    opts.onError?.(new Error(`Firebase popup URL missing providerId: ${url}`))
+    return
+  }
+  const env = detectFirebaseEnv(url)
+
+  // Kill any stale bridge from a prior sign-in attempt the user
+  // didn't complete. Without this, the second Sign-in click hits an
+  // EADDRINUSE on the fixed loopback port and the user sees an
+  // unhelpful auth/popup-blocked error from the embedded view (we
+  // denied the popup but couldn't open the replacement bridge).
+  if (activeBridge) {
+    try {
+      activeBridge.close()
+    } catch {
+      // best-effort
+    }
+    activeBridge = null
+  }
+
+  let handle: Awaited<ReturnType<typeof startBridgeServer>> | null = null
+  try {
+    handle = await startBridgeServer({ env, providerId })
+    activeBridge = handle
+    // Append a per-attempt nonce so browsers don't focus an existing
+    // stale tab from a previous (perhaps wrong-provider) sign-in
+    // attempt. macOS Chrome / Safari treat shell.openExternal of an
+    // identical URL as "focus the open tab" rather than "open fresh"
+    // — without the nonce the user would still see yesterday's GitHub
+    // bridge page when they intended to start a new Google flow.
+    void shell.openExternal(`${handle.url}?n=${Date.now().toString(36)}`)
+    const { user, apiKey } = await handle.signInPromise
+    if (comfyContents.isDestroyed()) return
+    // Hold for a beat so the user actually sees the "You're signed in"
+    // page (with its synchronised countdown) before we yank focus back
+    // to Desktop and reload the embedded view. Without this the focus
+    // grab happens essentially instantly after the OAuth callback
+    // lands, which feels jarring — they barely see the bridge confirm
+    // success before Desktop snatches focus.
+    await new Promise<void>((resolve) => setTimeout(resolve, POST_SIGNIN_HOLD_MS))
+    if (comfyContents.isDestroyed()) return
+    await comfyContents.executeJavaScript(buildIndexedDbInjectScript(user, apiKey), true)
+    // Pull the user back into the app. `show()` un-minimises on
+    // platforms that need it; `focus()` lifts the OS-level focus from
+    // the browser. Best-effort — a destroyed window is a no-op.
+    const { parentWindow } = opts
+    if (parentWindow && !parentWindow.isDestroyed()) {
+      if (parentWindow.isMinimized()) parentWindow.restore()
+      parentWindow.show()
+      parentWindow.focus()
+    }
+  } catch (err) {
+    opts.onError?.(err instanceof Error ? err : new Error(String(err)))
+  } finally {
+    handle?.close()
+    if (activeBridge === handle) activeBridge = null
+  }
+}
+
+// Re-export the supported provider type for callers that need to
+// narrow the union before passing to `handleFirebasePopup`.
+export type { SupportedProvider }

--- a/src/main/auth/firebaseBridge/inject.test.ts
+++ b/src/main/auth/firebaseBridge/inject.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildIndexedDbInjectScript } from './inject'
+
+describe('buildIndexedDbInjectScript', () => {
+  const sampleUser = {
+    uid: 'abc123',
+    email: 'user@example.com',
+    stsTokenManager: { refreshToken: 'rt', accessToken: 'at', expirationTime: 0 },
+  }
+
+  it('embeds the user JSON verbatim', () => {
+    const script = buildIndexedDbInjectScript(sampleUser, 'AIzaTEST')
+    expect(script).toContain('"uid":"abc123"')
+    expect(script).toContain('"refreshToken":"rt"')
+  })
+
+  it('uses Firebase\'s documented IDB schema', () => {
+    const script = buildIndexedDbInjectScript(sampleUser, 'AIzaTEST')
+    expect(script).toContain("'firebaseLocalStorageDb'")
+    expect(script).toContain("'firebaseLocalStorage'")
+    expect(script).toContain('fbase_key')
+    expect(script).toContain("firebase:authUser:' + apiKey + ':[DEFAULT]")
+  })
+
+  it('reloads the page after the IDB write commits', () => {
+    const script = buildIndexedDbInjectScript(sampleUser, 'AIzaTEST')
+    expect(script).toContain('location.reload()')
+  })
+
+  it('is parseable as JavaScript', () => {
+    const script = buildIndexedDbInjectScript(sampleUser, 'AIzaTEST')
+    // `Function` constructor surfaces syntax errors without executing the
+    // body — IndexedDB is not in scope but the parse alone is enough.
+    expect(() => new Function(script)).not.toThrow()
+  })
+
+  it('escapes embedded values to prevent script breakage', () => {
+    const tricky = { malicious: '"; alert(1); //' }
+    const script = buildIndexedDbInjectScript(tricky, 'AIza')
+    expect(() => new Function(script)).not.toThrow()
+  })
+})

--- a/src/main/auth/firebaseBridge/inject.ts
+++ b/src/main/auth/firebaseBridge/inject.ts
@@ -1,0 +1,52 @@
+/**
+ * Build the JavaScript string passed to `comfyContents.executeJavaScript`
+ * to write the captured Firebase user into the embedded view's IndexedDB
+ * and reload the page so Firebase's SDK rehydrates from persistence.
+ *
+ * Schema (stable across Firebase JS SDK v9-v11):
+ *   - DB:     `firebaseLocalStorageDb`
+ *   - Store:  `firebaseLocalStorage`
+ *   - KeyPath:`fbase_key`
+ *   - Key:    `firebase:authUser:<apiKey>:[DEFAULT]`
+ *   - Value:  `{ fbase_key, value: <user.toJSON()> }`
+ *
+ * After the write, `location.reload()` triggers Firebase's persistence
+ * read on init, which fires `onAuthStateChanged(user)` and lets the
+ * cloud frontend's existing `useSessionCookie.createSession()` flow
+ * post the ID token to `/auth/session` — same path as a normal popup
+ * sign-in.
+ */
+export function buildIndexedDbInjectScript(user: Record<string, unknown>, apiKey: string): string {
+  const userJson = JSON.stringify(user)
+  const apiKeyJson = JSON.stringify(apiKey)
+  // Wrapped in an IIFE that resolves once the IDB transaction commits
+  // (so `executeJavaScript`'s returned Promise tracks the actual write).
+  return `(async () => {
+  const userValue = ${userJson};
+  const apiKey = ${apiKeyJson};
+  const storageKey = 'firebase:authUser:' + apiKey + ':[DEFAULT]';
+  await new Promise((resolve, reject) => {
+    const req = indexedDB.open('firebaseLocalStorageDb', 1);
+    req.onupgradeneeded = (e) => {
+      const db = e.target.result;
+      if (!db.objectStoreNames.contains('firebaseLocalStorage')) {
+        db.createObjectStore('firebaseLocalStorage', { keyPath: 'fbase_key' });
+      }
+    };
+    req.onerror = () => reject(new Error('open: ' + (req.error && req.error.message || 'unknown')));
+    req.onsuccess = () => {
+      const db = req.result;
+      const tx = db.transaction('firebaseLocalStorage', 'readwrite');
+      tx.oncomplete = () => { db.close(); resolve(); };
+      tx.onerror = () => reject(new Error('tx: ' + (tx.error && tx.error.message || 'unknown')));
+      const store = tx.objectStore('firebaseLocalStorage');
+      store.put({ fbase_key: storageKey, value: userValue });
+    };
+  });
+  // Tell the next page-load (handled by attach.ts's dom-ready patch) to
+  // hide documentElement briefly so the cloud login page doesn't flash
+  // between Firebase rehydrating and the FE redirecting to the workspace.
+  try { sessionStorage.setItem('__comfyDesktopPostSignin', '1'); } catch (_) {}
+  location.reload();
+})()`
+}

--- a/src/main/auth/firebaseBridge/intercept.test.ts
+++ b/src/main/auth/firebaseBridge/intercept.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+
+import { extractProviderId, isFirebaseAuthHandlerUrl } from './intercept'
+
+describe('isFirebaseAuthHandlerUrl', () => {
+  it('matches the prod Firebase auth handler', () => {
+    expect(
+      isFirebaseAuthHandlerUrl(
+        'https://dreamboothy.firebaseapp.com/__/auth/handler?apiKey=AIza&providerId=google.com',
+      ),
+    ).toBe(true)
+  })
+
+  it('matches the dev Firebase auth handler', () => {
+    expect(
+      isFirebaseAuthHandlerUrl(
+        'https://dreamboothy-dev.firebaseapp.com/__/auth/handler?providerId=github.com',
+      ),
+    ).toBe(true)
+  })
+
+  it('rejects look-alike hosts', () => {
+    expect(
+      isFirebaseAuthHandlerUrl(
+        'https://dreamboothy.firebaseapp.com.evil.com/__/auth/handler',
+      ),
+    ).toBe(false)
+  })
+
+  it('rejects http (non-TLS) URLs', () => {
+    expect(
+      isFirebaseAuthHandlerUrl('http://dreamboothy.firebaseapp.com/__/auth/handler'),
+    ).toBe(false)
+  })
+
+  it('rejects other paths on the Firebase host', () => {
+    expect(
+      isFirebaseAuthHandlerUrl('https://dreamboothy.firebaseapp.com/some/other/path'),
+    ).toBe(false)
+  })
+
+  it('rejects unrelated URLs', () => {
+    expect(isFirebaseAuthHandlerUrl('https://accounts.google.com/o/oauth2/auth')).toBe(false)
+    expect(isFirebaseAuthHandlerUrl('https://cloud.comfy.org/')).toBe(false)
+  })
+
+  it('rejects unparseable inputs', () => {
+    expect(isFirebaseAuthHandlerUrl('')).toBe(false)
+    expect(isFirebaseAuthHandlerUrl('not a url')).toBe(false)
+  })
+})
+
+describe('extractProviderId', () => {
+  it('returns google.com for the Google IdP', () => {
+    expect(
+      extractProviderId(
+        'https://dreamboothy.firebaseapp.com/__/auth/handler?providerId=google.com&apiKey=AIza',
+      ),
+    ).toBe('google.com')
+  })
+
+  it('returns github.com for the GitHub IdP', () => {
+    expect(
+      extractProviderId(
+        'https://dreamboothy.firebaseapp.com/__/auth/handler?providerId=github.com',
+      ),
+    ).toBe('github.com')
+  })
+
+  it('returns null for unsupported providers', () => {
+    expect(
+      extractProviderId(
+        'https://dreamboothy.firebaseapp.com/__/auth/handler?providerId=facebook.com',
+      ),
+    ).toBeNull()
+  })
+
+  it('returns null when providerId is missing', () => {
+    expect(
+      extractProviderId('https://dreamboothy.firebaseapp.com/__/auth/handler'),
+    ).toBeNull()
+  })
+
+  it('returns null for unparseable input', () => {
+    expect(extractProviderId('')).toBeNull()
+  })
+})

--- a/src/main/auth/firebaseBridge/intercept.ts
+++ b/src/main/auth/firebaseBridge/intercept.ts
@@ -1,0 +1,56 @@
+/**
+ * URL discriminators for the Firebase auth-handler popup that the
+ * cloud frontend's `signInWithPopup(...)` opens via `window.open()`.
+ * We deny these popups at `setWindowOpenHandler` time and reroute the
+ * sign-in through the user's system browser via the loopback bridge.
+ *
+ * Both prod (`dreamboothy`) and dev (`dreamboothy-dev`) Firebase
+ * projects are matched. The cloud frontend chooses which based on
+ * its build-time flag + a runtime remote-config override; we match
+ * both and let the bridge mirror whichever project the URL points at.
+ */
+const FIREBASE_AUTH_HANDLER_HOSTS = [
+  'dreamboothy.firebaseapp.com',
+  'dreamboothy-dev.firebaseapp.com',
+] as const
+
+const FIREBASE_AUTH_HANDLER_PATH = '/__/auth/handler'
+
+export function isFirebaseAuthHandlerUrl(url: string): boolean {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return false
+  }
+  if (parsed.protocol !== 'https:') return false
+  if (!FIREBASE_AUTH_HANDLER_HOSTS.includes(parsed.host as (typeof FIREBASE_AUTH_HANDLER_HOSTS)[number])) {
+    return false
+  }
+  return parsed.pathname === FIREBASE_AUTH_HANDLER_PATH
+}
+
+/**
+ * `signInWithPopup` encodes the OAuth provider in the `providerId`
+ * query param of the auth-handler URL (e.g. `providerId=google.com`).
+ * The bridge needs this to construct the matching Firebase provider
+ * before `signInWithRedirect`.
+ *
+ * Returns `null` when the URL has no providerId or an unsupported one
+ * — callers should fall back to the existing popup behaviour.
+ */
+export type SupportedProvider = 'google.com' | 'github.com'
+
+export function extractProviderId(url: string): SupportedProvider | null {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return null
+  }
+  const providerId = parsed.searchParams.get('providerId')
+  if (providerId === 'google.com' || providerId === 'github.com') {
+    return providerId
+  }
+  return null
+}

--- a/src/main/auth/firebaseBridge/oauth.ts
+++ b/src/main/auth/firebaseBridge/oauth.ts
@@ -1,0 +1,188 @@
+import type { FirebaseProjectConfig } from './config'
+import type { SupportedProvider } from './intercept'
+
+/**
+ * Google Identity Toolkit (Firebase Identity Platform) REST endpoints.
+ * Both are key-authed with the project's public Firebase apiKey — no
+ * service-account credentials needed.
+ */
+const IDP_BASE = 'https://identitytoolkit.googleapis.com/v1'
+
+interface CreateAuthUriResponse {
+  /** Full OAuth URL to redirect the browser to. Includes the provider's client_id, the redirect_uri we pass, and a Firebase-managed `state`. */
+  authUri: string
+  /** Opaque token we must echo back on signInWithIdp so Firebase can match the in-flight session. */
+  sessionId: string
+  providerId: string
+}
+
+interface ProviderUserInfo {
+  providerId?: string
+  rawId?: string
+  email?: string
+  displayName?: string
+  photoUrl?: string
+}
+
+interface SignInWithIdpResponse {
+  /** Firebase ID token (JWT). */
+  idToken: string
+  /** Firebase refresh token (long-lived). */
+  refreshToken: string
+  /** Seconds until idToken expires. Stringified. */
+  expiresIn: string
+  /** Firebase UID. */
+  localId: string
+  email?: string
+  emailVerified?: boolean
+  displayName?: string
+  photoUrl?: string
+  providerId?: string
+  rawUserInfo?: string
+  oauthAccessToken?: string
+  oauthIdToken?: string
+  federatedId?: string
+  rawId?: string
+  /** Present when the user is newly created (first sign-in). */
+  isNewUser?: boolean
+  /** When Firebase returns multi-provider data. */
+  providerUserInfo?: ProviderUserInfo[]
+}
+
+/**
+ * Ask Firebase to generate an OAuth URL for the requested IdP. Firebase
+ * resolves the project's registered OAuth client (e.g. the Google
+ * client configured in the Firebase Console under Sign-in method →
+ * Google) and builds the authorize URL with our `continueUri` as the
+ * redirect target.
+ *
+ * We pass the bridge's loopback origin as `continueUri`. Firebase
+ * lists `localhost` and `127.0.0.1` on the authorized-domains list for
+ * both prod (`dreamboothy`) and dev (`dreamboothy-dev`) projects, so
+ * the resulting URL is accepted at the IdP without further config.
+ */
+export async function createOauthAuthUri(
+  apiKey: string,
+  providerId: SupportedProvider,
+  continueUri: string,
+): Promise<CreateAuthUriResponse> {
+  // Scopes mirror what Firebase's own signInWithPopup requests — keeps
+  // the consent screen identical to a normal sign-in.
+  const oauthScope =
+    providerId === 'github.com' ? 'read:user user:email' : 'profile email'
+  const resp = await fetch(`${IDP_BASE}/accounts:createAuthUri?key=${apiKey}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ providerId, continueUri, oauthScope }),
+  })
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => '')
+    throw new Error(`createAuthUri ${resp.status}: ${text || resp.statusText}`)
+  }
+  const data = (await resp.json()) as CreateAuthUriResponse
+  if (!data.authUri || !data.sessionId) {
+    throw new Error('createAuthUri returned without authUri/sessionId')
+  }
+  return data
+}
+
+/**
+ * Exchange the OAuth `code` returned by the IdP for a Firebase user.
+ * Firebase verifies the code against the IdP server-side, mints a
+ * Firebase ID token + refresh token, and returns the user record.
+ *
+ * `requestUri` MUST be the full URL the IdP redirected the browser to
+ * (including the query string with `code`, `state`, `scope`, etc.) —
+ * Firebase parses it the same way the JS SDK would.
+ */
+export async function signInWithIdpExchange(
+  apiKey: string,
+  providerId: SupportedProvider,
+  requestUri: string,
+  sessionId: string,
+): Promise<SignInWithIdpResponse> {
+  const queryStart = requestUri.indexOf('?')
+  const queryParams = queryStart >= 0 ? requestUri.slice(queryStart + 1) : ''
+  // Firebase expects providerId echoed in the postBody alongside the
+  // raw OAuth response — same shape the JS SDK sends.
+  const postBody = `${queryParams}&providerId=${encodeURIComponent(providerId)}`
+  const resp = await fetch(`${IDP_BASE}/accounts:signInWithIdp?key=${apiKey}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      postBody,
+      requestUri,
+      sessionId,
+      returnIdpCredential: true,
+      returnSecureToken: true,
+    }),
+  })
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => '')
+    throw new Error(`signInWithIdp ${resp.status}: ${text || resp.statusText}`)
+  }
+  return (await resp.json()) as SignInWithIdpResponse
+}
+
+/**
+ * Build the JSON shape Firebase JS SDK persists to IndexedDB at
+ * `firebase:authUser:<apiKey>:[DEFAULT]`. The Firebase SDK calls
+ * `User.toJSON()` on every persistence write — so our hand-built
+ * object must match that schema byte-for-byte (within the fields the
+ * SDK reads back on rehydration). Schema is stable across v9-v11.
+ */
+export function buildPersistedUser(
+  config: FirebaseProjectConfig,
+  resp: SignInWithIdpResponse,
+  providerId: SupportedProvider,
+): Record<string, unknown> {
+  const nowMs = Date.now()
+  const expiresInSec = Number(resp.expiresIn || '3600')
+  const expirationTime = nowMs + expiresInSec * 1000
+  // Provider data: prefer Firebase's parsed list, else synthesise a
+  // single entry from the top-level fields it returned.
+  const providerData =
+    resp.providerUserInfo && resp.providerUserInfo.length > 0
+      ? resp.providerUserInfo.map((p) => ({
+          providerId: p.providerId ?? providerId,
+          uid: p.rawId ?? resp.localId,
+          displayName: p.displayName ?? null,
+          email: p.email ?? null,
+          phoneNumber: null,
+          photoURL: p.photoUrl ?? null,
+        }))
+      : [
+          {
+            providerId,
+            uid: resp.federatedId ?? resp.rawId ?? resp.localId,
+            displayName: resp.displayName ?? null,
+            email: resp.email ?? null,
+            phoneNumber: null,
+            photoURL: resp.photoUrl ?? null,
+          },
+        ]
+
+  return {
+    uid: resp.localId,
+    email: resp.email ?? null,
+    emailVerified: resp.emailVerified ?? false,
+    displayName: resp.displayName ?? null,
+    isAnonymous: false,
+    photoURL: resp.photoUrl ?? null,
+    phoneNumber: null,
+    tenantId: null,
+    providerData,
+    stsTokenManager: {
+      refreshToken: resp.refreshToken,
+      accessToken: resp.idToken,
+      expirationTime,
+    },
+    // Firebase JS SDK stores these as stringified ms-epochs. We don't
+    // know the true createdAt server-side, so we set both to now —
+    // subsequent token refreshes will re-mint these from the server.
+    createdAt: String(nowMs),
+    lastLoginAt: String(nowMs),
+    apiKey: config.apiKey,
+    appName: '[DEFAULT]',
+  }
+}

--- a/src/main/auth/firebaseBridge/server.test.ts
+++ b/src/main/auth/firebaseBridge/server.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+
+import { BRIDGE_PORT, startBridgeServer } from './server'
+
+describe('startBridgeServer', () => {
+  it('serves a 204 for /favicon.ico', async () => {
+    const handle = await startBridgeServer({ env: 'prod', providerId: 'google.com', port: 0 })
+    try {
+      const res = await fetch(`${handle.url}favicon.ico`)
+      expect(res.status).toBe(204)
+    } finally {
+      handle.close()
+    }
+  })
+
+  it('serves a 404 for unknown paths', async () => {
+    const handle = await startBridgeServer({ env: 'prod', providerId: 'google.com', port: 0 })
+    try {
+      const res = await fetch(`${handle.url}does-not-exist`)
+      expect(res.status).toBe(404)
+    } finally {
+      handle.close()
+    }
+  })
+
+  it('serves the error page when the IdP redirects with ?error=...', async () => {
+    const handle = await startBridgeServer({ env: 'prod', providerId: 'google.com', port: 0 })
+    try {
+      const res = await fetch(
+        `${handle.url}?error=access_denied&error_description=user+cancelled`,
+        { redirect: 'manual' },
+      )
+      expect(res.status).toBe(200)
+      const body = await res.text()
+      expect(body).toContain('Sign-in failed')
+      expect(body).toContain('user cancelled')
+      await expect(handle.signInPromise).rejects.toThrow(/IdP error/)
+    } finally {
+      handle.close()
+    }
+  })
+
+  it('issues HTTP URL as http://localhost on a loopback port', async () => {
+    const handle = await startBridgeServer({ env: 'prod', providerId: 'google.com', port: 0 })
+    try {
+      expect(handle.url).toMatch(/^http:\/\/localhost:\d+\/$/)
+    } finally {
+      handle.close()
+    }
+  })
+
+  it('serves the popup-bridge HTML for github.com providers', async () => {
+    const handle = await startBridgeServer({ env: 'prod', providerId: 'github.com', port: 0 })
+    try {
+      const res = await fetch(handle.url, { redirect: 'manual' })
+      expect(res.status).toBe(200)
+      const body = await res.text()
+      expect(body).toContain('firebase-app.js')
+      expect(body).toContain('Continue with')
+      expect(body).toContain('"GitHub"')
+    } finally {
+      handle.close()
+    }
+  })
+
+  it('302s the browser to Google OAuth for google.com providers (raw-OAuth flow)', async () => {
+    const handle = await startBridgeServer({ env: 'prod', providerId: 'google.com', port: 0 })
+    try {
+      const res = await fetch(handle.url, { redirect: 'manual' })
+      expect(res.status).toBe(302)
+      const location = res.headers.get('location') || ''
+      expect(location).toContain('accounts.google.com')
+      expect(location).toContain('client_id=')
+    } finally {
+      handle.close()
+    }
+  })
+
+  it('exports the fixed port (9876) used by the Google OAuth client allowlist', () => {
+    // Asserting the constant rather than binding — the actual port may
+    // be held by a parallel dev process or another test instance, but
+    // the contract with the Firebase Google OAuth client redirect-URI
+    // allowlist is the constant.
+    expect(BRIDGE_PORT).toBe(9876)
+  })
+})

--- a/src/main/auth/firebaseBridge/server.test.ts
+++ b/src/main/auth/firebaseBridge/server.test.ts
@@ -25,6 +25,11 @@ describe('startBridgeServer', () => {
 
   it('serves the error page when the IdP redirects with ?error=...', async () => {
     const handle = await startBridgeServer({ env: 'prod', providerId: 'google.com', port: 0 })
+    // Attach the rejection handler BEFORE triggering the error fetch.
+    // The ?error= branch rejects signInPromise synchronously while
+    // handling the request; if no handler is attached yet, Vitest flags
+    // it as an unhandled rejection and fails the whole run.
+    const rejected = expect(handle.signInPromise).rejects.toThrow(/IdP error/)
     try {
       const res = await fetch(
         `${handle.url}?error=access_denied&error_description=user+cancelled`,
@@ -34,7 +39,7 @@ describe('startBridgeServer', () => {
       const body = await res.text()
       expect(body).toContain('Sign-in failed')
       expect(body).toContain('user cancelled')
-      await expect(handle.signInPromise).rejects.toThrow(/IdP error/)
+      await rejected
     } finally {
       handle.close()
     }

--- a/src/main/auth/firebaseBridge/server.ts
+++ b/src/main/auth/firebaseBridge/server.ts
@@ -1,0 +1,310 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
+import type { AddressInfo } from 'node:net'
+
+import { renderDoneHtml, renderErrorHtml, renderPopupBridgeHtml } from './bridgeHtml'
+import { getFirebaseConfig, type FirebaseEnv } from './config'
+import type { SupportedProvider } from './intercept'
+import {
+  buildPersistedUser,
+  createOauthAuthUri,
+  signInWithIdpExchange,
+} from './oauth'
+
+const MAX_BODY_BYTES = 64 * 1024
+
+async function readJsonBody(req: IncomingMessage): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = []
+    let total = 0
+    req.on('data', (chunk: Buffer) => {
+      total += chunk.length
+      if (total > MAX_BODY_BYTES) {
+        reject(new Error('Body too large'))
+        req.destroy()
+        return
+      }
+      chunks.push(chunk)
+    })
+    req.on('end', () => {
+      try {
+        resolve(JSON.parse(Buffer.concat(chunks).toString('utf8')))
+      } catch (err) {
+        reject(err instanceof Error ? err : new Error(String(err)))
+      }
+    })
+    req.on('error', reject)
+  })
+}
+
+/**
+ * Result handed to the orchestrator when the OAuth dance lands at our
+ * loopback callback and the Firebase exchange succeeds. `user` is the
+ * JSON shape Firebase JS SDK persists in IndexedDB at
+ * `firebase:authUser:<apiKey>:[DEFAULT]`.
+ */
+export interface SignInResult {
+  user: Record<string, unknown>
+  apiKey: string
+}
+
+export interface BridgeHandle {
+  /** URL to hand to `shell.openExternal` to start the sign-in flow. */
+  url: string
+  /** Resolves once the IdP callback completes and Firebase mints a user. */
+  signInPromise: Promise<SignInResult>
+  /** Shut the server down. Safe to call multiple times. */
+  close: () => void
+}
+
+/**
+ * Fixed loopback port for the OAuth callback. The Firebase Google
+ * OAuth client has `http://localhost:9876` registered as an authorized
+ * redirect URI — Google's policy for Web OAuth clients is exact-match
+ * (port included), so we have to commit to a specific port. 9876 is
+ * outside the well-known ephemeral range used by browsers / system
+ * tools, so collision risk is low in practice.
+ */
+export const BRIDGE_PORT = 9876
+
+export interface StartBridgeOpts {
+  env: FirebaseEnv
+  providerId: SupportedProvider
+  /** Default 5 minutes — long enough for password managers, 2FA, account-picker UI. */
+  timeoutMs?: number
+  /** Override the loopback port. Defaults to `BRIDGE_PORT` (9876). Tests pass `0` to get a kernel-assigned port. */
+  port?: number
+}
+
+/**
+ * Start the loopback bridge. Binds `127.0.0.1:<port>` (default 9876,
+ * RFC 8252 §7 compliant loopback) and advertises the URL as
+ * `http://localhost:<port>` — Firebase's Google OAuth client requires
+ * the redirect URI to match exactly, so the fixed port is registered
+ * in Google Cloud Console alongside the Firebase auth handler URIs.
+ *
+ * Flow:
+ *   GET /         (no query)              → call Firebase createAuthUri,
+ *                                            stash sessionId in closure,
+ *                                            HTTP 302 to the IdP authorize
+ *                                            URL. No client-side JS needed.
+ *   GET /?code=…&state=…                 → IdP callback. Call Firebase
+ *                                            signInWithIdp to exchange the
+ *                                            code for Firebase tokens,
+ *                                            build the persisted-user JSON,
+ *                                            resolve signInPromise, serve
+ *                                            the "Signed in" HTML.
+ *   GET /?error=…                        → IdP denied / user cancelled.
+ *                                            Reject signInPromise and serve
+ *                                            the error HTML.
+ *   anything else                        → 404.
+ */
+export function startBridgeServer(opts: StartBridgeOpts): Promise<BridgeHandle> {
+  const { env, providerId, timeoutMs = 5 * 60_000, port = BRIDGE_PORT } = opts
+  const firebaseConfig = getFirebaseConfig(env)
+
+  return new Promise((resolveHandle, rejectHandle) => {
+    let resolved = false
+    let sessionId: string | null = null
+    let signInResolve!: (r: SignInResult) => void
+    let signInReject!: (err: Error) => void
+    const signInPromise = new Promise<SignInResult>((res, rej) => {
+      signInResolve = res
+      signInReject = rej
+    })
+
+    let server: Server | null = null
+
+    const close = (): void => {
+      if (server) {
+        try {
+          // closeAllConnections() force-terminates any keep-alive sockets
+          // browsers may have established — without it, the browser would
+          // happily reuse a pinned TCP connection to a "closed" server on
+          // the next localhost:9876 fetch, routing requests into the OLD
+          // closure (with the OLD providerId, OLD signInPromise, etc.).
+          // close() alone only stops accepting new connections.
+          server.closeAllConnections?.()
+          server.close()
+        } catch {
+          // ignore — best-effort shutdown
+        }
+        server = null
+      }
+      clearTimeout(timeoutHandle)
+    }
+
+    const finishWithError = (err: Error): void => {
+      if (!resolved) {
+        resolved = true
+        signInReject(err)
+      }
+    }
+
+    const finishWithSuccess = (result: SignInResult): void => {
+      if (!resolved) {
+        resolved = true
+        signInResolve(result)
+      }
+    }
+
+    const timeoutHandle = setTimeout(() => {
+      finishWithError(new Error('Firebase bridge timed out waiting for sign-in'))
+      close()
+    }, timeoutMs)
+
+    server = createServer((req, res) => {
+      // Disable HTTP keep-alive so the bridge never holds onto sockets
+      // across the singleton-driven server swap. Browsers would
+      // otherwise reuse a connection pinned to a previous bridge's
+      // closure (with the wrong providerId / dead server reference).
+      res.setHeader('Connection', 'close')
+      void handleRequest(req, res).catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err)
+        if (!res.headersSent) {
+          res.statusCode = 500
+          res.setHeader('Content-Type', 'text/html; charset=utf-8')
+          res.end(renderErrorHtml(msg))
+        }
+        finishWithError(err instanceof Error ? err : new Error(msg))
+      })
+    })
+
+    async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+      // Belt-and-braces: only honour requests on the loopback socket.
+      // The bind itself enforces this; this is a defence-in-depth check.
+      const remoteHost = req.socket.remoteAddress ?? ''
+      const isLoopback =
+        remoteHost === '127.0.0.1' || remoteHost === '::1' || remoteHost === '::ffff:127.0.0.1'
+      if (!isLoopback) {
+        res.statusCode = 403
+        res.end()
+        return
+      }
+
+      const url = req.url ?? '/'
+      const queryStart = url.indexOf('?')
+      const path = queryStart >= 0 ? url.slice(0, queryStart) : url
+      const search = queryStart >= 0 ? url.slice(queryStart + 1) : ''
+      const params = new URLSearchParams(search)
+
+      if (req.method === 'GET' && path === '/favicon.ico') {
+        res.statusCode = 204
+        res.end()
+        return
+      }
+
+      // Popup-bridge callback (GitHub flow only): the in-browser
+      // Firebase SDK POSTs `auth.currentUser.toJSON()` here after a
+      // successful signInWithPopup. We forward it to the orchestrator
+      // for IndexedDB injection.
+      if (req.method === 'POST' && path === '/callback') {
+        if (providerId !== 'github.com') {
+          res.statusCode = 404
+          res.end()
+          return
+        }
+        const body = (await readJsonBody(req)) as { user?: Record<string, unknown> }
+        if (!body || typeof body !== 'object' || !body.user || typeof body.user !== 'object') {
+          res.statusCode = 400
+          res.setHeader('Content-Type', 'text/plain; charset=utf-8')
+          res.end('Missing user payload')
+          return
+        }
+        res.statusCode = 204
+        res.end()
+        finishWithSuccess({ user: body.user, apiKey: firebaseConfig.apiKey })
+        return
+      }
+
+      if (req.method !== 'GET' || path !== '/') {
+        res.statusCode = 404
+        res.end()
+        return
+      }
+
+      // IdP returned an explicit error (user denied consent, etc.)
+      const idpError = params.get('error')
+      if (idpError) {
+        const description =
+          params.get('error_description') || params.get('error_message') || idpError
+        res.statusCode = 200
+        res.setHeader('Content-Type', 'text/html; charset=utf-8')
+        res.end(renderErrorHtml(description))
+        finishWithError(new Error(`IdP error: ${description}`))
+        return
+      }
+
+      const code = params.get('code')
+      const state = params.get('state')
+
+      // Raw-OAuth callback arm — only relevant for Google (we drove the
+      // OAuth dance server-side via createAuthUri). For GitHub the
+      // bridge page handles the credential client-side (popup or
+      // Firebase JS SDK's redirect-fallback), so we fall through to
+      // serve the bridge HTML again on code+state arrival.
+      if (code && state && providerId === 'google.com') {
+        if (!sessionId) {
+          // Should not happen — would mean a callback arrived without
+          // a prior GET / on this server instance.
+          throw new Error('Callback arrived before initiator')
+        }
+        // Reconstruct the full URL the IdP redirected to; signInWithIdp
+        // parses query params from this string the same way the JS SDK does.
+        const requestUri = `http://localhost:${(server!.address() as AddressInfo).port}${url}`
+        const idpResponse = await signInWithIdpExchange(
+          firebaseConfig.apiKey,
+          providerId,
+          requestUri,
+          sessionId,
+        )
+        const persistedUser = buildPersistedUser(firebaseConfig, idpResponse, providerId)
+        res.statusCode = 200
+        res.setHeader('Content-Type', 'text/html; charset=utf-8')
+        res.setHeader('Cache-Control', 'no-store')
+        res.end(renderDoneHtml())
+        finishWithSuccess({ user: persistedUser, apiKey: firebaseConfig.apiKey })
+        return
+      }
+
+      // Initiator arm — first GET / with no callback params. Two flows:
+      //
+      //   Google: 302 to Google's OAuth URL (raw-OAuth zero-click flow).
+      //           Requires `http://localhost:<port>/` to be on the
+      //           Firebase Google OAuth client's authorized redirect
+      //           URIs (one-time Google Cloud Console setup).
+      //
+      //   GitHub: serve the popup-bridge HTML which initialises Firebase
+      //           JS SDK and runs signInWithPopup. Used because GitHub
+      //           OAuth Apps only allow a single Authorization Callback
+      //           URL (already reserved for web sign-in), so the loopback
+      //           redirect URI can't be added.
+      if (providerId === 'google.com') {
+        const continueUri = `http://localhost:${(server!.address() as AddressInfo).port}/`
+        const authResp = await createOauthAuthUri(firebaseConfig.apiKey, providerId, continueUri)
+        sessionId = authResp.sessionId
+        res.statusCode = 302
+        res.setHeader('Location', authResp.authUri)
+        res.setHeader('Cache-Control', 'no-store')
+        res.end()
+        return
+      }
+
+      res.statusCode = 200
+      res.setHeader('Content-Type', 'text/html; charset=utf-8')
+      res.setHeader('Cache-Control', 'no-store')
+      res.end(renderPopupBridgeHtml(firebaseConfig, providerId))
+    }
+
+    server.on('error', (err: Error) => {
+      finishWithError(err)
+      rejectHandle(err)
+      close()
+    })
+
+    server.listen(port, '127.0.0.1', () => {
+      const addr = server!.address() as AddressInfo
+      const url = `http://localhost:${addr.port}/`
+      resolveHandle({ url, signInPromise, close })
+    })
+  })
+}

--- a/src/main/host/attach.ts
+++ b/src/main/host/attach.ts
@@ -242,12 +242,70 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
       `read();` +
     `})()`
 
+  /**
+   * Two cloud-only patches injected on every dom-ready of the comfy view:
+   *
+   *   1. popup-blocked toast suppressor — observes new toast DOM nodes
+   *      and removes any that mention `auth/popup-blocked`. That error
+   *      is fired by the cloud frontend's Firebase SDK every time our
+   *      `setWindowOpenHandler` denies the auth popup (so the bridge
+   *      can take over), and the user has no way to dismiss the toast
+   *      in time before the bridge completes the sign-in.
+   *
+   *   2. post-signin flicker hide — when the bridge's IndexedDB inject
+   *      flips a sessionStorage flag before `location.reload()`, this
+   *      script hides documentElement for ~1s on the next load so the
+   *      user doesn't see the cloud login page flash before the
+   *      Firebase rehydrate redirects to the workspace.
+   */
+  const COMFY_CLOUD_PATCHES_JS =
+    `(function(){` +
+      `try{` +
+        `if(sessionStorage.getItem('__comfyDesktopPostSignin')==='1'){` +
+          `sessionStorage.removeItem('__comfyDesktopPostSignin');` +
+          `var de=document.documentElement;` +
+          `de.style.visibility='hidden';` +
+          `setTimeout(function(){de.style.visibility=''},1000);` +
+        `}` +
+      `}catch(_){}` +
+      `function looksBlocked(n){` +
+        `if(!n||n.nodeType!==1)return false;` +
+        `var t=(n.textContent||'').toLowerCase();` +
+        `return t.indexOf('auth/popup-blocked')>=0;` +
+      `}` +
+      `function nukeToast(n){` +
+        `var root=(n.closest&&n.closest('.p-toast-message,.p-toast-item,[role=alert]'))||n;` +
+        `try{root.remove()}catch(_){}` +
+      `}` +
+      `new MutationObserver(function(muts){` +
+        `for(var i=0;i<muts.length;i++){` +
+          `var added=muts[i].addedNodes;` +
+          `for(var j=0;j<added.length;j++){` +
+            `var n=added[j];` +
+            `if(looksBlocked(n)){nukeToast(n);continue;}` +
+            `if(n.querySelectorAll){` +
+              `var hits=n.querySelectorAll('*');` +
+              `for(var k=0;k<hits.length;k++){` +
+                `if(looksBlocked(hits[k])){nukeToast(hits[k]);break;}` +
+              `}` +
+            `}` +
+          `}` +
+        `}` +
+      `}).observe(document.documentElement,{childList:true,subtree:true});` +
+    `})()`
+
   const onDomReady = (): void => {
     comfyContents.executeJavaScript(COMFY_THEME_OBSERVER_JS).catch(() => {})
     const preamble = isLocal ? '' : 'window.__comfyDesktop2Remote = true;\n'
     comfyContents
       .executeJavaScript(preamble + getModelDownloadContentScript())
       .catch(() => {})
+    // Cloud-only patches (popup-blocked toast suppression + post-signin
+    // flicker hide). Skipped for local installs — they don't load cloud
+    // frontend, never see the toast or the redirect flash.
+    if (!isLocal) {
+      comfyContents.executeJavaScript(COMFY_CLOUD_PATCHES_JS).catch(() => {})
+    }
   }
   comfyContents.on('dom-ready', onDomReady)
 

--- a/src/main/host/createHostWindow.ts
+++ b/src/main/host/createHostWindow.ts
@@ -8,6 +8,7 @@ import {
   detachWindowDownloads,
   getDownloadsTrayState,
 } from '../lib/comfyDownloadManager'
+import { handleFirebasePopup, isFirebaseAuthHandlerUrl } from '../auth/firebaseBridge'
 import { isLikelyDownloadUrl, shouldOpenInPopup } from '../lib/allowedPopups'
 import { COMFY_BG, TITLEBAR_BG } from '../lib/theme'
 import {
@@ -765,6 +766,26 @@ export function buildComfyView(
     injectMacPasskeyWarning(childWindow)
   })
   comfyContents.setWindowOpenHandler(({ url: childUrl }) => {
+    // Intercept Firebase auth popups (`<authDomain>/__/auth/handler?...`)
+    // and reroute sign-in through the user's system browser so passkeys
+    // and saved-password autofill work. The bridge picks a per-provider
+    // flow: Google takes a server-side raw-OAuth path (zero clicks),
+    // GitHub takes a client-side popup-bridge path (1-2 clicks) because
+    // its OAuth App allows only a single Authorization Callback URL.
+    if (isFirebaseAuthHandlerUrl(childUrl)) {
+      void handleFirebasePopup(childUrl, comfyContents, {
+        parentWindow: comfyWindow,
+        onError: (err) => {
+          forwardDatadogError({
+            source: 'firebase-bridge-failed',
+            message: 'Firebase loopback bridge sign-in failed',
+            level: 'warn',
+            context: { origin: 'main-process', error: err.message },
+          })
+        },
+      })
+      return { action: 'deny' }
+    }
     if (shouldOpenInPopup(childUrl)) {
       // preload: undefined strips our title-bar bridge so OAuth/cloud-login
       // popups can't reach the file menu IPCs.


### PR DESCRIPTION
## Summary

The embedded cloud-workspace view opens Firebase's "Sign in with Google / GitHub" inside an Electron popup today. That popup can't use passkeys (unsupported in Electron) and doesn't share the user's saved passwords or existing provider sessions from their real browser.

This routes sign-in through the user's **system browser** instead, then propagates the resulting Firebase session back into the embedded view. No frontend or backend changes — pure Desktop main-process plumbing.

## How it works

A loopback HTTP bridge on `127.0.0.1:9876` is started when `setWindowOpenHandler` intercepts a Firebase auth-handler popup (`*.firebaseapp.com/__/auth/handler`):

- **Google** — fully server-side raw OAuth via Firebase's `accounts:createAuthUri` + `accounts:signInWithIdp` REST endpoints. The bridge `302`s the browser straight to Google, so it's **zero clicks** in the browser. The OAuth `code` is exchanged for a Firebase user server-side.
- **GitHub** — client-side popup bridge (Firebase JS SDK `signInWithPopup`). GitHub OAuth Apps only allow a single Authorization Callback URL (reserved for web sign-in), so the loopback redirect can't be registered. Falls back to a 1-click bridge page that still runs in the system browser (passkey-capable).

The resulting Firebase user (`User.toJSON()` shape) is written into the embedded view's `firebaseLocalStorageDb` IndexedDB and the view reloads. Firebase's SDK rehydrates from persistence on init and fires `onAuthStateChanged`, so the existing session-cookie flow runs **unchanged**.

Also includes: per-attempt nonce on the bridge URL (avoids stale-tab reuse), keep-alive disabled on the bridge server (avoids cross-bridge socket reuse), `auth/popup-blocked` toast suppression in the embedded view, a 3s post-signin countdown with auto-focus back to Desktop, and a brief flicker-hide on the post-signin reload.

## Required: Google Cloud Console change before this works

The Firebase **Google** OAuth client must have `http://localhost:9876/` added under **Authorized redirect URIs** (Google requires exact-match for Web OAuth clients). Needed on both projects:

- Prod (`dreamboothy`): `357148958219-...apps.googleusercontent.com`
- Dev (`dreamboothy-dev`): `313257147182-...apps.googleusercontent.com`

(Prod is already configured. Dev pending if you want to test against `stagingcloud.comfy.org`.)

## Scope

- Google zero-click sign-in: shipping in this PR.
- GitHub: stays on the popup-bridge path (1 click). A future follow-up could register a separate Desktop GitHub OAuth App for a redirect-based zero-click flow.

## Video

https://github.com/user-attachments/assets/18ed8ee2-efb2-41d2-9563-c5ae6f5f596b


## Test plan

- [x] Google: Sign in from the embedded cloud view → system browser opens → completes with passkey/saved-password → embedded view reloads signed-in, Desktop refocuses
- [x] GitHub: Sign in → bridge page → popup → completes → embedded view reloads signed-in
- [x] Sign out, switch providers, re-sign-in (verifies no stale-tab / stale-bridge state)
- [x] No `auth/popup-blocked` toast visible in the embedded view
- [x] Local (non-cloud) installs unaffected — no interception, no bridge
- [x] `pnpm test` (29 new unit tests across the firebaseBridge module), `pnpm run typecheck`, `pnpm lint`