### PR TITLE
fix(release): swap to Node tar + write bootstrap-python to correct extraResources staging dir

### DIFF
--- a/scripts/fetch-bootstrap-python.mjs
+++ b/scripts/fetch-bootstrap-python.mjs
@@ -29,7 +29,7 @@ import { pipeline } from 'node:stream/promises'
 import { Readable } from 'node:stream'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { execSync } from 'node:child_process'
+import * as tar from 'tar'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const projectRoot = path.resolve(__dirname, '..')
@@ -104,12 +104,17 @@ async function downloadAndExtract(url, destDir) {
     throw new Error(`Download failed: ${response.status} ${response.statusText}`)
   }
 
-  // Save to temp file first, then extract with tar
+  // Save to temp file first, then extract with the Node `tar` package.
+  // The previous shell-out to `tar -xzf` broke on todesktop's Windows
+  // builder: its GNU tar parsed the tmpFile's "C:" drive letter as a
+  // remote SSH host ("Cannot connect to C: resolve failed"). Node `tar`
+  // handles Windows paths natively and removes the dependency on whatever
+  // tar binary happens to be in PATH on the build machine.
   fs.mkdirSync(path.dirname(destDir), { recursive: true })
   const tmpFile = `${destDir}.tar.gz`
   try {
     await pipeline(Readable.fromWeb(response.body), fs.createWriteStream(tmpFile))
-    execSync(`tar -xzf "${tmpFile}" -C "${path.dirname(destDir)}"`, { stdio: 'inherit' })
+    await tar.x({ file: tmpFile, cwd: path.dirname(destDir) })
   } finally {
     if (fs.existsSync(tmpFile)) fs.unlinkSync(tmpFile)
   }

--- a/scripts/todesktop-beforeBuild.cjs
+++ b/scripts/todesktop-beforeBuild.cjs
@@ -38,12 +38,16 @@ module.exports = async ({ appDir, platform, arch }) => {
 
   console.log(`[todesktop:beforeBuild] Fetching bootstrap python for ${bootstrapPlatform}`)
   const script = path.join(appDir, 'scripts', 'fetch-bootstrap-python.mjs')
-  // todesktop resolves extraResources.from against `<appDir>/extraResources/`,
-  // not against the project source root — confirmed by the build log
-  // ("file source doesn't exist  from=<appDir>\extraResources\bootstrap-python\win-x64").
-  // Writing to <appDir>/bootstrap-python (the previous behaviour) put the
-  // archive in the wrong place and todesktop's packager skipped it silently.
-  const outDir = path.join(appDir, 'extraResources', 'bootstrap-python')
+  // todesktop layout:
+  //   <workingDir>/app-wrapper/app/         <- this is `appDir` (electron-builder appDirectory)
+  //   <workingDir>/app-wrapper/extraResources/  <- where extraResources.from is staged from
+  // extraResources.from in todesktop.json resolves against `app-wrapper/extraResources/`,
+  // NOT against the project root. The v0.6.6 mac build log proved this: the hook
+  // verified the binary inside `app-wrapper/app/extraResources/...` (correct relative
+  // to `appDir`) but electron-builder still warned `file source doesn't exist
+  // from=app-wrapper/extraResources/...` — and the dmg shipped without bootstrap-python.
+  // Going up one level from `appDir` puts the archive where todesktop actually reads it.
+  const outDir = path.join(appDir, '..', 'extraResources', 'bootstrap-python')
   // fetch-bootstrap-python.mjs now exits non-zero on failure, which bubbles
   // up here via execSync. Don't wrap in try/catch — a failed fetch must fail
   // the build (see 0.6.4 post-mortem: a swallowed fetch error shipped an


### PR DESCRIPTION
Follow-up to #615. The v0.6.6 ToDesktop build surfaced **two** distinct bugs that the strict-fail behaviour from #615 either caught (Windows) or "passed" with a misleading `Verified ✓` (Mac/Linux). Both are fixed here so v0.6.7 can ship a working installer on every platform.

## Bug #1 — Windows tar shell-out parses `C:` as a remote host

Windows build log:
```
[todesktop:beforeBuild] Fetching bootstrap python for win-x64
Fetching bootstrap-python archives from release bootstrap-v1
  win-x64: downloading bootstrap-python-win-x64.tar.gz (10.2 MB)
tar (child): Cannot connect to C: resolve failed
gzip: stdin: unexpected end of file
tar: Child returned status 128
```

GNU tar (on ToDesktop's Windows builder) parses `user@host:path` syntax as a remote SSH host. The temp archive at `C:\Users\...\win-x64.tar.gz` made tar try to "connect to C:" as if it were a host. The strict-fail correctly refused to ship a broken installer — exactly the class of silent failure #615 was designed to surface.

### Fix #1

Swap the `execSync('tar -xzf …')` shell-out in `scripts/fetch-bootstrap-python.mjs` for the Node [`tar`](https://www.npmjs.com/package/tar) package (already declared at `"tar": "^7.5.11"` in [package.json](package.json#L92)). Node `tar` handles Windows paths natively and removes the dependency on whatever tar binary happens to be in PATH on the build machine.

```diff
-import { execSync } from 'node:child_process'
+import * as tar from 'tar'
…
-execSync(`tar -xzf "${tmpFile}" -C "${path.dirname(destDir)}"`, { stdio: 'inherit' })
+await tar.x({ file: tmpFile, cwd: path.dirname(destDir) })
```

## Bug #2 — Hook wrote `bootstrap-python` one directory too deep

The v0.6.6 Mac build "succeeded" but the dmg shipped without `bootstrap-python`. Two key lines from the log:

```
[todesktop:beforeBuild] Verified .../app-wrapper/app/extraResources/bootstrap-python/mac-arm64/bin/python3
...
• file source doesn't exist  from=.../app-wrapper/extraResources/bootstrap-python/mac-arm64
```

The hook verified the binary inside `app-wrapper/app/extraResources/...` (one level deep) but electron-builder reads from `app-wrapper/extraResources/...` (one level up). My #615 fix was off by one directory. The Verified line was a "lie" — the strict check passed because the file existed where the hook put it, but ToDesktop's packager never picked it up. The same off-by-one affected Linux silently (Linux had been "matching" the old PLATFORM_MAP key by accident even before #615).

### Root cause

`appDir` passed to the `beforeBuild` callback is electron-builder's `appDirectory` (`app-wrapper/app`), **not** the env-info `appDir` shown at the top of the ToDesktop build log (`app-wrapper`). ToDesktop's `extraResources` staging dir is `app-wrapper/extraResources`, which is one level UP from the callback's `appDir`.

### Fix #2

```diff
-const outDir = path.join(appDir, 'extraResources', 'bootstrap-python')
+const outDir = path.join(appDir, '..', 'extraResources', 'bootstrap-python')
```

So `outDir` now resolves to `<app-wrapper>/extraResources/bootstrap-python/<platform>/` — exactly where electron-builder reads from.

## Verified locally

`node scripts/fetch-bootstrap-python.mjs --platform win-x64 --output-dir bootstrap-python/test-fetch`:
```
Fetching bootstrap-python archives from release bootstrap-v1
  win-x64: downloading bootstrap-python-win-x64.tar.gz (10.2 MB)
  win-x64: OK
Done.
```
Resulting `bootstrap-python/test-fetch/win-x64/python.exe` is 91,648 bytes — correct.

`pnpm run lint` ✅, `pnpm run typecheck` ✅.

## Aftermath of v0.6.6

- Windows: build failed at the strict check — no installer produced.
- Mac / Linux: builds completed, but the produced dmg/AppImage/.deb **do not contain `bootstrap-python`** (same end state as 0.6.4/0.6.5, different mechanism). Recommend not publishing the v0.6.6 draft release.

## Next steps after merge

1. Run `version-bump.yml` (`bump=patch, release=true`) → opens the `chore: bump version to v0.6.7` PR.
2. Merge it → triggers v0.6.7 tag + ToDesktop build.
3. Confirm the build log for every platform shows:
   - `[todesktop:beforeBuild] Fetching bootstrap python for <platform>`
   - `  <platform>: OK`
   - `[todesktop:beforeBuild] Verified .../app-wrapper/extraResources/bootstrap-python/<platform>/...`  (note: no `/app/` in the middle)
   - No `file source doesn't exist` warning.
4. Spot-check the produced installer artifacts contain `resources/bootstrap-python/python.exe` (Win) / `Contents/Resources/bootstrap-python/bin/python3` (Mac) / `resources/bootstrap-python/bin/python3` (Linux) before publishing.
