### PR TITLE
fix(dashboard): reword awkward "Stop & Return" confirm message

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -12,7 +12,7 @@
     "migrateBannerSkip": "New Install Without Migrating",
     "confirmStopLocal": {
       "title": "Return to Dashboard?",
-      "message": "This will stop ComfyUI for this installation.",
+      "message": "This will stop the current ComfyUI.",
       "confirmLabel": "Stop & Return"
     }
   },

--- a/locales/en.json
+++ b/locales/en.json
@@ -12,7 +12,7 @@
     "migrateBannerSkip": "New Install Without Migrating",
     "confirmStopLocal": {
       "title": "Return to Dashboard?",
-      "message": "ComfyUI for this installation will be stopped.",
+      "message": "This will stop ComfyUI for this installation.",
       "confirmLabel": "Stop & Return"
     }
   },

--- a/src/main/host/detach.ts
+++ b/src/main/host/detach.ts
@@ -223,7 +223,7 @@ async function confirmReturnToDashboardViaSystemModal(
     parent: entry.window,
     spec: {
       title: 'Return to Dashboard?',
-      message: 'ComfyUI for this installation will be stopped.',
+      message: 'This will stop ComfyUI for this installation.',
       confirmLabel: 'Stop & Return',
       cancelLabel: 'Cancel',
       confirmStyle: 'danger',

--- a/src/main/host/detach.ts
+++ b/src/main/host/detach.ts
@@ -223,7 +223,7 @@ async function confirmReturnToDashboardViaSystemModal(
     parent: entry.window,
     spec: {
       title: 'Return to Dashboard?',
-      message: 'This will stop ComfyUI for this installation.',
+      message: 'This will stop the current ComfyUI.',
       confirmLabel: 'Stop & Return',
       cancelLabel: 'Cancel',
       confirmStyle: 'danger',

--- a/src/renderer/src/panel/ComfyLifecycleView.test.ts
+++ b/src/renderer/src/panel/ComfyLifecycleView.test.ts
@@ -35,7 +35,7 @@ const messages = {
     dashboard: {
       confirmStopLocal: {
         title: 'Return to Dashboard?',
-        message: 'This will stop ComfyUI for this installation.',
+        message: 'This will stop the current ComfyUI.',
         confirmLabel: 'Stop & Return',
       },
     },

--- a/src/renderer/src/panel/ComfyLifecycleView.test.ts
+++ b/src/renderer/src/panel/ComfyLifecycleView.test.ts
@@ -35,7 +35,7 @@ const messages = {
     dashboard: {
       confirmStopLocal: {
         title: 'Return to Dashboard?',
-        message: 'ComfyUI for this installation will be stopped.',
+        message: 'This will stop ComfyUI for this installation.',
         confirmLabel: 'Stop & Return',
       },
     },

--- a/src/renderer/src/views/ProgressModal.test.ts
+++ b/src/renderer/src/views/ProgressModal.test.ts
@@ -42,7 +42,7 @@ const messages = {
     dashboard: {
       confirmStopLocal: {
         title: 'Return to Dashboard?',
-        message: 'ComfyUI for this installation will be stopped.',
+        message: 'This will stop ComfyUI for this installation.',
         confirmLabel: 'Stop & Return',
       },
     },

--- a/src/renderer/src/views/ProgressModal.test.ts
+++ b/src/renderer/src/views/ProgressModal.test.ts
@@ -42,7 +42,7 @@ const messages = {
     dashboard: {
       confirmStopLocal: {
         title: 'Return to Dashboard?',
-        message: 'This will stop ComfyUI for this installation.',
+        message: 'This will stop the current ComfyUI.',
         confirmLabel: 'Stop & Return',
       },
     },


### PR DESCRIPTION
## Summary

The return-to-dashboard confirmation dialog (shown when leaving an installing/running instance) read **"ComfyUI for this installation will be stopped."**, which is awkward English. Reworded to **"This will stop ComfyUI for this installation."**

The dialog renders from two code paths, both updated to stay in sync:
- `locales/en.json` — the `dashboard.confirmStopLocal.message` i18n string (renderer path via `useReturnToDashboardConfirm`).
- `src/main/host/detach.ts` — a hardcoded system-modal fallback used when the panel webview has been destroyed (it explicitly mirrors the i18n copy). Left unchanged this would have shown the old wording in one path.

Test i18n mock fixtures (`ProgressModal.test.ts`, `ComfyLifecycleView.test.ts`) updated to match.

Note: `zh.json` has no `confirmStopLocal` entry (it is a partial translation that falls back to English), so no zh change was needed.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes

Closes #705