### PR TITLE
feat(snapshots): Share action to export the latest snapshot

### DIFF
--- a/e2e/lifecycle-snapshot-share.test.ts
+++ b/e2e/lifecycle-snapshot-share.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Lifecycle E2E: snapshot "Share" — the promoted top-level export of an
+ * install's LATEST snapshot, reachable from two surfaces:
+ *
+ *   - **Dashboard tile kebab → Share** — the `share` context-menu item
+ *     in `useInstallContextMenu`; handled renderer-side in the panel
+ *     webContents (no confirm modal): `shareLatestSnapshot` →
+ *     `window.api.getSnapshots` (newest = `[0]`) → `window.api.exportSnapshot`.
+ *   - **Picker footer "More" → Share** — the `share` pin-bottom action in
+ *     the standalone source's `getDetailSections`, rendered in the
+ *     instance-picker popup's `MoreMenu` and intercepted in
+ *     `useComfyUISettings.runAction` so it runs the same export rather than
+ *     dispatching a (non-existent) source action.
+ *
+ * Both routes funnel into the same `export-snapshot` IPC →
+ * `dialog.showSaveDialog` → `writeFile(envelope)`. The native save dialog
+ * is monkey-patched (as in `lifecycle-snapshot-export`) so it never opens;
+ * the stub writes into the test's tmp dir and the assertions read the JSON
+ * to confirm the envelope carries exactly the newest snapshot.
+ *
+ * Pins both entry points so a future menu / action refactor can't silently
+ * drop Share from either surface, and so the "latest snapshot only"
+ * contract can't regress into exporting the wrong (or every) snapshot.
+ *
+ * The snapshot records are seeded directly via `installations[].snapshots`
+ * so the test does not depend on any real ComfyUI install on disk.
+ */
+
+import os from 'node:os'
+import path from 'node:path'
+import { mkdir, mkdtemp, readdir, readFile, rm } from 'node:fs/promises'
+import { test, expect } from '@playwright/test'
+import { launchApp, type AppContext } from './launchApp'
+import { expectChooserVisible } from './support/chooserHelpers'
+import { titlePopupPage, waitForWebContents } from './support/cdpPages'
+import { byTestId, TID } from './support/testIds'
+
+let ctx: AppContext
+let installPath = ''
+let exportDir = ''
+
+const INSTALL_ID = 'inst-snapshot-share-test'
+const INSTALL_NAME = 'Snapshot Share Test'
+const COMMIT_OLD = 'a'.repeat(40)
+const COMMIT_NEW = 'b'.repeat(40)
+const BASE_TAG = 'v0.3.10'
+
+interface ShareEnvelope {
+  type?: string
+  installationName?: string
+  snapshots?: Array<{ label?: string; comfyui?: { commit?: string } }>
+}
+
+test.describe.configure({ mode: 'serial' })
+
+test.beforeAll(async () => {
+  installPath = await mkdtemp(path.join(os.tmpdir(), 'comfyui-launcher-snapshot-share-e2e-'))
+  exportDir = await mkdtemp(path.join(os.tmpdir(), 'comfyui-launcher-snapshot-share-out-'))
+  await mkdir(path.join(installPath, 'ComfyUI'), { recursive: true })
+
+  ctx = await launchApp({
+    settings: { firstUseCompleted: true, telemetryEnabled: false },
+    installations: [
+      {
+        id: INSTALL_ID,
+        name: INSTALL_NAME,
+        installPath,
+        sourceId: 'standalone',
+        status: 'installed',
+        snapshots: [
+          {
+            trigger: 'manual',
+            label: 'older-seeded',
+            createdAt: '2026-01-01T00:00:00.000Z',
+            comfyui: {
+              ref: COMMIT_OLD,
+              commit: COMMIT_OLD,
+              releaseTag: BASE_TAG,
+              variant: 'cpu',
+              baseTag: BASE_TAG,
+              commitsAhead: 1,
+            },
+          },
+          {
+            trigger: 'manual',
+            label: 'newest-seeded',
+            createdAt: '2026-01-02T00:00:00.000Z',
+            comfyui: {
+              ref: COMMIT_NEW,
+              commit: COMMIT_NEW,
+              releaseTag: BASE_TAG,
+              variant: 'cpu',
+              baseTag: BASE_TAG,
+              commitsAhead: 2,
+            },
+          },
+        ],
+      },
+    ],
+  })
+
+  // Monkey-patch `dialog.showSaveDialog` in main so the native save dialog
+  // never opens. Patching the shared `dialog` module covers both the panel
+  // `export-snapshot` handler and the picker popup's delegating handler.
+  await ctx.app.evaluate(({ dialog }, dir) => {
+    ;(dialog as unknown as { showSaveDialog: unknown }).showSaveDialog = async (
+      _win: unknown,
+      opts: { defaultPath?: string },
+    ) => {
+      const raw = opts.defaultPath ?? 'snapshot-export.json'
+      const lastSep = Math.max(raw.lastIndexOf('/'), raw.lastIndexOf('\\'))
+      const base = lastSep >= 0 ? raw.slice(lastSep + 1) : raw
+      const sep = dir.includes('\\') ? '\\' : '/'
+      return { canceled: false, filePath: `${dir}${sep}${base}` }
+    }
+  }, exportDir)
+
+  await expectChooserVisible(ctx.panel)
+})
+
+test.afterAll(async () => {
+  await ctx?.cleanup()
+  if (installPath) await rm(installPath, { recursive: true, force: true })
+  if (exportDir) await rm(exportDir, { recursive: true, force: true })
+})
+
+/** Empty the export dir before each Share click. Both surfaces export the
+ *  same latest snapshot, so they land on an identical default filename —
+ *  clearing first guarantees each test reads the file IT produced, not a
+ *  stale one from the prior test. */
+async function clearExportDir(): Promise<void> {
+  const entries = await readdir(exportDir)
+  await Promise.all(entries.map((e) => rm(path.join(exportDir, e), { force: true })))
+}
+
+/** Poll until the single-snapshot `snapshot-*.json` envelope lands (the
+ *  `snapshots-*` plural prefix is Export-All, which Share never uses) and
+ *  return it parsed. */
+async function readSharedEnvelope(): Promise<ShareEnvelope> {
+  const exportedPath = await new Promise<string>((resolve, reject) => {
+    const deadline = Date.now() + 10_000
+    const poll = async (): Promise<void> => {
+      const entries = await readdir(exportDir)
+      const match = entries.find((e) => e.startsWith('snapshot-') && e.endsWith('.json'))
+      if (match) return resolve(path.join(exportDir, match))
+      if (Date.now() > deadline) return reject(new Error('shared snapshot file did not appear within 10s'))
+      setTimeout(poll, 200)
+    }
+    void poll()
+  })
+  return JSON.parse(await readFile(exportedPath, 'utf-8')) as ShareEnvelope
+}
+
+/** Share must export ONLY the newest snapshot (the current state), as a
+ *  single-entry envelope. */
+function expectLatestEnvelope(envelope: ShareEnvelope): void {
+  expect(envelope.type).toBe('comfyui-desktop-2-snapshot')
+  expect(envelope.installationName).toBe(INSTALL_NAME)
+  expect(envelope.snapshots?.length).toBe(1)
+  expect(envelope.snapshots?.[0]?.label).toBe('newest-seeded')
+  expect(envelope.snapshots?.[0]?.comfyui?.commit).toBe(COMMIT_NEW)
+}
+
+test('dashboard kebab → Share exports the latest snapshot @lifecycle', async () => {
+  await clearExportDir()
+  await ctx.panel.waitForSelector(byTestId(TID.dashboardTile(INSTALL_ID)), { timeout: 10_000 })
+
+  expect(await ctx.panel.click(byTestId(TID.dashboardTileKebab(INSTALL_ID)))).toBe(true)
+  await ctx.panel.waitForVisible(byTestId(TID.contextMenuItem('share')), { timeout: 5_000 })
+  expect(await ctx.panel.click(byTestId(TID.contextMenuItem('share')))).toBe(true)
+
+  expectLatestEnvelope(await readSharedEnvelope())
+})
+
+test('picker footer More → Share exports the latest snapshot @lifecycle', async () => {
+  await clearExportDir()
+
+  await ctx.panel.evaluate<boolean>(
+    `(() => {
+      window.api.openInstancePicker({
+        installationId: ${JSON.stringify(INSTALL_ID)},
+        initialTab: 'config',
+      })
+      return true
+    })()`,
+  )
+  await waitForWebContents(ctx.app, 'comfyTitlePopup.html')
+  const popup = titlePopupPage(ctx.app)
+
+  // Open the footer "More" overflow menu, then click the Share action.
+  await popup.waitForVisible('[data-more-trigger]', { timeout: 15_000 })
+  expect(await popup.click('[data-more-trigger]')).toBe(true)
+  await popup.waitForVisible(byTestId(TID.pinBottomAction('share')), { timeout: 10_000 })
+  expect(await popup.click(byTestId(TID.pinBottomAction('share')))).toBe(true)
+
+  expectLatestEnvelope(await readSharedEnvelope())
+})

--- a/locales/en.json
+++ b/locales/en.json
@@ -47,13 +47,13 @@
     "updatePill": "Update",
     "migratePill": "Migrate",
     "openInstall": "Open",
-    "manageInstall": "Manage…",
+    "manageInstall": "Manage",
     "moreActions": "More actions",
-    "menuUpdate": "Update…",
-    "menuMigrate": "Migrate to Standalone…",
-    "menuRestoreSnapshot": "Restore Snapshot…",
+    "menuUpdate": "Update",
+    "menuMigrate": "Migrate to Standalone",
+    "menuRestoreSnapshot": "Restore Snapshot",
     "menuRevealInFolder": "Open Folder",
-    "menuDelete": "Uninstall…"
+    "menuDelete": "Uninstall"
   },
 
   "titleBar": {
@@ -555,7 +555,8 @@
     "deleteConfirmMessage": "This will permanently uninstall ComfyUI and delete all its files. This cannot be undone.",
     "untrack": "Forget",
     "untrackConfirmTitle": "Forget Install",
-    "untrackConfirmMessage": "This will remove the install from the app. The files will not be deleted."
+    "untrackConfirmMessage": "This will remove the install from the app. The files will not be deleted.",
+    "share": "Share"
   },
 
   "migrate": {
@@ -799,6 +800,8 @@
     "createLabel": "Create Snapshot",
     "changesInSnapshot": "What changed in this snapshot",
     "ifYouRestore": "What restoring this would change",
+    "noSnapshotsToShare": "There are no snapshots to share yet.",
+    "shareFailed": "Could not share the snapshot.",
     "current": "Current",
     "triggerBoot": "Boot",
     "triggerRestart": "Manager",

--- a/src/main/sources/standalone/updateSections.ts
+++ b/src/main/sources/standalone/updateSections.ts
@@ -228,6 +228,7 @@ export function getDetailSections(installation: InstallationRecord): Record<stri
             field: 'name',
           } },
         openFolderAction(installation.installPath),
+        { id: 'share', label: t('actions.share'), style: 'default', enabled: installed },
         untrackAction(),
         deleteAction(installation),
       ],

--- a/src/renderer/src/composables/useComfyUISettings.ts
+++ b/src/renderer/src/composables/useComfyUISettings.ts
@@ -16,6 +16,7 @@ import {
   type Installation,
   type ShowProgressOpts,
 } from '../types/ipc'
+import { shareLatestSnapshot } from '../lib/snapshots'
 import { IN_PLACE_RELAUNCH, augmentActionWithStopWarning, stopAndWaitForExit } from '../lib/stopWarning'
 import { sleepRemainder } from '../lib/uiTiming'
 import type { SectionTab } from '../lib/pickerTabs'
@@ -507,6 +508,24 @@ export function useComfyUISettings(opts: UseComfyUISettingsOpts): UseComfyUISett
   async function runAction(action: ActionDef): Promise<void> {
     const inst = toValue(opts.installation)
     if (!inst) return
+
+    // Share — export the latest snapshot via the OS save dialog. It's a
+    // renderer-side IPC (export + native dialog), not a source action, so
+    // intercept it before the source-action dispatch chain below. A cancel
+    // is a silent no-op; only the genuine failures get an alert.
+    if (action.id === 'share') {
+      const result = await shareLatestSnapshot(inst.id)
+      if (!result.ok) {
+        await dialogs.alert({
+          title: action.label,
+          message:
+            result.reason === 'none'
+              ? t('snapshots.noSnapshotsToShare', 'There are no snapshots to share yet.')
+              : result.message ?? t('snapshots.shareFailed', 'Could not share the snapshot.'),
+        })
+      }
+      return
+    }
 
     const telemetryContext = { action_id: action.id }
 

--- a/src/renderer/src/composables/useInstallContextMenu.test.ts
+++ b/src/renderer/src/composables/useInstallContextMenu.test.ts
@@ -32,6 +32,8 @@ const apiMock = {
   runAction: vi.fn().mockResolvedValue({ ok: true }),
   getDetailSections: vi.fn().mockResolvedValue([]),
   onErrorDetail: vi.fn(() => () => {}),
+  getSnapshots: vi.fn().mockResolvedValue({ snapshots: [] }),
+  exportSnapshot: vi.fn().mockResolvedValue({ ok: true }),
 }
 vi.stubGlobal('window', {
   ...window,
@@ -41,12 +43,12 @@ vi.stubGlobal('window', {
 const messages = {
   en: {
     chooser: {
-      manageInstall: 'Manage…',
-      menuUpdate: 'Update…',
-      menuMigrate: 'Migrate to Standalone…',
-      menuRestoreSnapshot: 'Restore Snapshot…',
+      manageInstall: 'Manage',
+      menuUpdate: 'Update',
+      menuMigrate: 'Migrate to Standalone',
+      menuRestoreSnapshot: 'Restore Snapshot',
       menuRevealInFolder: 'Open Folder',
-      menuDelete: 'Delete…',
+      menuDelete: 'Uninstall',
     },
     actions: {
       copyInstallation: 'Copy Install',
@@ -58,6 +60,11 @@ const messages = {
       deleteConfirmTitle: 'Delete Install',
       deleteConfirmMessage:
         'This will permanently delete the install and all its files. This cannot be undone.',
+      share: 'Share',
+    },
+    snapshots: {
+      noSnapshotsToShare: 'There are no snapshots to share yet.',
+      shareFailed: 'Could not share the snapshot.',
     },
     progress: { working: 'Working…' },
     running: { dismiss: 'Dismiss' },
@@ -367,5 +374,66 @@ describe('useInstallContextMenu — untrack confirm-then-remove', () => {
     await menu.triggerAction('untrack', inst)
 
     expect(apiMock.runAction).not.toHaveBeenCalled()
+  })
+})
+
+describe('useInstallContextMenu — share (export latest snapshot)', () => {
+  beforeEach(() => {
+    apiMock.getSnapshots.mockReset()
+    apiMock.exportSnapshot.mockReset()
+    modalMock.alert.mockReset()
+  })
+
+  it('shows the Share item for an installed local install', () => {
+    const { menu } = mountHarness(makeInstall({ sourceCategory: 'local' }))
+    expect(findItem(menu.ctxMenuItems.value, 'share')).toBeTruthy()
+  })
+
+  it('hides the Share item for cloud installs (snapshots are local-only)', () => {
+    const { menu } = mountHarness(makeInstall({ sourceCategory: 'cloud' }))
+    expect(findItem(menu.ctxMenuItems.value, 'share')).toBeUndefined()
+  })
+
+  it('exports the newest snapshot and shows no alert on success', async () => {
+    apiMock.getSnapshots.mockResolvedValue({
+      snapshots: [{ filename: 'snap-newest.json' }, { filename: 'snap-older.json' }],
+    })
+    apiMock.exportSnapshot.mockResolvedValue({ ok: true })
+    const inst = makeInstall()
+    const { menu } = mountHarnessWithManage(() => {})
+
+    await menu.triggerAction('share', inst)
+
+    expect(apiMock.exportSnapshot).toHaveBeenCalledWith(inst.id, 'snap-newest.json')
+    expect(modalMock.alert).not.toHaveBeenCalled()
+  })
+
+  it('alerts and skips export when there are no snapshots', async () => {
+    apiMock.getSnapshots.mockResolvedValue({ snapshots: [] })
+    const inst = makeInstall()
+    const { menu } = mountHarnessWithManage(() => {})
+
+    await menu.triggerAction('share', inst)
+
+    expect(apiMock.exportSnapshot).not.toHaveBeenCalled()
+    expect(modalMock.alert).toHaveBeenCalledTimes(1)
+    expect(modalMock.alert.mock.calls[0]![0].message).toBe('There are no snapshots to share yet.')
+  })
+
+  it('surfaces a real export error but stays silent on a dialog cancel', async () => {
+    apiMock.getSnapshots.mockResolvedValue({ snapshots: [{ filename: 'snap.json' }] })
+    const inst = makeInstall()
+    const { menu } = mountHarnessWithManage(() => {})
+
+    // Cancel — export IPC returns { ok: false } with no message.
+    apiMock.exportSnapshot.mockResolvedValueOnce({ ok: false })
+    await menu.triggerAction('share', inst)
+    expect(modalMock.alert).not.toHaveBeenCalled()
+
+    // Real failure — a message is present, so it surfaces.
+    apiMock.exportSnapshot.mockResolvedValueOnce({ ok: false, message: 'Disk full' })
+    await menu.triggerAction('share', inst)
+    expect(modalMock.alert).toHaveBeenCalledTimes(1)
+    expect(modalMock.alert.mock.calls[0]![0].message).toBe('Disk full')
   })
 })

--- a/src/renderer/src/composables/useInstallContextMenu.ts
+++ b/src/renderer/src/composables/useInstallContextMenu.ts
@@ -5,6 +5,7 @@ import { useProgressStore } from '../stores/progressStore'
 import { useModal } from './useModal'
 import { revealInFolderLabel } from './usePlatform'
 import { progressOpKindForActionId, destroysInstanceForActionId } from '../lib/progressOpKind'
+import { shareLatestSnapshot } from '../lib/snapshots'
 import type { ContextMenuItem } from '../types/context-menu'
 import type { Installation, ShowProgressOpts } from '../types/ipc'
 
@@ -60,6 +61,7 @@ export type InstallMenuActionId =
   | 'migrate'
   | 'restore-snapshot'
   | 'reveal-in-folder'
+  | 'share'
   | 'copy-install'
   | 'untrack'
   | 'delete'
@@ -161,6 +163,14 @@ export function useInstallContextMenu(opts: {
         label: revealInFolderLabel(window.api?.platform),
         separator: items.length > 0,
       })
+    }
+
+    // Share — export the latest snapshot via the OS save dialog. Snapshots
+    // are local-only and captured once the install has booted, so gate on
+    // installed + local. Promotes the per-row Snapshots-tab export to a
+    // top-level action.
+    if (isInstalled(inst) && hasInstallPath(inst) && isLocalLikeInstall(inst)) {
+      items.push({ id: 'share', label: t('actions.share', 'Share') })
     }
 
     // Copy Installation — standalone source only (the `'copy'` action
@@ -269,6 +279,25 @@ export function useInstallContextMenu(opts: {
       opts.onManage?.(inst, { initialTab: 'snapshots' })
     } else if (id === 'reveal-in-folder') {
       await runInstantActionWithAlert(inst, 'open-folder', revealInFolderLabel(window.api?.platform))
+    } else if (id === 'share') {
+      // Share = export the latest snapshot. The export IPC owns its own OS
+      // save dialog; a cancel is a silent no-op. Only surface the genuine
+      // failure cases (no snapshots yet, or a write error).
+      const label = t('actions.share', 'Share')
+      try {
+        const result = await shareLatestSnapshot(inst.id)
+        if (!result.ok) {
+          await modal.alert({
+            title: label,
+            message:
+              result.reason === 'none'
+                ? t('snapshots.noSnapshotsToShare', 'There are no snapshots to share yet.')
+                : result.message ?? t('snapshots.shareFailed', 'Could not share the snapshot.'),
+          })
+        }
+      } catch (err) {
+        await modal.alert({ title: label, message: (err as Error)?.message || String(err) })
+      }
     } else if (id === 'copy-install') {
       // Route through the source-action def by handing the autoAction
       // off to `onManage`. Calling `window.api.runAction(id, 'copy')`

--- a/src/renderer/src/lib/snapshots.ts
+++ b/src/renderer/src/lib/snapshots.ts
@@ -22,6 +22,33 @@ export function setCachedSnapshotList(installationId: string, data: SnapshotList
   _snapshotListCache.set(installationId, data)
 }
 
+/**
+ * "Share" a snapshot = export the install's latest (newest) snapshot via the
+ * OS save dialog. This is the same operation as the per-row Export button,
+ * promoted to a top-level install action so it's reachable from the dashboard
+ * context menu and the IPP "More" menu without opening the Snapshots tab.
+ *
+ * Snapshots come back newest-first, so `[0]` is the current state. Returns a
+ * discriminated result so each caller can surface the right feedback in its
+ * own dialog system:
+ *  - `none`  — the install has no snapshots yet (menu items are gated to
+ *              installed local installs, but handle it defensively here too).
+ *  - `error` — the export failed with a message (e.g. a write error).
+ * A user cancelling the save dialog returns `{ ok: false }` with no message
+ * from the IPC, which we treat as a successful no-op (nothing to report).
+ */
+export async function shareLatestSnapshot(
+  installationId: string
+): Promise<{ ok: true } | { ok: false; reason: 'none' | 'error'; message?: string }> {
+  const list = await window.api.getSnapshots(installationId)
+  const latest = list?.snapshots?.[0]?.filename
+  if (!latest) return { ok: false, reason: 'none' }
+  const result = await window.api.exportSnapshot(installationId, latest)
+  if (result.ok) return { ok: true }
+  if (result.message) return { ok: false, reason: 'error', message: result.message }
+  return { ok: true }
+}
+
 /** Localised trigger label (requires the `t` function from `useI18n`). */
 export function triggerLabel(trigger: string, t: (key: string) => string): string {
   switch (trigger) {

--- a/src/renderer/src/views/ChooserView.test.ts
+++ b/src/renderer/src/views/ChooserView.test.ts
@@ -30,7 +30,7 @@ const messages = {
       filterCloud: 'Cloud',
       filterRemote: 'Remote',
       moreActions: 'More actions',
-      manageInstall: 'Manage…',
+      manageInstall: 'Manage',
       searchPlaceholder: 'Search for and open an instance',
       noMatches: 'No instances match',
     },


### PR DESCRIPTION
## Summary
- Adds a top-level **Share** action that exports an install's **latest** snapshot (current state) through the existing `export-snapshot` IPC + OS save dialog — promoting the per-row Snapshots-tab export so it's reachable without opening the tab.
- Available from two surfaces, gated to installed local installs (snapshots are local-only):
  - **Dashboard** — tile right-click / kebab → **Share**
  - **Instance picker** — select an install → footer **More** → **Share**
- Also drops the trailing `…` from the dashboard context-menu labels (Manage / Update / Migrate to Standalone / Restore Snapshot / Uninstall); those i18n keys are used only by that menu.

## Implementation
- Shared `shareLatestSnapshot()` helper (`lib/snapshots.ts`): `getSnapshots()[0]` → `exportSnapshot()`. A save-dialog cancel is a silent no-op; only "no snapshots yet" / a write error raises an alert.
- Dashboard: `share` item + `triggerAction` case in `useInstallContextMenu`.
- Picker / settings "More": `share` pin-bottom action in the standalone source's `getDetailSections`, intercepted in `useComfyUISettings.runAction` (renderer-side export, not a source action). The picker's `exportSnapshot` channel delegates to the same main handler, so the OS save dialog is shared.

## Video

https://github.com/user-attachments/assets/959f37dd-c04b-4719-b2a1-2001d11353e8


## Test plan
- [x] Unit (`useInstallContextMenu`): item shown for local / hidden for cloud; exports the newest snapshot; alerts on no-snapshots; surfaces a write error but stays silent on a dialog cancel
- [x] Lifecycle e2e (`lifecycle-snapshot-share`): `dashboard kebab → Share` and `picker More → Share`, each asserting a single-entry envelope = the latest snapshot — **2/2 pass**
- [x] `typecheck` (all 4 projects) + `eslint` clean (husky pre-commit) + production build succeeds
- [ ] Manual: click Share in both menus, confirm the save dialog opens defaulting to the latest snapshot and writes a valid envelope
