### PR TITLE
fix(settings): left-align Output Directory row in Shared Directories

### DIFF
--- a/src/main/sources/common/urlSource.ts
+++ b/src/main/sources/common/urlSource.ts
@@ -114,11 +114,11 @@ export function createUrlSource(config: UrlSourceConfig): SourcePlugin {
               editType: 'boolean', refreshSection: true, tooltip: t('tooltips.autoDownloadOutputs') },
             ...((installation.autoDownloadOutputs as boolean | undefined) !== false ? [
               { id: 'useSharedOutputDir', label: t('common.useSharedOutputDir'), value: (installation.useSharedOutputDir as boolean | undefined) ?? true, editable: true,
-                editType: 'boolean', refreshSection: true, tooltip: t('tooltips.useSharedOutputDir') },
+                editType: 'boolean', refreshSection: true, nested: true, tooltip: t('tooltips.useSharedOutputDir') },
               ...((installation.useSharedOutputDir as boolean | undefined) === false ? [
                 { id: 'outputDir', label: t('media.outputDir'),
                   value: (installation.outputDir as string | undefined) || settings.defaults.outputDir,
-                  editable: true, editType: 'path', browseOnly: true, tooltip: t('tooltips.outputDirPerInstall') },
+                  editable: true, editType: 'path', browseOnly: true, nested: true, tooltip: t('tooltips.outputDirPerInstall') },
               ] : []),
             ] : []),
           ],

--- a/src/renderer/src/views/comfyUISettings/SettingsSectionList.vue
+++ b/src/renderer/src/views/comfyUISettings/SettingsSectionList.vue
@@ -130,10 +130,8 @@ function toggleCollapsed(section: { title?: string }): void {
 
 const visibleSections = computed(() => props.sections)
 
-const NESTED_FIELD_IDS = new Set(['useSharedOutputDir', 'outputDir'])
-
 function isNestedField(field: DetailField): boolean {
-  return NESTED_FIELD_IDS.has(field.id ?? '')
+  return field.nested === true
 }
 
 function hasChannelPicker(section: DetailSection): boolean {

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -131,6 +131,13 @@ export interface DetailField {
    *  (e.g. switching update channel triggers `check-update`). */
   onChangeAction?: string
   browseOnly?: boolean
+  /** Renders the field indented behind a hairline rail to signal it
+   *  depends on the toggle directly above it (e.g. the per-install
+   *  output-path picker under "Use shared output directory"). Set
+   *  explicitly by the field builder — the renderer must not infer
+   *  nesting from the field id, since ids like `outputDir` are reused
+   *  for equal-weight rows in the Shared Directories section. */
+  nested?: boolean
   tooltip?: string
   /** Marks fields that only take effect on next process start.
    *  Renderer shows a per-field tag + promotes the footer Restart


### PR DESCRIPTION
## Issue
On the settings Shared Directories (Media) screen, the **Output Directory** row was indented (behind a hairline left rail) while **Input Directory** and the other rows sat flush-left. The two are equal-weight sibling fields, so the Output row read as misaligned.

## Root cause
`SettingsSectionList.vue` decided whether to apply the `is-nested` indent purely from the field **id** (`NESTED_FIELD_IDS = ['useSharedOutputDir', 'outputDir']`). The id `outputDir` is reused: once for the per-install *dependent* output-path picker under the "Use shared output directory" toggle (where the indent is correct), and once for the equal-weight Output Directory row in the Shared Directories section (where it is not). Matching on id alone indented both.

## Fix
- Add an explicit `nested?: boolean` flag to `DetailField`.
- Set `nested: true` on the genuinely-dependent per-install `useSharedOutputDir` + `outputDir` fields in `urlSource.ts`.
- `SettingsSectionList.vue` now keys `is-nested` off `field.nested` instead of guessing from the id, so the shared-dirs rows align left with their siblings while the per-install dependent fields keep their indent.

No styling/token changes; pure markup-driven alignment.

## Picture

<img width="963" height="732" alt="image" src="https://github.com/user-attachments/assets/b08bc1de-f1fe-48a5-b668-e9df3103e568" />

## Validation
- `pnpm typecheck` clean (node/web/e2e/integration)
- `pnpm lint` clean
- Renderer + picker unit tests pass. (`titlePopup.test.ts` fails to load in this worktree due to a missing Electron binary from `--prefer-offline` — verified identical failure on unmodified `main`, so it's environmental, not a regression; CI is the gate.)

## Visual verification needed
A screenshot of the Shared Directories settings screen exists in internal testing but wasn't available to me. Please confirm the Output Directory row now sits flush-left with Input Directory, and that the per-install "Use shared output directory" path picker is still indented as a dependent field.