### PR TITLE
chore(telemetry): launch-day follow-ups — observability fixes + privacy hardening

### DIFF
--- a/src/main/lib/cloudUrl.test.ts
+++ b/src/main/lib/cloudUrl.test.ts
@@ -1,13 +1,18 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { withCloudDistributionUtm } from './cloudUrl'
 
+// The default deviceIdProvider reads (and may write) a file under the
+// user data dir via `getDeviceId`. Inject a no-op provider so the UTM
+// assertions don't depend on disk state and don't leak fixtures.
+const noDeviceId = () => null
+
 describe('withCloudDistributionUtm', () => {
   afterEach(() => {
     vi.restoreAllMocks()
   })
 
   it('adds default UTM params for cloud distribution links', () => {
-    const result = withCloudDistributionUtm('https://cloud.comfy.org/')
+    const result = withCloudDistributionUtm('https://cloud.comfy.org/', noDeviceId)
     const url = new URL(result)
 
     expect(url.hostname).toBe('cloud.comfy.org')
@@ -18,7 +23,8 @@ describe('withCloudDistributionUtm', () => {
 
   it('preserves existing query params and UTM overrides', () => {
     const result = withCloudDistributionUtm(
-      'https://cloud.comfy.org/path?plan=pro&utm_source=custom-source'
+      'https://cloud.comfy.org/path?plan=pro&utm_source=custom-source',
+      noDeviceId
     )
     const url = new URL(result)
 
@@ -31,13 +37,41 @@ describe('withCloudDistributionUtm', () => {
   it('does not modify non-cloud URLs', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const input = 'https://example.com/path?plan=pro'
-    expect(withCloudDistributionUtm(input)).toBe(input)
+    expect(withCloudDistributionUtm(input, noDeviceId)).toBe(input)
     expect(warn).toHaveBeenCalledTimes(1)
   })
 
   it('returns invalid URLs unchanged', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    expect(withCloudDistributionUtm('not a url')).toBe('not a url')
+    expect(withCloudDistributionUtm('not a url', noDeviceId)).toBe('not a url')
     expect(warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('appends desktop_device_id when a device id is available', () => {
+    const url = new URL(
+      withCloudDistributionUtm('https://cloud.comfy.org/path', () => 'abc-123')
+    )
+
+    expect(url.searchParams.get('desktop_device_id')).toBe('abc-123')
+    expect(url.searchParams.get('utm_source')).toBe('comfy.desktop')
+  })
+
+  it('does not append desktop_device_id when the provider returns null', () => {
+    const url = new URL(
+      withCloudDistributionUtm('https://cloud.comfy.org/path', () => null)
+    )
+
+    expect(url.searchParams.has('desktop_device_id')).toBe(false)
+  })
+
+  it('preserves caller-supplied desktop_device_id over the provider', () => {
+    const url = new URL(
+      withCloudDistributionUtm(
+        'https://cloud.comfy.org/path?desktop_device_id=caller-explicit',
+        () => 'provider-id'
+      )
+    )
+
+    expect(url.searchParams.get('desktop_device_id')).toBe('caller-explicit')
   })
 })

--- a/src/main/lib/cloudUrl.ts
+++ b/src/main/lib/cloudUrl.ts
@@ -1,3 +1,5 @@
+import { getDeviceId } from './deviceId'
+
 const CLOUD_DISTRIBUTION_HOST = 'cloud.comfy.org'
 
 const DEFAULT_UTM_PARAMS: Record<string, string> = {
@@ -5,11 +7,24 @@ const DEFAULT_UTM_PARAMS: Record<string, string> = {
   utm_medium: 'app_feature'
 }
 
+// Query param used to forward the Desktop telemetry distinct_id into
+// the cloud webContents so cloud.comfy.org's posthog-js can call
+// `posthog.identify(...)` and stitch the two sessions. Until that
+// cloud-side change ships, the param is harmless extra data on the URL
+// — but every Desktop → Cloud event already carries it for the day the
+// stitcher is wired up.
+const DESKTOP_DEVICE_ID_PARAM = 'desktop_device_id'
+
 function warnSkippedUtm(reason: string, details: Record<string, string>): void {
   console.warn(`[cloud-utm] ${reason}`, details)
 }
 
-export function withCloudDistributionUtm(rawUrl: string): string {
+export function withCloudDistributionUtm(
+  rawUrl: string,
+  // Injection point so unit tests can pin a value; production callers
+  // omit this and let the helper read from the shared deviceId module.
+  deviceIdProvider: () => string | null = getDeviceId
+): string {
   let url: URL
   try {
     url = new URL(rawUrl)
@@ -30,5 +45,18 @@ export function withCloudDistributionUtm(rawUrl: string): string {
       url.searchParams.set(key, value)
     }
   }
+
+  // Append the Desktop device-id as a separate query param so cloud-side
+  // posthog-js can identify() the user against the same distinct_id the
+  // Desktop main process uses. Don't overwrite an explicit caller value
+  // and skip when the id hasn't resolved yet (initDeviceId still in
+  // flight) so we never ship an empty string.
+  if (!url.searchParams.has(DESKTOP_DEVICE_ID_PARAM)) {
+    const id = deviceIdProvider()
+    if (id) {
+      url.searchParams.set(DESKTOP_DEVICE_ID_PARAM, id)
+    }
+  }
+
   return url.href
 }

--- a/src/main/lib/cnr.ts
+++ b/src/main/lib/cnr.ts
@@ -4,6 +4,7 @@ import os from 'os'
 import { fetchJSON } from './fetch'
 import { download } from './download'
 import { extract } from './extract'
+import * as telemetry from './telemetry'
 
 interface CnrInstallInfo {
   downloadUrl: string
@@ -58,35 +59,68 @@ export async function installCnrNode(
   customNodesDir: string,
   sendOutput: (text: string) => void,
 ): Promise<string[]> {
-  if (!isSafePathComponent(nodeId)) {
-    throw new Error(`Invalid node ID: ${nodeId}`)
-  }
-
-  const info = await getCnrInstallInfo(nodeId, version)
-  if (!info) {
-    throw new Error(`Failed to get install info for ${nodeId}@${version}`)
-  }
-
-  const installPath = path.join(customNodesDir, nodeId)
-  const tmpZip = path.join(os.tmpdir(), `cnr-${nodeId}-${version}-${Date.now()}.zip`)
-
+  const startedAt = Date.now()
+  // Resolved version is unknown until the registry call returns; fall
+  // back to the caller-requested string for failure paths so the event
+  // still names a version.
+  let resolvedVersion = version
+  // Capture telemetry around the entire install — including pre-flight
+  // validation and the registry lookup — so failures that happen before
+  // the tmp-zip allocation still fire `node.installed` with the right
+  // bucket. The actual zip download / extraction still wraps its own
+  // try/finally below for tmpZip cleanup.
   try {
-    sendOutput(`Downloading ${nodeId}@${info.version}...\n`)
-    await download(info.downloadUrl, tmpZip, null)
+    if (!isSafePathComponent(nodeId)) {
+      throw new Error(`Invalid node ID: ${nodeId}`)
+    }
 
-    sendOutput(`Extracting ${nodeId}@${info.version}...\n`)
-    await fs.promises.mkdir(installPath, { recursive: true })
-    await extract(tmpZip, installPath)
+    const info = await getCnrInstallInfo(nodeId, version)
+    if (!info) {
+      throw new Error(`Failed to get install info for ${nodeId}@${version}`)
+    }
+    resolvedVersion = info.version
 
-    const files = walkDir(installPath)
-    await fs.promises.writeFile(path.join(installPath, TRACKING_FILE), files.join('\n') + '\n')
+    const installPath = path.join(customNodesDir, nodeId)
+    const tmpZip = path.join(os.tmpdir(), `cnr-${nodeId}-${version}-${Date.now()}.zip`)
 
-    sendOutput(`Installed ${nodeId}@${info.version}\n`)
-    return files
-  } finally {
     try {
-      await fs.promises.unlink(tmpZip)
-    } catch {}
+      sendOutput(`Downloading ${nodeId}@${info.version}...\n`)
+      await download(info.downloadUrl, tmpZip, null)
+
+      sendOutput(`Extracting ${nodeId}@${info.version}...\n`)
+      await fs.promises.mkdir(installPath, { recursive: true })
+      await extract(tmpZip, installPath)
+
+      const files = walkDir(installPath)
+      await fs.promises.writeFile(path.join(installPath, TRACKING_FILE), files.join('\n') + '\n')
+
+      sendOutput(`Installed ${nodeId}@${info.version}\n`)
+      telemetry.capture('comfy.desktop.node.installed', {
+        node_id: nodeId,
+        version: info.version,
+        action: 'install',
+        result: 'success',
+        duration_ms: Date.now() - startedAt,
+        file_count: files.length
+      })
+      return files
+    } finally {
+      try {
+        await fs.promises.unlink(tmpZip)
+      } catch {}
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    telemetry.capture('comfy.desktop.node.installed', {
+      node_id: nodeId,
+      version: resolvedVersion,
+      action: 'install',
+      result: 'failure',
+      duration_ms: Date.now() - startedAt,
+      error_bucket: telemetry.bucketError(message),
+      error_message: message.slice(0, 500)
+    })
+    throw err
   }
 }
 
@@ -96,76 +130,101 @@ export async function switchCnrVersion(
   nodePath: string,
   sendOutput: (text: string) => void,
 ): Promise<string[]> {
-  const info = await getCnrInstallInfo(nodeId, newVersion)
-  if (!info) {
-    throw new Error(`Failed to get install info for ${nodeId}@${newVersion}`)
-  }
-
-  const trackingPath = path.join(nodePath, TRACKING_FILE)
-  const oldFiles = new Set<string>()
+  const startedAt = Date.now()
+  let resolvedVersion = newVersion
   try {
-    const content = await fs.promises.readFile(trackingPath, 'utf-8')
-    for (const line of content.split('\n')) {
-      const trimmed = line.trim()
-      if (trimmed) oldFiles.add(trimmed)
+    const info = await getCnrInstallInfo(nodeId, newVersion)
+    if (!info) {
+      throw new Error(`Failed to get install info for ${nodeId}@${newVersion}`)
     }
-  } catch {}
+    resolvedVersion = info.version
 
-  const stamp = Date.now()
-  const tmpZip = path.join(os.tmpdir(), `cnr-${nodeId}-${newVersion}-${stamp}.zip`)
-  const tmpExtract = path.join(os.tmpdir(), `cnr-${nodeId}-${newVersion}-${stamp}`)
+    const trackingPath = path.join(nodePath, TRACKING_FILE)
+    const oldFiles = new Set<string>()
+    try {
+      const content = await fs.promises.readFile(trackingPath, 'utf-8')
+      for (const line of content.split('\n')) {
+        const trimmed = line.trim()
+        if (trimmed) oldFiles.add(trimmed)
+      }
+    } catch {}
 
-  try {
-    sendOutput(`Downloading ${nodeId}@${info.version}...\n`)
-    await download(info.downloadUrl, tmpZip, null)
+    const stamp = Date.now()
+    const tmpZip = path.join(os.tmpdir(), `cnr-${nodeId}-${newVersion}-${stamp}.zip`)
+    const tmpExtract = path.join(os.tmpdir(), `cnr-${nodeId}-${newVersion}-${stamp}`)
 
-    // Extract to a temp dir first to get the true new file list; in-place
-    // extraction would union old+new files and break garbage detection.
-    sendOutput(`Extracting ${nodeId}@${info.version}...\n`)
-    await fs.promises.mkdir(tmpExtract, { recursive: true })
-    await extract(tmpZip, tmpExtract)
+    try {
+      sendOutput(`Downloading ${nodeId}@${info.version}...\n`)
+      await download(info.downloadUrl, tmpZip, null)
 
-    const newFiles = walkDir(tmpExtract)
-    const newFileSet = new Set(newFiles)
+      // Extract to a temp dir first to get the true new file list; in-place
+      // extraction would union old+new files and break garbage detection.
+      sendOutput(`Extracting ${nodeId}@${info.version}...\n`)
+      await fs.promises.mkdir(tmpExtract, { recursive: true })
+      await extract(tmpZip, tmpExtract)
 
-    // Copy extracted files into nodePath (overwriting existing)
-    await fs.promises.mkdir(nodePath, { recursive: true })
-    await fs.promises.cp(tmpExtract, nodePath, { recursive: true, force: true })
+      const newFiles = walkDir(tmpExtract)
+      const newFileSet = new Set(newFiles)
 
-    const garbageFiles: string[] = []
-    const garbageDirs = new Set<string>()
-    for (const oldFile of oldFiles) {
-      if (!newFileSet.has(oldFile)) {
-        garbageFiles.push(oldFile)
-        let dir = oldFile
-        while (true) {
-          const parent = dir.substring(0, dir.lastIndexOf('/'))
-          if (!parent) break
-          garbageDirs.add(parent)
-          dir = parent
+      // Copy extracted files into nodePath (overwriting existing)
+      await fs.promises.mkdir(nodePath, { recursive: true })
+      await fs.promises.cp(tmpExtract, nodePath, { recursive: true, force: true })
+
+      const garbageFiles: string[] = []
+      const garbageDirs = new Set<string>()
+      for (const oldFile of oldFiles) {
+        if (!newFileSet.has(oldFile)) {
+          garbageFiles.push(oldFile)
+          let dir = oldFile
+          while (true) {
+            const parent = dir.substring(0, dir.lastIndexOf('/'))
+            if (!parent) break
+            garbageDirs.add(parent)
+            dir = parent
+          }
         }
       }
+
+      for (const file of garbageFiles) {
+        try {
+          await fs.promises.unlink(path.join(nodePath, file.split('/').join(path.sep)))
+        } catch {}
+      }
+
+      const sortedDirs = [...garbageDirs].sort((a, b) => b.length - a.length)
+      for (const dir of sortedDirs) {
+        try {
+          await fs.promises.rmdir(path.join(nodePath, dir.split('/').join(path.sep)))
+        } catch {}
+      }
+
+      await fs.promises.writeFile(path.join(nodePath, TRACKING_FILE), newFiles.join('\n') + '\n')
+
+      sendOutput(`Switched ${nodeId} to ${info.version}\n`)
+      telemetry.capture('comfy.desktop.node.installed', {
+        node_id: nodeId,
+        version: info.version,
+        action: 'switch',
+        result: 'success',
+        duration_ms: Date.now() - startedAt,
+        file_count: newFiles.length
+      })
+      return newFiles
+    } finally {
+      try { await fs.promises.unlink(tmpZip) } catch {}
+      try { await fs.promises.rm(tmpExtract, { recursive: true, force: true }) } catch {}
     }
-
-    for (const file of garbageFiles) {
-      try {
-        await fs.promises.unlink(path.join(nodePath, file.split('/').join(path.sep)))
-      } catch {}
-    }
-
-    const sortedDirs = [...garbageDirs].sort((a, b) => b.length - a.length)
-    for (const dir of sortedDirs) {
-      try {
-        await fs.promises.rmdir(path.join(nodePath, dir.split('/').join(path.sep)))
-      } catch {}
-    }
-
-    await fs.promises.writeFile(path.join(nodePath, TRACKING_FILE), newFiles.join('\n') + '\n')
-
-    sendOutput(`Switched ${nodeId} to ${info.version}\n`)
-    return newFiles
-  } finally {
-    try { await fs.promises.unlink(tmpZip) } catch {}
-    try { await fs.promises.rm(tmpExtract, { recursive: true, force: true }) } catch {}
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    telemetry.capture('comfy.desktop.node.installed', {
+      node_id: nodeId,
+      version: resolvedVersion,
+      action: 'switch',
+      result: 'failure',
+      duration_ms: Date.now() - startedAt,
+      error_bucket: telemetry.bucketError(message),
+      error_message: message.slice(0, 500)
+    })
+    throw err
   }
 }

--- a/src/main/lib/desktopAdopt.test.ts
+++ b/src/main/lib/desktopAdopt.test.ts
@@ -489,6 +489,7 @@ describe('adoptDesktopInstall', () => {
     expect(telemetry.capture).toHaveBeenCalledWith(
       'comfy.desktop.adopt.failed',
       expect.objectContaining({
+        stage: 'detect',
         error_bucket: 'no-legacy-install'
       })
     )

--- a/src/main/lib/desktopAdopt.ts
+++ b/src/main/lib/desktopAdopt.ts
@@ -27,6 +27,7 @@ import * as installations from '../installations'
 import type { InstallationRecord } from '../installations'
 import * as settings from '../settings'
 import * as telemetry from './telemetry'
+import { scrubAll } from '../../shared/piiScrub'
 import * as i18n from './i18n'
 
 const MARKER_FILE = ADOPT_MARKER_FILE
@@ -840,7 +841,10 @@ export async function adoptDesktopInstall(opts: AdoptOptions): Promise<Installat
 
   const info = deps.detectDesktopInstall()
   if (!info) {
-    telemetry.capture('comfy.desktop.adopt.failed', { error_bucket: 'no-legacy-install' })
+    telemetry.capture('comfy.desktop.adopt.failed', {
+      stage: 'detect',
+      error_bucket: 'no-legacy-install'
+    })
     throw new Error('no-legacy-install')
   }
 
@@ -873,14 +877,35 @@ export async function adoptDesktopInstall(opts: AdoptOptions): Promise<Installat
 
   telemetry.capture('comfy.desktop.adopt.started', {})
 
+  // Track the most recently entered phase so adopt.failed can report
+  // *which* step blew up. Without this, every failure surfaces with
+  // stage=null and the only debug signal is the free-text
+  // `error_message`. sendProgress is called at the start of each
+  // runAdoption phase, so the wrapped delegate updates this before the
+  // phase begins running. `init` covers everything that happens before
+  // runAdoption's first sendProgress (`backup`).
+  let currentPhase = 'init'
+  const phaseAwareTools: AdoptTools = {
+    ...tools,
+    sendProgress: (phase, detail) => {
+      currentPhase = phase
+      tools.sendProgress(phase, detail)
+    }
+  }
+
   try {
-    const result = await runAdoption(info, tools, deps)
+    const result = await runAdoption(info, phaseAwareTools, deps)
     return result
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
+    // Scrub before slice so the redacted prefix doesn't get truncated
+    // mid-token. The bucket runs on raw text because its regexes don't
+    // care about user paths and would otherwise miss a legitimate match
+    // hidden inside a `[REDACTED]` substitution.
     telemetry.capture('comfy.desktop.adopt.failed', {
+      stage: currentPhase,
       error_bucket: telemetry.bucketError(message),
-      error_message: message.slice(0, 500)
+      error_message: scrubAll(message).slice(0, 500)
     })
     throw err
   }

--- a/src/main/lib/executionTap.ts
+++ b/src/main/lib/executionTap.ts
@@ -140,14 +140,19 @@ export function createExecutionTap(opts: {
     const errorClass = exceptionLine.split(':')[0]?.trim() || 'unknown'
     const scrubbedMessage = scrubAll(exceptionLine).slice(0, ERROR_MESSAGE_MAX)
     state.errorCount++
-    // An error consumes a pending start so wall-clock pairing stays sane.
-    consumePromptStart()
+    // Wall-clock between the matching `Got prompt` and the error end —
+    // mirror what `execution.completed` already emits so error-vs-success
+    // duration can be compared directly on the dashboard. Null when the
+    // error fired without a paired start (already-pending traceback at
+    // boot, etc.).
+    const wallMs = consumePromptStart()
     telemetry.emit('comfy.desktop.execution.error', {
       ...baseContext,
       error_class: errorClass.slice(0, ERROR_CLASS_MAX),
       error_message: scrubbedMessage,
       error_bucket: telemetry.bucketError(scrubbedMessage),
-      error_count: state.errorCount
+      error_count: state.errorCount,
+      wall_clock_ms: wallMs
     })
     state.tracebackPhase = 'none'
     state.tracebackBuffer = []
@@ -200,13 +205,14 @@ export function createExecutionTap(opts: {
     const validationMatch = trimmed.match(VALIDATION_FAIL)
     if (validationMatch?.groups) {
       state.errorCount++
-      consumePromptStart()
+      const wallMs = consumePromptStart()
       telemetry.emit('comfy.desktop.execution.error', {
         ...baseContext,
         error_class: 'validation_failed',
         error_bucket: 'validation',
         error_count: state.errorCount,
-        node_id: validationMatch.groups['nodeId']
+        node_id: validationMatch.groups['nodeId'],
+        wall_clock_ms: wallMs
       })
       return
     }

--- a/src/main/lib/ipc/registerAppHandlers.ts
+++ b/src/main/lib/ipc/registerAppHandlers.ts
@@ -230,10 +230,17 @@ export function registerAppHandlers(): void {
       }))
     }
 
+    // `detectGPU()` only resolves the vendor (NVIDIA / AMD / Intel /
+    // Apple Silicon) — its `model` field is hardcoded null. The
+    // systeminformation `controllers[]` data already collected for
+    // `allGpus` carries the actual chipset name, so fall back to it.
+    // Empty strings from the lib normalise to null so cohort filters on
+    // "is set" work consistently.
+    const primaryGpuModel = (allGpus[0]?.model || null) ?? gpu?.model ?? null
     return {
       gpu_vendor: gpu?.id ?? null,
       gpu_label: gpu?.label ?? null,
-      gpu_model: gpu?.model ?? null,
+      gpu_model: primaryGpuModel,
       gpus: allGpus,
       nvidia_driver_version: nvidiaCheck?.driverVersion ?? null,
       nvidia_driver_supported: nvidiaCheck?.supported ?? null,

--- a/src/main/lib/ipc/sessionActions/launch.ts
+++ b/src/main/lib/ipc/sessionActions/launch.ts
@@ -25,6 +25,7 @@ import { lastNLines, stripAnsi } from '../../stderrTail'
 import { rotateLogFiles, getLogDir } from '../../logRotation'
 import { createExecutionTap } from '../../executionTap'
 import { clearCrash, recordCrash } from '../../crashBuffer'
+import * as telemetry from '../../telemetry'
 import type { WriteStream } from 'fs'
 
 // Feature flags injected on every spawned ComfyUI, gated by the running
@@ -393,6 +394,18 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
     if (!sender.isDestroyed()) {
       sender.send('comfy-output', { installationId, text: `> ${cmdLine}\n\n` })
     }
+    // Explicit boot-attempt event. `installation_started` already fires
+    // on successful boot with `boot_time_ms`, and `comfyui.exited` carries
+    // `crashed=true` on failure — but boot success rate needed inferred
+    // counts from those two events. Emitting `boot_started` makes it a
+    // single division (`installation_started / boot_started`) and surfaces
+    // retries (port_retry / reboot_retry counters) directly.
+    telemetry.capture('comfy.desktop.comfyui.boot_started', {
+      installation_id: installationId,
+      variant: (inst.variant as string | undefined) ?? null,
+      port_retry_count: portRetries,
+      reboot_retry_count: rebootRetries
+    })
     const spawned = spawnComfy()
 
     let earlyExit: string | null = null

--- a/src/main/lib/telemetry.test.ts
+++ b/src/main/lib/telemetry.test.ts
@@ -185,6 +185,18 @@ describe('telemetry.bucketError', () => {
     expect(telemetry.bucketError('Prompt outputs failed validation')).toBe('validation')
     expect(telemetry.bucketError('validation_failed for node 5')).toBe('validation')
   })
+  it('classifies migration source-missing failures', () => {
+    // Observed at launch: gitcode mirror clones that stall mid-stream
+    // and Desktop 1 trees that lost their ComfyUI source path so the
+    // adopter tries to "switch to managed" and finds nothing to copy.
+    expect(
+      telemetry.bucketError(
+        'source-missing: Downloading ComfyUI source from https://gitcode.com/gh_mirrors/co/ComfyUI.git'
+      )
+    ).toBe('source_missing')
+    expect(telemetry.bucketError('source-missing-switch-to-managed')).toBe('source_missing')
+    expect(telemetry.bucketError('source_missing')).toBe('source_missing')
+  })
   it('keeps "other" for messages with no known signal', () => {
     expect(telemetry.bucketError('this is just a sentence')).toBe('other')
   })
@@ -302,6 +314,69 @@ describe('telemetry.trackedStep', () => {
     await telemetry.trackedStep('test.step', {}, async () => 'ok')
     expect(captured).toHaveLength(0)
     telemetry.setConsent(true)
+  })
+
+  it('scrubs error_message before emit so user paths never leave the process', async () => {
+    captured.length = 0
+    await expect(
+      telemetry.trackedStep('migrate.flow', { foo: 'bar' }, async () => {
+        throw new Error("ENOENT 'C:\\Users\\Administrator\\ComfyUI-Installs\\ComfyUI\\__init__.py'")
+      })
+    ).rejects.toThrow()
+    expect(captured[1]!.event).toBe('migrate.flow.error')
+    const msg = captured[1]!.properties?.error_message as string
+    expect(msg).toContain('[REDACTED]')
+    expect(msg).not.toContain('Administrator')
+  })
+})
+
+describe('telemetry SDK-level privacy safety nets', () => {
+  beforeEach(async () => {
+    captured.length = 0
+    process.env['POSTHOG_API_KEY'] = 'test-key'
+    process.env['POSTHOG_ENABLED'] = '1'
+    telemetry.initTelemetry({ appVersion: '0.0.0', appEnv: 'test', isPackaged: true })
+    await telemetry.identify('test-distinct-id')
+    telemetry.setConsent(true)
+  })
+
+  afterEach(() => {
+    delete process.env['POSTHOG_API_KEY']
+    delete process.env['POSTHOG_ENABLED']
+  })
+
+  it('strips $ip from every emit so PostHog can never store it', () => {
+    captured.length = 0
+    telemetry.capture('comfy.desktop.session.started', { foo: 'bar' })
+    expect(captured).toHaveLength(1)
+    expect(captured[0]!.properties?.['$ip']).toBe('')
+  })
+
+  it('scrubs string properties as a last-resort safety net for emit sites that forget', () => {
+    captured.length = 0
+    // Simulates a call site that forgot to scrub locally — typical
+    // future-regression risk. The SDK pass redacts the path.
+    telemetry.capture('comfy.desktop.execution.error', {
+      error_class: 'FileNotFoundError',
+      error_message: "ENOENT 'C:\\Users\\64911\\Documents\\workflow.json'"
+    })
+    expect(captured).toHaveLength(1)
+    const msg = captured[0]!.properties?.error_message as string
+    expect(msg).toContain('[REDACTED]')
+    expect(msg).not.toContain('64911')
+  })
+
+  it('leaves non-string property types untouched', () => {
+    captured.length = 0
+    telemetry.capture('comfy.desktop.execution.completed', {
+      duration_seconds: 12.5,
+      completed_count: 7,
+      crashed: false
+    })
+    const props = captured[0]!.properties
+    expect(props?.duration_seconds).toBe(12.5)
+    expect(props?.completed_count).toBe(7)
+    expect(props?.crashed).toBe(false)
   })
 })
 

--- a/src/main/lib/telemetry.ts
+++ b/src/main/lib/telemetry.ts
@@ -112,6 +112,7 @@ import {
 } from '../../shared/posthogConfig'
 import { isDatadogMirroredEvent } from '../../shared/datadogMirroredEvents'
 import { bucketError as sharedBucketError } from '../../shared/errorBucket'
+import { scrubAll } from '../../shared/piiScrub'
 
 export type TelemetryValue = boolean | number | string | null | undefined
 export type TelemetryContext = Record<string, TelemetryValue | TelemetryValue[]>
@@ -483,14 +484,15 @@ export function initTelemetry(opts: InitOptions): void {
       host: cfg.host,
       flushAt: 20,
       flushInterval: 10_000,
-      // posthog-node defaults `disableGeoip: true` (it assumes a server
-      // whose IP isn't the user's). Here posthog-node runs in the
-      // desktop main process ON the user's machine, so the request IP is
-      // the real user IP — opt back into GeoIP so PostHog derives
-      // `$geoip_country_name` / region / city for geo cohorts. Only
-      // consented users emit at all (capture() is consent-gated), and we
-      // surface country/region for analytics, not the raw `$ip`.
-      disableGeoip: false
+      // Privacy: posthog-node runs in the desktop main process ON the
+      // user's machine, so the request IP would be the real user IP and
+      // the server would derive city-level geo. Both are high-cardinality
+      // identifiers we don't need for product analytics — explicitly
+      // disable server-side GeoIP derivation. Also strip `$ip` from
+      // every event payload (see `capture`) so PostHog never stores it.
+      // If we ever need country-level cohorts for paying users, derive
+      // it from Stripe checkout country at subscription time instead.
+      disableGeoip: true
     })
   } catch {
     client = null
@@ -684,6 +686,29 @@ export function unbindUserId(): void {
   }
 }
 
+/**
+ * Defense-in-depth: run every string-valued property through `scrubAll`
+ * before it leaves the process. Callers should still scrub at the emit
+ * site (so the field shape is intentional and the scrub is visible in
+ * code review) — this is the last-resort safety net that catches future
+ * emit sites that forget. Mirrors the renderer's `scrubTelemetryContext`
+ * pass; without it, any new main-process call site that ships raw
+ * strings (`error_message`, `last_stderr`, free-text from external libs)
+ * is one regression away from leaking a user path.
+ */
+function scrubProperties(properties: TelemetryContext): TelemetryContext {
+  let mutated: TelemetryContext | null = null
+  for (const key of Object.keys(properties)) {
+    const value = properties[key]
+    if (typeof value !== 'string') continue
+    const cleaned = scrubAll(value)
+    if (cleaned === value) continue
+    if (!mutated) mutated = { ...properties }
+    mutated[key] = cleaned
+  }
+  return mutated ?? properties
+}
+
 export function capture(event: string, properties: TelemetryContext = {}): void {
   if (!canEmit() || !distinctId) return
   if (!isAllowedToFire(event)) return
@@ -693,10 +718,14 @@ export function capture(event: string, properties: TelemetryContext = {}): void 
     // Per-call properties override defaults on key collision — callers
     // that explicitly pass `app_version` (e.g. session-start payload,
     // legacy event re-emitters) win.
+    // `$ip: ''` tells the PostHog server to treat the request as
+    // IP-less — paired with `disableGeoip: true` at init, this
+    // suppresses both raw IP storage and server-side geo derivation.
+    const merged = { ...defaultEventProperties, ...properties, $ip: '' }
     client!.capture({
       distinctId,
       event,
-      properties: { ...defaultEventProperties, ...properties }
+      properties: scrubProperties(merged)
     })
   } catch {
     // ignore – telemetry must never break the app
@@ -856,11 +885,16 @@ export async function trackedStep<T>(
     return result
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
+    // Bucket runs on raw text — its regexes don't care about user paths
+    // and would otherwise miss legitimate matches hidden inside a
+    // `[REDACTED]` substitution. The wire-bound field gets scrubbed
+    // before the 500-char slice so the redaction prefix can't get
+    // truncated mid-token.
     capture(`${step}.error`, {
       ...context,
       duration_ms: Date.now() - t0,
       error_bucket: bucketError(message),
-      error_message: message.slice(0, 500)
+      error_message: scrubAll(message).slice(0, 500)
     })
     throw err
   }

--- a/src/shared/errorBucket.ts
+++ b/src/shared/errorBucket.ts
@@ -18,6 +18,7 @@ export type ErrorBucket =
   | 'model_load'
   | 'validation'
   | 'python'
+  | 'source_missing'
   | 'other'
   | 'unknown'
 
@@ -77,6 +78,19 @@ export function bucketError(input: unknown): ErrorBucket {
     message.includes('prompt outputs failed validation')
   ) {
     return 'validation'
+  }
+  // Migration `source` phase — either the legacy ComfyUI tree is gone
+  // ("source-missing-switch-to-managed") or the replacement clone from
+  // a git mirror stalled mid-stream ("source-missing: Downloading
+  // ComfyUI source from …"). Bucketed before `network` because the
+  // mirror-clone failures also reach a fetch site and would otherwise
+  // bucket as network.
+  if (
+    message.includes('source-missing') ||
+    message.includes('source_missing') ||
+    /source.*clone.*fail/.test(message)
+  ) {
+    return 'source_missing'
   }
   if (message.includes('network') || message.includes('fetch')) return 'network'
   if (message.includes('disk') || message.includes('space') || message.includes('enospc'))


### PR DESCRIPTION
## Summary

Started as three small observability fixes; expanded to nine after a privacy audit of live event payloads surfaced raw user paths leaking through emit sites that hadn't been routed through the scrubber. Six observability fixes + three privacy fixes. All additive, no new flags.

## Observability

### 1. ``gpu_model`` populates for every user
The renderer-side ``gpu_model`` person property has been ``null`` across every hardware cohort observed. ``detectGPU()`` only resolves the vendor — its ``model`` field is hardcoded null. Fall back to ``allGpus[0]?.model`` from ``si.graphics().controllers[]``.

### 2. ``adopt.failed`` carries the failing stage + better bucket
- Wrap ``tools.sendProgress`` so the catch block reports ``stage: <phase>`` on every ``adopt.failed`` capture.
- Add a ``source_missing`` bucket to ``bucketError`` that catches source-clone failures ahead of the generic ``network`` rule.

### 3. ``desktop_device_id`` query param on cloud distribution links
Sets up Desktop ↔ Cloud identity stitching once the cloud-side consumer ships. Until then the param is harmless extra data on the URL.

### 4. ``comfy.desktop.comfyui.boot_started`` event
``installation_started`` already fires on successful boot and ``comfyui.exited`` on failure, but boot success rate had to be inferred. ``boot_started`` makes it a single division and surfaces ``port_retry_count`` / ``reboot_retry_count`` so retry-bound failures stop hiding inside healthy boots.

### 5. ``wall_clock_ms`` on ``execution.error``
The success path already emits it. The error path called ``consumePromptStart()`` for its bookkeeping but dropped the returned wall time. Now error-vs-success duration can be compared on the same axis.

### 6. ``comfy.desktop.node.installed`` event
Instruments ``installCnrNode`` + ``switchCnrVersion``:
- ``result: 'success' | 'failure'``
- ``action: 'install' | 'switch'``
- ``duration_ms`` (always)
- ``file_count`` (success only)
- ``error_bucket`` + scrubbed ``error_message`` (failure only)

## Privacy hardening

### 7. SDK-level scrub safety net in ``capture()``
Mirrors the renderer's ``scrubTelemetryContext``. Runs every string-valued property through ``scrubAll`` at the SDK boundary so any new main-process call site that ships raw strings is one regression away from a leak instead of zero. Catches the kind of miss that recently sent ``C:\Users\<name>\...`` paths in ``execution.error`` events to PostHog despite the upstream scrub being wired in.

### 8. ``scrubAll`` applied to ``trackedStep.error`` + ``adopt.failed``
Two upstream emit paths that previously sent ``error_message`` verbatim. Now scrubbed before the 500-char slice so the redaction prefix can't get truncated mid-token. The SDK safety net (#7) covers them too — belt and braces.

### 9. Strip ``$ip`` + disable server-side GeoIP derivation
- ``disableGeoip: true`` at PostHog client init.
- ``$ip: ''`` set on every emit so server-side IP capture is suppressed too.

Tradeoff: we lose server-derived country / region / city cohorts. City + IP are high-cardinality identifiers we don't need for product analytics; country-level cohorts for paid users can be derived from Stripe checkout country at subscription time if/when needed.

## Test plan

- [x] ``pnpm test`` — 1766/1766 green (9 new cases: cloudUrl device-id × 3, bucketError source_missing, desktopAdopt stage, trackedStep scrub, SDK strips $ip, SDK scrubs forgotten emit sites, non-string passthrough)
- [x] ``pnpm typecheck`` — clean (web + e2e + integration)
- [x] ``pnpm exec eslint`` — clean on changed files
- [ ] Manual QA on real Windows install: ``gpu_model`` lands populated
- [ ] Manual QA on real Mac install: same
- [ ] Manual QA on launch: ``boot_started`` fires with retry counts on port-retry + reboot-retry branches
- [ ] Manual QA on Manager-driven install + switch: ``node.installed`` fires with right action / result
- [ ] PostHog spot-check after merge: new events arrive without ``$ip`` / ``$geoip_*`` properties
- [ ] PostHog spot-check after merge: any error_message field contains ``[REDACTED]`` (or none of ``Users\\<name>``, ``/home/<name>``, ``/Users/<name>``)

## Out of scope

- Cloud-side ``posthog.identify(desktop_device_id)`` consumer (separate repo + PR)
- Datadog RUM SDK regression (separate investigation)
- Three new dashboards (Feature engagement, Onboarding deep-dive, Revenue & cloud conversion) — substantial work, separate PostHog-only PR
- Public "What Comfy Desktop sends" documentation page (separate docs PR)