### PR TITLE
fix(close-confirm): drop redundant body copy from Close Window dialog (#725)

### DIFF
--- a/src/main/host/detach.ts
+++ b/src/main/host/detach.ts
@@ -319,13 +319,18 @@ export async function confirmCloseInstanceWindow(
   isLastWindow: boolean,
   theme: { bg: string; text: string },
 ): Promise<boolean> {
+  // Body copy is intentionally omitted ('' so BaseAlert skips the
+  // message block): the confirm-button label already states the
+  // outcome ("Close & Return to Dashboard" / "Close Window"), so the
+  // long sentence under the title was pure restatement. Title + button
+  // label gives the user everything they need; the dialog itself
+  // signals "this is a confirm". Reported by QA (Robert) — the body
+  // felt unnecessary.
   return openSystemModalAsync({
     parent: window,
     spec: {
       title: 'Close Window',
-      message: isLastWindow
-        ? 'Close this window? This stops ComfyUI and returns you to the dashboard.'
-        : 'Close this window? This stops the running ComfyUI instance.',
+      message: '',
       confirmLabel: isLastWindow ? 'Close & Return to Dashboard' : 'Close Window',
       cancelLabel: 'Cancel',
       confirmStyle: 'danger',


### PR DESCRIPTION
## Summary
- Drops the explanatory body copy from the Close Window confirm — the confirm-button label already names the outcome.
- Hide the body block via `message: ''` (BaseAlert already skips it when empty), so no type/spec changes needed.

## Before / after
- **Before:** title `Close Window` · body `Close this window? This stops ComfyUI and returns you to the dashboard.` · `[Cancel] [Close & Return to Dashboard]`
- **After:** title `Close Window` · *(no body)* · `[Cancel] [Close & Return to Dashboard]`

For the non-last-window case the button label is just `Close Window`, which still names the outcome on its own.

## Why
- QA (Robert) asked whether the body text was necessary. It restates what the button says.
- Native macOS / Windows confirm dialogs typically follow this same `title + buttons` pattern.

Closes #725

## Test plan
- [x] `pnpm typecheck:node` clean
- [x] `pnpm lint` clean
- [ ] Visually confirm the dialog in dev (Close Window menu entry + native ✕)
