### PR TITLE
fix(track): enable Track Install when a directory is pasted into the path field

### DIFF
--- a/src/renderer/src/views/TrackModal.test.ts
+++ b/src/renderer/src/views/TrackModal.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+
+import TrackModal from './TrackModal.vue'
+import type { ProbeResult } from '../types/ipc'
+
+/**
+ * Regression harness for #726 — pasting/typing a path into the Install
+ * Directory field must auto-probe and enable the "Track Install" button.
+ * Previously `probe()` was wired only to the Browse button, so a pasted
+ * path left `selectedProbe` null and the primary button stayed disabled.
+ */
+
+// Minimal catalog covering the keys the template reads. Missing keys fall
+// back to the dotted path, which would surface in a failed assertion.
+const messages = {
+  en: {
+    common: {
+      name: 'Name',
+      browse: 'Browse',
+      namePlaceholder: 'e.g. ComfyUI Main',
+      backToDashboard: 'Back to Dashboard',
+    },
+    git: { venv: 'Virtual Environment', venvNotFound: 'Not found' },
+    track: {
+      grandTitle: 'Track Existing Install',
+      grandSubtitle: 'Add an existing local ComfyUI checkout.',
+      installDir: 'Install Directory',
+      selectDir: 'Select a directory',
+      detectedType: 'Detected Type',
+      browseDirFirst: 'Browse to a directory first',
+      detecting: 'Detecting',
+      noDetected: 'No known install detected',
+      trackInstallation: 'Track Install',
+      cannotTrack: 'Cannot Track',
+      version: 'Version',
+      repository: 'Repository',
+      branch: 'Branch',
+    },
+  },
+}
+
+function createTestI18n() {
+  return createI18n({ legacy: false, locale: 'en', messages })
+}
+
+interface MockApi {
+  getUniqueName: ReturnType<typeof vi.fn>
+  browseFolder: ReturnType<typeof vi.fn>
+  probeInstallation: ReturnType<typeof vi.fn>
+  trackInstallation: ReturnType<typeof vi.fn>
+}
+
+const gitProbe: ProbeResult = {
+  sourceId: 'git',
+  sourceLabel: 'Git',
+  version: 'abcdef12',
+  repo: 'https://github.com/comfyanonymous/ComfyUI.git',
+  branch: 'master',
+  commit: 'abcdef12',
+}
+
+function installMockApi(overrides: Partial<MockApi> = {}): MockApi {
+  const api: MockApi = {
+    getUniqueName: vi.fn().mockResolvedValue('ComfyUI'),
+    browseFolder: vi.fn().mockResolvedValue(undefined),
+    probeInstallation: vi.fn().mockResolvedValue([gitProbe]),
+    trackInstallation: vi.fn().mockResolvedValue({ ok: true }),
+    ...overrides,
+  }
+  ;(window as unknown as { api: MockApi }).api = api
+  return api
+}
+
+function mountTrack() {
+  return mount(TrackModal, {
+    global: {
+      plugins: [createTestI18n()],
+      stubs: {
+        // BrandTakeoverLayout renders the default slot so the card is in
+        // the DOM; the rest are inert presentational shells.
+        BrandTakeoverLayout: { template: '<div><slot /><slot name="footer-left" /></div>' },
+        TakeoverBack: true,
+        BaseSelect: true,
+        HardDrive: true,
+      },
+    },
+  })
+}
+
+function trackButton(wrapper: ReturnType<typeof mountTrack>) {
+  return wrapper.get('button.track-save')
+}
+
+describe('TrackModal — pasted-path probing (#726)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    installMockApi()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('probes and enables Track Install when a path is pasted into the field', async () => {
+    const api = installMockApi()
+    const wrapper = mountTrack()
+    ;(wrapper.vm as unknown as { open: () => void }).open()
+    await flushPromises()
+
+    expect(trackButton(wrapper).attributes('disabled')).toBeDefined()
+
+    // Simulate a paste: v-model updates trackPath via the input event.
+    await wrapper.get('#track-path').setValue('/Users/jo/ComfyUI')
+
+    // Debounced — no probe before the timer fires.
+    expect(api.probeInstallation).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(300)
+    await flushPromises()
+
+    expect(api.probeInstallation).toHaveBeenCalledWith('/Users/jo/ComfyUI')
+    expect(trackButton(wrapper).attributes('disabled')).toBeUndefined()
+  })
+
+  it('trims trailing whitespace from a pasted path before probing', async () => {
+    const api = installMockApi()
+    const wrapper = mountTrack()
+    ;(wrapper.vm as unknown as { open: () => void }).open()
+    await flushPromises()
+
+    await wrapper.get('#track-path').setValue('  /Users/jo/ComfyUI  ')
+    await vi.advanceTimersByTimeAsync(300)
+    await flushPromises()
+
+    expect(api.probeInstallation).toHaveBeenCalledWith('/Users/jo/ComfyUI')
+    expect(trackButton(wrapper).attributes('disabled')).toBeUndefined()
+  })
+
+  it('keeps the button disabled and clears results when the path is emptied', async () => {
+    const api = installMockApi()
+    const wrapper = mountTrack()
+    ;(wrapper.vm as unknown as { open: () => void }).open()
+    await flushPromises()
+
+    await wrapper.get('#track-path').setValue('/Users/jo/ComfyUI')
+    await vi.advanceTimersByTimeAsync(300)
+    await flushPromises()
+    expect(trackButton(wrapper).attributes('disabled')).toBeUndefined()
+
+    await wrapper.get('#track-path').setValue('')
+    await flushPromises()
+    expect(trackButton(wrapper).attributes('disabled')).toBeDefined()
+
+    // No probe should be queued for an empty value.
+    api.probeInstallation.mockClear()
+    await vi.advanceTimersByTimeAsync(300)
+    expect(api.probeInstallation).not.toHaveBeenCalled()
+  })
+
+  it('does not enable the button when no install is detected at the path', async () => {
+    const api = installMockApi({ probeInstallation: vi.fn().mockResolvedValue([]) })
+    const wrapper = mountTrack()
+    ;(wrapper.vm as unknown as { open: () => void }).open()
+    await flushPromises()
+
+    await wrapper.get('#track-path').setValue('/tmp/not-comfy')
+    await vi.advanceTimersByTimeAsync(300)
+    await flushPromises()
+
+    expect(api.probeInstallation).toHaveBeenCalledWith('/tmp/not-comfy')
+    expect(trackButton(wrapper).attributes('disabled')).toBeDefined()
+  })
+})

--- a/src/renderer/src/views/TrackModal.vue
+++ b/src/renderer/src/views/TrackModal.vue
@@ -32,6 +32,34 @@ let returnFocusTo: HTMLElement | null = null
 
 const saveDisabled = computed(() => !trackPath.value || !selectedProbe.value)
 
+/** Path most recently probed — guards the input watcher from re-probing
+ *  a value that `handleBrowse` (or a prior debounce) already handled. */
+let lastProbedPath = ''
+/** Generation counter — bumped on every probe so stale async responses
+ *  from an earlier path are discarded once the field changes again. */
+let probeGeneration = 0
+let probeDebounce: ReturnType<typeof setTimeout> | null = null
+
+/** Re-probe whenever the path field changes, not just via Browse. Typing
+ *  or pasting a directory now triggers detection so a valid existing
+ *  install enables the "Track install" button. Debounced to avoid
+ *  probing on every keystroke; trimmed so trailing whitespace from a
+ *  paste doesn't read as a distinct path. */
+watch(trackPath, (newPath) => {
+  const trimmed = newPath.trim()
+  if (trimmed === lastProbedPath) return
+  if (probeDebounce) clearTimeout(probeDebounce)
+  if (!trimmed) {
+    lastProbedPath = ''
+    probeResults.value = []
+    selectedProbe.value = null
+    return
+  }
+  probeDebounce = setTimeout(() => {
+    void probe(trimmed)
+  }, 300)
+})
+
 function onKeydown(e: KeyboardEvent): void {
   if (e.key === 'Escape' && isOpen.value) emit('close')
 }
@@ -54,11 +82,15 @@ watch(isOpen, async (open) => {
 
 onBeforeUnmount(() => {
   document.removeEventListener('keydown', onKeydown)
+  if (probeDebounce) clearTimeout(probeDebounce)
   if (returnFocusTo && document.contains(returnFocusTo)) returnFocusTo.focus()
   returnFocusTo = null
 })
 
 function open(): void {
+  if (probeDebounce) clearTimeout(probeDebounce)
+  probeDebounce = null
+  lastProbedPath = ''
   trackPath.value = ''
   trackName.value = ''
   probeResults.value = []
@@ -83,18 +115,25 @@ async function handleBrowse(): Promise<void> {
 }
 
 async function probe(dirPath: string): Promise<void> {
+  const generation = ++probeGeneration
+  lastProbedPath = dirPath.trim()
   probing.value = true
   selectedProbe.value = null
   probeResults.value = []
 
+  let results: ProbeResult[]
   try {
-    probeResults.value = await window.api.probeInstallation(dirPath)
+    results = await window.api.probeInstallation(dirPath)
   } finally {
-    probing.value = false
+    // Discard if the field moved on while this probe was in flight.
+    if (generation === probeGeneration) probing.value = false
   }
 
-  if (probeResults.value.length > 0) {
-    selectedProbe.value = probeResults.value[0] ?? null
+  // Stale response from an earlier path — drop it.
+  if (generation !== probeGeneration) return
+  probeResults.value = results
+  if (results.length > 0) {
+    selectedProbe.value = results[0] ?? null
   }
 }
 


### PR DESCRIPTION
## Summary

On the Track Existing Install screen, the **Track Install** button stayed disabled when a user typed or pasted a directory path into the Install Directory field. The install-detection probe (`probe()`) was wired only to the **Browse** button, so any path entered directly never set `selectedProbe` — and the button's `saveDisabled` gate (`!trackPath || !selectedProbe`) kept it disabled.

This adds a debounced watcher on the path field that re-probes on input, so a valid pasted/typed directory now detects the install and enables the button.

- Watcher trims the value (trailing whitespace from a paste no longer reads as a distinct path) and skips re-probing a path that Browse already handled.
- A generation counter discards stale async probe responses when the field changes again mid-flight.
- Clearing the field resets results and re-disables the button; the debounce timer is cleared on open and unmount.

Complements #736 (install-form URL/name validation, which touches `InstallWizardModal.vue`) — no overlap, and valid git URLs/paths are not rejected.

Reported via Prompt & Play QA (Jo Zhang).

Closes #726

## Videos

https://github.com/user-attachments/assets/13ba8d17-4f4a-4d8d-8474-568c3202fc10

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm exec vitest run src/renderer/src/views/TrackModal.test.ts` (4 new specs)
- [x] Manual: paste a git ComfyUI checkout path → detected, Track Install enabled
- [x] Manual: clear the field → button disabled again