### PR TITLE
feat(cloud): hide redundant "Download ComfyUI" CTA on cloud onboarding

### DIFF
--- a/src/main/host/attach.ts
+++ b/src/main/host/attach.ts
@@ -297,10 +297,7 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
         `if(!document.getElementById('__comfyDesktopHideDownloadCta')){` +
           `var st=document.createElement('style');` +
           `st.id='__comfyDesktopHideDownloadCta';` +
-          `st.textContent=` +
-            `'div.absolute.inset-0.flex.flex-col.justify-end.px-14.pb-\\\\[64px\\\\]'+` +
-            `':has(> .flex > .flex.items-center.gap-3){display:none !important}'+` +
-            `'[data-comfy-desktop-hide="download-cta"]{display:none !important}';` +
+          `st.textContent='[data-comfy-desktop-hide="download-cta"]{display:none !important}';` +
           `(document.head||document.documentElement).appendChild(st);` +
         `}` +
       `}catch(_){}` +
@@ -313,33 +310,54 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
         `var root=(n.closest&&n.closest('.p-toast-message,.p-toast-item,[role=alert]'))||n;` +
         `try{root.remove()}catch(_){}` +
       `}` +
-      `function tagDownloadCta(n){` +
-        `if(!n||n.nodeType!==1)return;` +
-        `var btns=(n.tagName==='BUTTON')?[n]:(n.querySelectorAll?n.querySelectorAll('button'):[]);` +
-        `for(var i=0;i<btns.length;i++){` +
-          `var b=btns[i];` +
-          `if(!b||(b.textContent||'').trim()!=='Download ComfyUI')continue;` +
-          `var host=(b.closest&&b.closest('div.absolute.inset-0.flex.flex-col.justify-end'))||b.parentElement;` +
-          `if(host&&host.setAttribute)host.setAttribute('data-comfy-desktop-hide','download-cta');` +
-        `}` +
-      `}` +
-      `tagDownloadCta(document.body);` +
-      `new MutationObserver(function(muts){` +
-        `for(var i=0;i<muts.length;i++){` +
-          `var added=muts[i].addedNodes;` +
-          `for(var j=0;j<added.length;j++){` +
-            `var n=added[j];` +
-            `if(looksBlocked(n)){nukeToast(n);continue;}` +
-            `if(n.querySelectorAll){` +
-              `var hits=n.querySelectorAll('*');` +
-              `for(var k=0;k<hits.length;k++){` +
-                `if(looksBlocked(hits[k])){nukeToast(hits[k]);break;}` +
-              `}` +
+      `function tagDownloadCta(){` +
+        `var els=document.querySelectorAll('button,a,[role="button"]');` +
+        `for(var i=0;i<els.length;i++){` +
+          `var el=els[i];` +
+          `if(!el)continue;` +
+          `var t=(el.textContent||'').trim().toLowerCase();` +
+          `if(t!=='download comfyui')continue;` +
+          `el.setAttribute('data-comfy-desktop-hide','download-cta');` +
+          `var cur=el.parentElement,tagged=false;` +
+          `while(cur&&cur!==document.body){` +
+            `var ct=(cur.textContent||'').toLowerCase();` +
+            `if(ct.indexOf('want to run')>=0&&ct.indexOf('comfyui')>=0){` +
+              `cur.setAttribute('data-comfy-desktop-hide','download-cta');` +
+              `tagged=true;break;` +
             `}` +
-            `tagDownloadCta(n);` +
+            `cur=cur.parentElement;` +
+          `}` +
+          `if(!tagged&&el.parentElement&&el.parentElement.setAttribute){` +
+            `el.parentElement.setAttribute('data-comfy-desktop-hide','download-cta');` +
           `}` +
         `}` +
-      `}).observe(document.documentElement,{childList:true,subtree:true});` +
+      `}` +
+      `tagDownloadCta();` +
+      `try{` +
+        `new MutationObserver(function(muts){` +
+          `for(var i=0;i<muts.length;i++){` +
+            `var added=muts[i].addedNodes;` +
+            `for(var j=0;j<added.length;j++){` +
+              `var n=added[j];` +
+              `if(looksBlocked(n)){nukeToast(n);continue;}` +
+              `if(n.querySelectorAll){` +
+                `var hits=n.querySelectorAll('*');` +
+                `for(var k=0;k<hits.length;k++){` +
+                  `if(looksBlocked(hits[k])){nukeToast(hits[k]);break;}` +
+                `}` +
+              `}` +
+            `}` +
+          `}` +
+          `tagDownloadCta();` +
+        `}).observe(document.documentElement,{childList:true,subtree:true});` +
+      `}catch(_){}` +
+      `try{` +
+        `var __ctaPolls=0;` +
+        `var __ctaPoll=setInterval(function(){` +
+          `tagDownloadCta();` +
+          `__ctaPolls++;if(__ctaPolls>60)clearInterval(__ctaPoll);` +
+        `},500);` +
+      `}catch(_){}` +
     `})()`
 
   const onDomReady = (): void => {

--- a/src/main/host/attach.ts
+++ b/src/main/host/attach.ts
@@ -253,7 +253,7 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
     `})()`
 
   /**
-   * Two cloud-only patches injected on every dom-ready of the comfy view:
+   * Three cloud-only patches injected on every dom-ready of the comfy view:
    *
    *   1. popup-blocked toast suppressor — observes new toast DOM nodes
    *      and removes any that mention `auth/popup-blocked`. That error
@@ -267,6 +267,21 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
    *      script hides documentElement for ~1s on the next load so the
    *      user doesn't see the cloud login page flash before the
    *      Firebase rehydrate redirects to the workspace.
+   *
+   *   3. cloud-onboarding "Download ComfyUI" CTA hider — desktop users
+   *      who hit the cloud onboarding screen see a bottom-right CTA
+   *      ("Want to run ComfyUI locally instead? — Download ComfyUI")
+   *      pointing at comfy.org/download. They already have desktop;
+   *      the link is redundant + confusing. We inject a <style> with
+   *      a :has() rule keyed on the CloudTemplate.vue container's
+   *      Tailwind class chain (CSS-only path — no race vs SPA
+   *      hydration since the rule matches continuously). The
+   *      MutationObserver below also tags any <button> with the
+   *      literal text "Download ComfyUI" via data-comfy-desktop-hide,
+   *      which the same stylesheet hides — that's the text-based
+   *      fallback for when the class chain shifts build-to-build.
+   *      TODO(desktop band-aid): remove once Comfy-Org/ComfyUI_frontend
+   *      PR <link-here> lands (conditional skip when running in desktop).
    */
   const COMFY_CLOUD_PATCHES_JS =
     `(function(){` +
@@ -278,6 +293,17 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
           `setTimeout(function(){de.style.visibility=''},1000);` +
         `}` +
       `}catch(_){}` +
+      `try{` +
+        `if(!document.getElementById('__comfyDesktopHideDownloadCta')){` +
+          `var st=document.createElement('style');` +
+          `st.id='__comfyDesktopHideDownloadCta';` +
+          `st.textContent=` +
+            `'div.absolute.inset-0.flex.flex-col.justify-end.px-14.pb-\\\\[64px\\\\]'+` +
+            `':has(> .flex > .flex.items-center.gap-3){display:none !important}'+` +
+            `'[data-comfy-desktop-hide="download-cta"]{display:none !important}';` +
+          `(document.head||document.documentElement).appendChild(st);` +
+        `}` +
+      `}catch(_){}` +
       `function looksBlocked(n){` +
         `if(!n||n.nodeType!==1)return false;` +
         `var t=(n.textContent||'').toLowerCase();` +
@@ -287,6 +313,17 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
         `var root=(n.closest&&n.closest('.p-toast-message,.p-toast-item,[role=alert]'))||n;` +
         `try{root.remove()}catch(_){}` +
       `}` +
+      `function tagDownloadCta(n){` +
+        `if(!n||n.nodeType!==1)return;` +
+        `var btns=(n.tagName==='BUTTON')?[n]:(n.querySelectorAll?n.querySelectorAll('button'):[]);` +
+        `for(var i=0;i<btns.length;i++){` +
+          `var b=btns[i];` +
+          `if(!b||(b.textContent||'').trim()!=='Download ComfyUI')continue;` +
+          `var host=(b.closest&&b.closest('div.absolute.inset-0.flex.flex-col.justify-end'))||b.parentElement;` +
+          `if(host&&host.setAttribute)host.setAttribute('data-comfy-desktop-hide','download-cta');` +
+        `}` +
+      `}` +
+      `tagDownloadCta(document.body);` +
       `new MutationObserver(function(muts){` +
         `for(var i=0;i<muts.length;i++){` +
           `var added=muts[i].addedNodes;` +
@@ -299,6 +336,7 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
                 `if(looksBlocked(hits[k])){nukeToast(hits[k]);break;}` +
               `}` +
             `}` +
+            `tagDownloadCta(n);` +
           `}` +
         `}` +
       `}).observe(document.documentElement,{childList:true,subtree:true});` +


### PR DESCRIPTION
## Summary

Temporary desktop-side band-aid to hide the bottom-right "Want to run ComfyUI locally instead? — Download ComfyUI" CTA that the cloud frontend's `CloudTemplate.vue` renders on the onboarding screen. Desktop users already have desktop; the CTA is redundant and confusing.

## Seam

Extends the existing `COMFY_CLOUD_PATCHES_JS` constant in `src/main/host/attach.ts` — the cloud-only `executeJavaScript` block already wired to fire on every `dom-ready` of the comfy webview (skipped for `isLocal` installs). No new injection points, no broadening of scope.

## Strategy: CSS-first, with a text-based fallback

CSS-only via injected `<style>` element. Two rules:

1. **Structural selector** keyed on `CloudTemplate.vue`'s class chain:
   ```css
   div.absolute.inset-0.flex.flex-col.justify-end.px-14.pb-\[64px\]
     :has(> .flex > .flex.items-center.gap-3) { display: none !important; }
   ```
   Hides the CTA-wrapper as soon as it mounts. CSS-only avoids any race with SPA hydration — the rule matches continuously, regardless of when the renderer paints.

2. **Text-based fallback** — the existing `MutationObserver` also walks added nodes for any `<button>` whose `textContent.trim() === 'Download ComfyUI'`, tags its closest CTA-container ancestor with `data-comfy-desktop-hide="download-cta"`, and a second CSS rule hides anything carrying that attribute. Covers build-to-build Tailwind class drift.

Picked CSS over a JS scan because the wrapper is well-anchored by its Tailwind classes and `:has()` is supported in the bundled Chromium; the JS path is just belt-and-suspenders for class drift.

## Out of scope / follow-up

Proper conditional skip in `Comfy-Org/ComfyUI_frontend` (`CloudTemplate.vue` detects desktop and omits the CTA) is going up in parallel. The TODO comment in `attach.ts` flags the band-aid + leaves a placeholder for that PR link.

## Constraints

- Touches **only** `src/main/host/attach.ts`.
- Cloud-only — gated by the existing `if (!isLocal)` in `onDomReady`.
- Repo just renamed to `Comfy-Org/Comfy-Desktop` — using the new slug here.

## Test plan

- [x] `pnpm typecheck` — green
- [x] `pnpm lint` — green
- [ ] Manual: launch desktop, sign into cloud onboarding, confirm the bottom-right "Want to run ComfyUI locally instead? / Download ComfyUI" row no longer renders. Confirm the rest of the cloud onboarding UI is unaffected.
- [ ] Manual: confirm a local install still shows the CTA-less view (the patch is correctly gated by `!isLocal` — should be unchanged for local).