### PR TITLE
fix(host): recover comfy-view zoom-in (zoom no longer stuck after restart)

### DIFF
--- a/src/main/host/attach.ts
+++ b/src/main/host/attach.ts
@@ -14,6 +14,7 @@ import {
   setLastFocusedInstallationId,
 } from './registry'
 import type { ComfyWindowEntry } from './registry'
+import { nextZoomLevel } from './zoom'
 
 const APP_VERSION = getAppVersion()
 
@@ -306,6 +307,14 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
     if (!isLocal) {
       comfyContents.executeJavaScript(COMFY_CLOUD_PATCHES_JS).catch(() => {})
     }
+    // Reconcile zoom: Electron re-applies the persisted per-partition
+    // zoom level on navigation, which can leave the view stranded at a
+    // stuck (zoomed-out) level across reload / restart. Re-assert the
+    // desktop-tracked level so it stays the single source of truth and
+    // the user can always recover to 1x. See #698.
+    if (!comfyContents.isDestroyed() && comfyContents.getZoomLevel() !== zoomLevel) {
+      comfyContents.setZoomLevel(zoomLevel)
+    }
   }
   comfyContents.on('dom-ready', onDomReady)
 
@@ -320,6 +329,20 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
     if (fx.relaunchStates.has(id)) return
     comfyContents.stop()
     comfyContents.loadURL(currentComfyUrl())
+  }
+  // Desktop-tracked zoom level — the single source of truth for the
+  // comfy view's zoom, seeded from whatever Electron restored for this
+  // session partition. Electron persists zoom per `persist:` partition,
+  // so a stuck (zoomed-out) level survives restart; `getZoomLevel()` can
+  // also drift out of sync with the visually-applied level after a
+  // navigation. Tracking the level here (and re-applying it on
+  // `dom-ready`) keeps zoom-in / zoom-out symmetric and always
+  // recoverable to 1x. See #698.
+  let zoomLevel = comfyContents.isDestroyed() ? 0 : comfyContents.getZoomLevel()
+  const applyZoomLevel = (next: number): void => {
+    if (comfyContents.isDestroyed()) return
+    zoomLevel = next
+    comfyContents.setZoomLevel(next)
   }
   const onBeforeInputEvent = (e: Electron.Event, input: Electron.Input): void => {
     if (input.type !== 'keyDown') return
@@ -351,8 +374,8 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
       e.preventDefault()
       if (comfyContents.isDestroyed()) return
       if (input.key === '0') {
-        const previousLevel = comfyContents.getZoomLevel()
-        comfyContents.setZoomLevel(0)
+        const previousLevel = zoomLevel
+        applyZoomLevel(0)
         // Only emit when this was a real reset (skip no-op presses at 1x)
         // so the event count tracks actual recovery actions, not key-spam.
         if (previousLevel !== 0) {
@@ -366,8 +389,7 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
         }
         return
       }
-      const step = input.key === '-' ? -0.5 : 0.5
-      comfyContents.setZoomLevel(comfyContents.getZoomLevel() + step)
+      applyZoomLevel(nextZoomLevel(input.key, zoomLevel))
     }
   }
   comfyContents.on('before-input-event', onBeforeInputEvent)

--- a/src/main/host/zoom.test.ts
+++ b/src/main/host/zoom.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import { nextZoomLevel, ZOOM_LEVEL_MAX, ZOOM_LEVEL_MIN, ZOOM_STEP } from './zoom'
+
+describe('nextZoomLevel — Ctrl/Cmd +/-/0 zoom (issue #698)', () => {
+  it('zooms IN symmetrically from a zoomed-out level (the regression)', () => {
+    // Stuck zoomed-out at -2 after restart; pressing "=" / "+" must climb
+    // back up the same step it shrank by. Driving off the tracked level
+    // (not a stale getZoomLevel) is what makes this recover.
+    expect(nextZoomLevel('=', -2)).toBe(-2 + ZOOM_STEP)
+    expect(nextZoomLevel('+', -2)).toBe(-2 + ZOOM_STEP)
+  })
+
+  it('zooms OUT by the same step', () => {
+    expect(nextZoomLevel('-', 1)).toBe(1 - ZOOM_STEP)
+  })
+
+  it('in and out are exact inverses around any level', () => {
+    const level = 1.5
+    expect(nextZoomLevel('-', nextZoomLevel('=', level))).toBe(level)
+  })
+
+  it('reset key returns to 1x (level 0) from either direction', () => {
+    expect(nextZoomLevel('0', 3)).toBe(0)
+    expect(nextZoomLevel('0', -3)).toBe(0)
+  })
+
+  it('clamps to the recoverable range so zoom never strands the view', () => {
+    expect(nextZoomLevel('=', ZOOM_LEVEL_MAX)).toBe(ZOOM_LEVEL_MAX)
+    expect(nextZoomLevel('-', ZOOM_LEVEL_MIN)).toBe(ZOOM_LEVEL_MIN)
+    // From the clamped-out extreme, zooming back in always makes progress.
+    expect(nextZoomLevel('=', ZOOM_LEVEL_MIN)).toBe(ZOOM_LEVEL_MIN + ZOOM_STEP)
+  })
+})

--- a/src/main/host/zoom.ts
+++ b/src/main/host/zoom.ts
@@ -1,0 +1,36 @@
+/**
+ * Pure zoom-level math for the comfy view's Ctrl/Cmd +/-/0 shortcut.
+ *
+ * Kept dependency-free (no electron import) so it stays trivially
+ * unit-testable, and so the desktop drives zoom off a tracked absolute
+ * level instead of a fresh `webContents.getZoomLevel()` read. After a
+ * navigation, Chromium can report a level out of sync with the visually-
+ * applied (persisted, per-`persist:` partition) zoom, which made zoom-in
+ * silently stall while zoom-out still shrank, and left a stuck level
+ * across restart. See issue #698.
+ */
+
+/** Zoom granularity. 0.5 mirrors Electron's standard zoomLevel step
+ *  (~91% / 110% / ...). */
+export const ZOOM_STEP = 0.5
+
+/** Bounds for the desktop-managed comfy-view zoom level. Chromium clamps
+ *  `setZoomLevel` to roughly [-7.6, 9] internally; we keep a tighter,
+ *  symmetric range so a user can always zoom back to 1x (level 0) from
+ *  either extreme. */
+export const ZOOM_LEVEL_MIN = -5
+export const ZOOM_LEVEL_MAX = 5
+
+/**
+ * Compute the next zoom level for a `before-input-event` keystroke.
+ *
+ * @param key      the event's `input.key` — one of `'='` / `'+'` (in),
+ *                 `'-'` (out), or `'0'` (reset).
+ * @param current  the desktop-tracked level (NOT a fresh getZoomLevel).
+ * @returns        the clamped next level.
+ */
+export function nextZoomLevel(key: string, current: number): number {
+  if (key === '0') return 0
+  const step = key === '-' ? -ZOOM_STEP : ZOOM_STEP
+  return Math.min(ZOOM_LEVEL_MAX, Math.max(ZOOM_LEVEL_MIN, current + step))
+}


### PR DESCRIPTION
## Summary

Closes #698.

In Desktop 2.0 you could only zoom **out** with Ctrl/Cmd +/- on the comfy view — you couldn't zoom back **in**, and the stuck level survived an app restart.

Two root causes, both on the desktop side:

- **Persists across restart:** the comfy `WebContentsView` lives in a `persist:` session partition, and Electron persists the zoom level per-partition. Nothing reconciled it on load, so a zoomed-out level was restored on every launch.
- **Can't zoom back in:** the `before-input-event` handler incremented off a fresh `webContents.getZoomLevel()`, which drifts out of sync with the visually-applied persisted zoom right after a navigation (known Electron behavior). Zoom-out still visibly shrank, but zoom-in stalled.

## Fix

- Track the zoom level as the single source of truth in the attach closure; drive +/-/0 off it (clamped to a recoverable range so 1x is always reachable).
- Re-assert the tracked level on `dom-ready` so a persisted/stale level can't strand the view across reload or restart.
- Extract the pure level math to `src/main/host/zoom.ts` with unit tests.

## Test plan

- [x] `pnpm typecheck` (node/web/e2e/integration) passes
- [x] `pnpm lint` passes
- [x] `pnpm exec vitest run src/main/host/zoom.test.ts` — 5/5 pass (zoom-in recovers from a zoomed-out level, in/out are inverses, reset returns to 1x, clamping)
- [ ] Manual: zoom out with Ctrl/Cmd+-, then zoom back in with Ctrl/Cmd+= to 1x; restart app and confirm zoom is no longer stuck