### PR TITLE
feat(install): validate instance name + URL fields

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -247,7 +247,9 @@
     "next": "Next",
     "recommended": "Recommended",
     "latest": "Latest",
-    "changeInstallType": "Change Install Type"
+    "changeInstallType": "Change Install Type",
+    "nameWhitespace": "Enter a name, or leave blank to use the suggested one.",
+    "urlInvalid": "Enter a valid URL (e.g. http://localhost:8188)."
   },
 
   "diskSpace": {

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -549,6 +549,17 @@ button.looks-disabled {
 .brand-input input::placeholder {
   color: var(--neutral-400);
 }
+/* Invalid state — paired with an adjacent .field-error message.
+ * Overrides hover/focus border so the danger cue stays visible. */
+.brand-input--invalid,
+.brand-input--invalid:hover,
+.brand-input--invalid:focus-within {
+  border-color: var(--danger);
+}
+.brand-input--invalid:has(input:focus-visible) {
+  border-color: var(--danger);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--danger) 35%, transparent);
+}
 
 .brand-tag-recommended {
   display: inline-block;

--- a/src/renderer/src/views/InstallWizardModal.vue
+++ b/src/renderer/src/views/InstallWizardModal.vue
@@ -134,12 +134,52 @@ watch(instPath, (newPath) => {
 /** Generation counter — incremented on each open/source change to discard stale responses */
 let loadGeneration = 0
 
+/** Whitespace-only instance name is rejected: it produces a name made
+ *  of nothing but spaces. A truly-blank field is allowed — `handleSave`
+ *  falls back to the suggested default — so the error only fires once
+ *  the user has typed something that trims to empty. */
+const nameError = computed(() =>
+  instName.value.length > 0 && instName.value.trim().length === 0
+    ? t('newInstall.nameWhitespace')
+    : ''
+)
+
+/** Renderer-side sanity check for the Remote Connection / Cloud URL
+ *  field. Mirrors main's `parseUrl`: a scheme-less value is tried as
+ *  `http://<value>` and must yield a hostname. Keeps the bad-URL guard
+ *  in the form instead of failing silently at connect time. */
+function isValidConnectionUrl(raw: string): boolean {
+  const trimmed = raw.trim()
+  if (!trimmed) return false
+  try {
+    const parsed = new URL(trimmed.includes('://') ? trimmed : `http://${trimmed}`)
+    return parsed.hostname.length > 0
+  } catch {
+    return false
+  }
+}
+
+/** Inline error for the editable connection URL (`url` text field on
+ *  Remote Connection / Cloud sources). Empty/whitespace or an
+ *  unparseable value both surface the same hint. Scoped to `id === 'url'`
+ *  so other text fields (e.g. git's repo) keep their own error flow. */
+const urlFieldError = computed(() => {
+  const source = currentSource.value
+  if (!source) return ''
+  const urlField = source.fields.find((f) => f.id === 'url' && f.type === 'text')
+  if (!urlField) return ''
+  const value = textFieldValues.value.get('url') ?? ''
+  return isValidConnectionUrl(value) ? '' : t('newInstall.urlInvalid')
+})
+
 /** Single-screen guardrail gate. Continue must respect every check
  *  the user can interact with on the Configure surface. `skipInstall`
  *  sources (Remote Connection) have no install path, so the path-issue
- *  guard doesn't apply to them. */
+ *  guard doesn't apply to them. The instance-name and connection-URL
+ *  validity guards apply to every source. */
 const canContinue = computed(() => {
   if (!currentSource.value) return false
+  if (nameError.value || urlFieldError.value) return false
   if (currentSource.value.skipInstall) return !saveDisabled.value
   return !saveDisabled.value && pathIssues.value.length === 0
 })
@@ -622,14 +662,19 @@ defineExpose({ open })
         <div class="config-card__body">
           <div class="config-field">
             <label class="config-label" for="inst-name-standalone">{{ $t('common.name') }}</label>
-            <div class="brand-input">
+            <div class="brand-input" :class="{ 'brand-input--invalid': nameError }">
               <input
                 id="inst-name-standalone"
                 :value="instName"
                 type="text"
                 :placeholder="suggestedName || $t('common.namePlaceholder')"
+                :aria-invalid="!!nameError"
+                :aria-describedby="nameError ? 'inst-name-error' : undefined"
                 @input="instName = ($event.target as HTMLInputElement).value"
               />
+            </div>
+            <div v-if="nameError" id="inst-name-error" class="field-error" role="alert">
+              {{ nameError }}
             </div>
           </div>
 
@@ -742,12 +787,21 @@ defineExpose({ open })
 
                     <template v-if="field.type === 'text'">
                       <div class="path-input">
-                        <div class="brand-input config-source-text">
+                        <div
+                          class="brand-input config-source-text"
+                          :class="{
+                            'brand-input--invalid': field.id === 'url' && urlFieldError
+                          }"
+                        >
                           <input
                             :id="`sf-${field.id}`"
                             type="text"
                             :value="textFieldValues.get(field.id) ?? ''"
                             :placeholder="field.defaultValue || ''"
+                            :aria-invalid="field.id === 'url' && !!urlFieldError"
+                            :aria-describedby="
+                              field.id === 'url' && urlFieldError ? `sf-${field.id}-error` : undefined
+                            "
                             @input="
                               textFieldValues.set(
                                 field.id,
@@ -768,6 +822,14 @@ defineExpose({ open })
                       </div>
                       <div v-if="fieldErrors.get(field.id)" class="field-error">
                         {{ fieldErrors.get(field.id) }}
+                      </div>
+                      <div
+                        v-else-if="field.id === 'url' && urlFieldError"
+                        :id="`sf-${field.id}-error`"
+                        class="field-error"
+                        role="alert"
+                      >
+                        {{ urlFieldError }}
                       </div>
                     </template>
 


### PR DESCRIPTION
## Summary

On the Configure (new install) screen you could submit with a whitespace-only instance name, and the localhost/connection URL accepted any string. This adds inline validation for both.

- **Instance name:** whitespace-only input (e.g. just spaces) is rejected with an inline error. A truly-blank field is still allowed — `handleSave` falls back to the suggested default.
- **Connection URL:** the `url` text field (Remote Connection / Cloud sources) is validated renderer-side, mirroring main's `parseUrl` — a scheme-less value is tried as `http://<value>` and must yield a hostname. Empty/whitespace or unparseable values surface a hint.
- Both errors disable the **Continue** button (`canContinue` gate) until resolved, with `aria-invalid` / `aria-describedby` wired to `role="alert"` messages.

Reported by Matt Miller via Prompt & Play QA.

Closes #703

## Test plan

- [ ] Type only spaces into the instance name → inline error, Continue disabled
- [ ] Leave name blank → no error, suggested default used on save
- [ ] Enter a garbage URL on a Remote Connection source → inline error, Continue disabled
- [ ] Enter `localhost:8188` or `http://localhost:8188` → valid, Continue enabled