### PR TITLE
feat(onboarding): first-instance coachmark pointing at the centre pill

### DIFF
--- a/e2e/update-pills.test.ts
+++ b/e2e/update-pills.test.ts
@@ -126,20 +126,26 @@ test('install-update chip stays hidden on the install-less chooser host even wit
 // ---------------------------------------------------------------------------
 
 /** True iff the embedded comfySystemModal popup is visible — same
- *  contract as `isPopupVisible` in chooser.test.ts. */
+ *  contract as `isPopupVisible` in chooser.test.ts. Returns false if the
+ *  main-process context is torn down mid-evaluate (window navigation /
+ *  teardown race) — a destroyed context means nothing is visible anyway. */
 async function isSystemModalVisible(app: ElectronApplication): Promise<boolean> {
-  return app.evaluate(({ BrowserWindow, WebContentsView }) => {
-    for (const win of BrowserWindow.getAllWindows()) {
-      for (const child of win.contentView.children) {
-        if (!(child instanceof WebContentsView)) continue
-        if (!child.webContents.getURL().includes('comfySystemModal.html')) continue
-        if (!child.getVisible()) return false
-        const b = child.getBounds()
-        return b.width > 0 && b.height > 0
+  try {
+    return await app.evaluate(({ BrowserWindow, WebContentsView }) => {
+      for (const win of BrowserWindow.getAllWindows()) {
+        for (const child of win.contentView.children) {
+          if (!(child instanceof WebContentsView)) continue
+          if (!child.webContents.getURL().includes('comfySystemModal.html')) continue
+          if (!child.getVisible()) return false
+          const b = child.getBounds()
+          return b.width > 0 && b.height > 0
+        }
       }
-    }
+      return false
+    })
+  } catch {
     return false
-  })
+  }
 }
 
 /** Cancel any open system-modal popup so a previous test's leftover

--- a/src/main/host/registry.ts
+++ b/src/main/host/registry.ts
@@ -479,6 +479,17 @@ export function findEntryByTitleBarSender(wc: WebContents): { id: number; entry:
   return null
 }
 
+/** Resolve a host BrowserWindow back to its registry entry. Used to map
+ *  a popup's parent window to the title-bar webContents (e.g. the
+ *  coachmark dismiss button routing its acknowledgement back to the
+ *  title-bar renderer). */
+export function findEntryByHostWindow(window: BrowserWindow): ComfyWindowEntry | null {
+  for (const entry of comfyWindows.values()) {
+    if (entry.window === window) return entry
+  }
+  return null
+}
+
 /** Find the first live host entry matching `pred`, preferring
  *  non-minimised over minimised. Within each visibility bucket, returns
  *  insertion order. Returns `null` when nothing matches. */

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -17,6 +17,7 @@ import { migrateXdgPaths } from './lib/paths'
 import { saveWindowBounds } from './lib/windowState'
 import { registerProcessErrorHandlers } from './lib/processErrorHandlers'
 import { registerTitleTooltipIpc } from './popups/titleTooltip'
+import { registerTitleCoachmarkIpc } from './popups/titleCoachmark'
 import { openSystemModal, openSystemModalAsync, registerSystemModalIpc } from './popups/systemModal'
 import {
   registerTitlePopupIpc,
@@ -78,6 +79,7 @@ import {
   consumeAttachClaim,
   dropAttachClaimsForWindow,
   findEntryByTitleBarSender,
+  findEntryByHostWindow,
   getEntryByInstallationId,
   isChooserHost,
   isInstallHost,
@@ -1189,6 +1191,11 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
     i18n.init(locale)
     registerTitleTooltipIpc({
       findParentByTitleBarSender: (wc) => findEntryByTitleBarSender(wc)?.entry.window ?? null
+    })
+    registerTitleCoachmarkIpc({
+      findParentByTitleBarSender: (wc) => findEntryByTitleBarSender(wc)?.entry.window ?? null,
+      findTitleBarByParent: (parent) =>
+        findEntryByHostWindow(parent)?.titleBarView.webContents ?? null
     })
     registerSystemModalIpc()
     // Swap-in-place contract: when the user picks a different install

--- a/src/main/popups/titleCoachmark.test.ts
+++ b/src/main/popups/titleCoachmark.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// titleCoachmark imports `ipcMain` at module load; the pure helpers under
+// test never touch it, but the module needs electron present to import.
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getPath: () => '/tmp',
+    getVersion: () => '0.0.0-test',
+    getLocale: () => 'en'
+  },
+  ipcMain: { handle: vi.fn(), on: vi.fn(), off: vi.fn() },
+  WebContentsView: class {},
+  BrowserWindow: { getAllWindows: () => [] },
+  nativeTheme: { on: vi.fn(), shouldUseDarkColors: false }
+}))
+
+// Stub embeddedPopupView so its electron usage doesn't load.
+vi.mock('./embeddedPopupView', () => ({ EmbeddedPopupView: class {} }))
+
+import {
+  buildCoachmarkConfig,
+  positionCoachmark,
+  COACHMARK_SHADOW_GUTTER,
+  COACHMARK_VERTICAL_GAP
+} from './titleCoachmark'
+
+describe('buildCoachmarkConfig', () => {
+  it('stamps the coachmark variant and carries title + body + dismiss copy', () => {
+    const cfg = buildCoachmarkConfig({
+      title: 'Switch & manage instances',
+      body: 'Click here to switch instances.',
+      dismissLabel: 'Got it',
+      token: 'cm-1'
+    })
+    expect(cfg.variant).toBe('coachmark')
+    expect(cfg.title).toBe('Switch & manage instances')
+    expect(cfg.body).toBe('Click here to switch instances.')
+    expect(cfg.dismissLabel).toBe('Got it')
+    expect(cfg.configToken).toBe('cm-1')
+    // Brand-accented theme distinct from the neutral hover tooltip.
+    expect(cfg.theme.accent).toMatch(/^#/)
+  })
+})
+
+describe('positionCoachmark', () => {
+  const parentBounds = { width: 1200, height: 800 }
+
+  it('centers the card under the pill and offsets below it', () => {
+    const bounds = positionCoachmark({
+      anchor: { leftX: 500, rightX: 700, bottomY: 36 },
+      bubble: { width: 260, height: 72 },
+      parentBounds
+    })
+    // Card horizontally centered on the pill center (600), view grown by
+    // the shadow gutter on each side.
+    const pillCenter = 600
+    const viewWidth = 260 + COACHMARK_SHADOW_GUTTER * 2
+    expect(bounds.width).toBe(viewWidth)
+    expect(bounds.x).toBe(Math.round(pillCenter - viewWidth / 2))
+    // Below the pill bottom plus the gap, lifted by the top gutter.
+    expect(bounds.y).toBe(Math.round(36 + COACHMARK_VERTICAL_GAP - COACHMARK_SHADOW_GUTTER / 2))
+  })
+
+  it('clamps to the parent content bounds so it never goes off-screen left', () => {
+    const bounds = positionCoachmark({
+      anchor: { leftX: 0, rightX: 20, bottomY: 36 },
+      bubble: { width: 260, height: 72 },
+      parentBounds
+    })
+    expect(bounds.x).toBeGreaterThanOrEqual(0)
+  })
+
+  it('clamps to the parent content bounds so it never overflows right', () => {
+    const bounds = positionCoachmark({
+      anchor: { leftX: 1180, rightX: 1200, bottomY: 36 },
+      bubble: { width: 260, height: 72 },
+      parentBounds
+    })
+    expect(bounds.x + bounds.width).toBeLessThanOrEqual(parentBounds.width)
+  })
+})

--- a/src/main/popups/titleCoachmark.ts
+++ b/src/main/popups/titleCoachmark.ts
@@ -1,0 +1,297 @@
+import { ipcMain } from 'electron'
+import type { BrowserWindow, WebContents } from 'electron'
+import { TITLEBAR_HEIGHT } from '../lib/titleBarOverlay'
+import { EmbeddedPopupView } from './embeddedPopupView'
+
+/**
+ * First-instance onboarding coachmark popup (issue #701). A sticky card
+ * with an upward beak pointing at the centre title-bar pill.
+ *
+ * Reuses the `comfyTitleTooltip` popup renderer (same clip-escaping
+ * `WebContentsView` and render-ack protocol — issue #514); the
+ * `variant: 'coachmark'` config switches the renderer to the beak +
+ * accent + dismiss-button card. Owns a popup view separate from the
+ * hover tooltip's so its sticky lifecycle (no auto-hide on blur — the
+ * dismiss button needs focus) doesn't fight the tooltip's auto-dismiss.
+ */
+
+const COACHMARK_POPUP_INITIAL_WIDTH = 300
+const COACHMARK_POPUP_INITIAL_HEIGHT = 96
+/** Vertical gap (px) between the pill's bottom edge and the card's top
+ *  edge — leaves room for the beak. */
+export const COACHMARK_VERTICAL_GAP = 10
+/** Side/top gutter (px) reserved for the card's box-shadow + beak so
+ *  neither gets clipped against the popup view's bounds. */
+export const COACHMARK_SHADOW_GUTTER = 18
+/** Fallback render-ack timeout (ms) — show at last-known size if the
+ *  renderer's `:rendered` ack is slow, so the coachmark never sticks
+ *  invisible. */
+const COACHMARK_RENDER_ACK_TIMEOUT_MS = 120
+
+export interface CoachmarkTheme {
+  bg: string
+  text: string
+  border: string
+  /** Brand-yellow accent for the beak + title — what visually marks
+   *  this as onboarding rather than a neutral tooltip. */
+  accent: string
+}
+
+export interface CoachmarkConfig {
+  variant: 'coachmark'
+  title: string
+  body: string
+  dismissLabel: string
+  theme: CoachmarkTheme
+  configToken: string
+}
+
+/** Hardcoded mirror of the brand tokens (`--brand-accent` neutral ramp)
+ *  so the popup renderer — which has no app stylesheet — matches the
+ *  in-app coachmark accent. */
+function resolveCoachmarkTheme(): CoachmarkTheme {
+  return { bg: '#211927', text: '#ffffff', border: '#38303d', accent: '#e3ff3c' }
+}
+
+/** Pure: assemble the coachmark config the renderer paints. Extracted so
+ *  the variant stamp + copy wiring is unit-testable without a window. */
+export function buildCoachmarkConfig(opts: {
+  title: string
+  body: string
+  dismissLabel: string
+  token: string
+}): CoachmarkConfig {
+  return {
+    variant: 'coachmark',
+    title: opts.title,
+    body: opts.body,
+    dismissLabel: opts.dismissLabel,
+    theme: resolveCoachmarkTheme(),
+    configToken: opts.token
+  }
+}
+
+/** Pure: compute the popup view bounds that center the card under the
+ *  pill and offset it below, clamped to the parent content area.
+ *  Extracted for unit testing. */
+export function positionCoachmark(opts: {
+  anchor: { leftX: number; rightX: number; bottomY: number }
+  bubble: { width: number; height: number }
+  parentBounds: { width: number; height: number }
+}): { x: number; y: number; width: number; height: number } {
+  const viewWidth = Math.max(
+    opts.bubble.width + COACHMARK_SHADOW_GUTTER * 2,
+    COACHMARK_SHADOW_GUTTER * 2 + 1
+  )
+  const viewHeight = Math.max(
+    opts.bubble.height + COACHMARK_SHADOW_GUTTER,
+    COACHMARK_SHADOW_GUTTER + 1
+  )
+  const pillCenter = (opts.anchor.leftX + opts.anchor.rightX) / 2
+  let x = Math.round(pillCenter - viewWidth / 2)
+  let y = Math.round(opts.anchor.bottomY + COACHMARK_VERTICAL_GAP - COACHMARK_SHADOW_GUTTER / 2)
+  if (x < 0) x = 0
+  if (x + viewWidth > opts.parentBounds.width) {
+    x = Math.max(0, opts.parentBounds.width - viewWidth)
+  }
+  if (y < 0) y = 0
+  if (y + viewHeight > opts.parentBounds.height) {
+    y = Math.max(0, opts.parentBounds.height - viewHeight)
+  }
+  return { x, y, width: viewWidth, height: viewHeight }
+}
+
+let _coachmarkTokenSeq = 0
+function nextCoachmarkToken(): string {
+  _coachmarkTokenSeq = (_coachmarkTokenSeq + 1) >>> 0
+  return `cm-${_coachmarkTokenSeq}`
+}
+
+interface CoachmarkPopupEntry {
+  view: EmbeddedPopupView
+  pendingConfig: CoachmarkConfig | null
+  pendingAnchor: { leftX: number; rightX: number; bottomY: number } | null
+  pendingConfigToken: string | null
+}
+
+const coachmarkPopupsByParent = new Map<number, CoachmarkPopupEntry>()
+const coachmarkPopupsByWebContents = new Map<number, CoachmarkPopupEntry>()
+
+function ensureCoachmarkPopup(parent: BrowserWindow): CoachmarkPopupEntry {
+  const existing = coachmarkPopupsByParent.get(parent.id)
+  if (existing && !existing.view.isDestroyed()) return existing
+
+  const view = new EmbeddedPopupView({
+    parent,
+    htmlName: 'comfyTitleTooltip',
+    preloadName: 'comfyTitleTooltipPreload.js',
+    initialBounds: {
+      x: 0,
+      y: 0,
+      width: COACHMARK_POPUP_INITIAL_WIDTH,
+      height: COACHMARK_POPUP_INITIAL_HEIGHT
+    },
+    // Sticky: hide only when the host window moves/resizes (stale anchor).
+    // Not on blur — the dismiss button needs focus.
+    hideOnParentEvents: ['will-move', 'move', 'resize'],
+    onParentClosed: () => {
+      coachmarkPopupsByParent.delete(parent.id)
+      coachmarkPopupsByWebContents.delete(view.popupWebContentsId)
+    },
+    onDestroyed: () => {
+      const cur = coachmarkPopupsByParent.get(parent.id)
+      if (cur && cur.view === view) coachmarkPopupsByParent.delete(parent.id)
+      coachmarkPopupsByWebContents.delete(view.popupWebContentsId)
+    }
+  })
+  const entry: CoachmarkPopupEntry = {
+    view,
+    pendingConfig: null,
+    pendingAnchor: null,
+    pendingConfigToken: null
+  }
+  coachmarkPopupsByParent.set(view.parentWindowId, entry)
+  coachmarkPopupsByWebContents.set(view.popupWebContentsId, entry)
+  return entry
+}
+
+function repositionAndShow(
+  entry: CoachmarkPopupEntry,
+  bubble: { width: number; height: number }
+): void {
+  if (!entry.pendingAnchor || entry.view.isDestroyed()) return
+  const parentBounds = entry.view.parentWindow.getContentBounds()
+  const bounds = positionCoachmark({ anchor: entry.pendingAnchor, bubble, parentBounds })
+  entry.view.popup.setBounds(bounds)
+  // Focus so the dismiss button is keyboard-reachable.
+  entry.view.showOnTop({ focus: true })
+}
+
+export function hideCoachmarkPopup(entry: CoachmarkPopupEntry | undefined): void {
+  if (!entry) return
+  entry.view.hide()
+}
+
+export function openCoachmarkPopup(opts: {
+  parent: BrowserWindow
+  title: string
+  body: string
+  dismissLabel: string
+  leftX: number
+  rightX: number
+  bottomY: number
+}): void {
+  const entry = ensureCoachmarkPopup(opts.parent)
+  if (entry.view.isDestroyed()) return
+
+  entry.pendingAnchor = { leftX: opts.leftX, rightX: opts.rightX, bottomY: opts.bottomY }
+  const token = nextCoachmarkToken()
+  const config = buildCoachmarkConfig({
+    title: opts.title,
+    body: opts.body,
+    dismissLabel: opts.dismissLabel,
+    token
+  })
+  entry.pendingConfigToken = token
+  if (entry.view.rendererReady) {
+    entry.view.popup.webContents.send('comfy-titletooltip:set-config', config)
+  } else {
+    entry.pendingConfig = config
+  }
+  entry.view.scheduleShowFallback(COACHMARK_RENDER_ACK_TIMEOUT_MS, () => {
+    const bounds = entry.view.popup.getBounds()
+    repositionAndShow(entry, {
+      width: Math.max(0, bounds.width - COACHMARK_SHADOW_GUTTER * 2),
+      height: Math.max(0, bounds.height - COACHMARK_SHADOW_GUTTER)
+    })
+  })
+}
+
+/** Wire the coachmark IPC. Shares the tooltip's `:ready` / `:rendered`
+ *  channels (same renderer entry), disambiguated by webContents id so
+ *  only acks from a coachmark popup view land here. */
+export function registerTitleCoachmarkIpc(opts: {
+  findParentByTitleBarSender: (wc: WebContents) => BrowserWindow | null
+  /** Resolve a host BrowserWindow back to its title-bar webContents so
+   *  the popup's dismiss button can tell the title-bar renderer to flip
+   *  the once-ever flag. `null` if the window has no live title bar. */
+  findTitleBarByParent: (parent: BrowserWindow) => WebContents | null
+}): void {
+  ipcMain.on('comfy-titletooltip:ready', (event) => {
+    const entry = coachmarkPopupsByWebContents.get(event.sender.id)
+    if (!entry) return
+    entry.view.rendererReady = true
+    if (entry.pendingConfig) {
+      entry.view.popup.webContents.send('comfy-titletooltip:set-config', entry.pendingConfig)
+      entry.pendingConfig = null
+    }
+  })
+
+  ipcMain.on(
+    'comfy-titletooltip:rendered',
+    (event, payload: { width?: unknown; height?: unknown; configToken?: unknown }) => {
+      const entry = coachmarkPopupsByWebContents.get(event.sender.id)
+      if (!entry) return
+      const ackToken = typeof payload?.configToken === 'string' ? payload.configToken : ''
+      if (!ackToken || ackToken !== entry.pendingConfigToken) return
+      const width = typeof payload?.width === 'number' && payload.width > 0 ? payload.width : 0
+      const height = typeof payload?.height === 'number' && payload.height > 0 ? payload.height : 0
+      if (entry.pendingAnchor) repositionAndShow(entry, { width, height })
+    }
+  )
+
+  ipcMain.on(
+    'comfy-window:show-titlebar-coachmark',
+    (
+      event,
+      payload: {
+        title?: unknown
+        body?: unknown
+        dismissLabel?: unknown
+        leftX?: unknown
+        rightX?: unknown
+        bottomY?: unknown
+      }
+    ) => {
+      const parent = opts.findParentByTitleBarSender(event.sender)
+      if (!parent || parent.isDestroyed()) return
+      const title = typeof payload?.title === 'string' ? payload.title : ''
+      const body = typeof payload?.body === 'string' ? payload.body : ''
+      if (!title && !body) return
+      // Renderer supplies the i18n label; main only forwards it (the
+      // renderer's own `cmDismissLabel` default covers an empty value).
+      const dismissLabel = typeof payload?.dismissLabel === 'string' ? payload.dismissLabel : ''
+      const leftX = typeof payload?.leftX === 'number' ? payload.leftX : 0
+      const rightX = typeof payload?.rightX === 'number' ? payload.rightX : leftX
+      const bottomY = typeof payload?.bottomY === 'number' ? payload.bottomY : TITLEBAR_HEIGHT
+      openCoachmarkPopup({
+        parent,
+        title,
+        body,
+        dismissLabel,
+        leftX: Math.round(leftX),
+        rightX: Math.round(rightX),
+        bottomY: Math.round(bottomY)
+      })
+    }
+  )
+
+  ipcMain.on('comfy-window:hide-titlebar-coachmark', (event) => {
+    const parent = opts.findParentByTitleBarSender(event.sender)
+    if (!parent) return
+    hideCoachmarkPopup(coachmarkPopupsByParent.get(parent.id))
+  })
+
+  // Dismiss fires from the popup's own webContents: hide it and tell the
+  // title-bar renderer to flip the once-ever flag (it owns persistence).
+  ipcMain.on('comfy-titlecoachmark:dismiss', (event) => {
+    const entry = coachmarkPopupsByWebContents.get(event.sender.id)
+    if (!entry) return
+    entry.view.hide()
+    const parent = entry.view.parentWindow
+    if (parent && !parent.isDestroyed()) {
+      const tb = opts.findTitleBarByParent(parent)
+      if (tb && !tb.isDestroyed()) tb.send('comfy-titlebar:coachmark-dismissed')
+    }
+  })
+}

--- a/src/preload/comfyTitleBarPreload.ts
+++ b/src/preload/comfyTitleBarPreload.ts
@@ -211,6 +211,25 @@ export interface ComfyTitleBarBridge {
   /** Issue #514 — hide the title-bar hover tooltip popup. Sent on
    *  pointer leave, focus loss, menu open, or panel switch. */
   hideTooltip(): void
+  /** First-instance onboarding coachmark (issue #701) — show the sticky
+   *  card pointing at the centre pill. Reuses the clip-escaping tooltip
+   *  popup pipeline (`variant: 'coachmark'`). `leftX`/`rightX` bracket
+   *  the pill's edges, `bottomY` is its bottom edge — title-bar-local
+   *  px (the title-bar view sits at window (0,0)). */
+  showCoachmark(payload: {
+    title: string
+    body: string
+    dismissLabel: string
+    leftX: number
+    rightX: number
+    bottomY: number
+  }): void
+  /** Hide the onboarding coachmark popup. */
+  hideCoachmark(): void
+  /** Subscribe to the coachmark's own dismiss button. Main forwards this
+   *  after the popup's ✕ / "Got it" is clicked so the renderer flips the
+   *  once-ever `hasSeenCentralPillHint` flag via `window.api`. */
+  onCoachmarkDismissed(cb: () => void): () => void
   /** Tell main this title bar is mounted; main responds with the initial state. */
   ready(): void
 }
@@ -394,6 +413,17 @@ const bridge: ComfyTitleBarBridge = {
   },
   hideTooltip: () => {
     ipcRenderer.send('comfy-window:hide-titlebar-tooltip')
+  },
+  showCoachmark: (payload) => {
+    ipcRenderer.send('comfy-window:show-titlebar-coachmark', payload)
+  },
+  hideCoachmark: () => {
+    ipcRenderer.send('comfy-window:hide-titlebar-coachmark')
+  },
+  onCoachmarkDismissed: (cb) => {
+    const handler = (): void => cb()
+    ipcRenderer.on('comfy-titlebar:coachmark-dismissed', handler)
+    return () => ipcRenderer.removeListener('comfy-titlebar:coachmark-dismissed', handler)
   },
   ready: () => {
     ipcRenderer.send('comfy-window:title-bar-ready')

--- a/src/preload/comfyTitleTooltipPreload.ts
+++ b/src/preload/comfyTitleTooltipPreload.ts
@@ -17,8 +17,16 @@ import type { IpcRendererEvent } from 'electron'
  * `setBounds` and flips it visible after the renderer acks paint.
  */
 export interface TitleTooltipConfig {
-  text: string
-  theme: { bg: string; text: string; border: string }
+  /** Absent / `'tooltip'` for the hover bubble; `'coachmark'` for the
+   *  sticky onboarding card (extra title / body / dismiss fields). */
+  variant?: 'tooltip' | 'coachmark'
+  /** Hover-bubble body (tooltip variant). */
+  text?: string
+  /** Coachmark fields (coachmark variant). */
+  title?: string
+  body?: string
+  dismissLabel?: string
+  theme: { bg: string; text: string; border: string; accent?: string }
   /** Round-trip token. Echoed verbatim by the renderer in
    *  `notifyRendered` so main can discard render-acks that don't
    *  match the most recently sent config (e.g. a fast pointer move
@@ -41,17 +49,27 @@ export interface ComfyTitleTooltipBridge {
   notifyRendered(payload: { width: number; height: number; configToken: string }): void
   /** Subscribe to config pushes (one fires per show). */
   onConfig(cb: (config: TitleTooltipConfig) => void): () => void
+  /** Coachmark dismiss button → main hides the popup and tells the
+   *  title-bar renderer to flip the once-ever flag. No-op for the
+   *  tooltip variant (which has no interactive controls). */
+  dismissCoachmark(): void
 }
 
 function isTooltipConfig(value: unknown): value is TitleTooltipConfig {
   if (!value || typeof value !== 'object') return false
   const v = value as Partial<TitleTooltipConfig>
-  if (typeof v.text !== 'string') return false
   if (typeof v.configToken !== 'string') return false
   if (!v.theme || typeof v.theme !== 'object') return false
   if (typeof v.theme.bg !== 'string') return false
   if (typeof v.theme.text !== 'string') return false
   if (typeof v.theme.border !== 'string') return false
+  // Coachmark needs title/body; tooltip needs text. Accept either so a
+  // single channel serves both variants.
+  if (v.variant === 'coachmark') {
+    if (typeof v.title !== 'string' && typeof v.body !== 'string') return false
+  } else if (typeof v.text !== 'string') {
+    return false
+  }
   return true
 }
 
@@ -68,6 +86,9 @@ const bridge: ComfyTitleTooltipBridge = {
     }
     ipcRenderer.on('comfy-titletooltip:set-config', handler)
     return () => ipcRenderer.removeListener('comfy-titletooltip:set-config', handler)
+  },
+  dismissCoachmark: () => {
+    ipcRenderer.send('comfy-titlecoachmark:dismiss')
   },
 }
 

--- a/src/renderer/src/comfyTitleBar/TitleBarApp.test.ts
+++ b/src/renderer/src/comfyTitleBar/TitleBarApp.test.ts
@@ -23,7 +23,7 @@ interface MockBridgeState {
   fullscreenChangedCallbacks: ((fullscreen: boolean) => void)[]
   menuOpenedCallbacks: ((info: { menu: 'menu' }) => void)[]
   menuClosedCallbacks: ((info: { menu: 'menu' }) => void)[]
-  firstUseModeChangedCallbacks: ((mode: 'none' | 'consent-lockdown' | 'post-consent') => void)[]
+  firstUseModeChangedCallbacks: ((mode: 'none' | 'consent-lockdown' | 'post-consent' | 'loading-lockdown') => void)[]
   previewModeChangedCallbacks: ((preview: boolean) => void)[]
   installationIdChangedCallbacks: ((installationId: string | null) => void)[]
   appUpdateStateCallbacks: ((state: {
@@ -46,6 +46,16 @@ interface MockBridgeState {
   resetZoomClicks: number
   showTooltipCalls: { text: string; leftX: number; rightX: number; bottomY: number }[]
   hideTooltipCalls: number
+  showCoachmarkCalls: {
+    title: string
+    body: string
+    dismissLabel: string
+    leftX: number
+    rightX: number
+    bottomY: number
+  }[]
+  hideCoachmarkCalls: number
+  coachmarkDismissedCallbacks: (() => void)[]
   readyCalls: number
 }
 
@@ -78,6 +88,9 @@ function installMockBridge(opts: { isMac?: boolean; installationId?: string | nu
     resetZoomClicks: 0,
     showTooltipCalls: [],
     hideTooltipCalls: 0,
+    showCoachmarkCalls: [],
+    hideCoachmarkCalls: 0,
+    coachmarkDismissedCallbacks: [],
     readyCalls: 0,
   }
   const installationId = opts.installationId === undefined ? 'test-id' : opts.installationId
@@ -120,7 +133,7 @@ function installMockBridge(opts: { isMac?: boolean; installationId?: string | nu
       state.menuClosedCallbacks.push(cb)
       return () => { }
     },
-    onFirstUseModeChanged: (cb: (mode: 'none' | 'consent-lockdown' | 'post-consent') => void) => {
+    onFirstUseModeChanged: (cb: (mode: 'none' | 'consent-lockdown' | 'post-consent' | 'loading-lockdown') => void) => {
       state.firstUseModeChangedCallbacks.push(cb)
       return () => { }
     },
@@ -176,6 +189,23 @@ function installMockBridge(opts: { isMac?: boolean; installationId?: string | nu
     },
     hideTooltip: () => {
       state.hideTooltipCalls += 1
+    },
+    showCoachmark: (payload: {
+      title: string
+      body: string
+      dismissLabel: string
+      leftX: number
+      rightX: number
+      bottomY: number
+    }) => {
+      state.showCoachmarkCalls.push(payload)
+    },
+    hideCoachmark: () => {
+      state.hideCoachmarkCalls += 1
+    },
+    onCoachmarkDismissed: (cb: () => void) => {
+      state.coachmarkDismissedCallbacks.push(cb)
+      return () => {}
     },
     ready: () => {
       state.readyCalls += 1
@@ -1253,6 +1283,105 @@ describe('TitleBarApp', () => {
       const titleBar = wrapper.find('.title-bar').element as HTMLElement
       expect(titleBar.style.getPropertyValue('--title-trailing-width')).toBe('0px')
       expect(wrapper.find('.title-install-pill').exists()).toBe(true)
+      wrapper.unmount()
+    })
+  })
+
+  describe('first-instance pill coachmark', () => {
+    let getSetting: ReturnType<typeof vi.fn>
+    let setSetting: ReturnType<typeof vi.fn>
+
+    beforeEach(() => {
+      getSetting = vi.fn().mockResolvedValue(undefined)
+      setSetting = vi.fn().mockResolvedValue(undefined)
+      ;(window as unknown as { api: unknown }).api = { getSetting, setSetting }
+      // Run the deferred rAF synchronously so the coachmark trigger
+      // resolves within a flushPromises() tick.
+      vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+        cb(0)
+        return 0
+      })
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+      delete (window as unknown as { api?: unknown }).api
+    })
+
+    it('shows the coachmark when a window attaches to an instance AFTER mount', async () => {
+      // The original bug: the trigger ran once at mount when the window
+      // was still install-less, so it never fired after attach. The
+      // reactive watcher must re-attempt when isInstallLess flips false.
+      bridgeState = installMockBridge({ installationId: null })
+      vi.resetModules()
+      const { default: TitleBarApp } = await import('./TitleBarApp.vue')
+      const wrapper = mount(TitleBarApp, { attachTo: document.body })
+      await flushPromises()
+      // Install-less at mount → no coachmark yet.
+      expect(bridgeState.showCoachmarkCalls.length).toBe(0)
+
+      // Main pushes an installation id — the window is now install-backed.
+      bridgeState.installationIdChangedCallbacks.forEach((cb) => cb('inst-1'))
+      await flushPromises()
+
+      expect(bridgeState.showCoachmarkCalls.length).toBe(1)
+      const payload = bridgeState.showCoachmarkCalls[0]
+      expect(payload.title).toBe('Switch & manage instances')
+      wrapper.unmount()
+    })
+
+    it('does not show the coachmark on an install-less (dashboard) window', async () => {
+      bridgeState = installMockBridge({ installationId: null })
+      vi.resetModules()
+      const { default: TitleBarApp } = await import('./TitleBarApp.vue')
+      const wrapper = mount(TitleBarApp, { attachTo: document.body })
+      await flushPromises()
+      expect(bridgeState.showCoachmarkCalls.length).toBe(0)
+      wrapper.unmount()
+    })
+
+    it('does not show the coachmark when already seen', async () => {
+      getSetting.mockImplementation((key: string) =>
+        key === 'hasSeenCentralPillHint' ? Promise.resolve(true) : Promise.resolve(undefined),
+      )
+      bridgeState = installMockBridge({ installationId: 'inst-1' })
+      vi.resetModules()
+      const { default: TitleBarApp } = await import('./TitleBarApp.vue')
+      const wrapper = mount(TitleBarApp, { attachTo: document.body })
+      await flushPromises()
+      expect(bridgeState.showCoachmarkCalls.length).toBe(0)
+      wrapper.unmount()
+    })
+
+    it('waits for loading-lockdown to clear (ComfyUI screen visible) before showing', async () => {
+      // An install-backed window with a progress / connect takeover up
+      // (loading-lockdown) must NOT show the coachmark over the brand
+      // loader — it should fire only once the lockdown clears to 'none'.
+      bridgeState = installMockBridge({ installationId: 'inst-1' })
+      vi.resetModules()
+      const { default: TitleBarApp } = await import('./TitleBarApp.vue')
+      const wrapper = mount(TitleBarApp, { attachTo: document.body })
+      bridgeState.firstUseModeChangedCallbacks.forEach((cb) => cb('loading-lockdown'))
+      await flushPromises()
+      expect(bridgeState.showCoachmarkCalls.length).toBe(0)
+
+      // Loader finished → ComfyUI is visible.
+      bridgeState.firstUseModeChangedCallbacks.forEach((cb) => cb('none'))
+      await flushPromises()
+      expect(bridgeState.showCoachmarkCalls.length).toBe(1)
+      wrapper.unmount()
+    })
+
+    it('lifts the pill to the brand-open state while the coachmark is showing', async () => {
+      bridgeState = installMockBridge({ installationId: 'inst-1' })
+      vi.resetModules()
+      const { default: TitleBarApp } = await import('./TitleBarApp.vue')
+      const wrapper = mount(TitleBarApp, { attachTo: document.body })
+      await flushPromises()
+      expect(bridgeState.showCoachmarkCalls.length).toBe(1)
+      // The pill carries the coachmark-highlight modifier (same yellow lift
+      // as is-open) so it reads as the thing the card points at.
+      expect(wrapper.find('.title-install-pill.is-coachmark').exists()).toBe(true)
       wrapper.unmount()
     })
   })

--- a/src/renderer/src/comfyTitleBar/TitleBarApp.vue
+++ b/src/renderer/src/comfyTitleBar/TitleBarApp.vue
@@ -17,6 +17,7 @@ import { useTitleBarMenus } from './useTitleBarMenus'
 import { useTitleBarIdentity } from './useTitleBarIdentity'
 import { useUpdatePills } from './useUpdatePills'
 import { useTitleBarHoverGate } from './useTitleBarHoverGate'
+import { useCentralPillCoachmark } from './useCentralPillCoachmark'
 import ComfyCLogo from '../components/icons/ComfyCLogo.vue'
 
 const { t, locale } = useI18n()
@@ -78,6 +79,18 @@ interface Bridge {
   showTooltip: (payload: { text: string; leftX: number; rightX: number; bottomY: number }) => void
   /** Issue #514 — hide the title-bar hover tooltip popup. */
   hideTooltip: () => void
+  /** First-instance onboarding coachmark (issue #701) — show/hide the
+   *  sticky card pointing at the centre pill; subscribe to its dismiss. */
+  showCoachmark: (payload: {
+    title: string
+    body: string
+    dismissLabel: string
+    leftX: number
+    rightX: number
+    bottomY: number
+  }) => void
+  hideCoachmark: () => void
+  onCoachmarkDismissed: (cb: () => void) => () => void
   onPanelChanged: (cb: (panel: ComfyPanelKey) => void) => () => void
   onTitleChanged: (cb: (title: string) => void) => () => void
   /** Install source-category pushes from main. The raw category
@@ -204,6 +217,7 @@ const {
   firstUseMode,
   isConsentLockdown,
   isFirstUseLockdown,
+  isLoadingLockdown,
   installTypeMeta,
   installTypeLabel,
   showInstallTypeIcon,
@@ -448,6 +462,26 @@ const {
   installPillRef
 })
 
+// First-instance onboarding coachmark pointing at the centre pill. Shares
+// the menus composable's pill ref; opening the drawer acknowledges it.
+const coachmark = useCentralPillCoachmark({
+  bridge,
+  isInstallLess,
+  isFirstUseLockdown,
+  isLoadingLockdown,
+  installPillRef,
+  title: t('titleBar.pillHintTitle'),
+  body: t('titleBar.pillHintBody'),
+  dismissLabel: t('titleBar.pillHintDismiss')
+})
+
+/** Wrap the pill opener so opening the drawer retires the coachmark
+ *  (the hint did its job) before delegating to the real handler. */
+function handleInstallPillWithCoachmark(): void {
+  void coachmark.acknowledgeViaPillOpen()
+  handleInstallPill()
+}
+
 /** One-shot "downloads started" attention flash. Driven by
  *  `downloadsStartedAt` from the menus composable, which bumps each
  *  time a brand-new active download appears. The flash is purely
@@ -470,6 +504,7 @@ watch(downloadsStartedAt, (next) => {
 let unsubPanel: (() => void) | undefined
 let unsubInstallationId: (() => void) | undefined
 let unsubZoom: (() => void) | undefined
+let unsubCoachmarkDismissed: (() => void) | undefined
 
 onMounted(() => {
   // Observe the trailing cluster so the left cluster can mirror its
@@ -514,8 +549,32 @@ onMounted(() => {
   unsubInstallationId = bridge.onInstallationIdChanged((installationId) => {
     isInstallLess.value = installationId === null
   })
+  // The popup's own dismiss button (✕ / "Got it") routes through main
+  // back to here — flip the once-ever flag + hide.
+  unsubCoachmarkDismissed = bridge.onCoachmarkDismissed(() => {
+    void coachmark.dismiss()
+  })
   bridge.ready()
 })
+
+// Gate inputs settle async via main's pushes after mount, so watch them
+// and re-attempt on each transition (the composable is idempotent) rather
+// than firing once on mount.
+watch(
+  [isInstallLess, isFirstUseLockdown, isLoadingLockdown],
+  ([installLess, lockdown, loading]) => {
+    if (installLess || lockdown || loading) return
+    // Defer past the responsive fit settle so the pill's centre is final
+    // before anchoring: nextTick flushes the DOM, the rAF the layout.
+    void nextTick().then(() => {
+      requestAnimationFrame(() => {
+        if (unmounted) return
+        void coachmark.maybeShow()
+      })
+    })
+  },
+  { immediate: true }
+)
 
 // Invalidate the learned restore costs when anything that materially
 // changes the trailing cluster's content width flips. The fit
@@ -540,6 +599,8 @@ onUnmounted(() => {
   unsubPanel?.()
   unsubInstallationId?.()
   unsubZoom?.()
+  unsubCoachmarkDismissed?.()
+  bridge?.hideCoachmark()
   hideTip()
   trailingObserver?.disconnect()
   trailingObserver = undefined
@@ -644,15 +705,16 @@ onUnmounted(() => {
         class="title-install-pill is-interactive"
         :class="{
           'is-open': isInstancePickerOpen,
+          'is-coachmark': coachmark.isShowing.value,
           'is-install-less': isInstallLess
         }"
         role="button"
         tabindex="0"
         aria-haspopup="dialog"
         :aria-expanded="isInstancePickerOpen"
-        @click="handleInstallPill"
-        @keydown.enter.prevent="handleInstallPill"
-        @keydown.space.prevent="handleInstallPill"
+        @click="handleInstallPillWithCoachmark"
+        @keydown.enter.prevent="handleInstallPillWithCoachmark"
+        @keydown.space.prevent="handleInstallPillWithCoachmark"
       >
         <!-- Leading mark: the Comfy logo only on the bare dashboard; on an
              actual instance the pill leads with that install's source/type
@@ -987,10 +1049,12 @@ onUnmounted(() => {
   background: var(--brand-surface-bg-hover);
   outline: none;
 }
-.title-install-pill.is-interactive.is-open {
-  /* Lift border + text to brand yellow when the picker is showing.
-   * The brand mark + caret both use `currentColor` so they inherit
-   * this lift automatically — one source of truth for the open tint. */
+.title-install-pill.is-interactive.is-open,
+.title-install-pill.is-interactive.is-coachmark {
+  /* Lift border + text to brand yellow when the picker is showing OR the
+   * first-instance coachmark is pointing at the pill. The brand mark +
+   * caret both use `currentColor` so they inherit this lift automatically
+   * — one source of truth for the open tint. */
   border-color: var(--neutral-50);
   color: var(--neutral-50);
 }

--- a/src/renderer/src/comfyTitleBar/useCentralPillCoachmark.test.ts
+++ b/src/renderer/src/comfyTitleBar/useCentralPillCoachmark.test.ts
@@ -1,0 +1,286 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref, shallowRef, type ShallowRef } from 'vue'
+
+import { useCentralPillCoachmark, CENTRAL_PILL_HINT_SEEN_KEY } from './useCentralPillCoachmark'
+
+type CoachmarkShowPayload = {
+  title: string
+  body: string
+  dismissLabel: string
+  leftX: number
+  rightX: number
+  bottomY: number
+}
+
+function makeBridge() {
+  return {
+    showCoachmark: vi.fn<(payload: CoachmarkShowPayload) => void>(),
+    hideCoachmark: vi.fn<() => void>()
+  }
+}
+
+/** A stand-in pill element whose `getBoundingClientRect` returns a fixed
+ *  rect so anchor math is deterministic. */
+function makePillRef(rect?: Partial<DOMRect>): ShallowRef<HTMLElement | null> {
+  const el = {
+    getBoundingClientRect: () =>
+      ({ left: 100, right: 240, top: 0, bottom: 36, width: 140, height: 36 }) as DOMRect,
+    ...rect
+  } as unknown as HTMLElement
+  return shallowRef(el)
+}
+
+describe('useCentralPillCoachmark', () => {
+  let getSetting: ReturnType<typeof vi.fn>
+  let setSetting: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    getSetting = vi.fn().mockResolvedValue(undefined)
+    setSetting = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('window', {
+      ...window,
+      api: { getSetting, setSetting },
+      requestAnimationFrame: (cb: FrameRequestCallback) => {
+        cb(0)
+        return 0
+      }
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('shows the coachmark on first instance entry when the gate passes', async () => {
+    const bridge = makeBridge()
+    const cm = useCentralPillCoachmark({
+      bridge,
+      isInstallLess: ref(false),
+      isFirstUseLockdown: ref(false),
+      installPillRef: makePillRef(),
+      title: 'T',
+      body: 'Switch & manage instances here.',
+      dismissLabel: 'Got it'
+    })
+
+    await cm.maybeShow()
+
+    expect(bridge.showCoachmark).toHaveBeenCalledTimes(1)
+    const payload = bridge.showCoachmark.mock.calls[0]?.[0]
+    if (!payload) throw new Error('showCoachmark was not called')
+    expect(payload.title).toBe('T')
+    expect(payload.body).toBe('Switch & manage instances here.')
+    expect(payload.dismissLabel).toBe('Got it')
+    // Anchored below the pill, centered on it.
+    expect(payload.leftX).toBe(100)
+    expect(payload.rightX).toBe(240)
+    expect(payload.bottomY).toBe(36)
+  })
+
+  it('does NOT show while a loading-lockdown (progress / connect screen) is up', async () => {
+    const bridge = makeBridge()
+    const cm = useCentralPillCoachmark({
+      bridge,
+      isInstallLess: ref(false),
+      isFirstUseLockdown: ref(false),
+      isLoadingLockdown: ref(true),
+      installPillRef: makePillRef(),
+      title: 'T',
+      body: 'hint',
+      dismissLabel: 'Got it'
+    })
+
+    await cm.maybeShow()
+
+    expect(bridge.showCoachmark).not.toHaveBeenCalled()
+  })
+
+  it('exposes isShowing — false until shown, true while open, false after dismiss', async () => {
+    const bridge = makeBridge()
+    const cm = useCentralPillCoachmark({
+      bridge,
+      isInstallLess: ref(false),
+      isFirstUseLockdown: ref(false),
+      installPillRef: makePillRef(),
+      title: 'T',
+      body: 'hint',
+      dismissLabel: 'Got it'
+    })
+
+    expect(cm.isShowing.value).toBe(false)
+    await cm.maybeShow()
+    expect(cm.isShowing.value).toBe(true)
+    await cm.dismiss()
+    expect(cm.isShowing.value).toBe(false)
+  })
+
+  it('does NOT show on an install-less host (the dashboard IS the picker)', async () => {
+    const bridge = makeBridge()
+    const cm = useCentralPillCoachmark({
+      bridge,
+      isInstallLess: ref(true),
+      isFirstUseLockdown: ref(false),
+      installPillRef: makePillRef(),
+      title: 'T',
+      body: 'hint',
+      dismissLabel: 'Got it'
+    })
+
+    await cm.maybeShow()
+
+    expect(bridge.showCoachmark).not.toHaveBeenCalled()
+  })
+
+  it('does NOT show during the first-use takeover lockdown', async () => {
+    const bridge = makeBridge()
+    const cm = useCentralPillCoachmark({
+      bridge,
+      isInstallLess: ref(false),
+      isFirstUseLockdown: ref(true),
+      installPillRef: makePillRef(),
+      title: 'T',
+      body: 'hint',
+      dismissLabel: 'Got it'
+    })
+
+    await cm.maybeShow()
+
+    expect(bridge.showCoachmark).not.toHaveBeenCalled()
+  })
+
+  it('does NOT show when the seen flag is already persisted', async () => {
+    getSetting.mockImplementation((key: string) =>
+      key === CENTRAL_PILL_HINT_SEEN_KEY ? Promise.resolve(true) : Promise.resolve(undefined)
+    )
+    const bridge = makeBridge()
+    const cm = useCentralPillCoachmark({
+      bridge,
+      isInstallLess: ref(false),
+      isFirstUseLockdown: ref(false),
+      installPillRef: makePillRef(),
+      title: 'T',
+      body: 'hint',
+      dismissLabel: 'Got it'
+    })
+
+    await cm.maybeShow()
+
+    expect(getSetting).toHaveBeenCalledWith(CENTRAL_PILL_HINT_SEEN_KEY)
+    expect(bridge.showCoachmark).not.toHaveBeenCalled()
+  })
+
+  it('persists the seen flag and hides the popup on dismiss (once ever)', async () => {
+    const bridge = makeBridge()
+    const cm = useCentralPillCoachmark({
+      bridge,
+      isInstallLess: ref(false),
+      isFirstUseLockdown: ref(false),
+      installPillRef: makePillRef(),
+      title: 'T',
+      body: 'hint',
+      dismissLabel: 'Got it'
+    })
+
+    await cm.maybeShow()
+    expect(bridge.showCoachmark).toHaveBeenCalledTimes(1)
+
+    await cm.dismiss()
+
+    expect(setSetting).toHaveBeenCalledWith(CENTRAL_PILL_HINT_SEEN_KEY, true)
+    expect(bridge.hideCoachmark).toHaveBeenCalledTimes(1)
+  })
+
+  it('is idempotent — a second dismiss does not re-persist or re-hide', async () => {
+    const bridge = makeBridge()
+    const cm = useCentralPillCoachmark({
+      bridge,
+      isInstallLess: ref(false),
+      isFirstUseLockdown: ref(false),
+      installPillRef: makePillRef(),
+      title: 'T',
+      body: 'hint',
+      dismissLabel: 'Got it'
+    })
+
+    await cm.maybeShow()
+    await cm.dismiss()
+    await cm.dismiss()
+
+    expect(setSetting).toHaveBeenCalledTimes(1)
+    expect(bridge.hideCoachmark).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not show again within the same session after a dismiss', async () => {
+    const bridge = makeBridge()
+    const cm = useCentralPillCoachmark({
+      bridge,
+      isInstallLess: ref(false),
+      isFirstUseLockdown: ref(false),
+      installPillRef: makePillRef(),
+      title: 'T',
+      body: 'hint',
+      dismissLabel: 'Got it'
+    })
+
+    await cm.maybeShow()
+    await cm.dismiss()
+    bridge.showCoachmark.mockClear()
+
+    await cm.maybeShow()
+
+    expect(bridge.showCoachmark).not.toHaveBeenCalled()
+  })
+
+  it('treats opening the pill drawer as "seen" — persists and stops showing', async () => {
+    const bridge = makeBridge()
+    const cm = useCentralPillCoachmark({
+      bridge,
+      isInstallLess: ref(false),
+      isFirstUseLockdown: ref(false),
+      installPillRef: makePillRef(),
+      title: 'T',
+      body: 'hint',
+      dismissLabel: 'Got it'
+    })
+
+    await cm.maybeShow()
+    // Pill click counts as acknowledgement.
+    await cm.acknowledgeViaPillOpen()
+
+    expect(setSetting).toHaveBeenCalledWith(CENTRAL_PILL_HINT_SEEN_KEY, true)
+    expect(bridge.hideCoachmark).toHaveBeenCalledTimes(1)
+  })
+
+  it('does nothing when the pill ref is not mounted yet', async () => {
+    const bridge = makeBridge()
+    const cm = useCentralPillCoachmark({
+      bridge,
+      isInstallLess: ref(false),
+      isFirstUseLockdown: ref(false),
+      installPillRef: shallowRef<HTMLElement | null>(null),
+      title: 'T',
+      body: 'hint',
+      dismissLabel: 'Got it'
+    })
+
+    await cm.maybeShow()
+
+    expect(bridge.showCoachmark).not.toHaveBeenCalled()
+  })
+
+  it('no-ops gracefully when the bridge is undefined', async () => {
+    const cm = useCentralPillCoachmark({
+      bridge: undefined,
+      isInstallLess: ref(false),
+      isFirstUseLockdown: ref(false),
+      installPillRef: makePillRef(),
+      title: 'T',
+      body: 'hint',
+      dismissLabel: 'Got it'
+    })
+
+    await expect(cm.maybeShow()).resolves.toBeUndefined()
+    await expect(cm.dismiss()).resolves.toBeUndefined()
+  })
+})

--- a/src/renderer/src/comfyTitleBar/useCentralPillCoachmark.ts
+++ b/src/renderer/src/comfyTitleBar/useCentralPillCoachmark.ts
@@ -1,0 +1,141 @@
+import { ref, type Ref, type ShallowRef } from 'vue'
+
+/** Persisted one-time flag — set the first time the central-pill
+ *  coachmark is dismissed (or the user opens the drawer). Mirrors the
+ *  `firstUseCompleted` one-time-flag convention in `useLauncherPrefs`,
+ *  but lives here because the title-bar renderer reaches settings via the
+ *  shared `window.api` bridge rather than the panel-side prefs singleton. */
+export const CENTRAL_PILL_HINT_SEEN_KEY = 'hasSeenCentralPillHint'
+
+interface CoachmarkBridge {
+  /** Show the central-pill onboarding coachmark popup. Reuses the
+   *  clip-escaping title-popup pipeline; `leftX`/`rightX` bracket the
+   *  pill's horizontal edges and `bottomY` is its bottom edge, all in
+   *  title-bar-local px (the title-bar view sits at window (0,0)). */
+  showCoachmark: (payload: {
+    title: string
+    body: string
+    dismissLabel: string
+    leftX: number
+    rightX: number
+    bottomY: number
+  }) => void
+  /** Hide the coachmark popup. */
+  hideCoachmark: () => void
+}
+
+interface UseCentralPillCoachmarkOpts {
+  bridge: CoachmarkBridge | undefined
+  /** Install-less host (chooser/dashboard) — the dashboard already IS the
+   *  picker, so the hint is pointless there. */
+  isInstallLess: Ref<boolean>
+  /** First-use takeover lockdown — the pill is static/non-interactive,
+   *  so never point at it mid-bootstrap. */
+  isFirstUseLockdown: Ref<boolean>
+  /** Loading-lockdown — a ProgressModal / connect-progress takeover is up
+   *  (install / launch / connect). Wait for it to clear so the coachmark
+   *  fires only once the actual ComfyUI screen is visible, not over the
+   *  brand loader. Optional; absent → treated as never-loading. */
+  isLoadingLockdown?: Ref<boolean>
+  /** Template ref for the centre install pill — anchors the coachmark. */
+  installPillRef: Readonly<ShallowRef<HTMLElement | null>>
+  /** Resolved coachmark copy (i18n done by the caller). */
+  title: string
+  body: string
+  dismissLabel: string
+}
+
+interface CentralPillCoachmarkApi {
+  /** Evaluate the gate and, if it passes, show the coachmark once. */
+  maybeShow: () => Promise<void>
+  /** Dismiss (✕ / blur): persist the seen flag and hide. Idempotent. */
+  dismiss: () => Promise<void>
+  /** The user opened the pill drawer — counts as acknowledgement. Same
+   *  effect as `dismiss`. */
+  acknowledgeViaPillOpen: () => Promise<void>
+  /** `true` between show and dismiss/hide — drives the pill's brand-yellow
+   *  highlight while the coachmark points at it. */
+  isShowing: Ref<boolean>
+}
+
+/**
+ * First-instance coachmark pointing at the central title-bar pill
+ * (issue #701). The first time a user lands in a real instance, a
+ * dismissable hint explains the pill is the instance picker. Shown once,
+ * ever. Owns the gate, once-ever persistence (`window.api`), anchoring,
+ * and dismiss wiring; the visual lives in the main-side popup, so this
+ * stays unit-testable without a WebContentsView.
+ */
+export function useCentralPillCoachmark(
+  opts: UseCentralPillCoachmarkOpts
+): CentralPillCoachmarkApi {
+  /** Drives the pill highlight — true while the coachmark is on screen. */
+  const isShowing = ref(false)
+  // Session guards so a show / dismiss sticks for this renderer's life
+  // even before the async `setSetting` round-trips.
+  let hasCoachmarkShown = false
+  let hasCoachmarkRetired = false
+
+  async function isSeen(): Promise<boolean> {
+    if (hasCoachmarkRetired) return true
+    try {
+      const v = await (window.api.getSetting(CENTRAL_PILL_HINT_SEEN_KEY) as Promise<
+        boolean | undefined
+      >)
+      return v === true
+    } catch {
+      // Read failed — treat as unseen so the hint still gets a chance.
+      return false
+    }
+  }
+
+  function gatePasses(): boolean {
+    return (
+      !opts.isInstallLess.value &&
+      !opts.isFirstUseLockdown.value &&
+      !opts.isLoadingLockdown?.value
+    )
+  }
+
+  async function maybeShow(): Promise<void> {
+    if (!opts.bridge) return
+    if (hasCoachmarkShown || hasCoachmarkRetired) return
+    if (!gatePasses() || !opts.installPillRef.value) return
+    if (await isSeen()) return
+    // Re-check gate + pill after the async read — the host could have
+    // flipped to install-less / lockdown while we awaited settings.
+    const pill = opts.installPillRef.value
+    if (!gatePasses() || !pill) return
+
+    const rect = pill.getBoundingClientRect()
+    hasCoachmarkShown = true
+    isShowing.value = true
+    opts.bridge.showCoachmark({
+      title: opts.title,
+      body: opts.body,
+      dismissLabel: opts.dismissLabel,
+      leftX: Math.round(rect.left),
+      rightX: Math.round(rect.right),
+      bottomY: Math.round(rect.bottom)
+    })
+  }
+
+  async function retire(): Promise<void> {
+    isShowing.value = false
+    if (hasCoachmarkRetired) return
+    hasCoachmarkRetired = true
+    opts.bridge?.hideCoachmark()
+    try {
+      await window.api.setSetting(CENTRAL_PILL_HINT_SEEN_KEY, true)
+    } catch {
+      // Persistence failed — a future launch simply re-offers the hint.
+    }
+  }
+
+  return {
+    maybeShow,
+    dismiss: retire,
+    acknowledgeViaPillOpen: retire,
+    isShowing
+  }
+}

--- a/src/renderer/src/comfyTitleTooltip/TitleTooltipApp.vue
+++ b/src/renderer/src/comfyTitleTooltip/TitleTooltipApp.vue
@@ -15,8 +15,16 @@ import { nextTick, onMounted, onUnmounted, ref, useTemplateRef, watch } from 'vu
  */
 
 interface TooltipConfig {
-  text: string
-  theme: { bg: string; text: string; border: string }
+  /** Absent (or `'tooltip'`) for the plain hover bubble; `'coachmark'`
+   *  for the sticky onboarding card with a beak + accent + dismiss. */
+  variant?: 'tooltip' | 'coachmark'
+  /** Hover-bubble body (tooltip variant). */
+  text?: string
+  /** Coachmark title + body + dismiss label (coachmark variant). */
+  title?: string
+  body?: string
+  dismissLabel?: string
+  theme: { bg: string; text: string; border: string; accent?: string }
   configToken: string
 }
 
@@ -24,14 +32,27 @@ interface Bridge {
   ready(): void
   notifyRendered(payload: { width: number; height: number; configToken: string }): void
   onConfig(cb: (config: TooltipConfig) => void): () => void
+  /** Coachmark dismiss button — tells main to hide + persist the
+   *  once-ever flag. No-op for the tooltip variant. */
+  dismissCoachmark?(): void
 }
 
 const bridge = (window as unknown as { __comfyTitleTooltip?: Bridge }).__comfyTitleTooltip
 
+const variant = ref<'tooltip' | 'coachmark'>('tooltip')
 const text = ref<string>('')
+const cmTitle = ref<string>('')
+const cmBody = ref<string>('')
+const cmDismissLabel = ref<string>('Got it')
 const themeBg = ref<string>('#211927')
 const themeText = ref<string>('#ffffff')
 const themeBorder = ref<string>('#38303d')
+const themeAccent = ref<string>('#e3ff3c')
+/** Whitish, semi-transparent hairline for the coachmark card + beak.
+ *  Brighter than the neutral tooltip border (`themeBorder`) so the card
+ *  reads as a distinct floating surface separated from the ComfyUI
+ *  content behind it, not a flush extension of the dark chrome. */
+const coachmarkBorder = 'rgba(255, 255, 255, 0.22)'
 /** Token from the most recently applied config — echoed back to main
  *  in every render-ack so main can discard stale acks. */
 let currentConfigToken = ''
@@ -79,10 +100,15 @@ async function measureAndAck(): Promise<void> {
 onMounted(() => {
   unsubConfig = bridge?.onConfig((cfg) => {
     currentConfigToken = cfg.configToken
-    text.value = cfg.text
+    variant.value = cfg.variant === 'coachmark' ? 'coachmark' : 'tooltip'
+    text.value = cfg.text ?? ''
+    cmTitle.value = cfg.title ?? ''
+    cmBody.value = cfg.body ?? ''
+    cmDismissLabel.value = cfg.dismissLabel ?? cmDismissLabel.value
     themeBg.value = cfg.theme.bg
     themeText.value = cfg.theme.text
     themeBorder.value = cfg.theme.border
+    if (cfg.theme.accent) themeAccent.value = cfg.theme.accent
     // Ack after Vue has flushed the DOM update *and* the browser has
     // painted with the actual web font. Main keeps the popup view
     // hidden until this ack arrives so the user never sees the
@@ -107,7 +133,11 @@ onMounted(() => {
 // measureAndAck). Keeping the watch here makes the renderer robust to
 // hot-module reload during dev and to future code that might mutate
 // `text` without going through `onConfig`.
-watch(text, () => { void measureAndAck() })
+watch([text, cmTitle, cmBody], () => { void measureAndAck() })
+
+function onDismiss(): void {
+  bridge?.dismissCoachmark?.()
+}
 
 onUnmounted(() => {
   unsubConfig?.()
@@ -115,7 +145,33 @@ onUnmounted(() => {
 </script>
 
 <template>
+  <!-- Coachmark variant: sticky onboarding card with an upward beak,
+       brand-accent title, body copy, and a dismiss button. -->
+  <div
+    v-if="variant === 'coachmark'"
+    ref="bubble"
+    class="coachmark"
+    role="dialog"
+    aria-modal="false"
+    :aria-label="cmTitle"
+    :style="{
+      background: themeBg,
+      color: themeText,
+      borderColor: coachmarkBorder,
+    }"
+  >
+    <span class="coachmark-beak" :style="{ background: themeBg, borderColor: coachmarkBorder }" />
+    <div class="coachmark-body">
+      <div class="coachmark-title" :style="{ color: themeAccent }">{{ cmTitle }}</div>
+      <p class="coachmark-text">{{ cmBody }}</p>
+      <button type="button" class="coachmark-dismiss" :style="{ color: themeAccent }" @click="onDismiss">
+        {{ cmDismissLabel }}
+      </button>
+    </div>
+  </div>
+  <!-- Hover-tooltip variant: the plain content-sized bubble. -->
   <span
+    v-else
     ref="bubble"
     class="bubble"
     :style="{
@@ -168,5 +224,71 @@ onUnmounted(() => {
   pointer-events: none;
   user-select: none;
   box-sizing: border-box;
+}
+
+/* Coachmark card — sticky onboarding hint. Wider than the tooltip,
+   interactive (dismiss button), with an upward beak that visually ties
+   it to the pill above. The view bounds are sized from this element's
+   measured rect (render-ack), so it shrink-wraps its content. */
+.coachmark {
+  position: relative;
+  display: block;
+  width: max-content;
+  max-width: 280px;
+  margin-top: 7px; /* room for the beak above the card */
+  padding: 12px 14px;
+  border-radius: 10px;
+  border: 1px solid;
+  /* Whitish hairline (set inline) + a soft inner highlight + a drop
+     shadow, so the card floats clearly above the ComfyUI content behind
+     it rather than blending into the dark canvas. */
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.04),
+    0 8px 24px rgba(0, 0, 0, 0.5);
+  font: 13px/1.45 var(--font-sans, 'Inter', system-ui, sans-serif);
+  user-select: none;
+  box-sizing: border-box;
+}
+
+/* Upward-pointing beak centered on the card's top edge. A rotated square
+   sharing the card's bg + border so only the top two edges show. */
+.coachmark-beak {
+  position: absolute;
+  top: -6px;
+  left: 50%;
+  width: 12px;
+  height: 12px;
+  transform: translateX(-50%) rotate(45deg);
+  border-top: 1px solid;
+  border-left: 1px solid;
+  border-top-left-radius: 3px;
+}
+
+.coachmark-title {
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.coachmark-text {
+  margin: 4px 0 10px;
+  font-size: 12px;
+  line-height: 1.5;
+  opacity: 0.88;
+}
+
+.coachmark-dismiss {
+  appearance: none;
+  background: transparent;
+  border: none;
+  padding: 2px 0;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.coachmark-dismiss:hover {
+  text-decoration: underline;
 }
 </style>

--- a/src/renderer/src/lib/i18nMessages.ts
+++ b/src/renderer/src/lib/i18nMessages.ts
@@ -113,7 +113,13 @@ export const en = {
     installUpdateVersion: 'ComfyUI {version}',
     installUpdateShort: 'Update',
     refreshInstanceTooltip: 'Refresh',
-    resetZoomTooltip: 'Reset zoom to 100%'
+    resetZoomTooltip: 'Reset zoom to 100%',
+    /** First-instance onboarding coachmark pointing at the centre pill —
+     *  teaches that the pill is the instance picker (switch / manage /
+     *  back to the dashboard for a new local install). Shown once ever. */
+    pillHintTitle: 'Switch & manage instances',
+    pillHintBody: 'Click here to switch instances, start a new local install, or return to the dashboard.',
+    pillHintDismiss: 'Got it'
   },
   fileMenu: {
     newWindow: 'New Window',


### PR DESCRIPTION
## Summary

New users don't realize the centre title-bar pill (`Desktop 2.0 Beta ▾`) is the instance picker — the one control that switches instances, manages them, and returns to the dashboard where the local **New Install** tile lives. This adds a one-time onboarding coachmark that points at the pill the first time a user lands in a real instance, giving them a clear route back to local (the gap reported in #701).

## Changes

**What**

- `useCentralPillCoachmark.ts` — new composable owning the gate (install-backed host, not in first-use/loading lockdown, not already seen), once-ever persistence via `window.api.getSetting`/`setSetting` (`hasSeenCentralPillHint`), pill anchoring, and dismiss wiring. Exposes `isShowing` for the pill highlight. Pure logic, unit-testable without a `WebContentsView`.
- `titleCoachmark.ts` — new main-process popup. A sticky card with an upward beak that reuses the `comfyTitleTooltip` renderer (`variant: 'coachmark'`) and its clip-escaping `WebContentsView` + render-ack pipeline (issue #514), but owns a separate popup view so its sticky lifecycle (no auto-hide on blur — the dismiss button needs focus) doesn't fight the hover tooltip's auto-dismiss.
- `TitleBarApp.vue` — watches the gate inputs (which settle async via main's pushes after mount) and re-attempts idempotently; lifts the pill to the brand-yellow open state (`is-coachmark`, same as `is-open`) while the card is showing; retires on dismiss or pill-open.
- `TitleTooltipApp.vue` — adds the `coachmark` variant markup + styles (beak, brand-accent title, whitish hairline border to separate it from the ComfyUI canvas, dismiss button).
- `comfyTitleBarPreload.ts` / `comfyTitleTooltipPreload.ts` — `showCoachmark`/`hideCoachmark`/`onCoachmarkDismissed` bridge methods + coachmark config validation.
- `registry.ts` — `findEntryByHostWindow` helper to route the popup's dismiss back to the title-bar renderer.
- `i18nMessages.ts` — `titleBar.pillHint*` strings (title-bar popups read from here, not `locales/*.json`).

**Breaking**

- None. Cloud onboarding / auto-launch is untouched; the hover-tooltip popup, its IPC channels, and render-ack protocol are unchanged (the coachmark shares the renderer but uses a separate cached view, disambiguated by webContents id).

## Review Focus

- The coachmark waits for `loading-lockdown` to clear (the existing firstUseMode pushed while a ProgressModal / connect takeover is up) so it fires only once the ComfyUI screen is visible, not over the brand loader. Reuses existing state — no new main-process signal.
- Deliberate non-extraction: `titleCoachmark.ts` and `titleTooltip.ts` already share `EmbeddedPopupView`; the remaining parallels are short and diverge in intent (sticky vs auto-hide, the tooltip's fast-path cache). They're siblings, not a hierarchy — no shared base class.
- Theme hex is hardcoded in the popup module (matching `titleTooltip.ts`'s `resolveTooltipTheme`): the popup renderer is a standalone `WebContentsView` with no app stylesheet.
- Scope is the coachmark only; the Cloud-first onboarding flow is intentionally left as-is (#701 is resolved indirectly by teaching the pill).

## Testing

Unit-level by design — the testable core (gate, once-ever persistence, anchoring, the loading-lockdown wait, pill highlight) is renderer/main logic with no cloud-auth dependency; an E2E would only re-exercise the existing onboarding flows.

- `useCentralPillCoachmark.test.ts` — gate (install-less / first-use / loading lockdown / already-seen), once-ever persist + idempotent dismiss, `isShowing` lifecycle, pill-open acknowledgement, bridge-undefined no-op.
- `titleCoachmark.test.ts` — `buildCoachmarkConfig` variant stamp, `positionCoachmark` centering + parent-bounds clamping.
- `TitleBarApp.test.ts` — shows on attach-after-mount, suppressed on install-less / already-seen, waits for loading-lockdown to clear, lifts the pill to `is-coachmark`.
- `pnpm typecheck` ✅ (node/web/e2e/integration) · `pnpm lint` ✅ · `pnpm test` ✅ 1681 passed (124 files).
- Manual: enter any instance on a fresh profile → coachmark appears under the pill once ComfyUI loads; ✕ / "Got it" / opening the drawer dismisses it; relaunch → does not reappear.

Screen Recording


https://github.com/user-attachments/assets/cdf66b4c-0130-4b63-b200-f7f0767c1902


Closes #701 
