### PR TITLE
fix(settings): drop copy button on date fields in Status panel

### DIFF
--- a/src/renderer/src/views/comfyUISettings/StatusFactPanel.vue
+++ b/src/renderer/src/views/comfyUISettings/StatusFactPanel.vue
@@ -52,8 +52,19 @@ function fieldValue(field: DetailField): string {
   return String(v)
 }
 
+/** Localised dates (e.g. the "Installed" field) come through as
+ *  `toLocaleDateString()` output — `5/28/2026` etc. — whose `/`
+ *  separators would otherwise trip the slash-based path heuristic and
+ *  sprout a copy button that makes no sense for a date (#712). A path
+ *  always carries a letter (drive/segment name), a backslash, or a
+ *  leading `~`; a date is only digits and date separators. */
+function looksLikeDate(value: string): boolean {
+  return /^[\d/.\-: ]+$/.test(value)
+}
+
 function isPathLike(value: string): boolean {
   if (!value || value === '—') return false
+  if (looksLikeDate(value)) return false
   return value.includes('/') || value.includes('\\') || value.startsWith('~')
 }
 


### PR DESCRIPTION
## Summary
The Status tab's "Installed" row renders a localised date via `toLocaleDateString()` (e.g. `5/28/2026`). Those `/` separators tripped the slash-based path heuristic in `StatusFactPanel.vue`, so a date row got a copy-to-clipboard button that makes no sense for a date.

This guards `isPathLike()` so values made up only of digits + date separators are not treated as paths. Real paths (drive letters, backslashes, leading `~`, named segments) and ids keep their copy buttons.

## Changes
- `src/renderer/src/views/comfyUISettings/StatusFactPanel.vue` — skip date-shaped values in the copyable heuristic.

## Test plan
- [ ] `pnpm typecheck` / `pnpm lint` pass
- [ ] Open an install's Status tab: the "Installed" date has no copy button
- [ ] Path/location rows still show their copy button

Closes #712