### PR TITLE
chore(branding): strip lingering 'Desktop 2.0' from user-facing strings

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -24,7 +24,7 @@ publish:
   provider: github
   owner: Comfy-Org
   repo: Comfy-Desktop
-artifactName: ComfyUI-Desktop-2.0-${version}-${os}-${arch}.${ext}
+artifactName: Comfy-Desktop-${version}-${os}-${arch}.${ext}
 win:
   target: nsis
   icon: assets/Comfy_Logo_x256.png

--- a/scripts/reset-linux.sh
+++ b/scripts/reset-linux.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# ComfyUI Desktop 2.0 -- Linux reset script
+# Comfy Desktop -- Linux reset script
 #
 # Wipes app settings, caches, and the Chromium profile for the current build
 # AND for the older beta names (ComfyUI Launcher / comfyui-launcher), in case
@@ -81,7 +81,7 @@ for t in "${TARGETS[@]}"; do
 done
 
 if [ ${#EXISTING[@]} -eq 0 ]; then
-  echo "Nothing to remove. No ComfyUI Desktop 2.0 / Launcher data found."
+  echo "Nothing to remove. No Comfy Desktop / Launcher data found."
   exit 0
 fi
 
@@ -110,6 +110,6 @@ for t in "${EXISTING[@]}"; do
 done
 
 echo
-echo "Done. Reinstall ComfyUI Desktop 2.0 from the latest .AppImage or .deb"
+echo "Done. Reinstall Comfy Desktop from the latest .AppImage or .deb"
 echo "if you haven't already, then launch it. The app should come up with a"
 echo "clean profile."

--- a/scripts/reset-mac.sh
+++ b/scripts/reset-mac.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# ComfyUI Desktop 2.0 -- macOS reset script
+# Comfy Desktop -- macOS reset script
 #
 # Wipes app settings, caches, and the Chromium profile for the current build
 # AND for the older beta names (ComfyUI Launcher / com.kosinkadink.* /
@@ -140,7 +140,7 @@ for t in "${TARGETS[@]}"; do
 done
 
 if [ ${#EXISTING[@]} -eq 0 ]; then
-  echo "Nothing to remove. No ComfyUI Desktop 2.0 / Launcher data found."
+  echo "Nothing to remove. No Comfy Desktop / Launcher data found."
   exit 0
 fi
 
@@ -182,5 +182,5 @@ for t in "${EXISTING[@]}"; do
 done
 
 echo
-echo "Done. Reinstall ComfyUI Desktop 2.0 from the latest .dmg if you haven't already,"
+echo "Done. Reinstall Comfy Desktop from the latest .dmg if you haven't already,"
 echo "then launch it. The app should come up with a clean profile."

--- a/src/main/lib/updater.test.ts
+++ b/src/main/lib/updater.test.ts
@@ -94,7 +94,7 @@ describe('isSystemPackageInstall (via get-update-capabilities)', () => {
   })
 
   it('returns standard for AppImage (APPIMAGE env set)', async () => {
-    mockAppImage = '/home/user/ComfyUI-Desktop-2.0.AppImage'
+    mockAppImage = '/home/user/Comfy-Desktop.AppImage'
     const caps = await getCapabilities()
     expect(caps).toEqual({ canAutoUpdate: true, systemManaged: false })
   })


### PR DESCRIPTION
## Summary

\`productName\` is already 'Comfy Desktop' everywhere; this cleans up the four spots that still ship 'Desktop 2.0' in actual user output / build artifacts.

| File | What changed |
|---|---|
| \`electron-builder.yml\` | \`artifactName\`: \`ComfyUI-Desktop-2.0-\${version}-...\` → \`Comfy-Desktop-\${version}-...\`. Affects local \`pnpm build:mac\` artifacts; ToDesktop hosted builds use their own naming scheme. |
| \`scripts/reset-mac.sh\` | Header comment + two user-facing echo lines |
| \`scripts/reset-linux.sh\` | Same pattern |
| \`src/main/lib/updater.test.ts\` | AppImage mock filename in one test |

## Intentionally NOT touched

- **\`legalDocs.ts\`** — EULA explicitly lists every historical name ('Comfy Desktop', 'ComfyUI Desktop', 'ComfyUI Desktop 2.0', 'Comfy Desktop 2'). Legal verbiage; don't strip.
- **Engineering doc comments** in \`desktopAdopt.ts\`, \`useAdoptAction.ts\`, \`docs/legacy-desktop-adopt-migration.md\` — 'Desktop 2.0' is the historical project codename in context, accurate.
- **\`PRODUCT_NAMES\` arrays + pgrep entries** in reset scripts — need to keep 'ComfyUI Desktop 2.0' to clean up data dirs from beta installs that predate the \`productName\` rename.
- **\`.docs/\`** historical research / outreach docs.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean (pre-commit hook)
- [x] \`pnpm vitest run src/main/lib/updater\` — 15/15 pass
- [ ] Sanity: next local \`pnpm build:mac\` should produce \`Comfy-Desktop-1.0.1-rc-mac-arm64.dmg\` (no '2.0' in filename)