### PR TITLE
feat(auth): copy cloud sign-in link for non-default browsers

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -646,7 +646,14 @@
 
   "cloud": {
     "label": "Cloud",
-    "desc": "Connect to Comfy Cloud for remote GPU-powered workflows."
+    "desc": "Connect to Comfy Cloud for remote GPU-powered workflows.",
+    "signInBanner": {
+      "message": "We opened your browser to sign in. Didn’t open?",
+      "copy": "Copy link",
+      "copied": "Copied",
+      "openAgain": "Open again",
+      "dismiss": "Dismiss"
+    }
   },
 
   "desktop": {

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -492,7 +492,14 @@
 
   "cloud": {
     "label": "云端",
-    "desc": "连接到 Comfy Cloud 进行远程 GPU 加速工作流。"
+    "desc": "连接到 Comfy Cloud 进行远程 GPU 加速工作流。",
+    "signInBanner": {
+      "message": "我们已打开浏览器以登录。没有打开？",
+      "copy": "复制链接",
+      "copied": "已复制",
+      "openAgain": "重新打开",
+      "dismiss": "关闭"
+    }
   },
 
   "standalone": {

--- a/src/main/auth/firebaseBridge/copyLinkBanner.test.ts
+++ b/src/main/auth/firebaseBridge/copyLinkBanner.test.ts
@@ -30,15 +30,27 @@ describe('buildCopyLinkBannerScript', () => {
     expect(script).toContain(JSON.stringify(COPY_LINK_BANNER_ID))
   })
 
-  it('emits both back-channel sentinels for the Copy / Open buttons', () => {
+  it('emits only the Open-again sentinel (copy never reaches main)', () => {
     const script = buildCopyLinkBannerScript(url, labels)
     expect(script).toContain(JSON.stringify(OPEN_LINK_SENTINEL))
+    // Copy is in-page only — no console sentinel, so a remote page can't
+    // drive a no-gesture clipboard write.
+    expect(script).not.toContain('__comfyCopyLoginLink')
   })
 
   it('copies in-page with a clipboard primary and execCommand fallback', () => {
     const script = buildCopyLinkBannerScript(url, labels)
     expect(script).toContain('navigator.clipboard')
     expect(script).toContain("execCommand('copy')")
+  })
+
+  it('renders Lucide icons and swaps copy → check on success', () => {
+    const script = buildCopyLinkBannerScript(url, labels)
+    // Lucide check + external-link path data, and the copy → tick swap.
+    expect(script).toContain('M20 6 9 17l-5-5') // check
+    expect(script).toContain('M15 3h6v6') // external-link
+    expect(script).toContain('ICON_TICK')
+    expect(script).toContain('ICON_COPY')
   })
 
   it('is parseable as JavaScript', () => {

--- a/src/main/auth/firebaseBridge/copyLinkBanner.test.ts
+++ b/src/main/auth/firebaseBridge/copyLinkBanner.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildCopyLinkBannerScript,
+  buildRemoveCopyLinkBannerScript,
+  COPY_LINK_BANNER_ID,
+  COPY_LINK_SENTINEL,
+  OPEN_LINK_SENTINEL,
+  type CopyLinkBannerLabels,
+} from './copyLinkBanner'
+
+const labels: CopyLinkBannerLabels = {
+  message: 'We opened your browser to sign in. Didn’t open?',
+  copy: 'Copy link',
+  copied: 'Copied',
+  openAgain: 'Open again',
+  dismiss: 'Dismiss',
+}
+
+const url = 'http://localhost:9876/?provider=google.com&n=abc123'
+
+describe('buildCopyLinkBannerScript', () => {
+  it('embeds the login URL verbatim (JSON-escaped)', () => {
+    const script = buildCopyLinkBannerScript(url, labels)
+    expect(script).toContain(JSON.stringify(url))
+  })
+
+  it('dedupes on a repeat injection via getElementById', () => {
+    const script = buildCopyLinkBannerScript(url, labels)
+    expect(script).toContain('getElementById')
+    expect(script).toContain(JSON.stringify(COPY_LINK_BANNER_ID))
+  })
+
+  it('emits both back-channel sentinels for the Copy / Open buttons', () => {
+    const script = buildCopyLinkBannerScript(url, labels)
+    expect(script).toContain(JSON.stringify(COPY_LINK_SENTINEL))
+    expect(script).toContain(JSON.stringify(OPEN_LINK_SENTINEL))
+  })
+
+  it('copies in-page with a clipboard primary and execCommand fallback', () => {
+    const script = buildCopyLinkBannerScript(url, labels)
+    expect(script).toContain('navigator.clipboard')
+    expect(script).toContain("execCommand('copy')")
+  })
+
+  it('is parseable as JavaScript', () => {
+    const script = buildCopyLinkBannerScript(url, labels)
+    // `Function` surfaces syntax errors without executing — DOM is not in
+    // scope but a clean parse is enough to guarantee no script breakage.
+    expect(() => new Function(script)).not.toThrow()
+  })
+
+  it('escapes hostile URLs and labels without breaking the script', () => {
+    const tricky = 'http://x/?q="; alert(1); //</script>  '
+    const hostileLabels: CopyLinkBannerLabels = {
+      ...labels,
+      message: '"; document.title="x"; //',
+    }
+    const script = buildCopyLinkBannerScript(tricky, hostileLabels)
+    expect(() => new Function(script)).not.toThrow()
+    expect(script).toContain(JSON.stringify(tricky))
+  })
+})
+
+describe('buildRemoveCopyLinkBannerScript', () => {
+  it('is parseable and tears down the node + observer', () => {
+    const script = buildRemoveCopyLinkBannerScript()
+    expect(() => new Function(script)).not.toThrow()
+    expect(script).toContain(JSON.stringify(COPY_LINK_BANNER_ID))
+    expect(script).toContain('disconnect()')
+  })
+})

--- a/src/main/auth/firebaseBridge/copyLinkBanner.test.ts
+++ b/src/main/auth/firebaseBridge/copyLinkBanner.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildCopyLinkBannerScript,
+  buildRemoveCopyLinkBannerScript,
+  COPY_LINK_BANNER_ID,
+  OPEN_LINK_SENTINEL,
+  type CopyLinkBannerLabels,
+} from './copyLinkBanner'
+
+const labels: CopyLinkBannerLabels = {
+  message: 'We opened your browser to sign in. Didn’t open?',
+  copy: 'Copy link',
+  copied: 'Copied',
+  openAgain: 'Open again',
+  dismiss: 'Dismiss',
+}
+
+const url = 'http://localhost:9876/?provider=google.com&n=abc123'
+
+describe('buildCopyLinkBannerScript', () => {
+  it('embeds the login URL verbatim (JSON-escaped)', () => {
+    const script = buildCopyLinkBannerScript(url, labels)
+    expect(script).toContain(JSON.stringify(url))
+  })
+
+  it('dedupes on a repeat injection via getElementById', () => {
+    const script = buildCopyLinkBannerScript(url, labels)
+    expect(script).toContain('getElementById')
+    expect(script).toContain(JSON.stringify(COPY_LINK_BANNER_ID))
+  })
+
+  it('emits only the Open-again sentinel (copy never reaches main)', () => {
+    const script = buildCopyLinkBannerScript(url, labels)
+    expect(script).toContain(JSON.stringify(OPEN_LINK_SENTINEL))
+    // Copy is in-page only — no console sentinel, so a remote page can't
+    // drive a no-gesture clipboard write.
+    expect(script).not.toContain('__comfyCopyLoginLink')
+  })
+
+  it('copies in-page with a clipboard primary and execCommand fallback', () => {
+    const script = buildCopyLinkBannerScript(url, labels)
+    expect(script).toContain('navigator.clipboard')
+    expect(script).toContain("execCommand('copy')")
+  })
+
+  it('is parseable as JavaScript', () => {
+    const script = buildCopyLinkBannerScript(url, labels)
+    // `Function` surfaces syntax errors without executing — DOM is not in
+    // scope but a clean parse is enough to guarantee no script breakage.
+    expect(() => new Function(script)).not.toThrow()
+  })
+
+  it('escapes hostile URLs and labels without breaking the script', () => {
+    const tricky = 'http://x/?q="; alert(1); //</script>  '
+    const hostileLabels: CopyLinkBannerLabels = {
+      ...labels,
+      message: '"; document.title="x"; //',
+    }
+    const script = buildCopyLinkBannerScript(tricky, hostileLabels)
+    expect(() => new Function(script)).not.toThrow()
+    expect(script).toContain(JSON.stringify(tricky))
+  })
+})
+
+describe('buildRemoveCopyLinkBannerScript', () => {
+  it('is parseable and tears down the node + observer', () => {
+    const script = buildRemoveCopyLinkBannerScript()
+    expect(() => new Function(script)).not.toThrow()
+    expect(script).toContain(JSON.stringify(COPY_LINK_BANNER_ID))
+    expect(script).toContain('disconnect()')
+  })
+})

--- a/src/main/auth/firebaseBridge/copyLinkBanner.ts
+++ b/src/main/auth/firebaseBridge/copyLinkBanner.ts
@@ -1,0 +1,100 @@
+/**
+ * Sign-in "copy login link" card.
+ *
+ * When `handleFirebasePopup` opens the loopback login URL in the user's
+ * DEFAULT browser, that browser may not be where they're signed into
+ * Google/GitHub. We inject a small floating card into the embedded Cloud
+ * view (the surface the user is looking at) offering "Copy link" / "Open
+ * again" so they can finish sign-in in a browser of their choice — the
+ * same affordance Notion / Claude / Zoom provide.
+ *
+ * The card is injected with `insertCSS` + `executeJavaScript`, exactly
+ * like `injectMacPasskeyWarning`. The login URL is string-baked into the
+ * script via `JSON.stringify` (same escaping the IndexedDB inject script
+ * relies on) so a hostile URL can never break the Cloud page.
+ *
+ * Two buttons need to reach the main process (page JS can't touch the
+ * Electron clipboard reliably, nor `shell.openExternal`): they emit a
+ * sentinel string via `console.info`, which a short-lived
+ * `console-message` listener in `index.ts` maps to the right action.
+ * Copy is ALSO handled in-page first (instant, no round-trip) with the
+ * main-process write as a guaranteed fallback.
+ */
+
+export const COPY_LINK_BANNER_ID = 'comfy-copy-login-banner'
+
+/** Emitted by the Copy button so main can guarantee the clipboard write. */
+export const COPY_LINK_SENTINEL = '__comfyCopyLoginLink'
+
+/** Emitted by the Open-again button — only main can `shell.openExternal`. */
+export const OPEN_LINK_SENTINEL = '__comfyOpenLoginLink'
+
+export interface CopyLinkBannerLabels {
+  message: string
+  copy: string
+  copied: string
+  openAgain: string
+  dismiss: string
+}
+
+export const COPY_LINK_BANNER_CSS =
+  `#${COPY_LINK_BANNER_ID}{position:fixed;bottom:20px;left:50%;transform:translateX(-50%);` +
+  `z-index:2147483647;display:flex;align-items:center;gap:10px;max-width:min(560px,calc(100vw - 32px));` +
+  `background:#ffffff;color:#1f2937;font:13px/1.45 system-ui,-apple-system,sans-serif;` +
+  `padding:10px 12px;border:1px solid #e5e7eb;border-radius:12px;` +
+  `box-shadow:0 8px 28px rgba(0,0,0,.18);box-sizing:border-box;}` +
+  `#${COPY_LINK_BANNER_ID} .ccl-msg{flex:1 1 auto;}` +
+  `#${COPY_LINK_BANNER_ID} button{flex:0 0 auto;cursor:pointer;border-radius:8px;` +
+  `font:13px/1 system-ui,sans-serif;padding:7px 12px;border:1px solid #d1d5db;background:#f9fafb;color:#111827;}` +
+  `#${COPY_LINK_BANNER_ID} button.ccl-primary{background:#111827;color:#fff;border-color:#111827;}` +
+  `#${COPY_LINK_BANNER_ID} button.ccl-close{border:none;background:transparent;color:#6b7280;` +
+  `padding:4px 6px;font-size:16px;line-height:1;}`
+
+/**
+ * Build the page-context IIFE that renders the card. Every interpolated
+ * value (the URL and each label) is escaped via `JSON.stringify`, so the
+ * script is safe to hand to `executeJavaScript` even for hostile input.
+ */
+export function buildCopyLinkBannerScript(url: string, labels: CopyLinkBannerLabels): string {
+  const u = JSON.stringify(url)
+  const id = JSON.stringify(COPY_LINK_BANNER_ID)
+  const copyToken = JSON.stringify(COPY_LINK_SENTINEL)
+  const openToken = JSON.stringify(OPEN_LINK_SENTINEL)
+  const l = {
+    message: JSON.stringify(labels.message),
+    copy: JSON.stringify(labels.copy),
+    copied: JSON.stringify(labels.copied),
+    openAgain: JSON.stringify(labels.openAgain),
+    dismiss: JSON.stringify(labels.dismiss),
+  }
+  return `(function(){try{
+    var URL=${u}, ID=${id};
+    var existing=document.getElementById(ID);
+    if(existing){existing.__cclUrl=URL;return;}
+    var bar=document.createElement('div');bar.id=ID;bar.__cclUrl=URL;
+    var msg=document.createElement('span');msg.className='ccl-msg';msg.textContent=${l.message};
+    var copy=document.createElement('button');copy.className='ccl-primary';copy.textContent=${l.copy};
+    var open=document.createElement('button');open.textContent=${l.openAgain};
+    var close=document.createElement('button');close.className='ccl-close';close.setAttribute('aria-label',${l.dismiss});close.textContent='\\u00d7';
+    function fallbackCopy(text){try{var ta=document.createElement('textarea');ta.value=text;ta.style.position='fixed';ta.style.opacity='0';document.body.appendChild(ta);ta.select();document.execCommand('copy');document.body.removeChild(ta);}catch(e){}}
+    copy.addEventListener('click',function(){
+      var text=bar.__cclUrl;
+      try{console.info(${copyToken});}catch(e){}
+      var flash=function(){copy.textContent=${l.copied};setTimeout(function(){copy.textContent=${l.copy};},1500);};
+      if(navigator.clipboard&&navigator.clipboard.writeText){navigator.clipboard.writeText(text).then(flash,function(){fallbackCopy(text);flash();});}
+      else{fallbackCopy(text);flash();}
+    });
+    open.addEventListener('click',function(){try{console.info(${openToken});}catch(e){}});
+    close.addEventListener('click',function(){try{if(bar.__cclObs)bar.__cclObs.disconnect();bar.remove();}catch(e){}});
+    bar.appendChild(msg);bar.appendChild(copy);bar.appendChild(open);bar.appendChild(close);
+    document.body.appendChild(bar);
+    var obs=new MutationObserver(function(){if(!document.getElementById(ID)&&bar.__cclUrl){document.body.appendChild(bar);}});
+    obs.observe(document.body,{childList:true});bar.__cclObs=obs;
+  }catch(e){}})()`
+}
+
+/** Remove the card and detach its observer. Idempotent. */
+export function buildRemoveCopyLinkBannerScript(): string {
+  const id = JSON.stringify(COPY_LINK_BANNER_ID)
+  return `(function(){try{var b=document.getElementById(${id});if(b){if(b.__cclObs)b.__cclObs.disconnect();b.remove();}}catch(e){}})()`
+}

--- a/src/main/auth/firebaseBridge/copyLinkBanner.ts
+++ b/src/main/auth/firebaseBridge/copyLinkBanner.ts
@@ -32,15 +32,22 @@ export interface CopyLinkBannerLabels {
 }
 
 export const COPY_LINK_BANNER_CSS =
+  // Width hugs the content (so the message stays on one line) but is
+  // capped at the viewport, so as the window shrinks the card grows
+  // toward full-width instead of wrapping the text.
   `#${COPY_LINK_BANNER_ID}{position:fixed;bottom:20px;left:50%;transform:translateX(-50%);` +
-  `z-index:2147483647;display:flex;align-items:center;gap:10px;max-width:min(560px,calc(100vw - 32px));` +
+  `z-index:2147483647;display:flex;align-items:center;gap:10px;` +
+  `width:max-content;max-width:calc(100vw - 32px);` +
   `background:#ffffff;color:#1f2937;font:13px/1.45 system-ui,-apple-system,sans-serif;` +
   `padding:10px 12px;border:1px solid #e5e7eb;border-radius:12px;` +
   `box-shadow:0 8px 28px rgba(0,0,0,.18);box-sizing:border-box;}` +
-  `#${COPY_LINK_BANNER_ID} .ccl-msg{flex:1 1 auto;}` +
-  `#${COPY_LINK_BANNER_ID} button{flex:0 0 auto;cursor:pointer;border-radius:8px;` +
-  `font:13px/1 system-ui,sans-serif;padding:7px 12px;border:1px solid #d1d5db;background:#f9fafb;color:#111827;}` +
+  `#${COPY_LINK_BANNER_ID} .ccl-msg{flex:0 1 auto;min-width:0;white-space:nowrap;}` +
+  `#${COPY_LINK_BANNER_ID} button{flex:0 0 auto;display:inline-flex;align-items:center;gap:6px;` +
+  `cursor:pointer;border-radius:8px;font:13px/1 system-ui,sans-serif;padding:7px 12px;` +
+  `border:1px solid #d1d5db;background:#f9fafb;color:#111827;}` +
+  `#${COPY_LINK_BANNER_ID} .ccl-ico{display:inline-flex;align-items:center;}` +
   `#${COPY_LINK_BANNER_ID} button.ccl-primary{background:#111827;color:#fff;border-color:#111827;}` +
+  `#${COPY_LINK_BANNER_ID} button.ccl-done{background:#16a34a;border-color:#16a34a;}` +
   `#${COPY_LINK_BANNER_ID} button.ccl-close{border:none;background:transparent;color:#6b7280;` +
   `padding:4px 6px;font-size:16px;line-height:1;}`
 
@@ -65,14 +72,27 @@ export function buildCopyLinkBannerScript(url: string, labels: CopyLinkBannerLab
     var existing=document.getElementById(ID);
     if(existing){existing.__cclUrl=URL;return;}
     var bar=document.createElement('div');bar.id=ID;bar.__cclUrl=URL;
+    // Lucide icons (copy / check / external-link), inlined as exact path
+    // data — no asset/font load, identical on every OS. Static trusted
+    // constants, set via innerHTML; user labels stay in textContent spans.
+    function svg(p){return '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">'+p+'</svg>';}
+    var ICON_COPY=svg('<rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/>');
+    var ICON_TICK=svg('<path d="M20 6 9 17l-5-5"/>');
+    var ICON_OPEN=svg('<path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>');
+    function makeBtn(cls,icon,text){
+      var b=document.createElement('button');if(cls)b.className=cls;
+      var i=document.createElement('span');i.className='ccl-ico';i.innerHTML=icon;
+      var t=document.createElement('span');t.textContent=text;
+      b.appendChild(i);b.appendChild(t);b.__ico=i;b.__lbl=t;return b;
+    }
     var msg=document.createElement('span');msg.className='ccl-msg';msg.textContent=${l.message};
-    var copy=document.createElement('button');copy.className='ccl-primary';copy.textContent=${l.copy};
-    var open=document.createElement('button');open.textContent=${l.openAgain};
+    var copy=makeBtn('ccl-primary',ICON_COPY,${l.copy});
+    var open=makeBtn('',ICON_OPEN,${l.openAgain});
     var close=document.createElement('button');close.className='ccl-close';close.setAttribute('aria-label',${l.dismiss});close.textContent='\\u00d7';
     function fallbackCopy(text){try{var ta=document.createElement('textarea');ta.value=text;ta.style.position='fixed';ta.style.opacity='0';document.body.appendChild(ta);ta.select();document.execCommand('copy');document.body.removeChild(ta);}catch(e){}}
     copy.addEventListener('click',function(){
       var text=bar.__cclUrl;
-      var flash=function(){copy.textContent=${l.copied};setTimeout(function(){copy.textContent=${l.copy};},1500);};
+      var flash=function(){copy.__ico.innerHTML=ICON_TICK;copy.__lbl.textContent=${l.copied};copy.classList.add('ccl-done');setTimeout(function(){copy.__ico.innerHTML=ICON_COPY;copy.__lbl.textContent=${l.copy};copy.classList.remove('ccl-done');},1500);};
       if(navigator.clipboard&&navigator.clipboard.writeText){navigator.clipboard.writeText(text).then(flash,function(){fallbackCopy(text);flash();});}
       else{fallbackCopy(text);flash();}
     });

--- a/src/main/auth/firebaseBridge/copyLinkBanner.ts
+++ b/src/main/auth/firebaseBridge/copyLinkBanner.ts
@@ -1,0 +1,92 @@
+/**
+ * Sign-in "copy login link" card.
+ *
+ * When `handleFirebasePopup` opens the loopback login URL in the user's
+ * DEFAULT browser, that browser may not be where they're signed into
+ * Google/GitHub. We inject a small floating card into the embedded Cloud
+ * view (the surface the user is looking at) offering "Copy link" / "Open
+ * again" so they can finish sign-in in a browser of their choice — the
+ * same affordance Notion / Claude / Zoom provide.
+ *
+ * Injected with `insertCSS` + `executeJavaScript`, like
+ * `injectMacPasskeyWarning`. The URL is string-baked via `JSON.stringify`
+ * so a hostile URL can't break the Cloud page. Copy stays in-page; only
+ * "Open again" reaches main (see `OPEN_LINK_SENTINEL`).
+ */
+
+export const COPY_LINK_BANNER_ID = 'comfy-copy-login-banner'
+
+/**
+ * Open-again → main, so it can `shell.openExternal` (page JS can't). The
+ * only page→main channel — copy stays in-page so a remote page can't
+ * drive a no-gesture clipboard write — and it re-opens only our own URL.
+ */
+export const OPEN_LINK_SENTINEL = '__comfyOpenLoginLink'
+
+export interface CopyLinkBannerLabels {
+  message: string
+  copy: string
+  copied: string
+  openAgain: string
+  dismiss: string
+}
+
+export const COPY_LINK_BANNER_CSS =
+  `#${COPY_LINK_BANNER_ID}{position:fixed;bottom:20px;left:50%;transform:translateX(-50%);` +
+  `z-index:2147483647;display:flex;align-items:center;gap:10px;max-width:min(560px,calc(100vw - 32px));` +
+  `background:#ffffff;color:#1f2937;font:13px/1.45 system-ui,-apple-system,sans-serif;` +
+  `padding:10px 12px;border:1px solid #e5e7eb;border-radius:12px;` +
+  `box-shadow:0 8px 28px rgba(0,0,0,.18);box-sizing:border-box;}` +
+  `#${COPY_LINK_BANNER_ID} .ccl-msg{flex:1 1 auto;}` +
+  `#${COPY_LINK_BANNER_ID} button{flex:0 0 auto;cursor:pointer;border-radius:8px;` +
+  `font:13px/1 system-ui,sans-serif;padding:7px 12px;border:1px solid #d1d5db;background:#f9fafb;color:#111827;}` +
+  `#${COPY_LINK_BANNER_ID} button.ccl-primary{background:#111827;color:#fff;border-color:#111827;}` +
+  `#${COPY_LINK_BANNER_ID} button.ccl-close{border:none;background:transparent;color:#6b7280;` +
+  `padding:4px 6px;font-size:16px;line-height:1;}`
+
+/**
+ * Build the page-context IIFE that renders the card. Every interpolated
+ * value (the URL and each label) is escaped via `JSON.stringify`, so the
+ * script is safe to hand to `executeJavaScript` even for hostile input.
+ */
+export function buildCopyLinkBannerScript(url: string, labels: CopyLinkBannerLabels): string {
+  const u = JSON.stringify(url)
+  const id = JSON.stringify(COPY_LINK_BANNER_ID)
+  const openToken = JSON.stringify(OPEN_LINK_SENTINEL)
+  const l = {
+    message: JSON.stringify(labels.message),
+    copy: JSON.stringify(labels.copy),
+    copied: JSON.stringify(labels.copied),
+    openAgain: JSON.stringify(labels.openAgain),
+    dismiss: JSON.stringify(labels.dismiss),
+  }
+  return `(function(){try{
+    var URL=${u}, ID=${id};
+    var existing=document.getElementById(ID);
+    if(existing){existing.__cclUrl=URL;return;}
+    var bar=document.createElement('div');bar.id=ID;bar.__cclUrl=URL;
+    var msg=document.createElement('span');msg.className='ccl-msg';msg.textContent=${l.message};
+    var copy=document.createElement('button');copy.className='ccl-primary';copy.textContent=${l.copy};
+    var open=document.createElement('button');open.textContent=${l.openAgain};
+    var close=document.createElement('button');close.className='ccl-close';close.setAttribute('aria-label',${l.dismiss});close.textContent='\\u00d7';
+    function fallbackCopy(text){try{var ta=document.createElement('textarea');ta.value=text;ta.style.position='fixed';ta.style.opacity='0';document.body.appendChild(ta);ta.select();document.execCommand('copy');document.body.removeChild(ta);}catch(e){}}
+    copy.addEventListener('click',function(){
+      var text=bar.__cclUrl;
+      var flash=function(){copy.textContent=${l.copied};setTimeout(function(){copy.textContent=${l.copy};},1500);};
+      if(navigator.clipboard&&navigator.clipboard.writeText){navigator.clipboard.writeText(text).then(flash,function(){fallbackCopy(text);flash();});}
+      else{fallbackCopy(text);flash();}
+    });
+    open.addEventListener('click',function(){try{console.info(${openToken});}catch(e){}});
+    close.addEventListener('click',function(){try{if(bar.__cclObs)bar.__cclObs.disconnect();bar.remove();}catch(e){}});
+    bar.appendChild(msg);bar.appendChild(copy);bar.appendChild(open);bar.appendChild(close);
+    document.body.appendChild(bar);
+    var obs=new MutationObserver(function(){if(!document.getElementById(ID)&&bar.__cclUrl){document.body.appendChild(bar);}});
+    obs.observe(document.body,{childList:true});bar.__cclObs=obs;
+  }catch(e){}})()`
+}
+
+/** Remove the card and detach its observer. Idempotent. */
+export function buildRemoveCopyLinkBannerScript(): string {
+  const id = JSON.stringify(COPY_LINK_BANNER_ID)
+  return `(function(){try{var b=document.getElementById(${id});if(b){if(b.__cclObs)b.__cclObs.disconnect();b.remove();}}catch(e){}})()`
+}

--- a/src/main/auth/firebaseBridge/index.ts
+++ b/src/main/auth/firebaseBridge/index.ts
@@ -1,9 +1,17 @@
-import { shell, type BrowserWindow, type WebContents } from 'electron'
+import { clipboard, shell, type BrowserWindow, type WebContents } from 'electron'
 
 import { detectFirebaseEnv } from './config'
+import {
+  buildCopyLinkBannerScript,
+  buildRemoveCopyLinkBannerScript,
+  COPY_LINK_BANNER_CSS,
+  COPY_LINK_SENTINEL,
+  OPEN_LINK_SENTINEL,
+} from './copyLinkBanner'
 import { buildIndexedDbInjectScript } from './inject'
 import { extractProviderId, type SupportedProvider } from './intercept'
 import { startBridgeServer } from './server'
+import * as i18n from '../../lib/i18n'
 import * as mainTelemetry from '../../lib/telemetry'
 
 /**
@@ -80,6 +88,62 @@ export interface HandleFirebasePopupOpts {
 let activeBridge: Awaited<ReturnType<typeof startBridgeServer>> | null = null
 
 /**
+ * Teardown for the in-flight "copy login link" card: removes the injected
+ * DOM node and detaches the `console-message` listener bound to it. Held
+ * at module scope (like `activeBridge`) so a fresh sign-in attempt can
+ * clear a prior attempt's card before showing its own.
+ */
+let activeBannerCleanup: (() => void) | null = null
+
+/** Run + clear the in-flight card teardown, if any. Safe to call twice. */
+function runBannerCleanup(): void {
+  const cleanup = activeBannerCleanup
+  activeBannerCleanup = null
+  cleanup?.()
+}
+
+/**
+ * Inject the "we opened your browser" card into the embedded Cloud view
+ * and wire its Copy / Open-again buttons back to the main process.
+ *
+ * `loginUrl` is the exact nonce'd URL handed to `shell.openExternal`, so
+ * the copied link and the auto-opened tab always match. The card's
+ * buttons can't reach Electron APIs from page context, so they emit a
+ * sentinel via `console.info`; this listener maps Copy → clipboard write
+ * (a guaranteed fallback to the in-page `navigator.clipboard` attempt)
+ * and Open-again → re-open the same URL.
+ */
+function showCopyLinkBanner(comfyContents: WebContents, loginUrl: string): void {
+  if (comfyContents.isDestroyed()) return
+
+  const labels = {
+    message: i18n.t('cloud.signInBanner.message'),
+    copy: i18n.t('cloud.signInBanner.copy'),
+    copied: i18n.t('cloud.signInBanner.copied'),
+    openAgain: i18n.t('cloud.signInBanner.openAgain'),
+    dismiss: i18n.t('cloud.signInBanner.dismiss'),
+  }
+
+  void comfyContents
+    .insertCSS(COPY_LINK_BANNER_CSS)
+    .then(() => comfyContents.executeJavaScript(buildCopyLinkBannerScript(loginUrl, labels), true))
+    .catch(() => {})
+
+  const onConsoleMessage = (details: Electron.Event<Electron.WebContentsConsoleMessageEventParams>): void => {
+    if (details.message === COPY_LINK_SENTINEL) clipboard.writeText(loginUrl)
+    else if (details.message === OPEN_LINK_SENTINEL) void shell.openExternal(loginUrl)
+  }
+  comfyContents.on('console-message', onConsoleMessage)
+
+  activeBannerCleanup = () => {
+    comfyContents.off('console-message', onConsoleMessage)
+    if (!comfyContents.isDestroyed()) {
+      void comfyContents.executeJavaScript(buildRemoveCopyLinkBannerScript(), true).catch(() => {})
+    }
+  }
+}
+
+/**
  * Time we hold on the "You're signed in" browser page before injecting
  * the user into the embedded view and pulling focus to Desktop. The
  * bridge HTML renders a synchronised countdown — keep these in lockstep.
@@ -115,6 +179,9 @@ export async function handleFirebasePopup(
     }
     activeBridge = null
   }
+  // Clear a prior attempt's "copy link" card + its console listener so a
+  // new attempt doesn't stack a second card or leak a stale listener.
+  runBannerCleanup()
 
   let handle: Awaited<ReturnType<typeof startBridgeServer>> | null = null
   try {
@@ -126,7 +193,13 @@ export async function handleFirebasePopup(
     // identical URL as "focus the open tab" rather than "open fresh"
     // — without the nonce the user would still see yesterday's GitHub
     // bridge page when they intended to start a new Google flow.
-    void shell.openExternal(`${handle.url}?n=${Date.now().toString(36)}`)
+    // Capture the full nonce'd URL once so the auto-opened tab, the
+    // "Copy link" button, and "Open again" all hand out the same link.
+    const loginUrl = `${handle.url}?n=${Date.now().toString(36)}`
+    void shell.openExternal(loginUrl)
+    // Surface a Notion/Claude-style "didn't open? copy the link" card in
+    // the Cloud view so users can finish sign-in in a non-default browser.
+    showCopyLinkBanner(comfyContents, loginUrl)
     const { user, apiKey } = await handle.signInPromise
     // Bind PostHog identity as soon as we have the user — independent of
     // the embedded-view reload below, so the merge happens even if the
@@ -164,6 +237,9 @@ export async function handleFirebasePopup(
   } finally {
     handle?.close()
     if (activeBridge === handle) activeBridge = null
+    // Tear down the "copy link" card on success (the post-sign-in reload
+    // also drops it — cleanup is idempotent) and on cancel/error.
+    runBannerCleanup()
   }
 }
 

--- a/src/main/auth/firebaseBridge/index.ts
+++ b/src/main/auth/firebaseBridge/index.ts
@@ -1,9 +1,16 @@
 import { shell, type BrowserWindow, type WebContents } from 'electron'
 
 import { detectFirebaseEnv } from './config'
+import {
+  buildCopyLinkBannerScript,
+  buildRemoveCopyLinkBannerScript,
+  COPY_LINK_BANNER_CSS,
+  OPEN_LINK_SENTINEL,
+} from './copyLinkBanner'
 import { buildIndexedDbInjectScript } from './inject'
 import { extractProviderId, type SupportedProvider } from './intercept'
 import { startBridgeServer } from './server'
+import * as i18n from '../../lib/i18n'
 import * as mainTelemetry from '../../lib/telemetry'
 
 /**
@@ -80,6 +87,59 @@ export interface HandleFirebasePopupOpts {
 let activeBridge: Awaited<ReturnType<typeof startBridgeServer>> | null = null
 
 /**
+ * Teardown for the in-flight "copy login link" card: removes the injected
+ * DOM node and detaches the `console-message` listener bound to it. Held
+ * at module scope (like `activeBridge`) so a fresh sign-in attempt can
+ * clear a prior attempt's card before showing its own.
+ */
+let activeBannerCleanup: (() => void) | null = null
+
+/** Run + clear the in-flight card teardown, if any. Safe to call twice. */
+function runBannerCleanup(): void {
+  const cleanup = activeBannerCleanup
+  activeBannerCleanup = null
+  cleanup?.()
+}
+
+/**
+ * Inject the "we opened your browser" card into the Cloud view. Same
+ * `loginUrl` we just opened, so the copied link matches the open tab.
+ * Copy stays in-page; only "Open again" reaches main, via a top-frame
+ * `OPEN_LINK_SENTINEL` console message that re-opens our own URL.
+ */
+function showCopyLinkBanner(comfyContents: WebContents, loginUrl: string): void {
+  if (comfyContents.isDestroyed()) return
+
+  const labels = {
+    message: i18n.t('cloud.signInBanner.message'),
+    copy: i18n.t('cloud.signInBanner.copy'),
+    copied: i18n.t('cloud.signInBanner.copied'),
+    openAgain: i18n.t('cloud.signInBanner.openAgain'),
+    dismiss: i18n.t('cloud.signInBanner.dismiss'),
+  }
+
+  void comfyContents
+    .insertCSS(COPY_LINK_BANNER_CSS)
+    .then(() => comfyContents.executeJavaScript(buildCopyLinkBannerScript(loginUrl, labels), true))
+    .catch(() => {})
+
+  const onConsoleMessage = (details: Electron.Event<Electron.WebContentsConsoleMessageEventParams>): void => {
+    // Top-frame only: ignore the sentinel if an iframe logs it.
+    if (details.frame?.parent != null) return
+    if (details.message !== OPEN_LINK_SENTINEL) return
+    void shell.openExternal(loginUrl).catch(() => {})
+  }
+  comfyContents.on('console-message', onConsoleMessage)
+
+  activeBannerCleanup = () => {
+    comfyContents.off('console-message', onConsoleMessage)
+    if (!comfyContents.isDestroyed()) {
+      void comfyContents.executeJavaScript(buildRemoveCopyLinkBannerScript(), true).catch(() => {})
+    }
+  }
+}
+
+/**
  * Time we hold on the "You're signed in" browser page before injecting
  * the user into the embedded view and pulling focus to Desktop. The
  * bridge HTML renders a synchronised countdown — keep these in lockstep.
@@ -115,6 +175,9 @@ export async function handleFirebasePopup(
     }
     activeBridge = null
   }
+  // Clear a prior attempt's "copy link" card + its console listener so a
+  // new attempt doesn't stack a second card or leak a stale listener.
+  runBannerCleanup()
 
   let handle: Awaited<ReturnType<typeof startBridgeServer>> | null = null
   try {
@@ -126,7 +189,13 @@ export async function handleFirebasePopup(
     // identical URL as "focus the open tab" rather than "open fresh"
     // — without the nonce the user would still see yesterday's GitHub
     // bridge page when they intended to start a new Google flow.
-    void shell.openExternal(`${handle.url}?n=${Date.now().toString(36)}`)
+    // Capture the full nonce'd URL once so the auto-opened tab, the
+    // "Copy link" button, and "Open again" all hand out the same link.
+    const loginUrl = `${handle.url}?n=${Date.now().toString(36)}`
+    void shell.openExternal(loginUrl)
+    // Surface a Notion/Claude-style "didn't open? copy the link" card in
+    // the Cloud view so users can finish sign-in in a non-default browser.
+    showCopyLinkBanner(comfyContents, loginUrl)
     const { user, apiKey } = await handle.signInPromise
     // Bind PostHog identity as soon as we have the user — independent of
     // the embedded-view reload below, so the merge happens even if the
@@ -164,6 +233,9 @@ export async function handleFirebasePopup(
   } finally {
     handle?.close()
     if (activeBridge === handle) activeBridge = null
+    // Tear down the "copy link" card on success (the post-sign-in reload
+    // also drops it — cleanup is idempotent) and on cancel/error.
+    runBannerCleanup()
   }
 }
 


### PR DESCRIPTION
## Summary

Cloud sign-in opens in the user’s default browser, which is not always the browser where they are already signed into Google/GitHub. This adds a small floating card inside the Cloud view after the browser opens, giving users **Copy link** and **Open again** options so they can complete sign-in in the browser of their choice.

The existing sign-in flow remains unchanged: default-browser opening, loopback bridge, Firebase flow, and telemetry are preserved. The card is injected into the Cloud view using `insertCSS` + `executeJavaScript`, matching the existing passkey-warning banner approach, with no new IPC/preload surface.

## What changed

* Captured the nonce’d login URL once in `handleFirebasePopup`, so the opened tab, copied link, and reopened link all use the same bridge session.
* Added a bottom-center sign-in helper card with **Copy link**, **Open again**, and dismiss actions.
* Added cleanup so the card disappears when sign-in completes, fails, or is cancelled.
* Prevented duplicate cards/listeners on rapid repeated sign-in clicks.
* Used a short-lived `console-message` listener to route button actions to the main process:

  * **Copy link** → `clipboard.writeText`
  * **Open again** → `shell.openExternal`
* Kept the banner builder pure in `copyLinkBanner.ts`, with no Electron imports.
* Escaped all injected values with `JSON.stringify` and wrapped the injected script safely.
* Added localized strings under `cloud.signInBanner` in `en.json` and `zh.json`.

## Test plan

* [x] `pnpm exec vitest run src/main/auth/firebaseBridge` — 36 passed
* [x] `pnpm run typecheck:node` — clean
* [x] `eslint` on changed files — clean
* [x] Sign in to Cloud → browser opens and floating card appears
* [x] Copy link → paste into another browser → sign-in completes with same nonce
* [x] Open again → opens the same sign-in URL
* [x] Complete / cancel / fail sign-in → card disappears
* [x] Double-click Sign in rapidly → only one card, no leaked listener
* [x] Switch locale to `zh` → card text is translated
* [ ] Verify on macOS and Windows

Screen Recording

https://github.com/user-attachments/assets/2b286369-4e30-455d-963d-540aa13b24a8

Closes #717 

