### PR TITLE
Feat/instance picker rename

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -554,7 +554,10 @@
     "untrack": "Forget",
     "untrackConfirmTitle": "Forget Install",
     "untrackConfirmMessage": "This will remove the install from the app. The files will not be deleted.",
-    "share": "Share"
+    "share": "Share",
+    "rename": "Rename",
+    "renameTitle": "Rename Install",
+    "renameMessage": "Enter a new name for this install."
   },
 
   "migrate": {
@@ -983,6 +986,7 @@
     "portConflictKilling": "Stopping…",
     "portConflictKillFailed": "Could not free port {port}. The process may require manual termination.",
     "duplicateName": "An install named \"{name}\" already exists. Please choose a different name.",
+    "nameRequired": "Please enter a name.",
     "unknownSource": "This installation has an unrecognized source type. It may have been created by a different version. Delete it and reinstall.",
     "operationInProgress": "\"{operation}\" is currently in progress for this installation. Would you like to cancel it?",
     "operationInProgressGeneric": "Another operation is currently in progress for this installation. Would you like to cancel it?",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -428,7 +428,10 @@
     "deleteConfirmDetail": "其他安装不受影响。",
     "untrack": "取消跟踪",
     "untrackConfirmTitle": "取消跟踪安装",
-    "untrackConfirmMessage": "这将从启动器中移除该安装。文件不会被删除。"
+    "untrackConfirmMessage": "这将从启动器中移除该安装。文件不会被删除。",
+    "rename": "重命名",
+    "renameTitle": "重命名安装",
+    "renameMessage": "为此安装输入新名称。"
   },
 
   "migrate": {
@@ -612,7 +615,7 @@
     "waitingTime": "等待 ComfyUI 就绪…（{secs}秒）",
     "portBusyUsing": "端口 {old} 被占用——改用端口 {new}…",
     "instanceRunningTitle": "实例正在运行",
-    "instanceRunningMessage": "选择"关闭并启动"将停止下方列出的实例。",
+    "instanceRunningMessage": "选择 \"关闭并启动\" 将停止下方列出的实例。",
     "instanceRunningListLabel": "将被停止",
     "instanceRunningProceed": "全部运行",
     "instanceRunningReplace": "关闭并启动此实例",
@@ -643,7 +646,8 @@
     "portConflictKillConfirmMessage": "这将强制停止当前使用此端口的进程。该 ComfyUI 实例中未保存的工作将丢失。",
     "portConflictKilling": "正在停止…",
     "portConflictKillFailed": "无法释放端口 {port}。该进程可能需要手动终止。",
-    "duplicateName": "名为 \"{name}\" 的安装已存在。请选择其他名称。"
+    "duplicateName": "名为 \"{name}\" 的安装已存在。请选择其他名称。",
+    "nameRequired": "请输入名称。"
   },
 
   "tooltips": {

--- a/src/main/installations.test.ts
+++ b/src/main/installations.test.ts
@@ -396,3 +396,44 @@ describe('installations.getRecentByCategory', () => {
     expect((await installations.getRecentByCategory('local', resolveCategory))!.id).toBe(a.id)
   })
 })
+
+describe('installations.hasNameConflict', () => {
+  it('is false when no other install shares the name', async () => {
+    const installations = await loadInstallations()
+    const a = await installations.add({
+      name: 'Alpha',
+      installPath: path.join(tmpRoot, 'a'),
+      sourceId: 'standalone',
+      status: 'installed',
+    })
+    expect(await installations.hasNameConflict(a.id, 'Beta')).toBe(false)
+  })
+
+  it('is true when another install already uses the name', async () => {
+    const installations = await loadInstallations()
+    await installations.add({
+      name: 'Taken',
+      installPath: path.join(tmpRoot, 'a'),
+      sourceId: 'standalone',
+      status: 'installed',
+    })
+    const b = await installations.add({
+      name: 'Free',
+      installPath: path.join(tmpRoot, 'b'),
+      sourceId: 'standalone',
+      status: 'installed',
+    })
+    expect(await installations.hasNameConflict(b.id, 'Taken')).toBe(true)
+  })
+
+  it('ignores the install being renamed (renaming to its own name is not a conflict)', async () => {
+    const installations = await loadInstallations()
+    const a = await installations.add({
+      name: 'Self',
+      installPath: path.join(tmpRoot, 'a'),
+      sourceId: 'standalone',
+      status: 'installed',
+    })
+    expect(await installations.hasNameConflict(a.id, 'Self')).toBe(false)
+  })
+})

--- a/src/main/installations.ts
+++ b/src/main/installations.ts
@@ -92,6 +92,15 @@ export async function list(): Promise<InstallationRecord[]> {
   return load()
 }
 
+/** True when `name` is already taken by an install other than `id`.
+ *  The single source of the rename uniqueness rule — shared by the
+ *  `update-installation` IPC handler and the `rename` session action so
+ *  the check can't drift between the two write paths. */
+export async function hasNameConflict(id: string, name: string): Promise<boolean> {
+  const all = await load()
+  return all.some((i) => i.id !== id && i.name === name)
+}
+
 export function uniqueName(baseName: string, existing: InstallationRecord[], excludeId?: string): string {
   const names = new Set(existing.filter((i) => i.id !== excludeId).map((i) => i.name))
   if (!names.has(baseName)) return baseName

--- a/src/main/lib/actions.ts
+++ b/src/main/lib/actions.ts
@@ -55,6 +55,22 @@ export function launchAction(enabled: boolean, disabledMessage?: string): Action
   }
 }
 
+export function renameAction(currentName: string): ActionDef {
+  return {
+    id: 'rename',
+    label: t('actions.rename'),
+    style: 'default',
+    enabled: true,
+    prompt: {
+      field: 'name',
+      title: t('actions.renameTitle'),
+      message: t('actions.renameMessage'),
+      defaultValue: currentName,
+      required: true,
+    },
+  }
+}
+
 export function openFolderAction(installPath: string): ActionDef {
   return {
     id: 'open-folder',

--- a/src/main/lib/ipc/registerInstallationHandlers.ts
+++ b/src/main/lib/ipc/registerInstallationHandlers.ts
@@ -410,8 +410,7 @@ export function registerInstallationHandlers(): void {
         }
       }
       if (filtered.name && filtered.name !== inst.name) {
-        const all = await installations.list()
-        if (all.some((i) => i.id !== installationId && i.name === filtered.name)) {
+        if (await installations.hasNameConflict(installationId, filtered.name as string)) {
           return {
             ok: false,
             message: i18n.t('errors.duplicateName', { name: filtered.name as string })

--- a/src/main/lib/ipc/sessionActions/basic.test.ts
+++ b/src/main/lib/ipc/sessionActions/basic.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// `./basic` imports `../shared`, which loads electron + the real install
+// store at module init. Stub the surface `handleRename` actually touches so
+// the unit test runs without a real Electron runtime or datastore.
+const hasNameConflict = vi.fn<(id: string, name: string) => Promise<boolean>>()
+const update = vi.fn<(id: string, data: Record<string, unknown>) => Promise<unknown>>()
+
+vi.mock('../shared', () => ({
+  installations: {
+    get hasNameConflict() {
+      return hasNameConflict
+    },
+    get update() {
+      return update
+    },
+  },
+  i18n: { t: (key: string, vars?: Record<string, unknown>) => (vars ? `${key}:${JSON.stringify(vars)}` : key) },
+  fs: {},
+  openPath: vi.fn(),
+}))
+
+import { handleRename } from './basic'
+import type { ActionContext } from './types'
+
+function ctx(overrides: Partial<ActionContext> = {}): ActionContext {
+  return {
+    event: {} as ActionContext['event'],
+    installationId: 'inst-1',
+    inst: { id: 'inst-1', name: 'Old Name' } as ActionContext['inst'],
+    actionData: { name: 'New Name' },
+    ...overrides,
+  }
+}
+
+describe('handleRename', () => {
+  beforeEach(() => {
+    hasNameConflict.mockReset()
+    update.mockReset()
+    hasNameConflict.mockResolvedValue(false)
+    update.mockResolvedValue(undefined)
+  })
+
+  it('renames and navigates back to detail on a fresh name', async () => {
+    const result = await handleRename(ctx())
+    expect(hasNameConflict).toHaveBeenCalledWith('inst-1', 'New Name')
+    expect(update).toHaveBeenCalledWith('inst-1', { name: 'New Name' })
+    expect(result).toEqual({ ok: true, navigate: 'detail' })
+  })
+
+  it('trims surrounding whitespace before persisting', async () => {
+    await handleRename(ctx({ actionData: { name: '  Padded  ' } }))
+    expect(update).toHaveBeenCalledWith('inst-1', { name: 'Padded' })
+  })
+
+  it('rejects an empty / whitespace-only name without writing', async () => {
+    const result = await handleRename(ctx({ actionData: { name: '   ' } }))
+    expect(update).not.toHaveBeenCalled()
+    expect(result.ok).toBe(false)
+    expect(result.message).toBe('errors.nameRequired')
+  })
+
+  it('rejects a duplicate name without writing', async () => {
+    hasNameConflict.mockResolvedValue(true)
+    const result = await handleRename(ctx())
+    expect(update).not.toHaveBeenCalled()
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('errors.duplicateName')
+  })
+
+  it('treats renaming to the current name as a no-op (no write, no conflict check)', async () => {
+    const result = await handleRename(ctx({ actionData: { name: 'Old Name' } }))
+    expect(hasNameConflict).not.toHaveBeenCalled()
+    expect(update).not.toHaveBeenCalled()
+    expect(result).toEqual({ ok: true, navigate: 'detail' })
+  })
+})

--- a/src/main/lib/ipc/sessionActions/basic.ts
+++ b/src/main/lib/ipc/sessionActions/basic.ts
@@ -10,6 +10,18 @@ export async function handleRemove({ installationId }: ActionContext): Promise<A
   return { ok: true, navigate: 'list' }
 }
 
+export async function handleRename({ installationId, inst, actionData }: ActionContext): Promise<ActionResult> {
+  const name = String(actionData?.name ?? '').trim()
+  if (!name) return { ok: false, message: i18n.t('errors.nameRequired') }
+  if (name !== inst.name) {
+    if (await installations.hasNameConflict(installationId, name)) {
+      return { ok: false, message: i18n.t('errors.duplicateName', { name }) }
+    }
+    await installations.update(installationId, { name })
+  }
+  return { ok: true, navigate: 'detail' }
+}
+
 export async function handleOpenFolder({ inst }: ActionContext): Promise<ActionResult> {
   if (inst.installPath) {
     if (fs.existsSync(inst.installPath)) {

--- a/src/main/lib/ipc/sessionActions/index.ts
+++ b/src/main/lib/ipc/sessionActions/index.ts
@@ -1,5 +1,5 @@
 import type { ActionContext, ActionResult } from './types'
-import { handleRemove, handleOpenFolder } from './basic'
+import { handleRemove, handleOpenFolder, handleRename } from './basic'
 import { handleDelete } from './delete'
 import { handleCopy, handleCopyUpdate, handleReleaseUpdate } from './copy'
 import { handleMigrateToStandalone } from './migrate'
@@ -7,7 +7,7 @@ import { handleLaunch } from './launch'
 import { handleDelegateToSource } from './delegate'
 
 export type { ActionContext, ActionResult } from './types'
-export { handleRemove, handleOpenFolder } from './basic'
+export { handleRemove, handleOpenFolder, handleRename } from './basic'
 export { handleDelete } from './delete'
 export { handleCopy, handleCopyUpdate, handleReleaseUpdate } from './copy'
 export { handleMigrateToStandalone } from './migrate'
@@ -19,6 +19,7 @@ export { withAbortableSessionAction } from './withAbortable'
  *  Anything outside this set is delegated to the install's source plugin. */
 const SESSION_ACTION_IDS = [
   'remove',
+  'rename',
   'open-folder',
   'delete',
   'copy',
@@ -46,6 +47,7 @@ function dispatchToSessionHandler(
 ): Promise<ActionResult> {
   switch (actionId) {
     case 'remove': return handleRemove(ctx)
+    case 'rename': return handleRename(ctx)
     case 'open-folder': return handleOpenFolder(ctx)
     case 'delete': return handleDelete(ctx)
     case 'copy': return handleCopy(ctx)

--- a/src/main/sources/common/urlSource.ts
+++ b/src/main/sources/common/urlSource.ts
@@ -1,4 +1,4 @@
-import { untrackAction } from '../../lib/actions'
+import { untrackAction, renameAction } from '../../lib/actions'
 import { parseUrl } from '../../lib/util'
 import { t } from '../../lib/i18n'
 import * as settings from '../../settings'
@@ -86,6 +86,7 @@ export function createUrlSource(config: UrlSourceConfig): SourcePlugin {
       const actions: Record<string, unknown>[] = [
         { id: 'launch', label: t('actions.connect'), style: 'primary', enabled: installation.status === 'installed',
           showProgress: true, progressTitle: t('actions.connecting'), cancellable: true },
+        renameAction(installation.name),
       ]
       if (includeUntrack) {
         actions.push(untrackAction())

--- a/src/main/sources/git.ts
+++ b/src/main/sources/git.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import { execFile } from 'child_process'
 import { fetchJSON } from '../lib/fetch'
 import { runLoggedProcess, formatProcessError } from '../lib/logged-process'
-import { untrackAction, launchAction, openFolderAction, migrateToStandaloneAction } from '../lib/actions'
+import { untrackAction, launchAction, openFolderAction, migrateToStandaloneAction, renameAction } from '../lib/actions'
 import { resolveGitDir, readGitHead, readGitRemoteUrl } from '../lib/git'
 import { parseArgs, extractPort } from '../lib/util'
 import { t } from '../lib/i18n'
@@ -197,6 +197,7 @@ export const gitSource: SourcePlugin = {
         pinBottom: true,
         actions: [
           launchAction(canLaunch, !canLaunch ? (!hasVenv ? t('git.noVenv') : !hasMain ? t('git.noMainPy') : t('errors.installNotReady')) : undefined),
+          renameAction(installation.name),
           openFolderAction(installation.installPath),
           { id: 'git-pull', label: t('git.gitPull'), style: 'default', enabled: installed,
             showProgress: true, progressTitle: t('git.gitPulling') },

--- a/src/main/sources/portable.ts
+++ b/src/main/sources/portable.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import { app } from 'electron'
 import { fetchJSON } from '../lib/fetch'
-import { deleteAction, untrackAction, launchAction, openFolderAction, migrateToStandaloneAction } from '../lib/actions'
+import { deleteAction, untrackAction, launchAction, openFolderAction, migrateToStandaloneAction, renameAction } from '../lib/actions'
 import { downloadAndExtract } from '../lib/installer'
 import { runLoggedProcess, formatProcessError } from '../lib/logged-process'
 import * as releaseCache from '../lib/release-cache'
@@ -216,6 +216,7 @@ export const portable: SourcePlugin = {
         pinBottom: true,
         actions: [
           launchAction(installed, !installed ? t('errors.installNotReady') : undefined),
+          renameAction(installation.name),
           openFolderAction(installation.installPath),
           migrateToStandaloneAction(installed),
           untrackAction(),

--- a/src/main/sources/standalone/updateSections.ts
+++ b/src/main/sources/standalone/updateSections.ts
@@ -6,7 +6,7 @@ import type { ChannelDef } from '../../lib/channel-cards'
 import { formatComfyVersion } from '../../lib/version'
 import type { ComfyVersion } from '../../lib/version'
 import { truncateNotes } from '../../lib/comfyui-releases'
-import { deleteAction, untrackAction, launchAction, openFolderAction } from '../../lib/actions'
+import { deleteAction, untrackAction, launchAction, openFolderAction, renameAction } from '../../lib/actions'
 import { t } from '../../lib/i18n'
 import { buildLaunchSettingsFields, buildSharedPathsField } from '../common/launchSettingsFields'
 import { getVariantLabel, DEFAULT_LAUNCH_ARGS } from './envPaths'
@@ -223,6 +223,7 @@ export function getDetailSections(installation: InstallationRecord): Record<stri
       pinBottom: true,
       actions: [
         launchAction(installed, !installed ? t('errors.installNotReady') : undefined),
+        renameAction(installation.name),
         { id: 'copy', label: t('actions.copyInstallation'), style: 'default', enabled: installed,
           showProgress: true, progressTitle: t('actions.copyingInstallation'), cancellable: true,
           prompt: {

--- a/src/renderer/src/components/settings/ComfyUISettingsContent.vue
+++ b/src/renderer/src/components/settings/ComfyUISettingsContent.vue
@@ -149,6 +149,7 @@ const {
   notice,
   sectionsFresh,
   updateField,
+  renameInstallation,
   pendingRestartFieldIds,
   fieldErrorMessages,
   runAction,
@@ -813,6 +814,7 @@ defineExpose({
                 :installation="installation"
                 :sections="statusSections"
                 :disk-usage="diskUsageItem"
+                :on-rename="renameInstallation"
               />
             </div>
             <div

--- a/src/renderer/src/composables/useComfyUISettings.test.ts
+++ b/src/renderer/src/composables/useComfyUISettings.test.ts
@@ -107,7 +107,7 @@ function installMockApi(overrides: Partial<MockApi> = {}): MockApi {
     updateInstallation: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   }
-  ;(window as unknown as { api: MockApi }).api = api
+    ; (window as unknown as { api: MockApi }).api = api
   return api
 }
 
@@ -423,7 +423,7 @@ describe('useComfyUISettings.runAction — stop-warning augment + self-stopping 
     } as ActionDef)
 
     expect(onShowProgress).toHaveBeenCalledTimes(1)
-    const opts = onShowProgress.mock.calls[0][0] as ShowProgressOpts
+    const opts = onShowProgress.mock.calls[0]?.[0] as ShowProgressOpts
     // triggersInstanceStart reflects the relaunch that the apiCall will
     // append — ProgressModal needs it to wire up the instance-started
     // listener that closes the chooser host.
@@ -464,7 +464,7 @@ describe('useComfyUISettings.runAction — stop-warning augment + self-stopping 
       confirm: { message: 'Update?' },
     } as ActionDef)
 
-    const opts = onShowProgress.mock.calls[0][0] as ShowProgressOpts
+    const opts = onShowProgress.mock.calls[0]?.[0] as ShowProgressOpts
     await opts.apiCall()
 
     expect(api.stopComfyUI).toHaveBeenCalledTimes(1)
@@ -495,7 +495,7 @@ describe('useComfyUISettings.runAction — stop-warning augment + self-stopping 
       confirm: { message: 'Copy & update?' },
     } as ActionDef)
 
-    const opts = onShowProgress.mock.calls[0][0] as ShowProgressOpts
+    const opts = onShowProgress.mock.calls[0]?.[0] as ShowProgressOpts
     // No auto-relaunch wired in → triggersInstanceStart stays false; the
     // new install opens in its own chooser-host window instead.
     expect(opts.triggersInstanceStart).toBe(false)
@@ -524,7 +524,7 @@ describe('useComfyUISettings.runAction — stop-warning augment + self-stopping 
       confirm: { message: 'Update?' },
     } as ActionDef)
 
-    const opts = onShowProgress.mock.calls[0][0] as ShowProgressOpts
+    const opts = onShowProgress.mock.calls[0]?.[0] as ShowProgressOpts
     expect(opts.triggersInstanceStart).toBe(false)
     await opts.apiCall()
 
@@ -734,7 +734,7 @@ describe('useComfyUISettings.updateField — optimistic write + restart-required
     // withTimeout's setTimeout should win and trigger rollback.
     vi.useFakeTimers()
     try {
-      const updateInstallation = vi.fn().mockReturnValue(new Promise<void>(() => {}))
+      const updateInstallation = vi.fn().mockReturnValue(new Promise<void>(() => { }))
       const { composable, scope } = await mountWithField('a', 'window', { updateInstallation })
       markRunning('a')
 
@@ -814,6 +814,77 @@ describe('useComfyUISettings.updateField — optimistic write + restart-required
       FOO: 'bar',
     })
     expect(composable.pendingRestartFieldIds.value.has('envVars')).toBe(false)
+    scope.stop()
+  })
+})
+
+describe('useComfyUISettings — renameInstallation', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    dialogsSpies.alert.mockReset()
+  })
+
+  async function mountRename(api: MockApi) {
+    const installation = ref<Installation | null>(makeInstall('a', 'Old Name'))
+    const scope = effectScope()
+    let composable!: ReturnType<typeof useComfyUISettings>
+    scope.run(() => {
+      composable = useComfyUISettings({ installation, onShowProgress: vi.fn() })
+    })
+    await nextTick()
+    await Promise.resolve()
+    await Promise.resolve()
+    return { composable, scope, api }
+  }
+
+  it('commits a fresh name, reloads sections, and resolves true', async () => {
+    const api = installMockApi({ updateInstallation: vi.fn().mockResolvedValue({ ok: true }) })
+    const { composable, scope } = await mountRename(api)
+    api.getDetailSections.mockClear()
+
+    const committed = await composable.renameInstallation('New Name')
+
+    expect(committed).toBe(true)
+    expect(api.updateInstallation).toHaveBeenCalledWith('a', { name: 'New Name' })
+    expect(api.getDetailSections).toHaveBeenCalled() // reload() ran
+    expect(dialogsSpies.alert).not.toHaveBeenCalled()
+    scope.stop()
+  })
+
+  it('trims surrounding whitespace before committing', async () => {
+    const api = installMockApi({ updateInstallation: vi.fn().mockResolvedValue({ ok: true }) })
+    const { composable, scope } = await mountRename(api)
+
+    await composable.renameInstallation('  Padded  ')
+
+    expect(api.updateInstallation).toHaveBeenCalledWith('a', { name: 'Padded' })
+    scope.stop()
+  })
+
+  it('is a no-op (no IPC) when the trimmed name is empty or unchanged', async () => {
+    const api = installMockApi()
+    const { composable, scope } = await mountRename(api)
+
+    expect(await composable.renameInstallation('   ')).toBe(false)
+    expect(await composable.renameInstallation('Old Name')).toBe(false)
+    expect(api.updateInstallation).not.toHaveBeenCalled()
+    scope.stop()
+  })
+
+  it('surfaces a rejection (duplicate name) as an alert and resolves false', async () => {
+    const api = installMockApi({
+      updateInstallation: vi.fn().mockResolvedValue({ ok: false, message: 'taken' }),
+    })
+    const { composable, scope } = await mountRename(api)
+    api.getDetailSections.mockClear()
+
+    const committed = await composable.renameInstallation('Dupe')
+
+    expect(committed).toBe(false)
+    expect(dialogsSpies.alert).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'taken' }),
+    )
+    expect(api.getDetailSections).not.toHaveBeenCalled() // no reload on failure
     scope.stop()
   })
 })

--- a/src/renderer/src/composables/useComfyUISettings.ts
+++ b/src/renderer/src/composables/useComfyUISettings.ts
@@ -10,6 +10,7 @@ import { progressOpKindForActionId, destroysInstanceForActionId } from '../lib/p
 import {
   REQUIRES_STOPPED,
   type ActionDef,
+  type ActionResult,
   type DetailField,
   type DetailSection,
   type DiskSpaceInfo,
@@ -123,6 +124,11 @@ export interface UseComfyUISettingsApi {
    *  inline pill surfaces the message. Auto-clears after a short
    *  timer or on the next edit of the same field. */
   fieldErrorMessages: ComputedRef<Map<string, string>>
+
+  /** Commit a new display name for the selected install (inline hero
+   *  edit). Resolves `true` when committed, `false` on no-op / rejection
+   *  (duplicate name → alert). */
+  renameInstallation: (newName: string) => Promise<boolean>
 
   /** Run an action coming off a `DetailSection.actions[]` entry. */
   runAction: (action: ActionDef) => Promise<void>
@@ -522,6 +528,30 @@ export function useComfyUISettings(opts: UseComfyUISettingsOpts): UseComfyUISett
     }
   }
 
+  /** Commit a new display name for the selected install. Shared by the
+   *  About-tab inline hero edit; the footer "More → Rename" path runs
+   *  through `runAction` instead, but both reconcile via
+   *  `update-installation` → `'changed'` → store refetch. The IPC handler
+   *  owns the duplicate-name guard — a rejection surfaces here as an alert
+   *  and the `installation` prop stays put.
+   *
+   *  Resolves `true` when the name was committed, `false` on a no-op
+   *  (empty / unchanged) or a rejection (duplicate). The hero uses this to
+   *  revert its optimistic text only when the write didn't land. */
+  async function renameInstallation(newName: string): Promise<boolean> {
+    const inst = toValue(opts.installation)
+    if (!inst) return false
+    const name = newName.trim()
+    if (!name || name === inst.name) return false
+    const result: ActionResult | void = await window.api.updateInstallation(inst.id, { name })
+    if (result?.ok === false) {
+      await dialogs.alert({ title: inst.name, message: result.message ?? '' })
+      return false
+    }
+    await reload()
+    return true
+  }
+
   async function runAction(action: ActionDef): Promise<void> {
     const inst = toValue(opts.installation)
     if (!inst) return
@@ -859,6 +889,7 @@ export function useComfyUISettings(opts: UseComfyUISettingsOpts): UseComfyUISett
     reload,
     refreshSection,
     updateField,
+    renameInstallation,
     pendingRestartFieldIds,
     fieldErrorMessages,
     runAction,

--- a/src/renderer/src/lib/i18nMessages.ts
+++ b/src/renderer/src/lib/i18nMessages.ts
@@ -51,6 +51,11 @@ export const en = {
     storageRestartNote:
       'Restart the application (or close and reopen) for these changes to take effect.'
   },
+  /** About-tab hero (StatusFactPanel.vue). The inline-editable name's
+   *  aria-label lives here so the popup-scoped catalog resolves it. */
+  statusFactPanel: {
+    editName: 'Edit installation name'
+  },
   models: {
     addDir: 'Add directory',
     removeDir: 'Remove',

--- a/src/renderer/src/views/comfyUISettings/StatusFactPanel.test.ts
+++ b/src/renderer/src/views/comfyUISettings/StatusFactPanel.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import { nextTick } from 'vue'
+
+import { en } from '../../lib/i18nMessages.ts'
+import StatusFactPanel from './StatusFactPanel.vue'
+import type { Installation } from '../../types/ipc'
+
+function makeI18n() {
+  return createI18n({ legacy: false, locale: 'en', messages: { en } })
+}
+
+function makeInstall(name: string): Installation {
+  return {
+    id: 'inst-1',
+    name,
+    sourceLabel: 'Standalone',
+    sourceCategory: 'local',
+    status: 'installed',
+    installPath: '/tmp/inst-1',
+  } as Installation
+}
+
+function mountPanel(props: {
+  installation: Installation | null
+  onRename?: (newName: string) => Promise<boolean>
+}) {
+  return mount(StatusFactPanel, {
+    props: { sections: [], diskUsage: null, ...props },
+    global: { plugins: [makeI18n()] },
+  })
+}
+
+describe('StatusFactPanel — hero name', () => {
+  // Regression: the contenteditable hero is painted imperatively, and the
+  // sync watcher's `immediate` run fired before the template ref was
+  // assigned — so the hero opened BLANK and only showed the name after an
+  // edit. The watcher must also key on the element ref so it paints once
+  // the contenteditable mounts.
+  it('shows the install name on initial mount, before any edit', async () => {
+    const wrapper = mountPanel({ installation: makeInstall('Maanil\'s Comfy') })
+    await nextTick()
+    const name = wrapper.find('.status-fact-hero-name')
+    expect(name.exists()).toBe(true)
+    expect(name.text()).toBe("Maanil's Comfy")
+  })
+
+  it('commits a changed name through onRename on blur', async () => {
+    const onRename = vi.fn().mockResolvedValue(true)
+    const wrapper = mountPanel({ installation: makeInstall('Old'), onRename })
+    await nextTick()
+
+    const el = wrapper.find('.status-fact-hero-name')
+    ;(el.element as HTMLElement).textContent = 'New Name'
+    await el.trigger('blur')
+
+    expect(onRename).toHaveBeenCalledWith('New Name')
+  })
+
+  it('does not call onRename when the name is unchanged', async () => {
+    const onRename = vi.fn().mockResolvedValue(true)
+    const wrapper = mountPanel({ installation: makeInstall('Same'), onRename })
+    await nextTick()
+
+    const el = wrapper.find('.status-fact-hero-name')
+    await el.trigger('blur')
+
+    expect(onRename).not.toHaveBeenCalled()
+  })
+
+  it('reverts to the canonical name when onRename rejects (duplicate)', async () => {
+    const onRename = vi.fn().mockResolvedValue(false)
+    const wrapper = mountPanel({ installation: makeInstall('Original'), onRename })
+    await nextTick()
+
+    const el = wrapper.find('.status-fact-hero-name')
+    ;(el.element as HTMLElement).textContent = 'Duplicate'
+    await el.trigger('blur')
+    await nextTick()
+
+    expect(onRename).toHaveBeenCalledWith('Duplicate')
+    expect((el.element as HTMLElement).textContent).toBe('Original')
+  })
+
+  it('repaints the hero when the installation name prop changes', async () => {
+    const wrapper = mountPanel({ installation: makeInstall('First') })
+    await nextTick()
+    expect(wrapper.find('.status-fact-hero-name').text()).toBe('First')
+
+    await wrapper.setProps({ installation: makeInstall('Second') })
+    await nextTick()
+    expect(wrapper.find('.status-fact-hero-name').text()).toBe('Second')
+  })
+})

--- a/src/renderer/src/views/comfyUISettings/StatusFactPanel.vue
+++ b/src/renderer/src/views/comfyUISettings/StatusFactPanel.vue
@@ -1,23 +1,102 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { Pencil } from 'lucide-vue-next'
 import BaseCopyButton from '../../components/ui/BaseCopyButton.vue'
 import type { DetailField, DetailSection, Installation } from '../../types/ipc'
 
 /**
  * Status tab — grouped install summary with identity hero and inset
  * fact groups. Replaces generic readonly SettingsSectionList rows.
+ *
+ * The hero name is inline-editable (contenteditable); committing it calls
+ * the `onRename` prop. Mirrors the legacy `DetailModal` title affordance.
  */
 
 interface Props {
   installation: Installation | null
   sections: DetailSection[]
   diskUsage: { label: string; value: string } | null
+  /** Commit a renamed install, resolving `true` when the write landed and
+   *  `false` on rejection. A function prop (not an emit) so the blur
+   *  handler can await the outcome and revert only on failure. */
+  onRename?: (newName: string) => Promise<boolean>
 }
 
 const props = defineProps<Props>()
 
 const { t } = useI18n()
+
+// The hero name is a `contenteditable` whose text we drive imperatively
+// rather than via Vue interpolation: mixing `{{ }}` with the inline pencil
+// icon in one editable element left Vue unable to patch the manually-edited
+// text node, so a committed rename painted everywhere except this hero
+// until a remount. Owning the text via this ref + the `watch` below keeps
+// the element in lockstep with the prop.
+const nameEl = useTemplateRef<HTMLElement>('nameEl')
+
+/** Write the install's name into the editable element if it differs.
+ *  Guarded so we don't stomp the caret while the user is mid-edit. */
+function syncName(): void {
+  const el = nameEl.value
+  if (!el) return
+  const name = props.installation?.name ?? ''
+  if (el.textContent !== name) el.textContent = name
+}
+
+// Watch both the name AND the element ref: the ref starts null and is
+// assigned after the first render, so keying on it too paints the initial
+// name once the contenteditable mounts (otherwise the `immediate` run fires
+// before the ref exists and the hero opens blank until the next change).
+watch(
+  [() => props.installation?.name ?? '', nameEl],
+  () => {
+    // Don't fight the user's caret while they're typing in this field.
+    if (document.activeElement !== nameEl.value) syncName()
+  },
+  { immediate: true, flush: 'post' },
+)
+
+function handleNameSelectAll(event: KeyboardEvent): void {
+  event.preventDefault()
+  const el = event.currentTarget as HTMLElement
+  const range = document.createRange()
+  range.selectNodeContents(el)
+  const sel = window.getSelection()
+  sel?.removeAllRanges()
+  sel?.addRange(range)
+}
+
+function handleNamePaste(event: ClipboardEvent): void {
+  event.preventDefault()
+  const text = event.clipboardData?.getData('text/plain') ?? ''
+  document.execCommand('insertText', false, text)
+}
+
+/** Escape abandons the edit: restore the original name and blur. The
+ *  blur handler then sees an unchanged value and no-ops. */
+function handleNameEscape(): void {
+  syncName()
+  nameEl.value?.blur()
+}
+
+async function handleNameBlur(event: FocusEvent): Promise<void> {
+  const el = event.target as HTMLElement
+  const current = props.installation?.name ?? ''
+  const newName = el.textContent?.trim() ?? ''
+  if (newName && newName !== current) {
+    // Keep the typed text optimistically (normalised to the trimmed value)
+    // so the hero doesn't flash back to the old name mid-round-trip. The
+    // watcher confirms it on success; only a rejection needs a manual
+    // revert, since an unchanged prop fires no watcher.
+    if (el.textContent !== newName) el.textContent = newName
+    const committed = await props.onRename?.(newName)
+    if (committed === false) syncName()
+    return
+  }
+  // Empty / whitespace-only / unchanged: restore the canonical name now.
+  syncName()
+}
 
 interface FactRow {
   id: string
@@ -187,7 +266,23 @@ const groups = computed<FactGroup[]>(() => {
   <div class="status-fact-panel">
     <header v-if="installation" class="status-fact-hero">
       <div class="status-fact-hero-title-row">
-        <p class="status-fact-hero-name">{{ installation.name }}</p>
+        <span class="status-fact-hero-name-wrap">
+          <span
+            ref="nameEl"
+            class="status-fact-hero-name"
+            role="textbox"
+            :aria-label="t('statusFactPanel.editName', 'Edit installation name')"
+            contenteditable="plaintext-only"
+            spellcheck="false"
+            @blur="handleNameBlur"
+            @keydown.enter.prevent="($event.target as HTMLElement).blur()"
+            @keydown.esc.prevent="handleNameEscape"
+            @keydown.ctrl.a.prevent="handleNameSelectAll"
+            @keydown.meta.a.prevent="handleNameSelectAll"
+            @paste="handleNamePaste"
+          />
+          <Pencil :size="13" class="status-fact-hero-edit-hint" aria-hidden="true" />
+        </span>
         <span v-if="installation.sourceLabel" class="status-fact-hero-badge">
           {{ installation.sourceLabel }}
         </span>
@@ -237,12 +332,61 @@ const groups = computed<FactGroup[]>(() => {
   gap: 8px;
 }
 
+/* Wrapper groups the editable name + the pencil hint as siblings (the
+   pencil can't live inside the contenteditable — `textContent =` writes
+   would wipe it). Hover/focus state is tracked on the wrap so the hint
+   reacts to interaction with the name. */
+.status-fact-hero-name-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 100%;
+  margin-left: -6px;
+}
+
 .status-fact-hero-name {
-  margin: 0;
   font-size: 18px;
   font-weight: 600;
   line-height: 24px;
   color: var(--text);
+  min-width: 0;
+  padding: 2px 6px;
+  border-radius: 6px;
+  outline: none;
+  cursor: text;
+  /* A long name ellipsizes at rest like the old static title did; editing
+     scrolls horizontally within the box rather than wrapping or overflowing
+     the hero. `nowrap` (not `pre`) so the field still collapses runs of
+     whitespace the way a single-line name field should. */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: background-color 120ms ease;
+}
+
+.status-fact-hero-name:hover {
+  background: var(--brand-surface-bg-hover);
+}
+
+.status-fact-hero-name:focus-visible {
+  background: var(--brand-surface-bg-hover);
+  box-shadow: 0 0 0 2px var(--focus-ring, var(--neutral-50));
+}
+
+/* Faded pencil hint — fades up on hover/focus so the name reads clean at
+   rest but advertises editability on intent. */
+.status-fact-hero-edit-hint {
+  flex-shrink: 0;
+  color: var(--text-muted);
+  opacity: 0;
+  transition: opacity 120ms ease;
+  user-select: none;
+  pointer-events: none;
+}
+
+.status-fact-hero-name-wrap:hover .status-fact-hero-edit-hint,
+.status-fact-hero-name:focus-visible ~ .status-fact-hero-edit-hint {
+  opacity: 0.6;
 }
 
 .status-fact-hero-badge {


### PR DESCRIPTION
## Summary

Re-adds the **rename instance** affordance that the old `SettingsModal`/`DetailModal` had but the redesigned Instance Picker never re-surfaced. Rename is now available in two places — a **Rename…** item in the footer **More** menu, and an **inline-editable name** in the **About** tab hero — both funnelling through the existing `update-installation` persistence path.

## Changes

**What**
- `installations.ts` — extract `hasNameConflict(id, name)` as the single source of the rename uniqueness rule, and reuse it inside the `update-installation` IPC handler (which previously inlined the same `all.some(...)` check).
- `sessionActions/basic.ts` — add `handleRename`: trims input, no-ops on an unchanged name, rejects empty (`errors.nameRequired`) and duplicates (`errors.duplicateName`), else `installations.update({ name })`. Registered in `sessionActions/index.ts` so `dispatchSessionAction` routes `rename` for **every** source (the `never`-exhaustive switch enforces the wiring at compile time) — no per-source `handleAction` duplication.
- `actions.ts` — add `renameAction(currentName)` factory: a `default`-style action carrying a `prompt` prefilled with the current name. Wired into the `pinBottom` menus of `portable` / `git` / `standalone` / `urlSource` (cloud + remote included; `desktop` is hidden/legacy and skipped).
- `useComfyUISettings.ts` — add `renameInstallation(newName)`: the single renderer-side rename path. Narrows the typed `ActionResult`, alerts on rejection, reloads on success, and resolves `true`/`false` so the hero knows whether to revert.
- `StatusFactPanel.vue` — make the About-tab hero name inline-editable (`contenteditable` + faded pencil hint; Enter commits, Esc reverts, Ctrl/Cmd+A select-all, plain-text paste). Text is driven imperatively via a `watch` keyed on both the name **and** the element ref, keeping the hero in lockstep with the prop. Calls the `onRename` function prop and reverts optimistic text only on rejection.
- `ComfyUISettingsContent.vue` — pass `renameInstallation` as the hero's `:on-rename`.
- i18n — `actions.rename*` + `errors.nameRequired` (en + zh); `statusFactPanel.editName` (renderer catalog).

**Breaking**
- None. No IPC channels, action ids, or telemetry shapes change. Persistence is the pre-existing `update-installation` → `installations.update` → `'changed'`/`'updated'` flow, so the list row and comfy window title bar update unchanged. `rename` is intentionally absent from `REQUIRES_STOPPED`/`IN_PLACE_RELAUNCH`, so renaming a running instance never stops it.

## Review Focus

- **No-duplication seams** — the two write paths share `hasNameConflict` (main) and the two UI surfaces share `renameInstallation` (renderer). The duplicate-name rule lives in exactly one place per side of the IPC boundary.
- **`rename` as a session action vs per-source `handleAction`** — chosen so one handler covers all sources; `delegate.ts`'s `update` tool bypasses the IPC dupe check, so a per-source approach would have re-implemented the guard N times.
- **Imperative hero text** — `StatusFactPanel`'s name is driven via a `watch` rather than `{{ }}` interpolation; mixing interpolation with the inline pencil icon left Vue unable to patch the manually-edited text node. The watch keys on the element ref so the name paints on first mount (regression: hero opened blank until first edit).
- **Scope** — rename only. Cloud/remote renameability is included (the name is a local display label); flip to local-only by dropping `renameAction` from `urlSource.ts` if undesired.

## Testing

Unit-only by design — the change is local IPC + a JSON merge plus a contenteditable surface, both fully exercisable without a real window; E2E would only re-run already-covered launch flows.

- `installations.test.ts` — `hasNameConflict`: no-conflict / conflict / self-rename ignored.
- `sessionActions/basic.test.ts` (new) — `handleRename`: commit→`detail`, trim, empty→`nameRequired`, duplicate→`duplicateName`, unchanged no-op.
- `useComfyUISettings.test.ts` — `renameInstallation`: commit+reload→`true`, trim, empty/unchanged no-op→`false`, rejection→alert + no reload→`false`.
- `StatusFactPanel.test.ts` (new) — name present on **initial mount** (regression), commit on blur, no-op on unchanged, revert on rejection, repaint on prop change.

Screen Recording

https://github.com/user-attachments/assets/ab8c87b8-4efe-4c14-b13b-e1bc524315e3
