### PR TITLE
fix(settings): trim redundant label-echo tooltips on settings tabs

### DIFF
--- a/src/renderer/src/components/settings/ComfyUISettingsContent.test.ts
+++ b/src/renderer/src/components/settings/ComfyUISettingsContent.test.ts
@@ -335,6 +335,79 @@ describe('ComfyUISettingsContent', () => {
     })
   })
 
+  describe('tab tooltips (#713 — no redundant label echo)', () => {
+    type ResizeCb = (entries: ResizeObserverEntry[], obs: ResizeObserver) => void
+    interface RoHandle {
+      el: Element
+      fire(width: number): void
+    }
+    let roHandles: RoHandle[]
+    let originalRo: typeof globalThis.ResizeObserver | undefined
+
+    beforeEach(() => {
+      roHandles = []
+      class StubRo {
+        cb: ResizeCb
+        constructor(cb: ResizeCb) {
+          this.cb = cb
+        }
+        observe(el: Element): void {
+          roHandles.push({
+            el,
+            fire: (width: number) => {
+              this.cb(
+                [{ contentRect: { width, height: 44 } as DOMRectReadOnly } as ResizeObserverEntry],
+                this as unknown as ResizeObserver,
+              )
+            },
+          })
+        }
+        disconnect(): void {}
+        unobserve(): void {}
+      }
+      originalRo = (globalThis as { ResizeObserver?: typeof globalThis.ResizeObserver })
+        .ResizeObserver
+      ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver =
+        StubRo as unknown as typeof globalThis.ResizeObserver
+    })
+    afterEach(() => {
+      if (originalRo) {
+        ;(globalThis as { ResizeObserver?: typeof globalThis.ResizeObserver }).ResizeObserver =
+          originalRo
+      } else {
+        delete (globalThis as { ResizeObserver?: typeof globalThis.ResizeObserver }).ResizeObserver
+      }
+    })
+
+    function tooltipDisabledFlags(w: VueWrapper): boolean[] {
+      return w
+        .findAllComponents({ name: 'Tooltip' })
+        .map((tt) => tt.props('disabled') as boolean)
+    }
+
+    it('disables every tab tooltip at full width (label is visible → pure echo)', async () => {
+      const w = await mountContent()
+      roHandles.forEach((h) => h.fire(900))
+      await nextTick()
+      const flags = tooltipDisabledFlags(w)
+      expect(flags.length).toBeGreaterThan(0)
+      expect(flags.every((d) => d === true)).toBe(true)
+    })
+
+    it('keeps the tooltip on collapsed icon-only tabs but not the active one', async () => {
+      const w = await mountContent({ initialTab: 'update' })
+      roHandles.forEach((h) => h.fire(300))
+      await nextTick()
+      const tooltips = w.findAllComponents({ name: 'Tooltip' })
+      // Active tab (Update) keeps its label → tooltip stays disabled.
+      const updateTip = tooltips.find((tt) => tt.props('text') === 'Update')
+      expect(updateTip?.props('disabled')).toBe(true)
+      // A collapsed, inactive tab hides its label → tooltip is live.
+      const statusTip = tooltips.find((tt) => tt.props('text') === 'About')
+      expect(statusTip?.props('disabled')).toBe(false)
+    })
+  })
+
   describe('op-event relay from SnapshotsView', () => {
     it('forwards op-cancel / op-retry / op-dismiss up to the host', async () => {
       const w = await mountContent({ initialTab: 'snapshots' })

--- a/src/renderer/src/components/settings/ComfyUISettingsContent.vue
+++ b/src/renderer/src/components/settings/ComfyUISettingsContent.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, onUnmounted, ref, toRef, useTemplateRef, watch } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, ref, toRef, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { CheckCircle, XCircle, ChevronUp, HardDrive, SlidersHorizontal, Info, RefreshCw, History } from 'lucide-vue-next'
 import { useComfyUISettings } from '../../composables/useComfyUISettings'
@@ -352,6 +352,42 @@ const statusSections = computed(() => sectionsForTab('status').value)
 const storageSections = computed(() => sectionsForTab('storage').value)
 
 const rootRef = useTemplateRef<HTMLElement>('root')
+const tabsRef = useTemplateRef<HTMLElement>('tabs')
+
+// Tab tooltips echo the visible tab label, which adds nothing when the
+// label is on-screen — and the bottom-anchored popover overlaps the
+// content below (#713). The strip only ever hides labels in its narrow
+// container state: at `< 520px` inactive tabs collapse to icon-only
+// (see the `@container settings-tabs` rule below), where the tooltip is
+// the only thing exposing their label. So we mirror that breakpoint in
+// JS via a ResizeObserver and only keep the tooltip alive for a tab
+// whose label is actually hidden — the active tab always keeps its
+// label, so its tooltip stays suppressed in every state.
+const TAB_COLLAPSE_PX = 520
+const tabsCollapsed = ref(false)
+let tabsObserver: ResizeObserver | undefined
+
+onMounted(() => {
+  if (tabsRef.value && typeof ResizeObserver !== 'undefined') {
+    tabsObserver = new ResizeObserver((entries) => {
+      const entry = entries[0]
+      if (!entry) return
+      tabsCollapsed.value = entry.contentRect.width < TAB_COLLAPSE_PX
+    })
+    tabsObserver.observe(tabsRef.value)
+  }
+})
+
+onUnmounted(() => {
+  tabsObserver?.disconnect()
+  tabsObserver = undefined
+})
+
+/** A tab's label is hidden — so its tooltip carries real info — only
+ *  when the strip is collapsed and the tab isn't the active one. */
+function isTabLabelHidden(key: ComfyUISettingsTab): boolean {
+  return tabsCollapsed.value && activeTab.value !== key
+}
 
 function handleTabKeydown(event: KeyboardEvent, index: number): void {
   if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') return
@@ -597,6 +633,7 @@ defineExpose({
 <template>
   <div ref="root" class="settings-v2-content">
     <nav
+      ref="tabs"
       class="settings-v2-tabs"
       :class="{ 'is-subpage-active': subPage !== null }"
       role="tablist"
@@ -608,6 +645,7 @@ defineExpose({
         :key="tab.key"
         :text="tab.label"
         side="bottom"
+        :disabled="!isTabLabelHidden(tab.key)"
       >
         <button
           type="button"


### PR DESCRIPTION
## Summary

The settings tab strip (Update · Startup Args · Snapshots · Storage · About) wrapped every tab button in a tooltip whose text just echoed the tab's own always-visible label. Hovering e.g. the "Snapshots" tab popped a "Snapshots" tooltip — zero added info, and the bottom-anchored popover overlapped the content beneath the strip (reported in Prompt & Play QA).

## Fix

Gate each tab tooltip on whether its label is actually hidden, rather than removing the tooltip outright:

- The strip only hides labels in its narrow-container state (`@container settings-tabs (max-width: 520px)`), where inactive tabs collapse to icon-only. There the tooltip is the sole way to read the label, so it's genuinely useful and is kept.
- In the wide state (the reported case) every label is visible, so all tab tooltips are suppressed.
- The active tab always keeps its label, so its echo tooltip is suppressed in every state.

A `ResizeObserver` (mirroring the existing `TitleBarApp` pattern, with the same `typeof ResizeObserver !== 'undefined'` guard) tracks the collapse breakpoint in JS and drives the `Tooltip`'s `disabled` prop.

Scope is strictly the tab-bar echo tooltips; panel-body help (e.g. #702's "what is a Snapshot") is untouched.

## Files

- `src/renderer/src/components/settings/ComfyUISettingsContent.vue`
- `src/renderer/src/components/settings/ComfyUISettingsContent.test.ts`

## Validation

- `pnpm typecheck` (node/web/e2e/integration) — pass
- `pnpm lint` — pass
- `pnpm vitest run ComfyUISettingsContent.test.ts` — 19/19 pass (2 new cases lock the suppress-at-wide / keep-on-collapsed behaviour)

Closes #713