### PR TITLE
fix(build): unblock ToDesktop build — remove invalid installer-art keys from todesktop.json

### DIFF
--- a/todesktop.json
+++ b/todesktop.json
@@ -31,10 +31,7 @@
   ],
   "windows": {
     "icon": "./assets/Comfy_Logo_x256.png",
-    "nsisInclude": "./scripts/installer.nsh",
-    "installerHeader": "./resources/installerHeader.bmp",
-    "installerSidebar": "./resources/installerSidebar.bmp",
-    "uninstallerSidebar": "./resources/uninstallerSidebar.bmp"
+    "nsisInclude": "./scripts/installer.nsh"
   },
   "mac": {
     "icon": "./assets/Comfy_Logo_mac_x1024.png",


### PR DESCRIPTION
## Problem

`main` has been **un-buildable on ToDesktop since #810** (`74fc2bd`). #810 added `installerHeader`, `installerSidebar`, and `uninstallerSidebar` to the `windows` block of `todesktop.json`. ToDesktop CLI 1.22.0 (pinned in `build-release.yml`) rejects those keys at config validation:

```
todesktop.json invalid.
ADDITIONAL PROPERTY must NOT have additional properties
  >  installerHeader is not expected to be here!
```

It went unnoticed because no build ran off `main` between #810 merging and now — the last green build (v0.6.13, 2026-06-01) predates it. The next real release would have failed.

## Fix

Remove the three installer-art keys from `todesktop.json`. The `windows` block keeps only `icon` + `nsisInclude`, which the CLI accepts. Verified: an ephemeral build with these keys removed clears config validation and proceeds to package (the failing builds died in <30s at validation).

## Note: this does NOT fix installer-art rendering on ToDesktop builds

#810's intent was to get the custom installer header/sidebar BMPs (in `resources/`, added in #614) to show on ToDesktop builds. They show on **local** electron-builder builds via `directories.buildResources` auto-discovery, but **not** on ToDesktop builds because ToDesktop reads `todesktop.json`, not `electron-builder.yml`. Putting electron-builder NSIS field names into `todesktop.json` is not a supported path (this PR's evidence).

That cosmetic issue is **pre-existing and separate**. The likely correct path is setting the MUI bitmaps (`MUI_HEADERIMAGE_BITMAP` / `MUI_WELCOMEFINISHPAGE_BITMAP` / `MUI_UNWELCOMEFINISHPAGE_BITMAP`, sourced from `${BUILD_RESOURCES_DIR}`) inside `scripts/installer.nsh`, which ToDesktop does process — but that needs build-and-visual verification on a Windows install and shouldn't ride along in a launch-blocking build fix. Tracking separately.

## Test plan
- [x] Ephemeral ToDesktop build clears config validation with keys removed
- [ ] CI green