### PR TITLE
fix(updater): release single-instance lock before macOS install/restart

### DIFF
--- a/src/main/lib/updater.ts
+++ b/src/main/lib/updater.ts
@@ -439,6 +439,18 @@ export function installUpdate(): void {
   })
   try {
     setQuitReason('update-install')
+    // macOS Squirrel quirk: if requestSingleInstanceLock is still held by
+    // the quitting process, ShipIt swaps the .app bundle correctly but
+    // the new Squirrel.Mac process cannot acquire the lock and exits
+    // silently — the user sees the app close and nothing relaunches.
+    // Electron's own docs call this out: quitAndInstall + single-instance
+    // lock is a known footgun on darwin. Releasing the lock immediately
+    // before restartAndInstall lets the next process come up cleanly.
+    // Windows / Linux update paths don't have this contention and don't
+    // need the release.
+    if (process.platform === 'darwin') {
+      app.releaseSingleInstanceLock()
+    }
     updater.restartAndInstall({ isSilent: true })
   } catch (err) {
     clearQuitReason()


### PR DESCRIPTION
## Bug

Reported on macOS Desktop 1 (0.9.x) → Desktop 2 (1.0.x) auto-update:

> mac users → see update → click → it shuts the existing one → nothing happens. The new app doesn't launch.

Manually launching the new bundle from \`/Applications/\` works fine. Migration UI fires correctly. The swap and the install side are healthy — only Squirrel's **post-install relaunch** drops silently.

## Cause

Electron's own docs call this out:

> On macOS, calling \`quitAndInstall\` while \`requestSingleInstanceLock\` is held will cause the app to quit but not be relaunched.

Sequence on a Mac update from main:

1. \`updater.restartAndInstall(...)\` → ToDesktop's wrapper around Squirrel.Mac
2. ShipIt swaps the \`.app\` bundle in \`/Applications/\` correctly
3. Squirrel.Mac spawns the new bundle
4. New bundle's main process calls \`app.requestSingleInstanceLock()\` — fails (the **soon-to-exit** old process still holds it)
5. New process exits silently → user sees nothing relaunch

Existing code:
- [src/main/index.ts:1037](src/main/index.ts#L1037) holds the lock for the entire app lifetime
- [src/main/lib/updater.ts:442](src/main/lib/updater.ts#L442) called \`restartAndInstall\` without releasing it first

## Fix

Two lines: on darwin only, release the lock immediately before \`restartAndInstall\`. Windows / Linux don't go through Squirrel (NSIS / AppImage / .deb installers don't have this contention) so no release needed there.

\`\`\`ts
if (process.platform === 'darwin') {
  app.releaseSingleInstanceLock()
}
updater.restartAndInstall({ isSilent: true })
\`\`\`

## Verification

- pnpm typecheck + lint clean
- existing \`src/main/lib/updater.test.ts\` passes (mocks the updater; doesn't exercise \`restartAndInstall\`)
- Real verification requires a Mac 0.9.x → 1.0.x update cycle through the ToDesktop CDN

## Out of scope

Not refactoring the update flow, not adding tests for native quirks we can't mock cleanly, not touching the bundled \`@todesktop/runtime\`. The fix matches the documented Electron workaround exactly.

## Launch impact

Without this, 100% of macOS users on 0.9.x see a "quit and nothing happens" UX on the rollout. Windows users are unaffected (NSIS path doesn't go through Squirrel).