### PR TITLE
fix(popups): restore comfyView focus on title-popup close

### DIFF
--- a/src/main/popups/titlePopup.ts
+++ b/src/main/popups/titlePopup.ts
@@ -1013,13 +1013,13 @@ function hideTitlePopup(
     && !entry.view.popup.webContents.isDestroyed()
     && !entry.view.parentWindow.isDestroyed()
   ) {
-    // Embedded WebContentsView: `BrowserWindow.focus()` raises the host
-    // window but doesn't deterministically land keyboard focus in any
-    // child view. Push focus into the title bar (the button that
-    // opened the popup) so subsequent keystrokes go somewhere
-    // sensible. Falls back to a plain window focus if the title-bar
-    // sender is no longer alive.
-    if (!entry.titleBarSender.isDestroyed()) {
+    /** comfyView first: it carries the `before-input-event` zoom
+     *  listener (attach.ts), so focusing elsewhere silently breaks
+     *  Ctrl/Cmd +/-/0. Title bar, then window, are fallbacks. */
+    const comfyContents = comfyWindows.get(entry.parentEntryId)?.comfyView.webContents
+    if (comfyContents && !comfyContents.isDestroyed()) {
+      comfyContents.focus()
+    } else if (!entry.titleBarSender.isDestroyed()) {
       entry.titleBarSender.focus()
     } else {
       entry.view.parentWindow.focus()


### PR DESCRIPTION
## Summary

Closing a title-bar popup (instance picker, file menu, downloads, global settings) handed keyboard focus to the title bar instead of the content view, which silently killed the `Ctrl/Cmd +/-/0` zoom shortcuts until the user clicked back into the canvas. `hideTitlePopup` now restores focus to the host `comfyView`, where the zoom listener actually lives.

## Changes

**What**
- `hideTitlePopup` (`src/main/popups/titlePopup.ts`): on the focus-release path, focus the host's `comfyView.webContents` (looked up via the already-imported `comfyWindows` registry by `entry.parentEntryId`) instead of `entry.titleBarSender`. The zoom shortcuts are registered as a `before-input-event` listener on `comfyView.webContents` only (`src/main/host/attach.ts`), so any other focus target makes them no-ops.
- Same function: graceful fallback chain — `comfyView` → `titleBarSender` → `parentWindow`, each guarded by `isDestroyed()` / existence checks, so a torn-down chooser host degrades to exactly the prior behavior.

**Breaking**
- None. No IPC channels, specs, or telemetry change. The fix lives entirely inside the existing `releaseFocusToParent` branch, so the only difference is *which* view receives focus on close.

## Review Focus

- The crux: focus must land on the view holding the zoom `before-input-event` listener (`comfyView`), not the title bar. See `src/main/host/attach.ts` for where the listener is bound.
- Scope is the focus-release path of `hideTitlePopup` only (X button / Escape via `comfy-titlepopup:close`, and backdrop via `comfy-popup-backdrop:dismiss`). The blur path is intentionally untouched — focus has already moved to wherever the user clicked.
- Applied to all popup kinds, not just `instance-picker`, since the close paths are shared and the same latent bug affected the others.
- Install-less / dashboard hosts: `comfyView` is collapsed but present and accepts focus harmlessly.

## Testing

Unit-only verification by design — no exported surface changed and the focus branch is module-internal, so there's no new behavior for unit tests to assert without exporting internals (deliberately avoided). Existing suite confirms no regression; the real fix is verified manually against the reproduction.

- `pnpm typecheck` (node/web/e2e/integration) — clean.
- `pnpm lint` — clean.
- `src/main/popups/titlePopup.test.ts` — 42/42 pass (unchanged; covers the exported pure helpers).
- Manual: zoom in with `Ctrl/Cmd +`, open the instance picker, close via X / Escape / backdrop, then confirm `Ctrl/Cmd +/-/0` zoom without first clicking into the canvas. Repeat for menu / downloads / global-settings. Confirm dashboard host shows no glitch.

Closes #698 