### PR TITLE
feat(settings): explain Instances and Snapshots with tooltips

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -975,6 +975,8 @@
   },
 
   "tooltips": {
+    "instances": "A separate ComfyUI installation with its own version, models, and settings.",
+    "snapshots": "A saved point-in-time state of an installation (versions + custom nodes) you can restore later.",
     "standalone": "A self-contained install with its own bundled Python and dependencies. Easy to update and manage.",
     "portable": "The official portable Windows build with embedded Python. Runs from a single folder without a system-wide install.",
     "git": "A git-based install cloned from the ComfyUI repository. Requires git and Python to be installed on your system.",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -638,6 +638,8 @@
   },
 
   "tooltips": {
+    "instances": "一个独立的 ComfyUI 安装，拥有各自的版本、模型和设置。",
+    "snapshots": "已保存的安装时间点状态（版本 + 自定义节点），可随时恢复。",
     "updateNow": "就地更新此安装。",
     "copyAndUpdate": "复制此安装并更新副本。原始安装保持不变。"
   }

--- a/src/renderer/src/comfyTitlePopup/InstancePickerView.vue
+++ b/src/renderer/src/comfyTitlePopup/InstancePickerView.vue
@@ -6,6 +6,7 @@ import BaseInput from '../components/ui/BaseInput.vue'
 import { FILTER_CHIPS, useInstallList } from '../composables/useInstallList'
 import { useSessionStore } from '../stores/sessionStore'
 import ComfyUISettingsContent from '../components/settings/ComfyUISettingsContent.vue'
+import InfoTooltip from '../components/InfoTooltip.vue'
 import InstanceRow from './instancePicker/InstanceRow.vue'
 import { resolvePickerTab, type PickerTab } from '../lib/pickerTabs'
 import { resolveProgressRouting } from '../lib/pickerProgressRouting'
@@ -550,7 +551,7 @@ function handleExpandedPrimaryAction(running: boolean): void {
     <div class="picker-body">
       <div class="picker-left">
         <div class="picker-list-section">
-          <div class="picker-list-section-title">{{ $t('instancePicker.instances') }}</div>
+          <div class="picker-list-section-title">{{ $t('instancePicker.instances') }}<InfoTooltip :text="$t('tooltips.instances')" side="bottom" /></div>
 
           <div class="picker-list" role="listbox">
             <InstanceRow

--- a/src/renderer/src/components/settings/ComfyUISettingsContent.test.ts
+++ b/src/renderer/src/components/settings/ComfyUISettingsContent.test.ts
@@ -339,7 +339,7 @@ describe('ComfyUISettingsContent', () => {
     })
   })
 
-  describe('tab tooltips (#713 — no redundant label echo)', () => {
+  describe('tab tooltips (#702 concept tooltips + #713 — no redundant label echo)', () => {
     type ResizeCb = (entries: ResizeObserverEntry[], obs: ResizeObserver) => void
     interface RoHandle {
       el: Element
@@ -383,19 +383,44 @@ describe('ComfyUISettingsContent', () => {
       }
     })
 
-    function tooltipDisabledFlags(w: VueWrapper): boolean[] {
+    const SNAPSHOTS_TOOLTIP =
+      'A saved point-in-time state of an installation (versions + custom nodes) you can restore later.'
+
+    /** Tooltips for tabs that only echo their label (no explicit concept
+     *  copy). The Snapshots tab carries a real concept tooltip and is
+     *  exempt from the "disabled at full width" rule. */
+    function labelEchoDisabledFlags(w: VueWrapper): boolean[] {
       return w
         .findAllComponents({ name: 'Tooltip' })
+        .filter((tt) => tt.props('text') !== SNAPSHOTS_TOOLTIP)
         .map((tt) => tt.props('disabled') as boolean)
     }
 
-    it('disables every tab tooltip at full width (label is visible → pure echo)', async () => {
+    it('disables label-echo tab tooltips at full width (label is visible → pure echo)', async () => {
       const w = await mountContent()
       roHandles.forEach((h) => h.fire(900))
       await nextTick()
-      const flags = tooltipDisabledFlags(w)
+      const flags = labelEchoDisabledFlags(w)
       expect(flags.length).toBeGreaterThan(0)
       expect(flags.every((d) => d === true)).toBe(true)
+    })
+
+    it('always shows the Snapshots concept tooltip regardless of strip width', async () => {
+      const w = await mountContent({ initialTab: 'snapshots' })
+      const snapshotTip = () =>
+        w
+          .findAllComponents({ name: 'Tooltip' })
+          .find((tt) => tt.props('text') === SNAPSHOTS_TOOLTIP)
+      // Full width — an echo tab would be suppressed here, but the concept
+      // tooltip stays live because it adds info beyond the label.
+      roHandles.forEach((h) => h.fire(900))
+      await nextTick()
+      expect(snapshotTip()?.props('disabled')).toBe(false)
+      // Collapsed — still live (and it's the active tab, which would also
+      // suppress a pure echo).
+      roHandles.forEach((h) => h.fire(300))
+      await nextTick()
+      expect(snapshotTip()?.props('disabled')).toBe(false)
     })
 
     it('keeps the tooltip on collapsed icon-only tabs but not the active one', async () => {

--- a/src/renderer/src/components/settings/ComfyUISettingsContent.test.ts
+++ b/src/renderer/src/components/settings/ComfyUISettingsContent.test.ts
@@ -335,6 +335,79 @@ describe('ComfyUISettingsContent', () => {
     })
   })
 
+  describe('tab tooltips (#713 — no redundant label echo)', () => {
+    type ResizeCb = (entries: ResizeObserverEntry[], obs: ResizeObserver) => void
+    interface RoHandle {
+      el: Element
+      fire(width: number): void
+    }
+    let roHandles: RoHandle[]
+    let originalRo: typeof globalThis.ResizeObserver | undefined
+
+    beforeEach(() => {
+      roHandles = []
+      class StubRo {
+        cb: ResizeCb
+        constructor(cb: ResizeCb) {
+          this.cb = cb
+        }
+        observe(el: Element): void {
+          roHandles.push({
+            el,
+            fire: (width: number) => {
+              this.cb(
+                [{ contentRect: { width, height: 44 } as DOMRectReadOnly } as ResizeObserverEntry],
+                this as unknown as ResizeObserver,
+              )
+            },
+          })
+        }
+        disconnect(): void {}
+        unobserve(): void {}
+      }
+      originalRo = (globalThis as { ResizeObserver?: typeof globalThis.ResizeObserver })
+        .ResizeObserver
+      ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver =
+        StubRo as unknown as typeof globalThis.ResizeObserver
+    })
+    afterEach(() => {
+      if (originalRo) {
+        ;(globalThis as { ResizeObserver?: typeof globalThis.ResizeObserver }).ResizeObserver =
+          originalRo
+      } else {
+        delete (globalThis as { ResizeObserver?: typeof globalThis.ResizeObserver }).ResizeObserver
+      }
+    })
+
+    function tooltipDisabledFlags(w: VueWrapper): boolean[] {
+      return w
+        .findAllComponents({ name: 'Tooltip' })
+        .map((tt) => tt.props('disabled') as boolean)
+    }
+
+    it('disables every tab tooltip at full width (label is visible → pure echo)', async () => {
+      const w = await mountContent()
+      roHandles.forEach((h) => h.fire(900))
+      await nextTick()
+      const flags = tooltipDisabledFlags(w)
+      expect(flags.length).toBeGreaterThan(0)
+      expect(flags.every((d) => d === true)).toBe(true)
+    })
+
+    it('keeps the tooltip on collapsed icon-only tabs but not the active one', async () => {
+      const w = await mountContent({ initialTab: 'update' })
+      roHandles.forEach((h) => h.fire(300))
+      await nextTick()
+      const tooltips = w.findAllComponents({ name: 'Tooltip' })
+      // Active tab (Update) keeps its label → tooltip stays disabled.
+      const updateTip = tooltips.find((tt) => tt.props('text') === 'Update')
+      expect(updateTip?.props('disabled')).toBe(true)
+      // A collapsed, inactive tab hides its label → tooltip is live.
+      const statusTip = tooltips.find((tt) => tt.props('text') === 'About')
+      expect(statusTip?.props('disabled')).toBe(false)
+    })
+  })
+
   describe('op-event relay from SnapshotsView', () => {
     it('forwards op-cancel / op-retry / op-dismiss up to the host', async () => {
       const w = await mountContent({ initialTab: 'snapshots' })

--- a/src/renderer/src/components/settings/ComfyUISettingsContent.test.ts
+++ b/src/renderer/src/components/settings/ComfyUISettingsContent.test.ts
@@ -34,6 +34,10 @@ const messages = {
       relaunch: 'Relaunch',
       more: 'More',
     },
+    tooltips: {
+      snapshots:
+        'A saved point-in-time state of an installation (versions + custom nodes) you can restore later.',
+    },
     instancePicker: {
       open: 'Open',
       restart: 'Restart',

--- a/src/renderer/src/components/settings/ComfyUISettingsContent.vue
+++ b/src/renderer/src/components/settings/ComfyUISettingsContent.vue
@@ -650,7 +650,7 @@ defineExpose({
         :key="tab.key"
         :text="tab.tooltip ?? tab.label"
         side="bottom"
-        :disabled="!isTabLabelHidden(tab.key)"
+        :disabled="tab.tooltip ? false : !isTabLabelHidden(tab.key)"
       >
         <button
           type="button"

--- a/src/renderer/src/components/settings/ComfyUISettingsContent.vue
+++ b/src/renderer/src/components/settings/ComfyUISettingsContent.vue
@@ -273,6 +273,10 @@ interface TabDef {
   sectionTab: SectionTab
   label: string
   icon: typeof SlidersHorizontal
+  /** Optional richer hover copy for the tab strip. Most tabs just echo
+   *  their label; concept-heavy tabs (e.g. Snapshots) explain the term
+   *  to new users instead. Falls back to `label` when unset. */
+  tooltip?: string
 }
 
 const ALL_TABS: TabDef[] = [
@@ -292,7 +296,8 @@ const ALL_TABS: TabDef[] = [
     key: 'snapshots',
     sectionTab: 'snapshots',
     label: t('comfyUISettings.tabSnapshots', 'Snapshots'),
-    icon: History
+    icon: History,
+    tooltip: t('tooltips.snapshots')
   },
   {
     key: 'storage',
@@ -606,7 +611,7 @@ defineExpose({
       <Tooltip
         v-for="(tab, i) in tabs"
         :key="tab.key"
-        :text="tab.label"
+        :text="tab.tooltip ?? tab.label"
         side="bottom"
       >
         <button

--- a/src/renderer/src/components/settings/ComfyUISettingsContent.vue
+++ b/src/renderer/src/components/settings/ComfyUISettingsContent.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, onUnmounted, ref, toRef, useTemplateRef, watch } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, ref, toRef, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { CheckCircle, XCircle, ChevronUp, HardDrive, SlidersHorizontal, Info, RefreshCw, History } from 'lucide-vue-next'
 import { useComfyUISettings } from '../../composables/useComfyUISettings'
@@ -352,6 +352,42 @@ const statusSections = computed(() => sectionsForTab('status').value)
 const storageSections = computed(() => sectionsForTab('storage').value)
 
 const rootRef = useTemplateRef<HTMLElement>('root')
+const tabsRef = useTemplateRef<HTMLElement>('tabs')
+
+// Tab tooltips echo the visible tab label, which adds nothing when the
+// label is on-screen — and the bottom-anchored popover overlaps the
+// content below (#713). The strip only ever hides labels in its narrow
+// container state: at `< 520px` inactive tabs collapse to icon-only
+// (see the `@container settings-tabs` rule below), where the tooltip is
+// the only thing exposing their label. So we mirror that breakpoint in
+// JS via a ResizeObserver and only keep the tooltip alive for a tab
+// whose label is actually hidden — the active tab always keeps its
+// label, so its tooltip stays suppressed in every state.
+const TAB_COLLAPSE_PX = 520
+const tabsCollapsed = ref(false)
+let tabsObserver: ResizeObserver | undefined
+
+onMounted(() => {
+  if (tabsRef.value && typeof ResizeObserver !== 'undefined') {
+    tabsObserver = new ResizeObserver((entries) => {
+      const entry = entries[0]
+      if (!entry) return
+      tabsCollapsed.value = entry.contentRect.width < TAB_COLLAPSE_PX
+    })
+    tabsObserver.observe(tabsRef.value)
+  }
+})
+
+onUnmounted(() => {
+  tabsObserver?.disconnect()
+  tabsObserver = undefined
+})
+
+/** A tab's label is hidden — so its tooltip carries real info — only
+ *  when the strip is collapsed and the tab isn't the active one. */
+function isTabLabelHidden(key: ComfyUISettingsTab): boolean {
+  return tabsCollapsed.value && activeTab.value !== key
+}
 
 function handleTabKeydown(event: KeyboardEvent, index: number): void {
   if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') return
@@ -597,6 +633,7 @@ defineExpose({
 <template>
   <div ref="root" class="settings-v2-content">
     <nav
+      ref="tabs"
       class="settings-v2-tabs"
       :class="{ 'is-subpage-active': subPage !== null }"
       role="tablist"
@@ -608,6 +645,7 @@ defineExpose({
         :key="tab.key"
         :text="tab.label"
         side="bottom"
+        :disabled="!isTabLabelHidden(tab.key)"
       >
         <button
           type="button"

--- a/src/renderer/src/lib/i18nMessages.ts
+++ b/src/renderer/src/lib/i18nMessages.ts
@@ -63,6 +63,10 @@ export const en = {
     moreActions: 'More actions'
   },
   tooltips: {
+    instances:
+      'A separate ComfyUI installation with its own version, models, and settings.',
+    snapshots:
+      'A saved point-in-time state of an installation (versions + custom nodes) you can restore later.',
     sharedModels:
       "Folders shared across all installations so models aren't downloaded twice. Newly downloaded models go to the primary folder. The system default folder is always kept and can't be removed, and the primary folder can't be removed while it's in use — pick a different primary first.",
     modelsPrimary:


### PR DESCRIPTION
Closes #702
Closes #713

## Summary

Prompt & Play QA (Robin Huang) flagged that core concepts — **Instances** and **Snapshots** — could use a bit more explanation. This adds two concept-explaining tooltips using the existing tooltip mechanism, plus their i18n strings.

- **Instances**: the "Instances" section title in the instance picker now carries an `InfoTooltip` (help-icon, bottom-anchored).
- **Snapshots**: the Snapshots settings tab now shows richer hover copy that explains the concept, instead of echoing its own label. Implemented via an optional `tooltip?` field on `TabDef` (`tab.tooltip ?? tab.label`), so other tabs keep their existing label-echo behavior.

## Strings

- `locales/en.json` + `locales/zh.json` — `tooltips.instances` / `tooltips.snapshots` (added into the existing `tooltips` block; zh already had that block).
- `src/renderer/src/lib/i18nMessages.ts` — same two keys, required because the title-popup webContents resolve against this catalog (not `locales/*.json`).

## Tests

- Added `tooltips.snapshots` to the `ComfyUISettingsContent.test.ts` i18n fixture so the new tab tooltip resolves (kills the `[intlify] Not found` warning).
- `pnpm typecheck` + `pnpm lint` clean. Renderer unit suites pass (main-process `src/main/**` test files fail only due to a missing local Electron binary, unrelated to this diff and reproducible on clean main).

## Merged with #742 (trim redundant label-echo tab tooltips)

This PR now also folds in #742, so it closes both #702 and #713. Combined tab-tooltip rule:

- A tab with an explicit concept tooltip (Snapshots) **always** shows it (`tab.tooltip ? false : …`).
- A tab with no concept tooltip (Update / Startup Args / Storage / About) shows its tooltip **only when the label is hidden** (collapsed/icon-only), gated by #742's `ResizeObserver` + `isTabLabelHidden()`.
- Net binding: `:text="tab.tooltip ?? tab.label"`, `:disabled="tab.tooltip ? false : !isTabLabelHidden(tab.key)"`.

Both PRs' test additions are merged and reconciled to this combined behavior; `ComfyUISettingsContent.test.ts` and `InstancePickerView.test.ts` pass.
