### PR TITLE
fix(settings): don't recreate default shared dirs when custom paths set

### DIFF
--- a/src/main/lib/ipc/sessionActions/launch.ts
+++ b/src/main/lib/ipc/sessionActions/launch.ts
@@ -140,9 +140,13 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
   const useSharedPaths = !launchCmd.skipSharedPaths && (inst.useSharedPaths as boolean | undefined) !== false && !!launchCmd.args
   let preLaunchExtras: string[] = []
   let sharedModelsDirs: string[] | undefined
+  // Issue #699 — when the user has a custom primary models path, don't
+  // recreate the deleted default `~/ComfyUI-Shared/models` tree on launch.
+  let modelsDirsToNotRecreate: string[] = []
   if (useSharedPaths) {
     sharedModelsDirs = settings.get('modelsDirs') as string[] | undefined
-    const { config } = syncCustomModelFolders(inst.installPath, sharedModelsDirs)
+    modelsDirsToNotRecreate = settings.getModelDirsToNotRecreate()
+    const { config } = syncCustomModelFolders(inst.installPath, sharedModelsDirs, [], modelsDirsToNotRecreate)
     if (config) {
       launchCmd.args!.push('--extra-model-paths-config', config.yamlPath)
     }
@@ -490,7 +494,7 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
   // Check if custom nodes created new model folders during startup
   let site1Relaunched = false
   if (useSharedPaths) {
-    const { newFolders } = syncCustomModelFolders(inst.installPath, sharedModelsDirs, preLaunchExtras)
+    const { newFolders } = syncCustomModelFolders(inst.installPath, sharedModelsDirs, preLaunchExtras, modelsDirsToNotRecreate)
     if (newFolders.length > 0) {
       sendOutput(`\n--- Restarting: new model folders detected (${newFolders.join(', ')}) ---\n\n`)
       if (_onModelFolderRelaunch) {
@@ -551,7 +555,7 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
           sendOutput('\n--- ComfyUI restarting ---\n\n')
         }
         if (useSharedPaths) {
-          const { config } = syncCustomModelFolders(inst.installPath, sharedModelsDirs)
+          const { config } = syncCustomModelFolders(inst.installPath, sharedModelsDirs, [], modelsDirsToNotRecreate)
           if (config) {
             for (const f of config.extraFolders) knownExtras.add(f)
           }
@@ -583,7 +587,7 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
               const currentExtras = discoverExtraModelFolders(inst.installPath)
               const newFolders = currentExtras.filter((f) => !knownExtras.has(f))
               if (newFolders.length > 0) {
-                const { config } = syncCustomModelFolders(inst.installPath, sharedModelsDirs)
+                const { config } = syncCustomModelFolders(inst.installPath, sharedModelsDirs, [], modelsDirsToNotRecreate)
                 if (config) {
                   for (const f of config.extraFolders) knownExtras.add(f)
                 }

--- a/src/main/lib/models.ts
+++ b/src/main/lib/models.ts
@@ -189,15 +189,28 @@ export function syncCustomModelFolders(
   installPath: string,
   modelsDirs: string[] | null | undefined,
   previousExtras: string[] = [],
+  /**
+   * Issue #699 — shared dirs whose folders must NOT be created on disk when
+   * they don't already exist. The default `ComfyUI-Shared/models` dir is
+   * always kept in `modelsDirs` (and the YAML) as a fallback, but once the
+   * user configures a custom models path we must stop recreating the empty
+   * default tree on every launch so they can delete it. Resolved absolute
+   * paths. An entry here that already exists on disk is still synced.
+   */
+  doNotCreateIfAbsent: string[] = [],
 ): SyncResult {
   if (!modelsDirs || !Array.isArray(modelsDirs) || modelsDirs.length === 0) {
     return { newFolders: [], config: null }
   }
 
+  const skipIfAbsent = new Set(doNotCreateIfAbsent.map((d) => path.resolve(d)))
+
   // Sync ALL model folders (including canonical ones) to shared roots so
   // users can place models in the shared directory for any folder type.
   const allFolders = allInstallModelFolders(installPath)
   for (const dir of modelsDirs) {
+    // Skip recreating a guarded default root that the user has deleted.
+    if (skipIfAbsent.has(path.resolve(dir)) && !fs.existsSync(dir)) continue
     for (const folder of allFolders) {
       const target = path.join(dir, folder)
       try {

--- a/src/main/settings.test.ts
+++ b/src/main/settings.test.ts
@@ -26,7 +26,8 @@ fs.mkdirSync(xdgCacheHome, { recursive: true })
 let settings: {
   set: (key: string, value: unknown) => void
   get: (key: string) => unknown
-  defaults: { onAppClose: 'tray' | 'quit' }
+  getModelDirsToNotRecreate: () => string[]
+  defaults: { onAppClose: 'tray' | 'quit'; inputDir: string; outputDir: string }
 }
 
 const settingsPath = process.platform === 'linux'
@@ -234,5 +235,50 @@ describe('modelsDirs user ordering', () => {
     const dirs = settings.get('modelsDirs') as string[]
     expect(dirs.length).toBe(1)
     expect(path.resolve(dirs[0]!)).toBe(path.join(homePath, 'ComfyUI-Shared', 'models'))
+  })
+})
+
+describe('default shared dir recreation guard (issue #699)', () => {
+  const defaultModelsDir = path.join(homePath, 'ComfyUI-Shared', 'models')
+
+  beforeEach(async () => {
+    // The shared default tree lives under homePath (outside the settings dir
+    // wiped by the top-level beforeEach), so clear it to isolate each case —
+    // mirrors a user who has deleted ~/ComfyUI-Shared.
+    fs.rmSync(path.join(homePath, 'ComfyUI-Shared'), { recursive: true, force: true })
+    vi.resetModules()
+    vi.doMock('electron', () => ({
+      app: {
+        getPath: (name: string) => (name === 'home' ? homePath : userDataPath),
+      },
+    }))
+    settings = await import('./settings')
+  })
+
+  it('creates the default ComfyUI-Shared models tree when no custom path is set', () => {
+    // First read materializes defaults on disk.
+    settings.get('modelsDirs')
+    expect(fs.existsSync(defaultModelsDir)).toBe(true)
+    expect(fs.existsSync(path.join(defaultModelsDir, 'checkpoints'))).toBe(true)
+    expect(settings.getModelDirsToNotRecreate()).toEqual([])
+  })
+
+  it('does not recreate the default models tree when a custom primary path is set', () => {
+    const customModels = path.join(tmpRoot, 'guard-custom-models')
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true })
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({ modelsDirs: [customModels] }, null, 2),
+      'utf-8'
+    )
+
+    const dirs = settings.get('modelsDirs') as string[]
+    // System default is still appended to the list as a fallback...
+    expect(path.resolve(dirs[0]!)).toBe(path.resolve(customModels))
+    expect(dirs.some((d) => path.resolve(d) === path.resolve(defaultModelsDir))).toBe(true)
+    // ...but it must NOT be materialized on disk so the user can delete it.
+    expect(fs.existsSync(defaultModelsDir)).toBe(false)
+    // And launch-time sync is told to skip recreating it.
+    expect(settings.getModelDirsToNotRecreate()).toEqual([defaultModelsDir])
   })
 })

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -111,6 +111,37 @@ export const defaults: SettingsDefaults = {
 const systemDefault = defaults.modelsDirs[0]!
 const shouldSanitizeCopiedUserDefaults = process.platform === 'win32'
 
+/**
+ * Issue #699 — the default `ComfyUI-Shared` model/input/output folders are
+ * always kept in `modelsDirs` as a fallback, but they should only be
+ * *materialized on disk* when the user is actually relying on them. A user
+ * who points models/input/output at custom directories wants to be able to
+ * delete the empty `~/ComfyUI-Shared` tree without it reappearing on the next
+ * launch. These helpers decide, per shared path, whether the user has opted
+ * into a custom location (so we can skip recreating the default on disk).
+ */
+function isCustomPath(value: string | undefined, defaultPath: string): boolean {
+  if (typeof value !== 'string' || value.trim() === '') return false
+  return path.resolve(value) !== path.resolve(defaultPath)
+}
+
+function hasCustomModelsDir(modelsDirs: unknown): boolean {
+  if (!Array.isArray(modelsDirs)) return false
+  const primary = modelsDirs.find((d): d is string => typeof d === 'string' && d.trim() !== '')
+  return isCustomPath(primary, systemDefault)
+}
+
+/**
+ * Issue #699 — the shared dirs whose contents should NOT be recreated on disk
+ * when they've been deleted, because the user has configured a custom primary
+ * models path. The default stays in `modelsDirs` as a fallback, but callers
+ * (e.g. launch-time `syncCustomModelFolders`) pass these to avoid recreating
+ * the empty `~/ComfyUI-Shared/models` tree on every launch.
+ */
+export function getModelDirsToNotRecreate(): string[] {
+  return hasCustomModelsDir(get('modelsDirs')) ? [systemDefault] : []
+}
+
 function resolveIfNonEmpty(value: unknown): string | null {
   return typeof value === 'string' && value.trim() !== '' ? path.resolve(value) : null
 }
@@ -290,14 +321,27 @@ function load(): Settings {
     result.modelsDirs.push(systemDefault)
     changed = true
   }
+  // Issue #699 — the system default models dir always stays in `modelsDirs`
+  // as a fallback, but it is only *materialized on disk* when the user hasn't
+  // pointed their primary models path at a custom location. A user with custom
+  // paths can then delete the empty default `~/ComfyUI-Shared/models` tree
+  // without it being recreated on every launch. We inspect the *persisted*
+  // user value (not `result`, whose `modelsDirs` has the default appended back).
+  const userModelsCustomized = hasCustomModelsDir(parsed?.['modelsDirs'])
+
   // Create the system default directory and model subdirectories on disk
-  try {
-    fs.mkdirSync(systemDefault, { recursive: true })
-    for (const folder of MODEL_FOLDER_TYPES) {
-      fs.mkdirSync(path.join(systemDefault, folder), { recursive: true })
-    }
-  } catch {}
-  // Create shared input/output directories
+  if (!userModelsCustomized) {
+    try {
+      fs.mkdirSync(systemDefault, { recursive: true })
+      for (const folder of MODEL_FOLDER_TYPES) {
+        fs.mkdirSync(path.join(systemDefault, folder), { recursive: true })
+      }
+    } catch {}
+  }
+  // Create shared input/output directories. `result.inputDir`/`outputDir` are
+  // single values that already resolve to the user's custom path when set, so
+  // the default `ComfyUI-Shared` input/output is never created once the user
+  // customizes those — no extra guard needed here.
   try {
     for (const key of ["inputDir", "outputDir"] as const) {
       const dir = (result[key] as string | undefined) || defaults[key]


### PR DESCRIPTION
## Summary

A user (Prompt & Play QA) who configured custom model/install directories still got the default `ComfyUI-Shared` (and `ComfyUI-Installs`) folders recreated under their home dir on every launch, and couldn't delete them.

This guards on-disk creation of the default shared models tree:
- The system default models dir still stays in `modelsDirs` (and the generated `shared_model_paths.yaml`) as a fallback — no behavior change there.
- It is only **materialized on disk** when the user hasn't pointed their primary models path at a custom location. A user with a custom path can delete `~/ComfyUI-Shared` and it will not reappear.
- Two creation sites fixed: `settings.ts` `load()` (every settings read) and launch-time `syncCustomModelFolders()` in `models.ts`, which previously re-`mkdir`'d every model subfolder into the always-appended default root.

`inputDir`/`outputDir` already resolve to the user's custom value when set, so the default input/output is not recreated once customized (no extra guard needed).

`ComfyUI-Installs` is only created when an install is actually placed there (install flows), not via a launch-time bootstrap, so it is out of scope here.

## Changes
- `src/main/settings.ts` — guard default models-tree creation behind a "no custom primary models path" check; add `getModelDirsToNotRecreate()`.
- `src/main/lib/models.ts` — `syncCustomModelFolders` accepts `doNotCreateIfAbsent`; skips recreating a guarded default root the user has deleted.
- `src/main/lib/ipc/sessionActions/launch.ts` — pass the guard to all four `syncCustomModelFolders` call sites.
- `src/main/settings.test.ts` — focused tests for the guard.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm vitest run src/main/settings.test.ts` (11 pass, incl. new guard tests)
- [x] `pnpm vitest run src/main/lib/ipc/sessionActions/launch.test.ts src/main/lib/oem.test.ts`
- [ ] Manual: set a custom models dir, delete `~/ComfyUI-Shared`, relaunch — folder stays gone

Closes #699