### PR TITLE
fix(ui): make folder-picker fields browse-only (no typing)

### DIFF
--- a/src/main/popups/titlePopup.ts
+++ b/src/main/popups/titlePopup.ts
@@ -1967,7 +1967,11 @@ function toDetailField(
     placeholder: f.placeholder,
     min: f.min,
     max: f.max,
-    openable: f.openable
+    openable: f.openable,
+    // SettingsField `path` always means "folder picker" — the value
+    // must come from the native dialog so it can be validated. Renderer
+    // honors `browseOnly` to lock the text input as read-only.
+    browseOnly: editType === 'path' ? true : undefined
   }
 }
 

--- a/src/main/sources/common/launchSettingsFields.ts
+++ b/src/main/sources/common/launchSettingsFields.ts
@@ -49,13 +49,15 @@ export function buildStorageFields(installation: InstallationRecord): Record<str
     {
       id: 'inputDir', label: t('common.perInstallInputDir'),
       value: (installation.inputDir as string | undefined) ?? '',
-      editable: true, editType: 'path', tooltip: t('tooltips.perInstallInputDir'),
+      editable: true, editType: 'path', browseOnly: true,
+      tooltip: t('tooltips.perInstallInputDir'),
       requiresRestart: true,
     },
     {
       id: 'outputDir', label: t('common.perInstallOutputDir'),
       value: (installation.outputDir as string | undefined) ?? '',
-      editable: true, editType: 'path', tooltip: t('tooltips.perInstallOutputDir'),
+      editable: true, editType: 'path', browseOnly: true,
+      tooltip: t('tooltips.perInstallOutputDir'),
       requiresRestart: true,
     },
   ]

--- a/src/main/sources/git.ts
+++ b/src/main/sources/git.ts
@@ -177,7 +177,7 @@ export const gitSource: SourcePlugin = {
           { label: t('git.repository'), value: (installation.repo as string) || '—' },
           { label: t('git.branch'), value: (installation.branch as string) || '—' },
           { label: t('git.commit'), value: (installation.commit as string) || '—' },
-          { id: 'venvPath', label: t('git.venv'), value: venvPath || '', editable: true, editType: 'path' },
+          { id: 'venvPath', label: t('git.venv'), value: venvPath || '', editable: true, editType: 'path', browseOnly: true },
           { label: t('common.location'), value: installation.installPath || '—' },
           { label: t('common.installed'), value: new Date(installation.createdAt).toLocaleDateString() },
         ],
@@ -188,7 +188,7 @@ export const gitSource: SourcePlugin = {
         fields: buildLaunchSettingsFields(installation, {
           defaultLaunchArgs: DEFAULT_LAUNCH_ARGS,
           extraFields: [
-            { id: 'venvPath', label: t('git.venv'), value: venvPath || '', editable: true, editType: 'path' },
+            { id: 'venvPath', label: t('git.venv'), value: venvPath || '', editable: true, editType: 'path', browseOnly: true },
           ],
         }),
       },

--- a/src/renderer/src/components/InstallNamePath.vue
+++ b/src/renderer/src/components/InstallNamePath.vue
@@ -42,7 +42,7 @@ defineEmits<{
         id="inst-path"
         :value="path"
         type="text"
-        @input="$emit('update:path', ($event.target as HTMLInputElement).value)"
+        readonly
       />
       <button @click="$emit('browse')">{{ $t('common.browse') }}</button>
       <button

--- a/src/renderer/src/views/InstallWizardModal.vue
+++ b/src/renderer/src/views/InstallWizardModal.vue
@@ -721,8 +721,8 @@ defineExpose({ open })
                     id="inst-path"
                     :value="instPath"
                     type="text"
+                    readonly
                     :disabled="!!currentSource?.skipInstall"
-                    @input="instPath = ($event.target as HTMLInputElement).value"
                   />
                 </div>
                 <button

--- a/src/renderer/src/views/TrackModal.test.ts
+++ b/src/renderer/src/views/TrackModal.test.ts
@@ -6,10 +6,10 @@ import TrackModal from './TrackModal.vue'
 import type { ProbeResult } from '../types/ipc'
 
 /**
- * Regression harness for #726 — pasting/typing a path into the Install
- * Directory field must auto-probe and enable the "Track Install" button.
- * Previously `probe()` was wired only to the Browse button, so a pasted
- * path left `selectedProbe` null and the primary button stayed disabled.
+ * The Install Directory field is browse-only: typing/pasting must not
+ * change it. The only way to populate it is the Browse button, which
+ * runs the probe and enables the "Track Install" button when an
+ * existing install is detected.
  */
 
 // Minimal catalog covering the keys the template reads. Missing keys fall
@@ -93,80 +93,66 @@ function trackButton(wrapper: ReturnType<typeof mountTrack>) {
   return wrapper.get('button.track-save')
 }
 
-describe('TrackModal — pasted-path probing (#726)', () => {
+describe('TrackModal — browse-only install directory', () => {
   beforeEach(() => {
-    vi.useFakeTimers()
     installMockApi()
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     vi.restoreAllMocks()
   })
 
-  it('probes and enables Track Install when a path is pasted into the field', async () => {
+  it('renders the install-directory input as readonly', async () => {
+    const wrapper = mountTrack()
+    ;(wrapper.vm as unknown as { open: () => void }).open()
+    await flushPromises()
+
+    const input = wrapper.get('#track-path')
+    expect(input.attributes('readonly')).toBeDefined()
+  })
+
+  it('does not probe when the user attempts to type into the field', async () => {
     const api = installMockApi()
+    const wrapper = mountTrack()
+    ;(wrapper.vm as unknown as { open: () => void }).open()
+    await flushPromises()
+
+    // Programmatically dispatch an input event — readonly prevents real
+    // keyboard input but a stray input dispatch must not reach probe().
+    await wrapper.get('#track-path').trigger('input')
+    await flushPromises()
+
+    expect(api.probeInstallation).not.toHaveBeenCalled()
+    expect(trackButton(wrapper).attributes('disabled')).toBeDefined()
+  })
+
+  it('probes and enables Track Install when a folder is picked via Browse', async () => {
+    const api = installMockApi({
+      browseFolder: vi.fn().mockResolvedValue('/Users/jo/ComfyUI'),
+    })
     const wrapper = mountTrack()
     ;(wrapper.vm as unknown as { open: () => void }).open()
     await flushPromises()
 
     expect(trackButton(wrapper).attributes('disabled')).toBeDefined()
 
-    // Simulate a paste: v-model updates trackPath via the input event.
-    await wrapper.get('#track-path').setValue('/Users/jo/ComfyUI')
-
-    // Debounced — no probe before the timer fires.
-    expect(api.probeInstallation).not.toHaveBeenCalled()
-    await vi.advanceTimersByTimeAsync(300)
+    await wrapper.get('button.brand-tertiary').trigger('click')
     await flushPromises()
 
     expect(api.probeInstallation).toHaveBeenCalledWith('/Users/jo/ComfyUI')
     expect(trackButton(wrapper).attributes('disabled')).toBeUndefined()
   })
 
-  it('trims trailing whitespace from a pasted path before probing', async () => {
-    const api = installMockApi()
+  it('keeps Track Install disabled when no install is detected at the picked folder', async () => {
+    const api = installMockApi({
+      browseFolder: vi.fn().mockResolvedValue('/tmp/not-comfy'),
+      probeInstallation: vi.fn().mockResolvedValue([]),
+    })
     const wrapper = mountTrack()
     ;(wrapper.vm as unknown as { open: () => void }).open()
     await flushPromises()
 
-    await wrapper.get('#track-path').setValue('  /Users/jo/ComfyUI  ')
-    await vi.advanceTimersByTimeAsync(300)
-    await flushPromises()
-
-    expect(api.probeInstallation).toHaveBeenCalledWith('/Users/jo/ComfyUI')
-    expect(trackButton(wrapper).attributes('disabled')).toBeUndefined()
-  })
-
-  it('keeps the button disabled and clears results when the path is emptied', async () => {
-    const api = installMockApi()
-    const wrapper = mountTrack()
-    ;(wrapper.vm as unknown as { open: () => void }).open()
-    await flushPromises()
-
-    await wrapper.get('#track-path').setValue('/Users/jo/ComfyUI')
-    await vi.advanceTimersByTimeAsync(300)
-    await flushPromises()
-    expect(trackButton(wrapper).attributes('disabled')).toBeUndefined()
-
-    await wrapper.get('#track-path').setValue('')
-    await flushPromises()
-    expect(trackButton(wrapper).attributes('disabled')).toBeDefined()
-
-    // No probe should be queued for an empty value.
-    api.probeInstallation.mockClear()
-    await vi.advanceTimersByTimeAsync(300)
-    expect(api.probeInstallation).not.toHaveBeenCalled()
-  })
-
-  it('does not enable the button when no install is detected at the path', async () => {
-    const api = installMockApi({ probeInstallation: vi.fn().mockResolvedValue([]) })
-    const wrapper = mountTrack()
-    ;(wrapper.vm as unknown as { open: () => void }).open()
-    await flushPromises()
-
-    await wrapper.get('#track-path').setValue('/tmp/not-comfy')
-    await vi.advanceTimersByTimeAsync(300)
+    await wrapper.get('button.brand-tertiary').trigger('click')
     await flushPromises()
 
     expect(api.probeInstallation).toHaveBeenCalledWith('/tmp/not-comfy')

--- a/src/renderer/src/views/TrackModal.vue
+++ b/src/renderer/src/views/TrackModal.vue
@@ -32,33 +32,9 @@ let returnFocusTo: HTMLElement | null = null
 
 const saveDisabled = computed(() => !trackPath.value || !selectedProbe.value)
 
-/** Path most recently probed — guards the input watcher from re-probing
- *  a value that `handleBrowse` (or a prior debounce) already handled. */
-let lastProbedPath = ''
 /** Generation counter — bumped on every probe so stale async responses
  *  from an earlier path are discarded once the field changes again. */
 let probeGeneration = 0
-let probeDebounce: ReturnType<typeof setTimeout> | null = null
-
-/** Re-probe whenever the path field changes, not just via Browse. Typing
- *  or pasting a directory now triggers detection so a valid existing
- *  install enables the "Track install" button. Debounced to avoid
- *  probing on every keystroke; trimmed so trailing whitespace from a
- *  paste doesn't read as a distinct path. */
-watch(trackPath, (newPath) => {
-  const trimmed = newPath.trim()
-  if (trimmed === lastProbedPath) return
-  if (probeDebounce) clearTimeout(probeDebounce)
-  if (!trimmed) {
-    lastProbedPath = ''
-    probeResults.value = []
-    selectedProbe.value = null
-    return
-  }
-  probeDebounce = setTimeout(() => {
-    void probe(trimmed)
-  }, 300)
-})
 
 function onKeydown(e: KeyboardEvent): void {
   if (e.key === 'Escape' && isOpen.value) emit('close')
@@ -82,15 +58,11 @@ watch(isOpen, async (open) => {
 
 onBeforeUnmount(() => {
   document.removeEventListener('keydown', onKeydown)
-  if (probeDebounce) clearTimeout(probeDebounce)
   if (returnFocusTo && document.contains(returnFocusTo)) returnFocusTo.focus()
   returnFocusTo = null
 })
 
 function open(): void {
-  if (probeDebounce) clearTimeout(probeDebounce)
-  probeDebounce = null
-  lastProbedPath = ''
   trackPath.value = ''
   trackName.value = ''
   probeResults.value = []
@@ -116,7 +88,6 @@ async function handleBrowse(): Promise<void> {
 
 async function probe(dirPath: string): Promise<void> {
   const generation = ++probeGeneration
-  lastProbedPath = dirPath.trim()
   probing.value = true
   selectedProbe.value = null
   probeResults.value = []
@@ -261,8 +232,9 @@ defineExpose({ open })
                 <HardDrive :size="14" aria-hidden="true" />
                 <input
                   id="track-path"
-                  v-model="trackPath"
+                  :value="trackPath"
                   type="text"
+                  readonly
                   :placeholder="$t('track.selectDir')"
                 />
               </div>

--- a/src/renderer/src/views/TrackModal.vue
+++ b/src/renderer/src/views/TrackModal.vue
@@ -63,12 +63,17 @@ onBeforeUnmount(() => {
 })
 
 function open(): void {
+  // Bump so any probe still in flight from a previous session is
+  // discarded by `probe()`'s generation check and can't populate the
+  // freshly-reset state.
+  probeGeneration++
   trackPath.value = ''
   trackName.value = ''
   probeResults.value = []
   selectedProbe.value = null
   venvOverride.value = null
   suggestedName.value = ''
+  probing.value = false
   isOpen.value = true
   void window.api
     .getUniqueName('ComfyUI')


### PR DESCRIPTION
## Summary

Every `picker + Browse` field across the app allowed direct text editing of the path. The intent is for the value to always come from the native folder dialog (so it can be validated, exists, has the right permissions, etc.). This PR locks all such fields as `readonly` so the only way to set them is via the dialog or the existing `Reset to Default` button.

## Fields affected

| Surface | Field | Was | Now |
|---|---|---|---|
| Settings ? Shared Directories | Input Directory, Output Directory | typable | browse-only |
| Per-install Storage | Per-install Input/Output Directory | typable | browse-only |
| Git source | `venvPath` | typable | browse-only |
| URL source | Per-install Output Directory (when shared off) | already browse-only ? | unchanged |
| Quick Install | Install Location | typable | browse-only |
| Install Wizard | Install Location | typable | browse-only |
| Track Existing Install | Install Directory | typable + paste-probe | browse-only, probe only via Browse |

## Implementation

**Backend producers** - added `browseOnly: true` to four `DetailField` producers (`launchSettingsFields.ts`, `git.ts`) and have `titlePopup.ts`'s `toDetailField` mark every `SettingsField` of `type: 'path'` as `browseOnly` (so the Shared Directories Input/Output paths inherit the lock without per-row plumbing). Existing renderers `DetailSection.vue` / `PathField.vue` already honor the flag.

**Bespoke modal inputs** - three modals embed their own install-location input rather than the `DetailField` pipeline. Switched each to `readonly` and dropped the `@input` plumbing:
- `InstallNamePath.vue` (used by Quick Install)
- `InstallWizardModal.vue`
- `TrackModal.vue`

**TrackModal cleanup** - the `#track-path` field previously ran a debounced re-probe on every keystroke (PR #726). With the input now `readonly`, that machinery is dead code: `handleBrowse` already calls `probe(dir)` directly. Removed `lastProbedPath`, `probeDebounce`, the `watch(trackPath, ...)`, and the related cleanup. The #726 paste-probe regression test suite is replaced with assertions that the input is `readonly` and that probing only fires via Browse.

## Test plan

- `pnpm typecheck` ?
- `pnpm lint` ?
- `pnpm build` ?
- `pnpm test` ? (1745 tests pass, including the rewritten TrackModal suite)

## Out of scope

- `DetailSection.vue` (legacy renderer carrying a `TODO(stale-old-modal)` deletion marker) inherits the producer-side fix without a template change.
- Read-only file pickers (Load Snapshot) and the Shared Models `Add` button were already dialog-only.
- Name fields (`inst-name`, `track-name`) stay typable - they're not path pickers.