### PR TITLE
Remove dead telemetry wiring from InstallWizardModal

### DIFF
--- a/src/main/lib/release-cache.test.ts
+++ b/src/main/lib/release-cache.test.ts
@@ -1,3 +1,9 @@
+// @vitest-environment node
+// release-cache.ts pulls in Node's `fs` module (main-process code). The
+// repo-wide default test environment is happy-dom, where `fs` resolves
+// to `__vite-browser-external` and the `vi.importActual('fs')` inside
+// the mock factory below throws. Force Node here so the real module is
+// available for the wrapper.
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type * as FsModule from 'fs'
 

--- a/src/renderer/src/views/InstallWizardModal.vue
+++ b/src/renderer/src/views/InstallWizardModal.vue
@@ -108,12 +108,6 @@ const estimatedInstallSize = computed(() => {
  * other entries).
  */
 
-/** Mirrored from the consent step so the user can re-affirm or flip
- *  telemetry on the Configure screen. Same setting key — no new state.
- *  `telemetryHydrated` gates the persist-on-change watch so an in-flight
- *  hydration can't clobber an early user toggle. */
-const telemetryEnabled = ref(true)
-const telemetryHydrated = ref(false)
 const advancedOpen = ref(false)
 const advancedRef = ref<HTMLElement | null>(null)
 
@@ -135,15 +129,6 @@ watch(instPath, (newPath) => {
   diskSpace.value = null
   pathIssues.value = []
   fetchDiskSpace(newPath)
-})
-
-/** Persist telemetry flips immediately (mirrors the consent step) so
- *  a cancel-out still respects the user's choice. Skip until hydration
- *  finishes — otherwise the initial `ref(true)` value writes back over
- *  whatever the user already persisted on the consent step. */
-watch(telemetryEnabled, (v) => {
-  if (!telemetryHydrated.value) return
-  void window.api.setSetting('telemetryEnabled', v)
 })
 
 /** Generation counter — incremented on each open/source change to discard stale responses */
@@ -201,19 +186,6 @@ onMounted(() => {
 
   installDirPromise = window.api.getDefaultInstallDir().catch(() => '')
   sourcesPromise = window.api.getSources()
-
-  // Brand-config re-affirms the consent-step telemetry choice. Hydrate
-  // from the persisted setting so the toggle reflects what the user
-  // already picked minutes ago.
-  void window.api
-    .getSetting('telemetryEnabled')
-    .then((v) => {
-      telemetryEnabled.value = v !== false
-    })
-    .catch(() => {})
-    .finally(() => {
-      telemetryHydrated.value = true
-    })
 })
 
 onBeforeUnmount(() => {


### PR DESCRIPTION
Closes #625.

## Background

The `Help improve Comfy` telemetry checkbox on the Configure screen was removed earlier because it duplicated the dedicated telemetry consent screen in the first-use flow (`FirstUseTakeover.vue`). The script-side wiring was left behind as inert code with a `TODO(brand-cleanup)` note.

## What this PR does

Removes the dead wiring from `InstallWizardModal.vue`:

- `telemetryEnabled` / `telemetryHydrated` refs
- The `watch(telemetryEnabled, .)` that persisted flips (could never fire - no UI mutated the ref after hydration)
- The `onMounted` hydration block that loaded `telemetryEnabled` from settings

The dedicated consent screen in `FirstUseTakeover.vue` remains the single source of telemetry consent.

## Verification

- `pnpm run typecheck` ?
- `pnpm run lint` ?
- `pnpm run build` ?
- `pnpm run test`: 107 passed / 1 pre-existing failure unrelated to this change (`src/main/lib/release-cache.test.ts` - same vi.mock/fs error on `origin/main` before this branch)
