### PR TITLE
fix(host): map monospace generic for comfyView

### DIFF
--- a/src/main/host/createHostWindow.ts
+++ b/src/main/host/createHostWindow.ts
@@ -884,7 +884,22 @@ export function buildComfyView(
   webPreferences: Electron.WebPreferences,
   windowKey: number,
 ): WebContentsView {
-  const comfyView = new WebContentsView({ webPreferences })
+  /**
+   * Map the `monospace` generic to a real face. Electron leaves it unmapped,
+   * so ComfyUI's prompt textarea renders proportional on Desktop (monospace on web).
+   */
+  const defaultFontFamily: Electron.WebPreferences['defaultFontFamily'] = {
+    ...webPreferences.defaultFontFamily,
+    monospace:
+      process.platform === 'darwin'
+        ? 'Menlo'
+        : process.platform === 'win32'
+          ? 'Consolas'
+          : 'monospace',
+  }
+  const comfyView = new WebContentsView({
+    webPreferences: { ...webPreferences, defaultFontFamily },
+  })
   comfyView.setBackgroundColor(COMFY_BG)
 
   const comfyContents = comfyView.webContents


### PR DESCRIPTION
ComfyUI's prompt / string textareas render in a **proportional** font on Desktop, but **monospace** on web — which also shifts node widths and text wrapping.

## Cause

ComfyUI styles those textareas with the generic `font-family: monospace`. How a generic family resolves is decided by the embedder's `webPreferences.defaultFontFamily`. A browser maps `monospace` → Menlo / SF Mono (macOS) or Consolas (Windows). The comfy `WebContentsView` set **no** `defaultFontFamily`, so Electron fell back to its proportional default.

This is **not** the desktop's Inter font leaking into the child — no CSS/fonts are injected into the comfy view. The opposite: the view was missing the generic-font mapping a real browser provides.

## Fix

Set `defaultFontFamily.monospace` in `buildComfyView` — the single chokepoint both comfyView construction paths (initial + `rebuildComfyViewIfNeeded`) flow through.

```ts
const defaultFontFamily: Electron.WebPreferences['defaultFontFamily'] = {
  ...webPreferences.defaultFontFamily,
  monospace:
    process.platform === 'darwin' ? 'Menlo'
    : process.platform === 'win32' ? 'Consolas'
    : 'monospace',
}
const comfyView = new WebContentsView({
  webPreferences: { ...webPreferences, defaultFontFamily },
})
```

| | Before | After |
|---|---|---|
| Prompt textarea | proportional sans | monospace (matches web) |
| Node widths / wrapping | drifted | matches web |

## Scope

- Only the ComfyUI `WebContentsView`. The title bar, panels, and popups are constructed separately and keep their Inter font.
- Only the `monospace` generic is mapped (additive — spreads existing `defaultFontFamily` first). `standard`/`sansSerif`/`serif` are untouched, so ComfyUI's proportional UI chrome is unaffected.

## Test plan

- [x] `pnpm run typecheck:node` passes
- [x] Probed a `WebContentsView` with vs without the mapping: `font-family: monospace` renders equal-width glyphs only with the fix
- [x] Verified in-app — prompt node renders monospace, matching web

Closes #772 