### PR TITLE
fix(instance-picker): clarify dashboard button + align Instances help icon

### DIFF
--- a/src/renderer/src/comfyTitlePopup/InstancePickerView.vue
+++ b/src/renderer/src/comfyTitlePopup/InstancePickerView.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, toRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { LayoutGrid, Plus, Search, X } from 'lucide-vue-next'
+import { LayoutDashboard, Plus, Search, X } from 'lucide-vue-next'
 import BaseInput from '../components/ui/BaseInput.vue'
 import { FILTER_CHIPS, useInstallList } from '../composables/useInstallList'
 import { useSessionStore } from '../stores/sessionStore'
 import ComfyUISettingsContent from '../components/settings/ComfyUISettingsContent.vue'
 import InfoTooltip from '../components/InfoTooltip.vue'
+import Tooltip from '../components/ui/Tooltip.vue'
 import InstanceRow from './instancePicker/InstanceRow.vue'
 import { resolvePickerTab, type PickerTab } from '../lib/pickerTabs'
 import { resolveProgressRouting } from '../lib/pickerProgressRouting'
@@ -523,15 +524,17 @@ function handleExpandedPrimaryAction(restartInPlace: boolean): void {
 
     <div class="picker-chips-row">
       <template v-if="isInstallHost">
-        <button
-          type="button"
-          class="picker-home"
-          :aria-label="$t('fileMenu.returnToDashboard')"
-          :title="$t('fileMenu.returnToDashboard')"
-          @click="handleOpenDashboard"
-        >
-          <LayoutGrid :size="14" />
-        </button>
+        <Tooltip :text="$t('instancePicker.openDashboardHint')" side="bottom">
+          <button
+            type="button"
+            class="picker-home"
+            :aria-label="$t('instancePicker.openDashboard')"
+            @click="handleOpenDashboard"
+          >
+            <LayoutDashboard :size="14" />
+            <span class="picker-home-label">{{ $t('instancePicker.openDashboard') }}</span>
+          </button>
+        </Tooltip>
         <span class="picker-chips-divider" aria-hidden="true"></span>
       </template>
       <div
@@ -706,24 +709,30 @@ function handleExpandedPrimaryAction(restartInPlace: boolean): void {
   flex-wrap: wrap;
   min-width: 0;
 }
-/* Home — naked icon button. The vertical divider that follows it
- * does the visual separation work; a pill border around the icon
+/* Open Dashboard — naked icon + label button. The vertical divider
+ * that follows it does the visual separation work; a pill border
  * would compete with the chip pills and read as another filter.
- * Hover lifts the icon to full text colour without painting a
- * background. */
+ * Hover lifts both icon and label to full text colour without
+ * painting a background. */
 .picker-home {
   flex: 0 0 auto;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 22px;
+  gap: 6px;
   height: 22px;
-  padding: 0;
+  padding: 0 6px 0 2px;
   border: none;
   background: transparent;
   color: var(--neutral-100);
   cursor: pointer;
   transition: color 100ms ease;
+}
+.picker-home-label {
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 16px;
+  white-space: nowrap;
 }
 .picker-home:hover,
 .picker-home:focus-visible {
@@ -801,6 +810,8 @@ function handleExpandedPrimaryAction(restartInPlace: boolean): void {
 }
 .picker-list-section-title {
   flex: 0 0 auto;
+  display: flex;
+  align-items: center;
   font-size: 14px;
   font-weight: 500;
   line-height: 20px;

--- a/src/renderer/src/components/InfoTooltip.vue
+++ b/src/renderer/src/components/InfoTooltip.vue
@@ -37,7 +37,7 @@ const props = withDefaults(
 
 .info-tooltip-icon {
   color: var(--text-muted);
-  opacity: 0.6;
+  opacity: 0.85;
   transition:
     opacity 0.15s,
     color 0.15s;

--- a/src/renderer/src/lib/i18nMessages.ts
+++ b/src/renderer/src/lib/i18nMessages.ts
@@ -206,6 +206,9 @@ export const en = {
   instancePicker: {
     instances: 'Instances',
     newInstance: 'New Instance',
+    openDashboard: 'Open Dashboard',
+    openDashboardHint:
+      'Opens the dashboard in a new window. Your running instance keeps running.',
     latestOnGithub: 'Latest on GitHub',
     open: 'Start',
     restart: 'Restart',


### PR DESCRIPTION
## Summary

Makes the instance picker's "Open Dashboard" control discoverable and self-explanatory, and tidies the `Instances` section header.

## Changes

**What**
- `InstancePickerView.vue` — replaced the bare `LayoutGrid` icon button with a `LayoutDashboard` icon + visible "Open Dashboard" label, wrapped in the custom `Tooltip` primitive (dropping the native `title`). The tooltip hint clarifies that the dashboard opens in a new window while the running instance keeps running.
- `InstancePickerView.vue` — widened `.picker-home` from a fixed square to an auto-width control sized to the chip baseline, and made `.picker-list-section-title` a flex row (`align-items: center`) so the `Instances` label and its help icon share a centerline.
- `InfoTooltip.vue` — raised the resting icon opacity `0.6 → 0.85` so the help icon reads clearly wherever it's used.
- `i18nMessages.ts` — added `instancePicker.openDashboard` and `instancePicker.openDashboardHint` (popup catalog, not `locales/*.json`).

**Breaking**
- None. `handleOpenDashboard` and the `bridge.activate('new-window')` behavior are unchanged; `fileMenu.returnToDashboard` (used by the file-menu item) is untouched.

## Review Focus

- Copy change: this control's wording moved from "Return to Dashboard" → "Open Dashboard" because nothing detaches — it opens a *new* window so the running instance keeps running.
- Scope is this picker control + the shared help-icon brightness only.

## Testing

CSS/markup + i18n change with no logic change, so no new unit tests — the existing picker suites still cover behavior. Verified via the full gauntlet:
- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm build` — clean
- `pnpm test` — 1526 passed (118 files)
- Manual: open picker from a running instance → icon + "Open Dashboard" label sits left of the chips with the divider intact; custom tooltip shows on hover/focus; click opens a new dashboard window with the instance still running; `Instances` header label and help icon are centered.

Closes #706 

Screen Recording

https://github.com/user-attachments/assets/f65c89c0-b9c4-44b9-b384-6fa62847e902



