### PR TITLE
fix(title-bar): clear popup backdrop when switching popup kind on th reused view

### DIFF
--- a/src/main/popups/titlePopup.ts
+++ b/src/main/popups/titlePopup.ts
@@ -72,6 +72,13 @@ interface TitlePopupMenuItem {
 
 type TitlePopupKind = 'menu' | 'downloads' | 'instance-picker' | 'global-settings'
 
+/** Kinds that dim the host body with the shared backdrop view. Single source
+ *  of truth — geometry, blur-dismiss opt-out, and backdrop show/hide all key
+ *  off this so a new kind only has to opt in here. */
+function kindUsesBackdrop(kind: TitlePopupKind): boolean {
+  return kind === 'instance-picker' || kind === 'global-settings'
+}
+
 /** Single install row pushed to the instance-picker popup. Mirrors the
  *  renderer-side `Installation` shape returned by the `get-installations`
  *  IPC handler (extra fields like `version`, `statusTag`, `sourceLabel`
@@ -588,11 +595,18 @@ function showPopupBackdrop(parent: BrowserWindow): void {
   entry.visible = true
 }
 
+/** Hide AND detach the backdrop. Detaching (not just `setVisible(false)`)
+ *  stops a lagging hidden view from intercepting body clicks; `showPopupBackdrop`
+ *  re-adds it on every show. */
 function hidePopupBackdrop(parent: BrowserWindow): void {
   const entry = popupBackdropsByParent.get(parent.id)
   if (!entry || !entry.visible) return
-  if (!entry.view.webContents.isDestroyed()) entry.view.setVisible(false)
   entry.visible = false
+  if (entry.view.webContents.isDestroyed()) return
+  entry.view.setVisible(false)
+  if (!parent.isDestroyed()) {
+    try { parent.contentView.removeChildView(entry.view) } catch { /* noop */ }
+  }
 }
 
 const POPUP_WIDTH = 220
@@ -879,11 +893,6 @@ function ensureTitlePopup(parent: BrowserWindow): TitlePopupEntry {
       titlePopupsByWebContents.delete(view.popupWebContentsId)
     },
     onHide: () => {
-      // Always fires when the popup transitions out of open/pending —
-      // including the blur / will-move / move / popup-blur auto-dismiss
-      // paths. Without this notify, the title-bar renderer's
-      // `isMenuOpen` flag stays stuck true and every subsequent click
-      // on the trigger button is suppressed by the reopen guard.
       if (!entry.titleBarSender.isDestroyed()) {
         entry.titleBarSender.send('comfy-titlebar:menu-closed', { menu: entry.kind })
       }
@@ -892,15 +901,9 @@ function ensureTitlePopup(parent: BrowserWindow): TitlePopupEntry {
       if (entry.kind === 'downloads' && !view.parentWindow.isDestroyed()) {
         downloadsHiddenAtByParent.set(view.parentWindow.id, Date.now())
       }
-      // Hide the popup backdrop on every dismiss path so the dim
-      // never outlives the popup. Cheap no-op for kinds that don't
-      // use the backdrop (menu / downloads).
-      if (
-        (entry.kind === 'instance-picker' || entry.kind === 'global-settings')
-        && !view.parentWindow.isDestroyed()
-      ) {
-        hidePopupBackdrop(view.parentWindow)
-      }
+      /** Unconditional — never gated on `entry.kind`, which may have been
+       *  reassigned by a kind-switch. No-op when the backdrop isn't visible. */
+      if (!view.parentWindow.isDestroyed()) hidePopupBackdrop(view.parentWindow)
     },
   })
   const entry: TitlePopupEntry = {
@@ -997,10 +1000,7 @@ function showTitlePopupNow(entry: TitlePopupEntry): void {
   // Bring the picker backdrop up first so it sits BELOW the popup in
   // the parent's child-view stack — the popup's own re-stack inside
   // `showOnTop` lands on top.
-  if (
-    (entry.kind === 'instance-picker' || entry.kind === 'global-settings')
-    && !entry.view.parentWindow.isDestroyed()
-  ) {
+  if (kindUsesBackdrop(entry.kind) && !entry.view.parentWindow.isDestroyed()) {
     showPopupBackdrop(entry.view.parentWindow)
   }
   // Tell the renderer the popup is about to be shown. Unlike
@@ -1256,19 +1256,23 @@ function openTitlePopup(opts: OpenTitlePopupOpts): void {
   const entry = ensureTitlePopup(opts.parent)
   if (entry.view.popup.webContents.isDestroyed()) return
 
+  // Switching kind on the reused view: close the outgoing popup first so its
+  // `onHide` runs (hides the backdrop, emits `menu-closed` for the OUTGOING
+  // kind) before `entry.kind` is overwritten below.
+  const isOpenOrPending = entry.view.isOpen || entry.view.pendingShowTimer !== null
+  if (isOpenOrPending && opts.kind !== entry.kind) {
+    hideTitlePopup(entry, { releaseFocusToParent: false })
+  }
+
   // Refresh the per-open routing context. `kind` + `parentEntryId` +
   // `titleBarSender` only matter for the *current* open, so we
   // overwrite on every open instead of allocating a new context object.
   entry.parentEntryId = opts.parentEntryId
   entry.kind = opts.kind
   entry.titleBarSender = opts.titleBarSender
-  // Picker + global-settings own their outside-click dismiss via the
-  // backdrop view — skip the blur-driven hide path so the toggle-on-
-  // pill-click is deterministic. File menu + downloads tray have no
-  // backdrop and still rely on blur to close when the user clicks
-  // away.
-  entry.view.suppressBlurDismiss =
-    opts.kind === 'instance-picker' || opts.kind === 'global-settings'
+  // Backdrop kinds own outside-click dismiss via the backdrop view, so skip
+  // the blur-driven hide. Menu / downloads have no backdrop and rely on blur.
+  entry.view.suppressBlurDismiss = kindUsesBackdrop(opts.kind)
 
   // Anchor coords are title-bar-local; the title-bar view sits at
   // content (0,0) so they map directly to parent-window content
@@ -1948,22 +1952,23 @@ export function registerTitlePopupIpc(bindings: TitlePopupHostBindings): void {
     hideTitlePopup(entry, { releaseFocusToParent: true })
   })
 
-  // Click on the picker backdrop — dismiss the matching parent's
-  // picker popup. The backdrop is keyed by the parent windowId so we
-  // can route from any backdrop instance back to its popup.
-  //
-  // Guarded against a stray dismiss during the open transition: if the
-  // popup was opened less than `BACKDROP_DISMISS_GUARD_MS` ago, ignore.
-  // Without this, a click that lands on the trigger pill can fire the
-  // backdrop's mousedown after the popup is composited but before the
-  // OS settles focus, causing open → immediate-close → reopen flicker.
+  /** Click on the picker backdrop. Always hides the backdrop itself (safety
+   *  valve so a scrim left over from a kind-switch can never trap the user),
+   *  then dismisses the popup only when the current kind owns the backdrop.
+   *  `BACKDROP_DISMISS_GUARD_MS` ignores the trigger-pill click that can fire
+   *  the backdrop mousedown mid-open and cause open → close → reopen flicker. */
   ipcMain.on('comfy-popup-backdrop:dismiss', (event) => {
     const parentId = popupBackdropsByWebContents.get(event.sender.id)
     if (parentId === undefined) return
     const popup = titlePopupsByParent.get(parentId)
     if (!popup) return
-    if (popup.kind !== 'instance-picker' && popup.kind !== 'global-settings') return
-    if (!popup.view.isOpen) return
+    const parent = popup.view.parentWindow
+    // Safety valve: a backdrop click should never fail to clear the scrim,
+    // even if the current kind no longer owns it (left over from a switch).
+    if (!kindUsesBackdrop(popup.kind) || !popup.view.isOpen) {
+      if (!parent.isDestroyed()) hidePopupBackdrop(parent)
+      return
+    }
     if (Date.now() - popup.openedAt < BACKDROP_DISMISS_GUARD_MS) return
     hideTitlePopup(popup, { releaseFocusToParent: true })
   })
@@ -2612,17 +2617,24 @@ export function registerTitlePopupIpc(bindings: TitlePopupHostBindings): void {
   })
 
   // ---- Global-settings popup IPC ----
+  /** Resolve the popup entry for a settings IPC sender, or null if the sender
+   *  isn't a settings-capable popup. Settings fields are reachable from both
+   *  the global-settings popup and the instance-picker (which embeds them). */
+  const settingsEntryFor = (senderId: number): TitlePopupEntry | null => {
+    const entry = titlePopupsByWebContents.get(senderId)
+    if (!entry || (entry.kind !== 'global-settings' && entry.kind !== 'instance-picker')) {
+      return null
+    }
+    return entry
+  }
+
   // Field update (Language / Theme / Cache / Advanced / Shared Dirs).
   // Same side-effects as the legacy `set-setting` handler, plus a
   // `globalSettingsEvents.emit('changed')` for the snapshot loop.
   ipcMain.handle(
     'comfy-titlepopup:global-settings-update-field',
     (event, payload: { fieldId?: unknown; value?: unknown }) => {
-      const popupEntry = titlePopupsByWebContents.get(event.sender.id)
-      if (
-        !popupEntry
-        || (popupEntry.kind !== 'global-settings' && popupEntry.kind !== 'instance-picker')
-      ) {
+      if (!settingsEntryFor(event.sender.id)) {
         return { ok: false, message: 'Global Settings popup not active.' }
       }
       const fieldId = payload?.fieldId
@@ -2642,13 +2654,7 @@ export function registerTitlePopupIpc(bindings: TitlePopupHostBindings): void {
   ipcMain.handle(
     'comfy-titlepopup:global-settings-set-models-dirs',
     (event, payload: { dirs?: unknown }) => {
-      const popupEntry = titlePopupsByWebContents.get(event.sender.id)
-      if (
-        !popupEntry
-        || (popupEntry.kind !== 'global-settings' && popupEntry.kind !== 'instance-picker')
-      ) {
-        return { ok: false }
-      }
+      if (!settingsEntryFor(event.sender.id)) return { ok: false }
       const dirs = payload?.dirs
       if (!Array.isArray(dirs) || dirs.some((d) => typeof d !== 'string')) {
         return { ok: false }
@@ -2664,13 +2670,8 @@ export function registerTitlePopupIpc(bindings: TitlePopupHostBindings): void {
   ipcMain.handle(
     'comfy-titlepopup:global-settings-browse-folder',
     async (event, payload: { defaultPath?: unknown } | undefined) => {
-      const popupEntry = titlePopupsByWebContents.get(event.sender.id)
-      if (
-        !popupEntry
-        || (popupEntry.kind !== 'global-settings' && popupEntry.kind !== 'instance-picker')
-      ) {
-        return null
-      }
+      const popupEntry = settingsEntryFor(event.sender.id)
+      if (!popupEntry) return null
       const parentEntry = comfyWindows.get(popupEntry.parentEntryId)
       if (!parentEntry || parentEntry.window.isDestroyed()) return null
       const defaultPath = typeof payload?.defaultPath === 'string' && payload.defaultPath.length > 0
@@ -2689,13 +2690,7 @@ export function registerTitlePopupIpc(bindings: TitlePopupHostBindings): void {
   ipcMain.on(
     'comfy-titlepopup:global-settings-open-path',
     (event, payload: { path?: unknown }) => {
-      const popupEntry = titlePopupsByWebContents.get(event.sender.id)
-      if (
-        !popupEntry
-        || (popupEntry.kind !== 'global-settings' && popupEntry.kind !== 'instance-picker')
-      ) {
-        return
-      }
+      if (!settingsEntryFor(event.sender.id)) return
       const targetPath = payload?.path
       if (typeof targetPath !== 'string' || targetPath.length === 0) return
       void openPathHelper(targetPath)

--- a/src/renderer/src/comfyTitleBar/useTitleBarMenus.test.ts
+++ b/src/renderer/src/comfyTitleBar/useTitleBarMenus.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent, h, shallowRef, type ShallowRef } from 'vue'
+import { mount } from '@vue/test-utils'
+import { useTitleBarMenus } from './useTitleBarMenus'
+
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (k: string) => k }) }))
+
+type TitleMenuKind = 'menu' | 'downloads' | 'instance-picker'
+
+interface Bridge {
+  openFileMenu: ReturnType<typeof vi.fn>
+  dismissFileMenu: ReturnType<typeof vi.fn>
+  clickDownloadsTray: ReturnType<typeof vi.fn>
+  clickInstallPill: ReturnType<typeof vi.fn>
+  onMenuOpened: (cb: (info: { menu: TitleMenuKind }) => void) => () => void
+  onMenuClosed: (cb: (info: { menu: TitleMenuKind }) => void) => () => void
+  onDownloadsChanged: (cb: (s: unknown) => void) => () => void
+}
+
+/** Mount the composable in a throwaway host so its `onMounted` bridge
+ *  subscriptions fire, then drive it via the captured menu-opened/closed
+ *  callbacks the title bar would receive from main. */
+function setup() {
+  const opened: ((info: { menu: TitleMenuKind }) => void)[] = []
+  const closed: ((info: { menu: TitleMenuKind }) => void)[] = []
+  const bridge: Bridge = {
+    openFileMenu: vi.fn(),
+    dismissFileMenu: vi.fn(),
+    clickDownloadsTray: vi.fn(),
+    clickInstallPill: vi.fn(),
+    onMenuOpened: (cb) => { opened.push(cb); return () => {} },
+    onMenuClosed: (cb) => { closed.push(cb); return () => {} },
+    onDownloadsChanged: () => () => {},
+  }
+  const nullRef = shallowRef<HTMLElement | null>(null) as Readonly<ShallowRef<HTMLElement | null>>
+  let api!: ReturnType<typeof useTitleBarMenus>
+  const Host = defineComponent({
+    setup() {
+      api = useTitleBarMenus({
+        bridge: bridge as never,
+        hideTip: () => {},
+        fileBtnRef: nullRef,
+        downloadsBtnRef: nullRef,
+        installPillRef: nullRef,
+      })
+      return () => h('div')
+    },
+  })
+  mount(Host)
+  return {
+    api,
+    bridge,
+    openMenu: (menu: TitleMenuKind) => opened.forEach((cb) => cb({ menu })),
+    closeMenu: (menu: TitleMenuKind) => closed.forEach((cb) => cb({ menu })),
+  }
+}
+
+describe('useTitleBarMenus — handleFileMenu toggle gate', () => {
+  it('opens the file menu when the instance picker is the open popup (does not toggle-close)', () => {
+    const { api, bridge, openMenu } = setup()
+    openMenu('instance-picker')
+    api.handleFileMenu()
+    expect(bridge.openFileMenu).toHaveBeenCalledTimes(1)
+    expect(bridge.dismissFileMenu).not.toHaveBeenCalled()
+  })
+
+  it('opens the file menu when the downloads tray is the open popup', () => {
+    const { api, bridge, openMenu } = setup()
+    openMenu('downloads')
+    api.handleFileMenu()
+    expect(bridge.openFileMenu).toHaveBeenCalledTimes(1)
+    expect(bridge.dismissFileMenu).not.toHaveBeenCalled()
+  })
+
+  it('toggle-closes only when the file menu itself is open', () => {
+    const { api, bridge, openMenu } = setup()
+    openMenu('menu')
+    api.handleFileMenu()
+    expect(bridge.dismissFileMenu).toHaveBeenCalledTimes(1)
+    expect(bridge.openFileMenu).not.toHaveBeenCalled()
+  })
+
+  it('a picker close (menu-closed: instance-picker) does not arm the file-menu reopen guard', () => {
+    const { api, bridge, openMenu, closeMenu } = setup()
+    openMenu('instance-picker')
+    closeMenu('instance-picker')
+    api.handleFileMenu()
+    expect(bridge.openFileMenu).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/comfyTitleBar/useTitleBarMenus.ts
+++ b/src/renderer/src/comfyTitleBar/useTitleBarMenus.ts
@@ -162,12 +162,17 @@ export function useTitleBarMenus(opts: UseTitleBarMenusOpts): TitleBarMenusApi {
     return { x: base.x, y: base.y + DOWNLOADS_POPUP_GAP_BELOW_TRIGGER_PX }
   }
 
+  /** True only when the FILE menu (not the picker / downloads) is the open
+   *  popup — `isMenuOpen` is set for every kind, so it can't gate the toggle. */
+  const isFileMenuOpen = computed(
+    () => isMenuOpen.value && !isDownloadsOpen.value && !isInstancePickerOpen.value,
+  )
+
   function handleFileMenu(): void {
     opts.hideTip()
-    // Toggle-close: on macOS clicking a sibling WebContentsView in the
-    // same parent window doesn't reliably blur the popup webContents,
-    // so the renderer asks main to dismiss explicitly.
-    if (isMenuOpen.value) {
+    // Toggle-close only when the file menu itself is open. macOS doesn't
+    // reliably blur a sibling WebContentsView, so dismiss explicitly.
+    if (isFileMenuOpen.value) {
       opts.bridge?.dismissFileMenu()
       return
     }


### PR DESCRIPTION
## Summary
Route every title-bar popup kind-switch through a clean close first, so the dim backdrop owned by the instance-picker / global-settings popups can never be left stranded over the host body. Fixes a frozen-app symptom (undismissable scrim) and a case where the hamburger menu wouldn't open over the picker.

## Changes
**What:**
- `openTitlePopup` — close the outgoing popup *before* overwriting `entry.kind`, so its `onHide` runs on every kind-switch. Previously `onHide` never fired on a switch, and it was the only place the backdrop got hidden — so the scrim was orphaned.
- `hidePopupBackdrop` — detach the view (`removeChildView`), not just `setVisible(false)`. A hidden-but-attached scrim can still swallow body clicks if a visibility flip lags; detaching makes that impossible.
- `onHide` — hide the backdrop unconditionally instead of gating on `entry.kind` (which may already be reassigned by a switch).
- `comfy-popup-backdrop:dismiss` — always clear the scrim as a safety valve, so a clicked backdrop can never fail to dismiss even if some future path strands it.
- Renderer `handleFileMenu` — toggle on a new `isFileMenuOpen` (the file menu specifically) instead of the shared `isMenuOpen`, which is set for every kind and made the hamburger toggle-close the picker instead of opening.
- Cleanup — consolidate the duplicated "is this a backdrop kind" check into `kindUsesBackdrop()`, and the four identical global-settings IPC sender guards into `settingsEntryFor()`.

**Breaking:** None. No IPC channels, specs, emits, or telemetry change. `kindUsesBackdrop()` and `settingsEntryFor()` are kept separate on purpose — "dims the body" and "may send settings IPC" are distinct rules that only happen to share a kind set today.

## Review Focus
- **Scope is the kind-switch teardown only.** The core fix is close-before-switch in `openTitlePopup`; the detach, unconditional `onHide`, and dismiss-handler safety valve are layered hardening, not independent fixes. The safety valve is the one piece removable for a leaner diff once the primary fix lands.
- `menu-closed` now reports the **outgoing** kind on a switch (e.g. `instance-picker`), which is why it no longer arms the file-menu reopen guard and the hamburger opens correctly over the picker.

## Testing
Renderer-side unit coverage by design — the main-side backdrop logic lives in unexported functions that would need a full Electron view-stack mock, and the existing `titlePopup.test.ts` deliberately tests only pure helpers, so Bug 1 was verified manually rather than adding that harness.
- `useTitleBarMenus.test.ts`: file menu opens over the picker / downloads (no toggle-close), toggle-closes only when the file menu itself is open, and a picker close doesn't arm the menu reopen guard.
- `pnpm typecheck`, `pnpm lint`, `pnpm test` (117 files, 1518 tests) all pass.
- Manual: picker → downloads no longer freezes; picker → hamburger opens the menu; swept all switch pairs and same-kind reclick — backdrop always clears.

Screen Recording

https://github.com/user-attachments/assets/501d7221-f9fd-4cf6-8832-d7b741e7a3d5

closes #774 