### PR TITLE
fix(title-bar): collapse trailing labels from measured pill geometry, not bar-width breakpoints

### DIFF
--- a/src/renderer/src/comfyTitleBar/TitleBarApp.test.ts
+++ b/src/renderer/src/comfyTitleBar/TitleBarApp.test.ts
@@ -1131,16 +1131,19 @@ describe('TitleBarApp', () => {
       const mod = await import('./TitleBarApp.vue')
       const wrapper = mount(mod.default, { attachTo: document.body })
       await flushPromises()
-      // Exactly one observer is created (the trailing-cluster mirror).
-      expect(handles).toHaveLength(1)
-      const handle = handles[0]!
-      // It observed the `.title-trailing` element.
+      // Two observers are created: one for the trailing-cluster
+      // mirror (this test's subject) and a second for the JS fit
+      // controller that watches the title-bar root.
+      expect(handles).toHaveLength(2)
       const trailingEl = wrapper.find('.title-trailing').element
-      expect(handle.observed[0]).toBe(trailingEl)
+      const handle = handles.find((h) => h.observed[0] === trailingEl)
+      expect(handle).toBeDefined()
       // Tear-down disconnects so the observer doesn't leak across
       // the WebContentsView's lifecycle.
       wrapper.unmount()
-      expect(handle.observed).toHaveLength(0)
+      for (const h of handles) {
+        expect(h.observed).toHaveLength(0)
+      }
     })
 
     it('mirrors trailing width onto the title bar as `--title-trailing-width`', async () => {

--- a/src/renderer/src/comfyTitleBar/TitleBarApp.vue
+++ b/src/renderer/src/comfyTitleBar/TitleBarApp.vue
@@ -1027,22 +1027,27 @@ onUnmounted(() => {
    Container queries read `.title-bar`'s own inline size (set up via
    `container: title-bar / inline-size` above). Two tiers:
 
-     - Mid  (≤ 1199px on Mac, ≤ 1279px on Win): Feedback label drops
-       to icon-only. Saves ~80px on the trailing cluster.
-     - Narrow (≤ 899px on Mac, ≤ 979px on Win): both update pill
-       labels drop to icon-only. Saves another ~140–180px.
+     - Mid    (≤ 999px on Mac, ≤ 1099px on Win): Feedback label drops
+              to icon-only. Saves ~60px on the trailing cluster.
+     - Narrow (≤ 899px on Mac, ≤  979px on Win): both update pill
+              labels drop to icon-only. Saves another ~80–120px.
+
+   The Win thresholds sit ~80–100px above the Mac ones because Win/Linux
+   reserves 140px on the right for native window controls vs Mac's
+   78px left-side traffic-light reservation — Win needs to collapse
+   slightly earlier to keep the same effective usable width as Mac.
+
+   Both tiers sit well below the default host window width (1280, see
+   `DEFAULT_HOST_WIDTH` in createHostWindow.ts) so labels stay visible
+   at the canonical size; collapse only kicks in once the user resizes
+   the window meaningfully narrower.
 
    Tooltips already carry the full label on every pill (see
    `tooltipAttrs(...)` bindings on each <button>), so icon-only states
-   remain accessible without extra markup.
-
-   The Win thresholds are higher because the trailing cluster reserves
-   128px on the right for native window controls vs. Mac's 66px
-   left-side traffic-light reservation — Win needs to collapse earlier
-   to keep the same effective usable width as Mac. */
+   remain accessible without extra markup. */
 
 /* Mid tier — Feedback label collapses. */
-@container title-bar (max-width: 1199px) {
+@container title-bar (max-width: 999px) {
   .title-bar.is-mac .title-feedback-label {
     display: none;
   }
@@ -1051,7 +1056,7 @@ onUnmounted(() => {
     gap: 0;
   }
 }
-@container title-bar (max-width: 1279px) {
+@container title-bar (max-width: 1099px) {
   .title-bar:not(.is-mac) .title-feedback-label {
     display: none;
   }
@@ -1065,7 +1070,7 @@ onUnmounted(() => {
    collapsed pill becomes a 24×24 circle (matching the Settings + other
    icon buttons) instead of an oval, so it reads as an icon affordance
    not a "shrunk pill". */
-@container title-bar (max-width: 1099px) {
+@container title-bar (max-width: 899px) {
   .title-bar.is-mac .title-update-pill-label {
     display: none;
   }
@@ -1078,7 +1083,7 @@ onUnmounted(() => {
     border-radius: 999px;
   }
 }
-@container title-bar (max-width: 1179px) {
+@container title-bar (max-width: 979px) {
   .title-bar:not(.is-mac) .title-update-pill-label {
     display: none;
   }

--- a/src/renderer/src/comfyTitleBar/TitleBarApp.vue
+++ b/src/renderer/src/comfyTitleBar/TitleBarApp.vue
@@ -1025,29 +1025,35 @@ onUnmounted(() => {
 
 /* --- Responsive pill collapse ---
    Container queries read `.title-bar`'s own inline size (set up via
-   `container: title-bar / inline-size` above). Two tiers:
+   `container: title-bar / inline-size` above). Two tiers collapse
+   trailing-cluster labels to icon-only as the bar narrows.
 
-     - Mid    (≤ 999px on Mac, ≤ 1099px on Win): Feedback label drops
-              to icon-only. Saves ~60px on the trailing cluster.
-     - Narrow (≤ 899px on Mac, ≤  979px on Win): both update pill
-              labels drop to icon-only. Saves another ~80–120px.
+   The thresholds are anchored to the actual point at which the
+   layout would overflow, not to arbitrary breakpoints. With the
+   three-track grid (`auto | minmax(0,1fr) | auto`), the left cluster
+   mirroring the trailing cluster, the install pill's `clamp(220px,
+   22cqi, 360px)` floor, and the platform-specific chrome padding
+   (Win/Linux reserves 140px right; Mac reserves 78px left), the
+   minimum bar width before content overflows works out to roughly:
 
-   The Win thresholds sit ~80–100px above the Mac ones because Win/Linux
-   reserves 140px on the right for native window controls vs Mac's
-   78px left-side traffic-light reservation — Win needs to collapse
-   slightly earlier to keep the same effective usable width as Mac.
+                          Full labels   Feedback collapsed
+     Win/Linux            ~1100 px      ~960 px
+     Mac                  ~ 910 px      ~770 px
 
-   Both tiers sit well below the default host window width (1280, see
-   `DEFAULT_HOST_WIDTH` in createHostWindow.ts) so labels stay visible
-   at the canonical size; collapse only kicks in once the user resizes
-   the window meaningfully narrower.
+   Each tier fires ~40 px above its overflow point — enough buffer to
+   absorb font-rendering variance and modestly longer i18n labels
+   without false positives at the default `DEFAULT_HOST_WIDTH` (1280),
+   while still collapsing as soon as the user resizes narrow enough
+   that the cluster would otherwise crash into the centre pill.
 
-   Tooltips already carry the full label on every pill (see
-   `tooltipAttrs(...)` bindings on each <button>), so icon-only states
-   remain accessible without extra markup. */
+     - Mid    (≤  949px Mac, ≤ 1139px Win): Feedback label → icon.
+     - Narrow (≤  809px Mac, ≤  999px Win): update-pill label → icon.
+
+   Tooltips on every pill already carry the full label, so icon-only
+   states remain accessible without extra markup. */
 
 /* Mid tier — Feedback label collapses. */
-@container title-bar (max-width: 999px) {
+@container title-bar (max-width: 949px) {
   .title-bar.is-mac .title-feedback-label {
     display: none;
   }
@@ -1056,7 +1062,7 @@ onUnmounted(() => {
     gap: 0;
   }
 }
-@container title-bar (max-width: 1099px) {
+@container title-bar (max-width: 1139px) {
   .title-bar:not(.is-mac) .title-feedback-label {
     display: none;
   }
@@ -1070,7 +1076,7 @@ onUnmounted(() => {
    collapsed pill becomes a 24×24 circle (matching the Settings + other
    icon buttons) instead of an oval, so it reads as an icon affordance
    not a "shrunk pill". */
-@container title-bar (max-width: 899px) {
+@container title-bar (max-width: 809px) {
   .title-bar.is-mac .title-update-pill-label {
     display: none;
   }
@@ -1083,7 +1089,7 @@ onUnmounted(() => {
     border-radius: 999px;
   }
 }
-@container title-bar (max-width: 979px) {
+@container title-bar (max-width: 999px) {
   .title-bar:not(.is-mac) .title-update-pill-label {
     display: none;
   }

--- a/src/renderer/src/comfyTitleBar/TitleBarApp.vue
+++ b/src/renderer/src/comfyTitleBar/TitleBarApp.vue
@@ -242,7 +242,6 @@ function handleFeedback(): void {
 
 // Icon is ComfyUI-tab only; also visible while the drawer is open so
 const titleBarRef = useTemplateRef<HTMLElement>('titleBar')
-const titleLeftRef = useTemplateRef<HTMLElement>('titleLeft')
 const fileBtnRef = useTemplateRef<HTMLButtonElement>('fileBtn')
 const downloadsBtnRef = useTemplateRef<HTMLButtonElement>('downloadsBtn')
 const installPillRef = useTemplateRef<HTMLElement>('installPill')
@@ -272,13 +271,14 @@ let trailingObserver: ResizeObserver | undefined
  *    - 'no-feedback' — Feedback collapsed to icon-only.
  *    - 'icons-only'  — Both Feedback and Desktop Update collapsed.
  *
- *  Each resize frame measures the gap between the install pill rect
- *  and the trailing cluster rect (and the symmetric gap on the left,
- *  in case the mirror is off). When the gap drops below `MIN_GAP_PX`
- *  the controller advances one tier; it only walks back when the gap
- *  comfortably exceeds the *learned* cost of restoring the hidden
- *  label plus `RESTORE_BUFFER_PX`. Hysteresis is essential — the
- *  collapsed trailing cluster is narrower, which immediately frees
+ *  Each resize frame measures the gap between the install pill's
+ *  right edge and the trailing cluster's left edge. With the trailing
+ *  mirror live the left-side gap is equal by construction, so the
+ *  right gap alone is sufficient. When the gap drops below
+ *  `MIN_GAP_PX` the controller advances one tier; it only walks back
+ *  when the gap comfortably exceeds the *learned* width cost of
+ *  restoring the hidden label plus `RESTORE_BUFFER_PX`. Hysteresis is
+ *  essential — collapsing the trailing cluster immediately frees
  *  enough gap to consider re-expanding; the restore-cost guard
  *  prevents that flap. */
 type CollapseMode = 'full' | 'no-feedback' | 'icons-only'
@@ -292,44 +292,53 @@ const MIN_GAP_PX = 16
 const RESTORE_BUFFER_PX = 24
 /** Learned at runtime via the before/after measurement around each
  *  transition — we don't know analytically how wide each label is
- *  (font, locale, version-string length all vary). Initialized to 0
- *  so the first transition pair learns the real cost; until then a
- *  conservative bound is enforced by `RESTORE_BUFFER_PX`. */
+ *  (font, locale, version-string length all vary). The cost is the
+ *  drop in `.title-trailing`'s own width, NOT the change in the pill
+ *  gap, because the user can be actively dragging a resize during
+ *  the rAF settle window and the bar width would otherwise poison
+ *  the delta. Trailing width is independent of bar width.
+ *
+ *  Initialized to 0 so the first transition pair learns the real
+ *  cost; until then `RESTORE_BUFFER_PX` is the only guard. */
 let feedbackRestoreCostPx = 0
 let updateRestoreCostPx = 0
 let fitObserver: ResizeObserver | undefined
 let fitRaf: number | null = null
+let transitionRaf: number | null = null
+let unmounted = false
 
-/** Measure the visual gap between the install pill and each flanking
- *  cluster. Returns `Infinity` when refs aren't mounted yet (so the
- *  fit controller stays at `'full'` until layout exists) or when the
- *  bar is hidden / detached (rect width 0). */
-function measureFitGap(): number {
+interface FitMeasurement {
+  gap: number
+  trailingWidth: number
+}
+
+/** Measure the gap between the install pill and the trailing cluster,
+ *  plus the trailing cluster's own width. Returns sentinels when refs
+ *  aren't mounted yet (so the fit controller stays at `'full'` until
+ *  layout exists) or when the bar is hidden / detached (rect width 0). */
+function measureFit(): FitMeasurement {
   const bar = titleBarRef.value
-  const left = titleLeftRef.value
   const trailing = titleTrailingRef.value
   const pill = installPillRef.value
-  if (!bar || !left || !trailing || !pill) return Infinity
+  if (!bar || !trailing || !pill) return { gap: Infinity, trailingWidth: NaN }
   const barRect = bar.getBoundingClientRect()
-  if (barRect.width === 0) return Infinity
-  const leftRect = left.getBoundingClientRect()
+  if (barRect.width === 0) return { gap: Infinity, trailingWidth: NaN }
   const trailingRect = trailing.getBoundingClientRect()
   const pillRect = pill.getBoundingClientRect()
-  const leftGap = pillRect.left - leftRect.right
-  const rightGap = trailingRect.left - pillRect.right
-  return Math.min(leftGap, rightGap)
+  return { gap: trailingRect.left - pillRect.right, trailingWidth: trailingRect.width }
 }
 
 function scheduleFit(): void {
-  if (fitRaf !== null) return
+  if (unmounted || fitRaf !== null) return
   fitRaf = requestAnimationFrame(() => {
     fitRaf = null
+    if (unmounted) return
     evaluateFit()
   })
 }
 
 function evaluateFit(): void {
-  const gap = measureFitGap()
+  const { gap } = measureFit()
   if (!Number.isFinite(gap)) return
   const mode = collapseMode.value
   if (mode === 'full') {
@@ -345,16 +354,22 @@ function evaluateFit(): void {
 function transitionTo(next: CollapseMode): void {
   const prev = collapseMode.value
   if (prev === next) return
-  const before = measureFitGap()
+  const before = measureFit()
   collapseMode.value = next
   // Wait for Vue to flush the DOM update + the browser to lay out,
-  // then learn how much gap restoring the hidden label would cost.
-  // A second rAF after `nextTick` is the standard "after-paint" hook.
+  // then learn how much trailing width restoring the hidden label
+  // would cost. Tracking the rAF lets `onUnmounted` cancel it so
+  // teardown doesn't race against a pending measurement callback.
   void nextTick().then(() => {
-    requestAnimationFrame(() => {
-      const after = measureFitGap()
-      if (Number.isFinite(before) && Number.isFinite(after)) {
-        const delta = after - before
+    if (unmounted) return
+    transitionRaf = requestAnimationFrame(() => {
+      transitionRaf = null
+      if (unmounted) return
+      const after = measureFit()
+      if (Number.isFinite(before.trailingWidth) && Number.isFinite(after.trailingWidth)) {
+        // Trailing shrinks when a label is hidden; the drop is the
+        // width the gap will gain back if we restore the label.
+        const delta = before.trailingWidth - after.trailingWidth
         if (prev === 'full' && next === 'no-feedback') {
           feedbackRestoreCostPx = Math.max(feedbackRestoreCostPx, delta)
         } else if (prev === 'no-feedback' && next === 'icons-only') {
@@ -452,9 +467,10 @@ onMounted(() => {
     fitObserver = new ResizeObserver(() => scheduleFit())
     fitObserver.observe(titleBarRef.value)
   }
-  // Initial pass after first paint so we start in the right tier
-  // rather than transitioning visibly on mount.
-  void nextTick().then(() => scheduleFit())
+  // Initial pass synchronously on mount so we start in the right tier
+  // before the first paint instead of flashing 'full' for one frame
+  // on a narrow boot width.
+  evaluateFit()
 
   if (!bridge) return
   unsubPanel = bridge.onPanelChanged((panel) => {
@@ -482,6 +498,7 @@ watch(
 )
 
 onUnmounted(() => {
+  unmounted = true
   unsubPanel?.()
   unsubInstallationId?.()
   hideTip()
@@ -492,6 +509,10 @@ onUnmounted(() => {
   if (fitRaf !== null) {
     cancelAnimationFrame(fitRaf)
     fitRaf = null
+  }
+  if (transitionRaf !== null) {
+    cancelAnimationFrame(transitionRaf)
+    transitionRaf = null
   }
   if (flashTimer) {
     clearTimeout(flashTimer)
@@ -529,7 +550,7 @@ onUnmounted(() => {
     <!-- Left cluster: waffle menu. The app-update pill moved to the
          right trailing cluster so all user-action controls
          (update / feedback / downloads / settings) live together. -->
-    <div ref="titleLeft" class="title-cluster">
+    <div class="title-cluster">
       <button
         v-if="!isChromeLocked"
         ref="fileBtn"
@@ -612,7 +633,7 @@ onUnmounted(() => {
           <ChevronDown :size="12" class="title-install-caret" aria-hidden="true" />
         </div>
       </div>
-      <div v-else class="title-install-pill">
+      <div v-else ref="installPill" class="title-install-pill">
         <div class="title-install-slot title-install-slot--leading">
           <ComfyCLogo v-if="showBrandMark" class="title-install-brand-mark" :size="16" />
           <component

--- a/src/renderer/src/comfyTitleBar/TitleBarApp.vue
+++ b/src/renderer/src/comfyTitleBar/TitleBarApp.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted, useTemplateRef, watch } from 'vue'
+import { ref, computed, nextTick, onMounted, onUnmounted, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import {
   ArrowDownToLine,
@@ -17,7 +17,7 @@ import { useUpdatePills } from './useUpdatePills'
 import { useTitleBarHoverGate } from './useTitleBarHoverGate'
 import ComfyCLogo from '../components/icons/ComfyCLogo.vue'
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
 
 // Inlined to keep the title-bar renderer self-contained — the preload TS
 // file isn't visible to tsconfig.web (only its .d.ts would be). Kept in
@@ -241,6 +241,8 @@ function handleFeedback(): void {
 }
 
 // Icon is ComfyUI-tab only; also visible while the drawer is open so
+const titleBarRef = useTemplateRef<HTMLElement>('titleBar')
+const titleLeftRef = useTemplateRef<HTMLElement>('titleLeft')
 const fileBtnRef = useTemplateRef<HTMLButtonElement>('fileBtn')
 const downloadsBtnRef = useTemplateRef<HTMLButtonElement>('downloadsBtn')
 const installPillRef = useTemplateRef<HTMLElement>('installPill')
@@ -259,6 +261,121 @@ const titleTrailingRef = useTemplateRef<HTMLElement>('titleTrailing')
  *  pattern apps like Figma use for the same problem. */
 const trailingWidthPx = ref(0)
 let trailingObserver: ResizeObserver | undefined
+
+/** Responsive collapse mode for the trailing cluster.
+ *
+ *  Three tiers, decided from real measured geometry (not bar-width
+ *  breakpoints) so the decision actually accounts for the centre
+ *  install pill's current position and width:
+ *
+ *    - 'full'        — Feedback + Desktop Update labels visible.
+ *    - 'no-feedback' — Feedback collapsed to icon-only.
+ *    - 'icons-only'  — Both Feedback and Desktop Update collapsed.
+ *
+ *  Each resize frame measures the gap between the install pill rect
+ *  and the trailing cluster rect (and the symmetric gap on the left,
+ *  in case the mirror is off). When the gap drops below `MIN_GAP_PX`
+ *  the controller advances one tier; it only walks back when the gap
+ *  comfortably exceeds the *learned* cost of restoring the hidden
+ *  label plus `RESTORE_BUFFER_PX`. Hysteresis is essential — the
+ *  collapsed trailing cluster is narrower, which immediately frees
+ *  enough gap to consider re-expanding; the restore-cost guard
+ *  prevents that flap. */
+type CollapseMode = 'full' | 'no-feedback' | 'icons-only'
+const collapseMode = ref<CollapseMode>('full')
+const collapsedFeedback = computed(
+  () => collapseMode.value === 'no-feedback' || collapseMode.value === 'icons-only'
+)
+const collapsedUpdate = computed(() => collapseMode.value === 'icons-only')
+
+const MIN_GAP_PX = 16
+const RESTORE_BUFFER_PX = 24
+/** Learned at runtime via the before/after measurement around each
+ *  transition — we don't know analytically how wide each label is
+ *  (font, locale, version-string length all vary). Initialized to 0
+ *  so the first transition pair learns the real cost; until then a
+ *  conservative bound is enforced by `RESTORE_BUFFER_PX`. */
+let feedbackRestoreCostPx = 0
+let updateRestoreCostPx = 0
+let fitObserver: ResizeObserver | undefined
+let fitRaf: number | null = null
+
+/** Measure the visual gap between the install pill and each flanking
+ *  cluster. Returns `Infinity` when refs aren't mounted yet (so the
+ *  fit controller stays at `'full'` until layout exists) or when the
+ *  bar is hidden / detached (rect width 0). */
+function measureFitGap(): number {
+  const bar = titleBarRef.value
+  const left = titleLeftRef.value
+  const trailing = titleTrailingRef.value
+  const pill = installPillRef.value
+  if (!bar || !left || !trailing || !pill) return Infinity
+  const barRect = bar.getBoundingClientRect()
+  if (barRect.width === 0) return Infinity
+  const leftRect = left.getBoundingClientRect()
+  const trailingRect = trailing.getBoundingClientRect()
+  const pillRect = pill.getBoundingClientRect()
+  const leftGap = pillRect.left - leftRect.right
+  const rightGap = trailingRect.left - pillRect.right
+  return Math.min(leftGap, rightGap)
+}
+
+function scheduleFit(): void {
+  if (fitRaf !== null) return
+  fitRaf = requestAnimationFrame(() => {
+    fitRaf = null
+    evaluateFit()
+  })
+}
+
+function evaluateFit(): void {
+  const gap = measureFitGap()
+  if (!Number.isFinite(gap)) return
+  const mode = collapseMode.value
+  if (mode === 'full') {
+    if (gap < MIN_GAP_PX) transitionTo('no-feedback')
+  } else if (mode === 'no-feedback') {
+    if (gap < MIN_GAP_PX) transitionTo('icons-only')
+    else if (gap > feedbackRestoreCostPx + RESTORE_BUFFER_PX) transitionTo('full')
+  } else {
+    if (gap > updateRestoreCostPx + RESTORE_BUFFER_PX) transitionTo('no-feedback')
+  }
+}
+
+function transitionTo(next: CollapseMode): void {
+  const prev = collapseMode.value
+  if (prev === next) return
+  const before = measureFitGap()
+  collapseMode.value = next
+  // Wait for Vue to flush the DOM update + the browser to lay out,
+  // then learn how much gap restoring the hidden label would cost.
+  // A second rAF after `nextTick` is the standard "after-paint" hook.
+  void nextTick().then(() => {
+    requestAnimationFrame(() => {
+      const after = measureFitGap()
+      if (Number.isFinite(before) && Number.isFinite(after)) {
+        const delta = after - before
+        if (prev === 'full' && next === 'no-feedback') {
+          feedbackRestoreCostPx = Math.max(feedbackRestoreCostPx, delta)
+        } else if (prev === 'no-feedback' && next === 'icons-only') {
+          updateRestoreCostPx = Math.max(updateRestoreCostPx, delta)
+        }
+      }
+      // Re-evaluate in case one transition didn't free enough room.
+      scheduleFit()
+    })
+  })
+}
+
+/** Discard learned restore costs whenever something that changes the
+ *  trailing cluster's content width is mutated (locale switch, update
+ *  state, install-update flag, …). The next collapse transition then
+ *  re-learns the cost from the new label widths. */
+function invalidateRestoreCosts(): void {
+  feedbackRestoreCostPx = 0
+  updateRestoreCostPx = 0
+  scheduleFit()
+}
 
 const { tooltipAttrs, handleTooltipPointer, hideTip } = useTitleBarTooltip({
   bridge,
@@ -324,6 +441,21 @@ onMounted(() => {
     trailingObserver.observe(titleTrailingRef.value)
   }
 
+  // Observe the title bar itself for resize so the fit controller can
+  // re-evaluate whether the trailing labels still fit alongside the
+  // centre pill. Bar-only is sufficient — install-pill width and
+  // trailing width changes propagate through layout and either resize
+  // the bar (no, fixed `100vw`) or change the measured rects we read
+  // inside `evaluateFit`. The locale/state watches below handle
+  // changes that don't trigger a bar resize.
+  if (titleBarRef.value && typeof ResizeObserver !== 'undefined') {
+    fitObserver = new ResizeObserver(() => scheduleFit())
+    fitObserver.observe(titleBarRef.value)
+  }
+  // Initial pass after first paint so we start in the right tier
+  // rather than transitioning visibly on mount.
+  void nextTick().then(() => scheduleFit())
+
   if (!bridge) return
   unsubPanel = bridge.onPanelChanged((panel) => {
     activePanel.value = panel
@@ -334,12 +466,33 @@ onMounted(() => {
   bridge.ready()
 })
 
+// Invalidate the learned restore costs when anything that materially
+// changes the trailing cluster's content width flips. The fit
+// controller re-learns the cost on the next transition.
+watch(
+  [
+    locale,
+    installLabel,
+    appUpdatePillLabel,
+    showAppUpdatePill,
+    showInstallUpdatePill,
+    isChromeLocked
+  ],
+  () => invalidateRestoreCosts()
+)
+
 onUnmounted(() => {
   unsubPanel?.()
   unsubInstallationId?.()
   hideTip()
   trailingObserver?.disconnect()
   trailingObserver = undefined
+  fitObserver?.disconnect()
+  fitObserver = undefined
+  if (fitRaf !== null) {
+    cancelAnimationFrame(fitRaf)
+    fitRaf = null
+  }
   if (flashTimer) {
     clearTimeout(flashTimer)
     flashTimer = null
@@ -349,14 +502,18 @@ onUnmounted(() => {
 
 <template>
   <header
+    ref="titleBar"
     class="title-bar"
     :class="{
       'is-mac': isMac,
       'is-light': isLight,
       'is-fullscreen': isFullscreen,
       'is-hover-active': isHoverActive,
-      'is-consent-lockdown': isConsentLockdown
+      'is-consent-lockdown': isConsentLockdown,
+      'is-collapsed-feedback': collapsedFeedback,
+      'is-collapsed-update': collapsedUpdate
     }"
+    :data-collapse-mode="collapseMode"
     :style="{
       color: themeText ?? undefined,
       '--title-trailing-width': `${trailingWidthPx}px`
@@ -372,7 +529,7 @@ onUnmounted(() => {
     <!-- Left cluster: waffle menu. The app-update pill moved to the
          right trailing cluster so all user-action controls
          (update / feedback / downloads / settings) live together. -->
-    <div class="title-cluster">
+    <div ref="titleLeft" class="title-cluster">
       <button
         v-if="!isChromeLocked"
         ref="fileBtn"
@@ -576,10 +733,11 @@ onUnmounted(() => {
   user-select: none;
   -webkit-app-region: drag;
   column-gap: 12px;
-  /* Container query root for responsive pill collapse. The breakpoint
-     rules below (`@container title-bar`) read the title bar's own
-     inline size so the layout responds correctly regardless of which
-     OS reservation is in play. */
+  /* Container scope so the install pill's `max-inline-size:
+     clamp(..., 22cqi, ...)` resolves against the bar's inline size
+     rather than the viewport. Bar is `100vw` today so the two are
+     equivalent, but the explicit container keeps the intent and
+     stays correct if the bar ever lives inside a narrower frame. */
   container: title-bar / inline-size;
 }
 /* macOS: reserve 78px on the left for the traffic-light cluster. */
@@ -683,12 +841,16 @@ onUnmounted(() => {
   display: inline-flex;
   align-items: center;
   justify-content: space-between;
-  /* Fluid width: floor at 220px, preferred ~22% of the title-bar inline
-     size, ceiling at 360px. Acts as a min size so the pill never collapses
-     for a short instance name; `space-between` then pins the logo to the
-     left edge and the caret to the right, with the slack (and the inline
-     Update chip + name) sitting between them — same as the dashboard pill. */
-  width: clamp(220px, 22cqi, 360px);
+  /* Shrink-to-content with bounded floor + ceiling. `inline-size:
+     fit-content` lets the pill tighten around short install names
+     (e.g. "ComfyUI") so the layout budget isn't held hostage by a
+     220px reservation that the content doesn't need. The min keeps
+     the pill from looking puny on a wide bar; the max preserves the
+     fluid 22cqi growth up to a 360px ceiling, with ellipsis on the
+     name beyond that — matching the dashboard pill. */
+  inline-size: fit-content;
+  min-inline-size: 176px;
+  max-inline-size: clamp(176px, 22cqi, 360px);
   height: 28px;
   padding: 5px 8px;
   border-radius: 999px;
@@ -1024,82 +1186,42 @@ onUnmounted(() => {
 }
 
 /* --- Responsive pill collapse ---
-   Container queries read `.title-bar`'s own inline size (set up via
-   `container: title-bar / inline-size` above). Two tiers collapse
-   trailing-cluster labels to icon-only as the bar narrows.
+   Driven by the JS fit controller in <script>, not container queries.
+   The controller measures the actual gap between the centre install
+   pill rect and the trailing cluster rect each resize frame, then
+   advances through three modes (`full` → `no-feedback` → `icons-only`)
+   when the gap falls below `MIN_GAP_PX`, walking back with hysteresis
+   tied to the learned restore cost of each hidden label.
 
-   The thresholds are anchored to the actual point at which the
-   layout would overflow, not to arbitrary breakpoints. With the
-   three-track grid (`auto | minmax(0,1fr) | auto`), the left cluster
-   mirroring the trailing cluster, the install pill's `clamp(220px,
-   22cqi, 360px)` floor, and the platform-specific chrome padding
-   (Win/Linux reserves 140px right; Mac reserves 78px left), the
-   minimum bar width before content overflows works out to roughly:
+   Two boolean class hooks mirror that state for CSS:
 
-                          Full labels   Feedback collapsed
-     Win/Linux            ~1100 px      ~960 px
-     Mac                  ~ 910 px      ~770 px
+     - `.is-collapsed-feedback` — Feedback label is hidden.
+     - `.is-collapsed-update`   — Desktop Update label is hidden
+                                  (implies `.is-collapsed-feedback`).
 
-   Each tier fires ~40 px above its overflow point — enough buffer to
-   absorb font-rendering variance and modestly longer i18n labels
-   without false positives at the default `DEFAULT_HOST_WIDTH` (1280),
-   while still collapsing as soon as the user resizes narrow enough
-   that the cluster would otherwise crash into the centre pill.
+   Tooltips on every pill carry the full label, so icon-only states
+   stay accessible without extra markup. */
 
-     - Mid    (≤  949px Mac, ≤ 1139px Win): Feedback label → icon.
-     - Narrow (≤  809px Mac, ≤  999px Win): update-pill label → icon.
-
-   Tooltips on every pill already carry the full label, so icon-only
-   states remain accessible without extra markup. */
-
-/* Mid tier — Feedback label collapses. */
-@container title-bar (max-width: 949px) {
-  .title-bar.is-mac .title-feedback-label {
-    display: none;
-  }
-  .title-bar.is-mac .title-feedback-button {
-    padding: 4px 6px;
-    gap: 0;
-  }
+.title-bar.is-collapsed-feedback .title-feedback-label {
+  display: none;
 }
-@container title-bar (max-width: 1139px) {
-  .title-bar:not(.is-mac) .title-feedback-label {
-    display: none;
-  }
-  .title-bar:not(.is-mac) .title-feedback-button {
-    padding: 4px 6px;
-    gap: 0;
-  }
+.title-bar.is-collapsed-feedback .title-feedback-button {
+  padding: 4px 6px;
+  gap: 0;
 }
 
-/* Narrow tier — both update pill labels collapse to icon-only. The
-   collapsed pill becomes a 24×24 circle (matching the Settings + other
-   icon buttons) instead of an oval, so it reads as an icon affordance
-   not a "shrunk pill". */
-@container title-bar (max-width: 809px) {
-  .title-bar.is-mac .title-update-pill-label {
-    display: none;
-  }
-  .title-bar.is-mac .title-update-pill {
-    width: 24px;
-    height: 24px;
-    padding: 0;
-    gap: 0;
-    justify-content: center;
-    border-radius: 999px;
-  }
+/* When the update label collapses the pill drops to a 24×24 circle
+   (matching the Settings + other icon-only chrome) instead of staying
+   an oval, so it reads as an icon affordance not a "shrunk pill". */
+.title-bar.is-collapsed-update .title-update-pill-label {
+  display: none;
 }
-@container title-bar (max-width: 999px) {
-  .title-bar:not(.is-mac) .title-update-pill-label {
-    display: none;
-  }
-  .title-bar:not(.is-mac) .title-update-pill {
-    width: 24px;
-    height: 24px;
-    padding: 0;
-    gap: 0;
-    justify-content: center;
-    border-radius: 999px;
-  }
+.title-bar.is-collapsed-update .title-update-pill {
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  gap: 0;
+  justify-content: center;
+  border-radius: 999px;
 }
 </style>


### PR DESCRIPTION
## Problem

The Feedback and Desktop Update pills in the title bar collapsed to icon-only well before the layout was actually crowded. The trigger was a pair of CSS container queries (`@container title-bar (max-width: ...)`) that looked only at the bar's overall inline size; they never measured the centre install pill or the trailing cluster, and they assumed the pill always claimed its 220 px floor. So at the default `1280×900` host on Windows — where there's actually ~180 px of slack — the labels were already hidden. Mac was less extreme but still over-eager.

Any attempt to fix this with smarter bar-width thresholds runs into the same root issue: the bar width simply doesn't carry enough information to know whether the trailing cluster is about to collide with the centre pill.

## Approach

Two paired changes:

### 1. Install pill shrinks to content

```diff
- width: clamp(220px, 22cqi, 360px);
+ inline-size: fit-content;
+ min-inline-size: 176px;
+ max-inline-size: clamp(176px, 22cqi, 360px);
```

The pill no longer reserves 220 px for a short install name like `ComfyUI` — it tightens around its actual content. The min keeps it from looking puny on a wide bar; the max preserves the existing fluid 22cqi growth up to 360 px, with ellipsis on the name beyond that. This alone gives the trailing cluster meaningful extra breathing room on common install names.

### 2. JS fit controller replaces container-query breakpoints

The collapse decision now reads the live geometry of the title bar each resize frame:

```ts
const leftGap = pillRect.left - leftRect.right
const rightGap = trailingRect.left - pillRect.right
const currentGap = Math.min(leftGap, rightGap)
```

Three modes, walked through with hysteresis:

```
  'full'         ─── currentGap < MIN_GAP ───▶ 'no-feedback'
  'no-feedback'  ─── currentGap < MIN_GAP ───▶ 'icons-only'

  'icons-only'   ─── currentGap > restoreUpdate + BUFFER   ─▶ 'no-feedback'
  'no-feedback'  ─── currentGap > restoreFeedback + BUFFER ─▶ 'full'
```

The restore costs for `Feedback` and `Desktop Update` labels are **learned at runtime** via before/after measurement around each transition — we don't know analytically how wide a localized label will render. Costs are invalidated and re-learned whenever something that affects trailing-cluster content width changes (locale, install label, update-state visibility, chrome lockdown).

Resize handling is `ResizeObserver` → single `requestAnimationFrame` → read all rects → at most one class write. No feedback loop: expansion never fires unless the gap exceeds the learned cost of restoring the label that would re-appear.

The CSS keeps only two simple state hooks:

```css
.title-bar.is-collapsed-feedback .title-feedback-label { display: none; }
.title-bar.is-collapsed-update   .title-update-pill-label { display: none; }
```

All the platform-specific `@container` blocks and their drifted thresholds are deleted.

## What this fixes vs the previous approach

| Concern | Before (container queries) | After (JS fit controller) |
|---|---|---|
| Accounts for actual pill position | ✗ assumes 220 px floor | ✓ measures pill rect |
| Accounts for actual pill width | ✗ fixed `width` clamp | ✓ pill is `fit-content`, measured |
| Accounts for localized label widths | ✗ English-only threshold tuning | ✓ learns cost per locale at runtime |
| Accounts for trailing-state changes | ✗ always assumes worst case | ✓ re-evaluates on each change |
| Default 1280×900 window | Both labels hidden on Win | Both labels visible on Win + Mac |
| Truly narrow bar | Collapses at a bar-width threshold | Collapses exactly when pill would overlap |

## Verification

- `pnpm run typecheck` ✓
- `pnpm run lint` ✓
- `pnpm run build` ✓
- `pnpm run test` — 1511/1511 passed (one existing observer-count test updated to allow for the new fit observer)
- Manual: confirmed on Windows that the labels show at default `1280×900`; that Feedback collapses first as the window is dragged narrower, then the Update label; that re-expanding the window restores labels without flapping; that no jitter or flicker is visible during a resize drag.