### PR TITLE
fix(titlebar): keep title padding at narrow widths

### DIFF
--- a/src/renderer/src/comfyTitleBar/TitleBarApp.test.ts
+++ b/src/renderer/src/comfyTitleBar/TitleBarApp.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 
@@ -1209,6 +1211,34 @@ describe('TitleBarApp', () => {
       expect(titleBar.style.getPropertyValue('--title-trailing-width')).toBe('0px')
       expect(wrapper.find('.title-install-pill').exists()).toBe(true)
       wrapper.unmount()
+    })
+  })
+
+  // Narrow-width padding guard. JSDOM can't compute the grid layout, so
+  // we assert on the scoped CSS contract directly: `.title-center` keeps
+  // a symmetric inline-padding floor so the install pill never ends up
+  // flush against the adjacent chrome when the centre 1fr track is
+  // squeezed at narrow widths. Symmetric padding leaves the
+  // `justify-self: center` true-window-centre anchor intact.
+  describe('narrow-width title padding (regression: pill flush against chrome)', () => {
+    it('reserves a symmetric horizontal padding floor on `.title-center`', () => {
+      const source = readFileSync(
+        resolve(process.cwd(), 'src/renderer/src/comfyTitleBar/TitleBarApp.vue'),
+        'utf8',
+      )
+      const centerBlock = source.slice(
+        source.indexOf('.title-center {'),
+        source.indexOf('.title-trailing {'),
+      )
+      // Symmetric inline padding keeps a gap on both sides at every
+      // width — and being symmetric it does not shift the centre.
+      expect(centerBlock).toMatch(/padding-inline:\s*8px/)
+      // border-box keeps the padding inside the declared `max-width:
+      // 100%` so the track never overflows.
+      expect(centerBlock).toMatch(/box-sizing:\s*border-box/)
+      // The centre anchor that holds the true-window-centre layout must
+      // remain in place.
+      expect(centerBlock).toMatch(/justify-self:\s*center/)
     })
   })
 })

--- a/src/renderer/src/comfyTitleBar/TitleBarApp.vue
+++ b/src/renderer/src/comfyTitleBar/TitleBarApp.vue
@@ -634,6 +634,18 @@ onUnmounted(() => {
   gap: 4px;
   min-width: 0;
   max-width: 100%;
+  /* Guarantee a minimum horizontal breathing room around the title
+     pill at every width. When the window narrows, the left + trailing
+     clusters squeeze the centre 1fr track toward zero and the pill
+     ends up flush against the adjacent chrome with no gap. This
+     symmetric inline padding reserves a floor of horizontal space on
+     both sides — symmetric, so the `justify-self: center` anchor (and
+     the true-window-centre mirror) is untouched; only the slack the
+     pill can grow into shrinks equally on each side. `box-sizing`
+     keeps the declared `max-width: 100%` accounting for the padding so
+     the track never overflows. */
+  box-sizing: border-box;
+  padding-inline: 8px;
 }
 
 .title-trailing {


### PR DESCRIPTION
### Issue

From internal desktop testing: "At certain widths, padding around title is non-existent. Should have some padding." When the window narrows, the left cluster (`min-width` mirroring the trailing cluster + the 128px Win control reservation) and the trailing cluster squeeze the centre `minmax(0, 1fr)` grid track toward zero. The install/title pill then ends up flush against the adjacent chrome with no horizontal breathing room.

### Fix

Reserve a symmetric inline-padding floor on `.title-center`:

```css
.title-center {
  box-sizing: border-box;
  padding-inline: 8px;
}
```

This guarantees a minimum horizontal gap on both sides of the title pill at every width. `box-sizing: border-box` keeps the padding inside the declared `max-width: 100%` so the track never overflows.

### Preserves the centered pill

The padding is symmetric, so the `justify-self: center` anchor and the ResizeObserver-driven true-window-centre mirror (PR #647) are untouched — only the slack the pill can grow into shrinks equally on each side. The centred-pill layout is preserved.

### Testing

- Added a regression assertion in `TitleBarApp.test.ts` (the layout itself isn't computable under happy-dom, so it asserts the scoped-CSS contract: symmetric `padding-inline`, `box-sizing: border-box`, and that the `justify-self: center` anchor remains).
- `pnpm test` scoped to `comfyTitleBar`: 50/50 pass.
- `pnpm typecheck` and `pnpm lint`: clean.

Visual verification needed at narrow widths (320 / 768 / 1024 / 1440px) on both Windows and macOS to confirm the gap and that the pill stays at true window centre.