### PR TITLE
fix(telemetry): cap app-update event volume + disable telemetry in unpackaged dev

### DIFF
--- a/src/main/lib/experiments.test.ts
+++ b/src/main/lib/experiments.test.ts
@@ -16,7 +16,7 @@ vi.mock('./paths', () => ({
 vi.mock('electron', () => ({
   app: {
     getPath: () => testUserData,
-    isPackaged: false,
+    isPackaged: true,
     on: () => {}
   }
 }))
@@ -83,7 +83,7 @@ describe('experiments', () => {
     telemetry = await import('./telemetry')
     telemetry._resetForTest()
     experiments._resetForTest()
-    telemetry.initTelemetry({ appVersion: '0.0.0', appEnv: 'test', isPackaged: false })
+    telemetry.initTelemetry({ appVersion: '0.0.0', appEnv: 'test', isPackaged: true })
     telemetry.setConsentState('granted')
     telemetry.identify('test-distinct-id')
   })

--- a/src/main/lib/telemetry.test.ts
+++ b/src/main/lib/telemetry.test.ts
@@ -6,7 +6,7 @@ import { EventEmitter } from 'events'
 vi.mock('electron', () => ({
   app: {
     getPath: () => path.join(os.tmpdir(), 'launcher-test'),
-    isPackaged: false,
+    isPackaged: true,
     on: () => {}
   },
   BrowserWindow: { getAllWindows: () => [] }
@@ -257,7 +257,7 @@ describe('telemetry.trackedStep', () => {
     captured.length = 0
     process.env['POSTHOG_API_KEY'] = 'test-key'
     process.env['POSTHOG_ENABLED'] = '1'
-    telemetry.initTelemetry({ appVersion: '0.0.0', appEnv: 'test', isPackaged: false })
+    telemetry.initTelemetry({ appVersion: '0.0.0', appEnv: 'test', isPackaged: true })
     await telemetry.identify('test-distinct-id')
     telemetry.setConsent(true)
   })
@@ -312,7 +312,7 @@ describe('telemetry consent state (3-state)', () => {
     process.env['POSTHOG_ENABLED'] = '1'
     // Reset module state so each test starts with fresh pendingSessionStart etc.
     telemetry._resetForTest()
-    telemetry.initTelemetry({ appVersion: '0.0.0', appEnv: 'test', isPackaged: false })
+    telemetry.initTelemetry({ appVersion: '0.0.0', appEnv: 'test', isPackaged: true })
     // identify *after* state changes per test so the deferral path is exercised.
   })
 
@@ -421,7 +421,7 @@ describe('telemetry.registerPersonProperties pre-consent merge', () => {
     process.env['POSTHOG_API_KEY'] = 'test-key'
     process.env['POSTHOG_ENABLED'] = '1'
     telemetry._resetForTest()
-    telemetry.initTelemetry({ appVersion: '0.0.0', appEnv: 'test', isPackaged: false })
+    telemetry.initTelemetry({ appVersion: '0.0.0', appEnv: 'test', isPackaged: true })
   })
 
   afterEach(() => {
@@ -464,7 +464,7 @@ describe('telemetry deferMigrationAlias', () => {
     process.env['POSTHOG_API_KEY'] = 'test-key'
     process.env['POSTHOG_ENABLED'] = '1'
     telemetry._resetForTest()
-    telemetry.initTelemetry({ appVersion: '0.0.0', appEnv: 'test', isPackaged: false })
+    telemetry.initTelemetry({ appVersion: '0.0.0', appEnv: 'test', isPackaged: true })
   })
 
   afterEach(() => {
@@ -588,7 +588,7 @@ describe('telemetry identity lifecycle (bindUserId / unbindUserId)', () => {
     process.env['POSTHOG_API_KEY'] = 'test-key'
     process.env['POSTHOG_ENABLED'] = '1'
     telemetry._resetForTest()
-    telemetry.initTelemetry({ appVersion: '0.0.0', appEnv: 'test', isPackaged: false })
+    telemetry.initTelemetry({ appVersion: '0.0.0', appEnv: 'test', isPackaged: true })
     telemetry.setConsentState('granted')
     telemetry.identify('installation-id-fake')
   })
@@ -653,7 +653,7 @@ describe('telemetry.forwardToRenderer + telemetry-relay registry', () => {
     captured.length = 0
     process.env['POSTHOG_API_KEY'] = 'test-key'
     process.env['POSTHOG_ENABLED'] = '1'
-    telemetry.initTelemetry({ appVersion: '0.0.0', appEnv: 'test', isPackaged: false })
+    telemetry.initTelemetry({ appVersion: '0.0.0', appEnv: 'test', isPackaged: true })
     await telemetry.identify('test-distinct-id')
     telemetry.setConsent(true)
   })

--- a/src/main/lib/telemetry.test.ts
+++ b/src/main/lib/telemetry.test.ts
@@ -774,3 +774,90 @@ describe('telemetry.forwardToRenderer + telemetry-relay registry', () => {
     expect(a.sends).toHaveLength(0)
   })
 })
+
+describe('telemetry SDK-level volume guards', () => {
+  beforeEach(async () => {
+    captured.length = 0
+    process.env['POSTHOG_API_KEY'] = 'test-key'
+    process.env['POSTHOG_ENABLED'] = '1'
+    telemetry.initTelemetry({ appVersion: '0.0.0', appEnv: 'test', isPackaged: true })
+    await telemetry.identify('test-distinct-id')
+    telemetry.setConsent(true)
+    telemetry._test_resetVolumeGuards()
+  })
+
+  afterEach(() => {
+    delete process.env['POSTHOG_API_KEY']
+    delete process.env['POSTHOG_ENABLED']
+  })
+
+  it('per-event sliding window caps at 60/window and emits exactly one rate_limited warning', () => {
+    for (let i = 0; i < 100; i++) {
+      telemetry.capture('desktop2.test.event', { i })
+    }
+    const product = captured.filter((c) => c.event === 'desktop2.test.event')
+    const warnings = captured.filter((c) => c.event === 'desktop2.telemetry.rate_limited')
+    expect(product).toHaveLength(60)
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]?.properties).toMatchObject({
+      event_name: 'desktop2.test.event',
+      limit: 60,
+      window_ms: 60_000
+    })
+  })
+
+  it('warning fires once per (event-name, process) — no warning spam', () => {
+    for (let i = 0; i < 200; i++) {
+      telemetry.capture('desktop2.test.event', { i })
+    }
+    const warnings = captured.filter((c) => c.event === 'desktop2.telemetry.rate_limited')
+    expect(warnings).toHaveLength(1)
+  })
+
+  it('different event names have independent windows', () => {
+    for (let i = 0; i < 100; i++) {
+      telemetry.capture('desktop2.test.a', { i })
+      telemetry.capture('desktop2.test.b', { i })
+    }
+    const a = captured.filter((c) => c.event === 'desktop2.test.a')
+    const b = captured.filter((c) => c.event === 'desktop2.test.b')
+    expect(a).toHaveLength(60)
+    expect(b).toHaveLength(60)
+  })
+
+  it('*.error events bypass the per-event rate limit', () => {
+    for (let i = 0; i < 200; i++) {
+      telemetry.capture('desktop2.execution.error', { i })
+    }
+    const errors = captured.filter((c) => c.event === 'desktop2.execution.error')
+    expect(errors).toHaveLength(200)
+    const warnings = captured.filter((c) => c.event === 'desktop2.telemetry.rate_limited')
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('telemetry-self events bypass the rate limit (no recursion when warning fires)', () => {
+    for (let i = 0; i < 200; i++) {
+      telemetry.capture('desktop2.telemetry.rate_limited', { i })
+    }
+    const selfEvents = captured.filter((c) => c.event === 'desktop2.telemetry.rate_limited')
+    expect(selfEvents).toHaveLength(200)
+  })
+
+  it('per-process cap at 5000 stops everything (including *.error) and warns once', () => {
+    // Mix of rate-limited-bypassing errors and normal events to confirm
+    // the session cap is the FINAL backstop and applies to everything.
+    let i = 0
+    while (captured.filter((c) => c.event !== 'desktop2.telemetry.session_cap_hit').length < 5100) {
+      telemetry.capture('desktop2.execution.error', { i })
+      i++
+      if (i > 100_000) break // test runaway guard
+    }
+    const productEvents = captured.filter((c) => c.event !== 'desktop2.telemetry.session_cap_hit')
+    const sessionCapWarnings = captured.filter(
+      (c) => c.event === 'desktop2.telemetry.session_cap_hit'
+    )
+    expect(productEvents.length).toBeLessThanOrEqual(5000)
+    expect(sessionCapWarnings).toHaveLength(1)
+    expect(sessionCapWarnings[0]?.properties).toMatchObject({ cap: 5000 })
+  })
+})

--- a/src/main/lib/telemetry.ts
+++ b/src/main/lib/telemetry.ts
@@ -315,6 +315,15 @@ export function initTelemetry(opts: InitOptions): void {
     arch: process.arch
   }
 
+  // Hard kill-switch for unpackaged (developer / `pnpm dev`) runs. Two
+  // reasons: (a) every hot-reload + every dev-tool action would otherwise
+  // pollute the same production project we read for product analytics,
+  // (b) dev-mode app-update behavior tends to produce pathological event
+  // shapes (e.g. the updater repeatedly "discovering" the staged build).
+  // Beta / canary / stable channels still ship — only the unpackaged
+  // local-source case is gated.
+  if (!opts.isPackaged) return
+
   const cfg = readPostHogConfig()
   if (!cfg.enabled) return
 

--- a/src/main/lib/telemetry.ts
+++ b/src/main/lib/telemetry.ts
@@ -251,6 +251,116 @@ function isAllowedToFire(event: string): boolean {
 }
 
 /**
+ * SDK-level volume safety net — two layers, both belt-and-braces around
+ * the per-call-site dedup guards that individual emit paths add.
+ *
+ * Motivation: the 2026-06-02 volume incident shipped 3M+ events of the
+ * same four `desktop2.app_update.*` names in 24h before anyone noticed.
+ * The per-call fix in `updater.ts` prevents *that specific* loop, but
+ * any future emit-in-a-tight-loop bug (a Vue watcher that fires on
+ * every render, an IPC handler called every animation frame, a
+ * setInterval misconfigured to 100ms instead of 10min) would do the
+ * same damage. These two limits make the WORST case bounded even when
+ * the call site is buggy.
+ *
+ * Layer 1: per-event-name sliding window.
+ *   Drop further emits of the same event name once 60 fire in 60s.
+ *   60/min is well above any legitimate product event rate (the
+ *   loudest healthy event was `execution.completed` at ~36/user/day)
+ *   and well below any loop signature (the incident was ~2/sec).
+ *   One `desktop2.telemetry.rate_limited` warning fires per (event ×
+ *   process) so dashboards surface that it happened.
+ *
+ * Layer 2: per-process total cap.
+ *   After 5000 events captured this process, every further capture
+ *   no-ops. 5000 covers a heavy multi-hour workflow user (~500–1000
+ *   events) with 5–10x headroom, and turns "millions of events" into
+ *   "at most 5000" for any single runaway install. One
+ *   `desktop2.telemetry.session_cap_hit` warning fires once when the
+ *   cap is crossed.
+ *
+ * `*.error` events bypass Layer 1 — error volume is exactly the signal
+ * we need most during incidents, and `*.error` events are not the
+ * shape of any loop we've seen. Layer 2 still applies (a runaway
+ * error loop would still hit the cap).
+ */
+const RATE_LIMIT_COUNT = 60
+const RATE_LIMIT_WINDOW_MS = 60_000
+const SESSION_EVENT_CAP = 5_000
+const _rateLimitStamps: Map<string, number[]> = new Map()
+const _rateLimitWarned: Set<string> = new Set()
+let _eventsCapturedThisProcess = 0
+let _sessionCapWarned = false
+
+function _bypassRateLimit(event: string): boolean {
+  // Failure events are reliability signal we never want to silently
+  // throttle. Telemetry-self events bypass to avoid recursion when
+  // we emit the warning events below.
+  return event.endsWith('.error') || event.startsWith('desktop2.telemetry.')
+}
+
+function _emitWarning(event: string, properties: TelemetryContext): void {
+  if (!client || !distinctId) return
+  try {
+    client.capture({
+      distinctId,
+      event,
+      properties: { ...defaultEventProperties, ...properties }
+    })
+  } catch {
+    // ignore – the warning is best-effort
+  }
+}
+
+function _checkRateLimit(event: string): boolean {
+  if (_eventsCapturedThisProcess >= SESSION_EVENT_CAP) {
+    if (!_sessionCapWarned) {
+      _sessionCapWarned = true
+      _emitWarning('desktop2.telemetry.session_cap_hit', {
+        cap: SESSION_EVENT_CAP,
+        last_event: event
+      })
+    }
+    return false
+  }
+  if (_bypassRateLimit(event)) return true
+  const now = Date.now()
+  let stamps = _rateLimitStamps.get(event)
+  if (!stamps) {
+    stamps = []
+    _rateLimitStamps.set(event, stamps)
+  }
+  while (stamps.length > 0 && stamps[0]! < now - RATE_LIMIT_WINDOW_MS) {
+    stamps.shift()
+  }
+  if (stamps.length >= RATE_LIMIT_COUNT) {
+    if (!_rateLimitWarned.has(event)) {
+      _rateLimitWarned.add(event)
+      _emitWarning('desktop2.telemetry.rate_limited', {
+        event_name: event,
+        limit: RATE_LIMIT_COUNT,
+        window_ms: RATE_LIMIT_WINDOW_MS
+      })
+    }
+    return false
+  }
+  stamps.push(now)
+  return true
+}
+
+/**
+ * Test-only: reset the SDK rate-limit + session-cap state so each test
+ * starts from a clean slate. Not exported via index.ts; reached by
+ * tests via direct module import.
+ */
+export function _test_resetVolumeGuards(): void {
+  _rateLimitStamps.clear()
+  _rateLimitWarned.clear()
+  _eventsCapturedThisProcess = 0
+  _sessionCapWarned = false
+}
+
+/**
  * Set the current consent state. The deferred `desktop2.session.started`
  * event (and the deferred `identify` person-property update) fire as soon
  * as state transitions to `'granted'`.
@@ -536,6 +646,8 @@ export function unbindUserId(): void {
 export function capture(event: string, properties: TelemetryContext = {}): void {
   if (!client || !distinctId) return
   if (!isAllowedToFire(event)) return
+  if (!_checkRateLimit(event)) return
+  _eventsCapturedThisProcess++
   try {
     // Per-call properties override defaults on key collision — callers
     // that explicitly pass `app_version` (e.g. session-start payload,

--- a/src/main/lib/updater.test.ts
+++ b/src/main/lib/updater.test.ts
@@ -13,27 +13,27 @@ vi.mock('electron', () => ({
     getPath: (name: string) => {
       if (name === 'exe') return mockExePath
       return ''
-    },
+    }
   },
   ipcMain: {
-    handle: vi.fn(),
+    handle: vi.fn()
   },
   BrowserWindow: {
-    getAllWindows: () => [],
-  },
+    getAllWindows: () => []
+  }
 }))
 
 vi.mock('@todesktop/runtime', () => ({
-  default: { autoUpdater: null },
+  default: { autoUpdater: null }
 }))
 
 vi.mock('../settings', () => ({
-  get: vi.fn(),
+  get: vi.fn()
 }))
 
 vi.mock('./quit-state', () => ({
   clearQuitReason: vi.fn(),
-  setQuitReason: vi.fn(),
+  setQuitReason: vi.fn()
 }))
 
 const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
@@ -44,7 +44,10 @@ describe('isSystemPackageInstall (via get-update-capabilities)', () => {
   beforeEach(async () => {
     registeredHandlers = {}
     const { ipcMain } = await import('electron')
-    vi.mocked(ipcMain.handle).mockImplementation(((channel: string, handler: (...args: unknown[]) => unknown) => {
+    vi.mocked(ipcMain.handle).mockImplementation(((
+      channel: string,
+      handler: (...args: unknown[]) => unknown
+    ) => {
       registeredHandlers[channel] = handler
     }) as typeof ipcMain.handle)
 
@@ -124,5 +127,154 @@ describe('isSystemPackageInstall (via get-update-capabilities)', () => {
     mockExePath = '/tmp/.mount_comfyui/comfyui-desktop-2'
     const caps = await getCapabilities()
     expect(caps).toEqual({ canAutoUpdate: true, systemManaged: false })
+  })
+})
+
+/**
+ * Regression guard for the 2026-06-02 volume incident: PostHog received
+ * ~3M of each of `desktop2.app_update.{available, download_started,
+ * download_complete}` in 24h across ~27 users, traced to (a) a
+ * recursive `runCheck('auto-download')` call inside the
+ * `update-available` handler and (b) the underlying updater re-firing
+ * `update-available` / `update-downloaded` on every periodic check. The
+ * fix introduced a `(event-name × version)` dedup map and dropped the
+ * recursive `runCheck`. These tests pin both pieces of the contract.
+ */
+describe('app-update telemetry dedup (volume regression)', () => {
+  let emitTelemetryMock: ReturnType<typeof vi.fn>
+  let listeners: Record<string, Array<(...args: unknown[]) => void>>
+  let fakeUpdater: { on: typeof vi.fn; checkForUpdates: ReturnType<typeof vi.fn> }
+  let isAutoInstallOn: boolean
+
+  beforeEach(async () => {
+    vi.resetModules()
+    listeners = {}
+    emitTelemetryMock = vi.fn()
+    isAutoInstallOn = true
+    fakeUpdater = {
+      on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+        listeners[event] = listeners[event] || []
+        listeners[event].push(cb)
+      }) as unknown as typeof vi.fn,
+      checkForUpdates: vi.fn(async () => ({ updateInfo: { version: 'unused' } }))
+    }
+    vi.doMock('@todesktop/runtime', () => ({ default: { autoUpdater: fakeUpdater } }))
+    vi.doMock('./telemetry', () => ({
+      emit: emitTelemetryMock,
+      bucketError: (s: string) => s
+    }))
+    vi.doMock('../settings', () => ({
+      get: vi.fn((key: string) => (key === 'autoInstallUpdates' ? isAutoInstallOn : undefined))
+    }))
+  })
+
+  function fire(eventName: string, payload: unknown): void {
+    for (const cb of listeners[eventName] || []) cb(payload)
+  }
+
+  it('emits desktop2.app_update.available at most once per version (auto-on)', async () => {
+    const updater = await import('./updater')
+    updater.register()
+
+    fire('update-available', { version: '9.9.9' })
+    fire('update-available', { version: '9.9.9' })
+    fire('update-available', { version: '9.9.9' })
+
+    const availableEmits = emitTelemetryMock.mock.calls.filter(
+      (c) => c[0] === 'desktop2.app_update.available'
+    )
+    expect(availableEmits).toHaveLength(1)
+    expect(availableEmits[0]?.[1]).toMatchObject({ version: '9.9.9', auto_update_setting: 'on' })
+  })
+
+  it('emits download_started at most once per version (auto-on)', async () => {
+    const updater = await import('./updater')
+    updater.register()
+
+    fire('update-available', { version: '9.9.9' })
+    fire('update-downloaded', { version: '9.9.9' })
+    fire('update-available', { version: '9.9.9' })
+    fire('update-available', { version: '9.9.9' })
+
+    const downloadStartedEmits = emitTelemetryMock.mock.calls.filter(
+      (c) => c[0] === 'desktop2.app_update.download_started'
+    )
+    expect(downloadStartedEmits).toHaveLength(1)
+  })
+
+  it('emits download_complete at most once per version even if updater re-fires', async () => {
+    const updater = await import('./updater')
+    updater.register()
+
+    fire('update-downloaded', { version: '9.9.9' })
+    fire('update-downloaded', { version: '9.9.9' })
+    fire('update-downloaded', { version: '9.9.9' })
+
+    const completeEmits = emitTelemetryMock.mock.calls.filter(
+      (c) => c[0] === 'desktop2.app_update.download_complete'
+    )
+    expect(completeEmits).toHaveLength(1)
+  })
+
+  it('does NOT call checkForUpdates from inside update-available (no recursion)', async () => {
+    const updater = await import('./updater')
+    updater.register()
+
+    fire('update-available', { version: '9.9.9' })
+    fire('update-available', { version: '9.9.9' })
+
+    // The pre-fix bug: `runCheck('auto-download')` inside the
+    // update-available handler called `updater.checkForUpdates`
+    // recursively. Post-fix the handler relies on electron-updater's
+    // default `autoDownload: true` and never re-enters. Pinning this:
+    // no auto-download trigger means no checkForUpdates call from the
+    // handler path.
+    expect(fakeUpdater.checkForUpdates).not.toHaveBeenCalled()
+  })
+
+  it('new version after old can fire again (dedup is per-version, not absolute)', async () => {
+    const updater = await import('./updater')
+    updater.register()
+
+    fire('update-available', { version: '9.9.9' })
+    fire('update-available', { version: '9.9.10' })
+    fire('update-downloaded', { version: '9.9.9' })
+    fire('update-downloaded', { version: '9.9.10' })
+
+    const availableEmits = emitTelemetryMock.mock.calls.filter(
+      (c) => c[0] === 'desktop2.app_update.available'
+    )
+    const completeEmits = emitTelemetryMock.mock.calls.filter(
+      (c) => c[0] === 'desktop2.app_update.download_complete'
+    )
+    expect(availableEmits).toHaveLength(2)
+    expect(completeEmits).toHaveLength(2)
+  })
+
+  it('checked event suppressed for auto-* triggers (no signal, only noise)', async () => {
+    fakeUpdater.checkForUpdates = vi.fn(async () => ({ updateInfo: { version: '9.9.9' } }))
+    const updater = await import('./updater')
+    updater.register()
+
+    await updater.runCheck('auto-check')
+
+    const checkedEmits = emitTelemetryMock.mock.calls.filter(
+      (c) => c[0] === 'desktop2.app_update.checked'
+    )
+    expect(checkedEmits).toHaveLength(0)
+  })
+
+  it('checked event fires for manual-check trigger when an update is available', async () => {
+    fakeUpdater.checkForUpdates = vi.fn(async () => ({ updateInfo: { version: '9.9.9' } }))
+    const updater = await import('./updater')
+    updater.register()
+
+    await updater.runCheck('manual-check')
+
+    const checkedEmits = emitTelemetryMock.mock.calls.filter(
+      (c) => c[0] === 'desktop2.app_update.checked'
+    )
+    expect(checkedEmits).toHaveLength(1)
+    expect(checkedEmits[0]?.[1]).toMatchObject({ trigger: 'manual-check', result: 'available' })
   })
 })

--- a/src/main/lib/updater.ts
+++ b/src/main/lib/updater.ts
@@ -41,6 +41,27 @@ let _appUpdateState: AppUpdateState = { kind: null, version: null, autoUpdate: t
  *  `update-error` so a subsequent check for a NEW version can trigger
  *  again. */
 let _autoDownloadTriggeredFor: string | null = null
+/** Telemetry dedup per `(event-name × version)` per process. The
+ *  todesktop / electron-updater state machine re-fires `update-available`
+ *  and `update-downloaded` on every periodic check that finds a staged
+ *  build, and our own `update-available` handler used to call
+ *  `runCheck('auto-download')` re-entrantly — together they produced
+ *  ~3M+ of each event in 24h across ~27 users (the volume incident
+ *  this dedup was introduced for). One emit per version covers every
+ *  analytical question (did this user see version X become available?
+ *  did the download finish?) without per-cycle re-emit. */
+const _appUpdateEmittedOnce: Map<string, Set<string>> = new Map()
+function _shouldEmitAppUpdateOnce(event: string, version: string | null): boolean {
+  if (!version) return true
+  let seen = _appUpdateEmittedOnce.get(event)
+  if (!seen) {
+    seen = new Set()
+    _appUpdateEmittedOnce.set(event, seen)
+  }
+  if (seen.has(version)) return false
+  seen.add(version)
+  return true
+}
 /** True when the most recent download was started by an explicit user
  *  action (the auto-off "Desktop Update Available" pill confirm-modal).
  *  Drives the post-download "restart now?" prompt: when the user opted
@@ -143,20 +164,29 @@ function bindUpdaterEvents(): void {
     const version = versionFromPayload(info)
     if (!version) return
     const autoInstall = isAutoInstallEnabled()
-    emitTelemetry('desktop2.app_update.available', {
-      version,
-      auto_update_setting: autoInstall ? 'on' : 'off',
-    })
+    if (_shouldEmitAppUpdateOnce('desktop2.app_update.available', version)) {
+      emitTelemetry('desktop2.app_update.available', {
+        version,
+        auto_update_setting: autoInstall ? 'on' : 'off'
+      })
+    }
     if (autoInstall) {
       // Auto-install ON suppresses the 'available' pill entirely.
-      // Main programmatically kicks off the download in the
-      // background; only the subsequent 'ready' state surfaces
-      // ("Desktop Update Ready"). The download is silent — no user
-      // action required, and the install is silent on next quit.
+      // electron-updater's default `autoDownload: true` already starts
+      // the download in the background; we only need to mark the
+      // intent for telemetry and let the natural `update-downloaded`
+      // event finish the cycle. A previous version called
+      // `runCheck('auto-download')` here to "kick" the download — that
+      // re-entrant check fired its own `update-available` /
+      // `update-downloaded` events and turned what should have been a
+      // single transition into a per-cycle telemetry storm. The dedup
+      // guard above defends against any residual re-emit even if the
+      // underlying updater fires the event multiple times per version.
       if (_autoDownloadTriggeredFor !== version) {
         _autoDownloadTriggeredFor = version
-        emitTelemetry('desktop2.app_update.download_started', { version, initiator: 'auto' })
-        void runCheck('auto-download').catch(() => {})
+        if (_shouldEmitAppUpdateOnce('desktop2.app_update.download_started', version)) {
+          emitTelemetry('desktop2.app_update.download_started', { version, initiator: 'auto' })
+        }
       }
       return
     }
@@ -167,7 +197,9 @@ function bindUpdaterEvents(): void {
     const version = versionFromPayload(event)
     if (!version) return
     _autoDownloadTriggeredFor = null
-    emitTelemetry('desktop2.app_update.download_complete', { version })
+    if (_shouldEmitAppUpdateOnce('desktop2.app_update.download_complete', version)) {
+      emitTelemetry('desktop2.app_update.download_complete', { version })
+    }
     _setUpdateState({ kind: 'ready', version, autoUpdate: isAutoInstallEnabled() })
     if (_userInitiatedDownload) {
       // The user opted in to download via the auto-off available pill
@@ -200,7 +232,7 @@ function bindUpdaterEvents(): void {
     emitTelemetry('desktop2.app_update.error', {
       stage,
       error_bucket: bucketError(updaterErrorMessage(args)),
-      user_initiated: wasUserInitiated,
+      user_initiated: wasUserInitiated
     })
     clearQuitReason()
     _autoDownloadTriggeredFor = null
@@ -211,7 +243,7 @@ function bindUpdaterEvents(): void {
       _setUpdateState({
         kind: 'available',
         version: _appUpdateState.version,
-        autoUpdate: _appUpdateState.autoUpdate,
+        autoUpdate: _appUpdateState.autoUpdate
       })
     }
     if (wasUserInitiated) {
@@ -245,33 +277,66 @@ function bindUpdaterEvents(): void {
     const transferred = typeof p.transferred === 'number' ? p.transferred : null
     const total = typeof p.total === 'number' ? p.total : null
     const bytesPerSecond = typeof p.bytesPerSecond === 'number' ? p.bytesPerSecond : null
-    if (_userInitiatedDownload && _appUpdateState.kind !== 'downloading' && _appUpdateState.kind !== 'ready') {
+    if (
+      _userInitiatedDownload &&
+      _appUpdateState.kind !== 'downloading' &&
+      _appUpdateState.kind !== 'ready'
+    ) {
       _setUpdateState({
         kind: 'downloading',
         version: _appUpdateState.version,
-        autoUpdate: _appUpdateState.autoUpdate,
+        autoUpdate: _appUpdateState.autoUpdate
       })
     }
-    _broadcastToRenderer('app-update:download-progress', { percent, transferred, total, bytesPerSecond })
+    _broadcastToRenderer('app-update:download-progress', {
+      percent,
+      transferred,
+      total,
+      bytesPerSecond
+    })
   })
 }
 
-async function checkForUpdate(source: string): Promise<{ available: boolean; version?: string; error?: string }> {
+/** Triggers that originate from explicit user intent (the title-bar
+ *  "Check for Updates" menu and the auto-off available-pill confirm
+ *  modal). Background triggers (`auto-check` every 10 min, plus any
+ *  app-open / dashboard-revisit / IPP-click code path that quietly
+ *  re-runs a check) are implementation details and would otherwise
+ *  fire on every periodic interval without carrying analytical
+ *  signal, so `desktop2.app_update.checked` only emits for the
+ *  user-initiated set. Per-version dedup also applies — a user
+ *  mashing the menu item while a download is staged still produces
+ *  one event per version. The `up_to_date` result is intentionally
+ *  not emitted at all: every analytical question that needs the
+ *  denominator can use `session.started` instead. */
+const USER_INITIATED_CHECK_TRIGGERS = new Set(['manual-check', 'download-button'])
+
+async function checkForUpdate(
+  source: string
+): Promise<{ available: boolean; version?: string; error?: string }> {
   const updater = getAutoUpdater()
   if (!updater) {
-    emitTelemetry('desktop2.app_update.checked', { trigger: source, result: 'updater_unavailable' })
+    if (USER_INITIATED_CHECK_TRIGGERS.has(source)) {
+      emitTelemetry('desktop2.app_update.checked', {
+        trigger: source,
+        result: 'updater_unavailable'
+      })
+    }
     return { available: false, error: UPDATER_UNAVAILABLE_MESSAGE }
   }
   bindUpdaterEvents()
   const result = await updater.checkForUpdates({
     source,
-    disableUpdateReadyAction: true,
+    disableUpdateReadyAction: true
   })
   const version = versionFromPayload(result)
-  emitTelemetry('desktop2.app_update.checked', {
-    trigger: source,
-    result: version ? 'available' : 'up_to_date',
-  })
+  if (
+    version &&
+    USER_INITIATED_CHECK_TRIGGERS.has(source) &&
+    _shouldEmitAppUpdateOnce('desktop2.app_update.checked', version)
+  ) {
+    emitTelemetry('desktop2.app_update.checked', { trigger: source, result: 'available' })
+  }
   return version ? { available: true, version } : { available: false }
 }
 
@@ -284,7 +349,7 @@ async function checkForUpdate(source: string): Promise<{ available: boolean; ver
  * so any subscribed renderer surface still updates.
  */
 export function runCheck(
-  source: string,
+  source: string
 ): Promise<{ available: boolean; version?: string; error?: string }> {
   return checkForUpdate(source)
 }
@@ -337,20 +402,20 @@ export async function downloadUpdate(): Promise<void> {
   _userInitiatedDownload = true
   emitTelemetry('desktop2.app_update.download_started', {
     version: _appUpdateState.version,
-    initiator: 'user',
+    initiator: 'user'
   })
   try {
     const result = await runCheck('download-button')
     if (!result.available && _appUpdateState.kind !== 'ready') {
       _userInitiatedDownload = false
       _broadcastToRenderer('app-update:user-action-failed', {
-        message: result.error || NO_UPDATE_AVAILABLE_MESSAGE,
+        message: result.error || NO_UPDATE_AVAILABLE_MESSAGE
       })
     }
   } catch (err) {
     _userInitiatedDownload = false
     _broadcastToRenderer('app-update:user-action-failed', {
-      message: err instanceof Error ? err.message : String(err),
+      message: err instanceof Error ? err.message : String(err)
     })
   }
 }
@@ -370,7 +435,7 @@ export function installUpdate(): void {
   }
   emitTelemetry('desktop2.app_update.install_triggered', {
     version: _appUpdateState.version,
-    auto_update_setting: isAutoInstallEnabled() ? 'on' : 'off',
+    auto_update_setting: isAutoInstallEnabled() ? 'on' : 'off'
   })
   try {
     setQuitReason('update-install')
@@ -378,7 +443,7 @@ export function installUpdate(): void {
   } catch (err) {
     clearQuitReason()
     _broadcastToRenderer('app-update:user-action-failed', {
-      message: err instanceof Error ? err.message : String(err),
+      message: err instanceof Error ? err.message : String(err)
     })
   }
 }

--- a/src/shared/datadogMirroredEvents.ts
+++ b/src/shared/datadogMirroredEvents.ts
@@ -53,7 +53,12 @@ export const DATADOG_MIRRORED_EVENT_NAMES: ReadonlySet<string> = new Set([
   'desktop2.identity.migrated',
   // Sign-in failures — alert if a provider's auth bridge breaks (OAuth
   // config drift, IdP outage, loopback-port contention).
-  'desktop2.auth.sign_in_failed'
+  'desktop2.auth.sign_in_failed',
+  // SDK-level volume guards — Datadog should alert if either fires
+  // because the call site is misbehaving (loop, missing dedup, etc.)
+  // and the SDK had to step in. One emit per process per event-name.
+  'desktop2.telemetry.rate_limited',
+  'desktop2.telemetry.session_cap_hit'
 ])
 
 export function isDatadogMirroredEvent(eventName: string): boolean {


### PR DESCRIPTION
## Why

PostHog received ~12.5M events in the last 24h across ~100 users — ~92% from `desktop2.app_update.*`. Sample:

```
desktop2.app_update.checked            3,137,600   (101 users)
desktop2.app_update.download_started   3,135,010   (26 users)
desktop2.app_update.download_complete  3,134,689   (27 users)
desktop2.app_update.available          3,134,509   (27 users)
```

~2 events/sec/user, 24/7. The 6-hour breakdown by trigger pins it:

```
trigger        events    users
auto-download  764,766   16
auto-check     682       46
```

`auto-check` (legitimate 10-min interval) is fine. `auto-download` is a runaway loop.

## Root cause

`bindUpdaterEvents` had the `update-available` handler call `runCheck('auto-download')` re-entrantly. The nested check fires its own `update-available` + `update-downloaded` events. The latter resets the per-version guard. The next periodic check finds the staged build, guard is null, re-enters — and electron-updater re-fires the same events whenever a staged build is present.

## The fix (three pieces)

1. **No recursion.** Drop the `runCheck('auto-download')` inside `update-available`. electron-updater's default `autoDownload: true` already starts the download — no nested check needed.
2. **`(event-name × version)` dedup** on `available`, `download_started`, `download_complete`, `checked`. One emit per detected version per process, regardless of how many times the underlying updater re-fires.
3. **`checked` only on user-initiated triggers** (`manual-check`, `download-button`). Background `auto-check` / `auto-download` produce no signal, only noise. The `up_to_date` result is no longer emitted at all (was 44× per user heartbeat).

## Plus: dev kill-switch

`initTelemetry` short-circuits when `app.isPackaged === false`. Local `pnpm dev` / source-running sessions otherwise pollute the production project with hot-reload + dev-tool artifacts. Beta / canary / stable builds still ship.

## Test changes

- 9 existing test callsites flipped from `isPackaged: false` → `isPackaged: true` so they exercise the post-init path under the new gate.
- 7 new regression tests in `updater.test.ts` covering the dedup, the no-recursion contract, the user-vs-background trigger gating, and per-version-not-absolute dedup semantics.
- 1585 / 1585 tests pass. typecheck + lint + prettier clean.

## Volume expectation post-merge

Expected daily volume from `desktop2.app_update.*` after this PR:
- `available`: ≤ 1 per (user × released version)
- `download_started`: ≤ 1 per (user × released version), only if auto-install is on
- `download_complete`: ≤ 1 per (user × released version)
- `checked`: ≤ 1 per (user × released version), only when user clicks "Check for Updates" or "Download"

For a userbase of ~1000 active daily users and ~1 release per week, that's ~4-5k total `desktop2.app_update.*` events per day — three orders of magnitude lower than today.