### PR TITLE
fix(window): native close (X) shows its confirm on Windows

### DIFF
--- a/src/main/host/createHostWindow.ts
+++ b/src/main/host/createHostWindow.ts
@@ -79,13 +79,13 @@ export interface HostWindowFactories {
   consultPanelRendererClose: (
     panelView: WebContentsView | null | undefined,
   ) => Promise<'cleared' | 'aborted' | 'defer'>
-  /** Shell-level "Close Window" confirm, owned by main so a hidden panel
-   *  renderer can't swallow it. Shared with the Close Window menu entry. */
-  confirmCloseInstanceWindow: (
-    window: BrowserWindow,
-    isLastWindow: boolean,
-    theme: { bg: string; text: string },
-  ) => Promise<boolean>
+  /** The instance menu's "Close Window" handler. The OS ✕ hands off to it
+   *  (on a fresh tick) for the no-overlay confirm so the modal is shown
+   *  the same way the menu does — from outside the `'close'` event, which
+   *  Windows requires (a modal shown from within a preventDefault'd close
+   *  continuation never surfaces there). It confirms, then detaches the
+   *  last window or re-closes (with the window pre-cleared) to tear down. */
+  confirmAndCloseHostWindow: (window: BrowserWindow) => Promise<void> | void
   /** Detach the install currently bound to a host entry (in-place flip). */
   detachInstallImpl: (entry: ComfyWindowEntry) => void
   /** WeakSet of host windows whose close was pre-cleared by the
@@ -596,18 +596,20 @@ export function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowRe
         // chooser hosts skip straight through.
         const consult = skipConsult ? 'cleared' : await fx.consultPanelRendererClose(entry?.panelView)
         if (consult === 'aborted') return
-        // Step 2 — for an install-backed host with no overlay, main shows
-        // the same Close Window confirm as the menu item. The dashboard
-        // closes with no prompt.
+        // Step 2 — for an install-backed host with no overlay, the close
+        // needs the same confirm the menu's Close Window shows. Hand off to
+        // that exact handler on a FRESH TICK and return: the confirm modal
+        // must be shown from OUTSIDE this `'close'` event or it never
+        // surfaces on Windows (the window sits in a closing limbo until the
+        // handler returns; the menu works precisely because it runs from an
+        // IPC handler). `confirmAndCloseHostWindow` shows the confirm, then
+        // detaches the last window or re-closes with `preClearedClose` set —
+        // which re-enters here (skipConsult → cleared) to tear down.
         const entryForClose = comfyWindows.get(windowKey)
         const isInstallHost = !!entryForClose && !isChooserHost(entryForClose)
         if (consult === 'defer' && isInstallHost && entryForClose) {
-          const confirmed = await fx.confirmCloseInstanceWindow(
-            comfyWindow,
-            isLastWindow,
-            entryForClose.lastTheme,
-          )
-          if (!confirmed) return
+          setImmediate(() => void fx.confirmAndCloseHostWindow(comfyWindow))
+          return
         }
         fx.preClearedClose.delete(comfyWindow)
         if (comfyWindow.isDestroyed()) return

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -83,7 +83,6 @@ import {
   _detachInstallImpl,
   confirmAndCloseAllHostWindows,
   confirmAndCloseHostWindow,
-  confirmCloseInstanceWindow,
   consultPanelRendererClose,
   detachOrphanedInstallHosts,
   preClearedClose,
@@ -977,7 +976,7 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
     // picker all flow through the registry).
     setHostWindowFactories({
       consultPanelRendererClose,
-      confirmCloseInstanceWindow,
+      confirmAndCloseHostWindow,
       detachInstallImpl: _detachInstallImpl,
       preClearedClose,
       computeInstallUpdateAvailable,


### PR DESCRIPTION
> **Status: parked / unconfirmed.** This was seen **once** on Windows (native ✕ on a running instance did nothing) but could **not be reproduced again** — possibly a stale build at the time. Parking this PR rather than merging. **If the symptom shows up again, this PR is the fix** — verify against plain `main` on Windows first to confirm the bug is real, then merge.

## Summary

Follow-up to #661. On **Windows**, clicking the native OS close (✕) on a running instance did **nothing** — the "Close window? This stops the running ComfyUI instance" confirm never appeared.

Root cause: the confirm was `await`ed from inside the preventDefault'd `'close'` event handler. On Windows the window sits in a "closing" limbo until that handler returns, so a child-view modal shown from within the continuation never surfaces. The hamburger **Close Window** works because it's invoked from an IPC handler, fully decoupled from any close event.

Fix: when the close needs the no-overlay confirm, hand off to the exact menu handler (`confirmAndCloseHostWindow`) on a fresh tick via `setImmediate` and return from the `'close'` handler immediately — so the modal is shown outside the close event, the same way the working menu does. The Tier 2/3 in-flight-operation cancel-prompt still runs inline (it's a renderer modal and was never affected).

Behavior is unchanged on macOS; this only changes *when/where* the confirm modal is invoked.

## Test plan

- [x] `pnpm typecheck` (node/web/e2e/integration)
- [x] `pnpm lint`
- [x] `pnpm test` (1349 unit tests)
- [x] macOS: native ✕ on an instance still confirms → closes / returns to dashboard; menu Close Window + Quit unchanged
- [ ] **Windows**: native ✕ on a running instance now shows the confirm → closes (stops instance) / returns to dashboard on the last window; never quits except the lone dashboard
- [ ] Windows: ✕ mid-install/update still shows the operation cancel-prompt