### PR TITLE
fix(title-bar): unify install/import + settings menu across all windows

### DIFF
--- a/src/main/popups/titlePopup.test.ts
+++ b/src/main/popups/titlePopup.test.ts
@@ -117,12 +117,13 @@ describe('buildTitlePopupMenuItems', () => {
     expect(ids).not.toContain('return-to-dashboard')
   })
 
-  it('omits install-creation entries on an install-backed host', () => {
+  it('includes install-creation entries and settings on an install-backed host', () => {
     const items = buildTitlePopupMenuItems(makeEntry({ installationId: 'inst-1' }))
     const ids = items.map((i) => i.id ?? null)
-    expect(ids).not.toContain('new-install')
-    expect(ids).not.toContain('track')
-    expect(ids).not.toContain('load-snapshot')
+    expect(ids).toContain('new-install')
+    expect(ids).toContain('track')
+    expect(ids).toContain('load-snapshot')
+    expect(ids).toContain('settings')
   })
 
   it('chooser host includes New Window, Settings, Send Feedback, and Quit ComfyUI', () => {
@@ -137,16 +138,22 @@ describe('buildTitlePopupMenuItems', () => {
     expect(quit?.label).toBe('Quit ComfyUI')
   })
 
-  // Install-host menu was deliberately trimmed (spec item 1): no
-  // Desktop Settings, no Return to Dashboard (replaced by the Home
-  // icon in the picker, spec item 10), no Reset Zoom (Ctrl/Cmd+0
-  // shortcut still works). "Quit ComfyUI" stays available from every
-  // window; "Close Window" is the instance-only counterpart. The four
-  // entries are New Window, Send Beta Feedback, Close Window, Quit ComfyUI.
-  it('install-host menu is trimmed to four essentials in the canonical order', () => {
+  // The install-host menu now mirrors the dashboard's install-creation +
+  // settings block, plus the instance-only "Close Window". Reset Zoom and
+  // Return to Dashboard stay off it (Ctrl/Cmd+0 and the picker Home icon).
+  it('install-host menu matches the unified order with Close Window', () => {
     const items = buildTitlePopupMenuItems(makeEntry({ installationId: 'inst-1' }))
     const ids = items.map((i) => i.id ?? null).filter((id) => id !== null)
-    expect(ids).toEqual(['new-window', 'feedback', 'exit-window', 'close-all-windows'])
+    expect(ids).toEqual([
+      'new-window',
+      'new-install',
+      'track',
+      'load-snapshot',
+      'settings',
+      'feedback',
+      'exit-window',
+      'close-all-windows',
+    ])
     const closeWindow = items.find((i) => i.id === 'exit-window')
     expect(closeWindow?.label).toBe('Close Window')
     const quit = items.find((i) => i.id === 'close-all-windows')
@@ -160,7 +167,6 @@ describe('buildTitlePopupMenuItems', () => {
     const ids = items.map((i) => i.id ?? null)
     expect(ids).not.toContain('reset-zoom')
     expect(ids).not.toContain('return-to-dashboard')
-    expect(ids).not.toContain('settings')
   })
 
   it('exposes Reset Zoom on chooser host only when comfy zoom is non-zero, with the percent in the label', () => {

--- a/src/main/popups/titlePopup.ts
+++ b/src/main/popups/titlePopup.ts
@@ -630,95 +630,47 @@ export function buildTitlePopupMenuItems(entry: ComfyWindowEntry): TitlePopupMen
       },
     ]
   }
-  // Issue #497 — file-menu order:
-  //   New Window
-  //   ── separator ──
-  //   (install-less only) New Install / Track / Load Snapshot
-  //   ── separator ──
-  //   Settings (unified — ComfyUI Settings on install-backed hosts,
-  //             Global Settings on install-less; PanelApp picks the
-  //             default tab at mount time)
-  //   Send Feedback
-  //   ── separator ──
-  //   (install-backed only) Return to Dashboard
-  //   Close All Windows
-  //
-  // Notes:
-  //   - "Close Window" is intentionally absent — the OS-X / native
-  //     close button already covers single-window dismissal; the menu
-  //     only surfaces the cross-window kill switch.
-  //   - Install-creation / import flows (New Install / Track / Load
-  //     Snapshot) live ONLY on the dashboard (install-less host)
-  //     waffle menu. Inside a Comfy Instance window the only escape
-  //     hatch back to the dashboard is "Return to Dashboard" — the
-  //     in-Comfy chrome stays closed-off per the design doc's
-  //     "Comfy Instance is closed-off" rule.
-  //   - "Return to Dashboard" is install-backed-only; install-less
-  //     host windows are already on the chooser body so the entry
-  //     would be a no-op there.
-  const items: TitlePopupMenuItem[] = [
+  const chooser = isChooserHost(entry)
+  // Reset Zoom recovers a comfyView zoomed too far to read. Chooser-only —
+  // the install host keeps Ctrl/Cmd + 0.
+  const resetZoom = chooser ? buildResetZoomItem(entry) : null
+  return [
     { id: 'new-window', label: 'New Window', labelKey: 'fileMenu.newWindow' },
     { kind: 'separator' },
-  ]
-  if (isChooserHost(entry)) {
-    items.push(
-      { id: 'new-install', label: 'New Install', labelKey: 'fileMenu.newInstall' },
-      {
-        id: 'track',
-        label: 'Add Existing Install',
-        labelKey: 'fileMenu.addExistingInstall',
-      },
-      { id: 'load-snapshot', label: 'Load Snapshot', labelKey: 'fileMenu.loadSnapshot' },
-      { kind: 'separator' },
-      {
-        id: 'settings',
-        label: 'Desktop Settings',
-        labelKey: 'fileMenu.globalSettings',
-      },
-      // Send Feedback (#493). The renderer-side handler resolves the
-      // support URL and emits the `desktop2.feedback.opened`
-      // telemetry action with `source: 'menu'`.
-      { id: 'feedback', label: 'Send Beta Feedback', labelKey: 'fileMenu.sendFeedback' },
-    )
-    // Reset Zoom — discoverable recovery path for users who zoom the
-    // comfyView too far to read. Only on the chooser host (the dummy
-    // comfyView there can still be zoomed via Ctrl/Cmd+scroll); the
-    // install host trims it out per the simplified menu spec.
-    if (!entry.comfyView.webContents.isDestroyed()) {
-      const level = entry.comfyView.webContents.getZoomLevel()
-      if (level !== 0) {
-        const percent = Math.round(Math.pow(1.2, level) * 100)
-        items.push({ id: 'reset-zoom', label: `Reset Zoom (${percent}%)` })
-      }
-    }
-    items.push(
-      { kind: 'separator' },
-      {
-        id: 'close-all-windows',
-        label: 'Quit ComfyUI',
-        labelKey: 'fileMenu.exitAllWindows',
-      },
-    )
-    return items
-  }
-  // Install-host menu: trimmed to the essentials. Desktop Settings,
-  // Return to Dashboard, and Reset Zoom are intentionally absent —
-  // Settings lives in the picker's Startup Args tab, the dashboard
-  // escape is the Home icon in the picker chips row, and Reset Zoom
-  // remains reachable via Ctrl/Cmd + 0. "Quit ComfyUI" stays available
-  // from every window; "Close Window" is instance-only — the dashboard
-  // omits it (there's nothing to close back to).
-  items.push(
-    { id: 'feedback', label: 'Send Beta Feedback', labelKey: 'fileMenu.sendFeedback' },
+    { id: 'new-install', label: 'New Install', labelKey: 'fileMenu.newInstall' },
+    {
+      id: 'track',
+      label: 'Add Existing Install',
+      labelKey: 'fileMenu.addExistingInstall',
+    },
+    { id: 'load-snapshot', label: 'Load Snapshot', labelKey: 'fileMenu.loadSnapshot' },
     { kind: 'separator' },
-    { id: 'exit-window', label: 'Close Window', labelKey: 'fileMenu.exitWindow' },
+    {
+      id: 'settings',
+      label: 'Desktop Settings',
+      labelKey: 'fileMenu.globalSettings',
+    },
+    { id: 'feedback', label: 'Send Beta Feedback', labelKey: 'fileMenu.sendFeedback' },
+    ...(resetZoom ? [resetZoom] : []),
+    { kind: 'separator' },
+    // Close Window is instance-only; the dashboard has nothing to close back to.
+    ...(chooser ? [] : [{ id: 'exit-window', label: 'Close Window', labelKey: 'fileMenu.exitWindow' }]),
     {
       id: 'close-all-windows',
       label: 'Quit ComfyUI',
       labelKey: 'fileMenu.exitAllWindows',
     },
-  )
-  return items
+  ]
+}
+
+/** Reset-zoom menu item with the live percent in the label, or null when
+ *  the comfyView is destroyed or already at 100%. */
+function buildResetZoomItem(entry: ComfyWindowEntry): TitlePopupMenuItem | null {
+  if (entry.comfyView.webContents.isDestroyed()) return null
+  const level = entry.comfyView.webContents.getZoomLevel()
+  if (level === 0) return null
+  const percent = Math.round(Math.pow(1.2, level) * 100)
+  return { id: 'reset-zoom', label: `Reset Zoom (${percent}%)` }
 }
 
 /** Push the downloads-tray snapshot to a single popup webContents. */
@@ -1730,13 +1682,14 @@ function activateTitlePopupMenuItem(
     }
   }
   else if (id === 'new-install' || id === 'track' || id === 'load-snapshot' || id === 'quick-install') {
-    // Install-creation / import flows are chooser-host-only.
-    // `buildTitlePopupMenuItems` already filters them out of the
-    // install-backed file menu; this guard is the belt-and-braces
-    // so a stale popup or an out-of-order IPC can't navigate an
-    // in-Comfy host into one of these panels.
+    // On the dashboard, navigate the current window's body. From an
+    // instance window, open a fresh dashboard routed to the panel so the
+    // running instance is left untouched.
     if (parentEntry && isChooserHost(parentEntry)) {
       bindings.setActivePanel(entry.parentEntryId, id)
+    } else {
+      bindings.openChooserHostWindow(id)
+      releaseFocusToParent = false
     }
   }
   // Item click — popup still has focus, so push it back to the parent


### PR DESCRIPTION
## Summary

The title-bar waffle menu gated **New Install**, **Add Existing Install**, **Load Snapshot**, and **Desktop Settings** to the install-less dashboard host, so they were missing from every instance window (cloud included). This surfaces them on every window — and from an instance window the install/import items open a fresh dashboard routed to the picked panel rather than navigating the running instance away.

## Changes

**What**

- `buildTitlePopupMenuItems` (`src/main/popups/titlePopup.ts`) — rewritten from a duplicated `if (isChooserHost)` / `else` (which listed `feedback` + `close-all-windows` in both branches) into a single declarative array literal. The four install/import + settings items now appear on every host; `reset-zoom` (chooser-only) and `exit-window`/Close Window (instance-only) are conditional spreads.
- `buildResetZoomItem` (`src/main/popups/titlePopup.ts`) — new small helper holding the reset-zoom percent-label logic, returning `null` when the comfyView is destroyed or already at 100%, so the main array stays declarative.
- `activateTitlePopupMenuItem` (`src/main/popups/titlePopup.ts`) — the `new-install`/`track`/`load-snapshot`/`quick-install` branch now routes by host: dashboard navigates the current body via `setActivePanel` (unchanged); an instance window calls `openChooserHostWindow(id)` and releases focus to the new window (mirrors `new-window` and the existing `+ New Instance` path).
- `titlePopup.test.ts` — flipped the two assertions that expected the items to be absent on install-backed hosts; the install-host menu now asserts the unified order incl. `exit-window`.

**Breaking**

- None. No IPC channels, telemetry, or i18n keys added or changed — `'new-install' | 'track' | 'load-snapshot'` are existing `ComfyPanelKey`s, the `fileMenu.*` strings already exist, and `openChooserHostWindow(initialPanel)` was already in use (`titlePopup.ts:2583`, `+ New Instance`).

## Review Focus

- The crux decision: from an instance window the install/import items **open a new dashboard window** (per product call) instead of detaching/navigating the current instance — see the `else` branch in `activateTitlePopupMenuItem`. `settings` was already host-agnostic (reads `parentEntry.installationId`, null-safe), so it needed no handler change.
- Deliberate non-changes: `reset-zoom` stays dashboard-only (install host keeps `Ctrl/Cmd+0`); `exit-window`/Close Window stays instance-only (dashboard has nothing to close back to); `return-to-dashboard` remains unbuilt.
- Scope is the main-process menu builder + activation handler only; no renderer (`MenuView.vue` / `TitlePopupApp.vue`) changes.

## Testing

- `titlePopup.test.ts` — asserts the install-backed menu now *includes* `new-install`/`track`/`load-snapshot`/`settings`, and the full unified id order incl. `exit-window`; chooser-host and reset-zoom cases unchanged and still green.
- `pnpm test src/main/popups/titlePopup.test.ts` → 27 passed. `pnpm typecheck` + `pnpm lint` clean (also run by the pre-commit hook).
- Manual: from a **cloud** instance window the four items appear; clicking **Add Existing Install** opens a new dashboard window already on that screen with the cloud instance untouched; same from a **local** instance; dashboard items still navigate in place.

Screen Recording

https://github.com/user-attachments/assets/65d0bea8-b11b-400d-b7f1-d8b86aef50ef



closes #720 