### PR TITLE
fix: auto-download 3D outputs (SaveGLB) from remote/cloud sessions

### DIFF
--- a/src/main/lib/comfyContentScript.test.ts
+++ b/src/main/lib/comfyContentScript.test.ts
@@ -92,4 +92,13 @@ describe('getModelDownloadContentScript', () => {
     expect(script).toContain('downloadAsset')
     expect(script).toContain('window.WebSocket')
   })
+
+  it('auto-downloads 3D outputs (SaveGLB) alongside images/audio/video', () => {
+    // SaveGLB emits its results under ui={"3d": [...]} (see
+    // ComfyUI/comfy_extras/nodes_save_3d.py). The remote/cloud
+    // WebSocket intercept iterates a fixed list of output-dict keys,
+    // so "3d" must be in that list or .glb files silently fail to
+    // download from cloud/remote sessions (issue #784).
+    expect(script).toContain(`['images', 'gifs', 'audio', 'video', '3d']`)
+  })
 })

--- a/src/main/lib/comfyContentScript.ts
+++ b/src/main/lib/comfyContentScript.ts
@@ -285,8 +285,8 @@ export function getModelDownloadContentScript(): string {
           var msg = JSON.parse(event.data);
           if (msg.type !== 'executed' || !msg.data || !msg.data.output) return;
           var output = msg.data.output;
-          // Process all known output arrays: images, gifs, audio, video
-          var keys = ['images', 'gifs', 'audio', 'video'];
+          // Process all known output arrays: images, gifs, audio, video, 3d (SaveGLB)
+          var keys = ['images', 'gifs', 'audio', 'video', '3d'];
           for (var k = 0; k < keys.length; k++) {
             var items = output[keys[k]];
             if (!items || !items.length) continue;


### PR DESCRIPTION
The WebSocket auto-download intercept in `comfyContentScript.ts` iterated a fixed list of output dict keys (`images`, `gifs`, `audio`, `video`) and ignored `3d`, so `.glb` files produced by the Save 3D Model (`SaveGLB`) node were silently dropped on remote/cloud connections.

- Added `'3d'` to the keys list. `SaveGLB` emits `ui={"3d": [{filename, subfolder, type: "output"}, ...]}` (see `ComfyUI/comfy_extras/nodes_save_3d.py`), which already matches the existing `_downloadItem()` shape.
- Added a regression test pinning the keys list so this can't silently drop 3D again.

Preview nodes (`PreviewUI3D`/`PreviewUI3DAdvanced`) emit `{"result": [...]}` instead and remain correctly ignored.

Fixes #784