### PR TITLE
fix(cloud-auth): suppress translated sign-in toast + reskin copy-link banner

### DIFF
--- a/src/main/auth/firebaseBridge/copyLinkBanner.ts
+++ b/src/main/auth/firebaseBridge/copyLinkBanner.ts
@@ -31,6 +31,17 @@ export interface CopyLinkBannerLabels {
   dismiss: string
 }
 
+// Values mirror the Comfy Desktop brand tokens defined in
+// `src/renderer/src/assets/main.css` — CSS vars don't cross into the
+// cloud webview, so we inline the resolved hex/rgba so this banner
+// reads as Desktop chrome on top of whatever cloud is rendering. Key
+// tokens used:
+//   --neutral-700: #2c2533   (deep plum surface)
+//   --neutral-100: #c2bfb9   (warm off-white text)
+//   --neutral-300: #8a8688   (muted text — close ✕, secondary copy)
+//   --accent-primary: #0b8ce9 (brand blue — primary CTA)
+//   --comfy-yellow: #f2ff59  (used for the success/copied flash so
+//                             the confirmation reads as branded)
 export const COPY_LINK_BANNER_CSS =
   // Width hugs the content (so the message stays on one line) but is
   // capped at the viewport, so as the window shrinks the card grows
@@ -38,18 +49,23 @@ export const COPY_LINK_BANNER_CSS =
   `#${COPY_LINK_BANNER_ID}{position:fixed;bottom:20px;left:50%;transform:translateX(-50%);` +
   `z-index:2147483647;display:flex;align-items:center;gap:10px;` +
   `width:max-content;max-width:calc(100vw - 32px);` +
-  `background:#ffffff;color:#1f2937;font:13px/1.45 system-ui,-apple-system,sans-serif;` +
-  `padding:10px 12px;border:1px solid #e5e7eb;border-radius:12px;` +
-  `box-shadow:0 8px 28px rgba(0,0,0,.18);box-sizing:border-box;}` +
+  `background:#2c2533;color:#c2bfb9;font:13px/1.45 system-ui,-apple-system,sans-serif;` +
+  `padding:10px 12px;border:1px solid rgba(255,255,255,0.12);border-radius:12px;` +
+  `box-shadow:0 12px 36px rgba(0,0,0,.5),0 0 0 1px rgba(0,0,0,.2);box-sizing:border-box;}` +
   `#${COPY_LINK_BANNER_ID} .ccl-msg{flex:0 1 auto;min-width:0;white-space:nowrap;}` +
   `#${COPY_LINK_BANNER_ID} button{flex:0 0 auto;display:inline-flex;align-items:center;gap:6px;` +
   `cursor:pointer;border-radius:8px;font:13px/1 system-ui,sans-serif;padding:7px 12px;` +
-  `border:1px solid #d1d5db;background:#f9fafb;color:#111827;}` +
+  `border:1px solid rgba(255,255,255,0.14);background:rgba(255,255,255,0.06);color:#c2bfb9;` +
+  `transition:background 120ms ease,border-color 120ms ease,color 120ms ease;}` +
+  `#${COPY_LINK_BANNER_ID} button:hover{background:rgba(255,255,255,0.1);border-color:rgba(255,255,255,0.22);color:#ffffff;}` +
   `#${COPY_LINK_BANNER_ID} .ccl-ico{display:inline-flex;align-items:center;}` +
-  `#${COPY_LINK_BANNER_ID} button.ccl-primary{background:#111827;color:#fff;border-color:#111827;}` +
-  `#${COPY_LINK_BANNER_ID} button.ccl-done{background:#16a34a;border-color:#16a34a;}` +
-  `#${COPY_LINK_BANNER_ID} button.ccl-close{border:none;background:transparent;color:#6b7280;` +
-  `padding:4px 6px;font-size:16px;line-height:1;}`
+  `#${COPY_LINK_BANNER_ID} button.ccl-primary{background:#0b8ce9;color:#ffffff;border-color:#0b8ce9;}` +
+  `#${COPY_LINK_BANNER_ID} button.ccl-primary:hover{background:#0a7dd1;border-color:#0a7dd1;color:#ffffff;}` +
+  `#${COPY_LINK_BANNER_ID} button.ccl-done{background:#f2ff59;color:#100c13;border-color:#f2ff59;}` +
+  `#${COPY_LINK_BANNER_ID} button.ccl-done:hover{background:#f2ff59;border-color:#f2ff59;color:#100c13;}` +
+  `#${COPY_LINK_BANNER_ID} button.ccl-close{border:none;background:transparent;color:#8a8688;` +
+  `padding:4px 6px;font-size:16px;line-height:1;}` +
+  `#${COPY_LINK_BANNER_ID} button.ccl-close:hover{background:transparent;color:#c2bfb9;}`
 
 /**
  * Build the page-context IIFE that renders the card. Every interpolated

--- a/src/main/host/attach.ts
+++ b/src/main/host/attach.ts
@@ -262,7 +262,9 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
    * Three cloud-only patches injected on every dom-ready of the comfy view:
    *
    *   1. popup-blocked toast suppressor — observes new toast DOM nodes
-   *      and removes any that mention `auth/popup-blocked`. That error
+   *      and removes any that mention `auth/popup-blocked` OR the
+   *      user-friendly variants the cloud frontend now maps that code
+   *      to ("Something went wrong while signing you in…"). That error
    *      is fired by the cloud frontend's Firebase SDK every time our
    *      `setWindowOpenHandler` denies the auth popup (so the bridge
    *      can take over), and the user has no way to dismiss the toast
@@ -310,7 +312,12 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
     `function looksBlocked(n){` +
     `if(!n||n.nodeType!==1)return false;` +
     `var t=(n.textContent||'').toLowerCase();` +
-    `return t.indexOf('auth/popup-blocked')>=0;` +
+    // Raw SDK error code (older cloud frontend builds surface it
+    // directly) + the user-friendly text current builds map it to.
+    // Both phrases are specific enough to the sign-in popup path
+    // that matching them won't catch unrelated toasts.
+    `return t.indexOf('auth/popup-blocked')>=0` +
+    `||t.indexOf('signing you in')>=0;` +
     `}` +
     `function nukeToast(n){` +
     `var root=(n.closest&&n.closest('.p-toast-message,.p-toast-item,[role=alert]'))||n;` +


### PR DESCRIPTION
## Summary
Two related polish fixes that both surface on the same flow — user clicks **Login with Google** in the Cloud view, Firebase's `signInWithPopup` is intercepted at `setWindowOpenHandler`, popup denied so the loopback bridge can take over via the system browser. The bridge ultimately succeeds and signs the user in, but two UX bugs spoil the moment:

### 1. Translated sign-in toast leaks through the suppressor
`src/main/host/attach.ts` injects a MutationObserver on every cloud `dom-ready` that nukes any toast containing `auth/popup-blocked` — the raw SDK error code Firebase throws when our `setWindowOpenHandler` returns `{ action: 'deny' }`. The cloud frontend now translates that error code to a user-friendly toast — **"Something went wrong while signing you in. Please try again."** — which doesn't contain the raw code, so the existing filter never catches it. Users see an alarming error toast even though the bridge is successfully signing them in.

**Fix:** add an OR-match on the substring `signing you in` (specific enough to the sign-in popup path that it won't catch unrelated cloud toasts).

```diff
-    return t.indexOf('auth/popup-blocked')>=0;
+    return t.indexOf('auth/popup-blocked')>=0
+      ||t.indexOf('signing you in')>=0;
```

### 2. Copy-link banner styled for a light theme
`src/main/auth/firebaseBridge/copyLinkBanner.ts` is the floating "We opened your browser to sign in. Didn't open?" card injected into the Cloud view (the Notion/Claude affordance for users whose default browser isn't where they're signed into Google). It was styled white-on-light — stark white card with light-gray border and dark-gray text — which reads as visually offensive against both cloud's dark workspace AND Desktop's own dark plum chrome.

Restyled to the Comfy Desktop brand palette. CSS vars don't cross into the cloud webview, so the resolved hex/rgba values are inlined; the comment block on `COPY_LINK_BANNER_CSS` documents which `--brand-*` token each value mirrors:

| Element | Before | After | Token |
|---|---|---|---|
| Card bg | `#ffffff` | `#2c2533` | `--neutral-700` (deep plum) |
| Card text | `#1f2937` | `#c2bfb9` | `--neutral-100` (warm off-white) |
| Card border | `#e5e7eb` | `rgba(255,255,255,0.12)` | matches `--brand-surface-border-hover` family |
| Card shadow | `0 8px 28px rgba(0,0,0,.18)` | `0 12px 36px rgba(0,0,0,.5)` + inner shadow | tuned for deeper float on dark cloud bg |
| Secondary button | `#f9fafb` / `#d1d5db` / `#111827` | `rgba(255,255,255,0.06)` / `rgba(255,255,255,0.14)` / `#c2bfb9`, hover lifts both bg + border | subtle white-glass |
| Primary "Copy" | `#111827` / `#fff` | `#0b8ce9` / `#fff` | `--accent-primary` (brand blue) |
| "Copied" flash | `#16a34a` (green) | `#f2ff59` (brand yellow) with `#100c13` ink text | `--comfy-yellow` so the confirmation reads as branded |
| Close ✕ | `#6b7280` | `#8a8688` muted, hover lifts to `#c2bfb9` | `--neutral-300` / `--neutral-100` |

All buttons gained a 120ms ease transition on bg/border/color so hover/state changes don't snap.

## Tests
- `src/main/auth/firebaseBridge/copyLinkBanner.test.ts` — 8/8 pass.
- `src/main/auth/firebaseBridge/intercept.test.ts` — 12/12 pass.
- `pnpm run typecheck` clean across web / e2e / integration.
- `pnpm exec eslint src/main/auth/firebaseBridge/copyLinkBanner.ts src/main/host/attach.ts` clean.
