### PR TITLE
fix(titlebar): center pill at true window center + unify OS-control color on Windows

### DIFF
--- a/src/main/host/createHostWindow.ts
+++ b/src/main/host/createHostWindow.ts
@@ -934,10 +934,10 @@ export function openChooserHostWindow(): BrowserWindow {
     initialTheme: initialChooserTheme,
     titleBarOverlay: process.platform === 'darwin'
       ? undefined
-      // Install-less hosts use the launcher renderer's --surface
-      // for the OS overlay so the close/min/max region matches the
-      // Vue title bar above it. Install-backed windows still use
-      // `comfyTitleBarOverlay()` (ComfyUI brand --comfy-menu-bg).
+      // Every host — install-less chooser AND install-backed instance —
+      // uses the same `titleBarOverlayForTheme` (TITLEBAR_BG) for the OS
+      // overlay so the close/min/max region matches the Vue title bar
+      // above it. The overlay never adapts to ComfyUI's in-page theme.
       : titleBarOverlayForTheme(resolveTheme() === 'dark'),
     // Dummy comfyView. Kept so layoutViews doesn't have to special-
     // case the install-less branch — its body always resolves to

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -40,10 +40,11 @@ import { get as getInstallation, installationEvents, list as listInstallations }
 import { startPeriodicReleaseChecks } from './lib/release-cache-startup'
 import { showModelFolderRelaunchPage } from './lib/relaunchPage'
 import { COMFY_BG, SPLASH_DARK, TITLEBAR_BG, type SplashTheme } from './lib/theme'
-import { comfyTitleBarOverlay } from './lib/titleBarOverlay'
+import { titleBarOverlayForTheme } from './lib/titleBarOverlay'
 import {
   sourceMap, _broadcastToRenderer, _runningSessions,
   _operationAborts, _activeOperationStatus, stopRunning,
+  resolveTheme,
   type PickerOperationStatus,
 } from './lib/ipc/shared'
 import { enrichInstallationsForRenderer } from './lib/ipc/registerInstallationHandlers'
@@ -426,7 +427,7 @@ function onLaunch({ port, url, process: proc, installation, mode }: {
     windowTitle: `${installation.name} — Desktop 2.0 v${APP_VERSION}`,
     boundsKey: installationId,
     initialTheme: { bg: COMFY_BG, text: '#dddddd' },
-    titleBarOverlay: process.platform === 'darwin' ? undefined : comfyTitleBarOverlay(),
+    titleBarOverlay: process.platform === 'darwin' ? undefined : titleBarOverlayForTheme(resolveTheme() === 'dark'),
     comfyWebPreferences: {
       nodeIntegration: false,
       contextIsolation: true,

--- a/src/main/lib/theme.ts
+++ b/src/main/lib/theme.ts
@@ -17,8 +17,14 @@ export const COMFY_BG_LIGHT = '#f5f5f5'
 /** Default dark background for comfy windows (used at creation time before theme is known). */
 export const COMFY_BG = '#171717'
 
-/** Title bar background — matches the inline CSS in resources/comfyTitleBar.html. */
-export const TITLEBAR_BG = '#353535'
+/** Title bar background. Must stay in sync with `--titlebar-bg` (the dark
+ *  theme's `--neutral-800`) in `src/renderer/src/assets/main.css` — this is the
+ *  color the Vue `.title-bar` header paints, and the OS window-controls overlay
+ *  (min/max/close) must use the same value so that region is seamless with the
+ *  rest of the bar on every window, dashboard AND instance. Previously `#353535`
+ *  (the old ComfyUI menu color), which is why instance windows painted the
+ *  controls a different shade than the bar above them. */
+export const TITLEBAR_BG = '#211927'
 
 export interface SplashTheme {
   bg: string

--- a/src/main/lib/titleBarOverlay.ts
+++ b/src/main/lib/titleBarOverlay.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow } from 'electron'
 import { resolveTheme } from './ipc/shared'
+import { TITLEBAR_BG } from './theme'
 
 /** Height (px) of the custom title bar — must match the CSS `--titlebar-height`. */
 export const TITLEBAR_HEIGHT = 36
@@ -7,27 +8,26 @@ export const TITLEBAR_HEIGHT = 36
 /** Position of macOS traffic-light buttons, vertically centered within the title bar. */
 export const TRAFFIC_LIGHT_POSITION: Electron.Point = { x: 13, y: Math.round((TITLEBAR_HEIGHT - 16) / 2) }
 
-/** Colors must stay in sync with `--titlebar-bg` in `src/renderer/src/assets/main.css`.
+/** The single source of truth for the OS window-controls overlay color is
+ *  {@link TITLEBAR_BG}, which mirrors `--titlebar-bg` (dark `--neutral-800`)
+ *  in `src/renderer/src/assets/main.css`.
+ *
  *  The title bar is locked to the dark surface for now regardless of the
  *  app theme — light-theme support across every title-bar surface (Vue
  *  pills, dropdown popups, tooltips, OS overlay) hasn't been audited yet,
  *  and rendering the bar in two themes while half the chrome inside it
  *  isn't theme-aware looks broken. Once light theme is plumbed through
  *  every title-bar surface, restore the `isDark`-branched values below.
- *  TODO(titlebar-light-theme): re-enable `color: isDark ? '#211927' : '#e9e9e9'`
- *  and `symbolColor: isDark ? '#dddddd' : '#333333'`. */
+ *  TODO(titlebar-light-theme): re-enable `color: isDark ? TITLEBAR_BG : '#e9e9e9'`
+ *  and `symbolColor: isDark ? '#dddddd' : '#333333'`.
+ *
+ *  Used by EVERY window — launcher, install-less chooser hosts, and
+ *  install-backed ComfyUI instance windows — so the min/max/close region
+ *  is identical to the Vue bar above it everywhere. Instance windows must
+ *  NOT adapt this to ComfyUI's in-page theme (see issue #609). */
 export function titleBarOverlayForTheme(_isDark: boolean): Electron.TitleBarOverlayOptions {
   return {
-    color: '#211927',
-    symbolColor: '#dddddd',
-    height: TITLEBAR_HEIGHT,
-  }
-}
-
-/** Overlay colors for ComfyUI windows — matches `--comfy-menu-bg` from the frontend design system. */
-export function comfyTitleBarOverlay(): Electron.TitleBarOverlayOptions {
-  return {
-    color: '#353535',
+    color: TITLEBAR_BG,
     symbolColor: '#dddddd',
     height: TITLEBAR_HEIGHT,
   }
@@ -35,8 +35,8 @@ export function comfyTitleBarOverlay(): Electron.TitleBarOverlayOptions {
 
 /**
  * Update the title bar overlay on the main launcher window only.
- * ComfyUI instance windows use their own fixed overlay color
- * (matching the frontend's --comfy-menu-bg) and should not be updated.
+ * Other windows set their overlay at creation via `titleBarOverlayForTheme`;
+ * this is the live-repaint path for the launcher when the theme setting flips.
  */
 let _mainWindowId: number | null = null
 

--- a/src/renderer/src/comfyTitleBar/TitleBarApp.vue
+++ b/src/renderer/src/comfyTitleBar/TitleBarApp.vue
@@ -593,10 +593,20 @@ onUnmounted(() => {
   gap: 4px;
   /* Mirror the trailing cluster's measured width (set by the
      ResizeObserver in <script>) so the left + trailing grid tracks
-     stay equal-width. This keeps the centre 1fr track perfectly
-     window-centred regardless of which side has more content — the
-     install pill anchors to true window centre at every width. */
+     stay equal-width. With symmetric OS-chrome padding (macOS, where
+     the left traffic-light inset is handled below) this centres the
+     1fr track at true window centre. */
   min-width: var(--title-trailing-width, 0px);
+}
+/* Win/Linux: the native window controls reserve 140px on the RIGHT, vs the
+   12px base padding on the left. Mirroring only the trailing width centres
+   the pill in the *content box*, which the asymmetric reservation shifts
+   64px left of true window centre — this is the off-centre pill on Windows.
+   Claim the 128px delta (140px controls − 12px base padding) as extra left
+   min-width so the 1fr centre track is pushed back to true window centre.
+   Keep this value in sync with the `padding-right` above. */
+.title-bar:not(.is-mac) .title-cluster {
+  min-width: calc(var(--title-trailing-width, 0px) + 128px);
 }
 
 .title-center {


### PR DESCRIPTION
Addresses two Windows-specific title-bar bullets from #609.

## 1. Center pill is off-center on Windows

The title bar is a 3-track grid `[auto | 1fr | auto]` with a `ResizeObserver` mirroring the trailing cluster's width onto the left cluster (`--title-trailing-width`) so the flanking tracks stay equal. The intent is to keep the center 1fr track at true window center.

But the native Windows controls reserve **140px on the right** (`padding-right: 140px`) while the left has only **12px** base padding. Equal cluster tracks then center the pill within the *content box*, which the asymmetric reservation shifts **64px left** of true window center — the off-center pill.

**Fix:** on Win/Linux, claim the 128px delta (`140px controls − 12px base padding`) as extra left-cluster `min-width`, pushing the 1fr center track back to true window center.

```css
.title-bar:not(.is-mac) .title-cluster {
  min-width: calc(var(--title-trailing-width, 0px) + 128px);
}
```

Verified live in a dev build (measured from the DOM):
```
[tb-measure] pillCenter=640.0 innerWidth=1280 target=640.0 offset=0.0 pillW=248.2
```
0.0px offset on a 1280px window. macOS is unaffected (its traffic-light inset is symmetric via the existing left-padding handling).

## 2. Min/max/close controls show the wrong background on instance windows

The OS window-controls overlay was driven by `TITLEBAR_BG`, but that constant still held the **old ComfyUI menu color `#353535`**, while the Vue `.title-bar` paints `--titlebar-bg` = **`#211927`** (dark `--neutral-800`). So instance windows rendered a lighter block behind the three controls than the rest of the bar — exactly the "buttons don't match the titlebar" report. The dashboard looked right because it used `titleBarOverlayForTheme()` (already `#211927`); instance windows used `TITLEBAR_BG`/`comfyTitleBarOverlay()` (`#353535`).

**Fix — one source of truth, used everywhere:**
- `TITLEBAR_BG` → `#211927` so it actually matches `--titlebar-bg`.
- `titleBarOverlayForTheme()` now sources `TITLEBAR_BG` and is used by **every** window — launcher, install-less chooser, and install-backed instance. The overlay never adapts to ComfyUI's in-page theme.
- Removed the divergent `comfyTitleBarOverlay()` and pointed instance-window creation (`index.ts`) at the unified helper.

This extends the earlier dashboard-only fix to instance windows too, per the issue note ("make sure this works on both dashboard AND instance windows").

## Screenshot
<img width="1276" height="896" alt="image" src="https://github.com/user-attachments/assets/e042b0c3-7763-469f-aa64-8fb7da8ba8c6" />

## Verification
- `pnpm typecheck:node` + `typecheck:web` clean; `TitleBarApp.test.ts` (49 tests) green; pre-commit lint passed.
- Ran a dev build on Windows and inspected a live **Comfy Cloud instance** window: the three native controls now blend seamlessly with the bar (no `#353535` block), and the pill measured dead-center (offset 0.0px).

## Test plan
- [ ] Windows: dashboard window — pill centered, controls match bar.
- [ ] Windows: install-backed instance window (e.g. a standalone install running) — pill centered, controls match bar, color does NOT shift when ComfyUI's theme changes.
- [ ] macOS: pill still centered, no regression from the Win/Linux-only rule.
- [ ] Resize the window — pill stays centered at any width.