### PR TITLE
fix(launcher): preserve GPU vendor logo aspect ratio

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -3034,7 +3034,7 @@ input[type='checkbox']:checked::after {
 .variant-card-icon img {
   width: 100%;
   height: 100%;
-  object-fit: cover;
+  object-fit: contain;
 }
 .variant-card-icon-text {
   font-size: 13px;

--- a/src/renderer/src/components/BrandVariantList.vue
+++ b/src/renderer/src/components/BrandVariantList.vue
@@ -112,7 +112,7 @@ const { t } = useI18n()
 .brand-variant-row__icon img {
   width: 100%;
   height: 100%;
-  object-fit: cover;
+  object-fit: contain;
 }
 .brand-variant-row__text {
   display: flex;


### PR DESCRIPTION
## Issue
On the New Install wizard (GPU vendor selection step), the Apple MPS logo looked distorted/squished. The vendor logos render inside square icon boxes (96x96 in the card grid, 40x40 in the variant list), but the Apple MPS asset is 420x210 (2:1) while NVIDIA, AMD, and Intel are square. With `object-fit: cover`, the wide logo was scaled to fill the square and got cropped/zoomed, so it read as distorted next to the cleanly-fitting square logos.

## Fix
Switch the logo `<img>` rules from `object-fit: cover` to `object-fit: contain` in both render paths:
- `.variant-card-icon img` (96x96 card grid) in `src/renderer/src/assets/main.css`
- `.brand-variant-row__icon img` (40x40 list row) in `src/renderer/src/components/BrandVariantList.vue`

`contain` preserves each logo's native aspect ratio and shows it in full (letterboxed within the box) rather than cropping. Square logos are unaffected.

## Validation
- `pnpm typecheck` — pass
- `pnpm lint` — pass

## Visual verification needed
A human should confirm the GPU vendor logos (especially Apple MPS) now display at the correct aspect ratio in the New Install wizard.