### PR TITLE
chore: bump version to 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-desktop-2",
-  "version": "1.0.1-rc",
+  "version": "1.0.1",
   "description": "Comfy Desktop",
   "author": {
     "name": "Comfy Org",


### PR DESCRIPTION
## Summary

Bumps \`package.json\` from \`1.0.1-rc\` → \`1.0.1\`. Promotes the rc to a stable release tag. First actual stable cut for the 1.x line.

## What happens on merge

\`release-from-pr-label.yml\` detects the \`Release\` label + version diff:

1. Creates and pushes tag \`v1.0.1\` on the merge commit.
2. Dispatches \`build-release.yml\` (ToDesktop build + Datadog sourcemaps + draft release).
3. Draft release appears at https://github.com/Comfy-Org/Comfy-Desktop/releases — hit Publish once the build finishes.

## Why manual (not \`version-bump.yml\`)

The automated bump workflow's regex only accepts \`X.Y.Z\` (strict). \`1.0.1-rc\` doesn't match → it throws \`Unsupported version format\`. Promotion from rc → stable is a one-line manual diff. Workflow-side support for pre-release suffixes is a separate follow-up.

## What's in this release vs 1.0.1-rc

Everything merged between \`v1.0.1-rc\` and now — most notably:

- \`fix(brand)\` canonical Comfy wordmark (#862) — fixes the squashed dashboard logo
- \`fix(app-update)\` respect quit-in-progress (#860) — Desktop Update Restart works on first click
- \`feat(first-use)\` default to Local on Windows/Linux (#861)
- \`fix(adopt)\` Legacy Desktop migration cleanup (#849)
- \`fix(dmg)\` regenerate background assets with 'Comfy Desktop' title (#856)
- \`fix(cloud-auth)\` suppress translated sign-in toast (#853)
- \`refactor\` aggressive comment cleanup (#851)
- \`chore(branding)\` strip lingering 'Desktop 2.0' from user-facing strings (#850)