### PR TITLE
fix(models): exclude custom_nodes and system dirs from extra model folder discovery

### DIFF
--- a/src/main/lib/models.ts
+++ b/src/main/lib/models.ts
@@ -40,6 +40,29 @@ const KNOWN_MODEL_FOLDERS = new Set<string>([
   't2i_adapter',    // secondary dir for controlnet
 ])
 
+// Folder names that must NEVER be registered as model search paths, even if
+// they appear inside a shared models directory. These are either ComfyUI
+// system directories (custom_nodes, user, input, output, temp), dotfolders
+// owned by tooling (.venv, .snapshots, .git, __pycache__), or the `models`
+// self-reference produced when a ComfyUI install root is itself configured
+// as a shared models dir.
+//
+// `custom_nodes` is especially important: ComfyUI's prestartup does
+// `os.listdir(path)` on every registered `custom_nodes` path and crashes if
+// the directory is missing under any shared base_path.
+const NON_MODEL_FOLDERS = new Set<string>([
+  'custom_nodes',
+  'user',
+  'input',
+  'output',
+  'temp',
+  'models',
+  '.venv',
+  '.snapshots',
+  '.git',
+  '__pycache__',
+])
+
 export interface ModelPathsResult {
   yamlPath: string
   extraFolders: string[]
@@ -71,10 +94,14 @@ function allFoldersIn(dir: string): string[] {
 }
 
 /**
- * Scans a directory for subdirectories whose names are not in KNOWN_MODEL_FOLDERS.
+ * Scans a directory for subdirectories whose names are not in
+ * KNOWN_MODEL_FOLDERS and not in NON_MODEL_FOLDERS (system/tooling dirs that
+ * must never be treated as model search paths).
  */
 function extraFoldersIn(dir: string): string[] {
-  return allFoldersIn(dir).filter((name) => !KNOWN_MODEL_FOLDERS.has(name))
+  return allFoldersIn(dir).filter(
+    (name) => !KNOWN_MODEL_FOLDERS.has(name) && !NON_MODEL_FOLDERS.has(name),
+  )
 }
 
 /**


### PR DESCRIPTION
## Problem

Launching any instance crashes immediately with:

``
File "...\ComfyUI\main.py", line 155, in execute_prestartup_script
    possible_modules = os.listdir(custom_node_path)
FileNotFoundError: [WinError 3] The system cannot find the path specified: 'C:\\Users\\<user>\\ComfyUI-Shared\\models\\custom_nodes'
```

ComfyUI's prestartup calls `os.listdir()` on **every** registered `custom_nodes` search path and crashes if any is missing.

## Root cause

`extraFoldersIn` in `src/main/lib/models.ts` used only an allowlist (`KNOWN_MODEL_FOLDERS`) to filter out canonical model folder names. Anything else found inside a shared models dir got treated as an extra model folder and was written into the generated `extra_model_paths.yaml` for **every** shared `base_path`, without ensuring that folder exists under each base_path.

If a user has a legacy ComfyUI install root (or any directory containing a `custom_nodes/` subdir) configured as a shared models dir, discovery picks up `custom_nodes`, `user`, `input`, `output`, `temp`, `.venv`, `.snapshots`, `models`, etc. as "extras". The YAML then claims a `custom_nodes` search path under `ComfyUI-Shared\models` (and every other base_path), even though that subdir doesn't exist there. ComfyUI's prestartup then fails on the missing directory.

Even outside this specific scenario, `custom_nodes` should **never** be treated as a model folder.

## Fix

Add a `NON_MODEL_FOLDERS` denylist of names that must never be registered as model search paths even when present in a shared dir:

- ComfyUI system dirs: `custom_nodes`, `user`, `input`, `output`, `temp`
- `models` self-reference (produced when an install root is configured as a shared models dir)
- Tooling dotfolders: `.venv`, `.snapshots`, `.git`, `__pycache__`

`extraFoldersIn` now filters by both allowlist and denylist, so these names are excluded from the generated YAML.

## Verification

- `pnpm run typecheck` ✅
- `pnpm run lint` ✅
- `pnpm run test` ✅ (118 files / 1526 tests)