### PR TITLE
reset-{mac,linux,windows}: sweep up electron-updater cache, Squirrel state, and legacy v1.x desktop leftovers

### DIFF
--- a/scripts/reset-linux.sh
+++ b/scripts/reset-linux.sh
@@ -32,9 +32,10 @@ if [ "$(uname -s)" != "Linux" ]; then
   exit 1
 fi
 
-# Refuse to run while the app is open
-if pgrep -f "comfyui-desktop-2|ComfyUI Desktop 2.0|comfyui-launcher|ComfyUI Launcher" >/dev/null 2>&1; then
-  echo "ComfyUI Desktop 2.0 / Launcher is running. Please quit it first,"
+# Refuse to run while the app is open (includes the upcoming post-rename
+# "ComfyUI Desktop" display name)
+if pgrep -f "comfyui-desktop-2|ComfyUI Desktop 2.0|ComfyUI Desktop|comfyui-launcher|ComfyUI Launcher" >/dev/null 2>&1; then
+  echo "ComfyUI Desktop / Launcher is running. Please quit it first,"
   echo "then re-run this script."
   exit 1
 fi
@@ -46,10 +47,16 @@ XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
 XDG_STATE_HOME="${XDG_STATE_HOME:-$HOME/.local/state}"
 
 # Every historical app/package name. The userData folder on Linux is named
-# after the package.json "name" field (NOT productName).
+# after the package.json "name" field (NOT productName). "ComfyUI Desktop"
+# is included for the upcoming post-rename productName. "ComfyUI" covers
+# the legacy v1.x desktop app (productName "ComfyUI") whose state can
+# survive an upgrade to the 2.0 beta and break a clean install (mirrors
+# #679's macOS findings).
 APP_NAMES=(
   "comfyui-desktop-2"
   "comfyui-launcher"
+  "ComfyUI"
+  "ComfyUI Desktop"
   "ComfyUI Desktop 2.0"
   "ComfyUI Launcher"
 )
@@ -58,10 +65,11 @@ TARGETS=()
 
 for name in "${APP_NAMES[@]}"; do
   TARGETS+=(
-    "$XDG_CONFIG_HOME/$name"     # userData / settings.json / Chromium profile
-    "$XDG_CACHE_HOME/$name"      # download-cache (after XDG migration)
-    "$XDG_DATA_HOME/$name"       # installations.json, shared_model_paths.yaml
-    "$XDG_STATE_HOME/$name"      # port-locks
+    "$XDG_CONFIG_HOME/$name"             # userData / settings.json / Chromium profile
+    "$XDG_CACHE_HOME/$name"              # download-cache (after XDG migration)
+    "$XDG_CACHE_HOME/${name}-updater"    # electron-updater pending update cache
+    "$XDG_DATA_HOME/$name"               # installations.json, shared_model_paths.yaml
+    "$XDG_STATE_HOME/$name"              # port-locks
   )
 done
 

--- a/scripts/reset-mac.sh
+++ b/scripts/reset-mac.sh
@@ -33,17 +33,35 @@ if [ "$(uname -s)" != "Darwin" ]; then
   exit 1
 fi
 
-# Refuse to run while the app is open
-if pgrep -x "ComfyUI Desktop 2.0" >/dev/null 2>&1 \
+# Refuse to run while the app is open (includes the upcoming post-rename
+# "ComfyUI Desktop" process name)
+if pgrep -x "ComfyUI Desktop"     >/dev/null 2>&1 \
+   || pgrep -x "ComfyUI Desktop 2.0" >/dev/null 2>&1 \
    || pgrep -x "ComfyUI Launcher"  >/dev/null 2>&1; then
-  echo "ComfyUI Desktop 2.0 / Launcher is running. Please quit it first (Cmd+Q),"
+  echo "ComfyUI Desktop / Launcher is running. Please quit it first (Cmd+Q),"
   echo "then re-run this script."
   exit 1
 fi
 
+# Product (display) names that map to ~/Library/Application Support and Logs
+# folders. Includes the upcoming post-rename name ("ComfyUI Desktop") so
+# scripts shipped today still work after the 2.0 suffix drops, and the
+# legacy v1.x desktop productName ("ComfyUI") whose userData/logs survive
+# an upgrade to the 2.0 beta and have caused clean-install issues (#679).
 PRODUCT_NAMES=(
+  "ComfyUI"
+  "ComfyUI Desktop"
   "ComfyUI Desktop 2.0"
   "ComfyUI Launcher"
+)
+
+# Package.json "name" values. Electron uses this for userData in dev/source
+# runs, and electron-updater uses it (+ "-updater") for the auto-update
+# cache that holds pending update.zip blobs — leaving this around lets a
+# fresh install get clobbered by a stale cached update on next launch.
+PACKAGE_NAMES=(
+  "comfyui-desktop-2"
+  "comfyui-launcher"
 )
 
 BUNDLE_IDS=(
@@ -61,10 +79,25 @@ for name in "${PRODUCT_NAMES[@]}"; do
   )
 done
 
+for name in "${PACKAGE_NAMES[@]}"; do
+  TARGETS+=(
+    # Dev / source-run userData (Electron falls back to package.json "name"
+    # when productName isn't honored).
+    "$HOME/Library/Application Support/$name"
+    # electron-updater pending-update cache (holds update.zip + pending/).
+    # If left in place, the updater can re-apply a stale update over the
+    # freshly-installed .app on next launch.
+    "$HOME/Library/Caches/${name}-updater"
+  )
+done
+
 for id in "${BUNDLE_IDS[@]}"; do
   TARGETS+=(
     "$HOME/Library/Preferences/${id}.plist"
     "$HOME/Library/Caches/${id}"
+    # Squirrel.Mac ShipIt cache — handles in-place app replacement during
+    # auto-update; stale state here can re-trigger an old swap.
+    "$HOME/Library/Caches/${id}.ShipIt"
     "$HOME/Library/Saved Application State/${id}.savedState"
     "$HOME/Library/WebKit/${id}"
   )
@@ -73,6 +106,16 @@ for id in "${BUNDLE_IDS[@]}"; do
            "$HOME/Library/HTTPStorages/${id}.binarycookies"; do
     TARGETS+=("$p")
   done
+done
+
+# Warn (don't auto-delete) about extra .app copies — multiple installs in
+# different locations are a common cause of "I reinstalled but it's still
+# broken" because the user keeps launching an older copy.
+APP_LOCATIONS=()
+for app_name in "${PRODUCT_NAMES[@]}"; do
+  while IFS= read -r line; do
+    [ -n "$line" ] && APP_LOCATIONS+=("$line")
+  done < <(mdfind "kMDItemFSName == '${app_name}.app'" 2>/dev/null)
 done
 
 EXISTING=()
@@ -96,6 +139,19 @@ echo
 echo "Your ComfyUI installs at ~/ComfyUI-Installs will NOT be touched."
 echo "(You may need to re-add them via 'Add existing installation' on first launch.)"
 echo
+
+# Surface any .app copies the user has on disk. We don't delete them — the
+# user may legitimately keep multiple builds around — but flag them so they
+# can verify they're launching the right one. Multiple .apps in different
+# locations is the most common reason a "reset" appears not to work: the
+# user's Dock keeps launching an older cached copy.
+if [ ${#APP_LOCATIONS[@]} -gt 0 ]; then
+  echo "Found these app copies on disk (NOT deleted — verify you launch the right one):"
+  for app in "${APP_LOCATIONS[@]}"; do
+    echo "  $app"
+  done
+  echo
+fi
 
 if [ "$YES" -ne 1 ]; then
   printf "Proceed? [y/N] "

--- a/scripts/reset-mac.sh
+++ b/scripts/reset-mac.sh
@@ -108,6 +108,10 @@ for id in "${BUNDLE_IDS[@]}"; do
            "$HOME/Library/HTTPStorages/${id}.binarycookies"; do
     TARGETS+=("$p")
   done
+  # Native macOS cookies jar (separate from Chromium's Cookies file
+  # inside userData). NSURLSession-style native calls write here if the
+  # app ever makes them.
+  TARGETS+=("$HOME/Library/Cookies/${id}.binarycookies")
   # Per-host Preferences (Squirrel.Mac writes ShipIt state under
   # ~/Library/Preferences/ByHost/<id>.ShipIt.<HOST-UUID>.plist; the
   # host-UUID suffix varies per machine so we glob).

--- a/scripts/reset-mac.sh
+++ b/scripts/reset-mac.sh
@@ -91,6 +91,8 @@ for name in "${PACKAGE_NAMES[@]}"; do
   )
 done
 
+shopt -s nullglob
+
 for id in "${BUNDLE_IDS[@]}"; do
   TARGETS+=(
     "$HOME/Library/Preferences/${id}.plist"
@@ -106,7 +108,15 @@ for id in "${BUNDLE_IDS[@]}"; do
            "$HOME/Library/HTTPStorages/${id}.binarycookies"; do
     TARGETS+=("$p")
   done
+  # Per-host Preferences (Squirrel.Mac writes ShipIt state under
+  # ~/Library/Preferences/ByHost/<id>.ShipIt.<HOST-UUID>.plist; the
+  # host-UUID suffix varies per machine so we glob).
+  for p in "$HOME/Library/Preferences/ByHost/${id}".*.plist; do
+    TARGETS+=("$p")
+  done
 done
+
+shopt -u nullglob
 
 # Warn (don't auto-delete) about extra .app copies — multiple installs in
 # different locations are a common cause of "I reinstalled but it's still

--- a/scripts/reset-windows.ps1
+++ b/scripts/reset-windows.ps1
@@ -20,8 +20,10 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-# Refuse to run while the app is open
+# Refuse to run while the app is open. "ComfyUI Desktop" covers the
+# upcoming post-rename productName (the "2.0" suffix is being dropped).
 $runningNames = @(
+  'ComfyUI Desktop',
   'ComfyUI Desktop 2.0',
   'ComfyUI Launcher',
   'comfyui-desktop-2',
@@ -29,14 +31,20 @@ $runningNames = @(
 )
 $running = Get-Process -Name $runningNames -ErrorAction SilentlyContinue
 if ($running) {
-  Write-Host "ComfyUI Desktop 2.0 / Launcher is running. Please quit it first,"
+  Write-Host "ComfyUI Desktop / Launcher is running. Please quit it first,"
   Write-Host "then re-run this script."
   exit 1
 }
 
 # Every historical app/package name. The userData folder on Windows is named
-# after the productName (or package.json "name") field.
+# after the productName (or package.json "name") field. "ComfyUI Desktop"
+# is included for the upcoming post-rename productName. "ComfyUI" covers
+# the legacy v1.x desktop app (productName "ComfyUI") whose state can
+# survive an upgrade to the 2.0 beta and break a clean install (mirrors
+# #679's macOS findings).
 $appNames = @(
+  'ComfyUI',
+  'ComfyUI Desktop',
   'ComfyUI Desktop 2.0',
   'ComfyUI Launcher',
   'comfyui-desktop-2',
@@ -53,6 +61,11 @@ foreach ($root in $roots) {
   if (-not $root) { continue }
   foreach ($name in $appNames) {
     $targets.Add((Join-Path $root $name))
+    # electron-updater pending-update cache (LOCALAPPDATA\<name>-updater).
+    # If left in place, the updater can re-apply a stale update.exe / nupkg
+    # over the freshly-installed app on next launch — a common cause of
+    # "I reinstalled but the bug is still there".
+    $targets.Add((Join-Path $root ($name + '-updater')))
   }
 }
 


### PR DESCRIPTION
Follow-up to #574 and #679 — extends the reset scripts to cover every leftover Electron/Squirrel/electron-updater location an upgraded user can have on disk. Picks up the macOS paths #679 documented and applies the same idea to Linux and Windows where it transfers.

## Why

Support reports of "removed the .app and ran reset-mac.sh, but the new install still launches broken (raw i18n keys, dead interactions)" turned out to be caused by leftover state the original reset script didn't touch. The smoking gun on macOS is `~/Library/Caches/comfyui-desktop-2-updater/pending/` — a stale `update.zip` (e.g. `ComfyUI Desktop 2.0 0.6.4 - Build ...zip` on my machine) that electron-updater re-applies on next launch, silently replacing the freshly-installed app with the old broken build.

## What this adds

### macOS

- `~/Library/Caches/<package-name>-updater` — **electron-updater pending-update cache.** Primary cause of "I reinstalled but it's still broken."
- `~/Library/Caches/<bundle-id>.ShipIt` — Squirrel.Mac in-place-replacement state.
- `~/Library/Preferences/ByHost/<bundle-id>.*.plist` — Squirrel per-host ShipIt plist (UUID suffix varies per machine, globbed with `nullglob`).
- `~/Library/Application Support/<package-name>` — dev/source-run userData (Electron's fallback when productName isn't honored).
- `~/Library/Cookies/<bundle-id>.binarycookies` — native macOS cookies jar.
- `~/Library/Application Support/ComfyUI` + `~/Library/Logs/ComfyUI` — **legacy v1.x ComfyUI Desktop state**, picked up via the new `"ComfyUI"` entry in `PRODUCT_NAMES` (matches the paths documented in #679).
- Surfaces every `.app` copy on disk via `mdfind kMDItemFSName ==` so users can verify they're launching the right build. Multiple copies in `/Applications`, `~/Applications`, `~/Downloads` etc. is another common reason a reset "appears not to work."
- Adds the upcoming post-rename productName `"ComfyUI Desktop"` (the `2.0` suffix is being dropped per bf44794) to both the running-process check and the target name list so the script keeps working after the rename ships.

### Linux

- `$XDG_CACHE_HOME/<name>-updater` — electron-updater pending-update cache (same risk).
- `"ComfyUI"` added to `APP_NAMES` — covers the legacy v1.x desktop userData/cache/data/state on Linux.
- `"ComfyUI Desktop"` added for the upcoming post-rename productName.

### Windows

- `%LOCALAPPDATA%\<name>-updater` — electron-updater pending-update cache (same risk).
- `'ComfyUI'` added to `$appNames` — covers the legacy v1.x desktop state under both `%APPDATA%` and `%LOCALAPPDATA%`.
- `'ComfyUI Desktop'` added for the upcoming post-rename productName, both in the running-process check and the target list.

## Audit

Full list of Electron/Squirrel locations checked on a representative macOS install; everything currently created by the app (or by older betas under `org.comfy.comfyui-launcher` / `com.kosinkadink.comfyui-launcher` / `comfyui-launcher`) is now in scope of the reset script. Confirmed N/A: `Containers`, `Group Containers`, `Application Scripts`, LaunchAgents, login items, custom URL-scheme registrations (no `Info.plist CFBundleURLTypes`, no `setAsDefaultProtocolClient`), no `setLoginItemSettings`. Intentionally preserved: `~/ComfyUI-Installs`, `~/ComfyUI-Shared`, the per-shared-dir `.desktop2-downloads/` temp dir.

Linux AppArmor profile (`/etc/apparmor.d/comfyui-desktop-2`) and dpkg-installed `.desktop` / icon files are left to `dpkg --purge` (the existing `scripts/after-remove.sh` already handles AppArmor); same on Windows for NSIS uninstaller-managed registry / Start Menu entries — those are out of scope for a user-mode reset script.

## Verification

- `bash -n` clean on both shell scripts.
- Dry-run on macOS shows the new targets resolving correctly:
  ```
  /Users/.../Library/Application Support/comfyui-desktop-2
  /Users/.../Library/Caches/comfyui-desktop-2-updater
  /Users/.../Library/Caches/org.comfy.comfyui-desktop-2.ShipIt
  /Users/.../Library/Preferences/ByHost/org.comfy.comfyui-desktop-2.ShipIt.<UUID>.plist
  ```
- `pnpm run typecheck` + `pnpm run lint` pass (husky pre-commit hook ran on every commit on this branch).

## How to test

1. Stop the app.
2. Confirm `~/Library/Caches/comfyui-desktop-2-updater/pending/` exists (it almost certainly does on any machine that's run a beta release).
3. Run `bash scripts/reset-mac.sh` (or `reset-linux.sh` / `reset-windows.ps1`).
4. Confirm the new targets show up in the prompt and get removed on `y`.
5. Reinstall from the latest release — the updater can no longer clobber the fresh app on first launch.

Amp-Thread-ID: https://ampcode.com/threads/T-019e70b1-15aa-762c-a75c-24ff90c34628