### PR TITLE
fix(main): raise all host windows on macOS dock activate

### DIFF
--- a/src/main/host/registry.test.ts
+++ b/src/main/host/registry.test.ts
@@ -27,7 +27,10 @@ import {
   getEntryByInstallationId,
   indexInstallationId,
   nextWindowKey,
+  raiseAllHostWindows,
   registerHostEntry,
+  setHostFactories,
+  setLastFocusedInstallationId,
   unregisterHostEntry,
   type ComfyWindowEntry,
 } from './registry'
@@ -37,6 +40,13 @@ interface FakeWindow {
   minimized: boolean
   isDestroyed: () => boolean
   isMinimized: () => boolean
+  /** show()/focus()/restore() calls, in order, so tests can assert
+   *  whether (and when) a window was raised. */
+  raised: string[]
+  show: () => void
+  focus: () => void
+  restore: () => void
+  setAlwaysOnTop: () => void
 }
 
 function makeWindow(opts: { destroyed?: boolean; minimized?: boolean } = {}): FakeWindow {
@@ -45,6 +55,16 @@ function makeWindow(opts: { destroyed?: boolean; minimized?: boolean } = {}): Fa
     minimized: opts.minimized ?? false,
     isDestroyed: () => win.destroyed,
     isMinimized: () => win.minimized,
+    raised: [],
+    show: () => win.raised.push('show'),
+    focus: () => win.raised.push('focus'),
+    restore: () => {
+      win.minimized = false
+      win.raised.push('restore')
+    },
+    // `bringToFront` uses this on Windows; no-op here so the helper is
+    // exercised regardless of the host platform running the suite.
+    setAlwaysOnTop: () => {},
   }
   return win
 }
@@ -91,6 +111,7 @@ afterEach(() => {
   comfyWindows.clear()
   _resetAttachClaimsForTest()
   _runningSessions.clear()
+  setLastFocusedInstallationId(null)
 })
 
 describe('nextWindowKey', () => {
@@ -264,5 +285,67 @@ describe('findPreferredHostByVisibility', () => {
     registerHostEntry(chooser)
     expect(findPreferredHostByVisibility((e) => e.installationId === null)).toBe(chooser)
     expect(findPreferredHostByVisibility((e) => e.installationId !== null)).toBe(install)
+  })
+})
+
+describe('raiseAllHostWindows', () => {
+  function fakeWin(entry: ComfyWindowEntry): FakeWindow {
+    return entry.window as unknown as FakeWindow
+  }
+
+  it('spawns a fresh chooser host when no live host exists', () => {
+    const spawned = makeWindow()
+    const createChooser = vi.fn(() => spawned as unknown as ComfyWindowEntry['window'])
+    setHostFactories({ createChooser })
+    const result = raiseAllHostWindows()
+    expect(createChooser).toHaveBeenCalledTimes(1)
+    expect(result).toBe(spawned as unknown as ComfyWindowEntry['window'])
+  })
+
+  it('raises every live host window to the front', () => {
+    const a = makeEntry({ installationId: null })
+    const b = makeEntry({ installationId: null })
+    const c = makeEntry({ installationId: null })
+    registerHostEntry(a)
+    registerHostEntry(b)
+    registerHostEntry(c)
+    raiseAllHostWindows()
+    expect(fakeWin(a).raised).toContain('focus')
+    expect(fakeWin(b).raised).toContain('focus')
+    expect(fakeWin(c).raised).toContain('focus')
+  })
+
+  it('skips destroyed entries', () => {
+    const live = makeEntry({ installationId: null })
+    const dead = makeEntry({ installationId: null, destroyed: true })
+    registerHostEntry(live)
+    registerHostEntry(dead)
+    raiseAllHostWindows()
+    expect(fakeWin(live).raised).toContain('focus')
+    expect(fakeWin(dead).raised).toEqual([])
+  })
+
+  it('leaves the preferred install host frontmost (raised last)', () => {
+    const order: string[] = []
+    const chooser = makeEntry({ installationId: null })
+    const install = makeEntry({ installationId: 'inst-A' })
+    // Tag focus calls so we can assert ordering across windows.
+    fakeWin(chooser).focus = () => order.push('chooser')
+    fakeWin(install).focus = () => order.push('install')
+    registerHostEntry(chooser)
+    registerHostEntry(install)
+    const result = raiseAllHostWindows()
+    // install-backed beats chooser, so it must be focused last (frontmost)
+    // and returned to the caller.
+    expect(order[order.length - 1]).toBe('install')
+    expect(result).toBe(install.window)
+  })
+
+  it('restores a minimised host before focusing it', () => {
+    const min = makeEntry({ installationId: null, minimized: true })
+    registerHostEntry(min)
+    raiseAllHostWindows()
+    expect(fakeWin(min).raised).toContain('restore')
+    expect(fakeWin(min).raised).toContain('focus')
   })
 })

--- a/src/main/host/registry.ts
+++ b/src/main/host/registry.ts
@@ -553,3 +553,32 @@ export function openOrFocusAnyHostWindow(): BrowserWindow {
   }
   return requireChooserFactory()()
 }
+
+/**
+ * macOS dock-icon `activate` behaviour: raise EVERY live host window to
+ * the front, matching the platform convention where clicking the dock
+ * icon brings all of an app's windows forward (not just one). The
+ * preferred host (same priority as `openOrFocusAnyHostWindow`) is shown
+ * last so it ends up frontmost / focused. When no live host exists, falls
+ * back to spawning a fresh chooser host.
+ *
+ * Returns the window left frontmost (or the freshly-spawned chooser).
+ *
+ * macOS-only by design — Windows / Linux re-launch keeps the single-window
+ * `openOrFocusAnyHostWindow` semantics, so the caller in `index.ts` guards
+ * this behind `process.platform === 'darwin'`.
+ */
+export function raiseAllHostWindows(): BrowserWindow {
+  const preferred =
+    findPreferredInstallHostWindow() ?? findPreferredChooserHostWindow()
+  if (!preferred) return requireChooserFactory()()
+
+  // Raise every other live host first so the whole app comes forward,
+  // then bring the preferred window up last so it lands frontmost.
+  for (const [, entry] of comfyWindows) {
+    if (entry.window.isDestroyed() || entry.window === preferred) continue
+    bringToFront(entry.window)
+  }
+  bringToFront(preferred)
+  return preferred
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -79,6 +79,7 @@ import {
   isInstallHost,
   openOrFocusAnyHostWindow,
   openOrFocusChooserHostWindow,
+  raiseAllHostWindows,
   setHostFactories
 } from './host/registry'
 import {
@@ -1748,9 +1749,17 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
   })
 
   app.on('activate', () => {
-    // macOS dock click — focus an existing host window before
-    // spawning a fresh chooser host.
-    openOrFocusAnyHostWindow()
+    // macOS dock click — raise ALL open host windows to the front
+    // (standard macOS behaviour: clicking the dock icon brings every
+    // window of the app forward, not just one). The preferred host is
+    // left frontmost. Falls back to spawning a fresh chooser host when
+    // none are open. The single-window `openOrFocusAnyHostWindow` path
+    // remains for non-darwin platforms / the `second-instance` hook.
+    if (process.platform === 'darwin') {
+      raiseAllHostWindows()
+    } else {
+      openOrFocusAnyHostWindow()
+    }
   })
 
   app.on('before-quit', () => {


### PR DESCRIPTION
Closes #718

## Problem

On macOS, clicking the app's dock icon did not bring all of the app's open windows to the front — it only focused a single preferred host window. Standard macOS behaviour is that clicking the dock icon raises every window of the app.

## Root cause

`app.on('activate')` routed through `openOrFocusAnyHostWindow()`, which focuses exactly one window (priority: install-backed beats chooser, visible beats minimised). With multiple windows open, the others stayed behind.

## Fix

Added `raiseAllHostWindows()` to the host registry. On `activate` (guarded by `process.platform === 'darwin'`) it now:

1. Resolves the preferred host using the existing priority order.
2. Calls `bringToFront()` on every other live host window (restores minimised, shows + focuses).
3. Raises the preferred host last so it lands frontmost / focused.
4. Falls back to spawning a fresh chooser host when none are open.

Non-darwin re-launch (`second-instance` on Windows/Linux) keeps the single-window `openOrFocusAnyHostWindow()` semantics — only the dock-click path changes.

## Scope

Minimal and macOS-guarded. No change to window-creation logic; destroyed entries are skipped; reuses the existing `bringToFront` (which already handles minimised-restore + Windows focus-theft).

## Tests

Added 5 unit tests to `registry.test.ts` covering: raises all live windows, skips destroyed entries, preferred host raised last + returned, minimised-restore-then-focus, and fresh-chooser fallback when empty.

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm vitest run src/main/host/registry.test.ts` — 27 passed ✅ (5 new)

## Needs macOS verification

This was developed on Windows; I could not run the macOS dock-click flow. Please verify on a Mac: open 2+ windows, Cmd+Tab away, click the dock icon — all windows should come forward with the preferred one frontmost. (The two `createHostWindow`/`detach` suites fail in my env only because the Electron binary isn't installed locally — unrelated to this change; the electron-mocked `registry.test.ts` passes.)

Reported in #temp-desktop-bug-dump (Prompt & Play QA) by Jo Zhang.
Slack: https://comfy-organization.slack.com/archives/C0B6R9Y4YDT/p1780009436227109