### PR TITLE
fix(build): stage installer BMPs into ToDesktop's build/ dir

### DIFF
--- a/scripts/todesktop-beforeBuild.cjs
+++ b/scripts/todesktop-beforeBuild.cjs
@@ -35,10 +35,48 @@ const UV_BINARY = {
   'linux-x64': 'bin/uv',
 }
 
+// MUI2 installer artwork that scripts/installer.nsh references via
+// `${BUILD_RESOURCES_DIR}\<name>.bmp`. Local electron-builder builds work
+// because electron-builder.yml sets `directories.buildResources: resources`,
+// so BUILD_RESOURCES_DIR resolves to ./resources/ and finds the files there.
+// ToDesktop bypasses electron-builder.yml entirely and uses its own
+// `<workingDir>/build/` for BUILD_RESOURCES_DIR (see the build log:
+// `BUILD_RESOURCES_DIR=...\todesktop\<id>\build`), so MUI_HEADERIMAGE_INIT
+// fails at NSIS compile time with "no files found." Stage the BMPs into
+// ToDesktop's build dir from the unpacked source archive so the macro
+// resolves. No-op on macOS / Linux (the windows installer.nsh include is
+// only consumed by the win NSIS target).
+const INSTALLER_ART = ['installerHeader.bmp', 'installerSidebar.bmp', 'uninstallerSidebar.bmp']
+
 module.exports = async ({ appDir, platform, arch }) => {
   const { execSync } = await import('node:child_process')
   const fs = await import('node:fs')
   const path = await import('node:path')
+
+  // Stage installer BMPs FIRST so a bootstrap-python skip / failure doesn't
+  // mask the windows installer issue. Only runs when there's something to
+  // copy AND we're on a windows build.
+  if (platform === 'windows') {
+    // Hook contract: appDir = <workingDir>/app-wrapper/app (see the comment
+    // on the bootstrap-python outDir below). build/ sits at workingDir level.
+    const buildDir = path.join(appDir, '..', '..', 'build')
+    fs.mkdirSync(buildDir, { recursive: true })
+    for (const name of INSTALLER_ART) {
+      const src = path.join(appDir, 'resources', name)
+      const dst = path.join(buildDir, name)
+      if (!fs.existsSync(src)) {
+        // Fail loudly. A silent skip here is what shipped the broken build —
+        // NSIS compile-time errors look unrelated to a beforeBuild no-op.
+        throw new Error(
+          `[todesktop:beforeBuild] Missing installer artwork: ${src}. ` +
+          `scripts/installer.nsh references this via \${BUILD_RESOURCES_DIR}\\${name}; ` +
+          `without it, MUI_HEADERIMAGE_INIT fails the windows build at NSIS compile time.`
+        )
+      }
+      fs.copyFileSync(src, dst)
+      console.log(`[todesktop:beforeBuild] Staged ${name} -> ${dst}`)
+    }
+  }
 
   const key = `${platform}-${arch}`
   const bootstrapPlatform = PLATFORM_MAP[key]


### PR DESCRIPTION
## The error

ToDesktop Windows NSIS step is failing on every build:

\`\`\`
File: \"C:\\...\\todesktop\\<id>\\build\\installerHeader.bmp\" -> no files found.
Error in macro MUI_HEADERIMAGE_INIT on macroline 17
Error in macro MUI_GUIINIT_OUTERDIALOG on macroline 20
Error in macro MUI_FUNCTION_GUIINIT on macroline 4
...
Error in script \"<stdin>\" on line 116 -- aborting creation process
\`\`\`

## Why

\`scripts/installer.nsh\` (added in #829) references the BMPs via:

\`\`\`nsh
!define MUI_HEADERIMAGE_BITMAP \"\${BUILD_RESOURCES_DIR}\\installerHeader.bmp\"
!define MUI_WELCOMEFINISHPAGE_BITMAP \"\${BUILD_RESOURCES_DIR}\\installerSidebar.bmp\"
!define MUI_UNWELCOMEFINISHPAGE_BITMAP \"\${BUILD_RESOURCES_DIR}\\uninstallerSidebar.bmp\"
\`\`\`

Local builds work because \`electron-builder.yml\` sets:

\`\`\`yml
directories:
  buildResources: resources
\`\`\`

…so \`BUILD_RESOURCES_DIR\` resolves to \`./resources/\` where the BMPs actually live.

**ToDesktop bypasses \`electron-builder.yml\` entirely** (it's excluded from \`appFiles\` in \`todesktop.json\`) and uses its own \`<workingDir>/build/\` for \`BUILD_RESOURCES_DIR\`. The BMPs are never staged into that directory, so NSIS can't find them at compile time.

## The fix

Copy the three BMPs from \`<appDir>/resources/\` to \`<workingDir>/build/\` in the existing \`scripts/todesktop-beforeBuild.cjs\` hook. Runs only on the \`windows\` platform (NSH include is windows-only). Throws if any source BMP is missing — silent skip is what shipped the broken build (NSIS compile-time errors look unrelated to a \`beforeBuild\` no-op).

Path math: \`appDir = <workingDir>/app-wrapper/app\` (same contract the bootstrap-python \`outDir\` already relies on); \`buildDir = path.join(appDir, '..', '..', 'build')\`.

## Verified

- pnpm typecheck + lint clean
- Script syntax-checks via \`node -e \"require(...)\"\`
- End-to-end verification is the next ToDesktop build itself

## Out of scope

Not touching \`electron-builder.yml\`, \`todesktop.json\`, or \`scripts/installer.nsh\`. Smallest-possible fix; the only thing that needed to change is *where* the BMPs sit at NSIS compile time.