### PR TITLE
fix(auth): user-friendly cloud sign-in error messages (hide Firebase / raw codes)

### DIFF
--- a/src/main/auth/firebaseBridge/bridgeHtml.test.ts
+++ b/src/main/auth/firebaseBridge/bridgeHtml.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+
+import { friendlyAuthErrorMessage, renderErrorHtml, renderPopupBridgeHtml } from './bridgeHtml'
+import { getFirebaseConfig } from './config'
+
+describe('friendlyAuthErrorMessage', () => {
+  it('maps known Firebase auth codes to friendly copy', () => {
+    expect(friendlyAuthErrorMessage('auth/account-exists-with-different-credential')).toContain(
+      'already exists',
+    )
+    expect(friendlyAuthErrorMessage('auth/network-request-failed')).toContain('internet connection')
+    expect(friendlyAuthErrorMessage('auth/popup-closed-by-user')).toContain('cancelled')
+  })
+
+  it('falls back to a generic message for unknown / missing codes', () => {
+    const generic = 'Sign-in failed. Please try again.'
+    expect(friendlyAuthErrorMessage('auth/something-new')).toBe(generic)
+    expect(friendlyAuthErrorMessage(null)).toBe(generic)
+    expect(friendlyAuthErrorMessage(undefined)).toBe(generic)
+    expect(friendlyAuthErrorMessage('')).toBe(generic)
+  })
+
+  it('never returns a raw auth code or the word "Firebase"', () => {
+    for (const code of [
+      'auth/account-exists-with-different-credential',
+      'auth/popup-closed-by-user',
+      'auth/network-request-failed',
+      'auth/internal-error',
+      'auth/unknown-code',
+    ]) {
+      const msg = friendlyAuthErrorMessage(code)
+      expect(msg.toLowerCase()).not.toContain('firebase')
+      expect(msg).not.toContain('auth/')
+    }
+  })
+})
+
+describe('renderErrorHtml', () => {
+  it('renders friendly copy and no monospace technical block', () => {
+    const html = renderErrorHtml('We couldn’t reach the sign-in service. Please try again.')
+    expect(html).toContain('Sign-in failed')
+    expect(html).toContain('reach the sign-in service')
+    expect(html).not.toContain('error-block')
+  })
+
+  it('falls back to generic copy when given an empty message', () => {
+    const html = renderErrorHtml('')
+    expect(html).toContain('Sign-in failed. Please try again.')
+  })
+})
+
+describe('renderPopupBridgeHtml', () => {
+  it('inlines the friendly auth-error map and never shows raw err.message', () => {
+    const html = renderPopupBridgeHtml(getFirebaseConfig('prod'), 'github.com')
+    // The friendly map is inlined for the client script.
+    expect(html).toContain('auth/account-exists-with-different-credential')
+    expect(html).toContain('friendlyError')
+    // Raw error message is no longer surfaced to the user.
+    expect(html).not.toContain('(err && err.message) || String(err)')
+    // The "Firebase SDK failed to load" leak is gone.
+    expect(html).not.toContain('The Firebase SDK failed to load')
+  })
+})

--- a/src/main/auth/firebaseBridge/bridgeHtml.ts
+++ b/src/main/auth/firebaseBridge/bridgeHtml.ts
@@ -23,6 +23,55 @@ const PROVIDER_LABEL: Record<SupportedProvider, string> = {
   'github.com': 'GitHub',
 }
 
+/**
+ * Friendly, human-readable copy for the Firebase auth error codes a user
+ * can realistically hit during the bridge sign-in. Keyed by the raw
+ * Firebase `error.code` (the `auth/*` strings the JS SDK throws). Anything
+ * not in this map falls back to a generic retry message — we never surface
+ * the raw code or the word "Firebase" to the user.
+ *
+ * Display-only: this maps error CODES to user copy. It does not change
+ * which errors are thrown, the sign-in flow, token handling, or redirects.
+ */
+const GENERIC_AUTH_ERROR = 'Sign-in failed. Please try again.'
+
+const FIREBASE_AUTH_ERROR_MESSAGES: Record<string, string> = {
+  'auth/account-exists-with-different-credential':
+    'An account already exists with this email address using a different sign-in method. Please sign in with the method you used originally.',
+  'auth/email-already-in-use':
+    'An account already exists with this email address. Please sign in with the method you used originally.',
+  'auth/credential-already-in-use':
+    'This account is already linked to another sign-in. Please sign in with the method you used originally.',
+  'auth/popup-closed-by-user': 'Sign-in was cancelled before it finished. Please try again.',
+  'auth/cancelled-popup-request': 'Sign-in was cancelled before it finished. Please try again.',
+  'auth/popup-blocked':
+    'Your browser blocked the sign-in window. Allow pop-ups for this page, then try again.',
+  'auth/user-cancelled': 'Sign-in was cancelled. Please try again.',
+  'auth/network-request-failed':
+    'We couldn’t reach the sign-in service. Check your internet connection and try again.',
+  'auth/timeout': 'Sign-in timed out. Please try again.',
+  'auth/too-many-requests': 'Too many sign-in attempts. Please wait a moment and try again.',
+  'auth/user-disabled': 'This account has been disabled. Please contact support.',
+  'auth/operation-not-allowed':
+    'This sign-in method isn’t available right now. Please try a different method.',
+  'auth/web-storage-unsupported':
+    'Your browser is blocking the storage needed to sign in. Enable cookies/site data and try again.',
+  'auth/internal-error': 'Something went wrong during sign-in. Please try again.',
+}
+
+/**
+ * Map a raw Firebase auth error code to friendly copy, falling back to a
+ * generic retry message for unknown codes. Exported for unit tests.
+ */
+export function friendlyAuthErrorMessage(code: string | null | undefined): string {
+  if (!code) return GENERIC_AUTH_ERROR
+  return FIREBASE_AUTH_ERROR_MESSAGES[code] ?? GENERIC_AUTH_ERROR
+}
+
+/** Inlined into the bridge page so the client script can map codes too. */
+const CLIENT_AUTH_ERROR_MESSAGES_JSON = JSON.stringify(FIREBASE_AUTH_ERROR_MESSAGES)
+const CLIENT_GENERIC_AUTH_ERROR_JSON = JSON.stringify(GENERIC_AUTH_ERROR)
+
 const PROVIDER_ICON: Record<SupportedProvider, string> = {
   'google.com': `<svg viewBox="0 0 18 18" width="18" height="18" aria-hidden="true">
     <path fill="#4285F4" d="M17.64 9.2c0-.64-.06-1.25-.16-1.84H9v3.48h4.84a4.14 4.14 0 0 1-1.8 2.71v2.26h2.92a8.78 8.78 0 0 0 2.68-6.6z"/>
@@ -115,16 +164,15 @@ p { color: var(--muted); margin: 0; line-height: 1.55; font-size: 14px; }
   color: var(--muted);
   line-height: 1.5;
 }
-.error-block {
+.error-note {
   margin-top: 18px;
   padding: 12px 14px;
   background: var(--error-bg);
   color: var(--error);
   border-radius: 8px;
   font-size: 13px;
+  line-height: 1.5;
   text-align: left;
-  word-break: break-word;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 .btn {
   display: inline-flex;
@@ -235,17 +283,22 @@ export function renderDoneHtml(): string {
 }
 
 /**
- * Terminal error page for IdP-denied or Firebase-exchange failures.
- * The user can retry by returning to ComfyUI Desktop and clicking
- * Sign in again.
+ * Terminal error page for IdP-denied or exchange failures. The user can
+ * retry by returning to ComfyUI Desktop and clicking Sign in again.
+ *
+ * `message` is the user-facing reason. Callers must pass friendly copy
+ * (e.g. from `friendlyAuthErrorMessage`) — never a raw exception string
+ * or provider error code. It's rendered as plain body text, not a
+ * monospace technical block.
  */
 export function renderErrorHtml(message: string): string {
+  const reason = message && message.trim().length > 0 ? message : GENERIC_AUTH_ERROR
   return shell(
     'Sign-in failed — ComfyUI Desktop',
     `<div class="status-icon error">${ERROR_ICON}</div>
     <h1>Sign-in failed</h1>
-    <p>We weren't able to complete sign-in. Return to ComfyUI Desktop and click Sign in again to retry.</p>
-    <div class="error-block">${escapeHtml(message)}</div>`,
+    <p>${escapeHtml(reason)}</p>
+    <p class="hint">Return to ComfyUI Desktop and click Sign in again to retry.</p>`,
   )
 }
 
@@ -299,6 +352,8 @@ export function renderPopupBridgeHtml(
     const providerId = ${providerJson}
     const providerLabel = ${providerLabelJson}
     const providerIcon = ${providerIconJson}
+    const AUTH_ERROR_MESSAGES = ${CLIENT_AUTH_ERROR_MESSAGES_JSON}
+    const GENERIC_AUTH_ERROR = ${CLIENT_GENERIC_AUTH_ERROR_JSON}
 
     const contentEl = document.getElementById('content')
 
@@ -311,8 +366,20 @@ export function renderPopupBridgeHtml(
         .replaceAll("'", '&#39;')
     }
 
+    // Display-only: turn a raw Firebase auth error into friendly copy.
+    // Never surfaces the raw code or the word "Firebase" to the user.
+    function friendlyError(err) {
+      const code = err && err.code
+      if (code && Object.prototype.hasOwnProperty.call(AUTH_ERROR_MESSAGES, code)) {
+        return AUTH_ERROR_MESSAGES[code]
+      }
+      return GENERIC_AUTH_ERROR
+    }
+
     function renderIdle(errorMessage) {
-      const err = errorMessage ? '<div class="error-block">' + escapeHtml(errorMessage) + '</div>' : ''
+      // errorMessage is already friendly human copy (see friendlyError) —
+      // render as a plain notice, not a monospace technical block.
+      const err = errorMessage ? '<div class="error-note">' + escapeHtml(errorMessage) + '</div>' : ''
       contentEl.innerHTML = \`
         <h1>\${errorMessage ? 'Try sign-in again' : 'Sign in to continue'}</h1>
         <p>Your browser keeps the passkeys, saved passwords, and provider sessions that the embedded popup can't.</p>
@@ -377,7 +444,7 @@ export function renderPopupBridgeHtml(
       const app = initializeApp(firebaseConfig)
       auth = getAuth(app)
     } catch (err) {
-      contentEl.innerHTML = '<h1>Sign-in unavailable</h1><p>The Firebase SDK failed to load. Please reopen sign-in from ComfyUI Desktop.</p>'
+      contentEl.innerHTML = '<h1>Sign-in unavailable</h1><p>We couldn’t start sign-in. Please reopen sign-in from ComfyUI Desktop and try again.</p>'
       throw err
     }
 
@@ -398,7 +465,7 @@ export function renderPopupBridgeHtml(
         await runSignIn()
         renderDone()
       } catch (err) {
-        renderIdle((err && err.message) || String(err))
+        renderIdle(friendlyError(err))
       }
     }
 
@@ -431,10 +498,13 @@ export function renderPopupBridgeHtml(
         renderDone()
       } catch (err) {
         const code = err && err.code
+        // popup-blocked / cancelled on the silent auto-attempt is expected
+        // (browser declined the no-gesture popup) — show the plain idle
+        // prompt so the user can click the button, with no error noise.
         if (code === 'auth/popup-blocked' || code === 'auth/cancelled-popup-request') {
           renderIdle(null)
         } else {
-          renderIdle((err && err.message) || String(err))
+          renderIdle(friendlyError(err))
         }
       }
     }

--- a/src/main/auth/firebaseBridge/server.ts
+++ b/src/main/auth/firebaseBridge/server.ts
@@ -1,7 +1,12 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
 import type { AddressInfo } from 'node:net'
 
-import { renderDoneHtml, renderErrorHtml, renderPopupBridgeHtml } from './bridgeHtml'
+import {
+  friendlyAuthErrorMessage,
+  renderDoneHtml,
+  renderErrorHtml,
+  renderPopupBridgeHtml,
+} from './bridgeHtml'
 import { getFirebaseConfig, type FirebaseEnv } from './config'
 import type { SupportedProvider } from './intercept'
 import {
@@ -11,6 +16,17 @@ import {
 } from './oauth'
 
 const MAX_BODY_BYTES = 64 * 1024
+
+/**
+ * Pull a Firebase-style `auth/...` error code out of a raw error string,
+ * if one is present, so it can be mapped to friendly copy. Returns null
+ * when no recognisable code is found (caller falls back to generic copy).
+ * Display-only helper — does not affect control flow.
+ */
+function extractAuthCode(raw: string): string | null {
+  const match = /\bauth\/[a-z0-9-]+\b/i.exec(raw)
+  return match ? match[0].toLowerCase() : null
+}
 
 async function readJsonBody(req: IncomingMessage): Promise<unknown> {
   return new Promise((resolve, reject) => {
@@ -163,7 +179,10 @@ export function startBridgeServer(opts: StartBridgeOpts): Promise<BridgeHandle> 
         if (!res.headersSent) {
           res.statusCode = 500
           res.setHeader('Content-Type', 'text/html; charset=utf-8')
-          res.end(renderErrorHtml(msg))
+          // Show friendly copy only — never the raw exception string (it
+          // may carry provider error codes, URLs, or token fragments).
+          // The raw `err` still flows to telemetry/Datadog below unchanged.
+          res.end(renderErrorHtml(friendlyAuthErrorMessage(extractAuthCode(msg))))
         }
         finishWithError(err instanceof Error ? err : new Error(msg))
       })


### PR DESCRIPTION
## Summary

Cloud auth failures surfaced raw/unfriendly errors on the loopback sign-in bridge pages — they mentioned "Firebase" and showed non-pretty `auth/*` codes. This maps known Firebase auth error codes to friendly, human-readable copy and suppresses raw strings from the user-facing UI. Unknown codes fall back to a generic retry message.

**Display-only.** No change to authentication logic, the sign-in flow, token handling, or redirect behavior. The raw error still flows to telemetry/Datadog unchanged (`finishWithError`, `sign_in_failed` emit).

Closes #680

## Where raw errors leaked (all desktop-repo code in `src/main/auth/firebaseBridge/`)
- `bridgeHtml.ts` `renderErrorHtml(message)` — dumped the raw exception / IdP string in a monospace `.error-block` (Google server-driven flow + catch-all).
- `bridgeHtml.ts` popup bridge client script `renderIdle(...)` — showed `(err && err.message) || String(err)` (GitHub flow); this is where `auth/*` codes surfaced.
- Hardcoded "The Firebase SDK failed to load" message.

## Error-code → friendly message map
| Firebase code | User-facing message |
|---|---|
| `auth/account-exists-with-different-credential` | An account already exists with this email address using a different sign-in method. Please sign in with the method you used originally. |
| `auth/email-already-in-use` | An account already exists with this email address. Please sign in with the method you used originally. |
| `auth/credential-already-in-use` | This account is already linked to another sign-in. Please sign in with the method you used originally. |
| `auth/popup-closed-by-user` | Sign-in was cancelled before it finished. Please try again. |
| `auth/cancelled-popup-request` | Sign-in was cancelled before it finished. Please try again. |
| `auth/popup-blocked` | Your browser blocked the sign-in window. Allow pop-ups for this page, then try again. |
| `auth/user-cancelled` | Sign-in was cancelled. Please try again. |
| `auth/network-request-failed` | We couldn't reach the sign-in service. Check your internet connection and try again. |
| `auth/timeout` | Sign-in timed out. Please try again. |
| `auth/too-many-requests` | Too many sign-in attempts. Please wait a moment and try again. |
| `auth/user-disabled` | This account has been disabled. Please contact support. |
| `auth/operation-not-allowed` | This sign-in method isn't available right now. Please try a different method. |
| `auth/web-storage-unsupported` | Your browser is blocking the storage needed to sign in. Enable cookies/site data and try again. |
| `auth/internal-error` | Something went wrong during sign-in. Please try again. |
| *(unknown / none)* | **Sign-in failed. Please try again.** |

## Note on i18n
These bridge pages are standalone HTML served to the user's system browser by the Node main process — they have no access to the renderer's `vue-i18n` runtime, so strings live in `bridgeHtml.ts` (not `locales/en.json`). No renderer Vue component renders these auth errors.

## Files changed
- `src/main/auth/firebaseBridge/bridgeHtml.ts`
- `src/main/auth/firebaseBridge/server.ts`
- `src/main/auth/firebaseBridge/bridgeHtml.test.ts` (new)

## Test plan
- [x] `pnpm typecheck` / `pnpm lint` pass
- [x] firebaseBridge unit tests pass (35, incl. new `bridgeHtml.test.ts`)
- [ ] **Visual verification needed**: trigger a failed Google + GitHub sign-in and confirm the bridge pages show friendly copy with no `Firebase` / `auth/*` strings.
- [ ] **Please confirm no auth-flow change** — this PR only touches user-facing strings; OAuth exchange, token injection, redirects, and telemetry are untouched.

Related (not fixed here): #681 (GitHub login when a Google account already exists) — now shows the friendly `account-exists-with-different-credential` copy, but the underlying linking behavior is unchanged.