### PR TITLE
fix(telemetry): allow consent_decision event to fire after 'denied' state flip

### DIFF
--- a/src/main/lib/telemetry.test.ts
+++ b/src/main/lib/telemetry.test.ts
@@ -335,15 +335,28 @@ describe('telemetry consent state (3-state)', () => {
     expect(events).toEqual(['desktop2.first_use.consent_decision'])
   })
 
-  it('denied suppresses every event including the consent_decision one', async () => {
+  it('denied suppresses everything EXCEPT the consent_decision allow-list entry', async () => {
+    // Regression for the 2026-06-03 finding: 232 accepts and 0 declines in
+    // 30 days, traced to the renderer's "Continue" handler awaiting the
+    // setting write (which flips state to 'denied') BEFORE emitting the
+    // decline event. If denied short-circuits without consulting the
+    // allow-list, every decline is dropped by its own decision and we
+    // lose 100% of decline signal.
     telemetry.setConsentState('denied')
     telemetry.identify('test-distinct-id')
     captured.length = 0
 
     telemetry.capture('desktop2.execution.started', {})
-    telemetry.capture('desktop2.first_use.consent_decision', { accepted: false })
+    telemetry.capture('desktop2.first_use.consent_decision', {
+      decision: 'decline',
+      telemetry_enabled: false
+    })
 
-    expect(captured).toHaveLength(0)
+    expect(captured.map((c) => c.event)).toEqual(['desktop2.first_use.consent_decision'])
+    expect(captured[0]?.properties).toMatchObject({
+      decision: 'decline',
+      telemetry_enabled: false
+    })
   })
 
   it('defers session.started + identify person properties until consent flips to granted', async () => {

--- a/src/main/lib/telemetry.ts
+++ b/src/main/lib/telemetry.ts
@@ -239,15 +239,28 @@ function deriveAppChannel(appVersion: string): string {
  * Three-state consent.
  *
  * - `'granted'` — user opted in. Everything ships.
- * - `'denied'` — user opted out. Nothing ships.
+ * - `'denied'` — user opted out. Nothing ships, EXCEPT the
+ *   `PRE_CONSENT_ALLOWED_EVENTS` set — see the next paragraph for why.
  * - `'undecided'` — user has not chosen yet (fresh install OR a Desktop-1
- * migrator whose `telemetryEnabled` setting was never set).
- * Only events in `PRE_CONSENT_ALLOWED_EVENTS` ship; everything
- * else is suppressed until the user makes a choice. Mirrors
- * the renderer's pre-consent gate in `rendererBootstrap.ts`.
+ *   migrator whose `telemetryEnabled` setting was never set).
+ *   Only events in `PRE_CONSENT_ALLOWED_EVENTS` ship; everything
+ *   else is suppressed until the user makes a choice. Mirrors
+ *   the renderer's pre-consent gate in `rendererBootstrap.ts`.
+ *
+ * **Why `PRE_CONSENT_ALLOWED_EVENTS` survive `'denied'`**: the consent
+ * decision event itself races the state flip. The renderer's "Continue"
+ * handler in `FirstUseTakeover.vue` awaits the telemetryEnabled setting
+ * write (which propagates to `setConsentState('denied')` here) and only
+ * then calls `emitTelemetryAction('first_use.consent_decision', { decision: 'decline' })`.
+ * If `isAllowedToFire` short-circuited on `'denied'` without consulting the
+ * allow-list, every decline would be dropped — meaning we'd have 100%
+ * accept-rate signal and zero ability to measure decline. The allow-list
+ * is intentionally the FIRST check so the decision event survives the
+ * exact state it triggers.
  *
  * Default at module load is `'undecided'`: if `setConsentState` is never
- * called (test paths, mis-wired boot), we fail closed.
+ * called (test paths, mis-wired boot), we fail closed for everything that
+ * isn't in the allow-list.
  */
 export type ConsentState = 'granted' | 'denied' | 'undecided'
 
@@ -258,9 +271,13 @@ const PRE_CONSENT_ALLOWED_EVENTS: ReadonlySet<string> = new Set([
 ])
 
 function isAllowedToFire(event: string): boolean {
+  // Allow-list takes precedence over every state, including 'denied'.
+  // See the ConsentState docstring above for the full reasoning — short
+  // version: the consent decision event races the 'denied' state flip
+  // and would otherwise be dropped by its own decision.
+  if (PRE_CONSENT_ALLOWED_EVENTS.has(event)) return true
   if (consentState === 'granted') return true
-  if (consentState === 'denied') return false
-  return PRE_CONSENT_ALLOWED_EVENTS.has(event)
+  return false
 }
 
 /**


### PR DESCRIPTION
## Why

PostHog data over the last 30 days:
- 232 users fired \`desktop2.first_use.consent_decision\` with \`decision='accept'\`
- **0 users fired it with \`decision='decline'\`**

That's not the user population — it's a code bug. Trace:

\`\`\`ts
// renderer/src/views/FirstUseTakeover.vue
await window.api.setSetting('telemetryEnabled', false)
//     ↑ awaits the write; main flips setConsentState('denied') before line 2 runs
emitTelemetryAction('desktop2.first_use.consent_decision', { decision: 'decline', ... })
//     ↑ IPC reaches main, capture() → isAllowedToFire()
\`\`\`

\`isAllowedToFire\` (pre-fix):
\`\`\`ts
if (consentState === 'granted') return true
if (consentState === 'denied') return false   // ← drops decline event
return PRE_CONSENT_ALLOWED_EVENTS.has(event)
\`\`\`

So every decline was dropped by its own decision.

## Fix

Consult the allow-list FIRST:

\`\`\`ts
if (PRE_CONSENT_ALLOWED_EVENTS.has(event)) return true
if (consentState === 'granted') return true
return false
\`\`\`

The renderer's pre-consent gate already treats the allow-list as "always fires" — main's gate now agrees. One-line semantic fix.

## Tests

Updated \`'denied suppresses every event including the consent_decision one'\` (which pinned the bug) to assert the correct contract: decline event survives the state it triggers, with \`decision='decline'\` and \`telemetry_enabled=false\` intact.

- 1744 / 1744 tests pass
- typecheck + lint + prettier clean

## Impact

Unblocks the "Consent decision (30d)" tile on [Launch HUD](https://us.posthog.com/project/204330/dashboard/1660520), which until now showed only accepts and was actively misleading.