### PR TITLE
feat(main): add "Check for Updates…" to the macOS app menu

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1041,8 +1041,15 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
     // OAuth / cloud-login popups (and every other window) can't reach
     // destructive items like "Close All Windows" that bypass our
     // managed shutdown. See `installAppMenu` for the per-platform
-    // template.
-    installAppMenu()
+    // template. The macOS app menu also exposes "Check for Updates…"
+    // (issue #693), wired to the existing `updater.runCheck` entry point
+    // — the result flows through the normal broadcast pipeline (title-bar
+    // pill / Global Settings panel), so no new update logic is added.
+    installAppMenu(process.platform, undefined, {
+      onCheckForUpdates: () => {
+        void updater.runCheck('app-menu').catch(() => {})
+      },
+    })
 
     // Bring up main-process telemetry as early as possible so install/migrate
     // sub-step events can fire even before the renderer mounts.

--- a/src/main/menu.test.ts
+++ b/src/main/menu.test.ts
@@ -6,6 +6,7 @@ const { setApplicationMenu, buildFromTemplate } = vi.hoisted(() => ({
 }))
 
 vi.mock('electron', () => ({
+  app: { name: 'ComfyUI' },
   Menu: {
     setApplicationMenu,
     buildFromTemplate,
@@ -96,6 +97,55 @@ describe('installAppMenu', () => {
     const allRoles = collectRoles(template as unknown as Array<{ role?: string; submenu?: unknown }>)
     expect(allRoles).not.toContain('close')
     expect(allRoles).not.toContain('closeAllWindows')
+  })
+
+  it('keeps the plain appMenu role on darwin when no check-for-updates handler is wired', () => {
+    installAppMenu('darwin')
+    const template = buildFromTemplate.mock.calls[0]?.[0] as Array<{
+      role?: string
+      label?: string
+    }>
+    expect(template[0]).toEqual({ role: 'appMenu' })
+  })
+
+  it('adds a click-wired "Check for Updates…" item to the darwin app menu', () => {
+    const onCheckForUpdates = vi.fn()
+    installAppMenu('darwin', undefined, { onCheckForUpdates })
+
+    const template = buildFromTemplate.mock.calls[0]?.[0] as Array<{
+      role?: string
+      label?: string
+      submenu?: Array<{ role?: string; label?: string; click?: () => void }>
+    }>
+    const appEntry = template[0]
+    expect(appEntry).toBeTruthy()
+    // Stock `appMenu` role is expanded into an explicit submenu so the
+    // item can sit right after About.
+    expect(appEntry?.role).toBeUndefined()
+    const items = appEntry?.submenu ?? []
+    const aboutIndex = items.findIndex((i) => i.role === 'about')
+    const checkIndex = items.findIndex((i) => i.label === 'Check for Updates…')
+    expect(aboutIndex).toBeGreaterThanOrEqual(0)
+    expect(checkIndex).toBe(aboutIndex + 1)
+
+    const check = items[checkIndex]
+    expect(typeof check?.click).toBe('function')
+    check?.click?.()
+    expect(onCheckForUpdates).toHaveBeenCalledTimes(1)
+
+    // Standard items are preserved.
+    const roles = items.map((i) => i.role)
+    expect(roles).toContain('services')
+    expect(roles).toContain('hide')
+    expect(roles).toContain('quit')
+  })
+
+  it('does not add the app menu item on non-darwin platforms', () => {
+    const onCheckForUpdates = vi.fn()
+    installAppMenu('win32', undefined, { onCheckForUpdates })
+    // win32 with no dev overrides strips the menu entirely.
+    expect(setApplicationMenu).toHaveBeenCalledWith(null)
+    expect(onCheckForUpdates).not.toHaveBeenCalled()
   })
 
   it('inserts a View submenu with click-based Toggle Developer Tools when dev overrides are passed', () => {

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -15,12 +15,23 @@
  *
  * ============================================================================ */
 
-import { Menu } from 'electron'
+import { app, Menu } from 'electron'
 import type { BaseWindow, MenuItemConstructorOptions } from 'electron'
 
 export type AppMenuDevOverrides = {
   /** ⚠️ Dev-only — see file banner. */
   toggleEmbeddedDevTools?: (focusedWindow?: BaseWindow | null) => void
+}
+
+export type AppMenuHandlers = {
+  /**
+   * macOS-only: invoked by the "Check for Updates…" item added to the
+   * standard app menu (issue #693). Wired in `index.ts` to the existing
+   * `updater.runCheck(...)` entry point — the result flows through the
+   * normal broadcast pipeline (title-bar pill / Global Settings panel),
+   * so this is purely the OS-menu affordance and builds no update logic.
+   */
+  onCheckForUpdates?: () => void
 }
 
 /**
@@ -53,6 +64,7 @@ export type AppMenuDevOverrides = {
 export function installAppMenu(
   platform: NodeJS.Platform = process.platform,
   devOverrides?: AppMenuDevOverrides,
+  handlers?: AppMenuHandlers,
 ): void {
   const routedDevTools =
     typeof devOverrides?.toggleEmbeddedDevTools === 'function'
@@ -84,8 +96,39 @@ export function installAppMenu(
     )
     return
   }
+  const onCheckForUpdates =
+    typeof handlers?.onCheckForUpdates === 'function' ? handlers.onCheckForUpdates : undefined
+
+  // Mirror Electron's stock `appMenu` role, but inject a "Check for
+  // Updates…" item right after About — the conventional macOS placement
+  // (issue #693). When no handler is wired we fall back to the plain
+  // `appMenu` role so behavior is unchanged. The remaining items match
+  // the default macOS app submenu (Services / Hide / Quit).
+  const appMenu: MenuItemConstructorOptions = onCheckForUpdates
+    ? {
+        label: app.name,
+        submenu: [
+          { role: 'about' },
+          {
+            label: 'Check for Updates…',
+            click: () => {
+              onCheckForUpdates()
+            },
+          },
+          { type: 'separator' },
+          { role: 'services' },
+          { type: 'separator' },
+          { role: 'hide' },
+          { role: 'hideOthers' },
+          { role: 'unhide' },
+          { type: 'separator' },
+          { role: 'quit' },
+        ],
+      }
+    : { role: 'appMenu' }
+
   const template: MenuItemConstructorOptions[] = [
-    { role: 'appMenu' },
+    appMenu,
     { role: 'editMenu' },
     ...(routedDevTools
       ? ([


### PR DESCRIPTION
## Summary

macOS apps conventionally expose "Check for Updates…" in the application menu, but currently the update check is only reachable from in-app settings. This adds a "Check for Updates…" item to the macOS app menu (right after About), wired to the **existing** update-check flow.

- `installAppMenu` gains an optional `onCheckForUpdates` handler (mirrors the existing `devOverrides` pattern). When provided, the stock macOS `appMenu` role is expanded into an explicit submenu so the item can sit right after About; standard items (Services / Hide / Quit) are preserved. Falls back to the plain `appMenu` role when no handler is wired.
- `index.ts` wires the handler to the existing `updater.runCheck('app-menu')` entry point — the same function the Global Settings update panel uses. Results flow through the normal broadcast pipeline (title-bar pill / Global Settings panel); **no new update logic added**.
- macOS-guarded: non-darwin platforms are unchanged.

## Test plan

- [x] `pnpm typecheck` (node/web/e2e/integration)
- [x] `pnpm lint`
- [x] `pnpm vitest run src/main/menu.test.ts` (8 passed — 4 new + 4 existing)
- [ ] **Needs macOS verification**: on a Mac build, confirm the app menu shows "Check for Updates…" after About and that selecting it triggers the existing update check (pill / settings panel react as for the in-settings check).

Closes #693