### PR TITLE
fix(install): release dropdown surfaces IPP channels instead of per-bundle tags

### DIFF
--- a/src/main/sources/standalone/index.test.ts
+++ b/src/main/sources/standalone/index.test.ts
@@ -74,41 +74,43 @@ describe('standalone.buildInstallation', () => {
     } as unknown as Record<string, unknown>,
   })
 
-  it('sets autoUpdateComfyUI when release value is "latest"', () => {
+  it('Stable: sets autoUpdateComfyUI (post-install update-to-stable), updateChannel left undefined', () => {
     const result = standalone.buildInstallation({
-      release: makeRelease('latest', 'v0.18.2-env1'),
+      release: makeRelease('stable', 'v0.18.2-env1'),
       variant: makeVariant(VENDOR_ID),
     })
     expect(result.autoUpdateComfyUI).toBe(true)
+    // updateChannel stays falsy: `getEffectiveChannel` defaults to
+    // 'stable' so the IPP picker still opens on Stable.
+    expect(result.updateChannel).toBeUndefined()
   })
 
-  it('does NOT set autoUpdateComfyUI for a specific release tag', () => {
-    const result = standalone.buildInstallation({
-      release: makeRelease('v0.18.2-env1'),
-      variant: makeVariant(VENDOR_ID),
-    })
-    expect(result.autoUpdateComfyUI).toBeUndefined()
-  })
-
-  it('uses r2Release tag as releaseTag when "latest" is selected', () => {
+  it('Latest on GitHub: persists updateChannel="latest", no autoUpdate', () => {
     const result = standalone.buildInstallation({
       release: makeRelease('latest', 'v0.18.2-env1'),
       variant: makeVariant(VENDOR_ID),
     })
-    expect(result.releaseTag).toBe('v0.18.2-env1')
+    expect(result.autoUpdateComfyUI).toBeUndefined()
+    // Persisted so the IPP Update tab opens on Latest on GitHub.
+    expect(result.updateChannel).toBe('latest')
   })
 
-  it('uses the release value directly as releaseTag for specific releases', () => {
-    const result = standalone.buildInstallation({
-      release: makeRelease('v0.18.2-env1'),
+  it('uses r2Release tag as releaseTag for both channels', () => {
+    const stable = standalone.buildInstallation({
+      release: makeRelease('stable', 'v0.18.2-env1'),
       variant: makeVariant(VENDOR_ID),
     })
-    expect(result.releaseTag).toBe('v0.18.2-env1')
+    const latest = standalone.buildInstallation({
+      release: makeRelease('latest', 'v0.18.2-env1'),
+      variant: makeVariant(VENDOR_ID),
+    })
+    expect(stable.releaseTag).toBe('v0.18.2-env1')
+    expect(latest.releaseTag).toBe('v0.18.2-env1')
   })
 
   it('freezes originalBuild and originalTorchVersion from r2Release on the installation', () => {
     const result = standalone.buildInstallation({
-      release: makeRelease('v0.18.2-env1'),
+      release: makeRelease('stable', 'v0.18.2-env1'),
       variant: makeVariant(VENDOR_ID),
     })
     expect(result.originalBuild).toBe(1)
@@ -132,51 +134,42 @@ describe('standalone.getFieldOptions release', () => {
     })
   }
 
-  it('includes "Latest Stable" when includeLatestStable is true', async () => {
+  it('returns exactly the two IPP channel options (Stable + Latest on GitHub)', async () => {
     setupMockReleases()
     const options = await standalone.getFieldOptions!('release', {}, { includeLatestStable: true })
-    expect(options[0]!.value).toBe('latest')
+    // No per-tag entries — only the two channel options surface, in
+    // the same order + with the same value ids the IPP Update tab uses.
+    expect(options.length).toBe(2)
+    expect(options[0]!.value).toBe('stable')
     expect(options[0]!.recommended).toBe(true)
-    // Real releases follow
-    expect(options[1]!.value).toBe('v0.18.3-env1')
-    expect(options[2]!.value).toBe('v0.18.2-env1')
+    expect(options[1]!.value).toBe('latest')
+    expect(options[1]!.recommended).toBeUndefined()
   })
 
-  it('excludes "Latest Stable" by default (no context flag)', async () => {
+  it('returns no options when includeLatestStable is omitted', async () => {
     setupMockReleases()
     const options = await standalone.getFieldOptions!('release', {}, {})
-    expect(options.every((o) => o.value !== 'latest')).toBe(true)
-    expect(options[0]!.value).toBe('v0.18.3-env1')
+    expect(options).toEqual([])
   })
 
-  it('excludes "Latest Stable" when includeLatestStable is false', async () => {
-    setupMockReleases()
-    const options = await standalone.getFieldOptions!('release', {}, { includeLatestStable: false })
-    expect(options.every((o) => o.value !== 'latest')).toBe(true)
-  })
-
-  it('"Latest Stable" entry uses the newest release tag', async () => {
+  it('both entries point data.tag at the newest available bundle', async () => {
     setupMockReleases()
     const options = await standalone.getFieldOptions!('release', {}, { includeLatestStable: true })
-    const latestEntry = options.find((o) => o.value === 'latest')!
-    const underlyingData = latestEntry.data as Record<string, unknown>
-    expect(underlyingData.tag).toBe('v0.18.3-env1')
+    const stableData = options.find((o) => o.value === 'stable')!.data as Record<string, unknown>
+    const latestData = options.find((o) => o.value === 'latest')!.data as Record<string, unknown>
+    expect(stableData.tag).toBe('v0.18.3-env1')
+    expect(latestData.tag).toBe('v0.18.3-env1')
   })
 
-  it('"Latest Stable" entry shows the upstream ComfyUI tag in description when resolved', async () => {
+  it('Stable entry threads the upstream stable tag through data.latestStableTag', async () => {
+    // The variant card reads `data.latestStableTag` to show the version
+    // the user lands on after post-install update — that survived the
+    // IPP-label cleanup so issue #708 stays fixed.
     setupMockReleases()
     mockedGetLatestStableTag.mockResolvedValue('v1.19.5')
     const options = await standalone.getFieldOptions!('release', {}, { includeLatestStable: true })
-    const latestEntry = options.find((o) => o.value === 'latest')!
-    expect(latestEntry.description).toBe('v1.19.5')
-  })
-
-  it('"Latest Stable" entry omits description when the tag lookup fails', async () => {
-    setupMockReleases()
-    mockedGetLatestStableTag.mockResolvedValue(null)
-    const options = await standalone.getFieldOptions!('release', {}, { includeLatestStable: true })
-    const latestEntry = options.find((o) => o.value === 'latest')!
-    expect(latestEntry.description).toBeUndefined()
+    const stableData = options.find((o) => o.value === 'stable')!.data as Record<string, unknown>
+    expect(stableData.latestStableTag).toBe('v1.19.5')
   })
 })
 
@@ -307,10 +300,10 @@ describe('standalone.getFieldOptions variant version display', () => {
     return releaseOptions.find((o) => o.value === value)!
   }
 
-  it('variant card shows the upstream stable version (not the bundled one) when "Latest Stable" is selected', async () => {
+  it('variant card shows the upstream stable version (not the bundled one) when "Stable" is selected', async () => {
     const { vendorId } = setupVersionGap()
     mockedGetLatestStableTag.mockResolvedValue('v0.22.3')
-    const release = await getReleaseOption('latest')
+    const release = await getReleaseOption('stable')
 
     const variants = await standalone.getFieldOptions!('variant', { release }, {})
     const card = variants.find((o) => o.value === vendorId)!
@@ -322,21 +315,23 @@ describe('standalone.getFieldOptions variant version display', () => {
   it('variant card falls back to the bundled version when the upstream tag is unresolved', async () => {
     const { vendorId } = setupVersionGap()
     mockedGetLatestStableTag.mockResolvedValue(null)
-    const release = await getReleaseOption('latest')
+    const release = await getReleaseOption('stable')
 
     const variants = await standalone.getFieldOptions!('variant', { release }, {})
     const card = variants.find((o) => o.value === vendorId)!
     expect(card.description).toContain('ComfyUI 0.20.1')
   })
 
-  it('variant card shows the bundled version for a pinned (non-latest) release', async () => {
+  it('variant card shows the bundled version when "Latest on GitHub" is selected', async () => {
     const { vendorId } = setupVersionGap()
     mockedGetLatestStableTag.mockResolvedValue('v0.22.3')
-    const release = await getReleaseOption('v0.20.1-env1')
+    const release = await getReleaseOption('latest')
 
     const variants = await standalone.getFieldOptions!('variant', { release }, {})
     const card = variants.find((o) => o.value === vendorId)!
-    // Pinned releases legitimately show the version baked into that env.
+    // Latest-on-GitHub leaves the install on whatever the bundle
+    // shipped with (master-ish HEAD); the card advertises that, not
+    // the stable tag the OTHER channel would land on.
     expect(card.description).toContain('ComfyUI 0.20.1')
   })
 })

--- a/src/main/sources/standalone/index.ts
+++ b/src/main/sources/standalone/index.ts
@@ -93,6 +93,12 @@ export const standalone: SourcePlugin = {
     const r2Release = vd?.r2Release
     const variantId = vd?.variantId || ''
     const isCpu = stripPlatform(variantId) === 'cpu' || stripPlatform(variantId).startsWith('cpu-')
+    // The release dropdown values now match the IPP channel ids:
+    // 'stable' triggers the post-install update-to-stable step;
+    // 'latest' (master HEAD) leaves the bundle's checked-in commit
+    // alone and only persists `updateChannel` so the IPP Update tab
+    // opens on the picked channel.
+    const isStable = selections.release?.value === 'stable'
     const isLatest = selections.release?.value === 'latest'
     const releaseTag = r2Release?.tag || (selections.release?.value || 'unknown')
     return {
@@ -112,7 +118,8 @@ export const standalone: SourcePlugin = {
       launchArgs: isCpu ? `${DEFAULT_LAUNCH_ARGS} --cpu` : DEFAULT_LAUNCH_ARGS,
       launchMode: 'window',
       browserPartition: 'unique',
-      ...(isLatest ? { autoUpdateComfyUI: true } : {}),
+      ...(isStable ? { autoUpdateComfyUI: true } : {}),
+      ...(isLatest ? { updateChannel: 'latest' } : {}),
     }
   },
 
@@ -285,32 +292,34 @@ export const standalone: SourcePlugin = {
 
       const options: FieldOption[] = []
 
-      // Synthetic "Latest Stable" entry.  Resolve the upstream ComfyUI tag
-      // (e.g. `v1.19.5`) via bootstrap pygit2 so users can see the concrete
-      // version they'll be installing.  Falls back to no description when
-      // the lookup fails (offline, pygit2 unavailable, etc.).
+      // Same two channel options the IPP Update tab uses (see
+      // `getChannelDefs()` in `./updateSections.ts`). 'stable' is
+      // recommended and triggers the post-install update-to-stable
+      // step. 'latest' (master HEAD) leaves the bundle's checked-in
+      // commit alone — the user can fast-forward from the IPP Update
+      // tab. Per-bundle-tag entries (v0.20.1-env1, etc.) were dropped
+      // at the same time; they exposed an implementation detail
+      // (the R2 bundle tag) instead of the channel users actually
+      // care about.
       if (tags.length > 0 && context?.includeLatestStable) {
         const latestStableTag = await getLatestStableTag()
+        const newestBundle = tags[0]!
         options.push({
-          value: 'latest',
-          label: t('standalone.latestVersion'),
-          ...(latestStableTag ? { description: latestStableTag } : {}),
+          value: 'stable',
+          label: t('standalone.channelStable'),
+          description: t('standalone.channelStableDesc'),
           recommended: true,
           // `latestStableTag` is the upstream ComfyUI version the post-install
-          // "update to stable" step resolves to (and what the dropdown advertises).
-          // Thread it through so the variant cards show that same version rather
-          // than the older ComfyUI baked into the standalone bundle — otherwise
-          // the two surfaces disagree (issue #708).
-          data: { tag: tags[0]!.tag, vendorReleases, latestStableTag } as unknown as Record<string, unknown>,
+          // "update to stable" step resolves to. Thread it through so the
+          // variant cards show that same version rather than the older
+          // ComfyUI baked into the standalone bundle (issue #708).
+          data: { tag: newestBundle.tag, vendorReleases, latestStableTag } as unknown as Record<string, unknown>,
         })
-      }
-
-      for (const entry of tags) {
-        const dateStr = entry.date.slice(0, 10)
         options.push({
-          value: entry.tag,
-          label: `${entry.tag}  —  ComfyUI ${entry.comfyui_version}  ·  ${dateStr}`,
-          data: { tag: entry.tag, vendorReleases } as unknown as Record<string, unknown>,
+          value: 'latest',
+          label: t('standalone.channelLatest'),
+          description: t('standalone.channelLatestDesc'),
+          data: { tag: newestBundle.tag, vendorReleases } as unknown as Record<string, unknown>,
         })
       }
       return options
@@ -322,15 +331,13 @@ export const standalone: SourcePlugin = {
       const prefix = PLATFORM_PREFIX[process.platform]
       if (!prefix) return []
 
-      const isLatest = selections.release?.value === 'latest'
+      const isStable = selections.release?.value === 'stable'
       const gpu = context?.gpu as string | undefined
 
       return Object.entries(releaseData.vendorReleases)
         .filter(([vendorId]) => vendorId.startsWith(prefix))
         .map(([vendorId, releases]): FieldOption | null => {
-          const release = isLatest
-            ? releases[0]
-            : releases.find((r) => r.tag === releaseData.tag)
+          const release = releases[0]
           if (!release) return null
 
           const sizeMB = (release.size / 1048576).toFixed(0)
@@ -339,14 +346,14 @@ export const standalone: SourcePlugin = {
             filename: release.file,
             size: release.size,
           }]
-          // For "Latest Stable", the card must advertise the version the user
+          // For Stable, the card must advertise the version the user
           // ends up with after post-install auto-update (the upstream stable
-          // tag the dropdown shows), not the older ComfyUI bundled in the R2
-          // standalone build. Strip a leading `v` to match the bare-version
-          // card format (`ComfyUI 0.22.3`). Falls back to the bundled version
-          // when the upstream tag couldn't be resolved (offline, etc.).
+          // tag), not the older ComfyUI bundled in the R2 standalone build.
+          // Strip a leading `v` to match the bare-version card format
+          // (`ComfyUI 0.22.3`). Falls back to the bundled version when the
+          // upstream tag couldn't be resolved (offline, etc.).
           const displayVersion =
-            isLatest && releaseData.latestStableTag
+            isStable && releaseData.latestStableTag
               ? releaseData.latestStableTag.replace(/^v/, '')
               : release.comfyui_version
           return {


### PR DESCRIPTION
## Summary
The New Install wizard's Release dropdown was listing every R2 standalone bundle tag (e.g. `v0.20.1-env1 — ComfyUI v0.20.1 · 2026-05-07`) alongside the synthetic "Latest Stable" entry. That asks users the wrong question — they care about *stable vs. master*, not which dated bundle artefact gets unpacked.

This PR drops the per-tag loop and surfaces the same two channel options the IPP Update tab already exposes via `getChannelDefs()` in `src/main/sources/standalone/updateSections.ts`:

- **Stable** (recommended) — *Tested releases, recommended for most users*
- **Latest on GitHub** — *Newest commits from the master branch*

Same value ids (`'stable'` / `'latest'`), same labels (`standalone.channelStable` / `standalone.channelLatest`), same descriptions. No new install-time UX vocabulary.

## Behaviour matrix

| Pick | `autoUpdateComfyUI` | `updateChannel` | Post-install | IPP Update tab opens on |
|---|---|---|---|---|
| Stable | `true` | (unset) | Runs existing update-to-stable | Stable (via `getEffectiveChannel` default) |
| Latest on GitHub | (unset) | `'latest'` | Skipped — bundle stays on shipped commit | Latest on GitHub |

The `Latest on GitHub` path intentionally skips the post-install update step — the user can fast-forward to master from the IPP Update tab, which now opens on the correct channel because `updateChannel` is persisted at install time. No changes to `install.ts`.

## Variant card display (issue #708 preserved)
The variant card's "upstream stable version" gate switched from `isLatest` to `isStable`. Stable still shows the version the user lands on after post-install update (e.g. `ComfyUI 0.22.3`); Latest on GitHub shows the bundle's checked-in version (e.g. `ComfyUI 0.20.1`).

## Tests
`src/main/sources/standalone/index.test.ts` — 18/18 green. Updated:
- `buildInstallation` tests for both channel ids.
- `getFieldOptions('release')` tests assert exactly the two IPP options, in IPP order, with `data.tag` pointing at the newest bundle for both.
- Variant-card upstream-tag tests switched to the `'stable'` selection.
- Per-tag dropdown tests deleted (the option no longer exists).

`pnpm run typecheck` clean across web / e2e / integration. `pnpm exec eslint src/main/sources/standalone/` clean.
