### PR TITLE
fix(renderer): make install/info log panel responsive on short windows

### DIFF
--- a/src/renderer/src/components/BrandFinishedSurface.vue
+++ b/src/renderer/src/components/BrandFinishedSurface.vue
@@ -270,16 +270,30 @@ function getLogText(): string {
 }
 
 /* Footer — only the logs accordion + its toggle live here when logs
- * are present. The action row is in the hero stack above. */
+ * are present. The action row is in the hero stack above.
+ * `top` is anchored so the block can never grow taller than the gap
+ * between the takeover's top padding and its bottom inset — on a short
+ * window the logs panel shrinks (see its flexible max-height below)
+ * instead of overflowing off the top edge and clipping the toggle.
+ * Mirrors ProgressModal's `.brand-progress__footer` — keep in sync. */
 .brand-progress__footer {
   position: absolute;
+  top: clamp(72px, 14vh, 160px);
   bottom: clamp(16px, 2.5vh, 32px);
   left: clamp(16px, 2.5vw, 32px);
   right: clamp(16px, 2.5vw, 32px);
   z-index: 3;
   display: flex;
   flex-direction: column;
+  justify-content: flex-end;
   gap: 8px;
+  min-height: 0;
+  pointer-events: none;
+}
+/* Re-enable interaction on the actual content — the container is only a
+ * geometric bound, so it stays click-through where it's empty. */
+.brand-progress__footer > * {
+  pointer-events: auto;
 }
 .brand-progress__footer-bar {
   display: flex;
@@ -333,10 +347,15 @@ function getLogText(): string {
 .brand-progress__logs-chevron.is-open {
   transform: rotate(0deg);
 }
-/* Log panel that opens above the footer bar */
+/* Log panel that opens above the footer bar. `min-height: 0` lets the
+ * accordion shrink within the bounded footer so short windows scroll the
+ * log body (capped via the panel's own `max-height`) instead of pushing
+ * the footer bar off-screen. Display stays `grid` (set by BaseAccordion)
+ * so the 0fr→1fr open/close animation is untouched. */
 .brand-progress__logs-wrap {
   border-radius: 10px;
   overflow: hidden;
+  min-height: 0;
 }
 .brand-progress__logs-wrap.is-expanded {
   border: 1px solid var(--brand-surface-border);
@@ -360,8 +379,14 @@ function getLogText(): string {
 }
 .brand-progress__logs {
   width: 100%;
-  height: clamp(140px, 25vh, 260px);
+  /* `max-height` (not a fixed `height`) so the panel shrinks on short
+   * windows instead of forcing the footer past the viewport. `25vh`
+   * tracks window height; the 88px floor keeps a couple of readable
+   * lines even on a very short window, and 260px caps it on tall ones. */
+  max-height: clamp(88px, 25vh, 260px);
+  min-height: 0;
   overflow-y: auto;
+  overscroll-behavior: contain;
   padding: 12px 14px;
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: 11px;

--- a/src/renderer/src/views/ProgressModal.vue
+++ b/src/renderer/src/views/ProgressModal.vue
@@ -1312,10 +1312,15 @@ defineExpose({ startOperation, showOperation })
 .brand-progress__logs-chevron.is-open {
   transform: rotate(0deg);
 }
-/* Log panel that opens above the footer bar */
+/* Log panel that opens above the footer bar. `min-height: 0` lets the
+   accordion shrink within the bounded footer so short windows scroll
+   the log body (capped via the panel's own `max-height`) instead of
+   pushing the footer bar off-screen. Display stays `grid` (set by
+   BaseAccordion) so the 0fr→1fr open/close animation is untouched. */
 .brand-progress__logs-wrap {
   border-radius: 10px;
   overflow: hidden;
+  min-height: 0;
 }
 .brand-progress__logs-wrap.is-expanded {
   border: 1px solid var(--brand-surface-border);
@@ -1339,8 +1344,14 @@ defineExpose({ startOperation, showOperation })
 }
 .brand-progress__logs {
   width: 100%;
-  height: clamp(140px, 25vh, 260px);
+  /* `max-height` (not a fixed `height`) so the panel shrinks on short
+     windows instead of forcing the footer past the viewport. `25vh`
+     tracks window height; the 88px floor keeps a couple of readable
+     lines even on a very short window, and 260px caps it on tall ones. */
+  max-height: clamp(88px, 25vh, 260px);
+  min-height: 0;
   overflow-y: auto;
+  overscroll-behavior: contain;
   padding: 12px 14px;
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: 11px;
@@ -1453,16 +1464,30 @@ defineExpose({ startOperation, showOperation })
   white-space: pre-wrap;
 }
 
-/* Footer — positioned container for the bar + the logs panel above it */
+/* Footer — positioned container for the bar + the logs panel above it.
+   `top` is anchored so the block can never grow taller than the gap
+   between the takeover's top padding and its bottom inset — on a short
+   window the logs panel shrinks (see its flexible height + min-height
+   below) instead of overflowing off the top edge and clipping the
+   toggle. `min-height: 0` lets the flex child shrink past its content. */
 .brand-progress__footer {
   position: absolute;
+  top: clamp(72px, 14vh, 160px);
   bottom: clamp(16px, 2.5vh, 32px);
   left: clamp(16px, 2.5vw, 32px);
   right: clamp(16px, 2.5vw, 32px);
   z-index: 3;
   display: flex;
   flex-direction: column;
+  justify-content: flex-end;
   gap: 8px;
+  min-height: 0;
+  pointer-events: none;
+}
+/* Re-enable interaction on the actual content — the container is only a
+   geometric bound, so it stays click-through where it's empty. */
+.brand-progress__footer > * {
+  pointer-events: auto;
 }
 .brand-progress__footer-bar {
   display: flex;


### PR DESCRIPTION
## Summary

The install/information log panel at the bottom of the brand-takeover window (shared by `ProgressModal` and `BrandFinishedSurface`) overflowed and clipped at narrow/short viewport sizes — the logs and the **View Logs** toggle were pushed off the top edge and became hard to read.

Root cause: the panel used a fixed-floor `height: clamp(140px, 25vh, 260px)` and the absolutely-positioned footer had only a `bottom` anchor with no top bound, so the block could grow taller than the viewport.

## Fix (CSS only)

- Anchor the footer's `top` (`clamp(72px, 14vh, 160px)`) so the block can never exceed the available height; `justify-content: flex-end` keeps the bar pinned to the bottom.
- Let the accordion shrink within the bounded footer (`min-height: 0`); `display` stays `grid` so the `BaseAccordion` open/close animation is untouched.
- Swap the log body's fixed `height` for a viewport-relative `max-height: clamp(88px, 25vh, 260px)` that scrolls (`overscroll-behavior: contain`), so it shrinks on short windows instead of overflowing.
- `pointer-events` kept click-through on the empty bounding container.

Applied identically to both surfaces (their CSS is intentionally mirrored).

No inline styles, no `dark:` variant, semantic tokens only. `pnpm typecheck` and `pnpm lint` pass.

**Visual verification needed** across narrow (320px) and short window heights.

Closes #711