### PR TITLE
feat(launcher): label primary launch action 'Start' instead of 'Open'

### DIFF
--- a/src/renderer/src/components/settings/ComfyUISettingsContent.test.ts
+++ b/src/renderer/src/components/settings/ComfyUISettingsContent.test.ts
@@ -35,7 +35,7 @@ const messages = {
       more: 'More',
     },
     instancePicker: {
-      open: 'Open',
+      open: 'Start',
       restart: 'Restart',
       progressUpdating: 'Updating…',
       progressDowngrading: 'Downgrading…',

--- a/src/renderer/src/components/settings/ComfyUISettingsContent.vue
+++ b/src/renderer/src/components/settings/ComfyUISettingsContent.vue
@@ -479,7 +479,7 @@ const primaryActionLabel = computed(() => {
   }
   return isInstallRunning.value
     ? t('instancePicker.restart', 'Restart')
-    : t('instancePicker.open', 'Open')
+    : t('instancePicker.open', 'Start')
 })
 
 function handlePrimaryAction(): void {

--- a/src/renderer/src/lib/i18nMessages.ts
+++ b/src/renderer/src/lib/i18nMessages.ts
@@ -203,7 +203,7 @@ export const en = {
     instances: 'Instances',
     newInstance: 'New Instance',
     latestOnGithub: 'Latest on GitHub',
-    open: 'Open',
+    open: 'Start',
     restart: 'Restart',
     restartConfirmTitle: 'Restart this instance?',
     restartConfirmDetail:


### PR DESCRIPTION
## Summary

The primary action button on an install's settings/launch surface reads **"Open"** when the install is idle. Clicking it actually starts/runs ComfyUI for that install, so the label is unclear. This changes the idle-state launch CTA label to **"Start"**, which also pairs naturally with the running-state **"Restart"** label.

The live string is the shared `instancePicker.open` key in `src/renderer/src/lib/i18nMessages.ts` (the catalog the panel / picker / settings surfaces resolve against). The matching `t()` fallback in `ComfyUISettingsContent.vue` and the test stub catalog were updated for parity.

Note: the unused legacy `chooser.openInstall` / `chooser.openCloud` keys in `locales/en.json` / `zh.json` are *not* the live launch CTA (no code references them) and were left untouched. There is no `instancePicker` namespace in `zh.json`, so no zh change was needed.

## Wording proposal

**"Start"** is a proposal, open to team preference. Alternatives: **"Run"**, **"Launch"**. Easy to swap — it's a single shared string.

## Test plan
- [x] `pnpm typecheck` (node / web / e2e / integration)
- [x] `pnpm lint`
- [x] `pnpm vitest run` for `ComfyUISettingsContent.test.ts` (17 passing)
- [ ] Manual: idle install shows "Start"; running install still shows "Restart"

Closes #694