### PR TITLE
fix(macOS): repair + probe pygit2 backends on boot to stop python spawn loop

### DIFF
--- a/lib/git_operations.py
+++ b/lib/git_operations.py
@@ -8,6 +8,7 @@ caller (src/main/lib/git.ts) can parse.
 Usage: python git_operations.py <subcommand> <repo_path> [args...]
 
 Subcommands:
+  healthcheck
   rev-parse          <repo_path> <ref>
   describe-tags      <repo_path> [commit]
   tag-list           <repo_path>
@@ -576,6 +577,7 @@ USAGE = """\
 Usage: python git_operations.py <subcommand> [args...]
 
 Subcommands:
+  healthcheck
   rev-parse          <repo_path> <ref>
   describe-tags      <repo_path> [commit]
   tag-list           <repo_path>
@@ -602,7 +604,14 @@ if __name__ == "__main__":
     subcmd = sys.argv[1]
 
     try:
-        if subcmd == "rev-parse":
+        if subcmd == "healthcheck":
+            # Minimal smoke test: prove Python starts, this script loads,
+            # and `import pygit2` (at module top) succeeded.  The TS
+            # caller probes this before configuring pygit2 as a fallback.
+            print("ok pygit2 %s" % getattr(pygit2, "__version__", "unknown"))
+            sys.exit(0)
+
+        elif subcmd == "rev-parse":
             if len(sys.argv) < 4:
                 print("Usage: git_operations.py rev-parse <repo_path> <ref>", file=sys.stderr)
                 sys.exit(1)

--- a/src/main/lib/git.test.ts
+++ b/src/main/lib/git.test.ts
@@ -8,7 +8,7 @@ vi.mock('child_process', async (importOriginal) => {
 
 import { execFile, spawn } from 'child_process'
 import { EventEmitter } from 'events'
-import { countCommitsAhead, findNearestTag, findLatestVersionTag, lsRemoteLatestTag, lsRemoteRef, isAncestorOf, findMergeBase, revParseRef, fetchTags, configurePygit2, isGitAvailable, resetGitAvailableCache, countUniqueCommits, gitClone, gitCheckoutCommit, gitFetchAndCheckout } from './git'
+import { countCommitsAhead, findNearestTag, findLatestVersionTag, lsRemoteLatestTag, lsRemoteRef, isAncestorOf, findMergeBase, revParseRef, fetchTags, configurePygit2, isGitAvailable, isPygit2Configured, getPygit2Status, resetPygit2State, probePygit2, resetGitAvailableCache, countUniqueCommits, gitClone, gitCheckoutCommit, gitFetchAndCheckout } from './git'
 
 const mockedExecFile = vi.mocked(execFile)
 const mockedSpawn = vi.mocked(spawn)
@@ -632,5 +632,116 @@ describe('pygit2 fallback', () => {
       expect(result.exitCode).toBe(1)
       expect(mockedSpawn).not.toHaveBeenCalled()
     })
+  })
+})
+
+// ===================================================================
+// pygit2 healthcheck probe + circuit-breaker tests
+// ===================================================================
+
+describe('probePygit2', () => {
+  beforeEach(() => { vi.resetAllMocks(); resetPygit2State() })
+
+  it('returns ok when healthcheck prints the success marker', async () => {
+    mockExecFile((_cmd, _args, _opts, cb) => { cb(null, 'ok pygit2 1.18.0\n', '') })
+    expect(await probePygit2('/usr/bin/python3', '/path/script.py')).toEqual({ ok: true })
+  })
+
+  it('runs the healthcheck subcommand against the bundled Python', async () => {
+    mockExecFile((_cmd, _args, _opts, cb) => { cb(null, 'ok pygit2 1.18.0\n', '') })
+    await probePygit2('/usr/bin/python3', '/path/script.py')
+    expect(mockedExecFile).toHaveBeenCalled()
+    const call = mockedExecFile.mock.calls[0]!
+    expect(call[0]).toBe('/usr/bin/python3')
+    expect(call[1]).toEqual(['-s', '-u', '/path/script.py', 'healthcheck'])
+  })
+
+  it('returns failure with stderr when the helper exits non-zero', async () => {
+    const err = new Error('non-zero exit') as Error & { code: number }
+    err.code = 1
+    mockExecFile((_cmd, _args, _opts, cb) => { cb(err, '', 'ImportError: pygit2 missing\n') })
+    const result = await probePygit2('/usr/bin/python3', '/path/script.py')
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toContain('ImportError')
+  })
+
+  it('returns failure when the marker is missing from stdout', async () => {
+    mockExecFile((_cmd, _args, _opts, cb) => { cb(null, 'something else\n', '') })
+    const result = await probePygit2('/usr/bin/python3', '/path/script.py')
+    expect(result.ok).toBe(false)
+  })
+})
+
+describe('pygit2 circuit breaker', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    resetPygit2State()
+    configurePygit2('/usr/bin/python3', '/path/to/git_operations.py')
+  })
+
+  it('disables pygit2 after 3 consecutive launch failures', async () => {
+    // Each call simulates a timeout (killed=true ⇒ launch failure)
+    const timeoutErr = new Error('timeout') as Error & { killed: boolean }
+    timeoutErr.killed = true
+    mockExecFile((_cmd, _args, _opts, cb) => { cb(timeoutErr, '', '') })
+
+    expect(isPygit2Configured()).toBe(true)
+    expect(await countCommitsAhead('/repo', 'v0.1.0')).toBeUndefined()
+    expect(await countCommitsAhead('/repo', 'v0.1.0')).toBeUndefined()
+    // Still healthy after 2 failures
+    expect(isPygit2Configured()).toBe(true)
+
+    expect(await countCommitsAhead('/repo', 'v0.1.0')).toBeUndefined()
+    // 3rd consecutive launch failure ⇒ disabled
+    expect(isPygit2Configured()).toBe(false)
+    expect(getPygit2Status().status).toBe('disabled')
+  })
+
+  it('does not count normal non-zero exits as launch failures', async () => {
+    // exit code 1 with no killed/signal ⇒ helper ran fine, just returned non-zero
+    const exitErr = new Error('exit 1') as Error & { code: number }
+    exitErr.code = 1
+    mockExecFile((_cmd, _args, _opts, cb) => { cb(exitErr, '', 'no such ref\n') })
+
+    for (let i = 0; i < 5; i++) {
+      await countCommitsAhead('/repo', 'v0.1.0')
+    }
+    expect(isPygit2Configured()).toBe(true)
+    expect(getPygit2Status().status).toBe('healthy')
+  })
+
+  it('resets failure counter after a successful call', async () => {
+    const timeoutErr = new Error('timeout') as Error & { killed: boolean }
+    timeoutErr.killed = true
+    mockExecFile((_cmd, _args, _opts, cb) => { cb(timeoutErr, '', '') })
+    await countCommitsAhead('/repo', 'v0.1.0')
+    await countCommitsAhead('/repo', 'v0.1.0')
+
+    // Healthy run resets the counter
+    mockExecFile((_cmd, _args, _opts, cb) => { cb(null, '7\n', '') })
+    expect(await countCommitsAhead('/repo', 'v0.1.0')).toBe(7)
+
+    // Two more launch failures should not trip the breaker (counter was reset)
+    mockExecFile((_cmd, _args, _opts, cb) => { cb(timeoutErr, '', '') })
+    await countCommitsAhead('/repo', 'v0.1.0')
+    await countCommitsAhead('/repo', 'v0.1.0')
+    expect(isPygit2Configured()).toBe(true)
+  })
+
+  it('falls back to system git (not pygit2) once disabled', async () => {
+    const timeoutErr = new Error('timeout') as Error & { killed: boolean }
+    timeoutErr.killed = true
+    mockExecFile((_cmd, _args, _opts, cb) => { cb(timeoutErr, '', '') })
+    for (let i = 0; i < 3; i++) await countCommitsAhead('/repo', 'v0.1.0')
+    expect(isPygit2Configured()).toBe(false)
+
+    // After disable, calls take the system-git branch — the Python path
+    // should no longer appear in execFile invocations.
+    mockedExecFile.mockClear()
+    mockExecFile((_cmd, _args, _opts, cb) => { cb(null, '7\n', '') })
+    expect(await countCommitsAhead('/repo', 'v0.1.0')).toBe(7)
+    const call = mockedExecFile.mock.calls[0]!
+    expect(call[0]).toBe('git')
+    expect(call[0]).not.toBe('/usr/bin/python3')
   })
 })

--- a/src/main/lib/git.ts
+++ b/src/main/lib/git.ts
@@ -4,38 +4,200 @@ import path from 'path'
 import { app } from 'electron'
 import { killProcTree } from './process'
 import { getBundledScriptPath } from './bundledScript'
+import { removeQuarantine, codesignBinaries } from '../sources/standalone/macRepair'
 
-let _pygit2Python: string | null = null
-let _pygit2Script: string | null = null
+// ───────────────────────────────────────────────────────────────────────────
+// pygit2 fallback state + circuit breaker
+//
+// Background: on machines without a global `git` binary we fall back to a
+// bundled Python interpreter (shipped in `standalone-env/`) plus our
+// `git_operations.py` helper.  On macOS in particular the Python binary
+// can be in a broken state (quarantine flag still set, codesignature
+// invalidated by extraction/copy/migration) — in which case every spawn
+// either hangs on Gatekeeper or fails fast.  Because various boot-time
+// paths (update checks, version resolution, renderer polling) call into
+// git frequently, an unhealthy Python helper used to manifest as a flood
+// of Python processes on application boot.
+//
+// To prevent that we:
+//   1. Probe with a real `--healthcheck` call before configuring.
+//   2. On macOS, repair the standalone-env (remove quarantine + adhoc
+//      codesign) once if the first probe fails, then re-probe.
+//   3. Track consecutive launch/timeout failures and disable the
+//      fallback for the rest of the session once a threshold is hit.
+//   4. Always run long-lived pygit2 spawns under a hard timeout.
+// ───────────────────────────────────────────────────────────────────────────
+
+type Pygit2State =
+  | { status: 'unconfigured' }
+  | { status: 'healthy'; python: string; script: string; failures: number }
+  | { status: 'disabled'; reason: string }
+
+let _pygit2: Pygit2State = { status: 'unconfigured' }
+
+/** Consecutive launch/timeout failures before disabling the fallback. */
+const PYGIT2_MAX_FAILURES = 3
+
+/** Hard timeout for long-running pygit2 spawn operations (clone / checkout). */
+const PYGIT2_LONG_TIMEOUT_MS = 20 * 60 * 1000 // 20 minutes
+
+/** Timeout for the boot-time `--healthcheck` probe. */
+const PYGIT2_PROBE_TIMEOUT_MS = 5_000
+
+/** Tracks env directories we have already attempted to repair this session,
+ *  so we don't pay the codesign cost more than once per env. */
+const _pygit2RepairedDirs = new Set<string>()
 
 export function configurePygit2(pythonPath: string, scriptPath: string): void {
-  _pygit2Python = pythonPath
-  _pygit2Script = scriptPath
+  _pygit2 = { status: 'healthy', python: pythonPath, script: scriptPath, failures: 0 }
 }
 
 export function isPygit2Configured(): boolean {
-  return _pygit2Python !== null && _pygit2Script !== null
+  return _pygit2.status === 'healthy'
 }
 
 export function getPygit2Config(): { python: string | null; script: string | null } {
-  return { python: _pygit2Python, script: _pygit2Script }
+  if (_pygit2.status === 'healthy') {
+    return { python: _pygit2.python, script: _pygit2.script }
+  }
+  return { python: null, script: null }
+}
+
+export function getPygit2Status(): Pygit2State {
+  return _pygit2
+}
+
+/** Reset all pygit2 state.  Tests + recovery flows only. */
+export function resetPygit2State(): void {
+  _pygit2 = { status: 'unconfigured' }
+  _pygit2RepairedDirs.clear()
+}
+
+function disablePygit2(reason: string): void {
+  if (_pygit2.status === 'disabled') return
+  console.warn('[git] disabling pygit2 fallback:', reason)
+  _pygit2 = { status: 'disabled', reason }
+}
+
+function recordPygit2Failure(reason: string): void {
+  if (_pygit2.status !== 'healthy') return
+  const failures = _pygit2.failures + 1
+  _pygit2 = { ..._pygit2, failures }
+  if (failures >= PYGIT2_MAX_FAILURES) {
+    disablePygit2(`disabled after ${failures} consecutive launch failures: ${reason}`)
+  }
+}
+
+function recordPygit2Success(): void {
+  if (_pygit2.status !== 'healthy' || _pygit2.failures === 0) return
+  _pygit2 = { ..._pygit2, failures: 0 }
+}
+
+/** Classify an execFile error: launch failure (timeout, ENOENT, signal) vs
+ *  normal non-zero exit from the helper. */
+function isLaunchFailure(error: ExecFileException | null): boolean {
+  if (!error) return false
+  if (error.killed) return true // timeout
+  if (error.signal) return true
+  const code = error.code
+  if (typeof code === 'string') return true // ENOENT, EACCES, etc.
+  return false
+}
+
+/** Resolve the path to the standalone Python interpreter for an install. */
+function getStandalonePythonPath(installPath: string): string {
+  return process.platform === 'win32'
+    ? path.join(installPath, 'standalone-env', 'python.exe')
+    : path.join(installPath, 'standalone-env', 'bin', 'python3')
+}
+
+/**
+ * Probe a candidate Python + helper script by running `healthcheck`.
+ * Validates that Python launches, the helper script loads, and `pygit2`
+ * (imported at module top) is importable.
+ */
+export function probePygit2(
+  pythonPath: string,
+  scriptPath: string,
+  timeoutMs: number = PYGIT2_PROBE_TIMEOUT_MS,
+): Promise<{ ok: true } | { ok: false; reason: string }> {
+  return new Promise((resolve) => {
+    execFile(pythonPath, ['-s', '-u', scriptPath, 'healthcheck'], {
+      encoding: 'utf-8',
+      windowsHide: true,
+      timeout: timeoutMs,
+    }, (error, stdout, stderr) => {
+      if (!error && (stdout ?? '').includes('ok pygit2')) {
+        resolve({ ok: true })
+        return
+      }
+      const reason = `${error?.message ?? ''}\n${(stderr ?? '').trim()}`.trim()
+        || 'pygit2 healthcheck failed'
+      resolve({ ok: false, reason })
+    })
+  })
+}
+
+/**
+ * Best-effort macOS repair for a Python env directory: remove quarantine
+ * flag and adhoc-sign Mach-O binaries.  Used for both the bundled
+ * bootstrap-python (whose codesignature gets invalidated when the .app is
+ * extracted from a zip) and standalone-env (copied/migrated installs).
+ *
+ * No-op on non-Darwin platforms or when already attempted for this dir
+ * in the current session.
+ */
+async function repairEnvForPygit2(envDir: string): Promise<void> {
+  if (process.platform !== 'darwin') return
+  if (_pygit2RepairedDirs.has(envDir)) return
+  _pygit2RepairedDirs.add(envDir)
+  if (!fs.existsSync(envDir)) return
+  const log = (msg: string): void => { console.log('[git] pygit2 repair:', msg.trim()) }
+  try {
+    log(`removing quarantine on ${envDir}`)
+    await removeQuarantine(envDir, log)
+    log(`adhoc codesigning ${envDir}`)
+    await codesignBinaries(envDir, log)
+  } catch (err) {
+    console.warn('[git] pygit2 repair failed:', err)
+  }
 }
 
 /**
  * Try to configure the pygit2 fallback using a standalone installation's
- * Python.  Validates that both the Python binary and the helper script
- * exist before calling {@link configurePygit2}.
+ * Python.  Verifies the binary actually works by running a healthcheck —
+ * and on macOS, transparently runs quarantine removal + adhoc codesigning
+ * once if the first probe fails, so the bundled Python is in a usable
+ * state before going live.
  *
- * @returns `true` if pygit2 was successfully configured.
+ * Refuses to configure when:
+ *   - the helper script or Python binary doesn't exist
+ *   - the healthcheck still fails after repair
+ *   - the fallback has already been disabled this session
+ *
+ * @returns `true` only if pygit2 is now healthy.
  */
-export function tryConfigurePygit2Fallback(installPath: string): boolean {
-  const pythonPath = process.platform === 'win32'
-    ? path.join(installPath, 'standalone-env', 'python.exe')
-    : path.join(installPath, 'standalone-env', 'bin', 'python3')
+export async function tryConfigurePygit2Fallback(installPath: string): Promise<boolean> {
+  if (_pygit2.status === 'disabled') return false
+  const pythonPath = getStandalonePythonPath(installPath)
   if (!fs.existsSync(pythonPath)) return false
   const scriptPath = getBundledScriptPath('git_operations.py')
   if (!fs.existsSync(scriptPath)) return false
+
+  let probe = await probePygit2(pythonPath, scriptPath)
+  if (!probe.ok && process.platform === 'darwin') {
+    console.warn(`[git] pygit2 probe failed; attempting macOS repair: ${probe.reason}`)
+    await repairEnvForPygit2(path.join(installPath, 'standalone-env'))
+    probe = await probePygit2(pythonPath, scriptPath)
+  }
+
+  if (!probe.ok) {
+    console.warn(`[git] pygit2 fallback rejected for ${installPath}: ${probe.reason}`)
+    return false
+  }
+
   configurePygit2(pythonPath, scriptPath)
+  console.log('[git] pygit2 fallback configured via', pythonPath)
   return true
 }
 
@@ -45,9 +207,16 @@ export function tryConfigurePygit2Fallback(installPath: string): boolean {
  * git operations to work from app launch, before any standalone
  * environment is downloaded.
  *
- * @returns `true` if pygit2 was successfully configured.
+ * Verifies the binary actually works by running a healthcheck — and on
+ * macOS, transparently runs quarantine removal + adhoc codesigning once
+ * if the first probe fails.  Without this guard, a broken bundled Python
+ * caused boot-time git callers to spawn an endless stream of Python
+ * processes on macOS.
+ *
+ * @returns `true` only if pygit2 is now healthy.
  */
-export function tryConfigureBootstrapPygit2(): boolean {
+export async function tryConfigureBootstrapPygit2(): Promise<boolean> {
+  if (_pygit2.status === 'disabled') return false
   const osName = process.platform === 'win32' ? 'win'
     : process.platform === 'darwin' ? 'mac'
     : 'linux'
@@ -61,21 +230,46 @@ export function tryConfigureBootstrapPygit2(): boolean {
   if (!fs.existsSync(pythonPath)) return false
   const scriptPath = getBundledScriptPath('git_operations.py')
   if (!fs.existsSync(scriptPath)) return false
+
+  let probe = await probePygit2(pythonPath, scriptPath)
+  if (!probe.ok && process.platform === 'darwin') {
+    console.warn(`[git] bootstrap pygit2 probe failed; attempting macOS repair: ${probe.reason}`)
+    await repairEnvForPygit2(bootstrapDir)
+    probe = await probePygit2(pythonPath, scriptPath)
+  }
+
+  if (!probe.ok) {
+    console.warn(`[git] bootstrap pygit2 rejected at ${pythonPath}: ${probe.reason}`)
+    return false
+  }
+
   configurePygit2(pythonPath, scriptPath)
+  console.log('[git] bootstrap pygit2 configured via', pythonPath)
   return true
 }
 
 function runPygit2(args: string[], timeout: number = 5000): Promise<{ exitCode: number; stdout: string; stderr: string }> {
   return new Promise((resolve) => {
-    execFile(_pygit2Python!, ['-s', '-u', _pygit2Script!, ...args], {
+    if (_pygit2.status !== 'healthy') {
+      resolve({ exitCode: 1, stdout: '', stderr: 'pygit2 fallback is not available' })
+      return
+    }
+    const { python, script } = _pygit2
+    execFile(python, ['-s', '-u', script, ...args], {
       encoding: 'utf-8',
       windowsHide: true,
       timeout,
     }, (error, stdout, stderr) => {
+      const stderrStr = (stderr ?? '').toString()
+      if (isLaunchFailure(error)) {
+        recordPygit2Failure(error?.message ?? stderrStr ?? 'launch failure')
+      } else {
+        recordPygit2Success()
+      }
       resolve({
         exitCode: error ? (typeof (error as ExecFileException).code === 'number' ? ((error as ExecFileException).code as number) : 1) : 0,
         stdout: (stdout ?? '').toString(),
-        stderr: (stderr ?? '').toString(),
+        stderr: stderrStr,
       })
     })
   })
@@ -84,9 +278,65 @@ function runPygit2(args: string[], timeout: number = 5000): Promise<{ exitCode: 
 function makeRunPygit2(
   sendOutput: (text: string) => void,
   signal?: AbortSignal,
+  timeoutMs: number = PYGIT2_LONG_TIMEOUT_MS,
 ): (args: string[]) => Promise<ProcessResult> {
-  return (args: string[]): Promise<ProcessResult> =>
-    spawnStreamed(_pygit2Python!, ['-s', '-u', _pygit2Script!, ...args], sendOutput, { signal })
+  return (args: string[]): Promise<ProcessResult> => {
+    if (signal?.aborted) return Promise.resolve({ exitCode: 1, stderr: '', stdout: '' })
+    if (_pygit2.status !== 'healthy') {
+      return Promise.resolve({ exitCode: 1, stderr: 'pygit2 fallback is not available', stdout: '' })
+    }
+    const { python, script } = _pygit2
+    return new Promise((resolve) => {
+      const stdoutChunks: string[] = []
+      const stderrChunks: string[] = []
+      const proc = spawn(python, ['-s', '-u', script, ...args], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        windowsHide: true,
+        detached: process.platform !== 'win32',
+      })
+      let settled = false
+      let timedOut = false
+      const finish = (result: ProcessResult): void => {
+        if (settled) return
+        settled = true
+        clearTimeout(timer)
+        signal?.removeEventListener('abort', onAbort)
+        resolve(result)
+      }
+      const timer = setTimeout(() => {
+        timedOut = true
+        const msg = `\nTimed out running pygit2 helper after ${Math.round(timeoutMs / 1000)}s\n`
+        sendOutput(msg)
+        stderrChunks.push(msg)
+        killProcTree(proc)
+        recordPygit2Failure('timeout in long-running pygit2 spawn')
+        finish({ exitCode: 1, stderr: stderrChunks.join(''), stdout: stdoutChunks.join('') })
+      }, timeoutMs)
+      const onAbort = (): void => { killProcTree(proc) }
+      signal?.addEventListener('abort', onAbort, { once: true })
+      if (signal?.aborted) onAbort()
+      proc.stdout.on('data', (data: Buffer) => {
+        const text = data.toString()
+        stdoutChunks.push(text)
+        sendOutput(text)
+      })
+      proc.stderr.on('data', (data: Buffer) => {
+        const text = data.toString()
+        stderrChunks.push(text)
+        sendOutput(text)
+      })
+      proc.on('error', (err) => {
+        recordPygit2Failure(err.message)
+        sendOutput(err.message)
+        finish({ exitCode: 1, stderr: stderrChunks.join('') + err.message, stdout: stdoutChunks.join('') })
+      })
+      proc.on('close', (code) => {
+        if (timedOut) return
+        if (code === 0) recordPygit2Success()
+        finish({ exitCode: code ?? 1, stderr: stderrChunks.join(''), stdout: stdoutChunks.join('') })
+      })
+    })
+  }
 }
 
 export interface ProcessResult {

--- a/src/main/lib/ipc/index.ts
+++ b/src/main/lib/ipc/index.ts
@@ -130,7 +130,7 @@ export function register(callbacks: RegisterCallbacks = {}): void {
     const configureGitBackend = async (): Promise<void> => {
       const forceBootstrap = process.env.COMFY_FORCE_BOOTSTRAP_GIT === '1'
 
-      if (tryConfigureBootstrapPygit2()) {
+      if (await tryConfigureBootstrapPygit2()) {
         console.log('[ipc] Using bootstrap pygit2 for git operations (default)')
         return
       }
@@ -155,7 +155,7 @@ export function register(callbacks: RegisterCallbacks = {}): void {
         const all = await installations.list()
         for (const inst of all) {
           if (inst.sourceId !== 'standalone' || !inst.installPath) continue
-          if (tryConfigurePygit2Fallback(inst.installPath)) {
+          if (await tryConfigurePygit2Fallback(inst.installPath)) {
             console.log(
               '[ipc] Configured pygit2 fallback via standalone install at',
               inst.installPath

--- a/src/main/lib/ipc/registerInstallationHandlers.ts
+++ b/src/main/lib/ipc/registerInstallationHandlers.ts
@@ -8,7 +8,7 @@ import {
   i18n,
   sourceMap,
   formatComfyVersion,
-  _resolveAndBroadcastVersions,
+  scheduleResolveAndBroadcastVersions,
   findDuplicatePath,
   uniqueName,
   sanitizeDirName,
@@ -113,8 +113,11 @@ export function registerInstallationHandlers(): void {
     const allInstalls = await installations.list()
     const { visible, enriched } = enrichInstallationsForRenderer(allInstalls)
 
-    // Resolve versions from git state in the background.
-    _resolveAndBroadcastVersions(visible).catch(() => {})
+    // Resolve versions from git state in the background.  Coalesced +
+    // TTL-throttled so repeated renderer refreshes don't trigger
+    // pygit2 bursts (every get-installations used to fire a fresh
+    // background git pass — see scheduleResolveAndBroadcastVersions).
+    scheduleResolveAndBroadcastVersions(visible)
 
     // Pre-warm the shared ComfyUI release cache so the dashboard /
     // title-bar update pills reflect upstream state without requiring

--- a/src/main/lib/ipc/shared.ts
+++ b/src/main/lib/ipc/shared.ts
@@ -479,6 +479,24 @@ export async function _fetchAndResolveLatestTags(
   return result
 }
 
+// Scheduling guard for the fire-and-forget background resolver invoked from
+// `get-installations`.  Renderer mounts / refreshes used to spawn a fresh
+// pygit2 burst on every call.  Now we coalesce overlapping invocations
+// (single-flight) and rate-limit subsequent runs (TTL) so repeated UI
+// fetches don't churn the bundled Python interpreter.
+let _resolveVersionsInFlight: Promise<void> | null = null
+let _lastResolveVersionsAt = 0
+const RESOLVE_VERSIONS_TTL_MS = 10 * 60 * 1000
+
+export function scheduleResolveAndBroadcastVersions(list: InstallationRecord[]): void {
+  if (_resolveVersionsInFlight) return
+  if (Date.now() - _lastResolveVersionsAt < RESOLVE_VERSIONS_TTL_MS) return
+  _lastResolveVersionsAt = Date.now()
+  _resolveVersionsInFlight = _resolveAndBroadcastVersions(list).catch(() => {}).finally(() => {
+    _resolveVersionsInFlight = null
+  })
+}
+
 export async function _resolveAndBroadcastVersions(list: InstallationRecord[]): Promise<void> {
   const candidates = list.flatMap((inst) => {
     const cv = inst.comfyVersion as ComfyVersion | undefined
@@ -594,20 +612,31 @@ export function resolveTheme(): ResolvedTheme {
   return theme === 'system' ? (nativeTheme.shouldUseDarkColors ? 'dark' : 'light') : theme
 }
 
-export async function checkInstallationUpdates(): Promise<void> {
-  try {
-    await Promise.allSettled(
-      ALL_UPDATE_CHANNELS.map((channel) =>
-        releaseCache.getOrFetch(COMFYUI_REPO, channel, async () => {
-          const release = await fetchLatestRelease(channel)
-          if (!release) return null
-          return releaseCache.buildCacheEntry(release)
-        }, true)
+// Single-flight guard: overlapping calls await the same in-flight run rather
+// than triggering parallel bursts of git / pygit2 work.  Boot + periodic
+// timer + manual refresh all share one execution.
+let _checkInstallationUpdatesInFlight: Promise<void> | null = null
+
+export function checkInstallationUpdates(): Promise<void> {
+  if (_checkInstallationUpdatesInFlight) return _checkInstallationUpdatesInFlight
+  _checkInstallationUpdatesInFlight = (async (): Promise<void> => {
+    try {
+      await Promise.allSettled(
+        ALL_UPDATE_CHANNELS.map((channel) =>
+          releaseCache.getOrFetch(COMFYUI_REPO, channel, async () => {
+            const release = await fetchLatestRelease(channel)
+            if (!release) return null
+            return releaseCache.buildCacheEntry(release)
+          }, true)
+        )
       )
-    )
-    await _enrichLatestCommitsAhead()
-    _broadcastToRenderer('installations-changed', {})
-  } catch {}
+      await _enrichLatestCommitsAhead()
+      _broadcastToRenderer('installations-changed', {})
+    } catch {}
+  })().finally(() => {
+    _checkInstallationUpdatesInFlight = null
+  })
+  return _checkInstallationUpdatesInFlight
 }
 
 async function _enrichLatestCommitsAhead(): Promise<void> {

--- a/src/main/sources/standalone/install.ts
+++ b/src/main/sources/standalone/install.ts
@@ -115,7 +115,7 @@ export async function postInstall(installation: InstallationRecord, { sendProgre
   // On machines without a global git binary, configure pygit2 using the
   // just-installed standalone Python so tag resolution works correctly.
   if (!isPygit2Configured() && !await isGitAvailable()) {
-    tryConfigurePygit2Fallback(installation.installPath)
+    await tryConfigurePygit2Fallback(installation.installPath)
   }
   const comfyuiDir = path.join(installation.installPath, 'ComfyUI')
   await writeComfyEnvironment(comfyuiDir)


### PR DESCRIPTION
## Problem

On macOS the bundled Python helpers that back pygit2 can be in a broken state — quarantine flag still set, codesignature invalidated by `.app` extraction / copy / migration. Two backends are affected:

- **`bootstrap-python`** — the env shipped with the Electron app (the *default* git backend on boot, exactly the *"built-in python environment that is there to call pygit2"* in the report)
- **`<install>/standalone-env`** — per-install fallback

In that broken state every spawn either hangs on Gatekeeper or fails fast. Combined with several boot-time paths that repeatedly call git, the symptom users see is a flood of `python` processes accumulating on launch until the machine is starved of resources.

The boot-time call chain that amplifies the failure:

```diagram
╭───────────────────────╮
│  app.whenReady()      │
╰──────────┬────────────╯
           │ configures bootstrap-pygit2 (blindly)
           ▼
╭──────────────────────────────╮     ╭──────────────────────────╮
│ checkInstallationUpdates @+3s│────▶│  fetchTags / commits     │──┐
│       + every 10 min         │     │  ahead per install       │  │ spawn python
╰──────────────────────────────╯     ╰──────────────────────────╯  │
           │ broadcasts                                            │
           ▼ installations-changed                                 │
╭──────────────────────╮     ╭──────────────────────────────────╮  │
│  renderer refresh    │────▶│ get-installations side-effect:   │──┤
╰──────────────────────╯     │ _resolveAndBroadcastVersions     │  │
                             ╰──────────────────────────────────╯  │
                                            │                      ▼
                                            ▼            ╭──────────────────╮
                                  broadcasts again ─────▶│ broken python    │
                                                         │ hangs, new ones  │
                                                         │ keep spawning    │
                                                         ╰──────────────────╯
```

## Root causes

1. **Unvalidated configuration.** `tryConfigureBootstrapPygit2` / `tryConfigurePygit2Fallback` only checked `fs.existsSync` on the Python binary, then trusted it forever. `isGitAvailable()` then returned `true` purely because pygit2 was configured, so every git-touching code path used the broken interpreter.
2. **No timeouts on long-lived pygit2 spawns.** `makeRunPygit2` used `spawn(..., { detached: true })` with no timeout — a hung helper sat forever while new ones kept being spawned.
3. **Feedback loops.** `checkInstallationUpdates` had no single-flight guard, and `_resolveAndBroadcastVersions` ran on every `get-installations`, which the renderer calls on every `installations-changed` broadcast.
4. **Repair only at install time.** `repairMacBinaries` (quarantine removal + adhoc codesign) was applied only during install / update, so restored / migrated / copied installs — and the bundled bootstrap-python after `.app` extraction — were never re-repaired even when the launcher tried to use their Python.

## Changes

### `lib/git_operations.py`
- New **`healthcheck`** subcommand prints `ok pygit2 <version>`. Because `pygit2` is imported at module top, a successful exit proves Python starts, the helper script loads, and pygit2 + its dylibs are usable.

### `src/main/lib/git.ts` (core)
- Replace the two-pointer pygit2 state with a discriminated union `Pygit2State = unconfigured | healthy | disabled` and a failure counter.
- New `probePygit2(pythonPath, scriptPath)` helper runs the `healthcheck` subcommand with a 5 s timeout.
- New `repairEnvForPygit2(envDir)` helper: macOS-only, removes quarantine + adhoc-codesigns Mach-O binaries in any env directory. Tracked per-dir per-session via `_pygit2RepairedDirs` so the codesign pass runs at most once per env.
- **`tryConfigureBootstrapPygit2` and `tryConfigurePygit2Fallback` are now `async`.** Both:
  1. probe first,
  2. on macOS, if the probe fails → call `repairEnvForPygit2` on the relevant env dir → re-probe,
  3. refuse to configure if the probe still fails,
  4. otherwise call `configurePygit2`.
- **Circuit breaker.** Launch failures (timeout / signal / spawn `ENOENT`) bump a counter; after 3 consecutive launch failures the fallback is **disabled** for the rest of the session. Subsequent `runPygit2` / `makeRunPygit2` calls short-circuit (no spawn) and git callers transparently take their system-git branch.
- **20-minute hard timeout** + `killProcTree` on `makeRunPygit2` so long-running clone / checkout helpers can no longer hang forever.

### `src/main/lib/ipc/index.ts`, `src/main/sources/standalone/install.ts`
- `await` the now-async `tryConfigureBootstrapPygit2` / `tryConfigurePygit2Fallback`.

### `src/main/lib/ipc/shared.ts`
- **Single-flight** guard around `checkInstallationUpdates` so boot + periodic + manual refresh coalesce into one execution.
- New **`scheduleResolveAndBroadcastVersions`** (TTL = 10 min + single-flight) wraps `_resolveAndBroadcastVersions`.

### `src/main/lib/ipc/registerInstallationHandlers.ts`
- Route the background version resolver in `get-installations` through `scheduleResolveAndBroadcastVersions`, breaking the `installations-changed` → renderer refresh → fresh pygit2 burst loop.

### `src/main/lib/git.test.ts`
- 8 new tests for `probePygit2` and the circuit breaker (disables after 3 launch failures, ignores normal non-zero exits, resets the counter on success, falls back to system git once disabled).

## Behavioural shift

- **Healthy users (any platform):** unaffected — probe succeeds immediately, configuration is identical to before.
- **macOS users on a broken bundled Python:** get one transparent repair attempt on boot, so the helper actually works.
- **macOS users whose env is still broken after repair:** pygit2 is rejected immediately and stays disabled — git operations gracefully degrade to "unknown" version info instead of spawning more Python.

## Verification

| Check | Result |
| --- | --- |
| `pnpm run typecheck` | ✅ |
| `pnpm run lint` | ✅ |
| `pnpm run build` | ✅ |
| `pnpm run test` | ✅ **1491 / 1491** (8 new) |