### PR TITLE
chore: bump version to 1.0.1-rc

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -23,7 +23,7 @@ const commonParserOptions = {
 
 export default defineConfig([
   {
-    ignores: ['out/*', 'dist/*', 'node_modules/*', '.claude/**']
+    ignores: ['out/*', 'dist/*', 'node_modules/*', '.claude/**', '.worktrees/**']
   },
   {
     files: ['./**/*.{ts,mts}'],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-desktop-2",
-  "version": "0.6.13",
+  "version": "1.0.1-rc",
   "description": "Comfy Desktop",
   "author": {
     "name": "Comfy Org",


### PR DESCRIPTION
## Summary

Bumps \`package.json\` version from \`0.6.13\` → \`1.0.1-rc\`. First release-candidate cut for the \`1.x\` line.

## What happens on merge

Once merged, [`release-from-pr-label.yml`](.github/workflows/release-from-pr-label.yml) detects the \`Release\` label + version diff and:

1. Creates and pushes tag \`v1.0.1-rc\` on the merge commit.
2. Dispatches [`build-release.yml`](.github/workflows/build-release.yml), which runs \`pnpm run build\`, uploads Datadog sourcemaps, runs \`todesktop build\`, and creates a draft GitHub Release.
3. Publish the draft from [Releases](../../releases) once the build completes.

The README's \`Latest Release\` badge is dynamic and will update automatically once the release is published.

## Why manual (not \`version-bump.yml\`)

The automated \`version-bump.yml\` only accepts \`patch | minor | major\` on the strict \`X.Y.Z\` semver format. The \`-rc\` suffix requires the documented manual fallback.

## Bundled change

Adds \`.worktrees/**\` to the eslint ignore list — local devs with multiple checked-out worktrees were hitting OOM in the pre-commit lint hook. Dev-only infra fix, doesn't touch produced binaries.