### PR TITLE
fix(install): defer baseline snapshot until after first-launch auto-update

### DIFF
--- a/src/main/sources/standalone/install.test.ts
+++ b/src/main/sources/standalone/install.test.ts
@@ -1,0 +1,193 @@
+// @vitest-environment node
+/**
+ * Unit tests for postInstall's snapshot-trigger decision.
+ *
+ * Regression guard for #707: a fresh "Latest Stable" install auto-updates the
+ * just-extracted bundled ComfyUI to the newest release, which writes its own
+ * `post-update` snapshot. Capturing a `boot` snapshot *before* that update
+ * recorded the bundled version (e.g. v0.20.x), leaving the snapshot history
+ * showing a phantom "upgrade" (bundled → latest) the user never performed.
+ *
+ * postInstall should therefore:
+ *  - skip the boot snapshot when an auto-update will run and succeed (the
+ *    post-update snapshot is the single baseline), and
+ *  - still capture a boot snapshot when no auto-update runs, or when the
+ *    auto-update is skipped/fails (so there is always a "Current" baseline).
+ *
+ * Heavy collaborators (uv/venv subprocess, package copy, git, version
+ * resolution, the update orchestrator, mac binary repair) are mocked so the
+ * test exercises only the snapshot decision logic.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import os from 'os'
+import fs from 'fs'
+import path from 'path'
+import { EventEmitter } from 'events'
+import type { InstallationRecord } from '../../installations'
+import type { PostInstallTools } from '../../types/sources'
+
+const SENTINEL_PYTHON = '__TEST_MASTER_PY__'
+const SENTINEL_UV_NAME = '__sentinel_uv__'
+
+vi.mock('electron', () => ({
+  app: { isPackaged: false, getPath: () => '' },
+  ipcMain: { handle: vi.fn() },
+}))
+
+vi.mock('../../lib/i18n', () => ({
+  t: (key: string, params?: Record<string, unknown>) =>
+    params ? `${key}:${JSON.stringify(params)}` : key,
+}))
+
+const saveSnapshot = vi.fn(async (_installPath: string, _installation: unknown, trigger: string) => `${trigger}-snap.json`)
+vi.mock('../../lib/snapshots', () => ({
+  saveSnapshot: (...args: unknown[]) => (saveSnapshot as unknown as (...a: unknown[]) => unknown)(...args),
+  getSnapshotCount: vi.fn(async () => 1),
+}))
+
+vi.mock('../../lib/copy', () => ({
+  copyDirWithProgress: vi.fn(async () => {}),
+}))
+
+vi.mock('../../lib/installer', () => ({
+  downloadAndExtract: vi.fn(async () => {}),
+  downloadAndExtractMulti: vi.fn(async () => {}),
+}))
+
+vi.mock('../../lib/git', () => ({
+  readGitHead: vi.fn(() => 'abc1234abc1234abc1234abc1234abc1234abcd'),
+  isGitAvailable: vi.fn(async () => true),
+  isPygit2Configured: vi.fn(() => true),
+  tryConfigurePygit2Fallback: vi.fn(),
+  fetchTags: vi.fn(async () => {}),
+}))
+
+vi.mock('../../lib/version-resolve', () => ({
+  resolveLocalVersion: vi.fn(async () => ({ commit: 'abc1234', baseTag: 'v0.20.0', commitsAhead: 0 })),
+}))
+
+const fetchLatestRelease = vi.fn(async () => ({ tag_name: 'v0.22.3' }))
+vi.mock('../../lib/comfyui-releases', () => ({
+  fetchLatestRelease: (...args: unknown[]) => (fetchLatestRelease as unknown as (...a: unknown[]) => unknown)(...args),
+}))
+
+vi.mock('./macRepair', () => ({
+  repairMacBinaries: vi.fn(async () => {}),
+  codesignBinaries: vi.fn(async () => {}),
+}))
+
+const runComfyUIUpdate = vi.fn(async (opts: { installation: InstallationRecord }) => ({
+  ok: true,
+  installation: opts.installation,
+}))
+vi.mock('./updateOrchestrator', () => ({
+  runComfyUIUpdate: (...args: unknown[]) => (runComfyUIUpdate as unknown as (...a: unknown[]) => unknown)(...args),
+}))
+
+vi.mock('./envPaths', () => ({
+  MANIFEST_FILE: 'manifest.json',
+  DEFAULT_LAUNCH_ARGS: '',
+  getUvPath: (p: string) => path.join(p, SENTINEL_UV_NAME),
+  getVenvDir: (p: string) => path.join(p, 'ComfyUI', '.venv'),
+  getMasterPythonPath: () => SENTINEL_PYTHON,
+  // Return a real, existing directory so createEnv's existsSync/copy path is satisfied.
+  findSitePackages: () => sitePackagesDir,
+  writeComfyEnvironment: vi.fn(async () => {}),
+}))
+
+// Mock child_process.execFile so createEnv's `uv venv` resolves immediately.
+vi.mock('child_process', () => ({
+  execFile: (_cmd: string, _args: string[], _opts: unknown, cb: (err: Error | null, stdout: string, stderr: string) => void) => {
+    setImmediate(() => cb(null, '', ''))
+    const proc = new EventEmitter() as EventEmitter & { kill: () => void }
+    proc.kill = () => {}
+    return proc
+  },
+}))
+
+// Shared dir referenced by the envPaths mock (set per-test in beforeEach).
+let sitePackagesDir = ''
+
+// Import SUT after mocks.
+import { postInstall } from './install'
+
+function makeInstallation(overrides: Partial<InstallationRecord> & { installPath: string }): InstallationRecord {
+  return {
+    id: 'test-install',
+    name: 'Test',
+    sourceId: 'standalone',
+    status: 'installed',
+    createdAt: new Date(0).toISOString(),
+    version: 'v0.20.0',
+    ...overrides,
+  } as InstallationRecord
+}
+
+function makeTools(installation: InstallationRecord): PostInstallTools {
+  return {
+    sendProgress: vi.fn(),
+    update: vi.fn(async (data: Record<string, unknown>) => {
+      Object.assign(installation, data)
+    }),
+  } as unknown as PostInstallTools
+}
+
+describe('postInstall snapshot trigger (#707)', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    saveSnapshot.mockClear()
+    runComfyUIUpdate.mockClear()
+    fetchLatestRelease.mockClear()
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'postinstall-'))
+    // Lay out the dirs createEnv / postInstall touch.
+    fs.mkdirSync(path.join(tmpDir, 'ComfyUI', '.git'), { recursive: true })
+    sitePackagesDir = path.join(tmpDir, 'standalone-env', 'site-packages')
+    fs.mkdirSync(sitePackagesDir, { recursive: true })
+    fs.mkdirSync(path.join(tmpDir, 'ComfyUI', '.venv'), { recursive: true })
+    fs.writeFileSync(path.join(tmpDir, SENTINEL_UV_NAME), '')
+  })
+
+  afterEach(() => {
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }) } catch {}
+  })
+
+  it('does NOT capture a boot snapshot when a successful auto-update will run', async () => {
+    const installation = makeInstallation({ installPath: tmpDir, autoUpdateComfyUI: true })
+    await postInstall(installation, makeTools(installation))
+
+    expect(runComfyUIUpdate).toHaveBeenCalledTimes(1)
+    // The only snapshot is the orchestrator's post-update one — no boot snapshot here.
+    const triggers = saveSnapshot.mock.calls.map((c) => c[2])
+    expect(triggers).not.toContain('boot')
+  })
+
+  it('captures a boot snapshot when no auto-update runs (pinned release)', async () => {
+    const installation = makeInstallation({ installPath: tmpDir })
+    await postInstall(installation, makeTools(installation))
+
+    expect(runComfyUIUpdate).not.toHaveBeenCalled()
+    const triggers = saveSnapshot.mock.calls.map((c) => c[2])
+    expect(triggers).toEqual(['boot'])
+  })
+
+  it('falls back to a boot snapshot when auto-update is skipped (latest unverifiable)', async () => {
+    fetchLatestRelease.mockResolvedValueOnce(null as unknown as { tag_name: string })
+    const installation = makeInstallation({ installPath: tmpDir, autoUpdateComfyUI: true })
+    await postInstall(installation, makeTools(installation))
+
+    expect(runComfyUIUpdate).not.toHaveBeenCalled()
+    const triggers = saveSnapshot.mock.calls.map((c) => c[2])
+    expect(triggers).toEqual(['boot'])
+  })
+
+  it('falls back to a boot snapshot when the auto-update fails', async () => {
+    runComfyUIUpdate.mockResolvedValueOnce({ ok: false, installation: makeInstallation({ installPath: tmpDir }) })
+    const installation = makeInstallation({ installPath: tmpDir, autoUpdateComfyUI: true })
+    await postInstall(installation, makeTools(installation))
+
+    expect(runComfyUIUpdate).toHaveBeenCalledTimes(1)
+    const triggers = saveSnapshot.mock.calls.map((c) => c[2])
+    expect(triggers).toEqual(['boot'])
+  })
+})

--- a/src/main/sources/standalone/install.ts
+++ b/src/main/sources/standalone/install.ts
@@ -130,20 +130,38 @@ export async function postInstall(installation: InstallationRecord, { sendProgre
     installation = { ...installation, comfyVersion } as InstallationRecord
   }
 
+  // A "Latest Stable" install auto-updates the just-extracted bundled
+  // ComfyUI to the newest release below, which writes its own `post-update`
+  // snapshot at the resolved version. Capturing a `boot` snapshot here first
+  // would record the bundled version (e.g. v0.20.x) and leave the snapshot
+  // history showing a phantom "upgrade" (bundled → latest) that the user
+  // never performed — it is all one uninterrupted fresh install. Defer to the
+  // post-update snapshot in that case so the baseline reflects what actually
+  // landed. When no auto-update runs (a pinned release, or no git), the boot
+  // snapshot is the only baseline and must be taken.
+  const willAutoUpdate = !!installation.autoUpdateComfyUI && fs.existsSync(path.join(comfyuiDir, '.git'))
+
   // Capture initial snapshot so the detail view shows "Current" immediately
-  try {
-    const filename = await snapshots.saveSnapshot(installation.installPath, installation, 'boot')
-    const snapshotCount = await snapshots.getSnapshotCount(installation.installPath)
-    await update({ lastSnapshot: filename, snapshotCount })
-  } catch (err) {
-    console.warn('Initial snapshot failed:', err)
+  if (!willAutoUpdate) {
+    try {
+      const filename = await snapshots.saveSnapshot(installation.installPath, installation, 'boot')
+      const snapshotCount = await snapshots.getSnapshotCount(installation.installPath)
+      await update({ lastSnapshot: filename, snapshotCount })
+    } catch (err) {
+      console.warn('Initial snapshot failed:', err)
+    }
   }
 
   // Auto-update to latest stable release if the user selected "Latest Stable"
-  if (installation.autoUpdateComfyUI && fs.existsSync(path.join(comfyuiDir, '.git'))) {
+  if (willAutoUpdate) {
     if (signal?.aborted) throw new Error('Cancelled')
     sendProgress('update', { percent: -1, status: 'Fetching latest stable version' })
 
+    // Whether the update path wrote its own snapshot (only the successful
+    // `runComfyUIUpdate` post-update path does). If it didn't — already on
+    // latest, network flake, or update failure — we still need a baseline
+    // boot snapshot below so the detail view has a "Current" entry.
+    let snapshotWritten = false
     try {
       // Bypass the in-memory tag cache: it can be poisoned with `null` at
       // app startup when no git backend is configured (installer ships no
@@ -173,6 +191,8 @@ export async function postInstall(installation: InstallationRecord, { sendProgre
         })
         installation = result.installation
         if (result.ok) {
+          // runComfyUIUpdate wrote a post-update snapshot at the resolved version.
+          snapshotWritten = true
           sendProgress('update', { percent: 100, status: 'Up to date' })
         } else {
           sendProgress('update', { percent: 100, status: 'Skipped (update failed)' })
@@ -182,6 +202,20 @@ export async function postInstall(installation: InstallationRecord, { sendProgre
       if ((err as Error).message === 'Cancelled') throw err
       console.warn('Auto-update to latest stable failed:', err)
       sendProgress('update', { percent: 100, status: 'Skipped' })
+    }
+
+    // Fallback baseline: if the update path didn't write a snapshot (already
+    // on latest, couldn't verify, or update failed), capture a boot snapshot
+    // now so the install still has a "Current" baseline. The deferred boot
+    // snapshot reflects the final installed state, so there's no phantom diff.
+    if (!snapshotWritten) {
+      try {
+        const filename = await snapshots.saveSnapshot(installation.installPath, installation, 'boot')
+        const snapshotCount = await snapshots.getSnapshotCount(installation.installPath)
+        await update({ lastSnapshot: filename, snapshotCount })
+      } catch (err) {
+        console.warn('Initial snapshot failed:', err)
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
On a fresh "Latest Stable" install, the snapshot history showed a phantom upgrade (e.g. v0.20.0 → v0.22.3) that the user never performed.

**Root cause:** `postInstall` saved a `boot` snapshot at the just-extracted *bundled* ComfyUI version, *then* ran the first-launch auto-update to the latest release — which writes its own `post-update` snapshot. The two snapshots left a diff in the history that reads as an upgrade, even though it was all one uninterrupted clean install. (Surfaced after #612 made that auto-update actually fire.)

**Fix:** Skip the `boot` snapshot when an auto-update will run; the `post-update` snapshot becomes the single baseline that reflects what actually landed. Fall back to a `boot` snapshot when no auto-update runs (pinned release / no git) or when the update is skipped/fails, so there's always a "Current" baseline.

## Test plan
- [x] New `install.test.ts` covers: successful auto-update (no boot snapshot), pinned release (boot snapshot), latest-unverifiable skip (fallback boot), and update failure (fallback boot)
- [x] `pnpm run typecheck:node` + `typecheck:integration` pass
- [x] `eslint` clean (pre-commit hook)
- [x] Full standalone + snapshot suites pass (119 tests)

Closes #707