### PR TITLE
fix(picker): switch to already-open window instead of restarting

### DIFF
--- a/src/renderer/src/comfyTitlePopup/InstancePickerView.test.ts
+++ b/src/renderer/src/comfyTitlePopup/InstancePickerView.test.ts
@@ -441,5 +441,35 @@ describe('comfyTitlePopup/InstancePickerView', () => {
       expect(bridge.restarts).toEqual(['a'])
       expect(bridge.picks).toEqual([])
     })
+
+    // Issue #749 — Cloud + local both open. The footer CTA for an install
+    // running in ANOTHER window must route through pickInstall (whose
+    // main-side focus-existing short-circuit raises that window), NOT
+    // restartInstall. The settings content emits restartInPlace=false for
+    // the running-elsewhere case; verify the picker maps that to pick.
+    it('dispatches pickInstall (not restart) for an install running in another window', async () => {
+      const { default: ComfyUISettingsContent } = await import(
+        '../components/settings/ComfyUISettingsContent.vue'
+      )
+      const wrapper = await mountPicker({
+        installs: [
+          makeInstall({ id: 'a', name: 'Alpha' }),
+          makeInstall({ id: 'b', name: 'Bravo' }),
+        ],
+        // Host window is attached to 'a'; the user selected 'b', which is
+        // running in its own separate window.
+        activeInstallationId: 'a',
+        selectedInstallationId: 'b',
+        runningInstallationIds: ['b'],
+      })
+      const settings = wrapper.findComponent(ComfyUISettingsContent)
+      expect(settings.exists()).toBe(true)
+      // The component decides restartInPlace=false (running elsewhere) and
+      // emits accordingly; assert the picker dispatches pickInstall.
+      settings.vm.$emit('primary-action', false)
+      await flushPromises()
+      expect(bridge.picks).toEqual(['b'])
+      expect(bridge.restarts).toEqual([])
+    })
   })
 })

--- a/src/renderer/src/comfyTitlePopup/InstancePickerView.vue
+++ b/src/renderer/src/comfyTitlePopup/InstancePickerView.vue
@@ -478,10 +478,16 @@ function handleSettingsNavigateList(): void {
   selectedId.value = null
 }
 
-function handleExpandedPrimaryAction(running: boolean): void {
+/** Footer primary CTA dispatch. `restartInPlace` is true only when the
+ *  selected install is running in THIS host window — then we stop +
+ *  relaunch in place via `restartInstall`. Otherwise (not running, or
+ *  running in another window — issue #749) we route to `pickInstall`,
+ *  whose main-side focus-existing short-circuit raises the already-open
+ *  window rather than restarting it. */
+function handleExpandedPrimaryAction(restartInPlace: boolean): void {
   const inst = selectedInstall.value
   if (!inst) return
-  if (running) {
+  if (restartInPlace) {
     bridge?.restartInstall(inst.id)
   } else {
     bridge?.pickInstall(inst.id)
@@ -590,6 +596,7 @@ function handleExpandedPrimaryAction(running: boolean): void {
               :auto-action-nonce="snapshot.autoActionNonce ?? 0"
               :global-settings-snapshot="snapshot.storage"
               :active-operation="activeOperation"
+              :active-installation-id="snapshot.activeInstallationId"
               class="picker-expanded-body"
               @show-progress="handleSettingsShowProgress"
               @navigate-list="handleSettingsNavigateList"

--- a/src/renderer/src/components/settings/ComfyUISettingsContent.test.ts
+++ b/src/renderer/src/components/settings/ComfyUISettingsContent.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mount, flushPromises, type VueWrapper } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
-import { createPinia, setActivePinia } from 'pinia'
+import { createPinia, getActivePinia, setActivePinia } from 'pinia'
 import { computed, ref, nextTick } from 'vue'
 
 import type { Installation } from '../../types/ipc'
+import { useSessionStore } from '../../stores/sessionStore'
 
 /**
  * Component tests for the picker / drawer's per-install settings body.
@@ -37,6 +38,8 @@ const messages = {
     instancePicker: {
       open: 'Open',
       restart: 'Restart',
+      switch: 'Switch',
+      restartToApply: 'Restart to apply changes',
       progressUpdating: 'Updating…',
       progressDowngrading: 'Downgrading…',
       progressSuccessStopped: 'Update complete',
@@ -138,6 +141,10 @@ const SAMPLE_INSTALL: Installation = {
 
 async function mountContent(props: Record<string, unknown> = {}): Promise<VueWrapper> {
   const { default: ComfyUISettingsContent } = await import('./ComfyUISettingsContent.vue')
+  // Reuse the active pinia (set in beforeEach) so tests that seed the
+  // session store via `useSessionStore()` share the same instance the
+  // mounted component reads.
+  const pinia = getActivePinia() ?? createPinia()
   const wrapper = mount(ComfyUISettingsContent, {
     props: {
       installation: SAMPLE_INSTALL,
@@ -145,7 +152,7 @@ async function mountContent(props: Record<string, unknown> = {}): Promise<VueWra
       activeOperation: null,
       ...props,
     },
-    global: { plugins: [createTestI18n(), createPinia()] },
+    global: { plugins: [createTestI18n(), pinia] },
   }) as VueWrapper
   await flushPromises()
   return wrapper
@@ -332,6 +339,60 @@ describe('ComfyUISettingsContent', () => {
       })
       await flushPromises()
       expect(w.find('[data-testid="more-menu"]').exists()).toBe(false)
+    })
+  })
+
+  // Issue #749 — the footer primary CTA must distinguish an install
+  // running in THIS window (Restart, in place) from one running in a
+  // DIFFERENT window (Switch → focus that window) from one not running
+  // (Open → launch). Pre-fix the label was "Restart" whenever a session
+  // existed anywhere, so switching between an already-open Cloud and
+  // local window was mislabeled and broke (it restarted instead of
+  // focusing the other window).
+  describe('footer primary action — running scope (issue #749)', () => {
+    function markRunning(installId: string): void {
+      const store = useSessionStore()
+      store.runningInstances.set(installId, {
+        installationId: installId,
+        installationName: 'X',
+        mode: '',
+      })
+    }
+
+    it('labels "Open" and emits restartInPlace=false when not running', async () => {
+      const w = await mountContent({ activeInstallationId: 'inst-1' })
+      expect(w.find('.settings-v2-relaunch').text()).toBe('Open')
+      await w.find('.settings-v2-relaunch').trigger('click')
+      expect(w.emitted('primary-action')).toEqual([[false]])
+    })
+
+    it('labels "Restart" and emits restartInPlace=true when running in THIS window', async () => {
+      markRunning('inst-1')
+      const w = await mountContent({ activeInstallationId: 'inst-1' })
+      expect(w.find('.settings-v2-relaunch').text()).toBe('Restart')
+      await w.find('.settings-v2-relaunch').trigger('click')
+      expect(w.emitted('primary-action')).toEqual([[true]])
+    })
+
+    it('labels "Switch" and emits restartInPlace=false when running in ANOTHER window', async () => {
+      // The host window is attached to a different install ('other'),
+      // while the selected install ('inst-1') is running elsewhere.
+      markRunning('inst-1')
+      const w = await mountContent({ activeInstallationId: 'other' })
+      expect(w.find('.settings-v2-relaunch').text()).toBe('Switch')
+      await w.find('.settings-v2-relaunch').trigger('click')
+      // restartInPlace=false → host routes to pickInstall (focus existing).
+      expect(w.emitted('primary-action')).toEqual([[false]])
+    })
+
+    it('treats a running install as "Switch" on an install-less (dashboard) host', async () => {
+      // No activeInstallationId → there is no in-place session to restart,
+      // so a running install always reads as "switch to its window".
+      markRunning('inst-1')
+      const w = await mountContent({ activeInstallationId: null })
+      expect(w.find('.settings-v2-relaunch').text()).toBe('Switch')
+      await w.find('.settings-v2-relaunch').trigger('click')
+      expect(w.emitted('primary-action')).toEqual([[false]])
     })
   })
 

--- a/src/renderer/src/components/settings/ComfyUISettingsContent.vue
+++ b/src/renderer/src/components/settings/ComfyUISettingsContent.vue
@@ -67,6 +67,14 @@ interface Props {
    *  When set and the active tab is `'update'`, the Update tab body
    *  is replaced with an inline progress / result view. */
   activeOperation?: ActiveOperation | null
+  /** Install attached to the host window that opened this picker (the
+   *  picker's `snapshot.activeInstallationId`). Used to decide whether
+   *  the footer primary action should restart in-place (running in THIS
+   *  window) or focus/switch to the install's already-open window
+   *  (running in ANOTHER window). Null on install-less (dashboard) hosts
+   *  — there's no in-place session to restart, so a running install is
+   *  always "switch to its window". */
+  activeInstallationId?: string | null
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -75,6 +83,7 @@ const props = withDefaults(defineProps<Props>(), {
   autoAction: null,
   autoActionNonce: 0,
   activeOperation: null,
+  activeInstallationId: null,
   globalSettingsSnapshot: () => ({
     sharedDirectoriesFields: [],
     modelsDirs: [],
@@ -91,12 +100,18 @@ const emit = defineEmits<{
    *  `navigate-list` so the host can animate out before navigation). */
   'request-close': []
   /** Footer primary CTA — host decides whether to call its bridge's
-   *  `pickInstall` (not-running case → Open) or `restartInstall`
-   *  (running case → Restart) so the same native-confirm flow runs
-   *  whether the affordance is clicked from the compact row or the
-   *  expanded view's footer. Payload carries the running flag so the
-   *  host doesn't have to re-derive it. */
-  'primary-action': [running: boolean]
+   *  `pickInstall` (Open / Switch case) or `restartInstall` (Restart
+   *  case) so the same native-confirm flow runs whether the affordance
+   *  is clicked from the compact row or the expanded view's footer.
+   *
+   *  The boolean is `restartInPlace`: true ONLY when the install is
+   *  running in the host window that owns this picker, where the action
+   *  genuinely stops + relaunches the session in place. When the install
+   *  is running in a DIFFERENT window (issue #749 — Cloud + local both
+   *  open), this is false so the host routes to `pickInstall`, whose
+   *  focus-existing short-circuit raises the already-open window instead
+   *  of restarting it. */
+  'primary-action': [restartInPlace: boolean]
   /** Inline progress CTA events — forwarded up to the host which owns
    *  the bridge methods for cancel / retry / dismiss. */
   'op-cancel': []
@@ -458,33 +473,59 @@ function handleSnapshotsRefresh(): void {
   void reload()
 }
 
-/** Footer primary CTA — host-agnostic. The host (picker / drawer)
- *  receives `primary-action` with the current running state and
- *  dispatches its own bridge call: `restartInstall` when running,
- *  `pickInstall` when not. This keeps the same native-confirm flow
- *  the compact PickerRow already uses for its Open/Restart button,
- *  so both surfaces share one underlying path. */
+/** Footer primary CTA — host-agnostic. The host (picker) receives
+ *  `primary-action` with `restartInPlace` and dispatches its own bridge
+ *  call: `restartInstall` when restarting in place, `pickInstall`
+ *  otherwise. This keeps the same native-confirm flow across surfaces.
+ *
+ *  `isInstallRunning` — a session exists for this install *somewhere*
+ *  (any window). Drives the row dot + the running-state copy. */
 const isInstallRunning = computed(() => {
   const inst = installation.value
   return inst ? sessionStore.isRunning(inst.id) : false
 })
 
+/** Running specifically in the host window that opened this picker.
+ *  Only here does "Restart" make sense: stop + relaunch the session in
+ *  place. When the install is running in a *different* window (issue
+ *  #749 — switching between an already-open Cloud and local), the right
+ *  action is to focus that window, not restart it. Install-less
+ *  (dashboard) hosts have no `activeInstallationId`, so this is always
+ *  false there and a running install reads as "switch to its window". */
+const isRunningInThisWindow = computed(() => {
+  const inst = installation.value
+  if (!inst || !isInstallRunning.value) return false
+  return props.activeInstallationId != null && inst.id === props.activeInstallationId
+})
+
+/** Running, but in another window — focus/switch instead of restart. */
+const isRunningElsewhere = computed(
+  () => isInstallRunning.value && !isRunningInThisWindow.value
+)
+
 const hasPendingRestart = computed(
-  () => isInstallRunning.value && pendingRestartFieldIds.value.size > 0
+  () => isRunningInThisWindow.value && pendingRestartFieldIds.value.size > 0
 )
 
 const primaryActionLabel = computed(() => {
   if (hasPendingRestart.value) {
     return t('instancePicker.restartToApply', 'Restart to apply changes')
   }
-  return isInstallRunning.value
-    ? t('instancePicker.restart', 'Restart')
-    : t('instancePicker.open', 'Open')
+  if (isRunningInThisWindow.value) {
+    return t('instancePicker.restart', 'Restart')
+  }
+  // Running in another window → focus/switch to it (issue #749).
+  if (isRunningElsewhere.value) {
+    return t('instancePicker.switch', 'Switch')
+  }
+  return t('instancePicker.open', 'Open')
 })
 
 function handlePrimaryAction(): void {
   if (!installation.value) return
-  emit('primary-action', isInstallRunning.value)
+  // Only restart in place when running in THIS window; running-elsewhere
+  // and not-running both route to pickInstall (focus existing / launch).
+  emit('primary-action', isRunningInThisWindow.value)
 }
 
 // Inline-progress state derived from the `activeOperation` prop.

--- a/src/renderer/src/lib/i18nMessages.ts
+++ b/src/renderer/src/lib/i18nMessages.ts
@@ -205,6 +205,10 @@ export const en = {
     latestOnGithub: 'Latest on GitHub',
     open: 'Open',
     restart: 'Restart',
+    /** Primary CTA when the selected install is already running in
+     *  another window — focuses/switches to it instead of restarting
+     *  (issue #749). */
+    switch: 'Switch',
     restartConfirmTitle: 'Restart this instance?',
     restartConfirmDetail:
       'Restarting will stop the running session. Any unsaved work in the workflow will be lost.',


### PR DESCRIPTION
## Summary

With two windows open (e.g. Comfy Cloud + a local install), the instance-picker footer CTA for the *other* install was mislabeled "Restart" and switching was broken — clicking stopped + relaunched a session in place instead of focusing the window that was already open. With only one window open it correctly read "Open" and switching worked.

## Root cause

`ComfyUISettingsContent.vue` drove the footer label + action purely off `sessionStore.isRunning(install.id)` — true whenever a session existed *anywhere*. So an install running in a *different* window fell into the "Restart" branch, dispatching `restartInstall` (stop + relaunch in place) instead of `pickInstall`, whose main-side focus-existing short-circuit (`getEntryByInstallationId` -> `show()` + `focus()`) raises the already-open window.

## Fix

Pass the host window's `activeInstallationId` into `ComfyUISettingsContent` and distinguish three states:

- running in **this** window -> "Restart" (`restartInstall`, in place)
- running in **another** window -> "Switch" (`pickInstall` -> focus existing window)
- not running -> "Open" (`pickInstall` -> launch)

The `primary-action` event now carries `restartInPlace` (true only for the in-this-window case); the picker maps that to restart vs pick. No main-process changes needed — the focus-existing path already existed.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] Unit tests: `ComfyUISettingsContent.test.ts` (new "running scope" block — Open / Restart / Switch / install-less host) + `InstancePickerView.test.ts` (new running-in-another-window -> pickInstall dispatch). 130 renderer tests pass.
- [ ] Manual: open Cloud + local in two windows; from each, the picker CTA for the other reads "Switch" and focuses the other window (no restart).

Closes #749