### PR TITLE
fix(installer): make detected-GPU field clearly read-only

### DIFF
--- a/src/renderer/src/views/InstallWizardModal.vue
+++ b/src/renderer/src/views/InstallWizardModal.vue
@@ -647,7 +647,11 @@ defineExpose({ open })
               :class="{ 'config-field--disabled': currentSource?.skipInstall }"
             >
               <label class="config-label">{{ $t('newInstall.detectedGpuLabel') }}</label>
-              <div class="brand-input config-select" role="textbox" aria-readonly="true">
+              <div
+                class="brand-input config-select config-select--readonly"
+                role="textbox"
+                aria-readonly="true"
+              >
                 <span class="config-select__value">{{ detectedGpu }}</span>
               </div>
             </div>
@@ -961,6 +965,18 @@ defineExpose({ open })
 .config-select {
   padding: 8px 12px;
   cursor: default;
+}
+/* The detected GPU is fixed to the host hardware and cannot be changed, so
+ * present it as a static read-only value: strip the .brand-input hover
+ * affordance (border/background shift) that otherwise implies it's editable
+ * like the surrounding name/path inputs. Mirrors the muted read-only
+ * treatment used for the same value in QuickInstallModal (.detected-hardware). */
+.config-select--readonly:hover {
+  border-color: var(--brand-surface-border);
+  background: var(--brand-surface-bg);
+}
+.config-select--readonly .config-select__value {
+  color: var(--text-muted);
 }
 .config-select__value {
   flex: 1 1 auto;


### PR DESCRIPTION
Closes #690

## Problem
In the New Install wizard (`InstallWizardModal.vue`), the "detected GPU" field reused the `.brand-input` styling shared with the editable name/path inputs — including the `:hover` border/background shift — so it looked like a selectable dropdown/input even though the value is fixed to the host hardware and clicking does nothing.

## Fix
Per the issue's "make it clearly read-only" option (we are intentionally *not* implementing GPU selection, which would be a larger behavioral change driving env/variant detection), present the field as a static read-only value:

- Add a `config-select--readonly` modifier on the field's `.brand-input` wrapper.
- Neutralize the interactive hover affordance (border/background no longer shift on hover).
- Mute the value text (`--text-muted`), mirroring the read-only treatment of the same detected-GPU value in `QuickInstallModal` (`.detected-hardware`).

The markup already carried `role="textbox" aria-readonly="true"`; this aligns the visual affordance with that semantic.

## Validation
- `pnpm typecheck` — pass
- `pnpm lint` — pass
- Visual verification needed (dev server not started in this environment).