### PR TITLE
fix(desktop2): small UX wins (error screen, picker, settings, cloud)

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -49,7 +49,8 @@
     "menuRestoreSnapshot": "Restore Snapshot",
     "menuRevealInFolder": "Open Folder",
     "menuDelete": "Uninstall",
-    "stoppedActionGatedReason": "Stop the running instance first."
+    "stoppedActionGatedReason": "Stop the running instance first.",
+    "menuDismissError": "Dismiss Error"
   },
 
   "titleBar": {

--- a/src/main/popups/titlePopup.test.ts
+++ b/src/main/popups/titlePopup.test.ts
@@ -218,7 +218,18 @@ describe('resolvePickerSelectedInstallId', () => {
     expect(resolvePickerSelectedInstallId(null, 'b', installs)).toBe('b')
   })
 
-  it('defaults to the first install on an install-less host', () => {
+  it('defaults to the most-recently-launched install on an install-less host', () => {
+    // Order in the list must NOT decide the default — recency does. Put the
+    // most-recently-launched install ('b') second to prove list order loses.
+    const installs = [
+      makeInstall({ id: 'a', lastLaunchedAt: 1000 }),
+      makeInstall({ id: 'b', lastLaunchedAt: 5000 }),
+      makeInstall({ id: 'c', lastLaunchedAt: 2000 }),
+    ]
+    expect(resolvePickerSelectedInstallId(null, null, installs)).toBe('b')
+  })
+
+  it('falls back to the first install on an install-less host when none have been launched', () => {
     const installs = [makeInstall({ id: 'a' }), makeInstall({ id: 'b' })]
     expect(resolvePickerSelectedInstallId(null, null, installs)).toBe('a')
   })

--- a/src/main/popups/titlePopup.test.ts
+++ b/src/main/popups/titlePopup.test.ts
@@ -234,6 +234,31 @@ describe('resolvePickerSelectedInstallId', () => {
     expect(resolvePickerSelectedInstallId(null, null, installs)).toBe('a')
   })
 
+  it('does not default to the seeded cloud entry just because it sorts first', () => {
+    // The auto-seeded "Comfy Cloud" install is first in the registry but has
+    // no launch history — a real install must win the default so it stays
+    // fair for users who never open cloud.
+    const installs = [
+      makeInstall({ id: 'cloud', sourceCategory: 'cloud' }),
+      makeInstall({ id: 'local-a', sourceCategory: 'local' }),
+      makeInstall({ id: 'local-b', sourceCategory: 'local' }),
+    ]
+    expect(resolvePickerSelectedInstallId(null, null, installs)).toBe('local-a')
+  })
+
+  it('still defaults to cloud when it was genuinely launched most-recently', () => {
+    const installs = [
+      makeInstall({ id: 'local-a', sourceCategory: 'local', lastLaunchedAt: 1000 }),
+      makeInstall({ id: 'cloud', sourceCategory: 'cloud', lastLaunchedAt: 5000 }),
+    ]
+    expect(resolvePickerSelectedInstallId(null, null, installs)).toBe('cloud')
+  })
+
+  it('falls back to cloud when it is the only install', () => {
+    const installs = [makeInstall({ id: 'cloud', sourceCategory: 'cloud' })]
+    expect(resolvePickerSelectedInstallId(null, null, installs)).toBe('cloud')
+  })
+
   it('returns null when there are no installs to select', () => {
     expect(resolvePickerSelectedInstallId(null, null, [])).toBeNull()
   })

--- a/src/main/popups/titlePopup.ts
+++ b/src/main/popups/titlePopup.ts
@@ -205,13 +205,28 @@ interface BuildInstancePickerSnapshotArgs {
   installOperationStatus?: InstancePickerSnapshot['installOperationStatus']
 }
 
-/** The most-recently-launched install in the list (largest `lastLaunchedAt`),
- *  or the first row when none carry a timestamp. Mirrors the renderer's
- *  `mostRecentInstallId` so main and the picker agree on "most recent". */
+/** The most-recently-launched install in the list (largest `lastLaunchedAt`).
+ *  Mirrors the renderer's `mostRecentInstallId` so main and the picker agree
+ *  on "most recent".
+ *
+ *  Tie-break: the always-seeded "Comfy Cloud" entry must NOT win the default
+ *  just by sorting first in the registry. Cloud is only the default when it
+ *  was genuinely launched most-recently (strictly higher `lastLaunchedAt`);
+ *  on a tie (e.g. nothing launched yet, or equal timestamps) a real install
+ *  wins. This keeps the "default = last opened" behaviour fair for users who
+ *  never open cloud. Cloud is still chosen when it's the only install. */
 function mostRecentlyLaunchedInstallId(installs: InstancePickerInstall[]): string | null {
   let best: InstancePickerInstall | undefined
   for (const inst of installs) {
-    if (!best || (inst.lastLaunchedAt ?? 0) > (best.lastLaunchedAt ?? 0)) {
+    if (!best) {
+      best = inst
+      continue
+    }
+    const ts = inst.lastLaunchedAt ?? 0
+    const bestTs = best.lastLaunchedAt ?? 0
+    if (ts > bestTs) {
+      best = inst
+    } else if (ts === bestTs && best.sourceCategory === 'cloud' && inst.sourceCategory !== 'cloud') {
       best = inst
     }
   }

--- a/src/main/popups/titlePopup.ts
+++ b/src/main/popups/titlePopup.ts
@@ -205,10 +205,24 @@ interface BuildInstancePickerSnapshotArgs {
   installOperationStatus?: InstancePickerSnapshot['installOperationStatus']
 }
 
+/** The most-recently-launched install in the list (largest `lastLaunchedAt`),
+ *  or the first row when none carry a timestamp. Mirrors the renderer's
+ *  `mostRecentInstallId` so main and the picker agree on "most recent". */
+function mostRecentlyLaunchedInstallId(installs: InstancePickerInstall[]): string | null {
+  let best: InstancePickerInstall | undefined
+  for (const inst of installs) {
+    if (!best || (inst.lastLaunchedAt ?? 0) > (best.lastLaunchedAt ?? 0)) {
+      best = inst
+    }
+  }
+  return best?.id ?? null
+}
+
 /**
  * Resolves which install the picker should show in its detail pane.
  * Install-less hosts (dashboard) have no active install; default to the
- * first row so the pane is not empty on open.
+ * most-recently-launched install so the picker opens on what the user last
+ * used, not whatever happens to sort first in the registry list.
  */
 export function resolvePickerSelectedInstallId(
   explicitSelection: string | null | undefined,
@@ -217,7 +231,7 @@ export function resolvePickerSelectedInstallId(
 ): string | null {
   const resolved = explicitSelection ?? hostInstallationId ?? null
   if (resolved) return resolved
-  return installs[0]?.id ?? null
+  return mostRecentlyLaunchedInstallId(installs)
 }
 
 /**

--- a/src/renderer/src/comfyTitlePopup/InstancePickerView.vue
+++ b/src/renderer/src/comfyTitlePopup/InstancePickerView.vue
@@ -174,6 +174,30 @@ const {
   lastLaunchedShortLabel
 } = useInstallList({ installations: installationsRef })
 
+/** Rows for the picker list. Unlike the dashboard (which pins the Cloud
+ *  card on top), the IPP folds cloud into the recency-sorted list so it
+ *  sorts by its own `lastLaunchedAt` — a local that was opened more
+ *  recently sits above it, so cloud no longer "sticks" on top.
+ *
+ *  Tie-break: when recency is equal (e.g. nothing launched yet), cloud
+ *  takes priority and is ordered first. Note this is ordering only — the
+ *  auto-*selected* default still favours a real install on a tie (see
+ *  `resolvePickerSelectedInstallId` in main), so cloud can lead the list
+ *  without being pre-selected for users who never open it.
+ *  `showCloudCard` still gates cloud per the active filter / search query. */
+const pickerRows = computed<Installation[]>(() => {
+  const rows = [...visibleInstalls.value]
+  if (showCloudCard.value && cloudInstall.value) {
+    rows.push(cloudInstall.value)
+  }
+  return rows.sort((a, b) => {
+    const ta = a.lastLaunchedAt ?? -Infinity
+    const tb = b.lastLaunchedAt ?? -Infinity
+    if (tb !== ta) return tb - ta
+    return (b.sourceCategory === 'cloud' ? 1 : 0) - (a.sourceCategory === 'cloud' ? 1 : 0)
+  })
+})
+
 const visibleChips = computed(() => {
   return FILTER_CHIPS.filter((chip) => {
     if (chip.key === 'all') return true
@@ -189,14 +213,29 @@ const visibleChips = computed(() => {
 
 /** The install the user most recently launched — the sensible default
  *  selection when the popup opens with no active or explicitly-selected
- *  install. Falls back to list order when nothing has ever been launched. */
+ *  install.
+ *
+ *  Tie-break mirrors main's `mostRecentlyLaunchedInstallId`: the always-
+ *  seeded "Comfy Cloud" entry must not win the default just by sorting
+ *  first. Cloud is the default only when genuinely launched most-recently
+ *  (strictly higher `lastLaunchedAt`); on a tie a real install wins, so the
+ *  default stays fair for users who never open cloud. */
 function mostRecentInstallId(installs: PickerInstall[]): string | null {
-  const first = installs[0]
-  if (!first) return null
-  return installs.reduce(
-    (best, i) => ((i.lastLaunchedAt ?? 0) > (best.lastLaunchedAt ?? 0) ? i : best),
-    first
-  ).id
+  let best: PickerInstall | undefined
+  for (const inst of installs) {
+    if (!best) {
+      best = inst
+      continue
+    }
+    const ts = inst.lastLaunchedAt ?? 0
+    const bestTs = best.lastLaunchedAt ?? 0
+    if (ts > bestTs) {
+      best = inst
+    } else if (ts === bestTs && best.sourceCategory === 'cloud' && inst.sourceCategory !== 'cloud') {
+      best = inst
+    }
+  }
+  return best?.id ?? null
 }
 
 function resolveInitialSelection(snapshot: PickerSnapshot): string | null {
@@ -515,20 +554,7 @@ function handleExpandedPrimaryAction(running: boolean): void {
 
           <div class="picker-list" role="listbox">
             <InstanceRow
-              v-if="showCloudCard && cloudInstall"
-              :key="cloudInstall.id"
-              :installation="cloudInstall"
-              :active="selectedId === cloudInstall.id"
-              :running="isRowRunning(cloudInstall)"
-              :is-current="isRowCurrent(cloudInstall)"
-              :update-available="isRowUpdateAvailable(cloudInstall)"
-              :operating="effectiveOperatingSet.has(cloudInstall.id)"
-              :last-launched-short-label="lastLaunchedShortLabel(cloudInstall)"
-              @select="handleSelect"
-            />
-
-            <InstanceRow
-              v-for="inst in visibleInstalls"
+              v-for="inst in pickerRows"
               :key="inst.id"
               :installation="inst"
               :active="selectedId === inst.id"

--- a/src/renderer/src/components/settings/ComfyUISettingsContent.vue
+++ b/src/renderer/src/components/settings/ComfyUISettingsContent.vue
@@ -307,9 +307,19 @@ const ALL_TABS: TabDef[] = [
     icon: Info
   }
 ]
-const tabs = computed<TabDef[]>(() =>
-  ALL_TABS.filter((tab) => sectionsForTab(tab.sectionTab).value.length > 0)
-)
+const tabs = computed<TabDef[]>(() => {
+  // Cloud (and other url-backed remotes) run no local process, so the
+  // `config` tab carries no real startup args — just output/storage +
+  // browser-cache settings. Relabel it "Storage" there so the tab name
+  // matches its contents. Cloud emits no separate `storage` section, so
+  // this can't collide with a real Storage tab.
+  const isCloud = installation.value?.sourceCategory === 'cloud'
+  return ALL_TABS.filter((tab) => sectionsForTab(tab.sectionTab).value.length > 0).map((tab) =>
+    isCloud && tab.key === 'config'
+      ? { ...tab, label: t('comfyUISettings.tabStorage', 'Storage'), icon: HardDrive }
+      : tab
+  )
+})
 
 const showUpdateBadge = computed(() => {
   const inst = installation.value

--- a/src/renderer/src/composables/useInstallContextMenu.test.ts
+++ b/src/renderer/src/composables/useInstallContextMenu.test.ts
@@ -331,6 +331,20 @@ describe('useInstallContextMenu — copy-install routing', () => {
     expect(onManage.mock.calls[0][1]).toEqual({ autoAction: 'copy' })
     expect(apiMock.runAction).not.toHaveBeenCalled()
   })
+
+  it('update opens the Update tab AND auto-fires the update (matches the title-bar pill)', async () => {
+    // Parity with the title-bar install-update pill (useDeepLinkRouter):
+    // open the picker on the Update tab with `autoAction: 'update-comfyui'`
+    // so the update modal runs, instead of just landing on the tab page.
+    const onManage = vi.fn<(inst: Installation, options?: { initialTab?: string; autoAction?: string | null }) => void>()
+    const inst = makeInstall()
+    const { menu } = mountHarnessWithManage(onManage)
+
+    await menu.triggerAction('update', inst)
+
+    expect(onManage).toHaveBeenCalledTimes(1)
+    expect(onManage.mock.calls[0][1]).toEqual({ initialTab: 'update', autoAction: 'update-comfyui' })
+  })
 })
 
 describe('useInstallContextMenu — untrack confirm-then-remove', () => {

--- a/src/renderer/src/composables/useInstallContextMenu.ts
+++ b/src/renderer/src/composables/useInstallContextMenu.ts
@@ -212,7 +212,7 @@ export function useInstallContextMenu(opts: {
     if (sessionStore.errorInstances.has(inst.id)) {
       items.push({
         id: 'dismiss-error',
-        label: t('running.dismiss'),
+        label: t('chooser.menuDismissError'),
         separator: items.length > 0,
       })
     }
@@ -278,7 +278,11 @@ export function useInstallContextMenu(opts: {
     if (id === 'manage') {
       opts.onManage?.(inst)
     } else if (id === 'update') {
-      opts.onManage?.(inst, { initialTab: 'update' })
+      // Match the title-bar install-update pill: open the picker on the
+      // Update tab AND auto-fire the update so the update modal runs,
+      // instead of just landing the user on the Update tab page. Same
+      // autoAction the deep-link / pill path uses (useDeepLinkRouter).
+      opts.onManage?.(inst, { initialTab: 'update', autoAction: 'update-comfyui' })
     } else if (id === 'migrate') {
       opts.onManage?.(inst, { autoAction: 'migrate-to-standalone' })
     } else if (id === 'restore-snapshot') {

--- a/src/renderer/src/views/ProgressModal.test.ts
+++ b/src/renderer/src/views/ProgressModal.test.ts
@@ -37,6 +37,7 @@ const messages = {
     common: {
       copy: 'Copy',
       cancel: 'Cancel',
+      back: 'Back',
     },
     dashboard: {
       confirmStopLocal: {
@@ -298,7 +299,7 @@ describe('ProgressModal — brand branch state transitions', () => {
     expect(wrapper.emitted('close')?.length).toBeGreaterThan(0)
   })
 
-  it('renders the error banner + error message + Reboot + Return-to-Dashboard, and does NOT auto-close', async () => {
+  it('renders the error banner + error message + Back + Reboot, and does NOT auto-close', async () => {
     const { wrapper, body } = await mountWithOp('inst-1', {
       finished: true,
       error: 'Disk write failed: ENOSPC',
@@ -320,10 +321,13 @@ describe('ProgressModal — brand branch state transitions', () => {
     // Inline Copy button rides alongside the message body.
     expect(body.exists('.brand-progress__error-copy')).toBe(true)
 
-    expect(body.exists('.brand-progress__footer')).toBe(true)
-    expect(body.selectorText('.brand-progress__footer')).toContain('Reboot')
-    expect(body.selectorText('.brand-progress__footer')).toContain('Return to Dashboard')
-    expect(body.selectorText('.brand-progress__footer')).not.toContain('Minimize')
+    // Error CTAs now live in the centered hero stack (directly under the
+    // error message), not the bottom-left footer — Back (ghost) on the
+    // left, Reboot (primary) on the right.
+    expect(body.exists('.brand-progress__error-actions')).toBe(true)
+    expect(body.selectorText('.brand-progress__error-actions')).toContain('Reboot')
+    expect(body.selectorText('.brand-progress__error-actions')).toContain('Back')
+    expect(body.selectorText('.brand-progress__footer')).not.toContain('Reboot')
 
     // Errors stay mounted so the user can read / copy. Verify no close
     // emit fires even after we advance well past the grace window.
@@ -404,15 +408,17 @@ describe('ProgressModal — brand branch state transitions', () => {
     expect(body.selectorText('.brand-progress__footer')).not.toContain('Return to Dashboard')
   })
 
-  it('renders Return to Dashboard (no Reboot) on a destroy op error', async () => {
+  it('renders Back (no Reboot) on a destroy op error', async () => {
     const { body } = await mountWithOp('inst-1', {
       destroysInstance: true,
       finished: true,
       error: 'Partial delete failed',
     })
-    expect(body.exists('.brand-progress__footer')).toBe(true)
-    expect(body.selectorText('.brand-progress__footer')).toContain('Return to Dashboard')
-    expect(body.selectorText('.brand-progress__footer')).not.toContain('Reboot')
+    // Destroy ops can't be rebooted, so only Back renders (as primary)
+    // in the centered error-actions row.
+    expect(body.exists('.brand-progress__error-actions')).toBe(true)
+    expect(body.selectorText('.brand-progress__error-actions')).toContain('Back')
+    expect(body.selectorText('.brand-progress__error-actions')).not.toContain('Reboot')
   })
 
   it('cancels the in-flight destroy op and emits close when Cancel is clicked', async () => {

--- a/src/renderer/src/views/ProgressModal.vue
+++ b/src/renderer/src/views/ProgressModal.vue
@@ -1000,6 +1000,38 @@ defineExpose({ startOperation, showOperation })
             class="brand-progress__error-copy"
           />
         </div>
+
+        <!-- Error actions — centered in the hero stack, directly below the
+             error message, mirroring the success-terminal action row. Keeps
+             the primary Reboot CTA with the failure context instead of
+             stranding it bottom-left in the footer. -->
+        <div
+          v-if="currentOp.finished && !!currentOp.error && !currentOp.cancelRequested && !isPortConflictOpen"
+          class="brand-progress__error-actions"
+        >
+          <button
+            type="button"
+            :class="
+              currentOp.destroysInstance
+                ? 'brand-primary brand-progress__footer-btn'
+                : 'brand-ghost brand-progress__footer-btn'
+            "
+            @click="returnToDashboard('crashed')"
+          >
+            <ArrowLeft :size="14" />
+            {{ $t('common.back') }}
+          </button>
+          <button
+            v-if="!currentOp.destroysInstance"
+            type="button"
+            class="brand-primary brand-progress__footer-btn"
+            :data-testid="TID.progressReboot"
+            @click="handleReboot"
+          >
+            <RefreshCcw :size="14" />
+            {{ $t('progress.reboot') }}
+          </button>
+        </div>
       </div>
     </div>
     <!-- Footer band — sibling to the centered hero stack so the action
@@ -1094,32 +1126,6 @@ defineExpose({ startOperation, showOperation })
                 @click="handleKillProcess(currentOp.result.portConflict.port)"
               >
                 {{ $t('errors.portConflictKill') }}
-              </button>
-            </template>
-            <template
-              v-else-if="currentOp.finished && !!currentOp.error && !currentOp.cancelRequested"
-            >
-              <button
-                v-if="!currentOp.destroysInstance"
-                type="button"
-                class="brand-primary brand-progress__footer-btn"
-                :data-testid="TID.progressReboot"
-                @click="handleReboot"
-              >
-                <RefreshCcw :size="14" />
-                {{ $t('progress.reboot') }}
-              </button>
-              <button
-                type="button"
-                :class="
-                  currentOp.destroysInstance
-                    ? 'brand-primary brand-progress__footer-btn'
-                    : 'brand-ghost brand-progress__footer-btn'
-                "
-                @click="returnToDashboard('crashed')"
-              >
-                <ArrowLeft :size="14" />
-                {{ $t('progress.returnToDashboard') }}
               </button>
             </template>
           </div>
@@ -1401,6 +1407,23 @@ defineExpose({ startOperation, showOperation })
   justify-content: center;
   gap: 12px;
   flex-wrap: wrap;
+}
+
+/* Error CTAs — centered in the hero stack under the error message.
+   Back (ghost) sits left, Reboot (primary) right; both flex to equal
+   width within a bounded row so the pair reads as a balanced unit
+   rather than two differently-sized chips. */
+.brand-progress__error-actions {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  gap: 12px;
+  width: 100%;
+  max-width: 420px;
+}
+.brand-progress__error-actions > .brand-progress__footer-btn {
+  flex: 1 1 0;
+  justify-content: center;
 }
 
 /* Error detail line beneath the banner. Selectable so users can copy

--- a/src/renderer/src/views/comfyUISettings/SettingsSectionList.vue
+++ b/src/renderer/src/views/comfyUISettings/SettingsSectionList.vue
@@ -504,8 +504,16 @@ function fieldOwnsLabel(field: DetailField): boolean {
   gap: 10px;
 }
 
-.settings-v2-section .settings-v2-field + .settings-v2-field {
-  margin-top: 4px;
+/* Dependent (nested) fields are revealed by the toggle directly above
+ * them — e.g. "Use shared output directory" only appears once
+ * "Auto-download outputs" is on, and the output-path picker only once
+ * that's off. Pull them up tight to their parent (cancelling most of the
+ * section's 16px row gap) and indent behind a hairline rail so the chain
+ * reads as one dependent group instead of equally-weighted rows. */
+.settings-v2-field.is-nested {
+  margin-top: -8px;
+  padding-left: 14px;
+  border-left: 1px solid color-mix(in srgb, var(--chooser-surface-border) 70%, transparent);
 }
 
 .settings-v2-field-label {


### PR DESCRIPTION
## Summary
A batch of small UX fixes across the error screen, instance picker, dashboard menu, and per-install settings.

## Fixes
- **Error screen (ProgressModal):** the failure CTAs (`Back` + `Reboot`) now sit centered **under the error message** as an equal-width pair (Back left, Reboot right) instead of stranded bottom-left. "Return to Dashboard" reads **Back** in this row.
- **Dashboard context menu:** `Dismiss` → **Dismiss Error** (scoped `chooser.menuDismissError`; the shared `running.dismiss` label is untouched).
- **Dashboard tile Update:** now opens the picker on the Update tab **and auto-fires the update** (`autoAction: 'update-comfyui'`), matching the title-bar update pill, instead of just landing on the Update tab page.
- **Cloud config tab:** labeled **Storage** (not "Startup Args") for cloud — it runs no local process, so the tab holds output/storage + browser-cache settings, not startup args.
- **Settings rows:** removed the redundant `gap + margin` double-spacing between fields. Dependent (nested) fields — e.g. an output toggle and the row it reveals — are now pulled in tight and indented behind a hairline rail so they read as one **sub-selection group**.
- **Instance-picker default selection:** defaults to the **most-recently-launched** install rather than registry list order.
- **Cloud no longer "sticks" in the IPP:** the auto-seeded **Comfy Cloud** entry no longer pins to the top or becomes the default for users who never open it. It folds into the recency-sorted list (a more-recently-opened local sits above it) and only the auto-*default* favors a real install on a tie; on a recency tie cloud takes ordering priority. The dashboard keeps its pinned Cloud card.

## Video

https://github.com/user-attachments/assets/1dc02555-4b1f-4127-a708-c3aa027a5e2a


## Test plan
- [x] `typecheck` (all 4 projects) + `eslint` clean (husky pre-commit on both commits)
- [x] Unit: `ProgressModal` (Back/Reboot placement + destroy-op), `useInstallContextMenu` (update auto-fire), `titlePopup` (`resolvePickerSelectedInstallId` recency + cloud tie-break), `ComfyUISettingsContent`, `InstancePickerView` — all green
- [ ] Manual: error screen CTAs; dashboard Update → modal; cloud tab reads "Storage"; nested output toggles grouped; IPP opens on last-used instance and cloud isn't pinned/auto-selected unless genuinely most-recent
