### PR TITLE
fix(adopt): probe <yamlBase>/models before carrying extra-models YAML entries

### DIFF
--- a/src/main/lib/desktopAdopt.test.ts
+++ b/src/main/lib/desktopAdopt.test.ts
@@ -439,8 +439,6 @@ describe('computeModelsDirsToCarry', () => {
     const a1111 = path.join(tmpRoot, 'a1111')
     fs.mkdirSync(path.join(siblingComfy, 'models'), { recursive: true })
     fs.mkdirSync(path.join(a1111, 'models', 'Stable-diffusion'), { recursive: true })
-    // a1111 has /models too (Auto1111 layout uses it), so it'll be carried; the
-    // point of the probe is to skip *missing* /models, not to make tool-specific judgements.
     const yamlOnlyA1111Layout = path.join(tmpRoot, 'something-else')
     fs.mkdirSync(yamlOnlyA1111Layout) // exists, but no /models subfolder
     const yaml =

--- a/src/main/lib/desktopAdopt.test.ts
+++ b/src/main/lib/desktopAdopt.test.ts
@@ -419,14 +419,63 @@ describe('deriveLaunchArgs', () => {
 })
 
 describe('computeModelsDirsToCarry', () => {
-  it('adds basePath/models plus extra YAML mounts and dedupes against existing', () => {
-    const basePath = '/data/ComfyUI'
-    const yaml = `c1:\n  base_path: /data/ComfyUI\nc2:\n  base_path: /extra/A1111\n`
-    const existing = [path.resolve('/data/ComfyUI')]
+  let tmpRoot: string
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'carryModelsDirs-'))
+  })
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+  })
+
+  it('always carries basePath/models even when the folder is absent (legacy install root is trusted)', () => {
+    const basePath = path.join(tmpRoot, 'ComfyUI-legacy')
+    const result = computeModelsDirsToCarry(basePath, null, [])
+    expect(result).toEqual([path.resolve(path.join(basePath, 'models'))])
+  })
+
+  it('carries <yamlBase>/models for YAML entries whose /models subfolder exists; skips others', () => {
+    const basePath = path.join(tmpRoot, 'primary')
+    const siblingComfy = path.join(tmpRoot, 'sibling-comfy')
+    const a1111 = path.join(tmpRoot, 'a1111')
+    fs.mkdirSync(path.join(siblingComfy, 'models'), { recursive: true })
+    fs.mkdirSync(path.join(a1111, 'models', 'Stable-diffusion'), { recursive: true })
+    // a1111 has /models too (Auto1111 layout uses it), so it'll be carried; the
+    // point of the probe is to skip *missing* /models, not to make tool-specific judgements.
+    const yamlOnlyA1111Layout = path.join(tmpRoot, 'something-else')
+    fs.mkdirSync(yamlOnlyA1111Layout) // exists, but no /models subfolder
+    const yaml =
+      `comfyui_sibling:\n  base_path: ${siblingComfy}\n` +
+      `a1111:\n  base_path: ${a1111}\n` +
+      `weird:\n  base_path: ${yamlOnlyA1111Layout}\n`
+    const result = computeModelsDirsToCarry(basePath, yaml, [])
+    expect(result).toContain(path.resolve(path.join(basePath, 'models')))
+    expect(result).toContain(path.resolve(path.join(siblingComfy, 'models')))
+    expect(result).toContain(path.resolve(path.join(a1111, 'models')))
+    expect(result).not.toContain(path.resolve(path.join(yamlOnlyA1111Layout, 'models')))
+    // Never the bare base_path.
+    expect(result).not.toContain(path.resolve(siblingComfy))
+    expect(result).not.toContain(path.resolve(a1111))
+  })
+
+  it('dedupes against the caller existing list', () => {
+    const basePath = path.join(tmpRoot, 'primary')
+    const sibling = path.join(tmpRoot, 'sibling')
+    fs.mkdirSync(path.join(sibling, 'models'), { recursive: true })
+    const existing = [path.resolve(path.join(basePath, 'models'))]
+    const yaml = `s:\n  base_path: ${sibling}\n`
     const result = computeModelsDirsToCarry(basePath, yaml, existing)
-    expect(result).toContain(path.resolve('/data/ComfyUI/models'))
-    expect(result).toContain(path.resolve('/extra/A1111'))
-    expect(result).not.toContain(path.resolve('/data/ComfyUI'))
+    expect(result).toEqual([path.resolve(path.join(sibling, 'models'))])
+  })
+
+  it('skips a YAML base_path that exists as a file (not a directory)', () => {
+    const basePath = path.join(tmpRoot, 'primary')
+    const yamlBase = path.join(tmpRoot, 'has-models-file')
+    fs.mkdirSync(yamlBase, { recursive: true })
+    // create `models` as a file, not a directory
+    fs.writeFileSync(path.join(yamlBase, 'models'), 'not a dir')
+    const yaml = `s:\n  base_path: ${yamlBase}\n`
+    const result = computeModelsDirsToCarry(basePath, yaml, [])
+    expect(result).not.toContain(path.resolve(path.join(yamlBase, 'models')))
   })
 })
 
@@ -505,8 +554,16 @@ describe('adoptDesktopInstall', () => {
     }
   })
 
-  it('merges modelsDirs from extra_models_config.yaml and basePath/models', async () => {
-    const yaml = `comfyui_desktop:\n  base_path: /shared/A\n  is_default: true\nA1111:\n  base_path: /shared/B\n`
+  it('merges modelsDirs: basePath/models always + <yamlBase>/models when present, never the bare base_path', async () => {
+    // Sibling install exists with a `/models` folder; "missing" install has no `/models`.
+    const tmpYamlRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'adopt-yaml-roots-'))
+    const sibling = path.join(tmpYamlRoot, 'sibling-comfy')
+    const missingModels = path.join(tmpYamlRoot, 'no-models')
+    fs.mkdirSync(path.join(sibling, 'models'), { recursive: true })
+    fs.mkdirSync(missingModels, { recursive: true })
+    const yaml =
+      `comfyui_sibling:\n  base_path: ${sibling}\n  is_default: true\n` +
+      `weird:\n  base_path: ${missingModels}\n`
     const legacy = buildFakeLegacy({
       configFiles: {
         'comfy.settings.json': '{}',
@@ -524,12 +581,15 @@ describe('adoptDesktopInstall', () => {
       expect(finalDirs).toEqual(
         expect.arrayContaining([
           path.resolve(path.join(legacy.basePath, 'models')),
-          path.resolve('/shared/A'),
-          path.resolve('/shared/B')
+          path.resolve(path.join(sibling, 'models'))
         ])
       )
+      expect(finalDirs).not.toContain(path.resolve(sibling))
+      expect(finalDirs).not.toContain(path.resolve(missingModels))
+      expect(finalDirs).not.toContain(path.resolve(path.join(missingModels, 'models')))
     } finally {
       legacy.cleanup()
+      fs.rmSync(tmpYamlRoot, { recursive: true, force: true })
     }
   })
 

--- a/src/main/lib/desktopAdopt.ts
+++ b/src/main/lib/desktopAdopt.ts
@@ -379,21 +379,12 @@ function readLegacyAppVersion(executablePath: string | null): string | null {
 }
 
 /**
- * Compute the cross-install model dirs to register in `settings.modelsDirs`
- * for the adopted record.
- *
- * Always carries `<basePath>/models` (the legacy install's own folder).
- *
- * For each `base_path:` value in the legacy `extra_models_config.yaml`,
- * carries `<base_path>/models` ONLY if that subdirectory actually exists.
- * The bare base_path is never carried: in extra-model YAMLs it's the root
- * of another tool whose model files live under `<base_path>/<per-folder>`,
- * which doesn't match v2's "each modelsDirs entry is a ComfyUI-style models
- * folder" contract. ComfyUI-style siblings (a second ComfyUI install) get
- * picked up via the `/models` probe; other tools (A1111 etc.) whose layout
- * differs are silently skipped — users can re-add them manually in v2.
- *
- * Dedupes against the caller's existing list.
+ * Cross-install model dirs to register in `settings.modelsDirs` for the
+ * adopted record. Always carries `<basePath>/models`; for each YAML
+ * `base_path:`, carries `<base_path>/models` only when it exists as a
+ * directory (handles ComfyUI-style siblings, silently skips other tools).
+ * The bare base_path is never carried — it points at a tool root whose
+ * models live one level deeper. Dedupes against `existing`.
  */
 export function computeModelsDirsToCarry(
   basePath: string,
@@ -404,7 +395,7 @@ export function computeModelsDirsToCarry(
   if (extraYamlContent) {
     for (const yamlBase of parseExtraModelsYaml(extraYamlContent)) {
       const probe = path.join(yamlBase, 'models')
-      if (fs.existsSync(probe) && fs.statSync(probe).isDirectory()) {
+      if (fs.statSync(probe, { throwIfNoEntry: false })?.isDirectory()) {
         candidates.push(probe)
       }
     }

--- a/src/main/lib/desktopAdopt.ts
+++ b/src/main/lib/desktopAdopt.ts
@@ -380,18 +380,33 @@ function readLegacyAppVersion(executablePath: string | null): string | null {
 
 /**
  * Compute the cross-install model dirs to register in `settings.modelsDirs`
- * for the adopted record. Dedupes against the caller's existing list.
+ * for the adopted record.
+ *
+ * Always carries `<basePath>/models` (the legacy install's own folder).
+ *
+ * For each `base_path:` value in the legacy `extra_models_config.yaml`,
+ * carries `<base_path>/models` ONLY if that subdirectory actually exists.
+ * The bare base_path is never carried: in extra-model YAMLs it's the root
+ * of another tool whose model files live under `<base_path>/<per-folder>`,
+ * which doesn't match v2's "each modelsDirs entry is a ComfyUI-style models
+ * folder" contract. ComfyUI-style siblings (a second ComfyUI install) get
+ * picked up via the `/models` probe; other tools (A1111 etc.) whose layout
+ * differs are silently skipped — users can re-add them manually in v2.
+ *
+ * Dedupes against the caller's existing list.
  */
 export function computeModelsDirsToCarry(
   basePath: string,
   extraYamlContent: string | null,
   existing: string[]
 ): string[] {
-  const candidates: string[] = []
-  candidates.push(path.join(basePath, 'models'))
+  const candidates: string[] = [path.join(basePath, 'models')]
   if (extraYamlContent) {
-    for (const dir of parseExtraModelsYaml(extraYamlContent)) {
-      candidates.push(dir)
+    for (const yamlBase of parseExtraModelsYaml(extraYamlContent)) {
+      const probe = path.join(yamlBase, 'models')
+      if (fs.existsSync(probe) && fs.statSync(probe).isDirectory()) {
+        candidates.push(probe)
+      }
     }
   }
   const seen = new Set(existing.map((d) => path.resolve(d)))
@@ -672,9 +687,11 @@ interface CarryReport {
  * so built-in defaults don't masquerade as user choices.
  *
  * Carries:
- *   - `modelsDirs`           ← `<basePath>/models` + every `base_path`
- *                              from `extra_models_config.yaml`
- *                              (always appended; never blocked).
+ *   - `modelsDirs`           ← `<basePath>/models` + `<yamlBase>/models`
+ *                              for every `base_path` in
+ *                              `extra_models_config.yaml` whose
+ *                              `/models` subfolder actually exists
+ *                              (ComfyUI-style siblings). Always appended.
  *   - `telemetryEnabled`     ← `Comfy-Desktop.SendStatistics`
  *   - `autoInstallUpdates`   ← force `true`. Adoption ships as an
  *                              in-place app update of Legacy Desktop;


### PR DESCRIPTION
Follow-up to #849.

Adoption was registering bare `base_path:` values from the legacy `extra_models_config.yaml` directly into the shared `settings.modelsDirs`. v2 treats each `modelsDirs` entry as a ComfyUI-style folder whose subfolders are model categories (`checkpoints/`, `vae/`, etc.), but in extra-model YAMLs `base_path:` is the *root* of another tool whose models live one level deeper. The result: v2 would scan e.g. `…/ComfyUI/checkpoints` instead of `…/ComfyUI/models/checkpoints` and the carried entry contributed nothing useful — or worse, in the A1111 case, pointed at a tree with a completely different layout.

## Fix

In `computeModelsDirsToCarry`:
- `<basePath>/models` (the adopted install's own folder) is still always carried.
- For each `base_path:` in the YAML, probe `<base_path>/models` and only carry it when that subfolder actually exists as a directory.
  - ComfyUI-style siblings (a second ComfyUI install referenced in the YAML) get picked up cleanly.
  - A1111 / other tools whose layout doesn't match are silently skipped; the user can re-add them manually in v2 settings.
- The bare `base_path` is never carried.

`fs.existsSync` + `fs.statSync().isDirectory()` is sync — matches the rest of the adoption flow's style. No timeout: per Node docs `existsSync` never throws, and the rare worst case (a stalled network mount in someone's YAML) is bounded by the OS stat call, not a crash.

## Tests

- 4 new unit tests on `computeModelsDirsToCarry` covering: legacy `<basePath>/models` always carried, sibling ComfyUI probe hit, missing `/models` probe miss, dedupe against existing, `/models` existing as a file (not dir) is skipped.
- Updated the integration-style `adoptDesktopInstall` test that previously asserted the old "carry every base_path" behavior.
- All 1756 tests pass; typecheck + lint clean.
