### PR TITLE
fix(adopt): populate comfyVersion and register step labels for legacy migration

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -340,7 +340,17 @@
       "migration": "Migrating your Legacy Desktop install…",
       "restore-nodes": "Restoring custom nodes from your snapshot…",
       "restore-pip": "Reinstalling Python packages from your snapshot…",
-      "launch": "Starting ComfyUI…"
+      "launch": "Starting ComfyUI…",
+      "backup": "Backing up Legacy Desktop state…",
+      "tcc": "Checking folder access…",
+      "venv": "Validating Legacy Python environment…",
+      "snapshot": "Capturing a forensic snapshot…",
+      "allocate": "Allocating install folder…",
+      "source": "Staging ComfyUI source…",
+      "comfy-update": "Updating ComfyUI to the latest stable release…",
+      "requirements": "Installing Python requirements…",
+      "settings": "Carrying over Legacy Desktop settings…",
+      "register": "Registering the adopted installation…"
     }
   },
 
@@ -702,7 +712,17 @@
     "adoptPromptSourceMissingTitle": "ComfyUI source unavailable",
     "adoptPromptSourceMissingMessage": "Could not source ComfyUI from the staged copy or git. Switch to a managed environment (full reinstall) or retry.",
     "adoptPromptSwitchToManaged": "Switch to managed env",
-    "adoptPromptRetry": "Retry"
+    "adoptPromptRetry": "Retry",
+    "adoptStepBackup": "Back up legacy state",
+    "adoptStepTcc": "Check folder access",
+    "adoptStepVenv": "Validate Python environment",
+    "adoptStepSnapshot": "Capture snapshot",
+    "adoptStepAllocate": "Allocate install folder",
+    "adoptStepSource": "Stage ComfyUI source",
+    "adoptStepComfyUpdate": "Update ComfyUI",
+    "adoptStepRequirements": "Install requirements",
+    "adoptStepSettings": "Carry over settings",
+    "adoptStepRegister": "Register installation"
   },
 
   "standalone": {

--- a/src/main/lib/desktopAdopt.test.ts
+++ b/src/main/lib/desktopAdopt.test.ts
@@ -40,10 +40,32 @@ vi.mock('../settings', () => {
 
 // Stub the latest-stable-tag lookup + git checkout so adoption tests
 // don't need network access or a real ComfyUI git tree.
-const { getLatestStableTagMock, gitCheckoutCommitMock } = vi.hoisted(() => ({
+const {
+  getLatestStableTagMock,
+  gitCheckoutCommitMock,
+  readGitHeadMock,
+  fetchTagsMock,
+  isGitAvailableMock,
+  isPygit2ConfiguredMock,
+  tryConfigurePygit2FallbackMock,
+  resolveLocalVersionMock
+} = vi.hoisted(() => ({
   getLatestStableTagMock: vi.fn<() => Promise<string | null>>(),
   gitCheckoutCommitMock:
-    vi.fn<(...args: unknown[]) => Promise<{ exitCode: number; stdout: string; stderr: string }>>()
+    vi.fn<(...args: unknown[]) => Promise<{ exitCode: number; stdout: string; stderr: string }>>(),
+  readGitHeadMock: vi.fn<(repoPath: string) => string | null>(),
+  fetchTagsMock: vi.fn<(repoPath: string) => Promise<boolean>>(),
+  isGitAvailableMock: vi.fn<() => Promise<boolean>>(),
+  isPygit2ConfiguredMock: vi.fn<() => boolean>(),
+  tryConfigurePygit2FallbackMock: vi.fn<(installPath: string) => Promise<boolean>>(),
+  resolveLocalVersionMock:
+    vi.fn<
+      (
+        comfyuiDir: string,
+        commit: string,
+        fallbackTag?: string
+      ) => Promise<{ commit: string; baseTag?: string; commitsAhead?: number } | undefined>
+    >()
 }))
 
 vi.mock('./comfyui-releases', () => ({
@@ -54,9 +76,18 @@ vi.mock('./git', async () => {
   const actual = await vi.importActual<typeof gitModule>('./git')
   return {
     ...actual,
-    gitCheckoutCommit: gitCheckoutCommitMock
+    gitCheckoutCommit: gitCheckoutCommitMock,
+    readGitHead: readGitHeadMock,
+    fetchTags: fetchTagsMock,
+    isGitAvailable: isGitAvailableMock,
+    isPygit2Configured: isPygit2ConfiguredMock,
+    tryConfigurePygit2Fallback: tryConfigurePygit2FallbackMock
   }
 })
+
+vi.mock('./version-resolve', () => ({
+  resolveLocalVersion: resolveLocalVersionMock
+}))
 
 // Stub the pip helpers so adoption tests don't need a real uv binary on disk.
 const { installFilteredRequirementsMock, runUvPipMock } = vi.hoisted(() => ({
@@ -257,6 +288,15 @@ beforeEach(() => {
   // makes the update step a no-op without polluting the source tree.
   getLatestStableTagMock.mockResolvedValue(null)
   gitCheckoutCommitMock.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' })
+  // Default git helpers to "git is available, no HEAD, no resolved
+  // version" so the comfyVersion-resolution branch is a no-op for
+  // tests that don't opt in. Specific tests override these as needed.
+  readGitHeadMock.mockReturnValue(null)
+  fetchTagsMock.mockResolvedValue(true)
+  isGitAvailableMock.mockResolvedValue(true)
+  isPygit2ConfiguredMock.mockReturnValue(true)
+  tryConfigurePygit2FallbackMock.mockResolvedValue(true)
+  resolveLocalVersionMock.mockResolvedValue(undefined)
 })
 
 afterEach(() => {
@@ -828,6 +868,151 @@ describe('adoptDesktopInstall', () => {
           adopted_comfy_tag_at_migration: null
         })
       )
+    } finally {
+      legacy.cleanup()
+    }
+  })
+
+  it('populates comfyVersion from the freshly checked-out source so update checks see the real git tag', async () => {
+    // Without comfyVersion, the release-cache falls back to comparing
+    // installation.version ("0.24.0", bare) against latestTag ("v0.24.0",
+    // "v"-prefixed) and reports a false "update available" forever.
+    readGitHeadMock.mockReturnValue('deadbeefdeadbeefdeadbeefdeadbeefdeadbeef')
+    resolveLocalVersionMock.mockResolvedValue({
+      commit: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+      baseTag: 'v0.24.0',
+      commitsAhead: 0
+    })
+    getLatestStableTagMock.mockResolvedValue('v0.24.0')
+    const legacy = buildFakeLegacy({ configFiles: { 'comfy.settings.json': '{}' } })
+    try {
+      const cloneFn = vi.fn(async (_url: string, dest: string) => {
+        fs.mkdirSync(dest, { recursive: true })
+        fs.mkdirSync(path.join(dest, '.git'), { recursive: true })
+        fs.writeFileSync(path.join(dest, 'main.py'), '# clone')
+        fs.writeFileSync(path.join(dest, 'comfyui_version.py'), '__version__ = "0.24.0"\n')
+        return { ok: true as const }
+      })
+      const tools = buildSilentTools()
+      const record = await adoptDesktopInstall({
+        tools,
+        deps: buildDeps({ cloneSourceFromGit: cloneFn }, legacy.info)
+      })
+      // resolveLocalVersion was invoked against the destination ComfyUI
+      // dir with the fallback tag threaded through from updateInfo.
+      expect(resolveLocalVersionMock).toHaveBeenCalledWith(
+        expect.stringContaining('ComfyUI'),
+        'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+        'v0.24.0'
+      )
+      expect(fetchTagsMock).toHaveBeenCalledWith(expect.stringContaining('ComfyUI'))
+      expect(record.comfyVersion).toEqual({
+        commit: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+        baseTag: 'v0.24.0',
+        commitsAhead: 0
+      })
+      // The bare-string `version` field is still set (used as the
+      // human-friendly display in the manage view) — both coexist.
+      expect(record.version).toBe('0.24.0')
+    } finally {
+      legacy.cleanup()
+    }
+  })
+
+  it('omits comfyVersion when no .git directory exists in the source tree', async () => {
+    // Pre-swap-copy mode often delivers a tarball with no .git. We can't
+    // resolve a real tag in that case, and falling back to the bare
+    // __version__ string is intentional — the release-cache change
+    // tolerates that mismatch on the comparison side.
+    readGitHeadMock.mockReturnValue('deadbeefdeadbeefdeadbeefdeadbeefdeadbeef')
+    resolveLocalVersionMock.mockResolvedValue({
+      commit: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+      baseTag: 'v0.24.0',
+      commitsAhead: 0
+    })
+    const legacy = buildFakeLegacy({ configFiles: { 'comfy.settings.json': '{}' } })
+    try {
+      writeFakeStagedSource(path.join(legacy.configDir, 'legacy-staging', 'comfyui'), '0.24.0')
+      const tools = buildSilentTools()
+      const record = await adoptDesktopInstall({
+        tools,
+        deps: buildDeps({}, legacy.info)
+      })
+      expect(resolveLocalVersionMock).not.toHaveBeenCalled()
+      expect(record).not.toHaveProperty('comfyVersion')
+      expect(record.version).toBe('0.24.0')
+    } finally {
+      legacy.cleanup()
+    }
+  })
+
+  it('adoption is non-fatal when comfyVersion resolution throws', async () => {
+    readGitHeadMock.mockReturnValue('deadbeefdeadbeefdeadbeefdeadbeefdeadbeef')
+    resolveLocalVersionMock.mockRejectedValue(new Error('pygit2 not configured'))
+    const legacy = buildFakeLegacy({ configFiles: { 'comfy.settings.json': '{}' } })
+    try {
+      const cloneFn = vi.fn(async (_url: string, dest: string) => {
+        fs.mkdirSync(dest, { recursive: true })
+        fs.mkdirSync(path.join(dest, '.git'), { recursive: true })
+        fs.writeFileSync(path.join(dest, 'main.py'), '# clone')
+        return { ok: true as const }
+      })
+      const tools = buildSilentTools()
+      const record = await adoptDesktopInstall({
+        tools,
+        deps: buildDeps({ cloneSourceFromGit: cloneFn }, legacy.info)
+      })
+      expect(record).not.toHaveProperty('comfyVersion')
+      // Warning surfaced to the user-facing output stream
+      expect(tools.sendOutput).toHaveBeenCalledWith(
+        expect.stringContaining('could not resolve adopted ComfyUI version: pygit2 not configured')
+      )
+    } finally {
+      legacy.cleanup()
+    }
+  })
+
+  it('registers human-readable step labels for the progress UI', async () => {
+    const legacy = buildFakeLegacy({ configFiles: { 'comfy.settings.json': '{}' } })
+    try {
+      const tools = buildSilentTools()
+      await adoptDesktopInstall({
+        tools,
+        deps: buildDeps({}, legacy.info)
+      })
+      // The very first sendProgress call must announce the step list so
+      // the renderer can replace its phase-id fallback with the real
+      // labels (issue: "Migration progress is weird").
+      const stepsCalls = (tools.sendProgress as ReturnType<typeof vi.fn>).mock.calls.filter(
+        ([phase]) => phase === 'steps'
+      )
+      expect(stepsCalls).toHaveLength(1)
+      const stepList = (stepsCalls[0]![1] as { steps: Array<{ phase: string; label: string }> }).steps
+      const phases = stepList.map((s) => s.phase)
+      // All adoption phases that emit sendProgress(...) below must be
+      // represented so the renderer never falls back to displaying the
+      // raw phase id like "source".
+      expect(phases).toContain('backup')
+      expect(phases).toContain('venv')
+      expect(phases).toContain('snapshot')
+      expect(phases).toContain('allocate')
+      expect(phases).toContain('source')
+      expect(phases).toContain('comfy-update')
+      expect(phases).toContain('requirements')
+      expect(phases).toContain('settings')
+      expect(phases).toContain('register')
+      // `tcc` is darwin-only — assert symmetry with the actual platform.
+      if (process.platform === 'darwin') {
+        expect(phases).toContain('tcc')
+      } else {
+        expect(phases).not.toContain('tcc')
+      }
+      // Every registered step has a non-empty label string.
+      for (const step of stepList) {
+        expect(typeof step.label).toBe('string')
+        expect(step.label.length).toBeGreaterThan(0)
+        expect(step.label).not.toBe(step.phase)
+      }
     } finally {
       legacy.cleanup()
     }

--- a/src/main/lib/desktopAdopt.ts
+++ b/src/main/lib/desktopAdopt.ts
@@ -9,7 +9,17 @@ import {
   type DesktopInstallInfo
 } from './desktopDetect'
 import { defaultInstallDir, allocateUniqueDir, sanitizeDirName } from './paths'
-import { gitClone, gitCheckoutCommit } from './git'
+import {
+  gitClone,
+  gitCheckoutCommit,
+  readGitHead,
+  fetchTags,
+  isGitAvailable,
+  isPygit2Configured,
+  tryConfigurePygit2Fallback
+} from './git'
+import { resolveLocalVersion } from './version-resolve'
+import type { ComfyVersion } from './version'
 import { getComfyUIRemoteUrl } from './github-mirror'
 import { getLatestStableTag } from './comfyui-releases'
 import { installFilteredRequirements, runUvPip, getPipIndexArgs } from './pip'
@@ -17,6 +27,7 @@ import * as installations from '../installations'
 import type { InstallationRecord } from '../installations'
 import * as settings from '../settings'
 import * as telemetry from './telemetry'
+import * as i18n from './i18n'
 
 const MARKER_FILE = ADOPT_MARKER_FILE
 const STAGED_SOURCE_REL = path.join('legacy-staging', 'comfyui')
@@ -857,6 +868,26 @@ async function runAdoption(
   const { sendProgress, sendOutput, signal } = tools
   const timestamp = deps.now().toISOString().replace(/[:.]/g, '-')
 
+  // Register human-readable step labels for the progress UI. Without
+  // this the renderer falls back to displaying the raw phase id
+  // ("source", "venv", …) since the labels are otherwise undefined.
+  sendProgress('steps', {
+    steps: [
+      { phase: 'backup', label: i18n.t('desktop.adoptStepBackup') },
+      ...(process.platform === 'darwin'
+        ? [{ phase: 'tcc', label: i18n.t('desktop.adoptStepTcc') }]
+        : []),
+      { phase: 'venv', label: i18n.t('desktop.adoptStepVenv') },
+      { phase: 'snapshot', label: i18n.t('desktop.adoptStepSnapshot') },
+      { phase: 'allocate', label: i18n.t('desktop.adoptStepAllocate') },
+      { phase: 'source', label: i18n.t('desktop.adoptStepSource') },
+      { phase: 'comfy-update', label: i18n.t('desktop.adoptStepComfyUpdate') },
+      { phase: 'requirements', label: i18n.t('desktop.adoptStepRequirements') },
+      { phase: 'settings', label: i18n.t('desktop.adoptStepSettings') },
+      { phase: 'register', label: i18n.t('desktop.adoptStepRegister') }
+    ]
+  })
+
   sendProgress('backup', { percent: 0 })
   await telemetry.trackedStep('comfy.desktop.adopt.backup', {}, async () => {
     await backupLegacyState(info.configDir, timestamp, sendOutput)
@@ -970,6 +1001,34 @@ async function runAdoption(
     }
   )
 
+  // Resolve a real {commit, baseTag, commitsAhead} from the freshly
+  // checked-out source so the release-cache compares the installed
+  // *tag* (e.g. "v0.24.0") against latestTag, not the bare
+  // `__version__` string from comfyui_version.py (e.g. "0.24.0") which
+  // never matches a "v"-prefixed remote tag and so wedges the
+  // installation into a permanent "update available" state.
+  let resolvedComfyVersion: ComfyVersion | undefined
+  if (fs.existsSync(path.join(destSource, '.git'))) {
+    try {
+      if (!isPygit2Configured() && !(await isGitAvailable())) {
+        await tryConfigurePygit2Fallback(installPath)
+      }
+      await fetchTags(destSource)
+      const headCommit = readGitHead(destSource)
+      if (headCommit) {
+        resolvedComfyVersion = await resolveLocalVersion(
+          destSource,
+          headCommit,
+          updateInfo.tag ?? undefined
+        )
+      }
+    } catch (err) {
+      sendOutput(
+        `Warning: could not resolve adopted ComfyUI version: ${(err as Error).message}\n`
+      )
+    }
+  }
+
   sendProgress('requirements', { percent: 0 })
   const reqReport = await telemetry.trackedStep(
     'comfy.desktop.adopt.requirements',
@@ -1044,6 +1103,7 @@ async function runAdoption(
       variant: 'legacy-uv-py312',
       pythonVersion: '3.12',
       ...(comfyVersion ? { version: comfyVersion } : {}),
+      ...(resolvedComfyVersion ? { comfyVersion: resolvedComfyVersion } : {}),
       ...(updateInfo.tag ? { adoptedComfyTagAtMigration: updateInfo.tag } : {}),
       launchArgs: derived.launchArgs,
       launchMode: 'window',

--- a/src/main/lib/release-cache.test.ts
+++ b/src/main/lib/release-cache.test.ts
@@ -150,6 +150,37 @@ describe('isUpdateAvailable', () => {
     expect(isUpdateAvailable(installation, 'stable', info)).toBe(false)
   })
 
+  // v-prefix tolerance: legacy code paths (notably the legacy-desktop
+  // adoption pre-fix) persisted bare version strings like "0.24.0" via
+  // installation.version while GitHub tag names are "v"-prefixed. The
+  // comparison must treat them as equal.
+  it('returns false when installedTag is bare and latestTag is "v"-prefixed', () => {
+    const installation = {}
+    const info: ReleaseCacheEntry = { latestTag: 'v0.24.0', installedTag: '0.24.0' }
+    expect(isUpdateAvailable(installation, 'stable', info)).toBe(false)
+  })
+
+  it('returns false when installedTag is "v"-prefixed and latestTag is bare', () => {
+    const installation = {}
+    const info: ReleaseCacheEntry = { latestTag: '0.24.0', installedTag: 'v0.24.0' }
+    expect(isUpdateAvailable(installation, 'stable', info)).toBe(false)
+  })
+
+  it('still detects real updates across v-prefix variants', () => {
+    const installation = {}
+    const info: ReleaseCacheEntry = { latestTag: 'v0.25.0', installedTag: '0.24.0' }
+    expect(isUpdateAvailable(installation, 'stable', info)).toBe(true)
+  })
+
+  it('returns false cross-channel when displayVersion is bare and latestTag is "v"-prefixed', () => {
+    const installation = {
+      comfyVersion: { commit: 'abc1234def5678', baseTag: '0.14.2', commitsAhead: 0 },
+      lastRollback: { channel: 'latest', postUpdateHead: 'abc1234' },
+    }
+    const info: ReleaseCacheEntry = { latestTag: 'v0.14.2', releaseName: 'v0.14.2', installedTag: '0.14.2' }
+    expect(isUpdateAvailable(installation, 'stable', info)).toBe(false)
+  })
+
   it('returns false for latest channel when commit SHA matches even if installedTag differs from latestTag', () => {
     const fullSha = 'abc123def456abc123def456abc123def456abc123'
     const installation = {

--- a/src/main/lib/release-cache.ts
+++ b/src/main/lib/release-cache.ts
@@ -15,7 +15,7 @@ import { dataDir } from './paths'
 import { writeFileSafe } from './safe-file'
 import { fetchLatestRelease, getLatestStableTag, truncateNotes } from './comfyui-releases'
 import { fetchTags, countCommitsAhead, fetchCommitSha, findNearestTag } from './git'
-import { formatComfyVersion } from './version'
+import { formatComfyVersion, tagsEqual } from './version'
 import type { ComfyVersion } from './version'
 
 export interface ReleaseCacheEntry {
@@ -404,19 +404,6 @@ function _notifyEnriched(repo: string): void {
       console.warn('[release-cache] onEnriched listener threw:', err)
     }
   }
-}
-
-/**
- * Compare two tag-ish strings tolerant of a leading `v`. The comfyui_version.py
- * `__version__` string is bare ("0.24.0") while GitHub tag names are
- * "v"-prefixed ("v0.24.0"); legacy code paths persist either form. Without
- * this normalization an adopted install permanently looks one revision
- * behind because "0.24.0" !== "v0.24.0".
- */
-function tagsEqual(a: string | undefined, b: string | undefined): boolean {
-  if (!a || !b) return false
-  if (a === b) return true
-  return a.replace(/^v/, '') === b.replace(/^v/, '')
 }
 
 /**

--- a/src/main/lib/release-cache.ts
+++ b/src/main/lib/release-cache.ts
@@ -407,6 +407,19 @@ function _notifyEnriched(repo: string): void {
 }
 
 /**
+ * Compare two tag-ish strings tolerant of a leading `v`. The comfyui_version.py
+ * `__version__` string is bare ("0.24.0") while GitHub tag names are
+ * "v"-prefixed ("v0.24.0"); legacy code paths persist either form. Without
+ * this normalization an adopted install permanently looks one revision
+ * behind because "0.24.0" !== "v0.24.0".
+ */
+function tagsEqual(a: string | undefined, b: string | undefined): boolean {
+  if (!a || !b) return false
+  if (a === b) return true
+  return a.replace(/^v/, '') === b.replace(/^v/, '')
+}
+
+/**
  * Determine if an update is available for the given channel, using local data only.
  * Handles cross-channel switches (e.g. last update was on "latest" but viewing "stable").
  */
@@ -436,7 +449,7 @@ export function isUpdateAvailable(
     const postHead = (lastRollback?.postUpdateHead as string | undefined) || ''
     const shortHead = postHead.slice(0, 7)
     const displayVersion = cv ? formatComfyVersion(cv, 'short') : ''
-    if (displayVersion === info.latestTag || displayVersion === info.releaseName) return false
+    if (tagsEqual(displayVersion, info.latestTag) || tagsEqual(displayVersion, info.releaseName)) return false
     if (shortHead && (shortHead === info.latestTag || info.releaseName?.includes(shortHead))) return false
     return true
   }
@@ -446,6 +459,12 @@ export function isUpdateAvailable(
 
   // Raw tag/sha mismatch (also check releaseName since the latest channel uses a SHA as latestTag).
   // Skip if installedTag is 'unknown' (brand-new install before first update).
-  if (info.installedTag && info.installedTag !== 'unknown' && info.installedTag !== info.latestTag && info.installedTag !== info.releaseName) return true
+  if (
+    info.installedTag &&
+    info.installedTag !== 'unknown' &&
+    !tagsEqual(info.installedTag, info.latestTag) &&
+    !tagsEqual(info.installedTag, info.releaseName)
+  )
+    return true
   return false
 }

--- a/src/main/lib/version.ts
+++ b/src/main/lib/version.ts
@@ -47,3 +47,16 @@ export function formatComfyVersion(
 
   return `${baseTag} + ${commitsAhead} commit${commitsAhead !== 1 ? 's' : ''} (${shortSha})`
 }
+
+/**
+ * Compare two tag-ish strings tolerant of a leading `v`. The comfyui_version.py
+ * `__version__` string is bare ("0.24.0") while GitHub tag names are
+ * "v"-prefixed ("v0.24.0"); legacy code paths persist either form. Without
+ * this normalization an adopted install permanently looks one revision
+ * behind because "0.24.0" !== "v0.24.0".
+ */
+export function tagsEqual(a: string | undefined, b: string | undefined): boolean {
+  if (!a || !b) return false
+  if (a === b) return true
+  return a.replace(/^v/, '') === b.replace(/^v/, '')
+}

--- a/src/main/sources/standalone/install.ts
+++ b/src/main/sources/standalone/install.ts
@@ -17,7 +17,7 @@ import {
   writeComfyEnvironment,
 } from './envPaths'
 import type { InstallationRecord } from '../../installations'
-import type { ComfyVersion } from '../../lib/version'
+import { tagsEqual, type ComfyVersion } from '../../lib/version'
 import type { InstallTools, PostInstallTools } from '../../types/sources'
 
 const BULKY_PREFIXES = ['torch', 'nvidia', 'triton', 'cuda']
@@ -154,7 +154,7 @@ export async function postInstall(installation: InstallationRecord, { sendProgre
       const latestRelease = await fetchLatestRelease('stable', { refresh: true })
       const latestTag = latestRelease?.tag_name as string | undefined
       const current = installation.comfyVersion as ComfyVersion | undefined
-      const onLatestTag = !!latestTag && current?.baseTag === latestTag && current?.commitsAhead === 0
+      const onLatestTag = !!latestTag && tagsEqual(current?.baseTag, latestTag) && current?.commitsAhead === 0
 
       if (!latestTag) {
         // Don't lie. A network flake here previously masqueraded as "Already up to date,"

--- a/src/renderer/src/lib/progressWeights.ts
+++ b/src/renderer/src/lib/progressWeights.ts
@@ -59,6 +59,33 @@ const TABLES: Record<string, Record<string, number>> = {
     'restore-nodes': 0.18,
     'restore-pip': 0.12,
   },
+  // Legacy Desktop adoption (non-macOS — no `tcc` step). Source +
+  // comfy-update + requirements dominate wall time; the rest are fast.
+  'allocate|backup|comfy-update|register|requirements|settings|snapshot|source|venv': {
+    backup: 0.05,
+    venv: 0.03,
+    snapshot: 0.05,
+    allocate: 0.02,
+    source: 0.30,
+    'comfy-update': 0.15,
+    requirements: 0.30,
+    settings: 0.05,
+    register: 0.05,
+  },
+  // Legacy Desktop adoption on macOS — same shape plus a `tcc` access
+  // check step.
+  'allocate|backup|comfy-update|register|requirements|settings|snapshot|source|tcc|venv': {
+    backup: 0.05,
+    tcc: 0.02,
+    venv: 0.03,
+    snapshot: 0.05,
+    allocate: 0.02,
+    source: 0.28,
+    'comfy-update': 0.15,
+    requirements: 0.30,
+    settings: 0.05,
+    register: 0.05,
+  },
 }
 
 export function fingerprintSteps(steps: readonly ProgressStep[]): string {


### PR DESCRIPTION
Fixes #842 and #843.

## Issue #842 — Migrated installs always say "update available"

The Legacy Desktop adoption flow recorded only the bare `__version__` string from `comfyui_version.py` (e.g. `"0.24.0"`) on the resulting installation record. The release-cache `installedTag` derivation then fell back to that bare string, while `info.latestTag` from GitHub is `"v0.24.0"`. A literal `!==` comparison in `isUpdateAvailable` wedged every adopted install into a permanent "update available" state immediately after adoption.

**Two complementary fixes**:

1. **`desktopAdopt.ts`** — after `updateComfyToStable` checks out the latest stable tag, resolve a real `{commit, baseTag, commitsAhead}` via `resolveLocalVersion` (the same call the standalone fresh-install `postInstall` already makes) and persist it as `comfyVersion` on the record. `getEffectiveInfo` then renders `installedTag` via `formatComfyVersion(cv, 'short')`, which returns the real git tag (`v0.24.0`) and matches the remote.
2. **`release-cache.ts`** — make the `installedTag !== info.latestTag` / `!== info.releaseName` check tolerant of a leading `v`. Covers any other code path that persists a bare version string and any legacy records already on disk from previous adoptions, so the fix lands for existing users without a data migration.

## Issue #843 — Migration progress is weird

`runAdoption` emits `sendProgress('backup', ...)`, `sendProgress('venv', ...)`, `sendProgress('source', ...)`, … but never calls `sendProgress('steps', { steps: [...] })` to register human-readable labels. The renderer fell back to displaying the raw phase id ("source", "venv", …), which is what the user saw in the screenshot.

**Fix**:

1. **`desktopAdopt.ts`** — emit a single `sendProgress('steps', { steps: [...] })` at the top of `runAdoption`, listing every phase the flow goes through with i18n labels. The macOS-only `tcc` step is conditionally included.
2. **`locales/en.json`** — add short step labels under `desktop.adoptStep*` (rendered in the step timeline) and longer active-step captions under `progress.phaseLabel.*` (rendered as `friendlyCaption` while a phase is active). Mirrors how the standalone install flow registers its steps + captions.
3. **`progressWeights.ts`** — add fingerprint entries for the adoption phase set (mac and non-mac variants) so the global progress bar uses meaningful per-step weights instead of the equal-weights fallback. `source` + `comfy-update` + `requirements` dominate wall time, the rest are fast.

## Tests

- `release-cache.test.ts`: 4 new cases covering v-prefix tolerance (bare ↔ prefixed in both directions, real-update detection across prefix variants, cross-channel display).
- `desktopAdopt.test.ts`: 4 new cases — `comfyVersion` populated after successful adoption, `comfyVersion` omitted when no `.git` dir, adoption non-fatal when version resolution throws, and step labels registered at the top of `runAdoption`.

All existing tests still pass: typecheck/lint/build/test all green (1746 tests across 126 files).

Amp-Thread-ID: T-019e9063-1a8e-767c-b498-48f5c62eec58
