### PR TITLE
fix(install-cta): recognize launching state so Restart/Switch fire from instance-launching

### DIFF
--- a/src/main/host/attachHostPreview.ts
+++ b/src/main/host/attachHostPreview.ts
@@ -2,7 +2,7 @@ import { sourceMap } from '../lib/ipc/shared'
 import { getAppVersion } from '../lib/ipc'
 import { get as getInstallation } from '../installations'
 import type { ComfyWindowEntry } from './registry'
-import { isInstallHost } from './registry'
+import { hostInstallEvents, isInstallHost } from './registry'
 import {
   applyChooserHostTheme,
   CHOOSER_HOST_TITLE_TEXT,
@@ -31,6 +31,7 @@ export async function applyAttachHostPreview(
   if (isInstallHost(entry)) return
   const installation = await getInstallation(installationId)
   if (!installation) return
+  const previewChanged = entry.previewInstallationId !== installationId
   entry.previewInstallationId = installationId
   entry.titleBarText = installation.name
   entry.sourceCategory = sourceMap[installation.sourceId]?.category ?? null
@@ -46,6 +47,13 @@ export async function applyAttachHostPreview(
     )
     entry.titleBarView.webContents.send('comfy-titlebar:preview-mode-changed', true)
   }
+  // Treat the preview-id flip like an attach for picker-snapshot
+  // purposes — the snapshot folds previewInstallationId into the
+  // "Current" pill decision so the dashboard's chrome reads as
+  // "owns this install" from the moment the chooser stakes the
+  // attach claim, instead of waiting for `attachInstall` (which
+  // doesn't run until the port binds).
+  if (previewChanged) hostInstallEvents.emit('changed')
 }
 
 /**
@@ -58,8 +66,16 @@ export async function applyAttachHostPreview(
 export function clearAttachHostPreview(entry: ComfyWindowEntry): void {
   if (entry.previewInstallationId === null) return
   entry.previewInstallationId = null
-  if (entry.window.isDestroyed()) return
-  if (isInstallHost(entry)) return
+  if (entry.window.isDestroyed()) {
+    // Still emit so any picker listener can drop the stale id even
+    // when the chrome push paths short-circuit on a destroyed window.
+    hostInstallEvents.emit('changed')
+    return
+  }
+  if (isInstallHost(entry)) {
+    hostInstallEvents.emit('changed')
+    return
+  }
   entry.titleBarText = CHOOSER_HOST_TITLE_TEXT
   entry.sourceCategory = null
   entry.window.setTitle(CHOOSER_HOST_WINDOW_TITLE)
@@ -76,4 +92,7 @@ export function clearAttachHostPreview(entry: ComfyWindowEntry): void {
   // the call here so any future identity-tied theme tweak survives the
   // revert.
   applyChooserHostTheme(entry)
+  // Symmetric with the apply path so the picker drops the "Current"
+  // pill the moment the preview is released (op cancelled / errored).
+  hostInstallEvents.emit('changed')
 }

--- a/src/main/host/attachHostPreview.ts
+++ b/src/main/host/attachHostPreview.ts
@@ -31,6 +31,14 @@ export async function applyAttachHostPreview(
   if (isInstallHost(entry)) return
   const installation = await getInstallation(installationId)
   if (!installation) return
+  // Re-check after the await: `claim-attach-host` calls us fire-and-
+  // forget (`void applyAttachHostPreview(...)`), so a fast launch can
+  // attach the install (or destroy the window) while the disk lookup
+  // is in flight. Without these guards we would overwrite the real
+  // `installationId` push from `attachInstall` with a stale preview
+  // and the title-bar chrome would diverge from reality.
+  if (entry.window.isDestroyed()) return
+  if (isInstallHost(entry)) return
   const previewChanged = entry.previewInstallationId !== installationId
   entry.previewInstallationId = installationId
   entry.titleBarText = installation.name

--- a/src/main/host/registry.test.ts
+++ b/src/main/host/registry.test.ts
@@ -23,8 +23,10 @@ import {
   computeBodyMode,
   consumeAttachClaim,
   dropAttachClaimsForWindow,
+  dropInstallationIndex,
   findPreferredHostByVisibility,
   getEntryByInstallationId,
+  hostInstallEvents,
   indexInstallationId,
   nextWindowKey,
   raiseAllHostWindows,
@@ -285,6 +287,72 @@ describe('register/unregister + getEntryByInstallationId', () => {
     // secondary-index pointer.
     unregisterHostEntry(first)
     expect(getEntryByInstallationId('inst-A')).toBe(second)
+  })
+})
+
+describe('hostInstallEvents', () => {
+  // Picker snapshots embed `parentEntry.installationId` as
+  // `activeInstallationId`. The "Current" pill on a row flips on when
+  // attach lands; without this event the picker would only repaint at
+  // `instance-started` time (via `markLaunched` → installationEvents
+  // 'changed') and the user would see a Current-less row for the
+  // entire launching window.
+  let events: string[]
+  let listener: () => void
+  beforeEach(() => {
+    events = []
+    listener = () => events.push('changed')
+    hostInstallEvents.on('changed', listener)
+  })
+  afterEach(() => {
+    hostInstallEvents.off('changed', listener)
+  })
+
+  it('fires on indexInstallationId (attach)', () => {
+    indexInstallationId('inst-A', 1)
+    expect(events).toEqual(['changed'])
+  })
+
+  it('fires on dropInstallationIndex when the index actually shrinks', () => {
+    indexInstallationId('inst-A', 1)
+    events.length = 0
+    dropInstallationIndex('inst-A')
+    expect(events).toEqual(['changed'])
+  })
+
+  it('does NOT fire on dropInstallationIndex when the id was already absent', () => {
+    // No-op drops shouldn't churn picker snapshots; mirrors how the
+    // installationEvents 'changed' bus avoids spurious emissions.
+    dropInstallationIndex('inst-never-indexed')
+    expect(events).toEqual([])
+  })
+
+  it('fires on registerHostEntry when the entry is install-backed', () => {
+    registerHostEntry(makeEntry({ installationId: 'inst-A' }))
+    expect(events).toEqual(['changed'])
+  })
+
+  it('does NOT fire on registerHostEntry for an install-less (chooser) host', () => {
+    // Construction of a fresh chooser host shouldn't repaint open
+    // pickers — there's no attached install for `activeInstallationId`
+    // to surface.
+    registerHostEntry(makeEntry({ installationId: null }))
+    expect(events).toEqual([])
+  })
+
+  it('fires on unregisterHostEntry (detach via close handler) for an install-backed host', () => {
+    const entry = makeEntry({ installationId: 'inst-A' })
+    registerHostEntry(entry)
+    events.length = 0
+    unregisterHostEntry(entry)
+    expect(events).toEqual(['changed'])
+  })
+
+  it('does NOT fire on unregisterHostEntry for an install-less host', () => {
+    const entry = makeEntry({ installationId: null })
+    registerHostEntry(entry)
+    unregisterHostEntry(entry)
+    expect(events).toEqual([])
   })
 })
 

--- a/src/main/host/registry.ts
+++ b/src/main/host/registry.ts
@@ -1,6 +1,23 @@
+import { EventEmitter } from 'events'
 import type { BrowserWindow, WebContents, WebContentsView } from 'electron'
 import { _runningSessions } from '../lib/ipc/shared'
 import type { FirstUseMode } from '../../shared/firstUseMode'
+
+/**
+ * Internal main-process bus for host-window install attachment changes.
+ *
+ *  Events:
+ *  - `'changed'`(): the `installationId → windowKey` secondary index
+ *    mutated — a host attached, detached, or re-attached an install.
+ *    Distinct from `installationEvents.changed` (which fires on
+ *    install-record mutations: add/remove/rename/markLaunched).
+ *    Surfaces like the instance picker, whose snapshot embeds
+ *    `parentEntry.installationId` as `activeInstallationId`, listen to
+ *    this so the "Current" pill flips on as soon as a launch attaches
+ *    its install — not at `instance-started` time, which is when
+ *    `markLaunched` would have fired the install-record change.
+ */
+export const hostInstallEvents = new EventEmitter()
 
 /**
  * Title-bar pill key — one of the three user-visible navigation tabs.
@@ -315,19 +332,24 @@ export function getEntryByInstallationId(installationId: string): ComfyWindowEnt
 /**
  * Set the install-id → window-key secondary index entry. Use from
  * `attachInstall` after it pivots the entry's `installationId`.
+ * Emits `hostInstallEvents.changed` so picker snapshots repaint with
+ * the new `activeInstallationId` without waiting on `instance-started`.
  */
 export function indexInstallationId(installationId: string, windowKey: number): void {
   installationIdToWindowKey.set(installationId, windowKey)
+  hostInstallEvents.emit('changed')
 }
 
 /**
  * Drop a stale `installationId` from the secondary index without
  * touching the primary `comfyWindows` map. Use after destructive
  * lifecycle events (uninstall, file removed) where the entry may or
- * may not still be live.
+ * may not still be live. Emits `hostInstallEvents.changed` (the index
+ * shrunk) so picker snapshots clear the stale `activeInstallationId`.
  */
 export function dropInstallationIndex(installationId: string): void {
-  installationIdToWindowKey.delete(installationId)
+  const had = installationIdToWindowKey.delete(installationId)
+  if (had) hostInstallEvents.emit('changed')
 }
 
 /**
@@ -339,6 +361,7 @@ export function registerHostEntry(entry: ComfyWindowEntry): void {
   comfyWindows.set(entry.windowKey, entry)
   if (entry.installationId !== null) {
     installationIdToWindowKey.set(entry.installationId, entry.windowKey)
+    hostInstallEvents.emit('changed')
   }
 }
 
@@ -353,6 +376,7 @@ export function unregisterHostEntry(entry: ComfyWindowEntry): void {
     const indexed = installationIdToWindowKey.get(entry.installationId)
     if (indexed === entry.windowKey) {
       installationIdToWindowKey.delete(entry.installationId)
+      hostInstallEvents.emit('changed')
     }
   }
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -74,6 +74,7 @@ import {
   comfyWindows,
   computeBodyMode,
   consumeAttachClaim,
+  dropAttachClaimsForWindow,
   findEntryByTitleBarSender,
   getEntryByInstallationId,
   isChooserHost,
@@ -947,6 +948,12 @@ ipcMain.handle('release-attach-host-preview', (event) => {
     if (entry.window.isDestroyed()) continue
     if (isInstallHost(entry)) continue
     if (entry.panelView?.webContents !== event.sender) continue
+    // Drop any pending in-place attach claims for this window too —
+    // the renderer is signalling "this op is over, nothing will land
+    // on the claim". Without this a stale claim could be consumed by
+    // a later unrelated `onLaunch` and flip the chooser host into
+    // the wrong install.
+    dropAttachClaimsForWindow(entry.windowKey)
     clearAttachHostPreview(entry)
     return true
   }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -49,6 +49,7 @@ import {
   _runningSessions,
   _operationAborts,
   _activeOperationStatus,
+  _getLaunchingInstallationIds,
   stopRunning,
   resolveTheme,
   MSG_CANCELLED,
@@ -1500,6 +1501,7 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
         return enriched as unknown as InstancePickerInstall[]
       },
       getRunningInstallationIds: () => Array.from(_runningSessions.keys()),
+      getLaunchingInstallationIds: () => _getLaunchingInstallationIds(),
       // Per-install Settings + Snapshots payload for the picker's
       // right-pane accordions. Both reads route through the same
       // source helpers the unified Settings drawer uses

--- a/src/main/lib/cloudCapacity.ts
+++ b/src/main/lib/cloudCapacity.ts
@@ -63,11 +63,11 @@ export function initCloudCapacity(opts: {
       }
       // Else keep `'normal'` — covers undefined (no client, timeout,
       // missing flag), boolean values, and unknown strings.
-      // eslint-disable-next-line no-console
+       
       console.log('[cloud-capacity] init: fetched=', value, '→ cached=', cached)
     })
     .catch((err) => {
-      // eslint-disable-next-line no-console
+       
       console.log('[cloud-capacity] init error:', err)
       /* fail-safe: keep `'normal'` */
     })

--- a/src/main/lib/ipc/sessionActions/launch.ts
+++ b/src/main/lib/ipc/sessionActions/launch.ts
@@ -8,8 +8,9 @@ import {
   COMFY_BOOT_TIMEOUT_MS, SENSITIVE_ARG_RE,
   _onLaunch, _onComfyExited, _onComfyRestarted, _onModelFolderRelaunch,
   _operationAborts, _runningSessions, _pendingPorts,
-  _reservePort, _releasePort, _broadcastToRenderer,
+  _reservePort, _releasePort,
   _addSession, _removeSession,
+  _markLaunching, _clearLaunchingFailed,
   isEffectivelyEmptyInstallDir,
   captureSnapshotIfChanged, getSnapshotCount,
   syncCustomModelFolders, discoverExtraModelFolders,
@@ -198,7 +199,7 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
 
   // Skip port logic entirely
   if (launchCmd.skipPortWait) {
-    _broadcastToRenderer('instance-launching', { installationId, installationName: inst.name })
+    _markLaunching(installationId, inst.name)
     const sendOutput = makeSendOutput(sender, installationId)
     const launchEnv = buildLaunchEnv(inst)
 
@@ -344,7 +345,7 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
 
   // Reserve port eagerly
   _reservePort(launchCmd.port!, inst.name)
-  _broadcastToRenderer('instance-launching', { installationId, installationName: inst.name })
+  _markLaunching(installationId, inst.name)
 
   const sessionPath = createSessionPath()
   const launchEnv = buildLaunchEnv(inst, sessionPath)
@@ -458,7 +459,7 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
     logStream.end()
     _releasePort(launchCmd.port!)
     _operationAborts.delete(installationId)
-    _broadcastToRenderer('instance-launch-failed', { installationId })
+    _clearLaunchingFailed(installationId)
     if (launchResult.cancelled) return { ok: false, cancelled: true }
     return { ok: false, message: launchResult.message }
   }
@@ -522,7 +523,7 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
         logStream.end()
         await killProcessTree(proc)
         _removeSession(installationId)
-        _broadcastToRenderer('instance-launch-failed', { installationId })
+        _clearLaunchingFailed(installationId)
         if (abort.signal.aborted) return { ok: false, cancelled: true }
         return { ok: false, message: (err as Error).message }
       }

--- a/src/main/lib/ipc/shared.ts
+++ b/src/main/lib/ipc/shared.ts
@@ -1,6 +1,7 @@
 import path from 'path'
 import fs from 'fs'
 import os from 'os'
+import { EventEmitter } from 'events'
 import { app, ipcMain, dialog, shell, BrowserWindow, nativeTheme } from 'electron'
 import { execFile, spawn, execFileSync } from 'child_process'
 import type { ChildProcess } from 'child_process'
@@ -177,6 +178,60 @@ let _gpuPromise: Promise<GpuInfo | null> | null = null
 export const _operationAborts = new Map<string, AbortController>()
 export const _runningSessions = new Map<string, SessionInfo>()
 export const _pendingPorts = new Map<number, string>()
+
+/**
+ * Installation IDs that are mid-launch — between `instance-launching`
+ * (port reserved, child spawned) and `instance-started` (live, in
+ * `_runningSessions`) or `instance-launch-failed`. Mirrors the
+ * renderer-side `sessionStore.launchingInstances` so the picker
+ * popup — which can't subscribe to `instance-launching` itself
+ * (different preload, no `window.api`) — can be hydrated from a
+ * snapshot field instead.
+ *
+ * Kept as an internal Set so the producer/consumer/cleanup sites
+ * (`_markLaunching` / `_clearLaunching` / `_addSession` / launch
+ * teardown) can't drift apart. Read via `_getLaunchingInstallationIds`.
+ */
+const _launchingInstallationIds = new Set<string>()
+
+/**
+ * Internal bus for session lifecycle changes — emitted whenever the
+ * launching set or `_runningSessions` mutates. The picker popup
+ * subscribes via `titlePopup.ts` to rebroadcast its snapshot so the
+ * "Current" pill / CTA / running-dot flip live during the launching
+ * window without waiting for the install-record `markLaunched` round-
+ * trip at `instance-started` time.
+ */
+export const sessionLifecycleEvents = new EventEmitter()
+
+export function _getLaunchingInstallationIds(): string[] {
+  return Array.from(_launchingInstallationIds)
+}
+
+/**
+ * Mark `installationId` as mid-launch, broadcast `instance-launching`,
+ * and notify subscribers so the picker repaints. Idempotent — a
+ * duplicate mark for the same id is a no-op (no spurious snapshot
+ * churn). Called from `launch.ts` right after reserving the port.
+ */
+export function _markLaunching(installationId: string, installationName: string): void {
+  const wasNew = !_launchingInstallationIds.has(installationId)
+  _launchingInstallationIds.add(installationId)
+  _broadcastToRenderer('instance-launching', { installationId, installationName })
+  if (wasNew) sessionLifecycleEvents.emit('changed')
+}
+
+/**
+ * Symmetric clear for `_markLaunching` on the failure path —
+ * broadcasts `instance-launch-failed`. The success path goes through
+ * `_addSession` which clears the set inline before broadcasting
+ * `instance-started`.
+ */
+export function _clearLaunchingFailed(installationId: string): void {
+  const had = _launchingInstallationIds.delete(installationId)
+  _broadcastToRenderer('instance-launch-failed', { installationId })
+  if (had) sessionLifecycleEvents.emit('changed')
+}
 
 export interface PickerOperationStatus {
   /** Current phase label. Empty string while not yet started. */
@@ -419,7 +474,12 @@ export { _registerExtraBroadcastTarget, _unregisterExtraBroadcastTarget, _broadc
 
 export function _addSession(installationId: string, { proc, port, url, mode, installationName }: Omit<SessionInfo, 'startedAt'>, bootTimeMs?: number): void {
   _runningSessions.set(installationId, { proc, port, url, mode, installationName, startedAt: Date.now() })
+  // Clear the launching marker first so the lifecycle-event
+  // subscribers see a coherent snapshot (running set ∪ launching set
+  // never double-counts an id across the transition).
+  _launchingInstallationIds.delete(installationId)
   _broadcastToRenderer('instance-started', { installationId, port, url, mode, installationName, bootTimeMs })
+  sessionLifecycleEvents.emit('changed')
   // Stamps `lastLaunchedAt` + `lastLaunchedAtByCategory[category]` so
   // per-category recency surfaces don't scan every record. Resolver
   // runs inside `markLaunched`'s lock to avoid an extra read.
@@ -436,6 +496,7 @@ export function _removeSession(installationId: string): void {
   if (session.port) removePortLock(session.port)
   _runningSessions.delete(installationId)
   _broadcastToRenderer('instance-stopped', { installationId })
+  sessionLifecycleEvents.emit('changed')
 }
 
 export function _getPublicSessions(): Record<string, unknown>[] {
@@ -679,6 +740,7 @@ export async function stopRunning(installationId?: string): Promise<void> {
       await killProcessTree(session.proc)
     }
     _broadcastToRenderer('instance-stopped', { installationId })
+    sessionLifecycleEvents.emit('changed')
   } else {
     const sessions = [..._runningSessions.entries()]
     for (const [id] of sessions) {
@@ -698,6 +760,7 @@ export async function stopRunning(installationId?: string): Promise<void> {
     for (const [id] of sessions) {
       _broadcastToRenderer('instance-stopped', { installationId: id })
     }
+    if (sessions.length > 0) sessionLifecycleEvents.emit('changed')
   }
 }
 

--- a/src/main/lib/telemetry.test.ts
+++ b/src/main/lib/telemetry.test.ts
@@ -777,13 +777,18 @@ describe('telemetry.forwardToRenderer + telemetry-relay registry', () => {
 
 describe('telemetry SDK-level volume guards', () => {
   beforeEach(async () => {
-    captured.length = 0
     process.env['POSTHOG_API_KEY'] = 'test-key'
     process.env['POSTHOG_ENABLED'] = '1'
     telemetry.initTelemetry({ appVersion: '0.0.0', appEnv: 'test', isPackaged: true })
     await telemetry.identify('test-distinct-id')
     telemetry.setConsent(true)
     telemetry._test_resetVolumeGuards()
+    // Clear AFTER setConsent — granting consent flushes the deferred
+    // `desktop2.session.started` event into `captured`, which would
+    // otherwise count toward each test's product-event totals and
+    // throw the per-process cap assertions off by one (and make the
+    // 5000-cap test loop runaway-guard out, eating the 5s timeout).
+    captured.length = 0
   })
 
   afterEach(() => {

--- a/src/main/lib/telemetry.test.ts
+++ b/src/main/lib/telemetry.test.ts
@@ -849,19 +849,21 @@ describe('telemetry SDK-level volume guards', () => {
   })
 
   it('per-process cap at 5000 stops everything (including *.error) and warns once', () => {
-    // Mix of rate-limited-bypassing errors and normal events to confirm
-    // the session cap is the FINAL backstop and applies to everything.
-    let i = 0
-    while (captured.filter((c) => c.event !== 'desktop2.telemetry.session_cap_hit').length < 5100) {
+    // Fire enough rate-limited-bypassing errors to overshoot the 5000
+    // session cap by a healthy margin — the cap is the FINAL backstop
+    // and must apply even to events that bypass the per-event window.
+    // Use a fixed iteration count instead of polling `captured.filter()`
+    // each loop turn: that filter is O(N) over a growing array, so a
+    // while-condition variant is O(N²) and blows the 5s test timeout
+    // on slower CI hosts.
+    for (let i = 0; i < 6000; i++) {
       telemetry.capture('desktop2.execution.error', { i })
-      i++
-      if (i > 100_000) break // test runaway guard
     }
     const productEvents = captured.filter((c) => c.event !== 'desktop2.telemetry.session_cap_hit')
     const sessionCapWarnings = captured.filter(
       (c) => c.event === 'desktop2.telemetry.session_cap_hit'
     )
-    expect(productEvents.length).toBeLessThanOrEqual(5000)
+    expect(productEvents).toHaveLength(5000)
     expect(sessionCapWarnings).toHaveLength(1)
     expect(sessionCapWarnings[0]?.properties).toMatchObject({ cap: 5000 })
   })

--- a/src/main/lib/userTier.ts
+++ b/src/main/lib/userTier.ts
@@ -88,7 +88,7 @@ export function initUserTier(): Promise<void> {
     } catch {
       // first launch, missing file, or corrupt — stay 'unknown'
     }
-    // eslint-disable-next-line no-console
+     
     console.log('[user-tier] init: persisted=', cached)
   })()
   return initPromise
@@ -131,7 +131,7 @@ async function setTier(rawTierName: string | null | undefined): Promise<void> {
       'utf-8',
     )
   } catch (err) {
-    // eslint-disable-next-line no-console
+     
     console.log('[user-tier] persist failed:', err)
   }
 }
@@ -201,15 +201,15 @@ export async function refreshCloudUserTier(webContents: WebContents): Promise<vo
       return
     }
     if (result.error) {
-      // eslint-disable-next-line no-console
+       
       console.log('[user-tier] refresh skipped:', result.error)
       return
     }
     await setTier(result.tier ?? null)
-    // eslint-disable-next-line no-console
+     
     console.log('[user-tier] refresh: raw=', result.tier, '→ cached=', cached)
   } catch (err) {
-    // eslint-disable-next-line no-console
+     
     console.log('[user-tier] executeJavaScript failed:', err)
   }
 }

--- a/src/main/popups/titlePopup.test.ts
+++ b/src/main/popups/titlePopup.test.ts
@@ -371,6 +371,7 @@ describe('buildInstancePickerSnapshot', () => {
       installs,
       hostInstallationId: null,
       runningInstallationIds: [],
+      launchingInstallationIds: [],
       storage: EMPTY_STORAGE,
     })
     expect(snap.installs).toEqual(installs)
@@ -381,6 +382,7 @@ describe('buildInstancePickerSnapshot', () => {
       installs: [makeInstall({ id: 'a' })],
       hostInstallationId: 'a',
       runningInstallationIds: [],
+      launchingInstallationIds: [],
       storage: EMPTY_STORAGE,
     })
     expect(snap.activeInstallationId).toBe('a')
@@ -391,6 +393,7 @@ describe('buildInstancePickerSnapshot', () => {
       installs: [],
       hostInstallationId: null,
       runningInstallationIds: [],
+      launchingInstallationIds: [],
       storage: EMPTY_STORAGE,
     })
     expect(snap.activeInstallationId).toBeNull()
@@ -401,6 +404,7 @@ describe('buildInstancePickerSnapshot', () => {
       installs: [],
       hostInstallationId: null,
       runningInstallationIds: ['b', 'a', 'c'],
+      launchingInstallationIds: [],
       storage: EMPTY_STORAGE,
     })
     expect(snap.runningInstallationIds).toEqual(['b', 'a', 'c'])
@@ -411,9 +415,51 @@ describe('buildInstancePickerSnapshot', () => {
       installs: [makeInstall({ id: 'a' })],
       hostInstallationId: null,
       runningInstallationIds: [],
+      launchingInstallationIds: [],
       storage: EMPTY_STORAGE,
     })
     expect(snap.runningInstallationIds).toEqual([])
+  })
+
+  it('falls back to previewInstallationId when no real attach yet', () => {
+    // Chooser host that staked an attach claim before the launch
+    // completed: `applyAttachHostPreview` sets previewInstallationId
+    // while installationId is still null. Picker should still treat
+    // this host as "owning" the install.
+    const snap = buildInstancePickerSnapshot({
+      installs: [makeInstall({ id: 'a' })],
+      hostInstallationId: null,
+      previewInstallationId: 'a',
+      runningInstallationIds: [],
+      launchingInstallationIds: ['a'],
+      storage: EMPTY_STORAGE,
+    })
+    expect(snap.activeInstallationId).toBe('a')
+  })
+
+  it('prefers the real hostInstallationId over previewInstallationId', () => {
+    // Once `attachInstall` runs, the real installationId takes over;
+    // a stale preview should never override it.
+    const snap = buildInstancePickerSnapshot({
+      installs: [makeInstall({ id: 'a' }), makeInstall({ id: 'b' })],
+      hostInstallationId: 'a',
+      previewInstallationId: 'b',
+      runningInstallationIds: ['a'],
+      launchingInstallationIds: [],
+      storage: EMPTY_STORAGE,
+    })
+    expect(snap.activeInstallationId).toBe('a')
+  })
+
+  it('surfaces launchingInstallationIds verbatim for popup hydration', () => {
+    const snap = buildInstancePickerSnapshot({
+      installs: [makeInstall({ id: 'a' })],
+      hostInstallationId: null,
+      runningInstallationIds: [],
+      launchingInstallationIds: ['a', 'b'],
+      storage: EMPTY_STORAGE,
+    })
+    expect(snap.launchingInstallationIds).toEqual(['a', 'b'])
   })
 })
 

--- a/src/main/popups/titlePopup.ts
+++ b/src/main/popups/titlePopup.ts
@@ -19,6 +19,7 @@ import {
   getAppVersion,
   _activeOperationStatus,
   _operationAborts,
+  sessionLifecycleEvents,
   type PickerOperationStatus,
 } from '../lib/ipc/shared'
 import {
@@ -125,6 +126,13 @@ export interface InstancePickerSnapshot {
   installs: InstancePickerInstall[]
   activeInstallationId: string | null
   runningInstallationIds: string[]
+  /** Installs mid-launch — `instance-launching` fired, `instance-started`
+   *  has not. Mirrors `_launchingInstallationIds` in main so the picker
+   *  popup can hydrate `sessionStore.launchingInstances` from the
+   *  snapshot (its preload doesn't expose `onInstanceLaunching`).
+   *  Drives the CTA flip from **Start → Restart / Switch** during the
+   *  launching window via `useInstallCta`. */
+  launchingInstallationIds: string[]
   selectedInstallationId: string | null
   selectedSettings: Record<string, unknown>[] | null
   selectedSnapshots: Record<string, unknown> | null
@@ -202,7 +210,15 @@ export interface GlobalSettingsSnapshot {
 interface BuildInstancePickerSnapshotArgs {
   installs: InstancePickerInstall[]
   hostInstallationId: string | null
+  /** Optional fallback for `hostInstallationId` — set by the chooser
+   *  attach-claim path (`applyAttachHostPreview`) so a dashboard that
+   *  has staked a claim against an install reads as "currently owning"
+   *  it for picker purposes (Current pill + per-window CTA) from the
+   *  moment the claim is staked, instead of waiting for the real
+   *  `attachInstall` after `instance-started`. */
+  previewInstallationId?: string | null
   runningInstallationIds: string[]
+  launchingInstallationIds: string[]
   selectedInstallationId?: string | null
   selectedSettings?: Record<string, unknown>[] | null
   selectedSnapshots?: Record<string, unknown> | null
@@ -268,8 +284,14 @@ export function buildInstancePickerSnapshot(
 ): InstancePickerSnapshot {
   return {
     installs: args.installs,
-    activeInstallationId: args.hostInstallationId,
+    // Use the real attached install when available; fall back to the
+    // chooser's preview claim (set by `applyAttachHostPreview` when
+    // the chooser stakes an in-place attach claim ahead of a launch).
+    // Either case represents "this host is the one acting on the
+    // install" from the picker's perspective.
+    activeInstallationId: args.hostInstallationId ?? args.previewInstallationId ?? null,
     runningInstallationIds: args.runningInstallationIds,
+    launchingInstallationIds: args.launchingInstallationIds,
     selectedInstallationId: args.selectedInstallationId ?? null,
     selectedSettings: args.selectedSettings ?? null,
     selectedSnapshots: args.selectedSnapshots ?? null,
@@ -754,14 +776,22 @@ async function broadcastInstancePickerSnapshotToTitlePopups(
   // entry would waste IO on the rare multi-window case.
   const installs = await bindings.getInstancePickerInstalls()
   const runningInstallationIds = bindings.getRunningInstallationIds()
+  const launchingInstallationIds = bindings.getLaunchingInstallationIds()
   for (const entry of titlePopupsByParent.values()) {
     if (entry.kind !== 'instance-picker') continue
     if (!entry.view.isOpen && entry.view.pendingShowTimer === null) continue
     if (entry.view.popup.webContents.isDestroyed()) continue
     const parentEntry = comfyWindows.get(entry.parentEntryId)
+    // For picker selection / Current-pill purposes a chooser host
+    // that has staked an attach claim (previewInstallationId set,
+    // installationId still null) reads as "owning" the install — see
+    // `applyAttachHostPreview` + buildInstancePickerSnapshot's
+    // hostInstallationId/previewInstallationId fallback.
+    const effectiveHostInstallationId =
+      parentEntry?.installationId ?? parentEntry?.previewInstallationId ?? null
     const selectedId = resolvePickerSelectedInstallId(
       entry.pickerSelectedInstallationId,
-      parentEntry?.installationId,
+      effectiveHostInstallationId,
       installs,
     )
     if (!entry.pickerSelectedInstallationId && selectedId) {
@@ -776,7 +806,9 @@ async function broadcastInstancePickerSnapshotToTitlePopups(
     const snapshot = buildInstancePickerSnapshot({
       installs,
       hostInstallationId: parentEntry?.installationId ?? null,
+      previewInstallationId: parentEntry?.previewInstallationId ?? null,
       runningInstallationIds,
+      launchingInstallationIds,
       selectedInstallationId: selectedId,
       selectedSettings: details.settings,
       selectedSnapshots: details.snapshots,
@@ -1420,6 +1452,13 @@ export interface TitlePopupHostBindings {
   /** Currently-running installation ids. Drives the picker's "running"
    *  row indicator and the focus-vs-launch decision in `pickInstall`. */
   getRunningInstallationIds: () => string[]
+  /** Installs mid-launch (between `instance-launching` and
+   *  `instance-started` / `instance-launch-failed`). Surfaced in the
+   *  picker snapshot so the popup — whose preload doesn't expose the
+   *  `onInstanceLaunching` IPC channel — can hydrate
+   *  `sessionStore.launchingInstances` and let `useInstallCta` flip the
+   *  CTA from Start to Restart/Switch during the launching window. */
+  getLaunchingInstallationIds: () => string[]
   /** Picker chose an install. The "from a Comfy window pick" contract:
    *  if the install is already running, focus its window; otherwise
    *  open a new Comfy window for it. NEVER swap the active install out
@@ -1563,9 +1602,14 @@ function openInstancePickerForHost(
   if (parentEntry.window.isDestroyed()) return
   const installs: InstancePickerInstall[] = cachedInstallsForPicker.slice()
   const runningInstallationIds = bindings.getRunningInstallationIds()
+  const launchingInstallationIds = bindings.getLaunchingInstallationIds()
+  // A chooser host that already staked a claim (preview) reads as
+  // owning the install for default-selection purposes.
+  const effectiveHostInstallationId =
+    parentEntry.installationId ?? parentEntry.previewInstallationId ?? null
   const initialSelectedId = resolvePickerSelectedInstallId(
     selectedInstallationId,
-    parentEntry.installationId,
+    effectiveHostInstallationId,
     installs,
   )
   // Bump the nonce whenever this open carries an autoAction so a repeat
@@ -1581,7 +1625,9 @@ function openInstancePickerForHost(
   const snapshot = buildInstancePickerSnapshot({
     installs,
     hostInstallationId: parentEntry.installationId,
+    previewInstallationId: parentEntry.previewInstallationId,
     runningInstallationIds,
+    launchingInstallationIds,
     selectedInstallationId: initialSelectedId,
     selectedSettings: null,
     selectedSnapshots: null,
@@ -2790,14 +2836,23 @@ export function registerTitlePopupIpc(bindings: TitlePopupHostBindings): void {
     void broadcastInstancePickerSnapshotToTitlePopups(bindings)
     void broadcastGlobalSettingsSnapshotToTitlePopups(bindings)
   })
-  // Host attach/detach flips `parentEntry.installationId`, which the
-  // picker snapshot folds into `activeInstallationId` (drives the
-  // "Current" pill on the row and the per-window CTA decision in
-  // `useInstallCta`). Without this listener the picker would only
-  // repaint at `instance-started` (via `markLaunched` → installation
-  // 'changed'), leaving the launching window without a Current pill
-  // for the entire launch.
+  // Host attach/detach (and the chooser's preview-claim apply/clear)
+  // flips `parentEntry.installationId` / `previewInstallationId`,
+  // which the picker snapshot folds into `activeInstallationId`
+  // (drives the "Current" pill on the row and the per-window CTA
+  // decision in `useInstallCta`). Without this listener the picker
+  // would only repaint at `instance-started` (via `markLaunched` →
+  // installation 'changed'), leaving the launching window without a
+  // Current pill for the entire launch.
   hostInstallEvents.on('changed', () => {
+    void broadcastInstancePickerSnapshotToTitlePopups(bindings)
+  })
+  // Session lifecycle (launching set + running set) drives the
+  // picker's row-side "running" indicator and the Start/Restart/Switch
+  // CTA. The popup's preload doesn't expose `onInstanceLaunching` —
+  // the only path that brings launching state into the popup is the
+  // snapshot itself, so we must rebroadcast on every transition.
+  sessionLifecycleEvents.on('changed', () => {
     void broadcastInstancePickerSnapshotToTitlePopups(bindings)
   })
   // Settings writes (applySettingSet) emit 'changed' — rebroadcast so

--- a/src/main/popups/titlePopup.ts
+++ b/src/main/popups/titlePopup.ts
@@ -758,6 +758,19 @@ function broadcastDownloadsToTitlePopups(): void {
   }
 }
 
+/**
+ *  Monotonic sequence stamped on every call to
+ *  `broadcastInstancePickerSnapshotToTitlePopups`. The function
+ *  awaits the install list and (per entry) the picker-detail payload;
+ *  back-to-back triggers (`hostInstallEvents.changed` +
+ *  `sessionLifecycleEvents.changed` firing in the same tick around a
+ *  fast launch/stop/restart) can otherwise resolve out of order and
+ *  let an older snapshot overwrite the newer one. Each in-flight
+ *  build re-checks this value after every await and aborts when
+ *  superseded.
+ */
+let pickerSnapshotBroadcastSeq = 0
+
 /** Push an updated instance-picker snapshot to every popup whose
  *  current kind is `'instance-picker'`. Triggered by the
  *  `installationEvents.on('changed')` subscription wired in
@@ -766,6 +779,7 @@ function broadcastDownloadsToTitlePopups(): void {
 async function broadcastInstancePickerSnapshotToTitlePopups(
   bindings: TitlePopupHostBindings,
 ): Promise<void> {
+  const mySeq = ++pickerSnapshotBroadcastSeq
   const hasActivePicker = Array.from(titlePopupsByParent.values()).some(
     (entry) => entry.kind === 'instance-picker'
       && (entry.view.isOpen || entry.view.pendingShowTimer !== null),
@@ -775,6 +789,7 @@ async function broadcastInstancePickerSnapshotToTitlePopups(
   // typically there is only one, but reading the disk-backed list per
   // entry would waste IO on the rare multi-window case.
   const installs = await bindings.getInstancePickerInstalls()
+  if (mySeq !== pickerSnapshotBroadcastSeq) return
   const runningInstallationIds = bindings.getRunningInstallationIds()
   const launchingInstallationIds = bindings.getLaunchingInstallationIds()
   for (const entry of titlePopupsByParent.values()) {
@@ -803,6 +818,7 @@ async function broadcastInstancePickerSnapshotToTitlePopups(
         snapshots: null,
       }))
       : { settings: null, snapshots: null }
+    if (mySeq !== pickerSnapshotBroadcastSeq) return
     const snapshot = buildInstancePickerSnapshot({
       installs,
       hostInstallationId: parentEntry?.installationId ?? null,

--- a/src/main/popups/titlePopup.ts
+++ b/src/main/popups/titlePopup.ts
@@ -33,6 +33,7 @@ import {
   comfyWindows,
   findEntryByTitleBarSender,
   getEntryByInstallationId,
+  hostInstallEvents,
   isChooserHost,
 } from '../host/registry'
 import type { ComfyPanelKey, ComfyWindowEntry } from '../host/registry'
@@ -2788,6 +2789,16 @@ export function registerTitlePopupIpc(bindings: TitlePopupHostBindings): void {
     void refreshCachedInstallsForPicker()
     void broadcastInstancePickerSnapshotToTitlePopups(bindings)
     void broadcastGlobalSettingsSnapshotToTitlePopups(bindings)
+  })
+  // Host attach/detach flips `parentEntry.installationId`, which the
+  // picker snapshot folds into `activeInstallationId` (drives the
+  // "Current" pill on the row and the per-window CTA decision in
+  // `useInstallCta`). Without this listener the picker would only
+  // repaint at `instance-started` (via `markLaunched` → installation
+  // 'changed'), leaving the launching window without a Current pill
+  // for the entire launch.
+  hostInstallEvents.on('changed', () => {
+    void broadcastInstancePickerSnapshotToTitlePopups(bindings)
   })
   // Settings writes (applySettingSet) emit 'changed' — rebroadcast so
   // the popup sees Language / Theme / Cache / Models / etc. flip live.

--- a/src/renderer/src/comfyTitlePopup/InstancePickerView.test.ts
+++ b/src/renderer/src/comfyTitlePopup/InstancePickerView.test.ts
@@ -50,6 +50,9 @@ interface MockSnapshot {
   installs: MockInstall[]
   activeInstallationId: string | null
   runningInstallationIds: string[]
+  /** Optional — defaults to `[]` in `mountPicker`. Tests that exercise
+   *  the launching state explicitly set this. */
+  launchingInstallationIds?: string[]
   selectedInstallationId?: string | null
   selectedSettings?: unknown[] | null
   selectedSnapshots?: unknown | null
@@ -123,6 +126,7 @@ async function mountPicker(snapshot: MockSnapshot) {
     selectedInstallationId: snapshot.activeInstallationId,
     selectedSettings: null,
     selectedSnapshots: emptySnapshotListPayload,
+    launchingInstallationIds: [] as string[],
     ...snapshot,
   }
   return mount(InstancePickerView, {
@@ -470,6 +474,67 @@ describe('comfyTitlePopup/InstancePickerView', () => {
       await flushPromises()
       expect(bridge.picks).toEqual(['b'])
       expect(bridge.restarts).toEqual([])
+    })
+  })
+
+  // The popup's `sessionStore` is hydrated solely from the picker
+  // snapshot — its preload doesn't expose `onInstanceLaunching` /
+  // `onInstanceStarted`. The hydration watcher must fire on launching-
+  // only transitions or `useInstallCta` will keep the CTA on Start
+  // for the entire launching window when the running set hasn't yet
+  // changed (the exact bug #785 fixes).
+  describe('session-store hydration from snapshot', () => {
+    it('hydrates launching ids when only launchingInstallationIds changes', async () => {
+      const { useSessionStore } = await import('../stores/sessionStore')
+      const wrapper = await mountPicker({
+        installs: [makeInstall({ id: 'a', name: 'Alpha' })],
+        activeInstallationId: null,
+        runningInstallationIds: [],
+        launchingInstallationIds: [],
+      })
+      const sessionStore = useSessionStore()
+      expect(sessionStore.isLaunching('a')).toBe(false)
+
+      await wrapper.setProps({
+        snapshot: {
+          installs: [makeInstall({ id: 'a', name: 'Alpha' })],
+          activeInstallationId: 'a',
+          runningInstallationIds: [],
+          launchingInstallationIds: ['a'],
+          selectedInstallationId: null,
+          selectedSettings: null,
+          selectedSnapshots: emptySnapshotListPayload,
+        },
+      })
+      await flushPromises()
+      expect(sessionStore.isLaunching('a')).toBe(true)
+    })
+
+    it('clears a launching id when it drops out of the snapshot', async () => {
+      const { useSessionStore } = await import('../stores/sessionStore')
+      const wrapper = await mountPicker({
+        installs: [makeInstall({ id: 'a', name: 'Alpha' })],
+        activeInstallationId: 'a',
+        runningInstallationIds: [],
+        launchingInstallationIds: ['a'],
+      })
+      const sessionStore = useSessionStore()
+      expect(sessionStore.isLaunching('a')).toBe(true)
+
+      await wrapper.setProps({
+        snapshot: {
+          installs: [makeInstall({ id: 'a', name: 'Alpha' })],
+          activeInstallationId: 'a',
+          runningInstallationIds: ['a'],
+          launchingInstallationIds: [],
+          selectedInstallationId: null,
+          selectedSettings: null,
+          selectedSnapshots: emptySnapshotListPayload,
+        },
+      })
+      await flushPromises()
+      expect(sessionStore.isLaunching('a')).toBe(false)
+      expect(sessionStore.isRunning('a')).toBe(true)
     })
   })
 })

--- a/src/renderer/src/comfyTitlePopup/InstancePickerView.vue
+++ b/src/renderer/src/comfyTitlePopup/InstancePickerView.vue
@@ -402,8 +402,18 @@ const initialExpandedTab = computed<PickerTab>(() =>
   resolvePickerTab(props.snapshot.initialTab, 'update')
 )
 
+// Both lifecycle id arrays must be watched — the popup's preload
+// has no `instance-launching` / `instance-started` IPC listeners, so
+// the snapshot is the sole source of truth for `sessionStore`. Watching
+// only `runningInstallationIds` would miss the launching-only
+// transitions this drawer relies on to flip the CTA from Start to
+// Restart/Switch mid-launch. NUL-joined so an id containing a comma
+// can't collide a unique boundary.
 watch(
-  () => props.snapshot.runningInstallationIds.join(','),
+  [
+    () => props.snapshot.runningInstallationIds.join('\0'),
+    () => (props.snapshot.launchingInstallationIds ?? []).join('\0')
+  ],
   () => hydrateSessionStoreFromSnapshot(),
   { immediate: true }
 )

--- a/src/renderer/src/comfyTitlePopup/InstancePickerView.vue
+++ b/src/renderer/src/comfyTitlePopup/InstancePickerView.vue
@@ -71,6 +71,12 @@ interface PickerSnapshot {
   installs: PickerInstall[]
   activeInstallationId: string | null
   runningInstallationIds: string[]
+  /** Installs whose `instance-launching` has fired but `instance-started`
+   *  has not. Hydrated into `sessionStore.launchingInstances` because
+   *  the popup preload doesn't expose `onInstanceLaunching`. Drives
+   *  the **Start → Restart / Switch** CTA flip during the launching
+   *  window via `useInstallCta`. */
+  launchingInstallationIds: string[]
   selectedInstallationId: string | null
   selectedSettings: DetailSection[] | null
   selectedSnapshots: SnapshotListData | null
@@ -102,6 +108,20 @@ function hydrateSessionStoreFromSnapshot(): void {
         mode: ''
       }
       sessionStore.runningInstances.set(id, placeholder)
+    }
+  }
+  // The popup preload doesn't expose `onInstanceLaunching`, so the
+  // only path that brings launching state in is this snapshot.
+  // Without this hydration, `sessionStore.isLaunching(id)` would stay
+  // false during the launching window and `useInstallCta` would leave
+  // the CTA on Start (instead of flipping to Restart/Switch).
+  const nextLaunching = new Set(props.snapshot.launchingInstallationIds ?? [])
+  for (const id of Array.from(sessionStore.launchingInstances.keys())) {
+    if (!nextLaunching.has(id)) sessionStore.launchingInstances.delete(id)
+  }
+  for (const id of nextLaunching) {
+    if (!sessionStore.launchingInstances.has(id)) {
+      sessionStore.launchingInstances.set(id, { installationName: '' })
     }
   }
 }

--- a/src/renderer/src/comfyTitlePopup/TitlePopupApp.vue
+++ b/src/renderer/src/comfyTitlePopup/TitlePopupApp.vue
@@ -84,6 +84,11 @@ interface PickerSnapshot {
   installs: PickerInstall[]
   activeInstallationId: string | null
   runningInstallationIds: string[]
+  /** Installs mid-launch — hydrated into `sessionStore.launchingInstances`
+   *  in the popup because its preload doesn't expose
+   *  `onInstanceLaunching`. Drives the CTA flip during the launching
+   *  window via `useInstallCta`. */
+  launchingInstallationIds: string[]
   /** Per-row Settings + Snapshots payload for the picker's right
    *  pane. Scoped to the picker's currently-selected install (changes
    *  every time the user clicks a different row; popup tells main via
@@ -189,6 +194,7 @@ const pickerSnapshot = ref<PickerSnapshot>({
   installs: [],
   activeInstallationId: null,
   runningInstallationIds: [],
+  launchingInstallationIds: [],
   selectedInstallationId: null,
   selectedSettings: null,
   selectedSnapshots: null,

--- a/src/renderer/src/composables/useInstallCta.test.ts
+++ b/src/renderer/src/composables/useInstallCta.test.ts
@@ -8,22 +8,33 @@ vi.mock('vue-i18n', () => ({
   }),
 }))
 
-// Wrap the running-set in a shallowRef so `setRunning` can trigger the
-// composable's computed properties on real session-store mutations,
-// not on incidental dep churn from the test.
-const sessionState = vi.hoisted(() => ({ running: new Set<string>() }))
+// Wrap the session-state in a shallowRef so the `set*` helpers can
+// trigger the composable's computed properties on real session-store
+// mutations, not on incidental dep churn from the test.
+const sessionState = vi.hoisted(() => ({
+  running: new Set<string>(),
+  launching: new Set<string>(),
+}))
 function setRunning(running: Set<string>): void {
   sessionState.running = running
+  triggerRef(sessionStoreVersion)
+}
+function setLaunching(launching: Set<string>): void {
+  sessionState.launching = launching
   triggerRef(sessionStoreVersion)
 }
 const sessionStoreVersion = shallowRef(0)
 vi.mock('../stores/sessionStore', () => ({
   useSessionStore: () => ({
     isRunning: (id: string) => {
-      // Touch the version ref so the computed re-runs when `setRunning`
+      // Touch the version ref so the computed re-runs when `set*`
       // triggers it.
       void sessionStoreVersion.value
       return sessionState.running.has(id)
+    },
+    isLaunching: (id: string) => {
+      void sessionStoreVersion.value
+      return sessionState.launching.has(id)
     },
   }),
 }))
@@ -37,6 +48,7 @@ function installation(id: string): Installation {
 
 beforeEach(() => {
   setRunning(new Set<string>())
+  setLaunching(new Set<string>())
 })
 
 describe('useInstallCta', () => {
@@ -126,5 +138,48 @@ describe('useInstallCta', () => {
     // install now reads as "running elsewhere".
     active.value = null
     expect(cta.label.value).toBe('Switch')
+  })
+
+  // Launching state — the install has been attached to a window but
+  // `instance-started` has not yet fired (port not bound). The CTA
+  // must already read as "session attached" or the user sees a Start
+  // button in the very window the launch is happening in, and other
+  // windows see a Start button that the main-side single-attach guard
+  // would just reject.
+  it('returns Restart when the install is LAUNCHING in this host window', () => {
+    setLaunching(new Set<string>(['inst-A']))
+    const cta = useInstallCta(ref(installation('inst-A')), {
+      activeInstallationId: ref<string | null>('inst-A'),
+    })
+    expect(cta.runningAnywhere.value).toBe(true)
+    expect(cta.runningInThisWindow.value).toBe(true)
+    expect(cta.runningElsewhere.value).toBe(false)
+    expect(cta.restartInPlace.value).toBe(true)
+    expect(cta.label.value).toBe('Restart')
+  })
+
+  it('returns Switch when the install is LAUNCHING in another host window', () => {
+    setLaunching(new Set<string>(['inst-B']))
+    const cta = useInstallCta(ref(installation('inst-B')), {
+      activeInstallationId: ref<string | null>('inst-A'),
+    })
+    expect(cta.runningAnywhere.value).toBe(true)
+    expect(cta.runningInThisWindow.value).toBe(false)
+    expect(cta.runningElsewhere.value).toBe(true)
+    expect(cta.label.value).toBe('Switch')
+  })
+
+  it('keeps Restart across the launching → running handoff in the same window', () => {
+    // `instance-launching` arrives first → composable should already
+    // read Restart. Then `instance-started` arrives (launching clears,
+    // running sets) — same label, no flicker through Start.
+    setLaunching(new Set<string>(['inst-A']))
+    const cta = useInstallCta(ref(installation('inst-A')), {
+      activeInstallationId: ref<string | null>('inst-A'),
+    })
+    expect(cta.label.value).toBe('Restart')
+    setLaunching(new Set<string>())
+    setRunning(new Set<string>(['inst-A']))
+    expect(cta.label.value).toBe('Restart')
   })
 })

--- a/src/renderer/src/composables/useInstallCta.ts
+++ b/src/renderer/src/composables/useInstallCta.ts
@@ -9,12 +9,21 @@ import type { Installation } from '../types/ipc'
  * An install can be running in at most one window at a time
  * (`getEntryByInstallationId` on the main side enforces this), so the
  * answer to "what should the primary CTA do?" decomposes into three
- * cases driven by the global `sessionStore.isRunning(id)` flag and the
- * host window's own `activeInstallationId`:
+ * cases driven by the install's session state and the host window's
+ * own `activeInstallationId`:
  *
- *   - not running anywhere       → **Start**, launch via `pickInstall`
- *   - running in this window     → **Restart**, stop + relaunch in place
- *   - running in another window  → **Switch**, focus the existing window
+ *   - no session anywhere        → **Start**, launch via `pickInstall`
+ *   - session in this window     → **Restart**, stop + relaunch in place
+ *   - session in another window  → **Switch**, focus the existing window
+ *
+ * "Session" covers both `isLaunching` (mid-startup, no port yet) and
+ * `isRunning` (live). Treating the launching state as a session keeps
+ * the CTA honest from the moment the user clicks Start: the window
+ * the launch was attached to flips straight from **Start** to
+ * **Restart** instead of lingering on **Start** until
+ * `instance-started` fires, and other windows correctly see **Switch**
+ * during the startup window instead of offering to start a parallel
+ * launch that the main-side single-attach guard would just reject.
  *
  * Centralizing the decision here so the picker row indicators and the
  * settings footer CTA can't drift apart (issue #755 — the original
@@ -23,15 +32,18 @@ import type { Installation } from '../types/ipc'
  * `ComfyUISettingsContent`).
  */
 export interface InstallCta {
-  /** True when the install is running in the host window that owns
-   *  this composable. Only here does "Restart" make sense. */
+  /** True when the install has a session (launching or running) in the
+   *  host window that owns this composable. Only here does "Restart"
+   *  make sense. */
   runningInThisWindow: ComputedRef<boolean>
-  /** True when the install is running in some *other* host window —
-   *  the right action is to focus that window, not restart. */
+  /** True when the install has a session (launching or running) in
+   *  some *other* host window — the right action is to focus that
+   *  window, not restart. */
   runningElsewhere: ComputedRef<boolean>
-  /** True when the install has a running session anywhere. Use this
-   *  for genuinely global gates (delete / snapshot-restore) that
-   *  shouldn't fire while the install is in use anywhere. */
+  /** True when the install has a session (launching or running)
+   *  anywhere. Use this for genuinely global gates (delete /
+   *  snapshot-restore) that shouldn't fire while the install is in
+   *  use anywhere. */
   runningAnywhere: ComputedRef<boolean>
   /** Localized primary-action label: `Start` / `Restart` / `Switch`.
    *  Components can override (e.g. settings shows "Restart to apply
@@ -50,9 +62,17 @@ export function useInstallCta(
   const { t } = useI18n()
   const sessionStore = useSessionStore()
 
+  // `isLaunching || isRunning` — covers the full attached-session
+  // window. The launching state lasts from `instance-launching` (port
+  // not yet bound) until `instance-started` (live), and the main-side
+  // attach happens BEFORE `instance-launching` fires (see launch.ts +
+  // `attachInstall`), so by the time `runningAnywhere` flips true the
+  // target window's `activeInstallationId` already matches and the
+  // "in this window?" comparison is honest.
   const runningAnywhere = computed(() => {
     const inst = installation.value
-    return inst ? sessionStore.isRunning(inst.id) : false
+    if (!inst) return false
+    return sessionStore.isRunning(inst.id) || sessionStore.isLaunching(inst.id)
   })
 
   const runningInThisWindow = computed(() => {

--- a/src/renderer/src/composables/useListAction.test.ts
+++ b/src/renderer/src/composables/useListAction.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string, params?: Record<string, unknown>) =>
+      params ? `${key}:${JSON.stringify(params)}` : key,
+  }),
+}))
+
+const mockModalConfirm = vi.hoisted(() => vi.fn())
+const mockModalAlert = vi.hoisted(() => vi.fn())
+vi.mock('./useModal', () => ({
+  useModal: () => ({ confirm: mockModalConfirm, alert: mockModalAlert }),
+}))
+
+const mockCheckBeforeAction = vi.hoisted(() => vi.fn())
+vi.mock('./useActionGuard', () => ({
+  useActionGuard: () => ({ checkBeforeAction: mockCheckBeforeAction }),
+}))
+
+const mockCheckBeforeLaunch = vi.hoisted(() => vi.fn())
+vi.mock('./useLocalInstanceGuard', () => ({
+  useLocalInstanceGuard: () => ({ checkBeforeLaunch: mockCheckBeforeLaunch }),
+}))
+
+const sessionState = vi.hoisted(() => ({
+  running: new Set<string>(),
+  errorCleared: [] as string[],
+}))
+vi.mock('../stores/sessionStore', () => ({
+  useSessionStore: () => ({
+    isRunning: (id: string) => sessionState.running.has(id),
+    clearErrorInstance: (id: string) => {
+      sessionState.errorCleared.push(id)
+    },
+  }),
+}))
+
+vi.mock('../lib/telemetry', () => ({
+  emitTelemetryAction: vi.fn(),
+  toErrorBucket: () => 'unknown',
+}))
+
+const mockRunAction = vi.hoisted(() => vi.fn())
+;(globalThis as unknown as { window: { api: { runAction: typeof mockRunAction } } }).window = {
+  api: { runAction: mockRunAction },
+}
+
+import { useListAction } from './useListAction'
+import type { Installation, ListAction } from '../types/ipc'
+
+const INSTALL: Installation = {
+  id: 'inst-launch',
+  name: 'Test Install',
+  sourceLabel: 'standalone',
+  sourceCategory: 'local',
+}
+
+const LAUNCH_ACTION: ListAction = {
+  id: 'launch',
+  label: 'Launch',
+  style: 'primary',
+  showProgress: true,
+}
+
+describe('useListAction.executeAction onGuardsPassed hook', () => {
+  beforeEach(() => {
+    sessionState.running.clear()
+    sessionState.errorCleared.length = 0
+    mockModalConfirm.mockReset()
+    mockModalAlert.mockReset()
+    mockCheckBeforeAction.mockReset().mockResolvedValue(true)
+    mockCheckBeforeLaunch.mockReset().mockResolvedValue(true)
+    mockRunAction.mockReset().mockResolvedValue({ ok: true })
+  })
+
+  it('fires onGuardsPassed when every guard resolves positively', async () => {
+    const onGuardsPassed = vi.fn(async () => {})
+    const showProgress = vi.fn()
+    const { executeAction } = useListAction('chooser', { showProgress })
+
+    await executeAction(INSTALL, LAUNCH_ACTION, { onGuardsPassed })
+
+    expect(onGuardsPassed).toHaveBeenCalledOnce()
+    expect(showProgress).toHaveBeenCalledOnce()
+    // Hook must fire BEFORE showProgress so the chooser claim is in place
+    // by the time the launch op is dispatched.
+    expect(onGuardsPassed.mock.invocationCallOrder[0]).toBeLessThan(
+      showProgress.mock.invocationCallOrder[0],
+    )
+  })
+
+  it('does NOT fire onGuardsPassed when the action is disabled', async () => {
+    const onGuardsPassed = vi.fn()
+    const showProgress = vi.fn()
+    const disabledAction: ListAction = {
+      ...LAUNCH_ACTION,
+      enabled: false,
+      disabledMessage: 'Cannot launch right now',
+    }
+    const { executeAction } = useListAction('chooser', { showProgress })
+
+    await executeAction(INSTALL, disabledAction, { onGuardsPassed })
+
+    expect(mockModalAlert).toHaveBeenCalledOnce()
+    expect(onGuardsPassed).not.toHaveBeenCalled()
+    expect(showProgress).not.toHaveBeenCalled()
+  })
+
+  it('does NOT fire onGuardsPassed when the busy guard cancels', async () => {
+    mockCheckBeforeAction.mockResolvedValueOnce(false)
+    const onGuardsPassed = vi.fn()
+    const showProgress = vi.fn()
+    const { executeAction } = useListAction('chooser', { showProgress })
+
+    await executeAction(INSTALL, LAUNCH_ACTION, { onGuardsPassed })
+
+    expect(onGuardsPassed).not.toHaveBeenCalled()
+    expect(showProgress).not.toHaveBeenCalled()
+  })
+
+  it('does NOT fire onGuardsPassed when the user cancels a confirm modal', async () => {
+    mockModalConfirm.mockResolvedValueOnce(false)
+    const onGuardsPassed = vi.fn()
+    const showProgress = vi.fn()
+    const confirmedAction: ListAction = {
+      ...LAUNCH_ACTION,
+      confirm: { title: 'Sure?', message: 'Really?' },
+    }
+    const { executeAction } = useListAction('chooser', { showProgress })
+
+    await executeAction(INSTALL, confirmedAction, { onGuardsPassed })
+
+    expect(onGuardsPassed).not.toHaveBeenCalled()
+    expect(showProgress).not.toHaveBeenCalled()
+  })
+
+  it('does NOT fire onGuardsPassed when the local-instance launch guard cancels', async () => {
+    mockCheckBeforeLaunch.mockResolvedValueOnce(false)
+    const onGuardsPassed = vi.fn()
+    const showProgress = vi.fn()
+    const { executeAction } = useListAction('chooser', { showProgress })
+
+    await executeAction(INSTALL, LAUNCH_ACTION, { onGuardsPassed })
+
+    expect(onGuardsPassed).not.toHaveBeenCalled()
+    expect(showProgress).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/composables/useListAction.ts
+++ b/src/renderer/src/composables/useListAction.ts
@@ -18,6 +18,23 @@ export interface ListActionCallbacks {
   onNavigate?: (result: ActionResult, action: ListAction) => void | Promise<void>
 }
 
+/**
+ * Per-call hooks for an `executeAction` invocation.
+ *
+ * `onGuardsPassed` fires exactly once, after every cancel-path
+ * (disabled-message alert, busy guard, confirm modal, local-instance
+ * guard) has resolved positively but BEFORE the action is actually
+ * dispatched (either through `callbacks.showProgress` or the inline
+ * `runAction` path). The chooser-host pick flow uses this to stake the
+ * in-place attach claim only when the launch will really proceed —
+ * staking earlier (before the guard) would cross-window overwrite a
+ * sibling chooser's existing claim and leave the wrong window with the
+ * preview / claim if the user cancels.
+ */
+export interface ListActionInvocationHooks {
+  onGuardsPassed?: () => Promise<void> | void
+}
+
 export function useListAction(uiSurface: string, callbacks: ListActionCallbacks) {
   const { t } = useI18n()
   const modal = useModal()
@@ -25,7 +42,11 @@ export function useListAction(uiSurface: string, callbacks: ListActionCallbacks)
   const localInstanceGuard = useLocalInstanceGuard()
   const sessionStore = useSessionStore()
 
-  async function executeAction(inst: Installation, action: ListAction): Promise<void> {
+  async function executeAction(
+    inst: Installation,
+    action: ListAction,
+    hooks?: ListActionInvocationHooks,
+  ): Promise<void> {
     const telemetryContext = {
       source_category: inst.sourceCategory || 'unknown',
       ui_surface: uiSurface
@@ -82,6 +103,11 @@ export function useListAction(uiSurface: string, callbacks: ListActionCallbacks)
         return
       }
     }
+
+    // All cancel-paths have committed to running. Side effects that
+    // must NOT survive a cancel (chooser in-place attach claim +
+    // title-bar preview) belong in this hook.
+    if (hooks?.onGuardsPassed) await hooks.onGuardsPassed()
 
     sessionStore.clearErrorInstance(inst.id)
     emitTelemetryAction('desktop2.action.invoked', { action_id: action.id, ...telemetryContext })

--- a/src/renderer/src/panel/useChooserHandoff.ts
+++ b/src/renderer/src/panel/useChooserHandoff.ts
@@ -170,8 +170,17 @@ export function useChooserHandoff(opts: ChooserHandoffOpts): ChooserHandoffApi {
       onMissingLaunchAction()
       return 'missing-action'
     }
-    await prepareChooserHostHandoff(installation.id)
-    await executeChooserAction(installation, launchAction)
+    // Stake the in-place attach claim only after `executeChooserAction`'s
+    // guard chain has committed to running. If the user cancels the
+    // "operation in progress" prompt (e.g. a sibling chooser window
+    // already started this install), staking pre-guard would have
+    // cross-window overwritten the sibling's claim AND left this
+    // window's title bar showing the install's preview chrome — so
+    // when the sibling's launch completed, main would consume *this*
+    // window's stale claim and attach the install to the wrong window.
+    await executeChooserAction(installation, launchAction, {
+      onGuardsPassed: () => prepareChooserHostHandoff(installation.id),
+    })
     return 'launched'
   }
 


### PR DESCRIPTION
## Summary

Three bugs all visible during the **launching window** (between `instance-launching` and `instance-started`), all rooted in "the launching state isn't treated as a session yet". The most visible one — **the picker drawer is wrong during a Start from the dashboard** — turned out to need more than the earlier CTA + attach-event fixes, because the popup that renders the drawer doesn't share the main host's `sessionStore` and its preload doesn't expose `onInstanceLaunching` at all.

## Bug 1 — CTA says "Start" during launching

`useInstallCta` derived `runningAnywhere` from `sessionStore.isRunning(id)` alone:

```ts
const runningAnywhere = computed(() => {
  const inst = installation.value
  return inst ? sessionStore.isRunning(inst.id) : false
})
```

`isRunning(id)` flips only on `instance-started`. During the launching window the install lives in `launchingInstances` but not `runningInstances`, so the composable reported it as "not running anywhere" → label = **Start**.

Extended the predicate to cover the full attached-session window:

```ts
return sessionStore.isRunning(inst.id) || sessionStore.isLaunching(inst.id)
```

## Bug 2 — Picker snapshot didn't repaint on attach

`TitlePopupController` rebroadcast picker snapshots on `installationEvents.changed` (which fires at `instance-started`-time via `markLaunched`) and on lifecycle events — but not on actual host attach / detach. New `hostInstallEvents` bus in [registry.ts](file:///f%3A/workspaces/station1/stations/station1/ComfyUI-Launcher/src/main/host/registry.ts) emits `'changed'` whenever the install ↔ host attachment index mutates (`indexInstallationId`, `dropInstallationIndex`, install-backed register/unregister), and `titlePopup.ts` listens to rebroadcast.

## Bug 3 — Picker drawer was blind to launching state and to chooser preview claims

The bug the user could still reproduce after fixes 1 and 2: open the **dashboard**, click **Start** on a tile, then open the picker drawer mid-launch. CTA still **Start**, no **Current** pill on the install.

Two compounding root causes:

**Root cause A — the popup's session store never sees launching state.**

The picker drawer is rendered in a separate `WebContentsView` with [`comfyTitlePopupPreload.ts`](file:///f%3A/workspaces/station1/stations/station1/ComfyUI-Launcher/src/preload/comfyTitlePopupPreload.ts) as its preload — which intentionally doesn't expose `window.api`. The popup's `sessionStore` is hydrated by `hydrateSessionStoreFromSnapshot` from the picker payload, and that payload only carried `runningInstallationIds`. So `sessionStore.isLaunching(id)` was always `false` inside the popup, and Bug 1's fix couldn't fire because its precondition wasn't there.

**Root cause B — the snapshot ignored the chooser's attach-claim preview.**

When the user clicks Start from a dashboard tile, the chooser stakes an attach claim via `claim-attach-host` → [`applyAttachHostPreview`](file:///f%3A/workspaces/station1/stations/station1/ComfyUI-Launcher/src/main/host/attachHostPreview.ts) sets `entry.previewInstallationId` and pushes preview chrome to the title bar. But `entry.installationId` is still `null` — the real `attachInstall` doesn't run until `_onLaunch` (post-port-bind, after `instance-started`). The picker snapshot used only `parentEntry.installationId` as `activeInstallationId`, so the dashboard read as "not owning anything" → no Current pill → CTA = Start.

**Fix:**

- New `_launchingInstallationIds` set in [shared.ts](file:///f%3A/workspaces/station1/stations/station1/ComfyUI-Launcher/src/main/lib/ipc/shared.ts), plus `_markLaunching` / `_clearLaunchingFailed` helpers used by [launch.ts](file:///f%3A/workspaces/station1/stations/station1/ComfyUI-Launcher/src/main/lib/ipc/sessionActions/launch.ts). `_addSession` clears the marker inline before broadcasting `instance-started`.
- New `sessionLifecycleEvents` bus emitted on every launching/running transition; `titlePopup.ts` listens and rebroadcasts so the popup tracks lifecycle without subscribing to IPC directly.
- Snapshot grew `launchingInstallationIds: string[]`. `hydrateSessionStoreFromSnapshot` now mirrors it into `sessionStore.launchingInstances`, restoring the precondition Bug 1's `useInstallCta` fix needs.
- Snapshot's `activeInstallationId` resolves to `hostInstallationId ?? previewInstallationId`. `applyAttachHostPreview` / `clearAttachHostPreview` emit `hostInstallEvents.changed` so the picker repaints the moment the chooser stakes (or releases) its claim.

Net effect for a dashboard-tile Start: the moment the user clicks Start, the claim is staked → preview push → snapshot rebroadcast → drawer's `activeInstallationId` is the install, Current pill is lit. A beat later `instance-launching` fires → `_markLaunching` → snapshot rebroadcast → drawer's `launchingInstances` has the id → `useInstallCta` flips CTA to **Restart**. No more lying chrome until `instance-started`.

## Behavior matrix

| Stage | Dashboard tile that owns the launch | Other windows |
|---|---|---|
| `claim-attach-host` (immediate on click) | Drawer reopens with **Current** pill on the install, CTA = **Start → (pending)** | Unaffected |
| `instance-launching` fires | CTA flips to **Restart** | CTA = **Start → Switch** |
| `instance-started` fires | **Restart** (no change), real attach takes over from preview | **Switch** (no change) |
| `instance-stopped` fires | **Restart → Start** | **Switch → Start** |

No flicker through Start across launching → running.

## Why not a bigger refactor

[Issue #755](https://github.com/Comfy-Org/ComfyUI-Desktop-2.0-Beta/issues/755) proposed a per-window IPC restructure (broadcast `windowKey` alongside `RunningInstance`, derive everything from window identity). The actual user-visible bugs — these three — are solved without that, because the existing `activeInstallationId` push, the chooser's attach-claim preview, and the new launching-state snapshot field all arrive in time. The proposed refactor would unlock cross-window UI hints we haven't built; until we do, it's complexity without a consumer.

## Tests

`useInstallCta.test.ts`:
- New cases for launching-in-this-window → Restart, launching-in-other-window → Switch, no Start flicker across launching → running handoff.

`registry.test.ts`:
- `hostInstallEvents` emits on attach, detach, host-register-with-install, host-unregister-with-install; not on chrome-only updates.

`titlePopup.test.ts`:
- Snapshot falls back to `previewInstallationId` when `hostInstallationId` is null.
- Real `hostInstallationId` wins over a stale preview.
- `launchingInstallationIds` flows through the snapshot verbatim.

`pnpm typecheck` ✅ · `pnpm lint` ✅ · `pnpm test` ✅ 1583 tests · `pnpm build` ✅

## Manual verification

- [ ] **Dashboard tile → Start**, then open the picker drawer mid-launch → that install's row shows the **Current** pill the moment the launch starts (was: missing until ready) and the CTA reads **Restart** (was: stuck on Start).
- [ ] Same window, watch the CTA across the launching → running transition → no flicker through Start.
- [ ] Open a second window's picker for the same install while it's launching → CTA reads **Switch** (was: Start, which would have failed at the main-side single-attach guard).
- [ ] Cancel a launch from the dashboard before it completes → the **Current** pill drops back off the install in the drawer immediately (was: stuck on Current).

Closes #755.
