### PR TITLE
fix(installer): align variant-card ComfyUI version with selected release

### DIFF
--- a/src/main/sources/standalone/index.test.ts
+++ b/src/main/sources/standalone/index.test.ts
@@ -176,3 +176,63 @@ describe('standalone.getFieldOptions release', () => {
     expect(latestEntry.description).toBeUndefined()
   })
 })
+
+// --- getFieldOptions('variant') — version-display consistency (issue #708) ---
+
+describe('standalone.getFieldOptions variant version display', () => {
+  // The newest R2 standalone bundle ships an OLDER ComfyUI (0.20.1) than the
+  // upstream stable tag the wizard auto-updates to (v0.22.3). Set up that gap.
+  function setupVersionGap() {
+    const { latest, vendorReleases, vendorId } = makeR2Releases(
+      ['v0.20.1-env1'],
+      { comfyuiVersion: '0.20.1' },
+    )
+    mockedFetchJSON.mockImplementation((url: string) => {
+      if (url.includes('latest.json')) return Promise.resolve(latest)
+      return Promise.resolve(vendorReleases[vendorId]!)
+    })
+    return { vendorId }
+  }
+
+  async function getReleaseOption(value: string) {
+    const releaseOptions = await standalone.getFieldOptions!(
+      'release',
+      {},
+      { includeLatestStable: true },
+    )
+    return releaseOptions.find((o) => o.value === value)!
+  }
+
+  it('variant card shows the upstream stable version (not the bundled one) when "Latest Stable" is selected', async () => {
+    const { vendorId } = setupVersionGap()
+    mockedGetLatestStableTag.mockResolvedValue('v0.22.3')
+    const release = await getReleaseOption('latest')
+
+    const variants = await standalone.getFieldOptions!('variant', { release }, {})
+    const card = variants.find((o) => o.value === vendorId)!
+    // The card and the dropdown must agree: both surface 0.22.3.
+    expect(card.description).toContain('ComfyUI 0.22.3')
+    expect(card.description).not.toContain('ComfyUI 0.20.1')
+  })
+
+  it('variant card falls back to the bundled version when the upstream tag is unresolved', async () => {
+    const { vendorId } = setupVersionGap()
+    mockedGetLatestStableTag.mockResolvedValue(null)
+    const release = await getReleaseOption('latest')
+
+    const variants = await standalone.getFieldOptions!('variant', { release }, {})
+    const card = variants.find((o) => o.value === vendorId)!
+    expect(card.description).toContain('ComfyUI 0.20.1')
+  })
+
+  it('variant card shows the bundled version for a pinned (non-latest) release', async () => {
+    const { vendorId } = setupVersionGap()
+    mockedGetLatestStableTag.mockResolvedValue('v0.22.3')
+    const release = await getReleaseOption('v0.20.1-env1')
+
+    const variants = await standalone.getFieldOptions!('variant', { release }, {})
+    const card = variants.find((o) => o.value === vendorId)!
+    // Pinned releases legitimately show the version baked into that env.
+    expect(card.description).toContain('ComfyUI 0.20.1')
+  })
+})

--- a/src/main/sources/standalone/index.ts
+++ b/src/main/sources/standalone/index.ts
@@ -221,7 +221,12 @@ export const standalone: SourcePlugin = {
           label: t('standalone.latestVersion'),
           ...(latestStableTag ? { description: latestStableTag } : {}),
           recommended: true,
-          data: { tag: tags[0]!.tag, vendorReleases } as unknown as Record<string, unknown>,
+          // `latestStableTag` is the upstream ComfyUI version the post-install
+          // "update to stable" step resolves to (and what the dropdown advertises).
+          // Thread it through so the variant cards show that same version rather
+          // than the older ComfyUI baked into the standalone bundle — otherwise
+          // the two surfaces disagree (issue #708).
+          data: { tag: tags[0]!.tag, vendorReleases, latestStableTag } as unknown as Record<string, unknown>,
         })
       }
 
@@ -237,7 +242,7 @@ export const standalone: SourcePlugin = {
     }
 
     if (fieldId === 'variant') {
-      const releaseData = selections.release?.data as { tag: string; vendorReleases: Record<string, R2Variant[]> } | undefined
+      const releaseData = selections.release?.data as { tag: string; vendorReleases: Record<string, R2Variant[]>; latestStableTag?: string | null } | undefined
       if (!releaseData) return []
       const prefix = PLATFORM_PREFIX[process.platform]
       if (!prefix) return []
@@ -259,10 +264,20 @@ export const standalone: SourcePlugin = {
             filename: release.file,
             size: release.size,
           }]
+          // For "Latest Stable", the card must advertise the version the user
+          // ends up with after post-install auto-update (the upstream stable
+          // tag the dropdown shows), not the older ComfyUI bundled in the R2
+          // standalone build. Strip a leading `v` to match the bare-version
+          // card format (`ComfyUI 0.22.3`). Falls back to the bundled version
+          // when the upstream tag couldn't be resolved (offline, etc.).
+          const displayVersion =
+            isLatest && releaseData.latestStableTag
+              ? releaseData.latestStableTag.replace(/^v/, '')
+              : release.comfyui_version
           return {
             value: vendorId,
             label: getVariantLabel(vendorId),
-            description: `ComfyUI ${release.comfyui_version}  ·  Python ${release.python_version}  ·  ${sizeMB} MB`,
+            description: `ComfyUI ${displayVersion}  ·  Python ${release.python_version}  ·  ${sizeMB} MB`,
             data: {
               variantId: vendorId,
               manifest: { id: vendorId, comfyui_ref: release.comfyui_version, python_version: release.python_version },


### PR DESCRIPTION
Closes #708

## Problem
On the New Install wizard (Standalone tab), the **Release** dropdown's "Latest Stable (Recommended)" showed one ComfyUI version (e.g. `v0.22.3`) while the hardware **variant cards** (NVIDIA / Intel Arc / CPU) showed a different one (e.g. `ComfyUI 0.20.1`). They are sourced from two independent places, so they could disagree:

- **Dropdown description** = `getLatestStableTag()` — the latest upstream `Comfy-Org/ComfyUI` git tag (what the post-install "update to stable" step resolves to).
- **Variant cards** = `release.comfyui_version` from the newest R2 standalone bundle — an older ComfyUI baked into the prebuilt env. With `autoUpdateComfyUI: true` set for the `latest` selection, the install then auto-updates past it.

So a user picking "Latest Stable" ends up on the upstream stable version, but the card advertised the bundle's older version.

## Fix
Thread the resolved latest-stable tag through the `latest` release option's `data`, and have the variant cards display that version when "Latest Stable" is selected — matching the dropdown and the version the user actually ends up with after auto-update.

- Pinned (non-latest) releases still show the version baked into that env (correct, by design).
- Falls back to the bundled version when the upstream tag can't be resolved (offline / git unavailable).
- Display-only: the frozen install-time fingerprint (`originalBuild`, `originalTorchVersion`) still tracks the actual downloaded bundle.

Isolated to `src/main/sources/standalone/index.ts`; does not touch `InstallWizardModal.vue` (no conflict with #700).

## Validation
- `pnpm typecheck` — pass (node/web/e2e/integration)
- `pnpm lint` — pass
- `pnpm vitest run src/main/sources/standalone/index.test.ts` — 14 pass (3 new covering latest/fallback/pinned version display)