### PR TITLE
fix(release): move tar from devDependencies to dependencies so todesktop install includes it

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "posthog-js": "^1.372.4",
     "posthog-node": "^5.30.7",
     "smol-toml": "^1.6.1",
-    "systeminformation": "^5.31.5"
+    "systeminformation": "^5.31.5",
+    "tar": "^7.5.11"
   },
   "devDependencies": {
     "@datadog/datadog-ci": "^5.9.0",
@@ -89,7 +90,6 @@
     "playwright": "^1.58.2",
     "prettier": "^3.8.1",
     "tailwindcss": "^4.1.8",
-    "tar": "^7.5.11",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.56.0",
     "vite": "^7.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       systeminformation:
         specifier: ^5.31.5
         version: 5.31.5
+      tar:
+        specifier: ^7.5.11
+        version: 7.5.11
     devDependencies:
       '@datadog/datadog-ci':
         specifier: ^5.9.0
@@ -108,9 +111,6 @@ importers:
       tailwindcss:
         specifier: ^4.1.8
         version: 4.2.1
-      tar:
-        specifier: ^7.5.11
-        version: 7.5.11
       typescript:
         specifier: ^5.9.3
         version: 5.9.3


### PR DESCRIPTION
Follow-up to #638. The v0.6.7 ToDesktop build failed on every platform with:

```
[todesktop:beforeBuild] Fetching bootstrap python for win-x64
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'tar' imported from
  .../app-wrapper/app/scripts/fetch-bootstrap-python.mjs
```

## Root cause

PR #638 swapped the system `tar` shell-out for the Node `tar` package — but `tar` was a `devDependency`. ToDesktop's `pnpm install` (with `TODESKTOP_INITIAL_INSTALL_PHASE=true` and their `packageJson.extends`-based config) does not include `tar` in the resolved `node_modules`. The `beforeBuild` hook crashed before extracting the archive.

The strict-fail behaviour from #615 correctly caught it — the build refused to ship a broken installer.

## Fix

Move `"tar": "^7.5.11"` from `devDependencies` to `dependencies` in [package.json](package.json):

```diff
   "dependencies": {
     ...
-    "systeminformation": "^5.31.5"
+    "systeminformation": "^5.31.5",
+    "tar": "^7.5.11"
   },
   "devDependencies": {
     ...
-    "tar": "^7.5.11",
     ...
   }
```

`tar` is ~50KB with no transitive deps to speak of — runtime cost is negligible. This guarantees it's present whatever pruning ToDesktop's install does.

The lockfile reflects the new classification: `tar` now appears under the top-level `dependencies:` block in `pnpm-lock.yaml` (no other version changes).

## Verified

- `pnpm install --lockfile-only` cleanly updated the lockfile, no version churn outside `tar`'s placement.
- `pnpm run lint` ✅
- `pnpm run typecheck` ✅

## Next steps after merge

1. Run `version-bump.yml` (`bump=patch, release=true`) → opens the `chore: bump version to v0.6.8` PR.
2. Merge it → triggers v0.6.8 tag + ToDesktop build.
3. Confirm every platform's build log shows `<platform>: OK` → `Verified .../app-wrapper/extraResources/bootstrap-python/<platform>/...` → no `file source doesn't exist` warning.
4. Spot-check the installer artifact actually contains `bootstrap-python` before publishing.
