### PR TITLE
fix(picker): reset source filter to All when the active chip disappears

### DIFF
--- a/src/renderer/src/comfyTitlePopup/InstancePickerView.test.ts
+++ b/src/renderer/src/comfyTitlePopup/InstancePickerView.test.ts
@@ -352,6 +352,43 @@ describe('comfyTitlePopup/InstancePickerView', () => {
       expect(rows[0]!.text()).toContain('RemoteThing')
     })
 
+    // Regression (#723): a category chip only renders while an install
+    // backs it, so when the active category empties (e.g. the cloud /
+    // remote install drops out of a snapshot refresh) its chip vanishes.
+    // `activeFilter` must fall back to 'all' instead of staying pinned to
+    // the now-hidden key — otherwise the list is stuck showing nothing and
+    // the surviving installs (locals) never reappear.
+    it('resets the filter to All when the active chip disappears so installs reappear', async () => {
+      const wrapper = await mountPicker({
+        installs: [
+          makeInstall({ id: 'l', name: 'LocalThing', sourceCategory: 'local' }),
+          makeInstall({ id: 'r', name: 'RemoteThing', sourceCategory: 'remote' }),
+        ],
+        activeInstallationId: null,
+        runningInstallationIds: [],
+      })
+      const remoteChip = wrapper.findAll('.picker-chip').find((c) => c.text() === 'Remote')
+      await remoteChip!.trigger('click')
+      await flushPromises()
+      expect(wrapper.findAll('.picker-row').map((r) => r.text())).toEqual(['RemoteThing'])
+
+      // The remote install is removed (snapshot refresh) — its chip goes away.
+      await wrapper.setProps({
+        snapshot: {
+          ...wrapper.props('snapshot'),
+          installs: [makeInstall({ id: 'l', name: 'LocalThing', sourceCategory: 'local' })],
+        },
+      })
+      await flushPromises()
+
+      const chips = wrapper.findAll('.picker-chip')
+      expect(chips.some((c) => c.text() === 'Remote')).toBe(false)
+      // All is active again and the surviving local install is visible.
+      const allChip = chips.find((c) => c.text() === 'All')
+      expect(allChip!.classes()).toContain('is-active')
+      expect(wrapper.findAll('.picker-row').some((r) => r.text().includes('LocalThing'))).toBe(true)
+    })
+
     it('shows the empty-state hint when no rows match', async () => {
       const wrapper = await mountPicker({
         installs: [makeInstall({ id: 'a', name: 'Alpha' })],

--- a/src/renderer/src/comfyTitlePopup/InstancePickerView.vue
+++ b/src/renderer/src/comfyTitlePopup/InstancePickerView.vue
@@ -211,6 +211,19 @@ const visibleChips = computed(() => {
   })
 })
 
+// A category chip only renders while at least one install backs it. When
+// the active category empties (e.g. the cloud / remote install drops out of
+// a snapshot refresh) its chip vanishes — but `activeFilter` would otherwise
+// stay pinned to the now-hidden key, leaving the list stuck on an empty
+// filter with no highlighted chip and no obvious way back. Fall back to
+// 'all' so every install reappears. ('all' is always present, so it never
+// triggers this.) Mirrors the same guard in `DownloadsModal.vue`.
+watch(visibleChips, (chips) => {
+  if (!chips.some((chip) => chip.key === activeFilter.value)) {
+    activeFilter.value = 'all'
+  }
+})
+
 /** The install the user most recently launched — the sensible default
  *  selection when the popup opens with no active or explicitly-selected
  *  install.


### PR DESCRIPTION
## Summary

On the dashboard instance picker, a source-filter chip (Local / Cloud / Remote) only renders while at least one install backs that category. When the active category emptied — e.g. the cloud or remote install dropped out of a snapshot refresh — its chip disappeared, but `activeFilter` stayed pinned to the now-hidden key. The list was then stuck showing nothing, no chip was highlighted, and the surviving local installs never reappeared. This is the "'All' hides local installs after toggling Cloud then back" symptom from the report.

## Fix

Watch the visible chip set in `InstancePickerView.vue`; when the active filter key is no longer among the rendered chips, fall back to `'all'`. This mirrors the existing guard already used in `DownloadsModal.vue`, so the two filter surfaces behave consistently.

## Test plan

- [x] Added a focused regression test: activate Remote, remove the remote install, assert the filter resets to All (highlighted) and the surviving local install reappears.
- [x] `pnpm typecheck` (node/web/e2e/integration) passes
- [x] `pnpm lint` passes
- [x] `InstancePickerView` / `useInstallList` / `ChooserView` unit suites pass (58 tests)

Closes #723