### PR TITLE
fix(snapshots): surface the pip failure reason on a failed restore (#633)

### DIFF
--- a/src/main/lib/snapshots.test.ts
+++ b/src/main/lib/snapshots.test.ts
@@ -23,7 +23,7 @@ vi.mock('./telemetry', () => ({
   capture: vi.fn(),
 }))
 
-import { buildExportEnvelope, validateExportEnvelope, importSnapshots, diffSnapshots, listSnapshots, restoreComfyUIVersion, buildPostRestoreState, restorePipPackages, formatSnapshotVersion } from './snapshots'
+import { buildExportEnvelope, validateExportEnvelope, importSnapshots, diffSnapshots, listSnapshots, restoreComfyUIVersion, buildPostRestoreState, restorePipPackages, formatSnapshotVersion, extractPipFailureReason } from './snapshots'
 import type { Snapshot, SnapshotEntry, SnapshotExportEnvelope } from './snapshots'
 import type { ScannedNode } from './nodes'
 import type { InstallationRecord } from '../installations'
@@ -787,6 +787,65 @@ describe('restorePipPackages', () => {
     expect(uninstallCall).toBeDefined()
     expect(uninstallCall).toContain('new-pkg-a')
     expect(uninstallCall).toContain('new-pkg-b')
+  })
+
+  it('captures the pip failure reason in result.errors (issue #633)', async () => {
+    mockedPipFreeze.mockResolvedValue({})
+
+    // Bulk install fails → one-by-one fallback; the single install emits a
+    // real pip error to its output stream and fails.
+    mockedRunUvPip.mockImplementation(
+      async (_uvPath, args, _cwd, sendOutput, _signal?) => {
+        if (args.includes('install')) {
+          if (args.includes('--no-deps')) {
+            sendOutput('Resolving dependencies…\n')
+            sendOutput('ERROR: No matching distribution found for bad-pkg==9.9.9\n')
+            return 1
+          }
+          return 1 // bulk install fails → fall through to one-by-one
+        }
+        return 0 // uninstall calls during revert succeed
+      }
+    )
+
+    const snapshot = makeSnapshot({ pipPackages: { 'bad-pkg': '9.9.9' } })
+    const noop = () => {}
+
+    const result = await restorePipPackages(
+      tmpDir, installation, snapshot, noop as never, noop, undefined
+    )
+
+    const installError = result.errors.find((e) => e.startsWith('Failed to install'))
+    expect(installError).toBeDefined()
+    // The actual reason — not just "Failed to install bad-pkg==9.9.9".
+    expect(installError).toContain('No matching distribution found for bad-pkg==9.9.9')
+  })
+})
+
+describe('extractPipFailureReason', () => {
+  it('prefers error-looking lines over surrounding noise', () => {
+    const out = [
+      'Resolving dependencies…',
+      'Downloading numpy…',
+      'ERROR: Could not find a version that satisfies the requirement foo==1',
+    ].join('\n')
+    expect(extractPipFailureReason(out)).toContain('Could not find a version')
+  })
+
+  it('falls back to the last non-empty lines when nothing looks like an error', () => {
+    expect(extractPipFailureReason('step one\nstep two\n')).toBe('step one step two')
+    expect(extractPipFailureReason('only line\n', 1)).toBe('only line')
+  })
+
+  it('returns an empty string for empty output', () => {
+    expect(extractPipFailureReason('')).toBe('')
+  })
+
+  it('caps very long output', () => {
+    const long = 'error: ' + 'x'.repeat(500)
+    const reason = extractPipFailureReason(long)
+    expect(reason.length).toBeLessThanOrEqual(300)
+    expect(reason.endsWith('…')).toBe(true)
   })
 })
 

--- a/src/main/lib/snapshots/index.ts
+++ b/src/main/lib/snapshots/index.ts
@@ -32,7 +32,7 @@ export {
 export { buildExportEnvelope, validateExportEnvelope, importSnapshots } from './exportImport'
 
 // Restore
-export { restoreComfyUIVersion, buildPostRestoreState, restorePipPackages, restoreCustomNodes } from './restore'
+export { restoreComfyUIVersion, buildPostRestoreState, restorePipPackages, restoreCustomNodes, extractPipFailureReason } from './restore'
 
 // Tab Data
 export { getSnapshotListData, getSnapshotDetailData, getSnapshotDiffVsPrevious } from './tabData'

--- a/src/main/lib/snapshots/restore.ts
+++ b/src/main/lib/snapshots/restore.ts
@@ -264,6 +264,28 @@ export function buildPostRestoreState(
 }
 
 /**
+ * Pull the most useful line(s) out of a failed uv/pip command's captured
+ * output so a restore failure can explain WHY (issue #633) instead of a
+ * bare "Failed to install X". Prefers lines that look like an error;
+ * falls back to the last few non-empty lines. Capped so the surfaced
+ * message stays readable.
+ */
+export function extractPipFailureReason(output: string, maxLines = 2): string {
+  const lines = output.split('\n').map((l) => l.trim()).filter(Boolean)
+  const errorLines = lines.filter((l) =>
+    /\b(error|failed|no matching distribution|could not find|not found|conflict|incompatible|cannot|unable)\b/i.test(
+      l,
+    ),
+  )
+  const reason = (errorLines.length > 0 ? errorLines : lines)
+    .slice(-maxLines)
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+  return reason.length > 300 ? `${reason.slice(0, 299)}…` : reason
+}
+
+/**
  * Restore pip packages to match a target snapshot.
  * Creates a targeted backup of affected packages before making changes.
  * On failure, reverts from backup.
@@ -399,13 +421,21 @@ export async function restorePipPackages(
           const percent = 20 + Math.round((i / totalOps) * 50)
           sendProgress('restore', { percent, status: `Installing ${name}…` })
 
+          // Capture this command's output so a failure can report WHY,
+          // not just that it failed (issue #633). Still streamed live.
+          let captured = ''
+          const captureOut = (text: string): void => {
+            captured += text
+            sendOutput(text)
+          }
           const singleResult = await runUvPip(
-            uvPath, ['pip', 'install', spec, '--no-deps', '--python', pythonPath, ...indexArgs], installPath, sendOutput, signal
+            uvPath, ['pip', 'install', spec, '--no-deps', '--python', pythonPath, ...indexArgs], installPath, captureOut, signal
           )
 
           if (singleResult !== 0) {
             result.failed.push(name)
-            result.errors.push(`Failed to install ${spec}`)
+            const reason = extractPipFailureReason(captured)
+            result.errors.push(reason ? `Failed to install ${spec}: ${reason}` : `Failed to install ${spec}`)
           } else if (!result.changed.some((c) => c.name === name)) {
             result.installed.push(name)
           }
@@ -432,14 +462,20 @@ export async function restorePipPackages(
         result.removed.push(...toRemove)
       } else {
         for (const name of toRemove) {
+          let captured = ''
+          const captureOut = (text: string): void => {
+            captured += text
+            sendOutput(text)
+          }
           const singleResult = await runUvPip(
-            uvPath, ['pip', 'uninstall', name, '--python', pythonPath], installPath, sendOutput, signal
+            uvPath, ['pip', 'uninstall', name, '--python', pythonPath], installPath, captureOut, signal
           )
           if (singleResult === 0) {
             result.removed.push(name)
           } else {
             result.failed.push(name)
-            result.errors.push(`Failed to remove ${name}`)
+            const reason = extractPipFailureReason(captured)
+            result.errors.push(reason ? `Failed to remove ${name}: ${reason}` : `Failed to remove ${name}`)
           }
         }
       }


### PR DESCRIPTION
## Summary

Closes #633. A failed snapshot restore surfaced only a **generic** error — "Failed to install `<spec>`" / "Pip restore failed — reverted to pre-restore state" — with no explanation of *why*. The real pip/uv error (version conflict, no matching distribution, etc.) was streamed to the terminal log but never made it into the message shown in the progress modal's error row.

This captures each failing single install/uninstall command's output and extracts the meaningful error line(s) (`extractPipFailureReason`), appending them to `result.errors`. That detail already propagates through `actions.ts` → the operation's `error` → the progress modal, so the user now sees the actual cause.

- Prefers error-looking lines (`error`, `no matching distribution`, `conflict`, …); falls back to the last non-empty line(s); capped at ~300 chars.
- The streamed live log is unchanged — output is still forwarded as before.

## Notes

The original failure isn't currently reproducible locally, so this is verified by unit tests (a simulated failing `uv pip install` that emits a real error line) rather than a live repro.

## Test plan

- [x] `pnpm typecheck` (node/web/e2e/integration)
- [x] `pnpm lint`
- [x] `pnpm test` — 1354 unit tests, incl. new `restorePipPackages` reason-capture case + `extractPipFailureReason` unit tests
- [ ] If a real restore failure can be reproduced: confirm the progress-modal error row shows the underlying pip reason, not just the generic headline