### PR TITLE
feat(first-use): A/B desktop-first-use-fork-default — Cloud-vs-Local default

### DIFF
--- a/src/renderer/src/views/FirstUseTakeover.test.ts
+++ b/src/renderer/src/views/FirstUseTakeover.test.ts
@@ -379,7 +379,7 @@ describe('FirstUseTakeover desktop-first-use-fork-default experiment', () => {
     })
   })
 
-  it("pre-selects Cloud when the flag returns 'cloud' (treatment) and fires exposure with source='cache'", async () => {
+  it("pre-selects Cloud when the flag returns 'cloud' (cloud-default arm) and fires exposure with source='cache'", async () => {
     ;(window.api.telemetryGetExperimentFlag as ReturnType<typeof vi.fn>).mockResolvedValue('cloud')
     const wrapper = mountTakeover()
     await flushPromises()
@@ -395,7 +395,39 @@ describe('FirstUseTakeover desktop-first-use-fork-default experiment', () => {
     expect(wrapper.emitted('chain-local')).toBeFalsy()
     expect(window.api.telemetryRecordExposure).toHaveBeenCalledWith({
       experimentKey: 'desktop-first-use-fork-default',
-      variant: 'treatment',
+      variant: 'cloud-default',
+      source: 'cache'
+    })
+  })
+
+  it("pre-selects nothing when the flag returns 'none' (no-default arm) and disables Continue until a card is picked", async () => {
+    ;(window.api.telemetryGetExperimentFlag as ReturnType<typeof vi.fn>).mockResolvedValue('none')
+    const wrapper = mountTakeover()
+    await flushPromises()
+
+    await wrapper
+      .find('[data-testid="first-use-consent-tos"] input[type="checkbox"]')
+      .setValue(true)
+
+    // Continue stays disabled even with ToS accepted — the no-default
+    // arm requires an explicit pick before commit.
+    const btn = wrapper.find('[data-testid="first-use-continue"]')
+    expect(btn.attributes('disabled')).toBeDefined()
+
+    // Clicking it does nothing — no emit fires.
+    await btn.trigger('click')
+    expect(wrapper.emitted('chain-local')).toBeFalsy()
+    expect(wrapper.emitted('complete-cloud')).toBeFalsy()
+
+    // Pick Local → Continue activates.
+    await wrapper.find('[data-testid="first-use-pick-local"]').trigger('click')
+    expect(btn.attributes('disabled')).toBeUndefined()
+    await btn.trigger('click')
+    expect(wrapper.emitted('chain-local')).toBeTruthy()
+
+    expect(window.api.telemetryRecordExposure).toHaveBeenCalledWith({
+      experimentKey: 'desktop-first-use-fork-default',
+      variant: 'no-default',
       source: 'cache'
     })
   })
@@ -418,7 +450,7 @@ describe('FirstUseTakeover desktop-first-use-fork-default experiment', () => {
     })
   })
 
-  it('legacy-desktop precedence forces Local even when the treatment variant says Cloud', async () => {
+  it('legacy-desktop precedence forces Local even when the cloud-default variant says Cloud', async () => {
     ;(window.api.telemetryGetExperimentFlag as ReturnType<typeof vi.fn>).mockResolvedValue('cloud')
     const wrapper = mountTakeover()
     await (
@@ -427,11 +459,42 @@ describe('FirstUseTakeover desktop-first-use-fork-default experiment', () => {
     await flushPromises()
 
     // The migrate-existing checkbox renders → user with legacy install
-    // landed on Local even though the treatment arm would have flipped
-    // them to Cloud. Precedence holds.
+    // landed on Local even though the cloud-default arm would have
+    // flipped them to Cloud. Precedence holds.
     expect(wrapper.find('[data-testid="first-use-migrate-existing"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="first-use-express-install"]').classes()).not.toContain(
       'start-express--hidden'
     )
+  })
+
+  it('legacy-desktop precedence forces Local even when the no-default variant says pick-nothing', async () => {
+    // Migration flow is the whole reason legacy users exist as a
+    // cohort — we know they want their existing install brought over.
+    // Pre-selecting nothing for them would force an extra click for
+    // zero signal value, so the experiment is bypassed on this path.
+    ;(window.api.telemetryGetExperimentFlag as ReturnType<typeof vi.fn>).mockResolvedValue('none')
+    const wrapper = mountTakeover()
+    await (
+      wrapper.vm as unknown as { open: (opts: { hasLegacyDesktop: boolean }) => Promise<void> }
+    ).open({ hasLegacyDesktop: true })
+    await flushPromises()
+
+    // Continue is immediately actionable — Local is pre-selected.
+    await wrapper
+      .find('[data-testid="first-use-consent-tos"] input[type="checkbox"]')
+      .setValue(true)
+    const btn = wrapper.find('[data-testid="first-use-continue"]')
+    expect(btn.attributes('disabled')).toBeUndefined()
+
+    // Migrate-existing checkbox + Express checkbox both render —
+    // confirms the Local card is the resolved pick (not null).
+    expect(wrapper.find('[data-testid="first-use-migrate-existing"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="first-use-express-install"]').classes()).not.toContain(
+      'start-express--hidden'
+    )
+
+    await btn.trigger('click')
+    // Default opts: Migrate + Express both pre-ticked → chain-migrate.
+    expect(wrapper.emitted('chain-migrate')).toBeTruthy()
   })
 })

--- a/src/renderer/src/views/FirstUseTakeover.test.ts
+++ b/src/renderer/src/views/FirstUseTakeover.test.ts
@@ -1,6 +1,6 @@
 // Start-screen tests for FirstUseTakeover. Heavy children are stubbed to focus on the start-step DOM.
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { mount, flushPromises } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
 
 vi.mock('../lib/telemetry', () => ({
@@ -60,6 +60,11 @@ beforeEach(() => {
     detectGPU: vi.fn().mockResolvedValue(null),
     setFirstUseMode: vi.fn(),
     closeHostWindow: vi.fn().mockResolvedValue(undefined),
+    // Default to undefined so the existing tests exercise the control
+    // branch (Local-default). Tests that need the treatment arm mutate
+    // this per-case before mounting.
+    telemetryGetExperimentFlag: vi.fn().mockResolvedValue(undefined),
+    telemetryRecordExposure: vi.fn(),
   } as unknown as typeof window.api
 })
 
@@ -348,5 +353,85 @@ describe('FirstUseTakeover start step', () => {
 
     expect(wrapper.emitted('chain-local')).toBeTruthy()
     expect(wrapper.emitted('complete-cloud')).toBeFalsy()
+  })
+})
+
+describe('FirstUseTakeover desktop-first-use-fork-default experiment', () => {
+  it('keeps Local as the default when the flag is missing (control / fallback)', async () => {
+    const wrapper = mountTakeover()
+    await flushPromises()
+
+    await wrapper
+      .find('[data-testid="first-use-consent-tos"] input[type="checkbox"]')
+      .setValue(true)
+    await wrapper.find('[data-testid="first-use-continue"]').trigger('click')
+
+    // Local is the resolved default → routed to chain-local without
+    // touching the picker.
+    expect(wrapper.emitted('chain-local')).toBeTruthy()
+    expect(wrapper.emitted('complete-cloud')).toBeFalsy()
+    // Exposure fires with source='fallback' because the flag returned
+    // undefined (no cache, no recognised value).
+    expect(window.api.telemetryRecordExposure).toHaveBeenCalledWith({
+      experimentKey: 'desktop-first-use-fork-default',
+      variant: 'control',
+      source: 'fallback'
+    })
+  })
+
+  it("pre-selects Cloud when the flag returns 'cloud' (treatment) and fires exposure with source='cache'", async () => {
+    ;(window.api.telemetryGetExperimentFlag as ReturnType<typeof vi.fn>).mockResolvedValue('cloud')
+    const wrapper = mountTakeover()
+    await flushPromises()
+
+    await wrapper
+      .find('[data-testid="first-use-consent-tos"] input[type="checkbox"]')
+      .setValue(true)
+    await wrapper.find('[data-testid="first-use-continue"]').trigger('click')
+
+    // Cloud is now the resolved default → Continue without touching
+    // the picker routes to complete-cloud.
+    expect(wrapper.emitted('complete-cloud')).toBeTruthy()
+    expect(wrapper.emitted('chain-local')).toBeFalsy()
+    expect(window.api.telemetryRecordExposure).toHaveBeenCalledWith({
+      experimentKey: 'desktop-first-use-fork-default',
+      variant: 'treatment',
+      source: 'cache'
+    })
+  })
+
+  it("treats any other flag value ('control', unknown string, true) as control", async () => {
+    ;(window.api.telemetryGetExperimentFlag as ReturnType<typeof vi.fn>).mockResolvedValue('control')
+    const wrapper = mountTakeover()
+    await flushPromises()
+    await wrapper
+      .find('[data-testid="first-use-consent-tos"] input[type="checkbox"]')
+      .setValue(true)
+    await wrapper.find('[data-testid="first-use-continue"]').trigger('click')
+    expect(wrapper.emitted('chain-local')).toBeTruthy()
+    // 'control' is a string PostHog *might* return, so source is 'cache'
+    // not 'fallback' even though the variant is the same as no-flag.
+    expect(window.api.telemetryRecordExposure).toHaveBeenCalledWith({
+      experimentKey: 'desktop-first-use-fork-default',
+      variant: 'control',
+      source: 'cache'
+    })
+  })
+
+  it('legacy-desktop precedence forces Local even when the treatment variant says Cloud', async () => {
+    ;(window.api.telemetryGetExperimentFlag as ReturnType<typeof vi.fn>).mockResolvedValue('cloud')
+    const wrapper = mountTakeover()
+    await (
+      wrapper.vm as unknown as { open: (opts: { hasLegacyDesktop: boolean }) => Promise<void> }
+    ).open({ hasLegacyDesktop: true })
+    await flushPromises()
+
+    // The migrate-existing checkbox renders → user with legacy install
+    // landed on Local even though the treatment arm would have flipped
+    // them to Cloud. Precedence holds.
+    expect(wrapper.find('[data-testid="first-use-migrate-existing"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="first-use-express-install"]').classes()).not.toContain(
+      'start-express--hidden'
+    )
   })
 })

--- a/src/renderer/src/views/FirstUseTakeover.vue
+++ b/src/renderer/src/views/FirstUseTakeover.vue
@@ -11,10 +11,14 @@
  * Step ordering:
  *   1. `start`   — Merged T&C + Cloud-vs-Local picker on a single page.
  *                  T&C + telemetry checkboxes, an Express-Install
- *                  opt-out modifier, and two radio cards (Cloud
- *                  pre-selected). A single Continue commit persists
- *                  telemetry, fires fork_chosen, and routes to the
- *                  next step. Cancel closes the host window.
+ *                  opt-out modifier, and two radio cards. The
+ *                  pre-selected card is variant-dependent: see
+ *                  `desktop-first-use-fork-default` below — Local
+ *                  (control), Cloud (cloud-default), or neither
+ *                  (no-default, requires explicit click). A single
+ *                  Continue commit persists telemetry, fires
+ *                  fork_chosen, and routes to the next step. Cancel
+ *                  closes the host window.
  *   2. `mirrors` — Only inserted when the resolved locale starts with
  *                  'zh'. Reuses the existing `chineseMirrorsSuggest*`
  *                  copy in en/zh + the `useChineseMirrors` setting; we
@@ -96,24 +100,29 @@ const step = ref<Step>('start')
 const telemetryEnabled = ref(true)
 const locale = ref('en')
 
-/** A/B experiment that varies the pre-selected fork on the merged start
- *  screen. Multivariate PostHog flag — variant strings come straight
- *  from the server (`'local'` = control, `'cloud'` = treatment). Any
- *  other value (missing cache entry, unrecognised string, network
- *  failure on first-ever boot) falls back to `'local'` so the default
- *  remains the Download-Local intent we shipped. */
+/** A/B/C experiment that varies the pre-selected fork on the merged
+ *  start screen. Multivariate PostHog flag — three equal cohorts
+ *  (33-33-33). Variant strings come straight from the server:
+ *  `'control'` = Local pre-selected (shipped baseline), `'cloud'` =
+ *  Cloud pre-selected, `'none'` = neither card pre-selected (user
+ *  has to actively click one). Any other value (missing cache entry,
+ *  unrecognised string, network failure on first-ever boot) falls
+ *  back to `'control'` so the default remains the Download-Local
+ *  intent we shipped. */
 const FORK_DEFAULT_EXPERIMENT_KEY = 'desktop-first-use-fork-default'
+type ForkVariant = 'control' | 'cloud-default' | 'no-default'
 /** Variant assigned to this install. `null` until the boot-time fetch
  *  resolves; treat as `'control'` for default-rendering purposes. */
-const forkExperimentVariant = ref<'control' | 'treatment' | null>(null)
+const forkExperimentVariant = ref<ForkVariant | null>(null)
 
 /** Cloud-vs-Local selection picked on the merged start screen. Local
  *  is the shipped default — the user got here by clicking
  *  "Download Local" upstream, so honor that intent unless the
- *  experiment flips the variant to `'treatment'` (Cloud-default).
- *  Cloud is rendered as an equal-weight peer card regardless; users
- *  can flip to it before pressing Continue. */
-const pickedChoice = ref<'cloud' | 'local'>('local')
+ *  experiment overrides it: `'cloud-default'` pre-selects Cloud,
+ *  `'no-default'` pre-selects neither (user must click a card before
+ *  Continue activates). Cloud is rendered as an equal-weight peer
+ *  card regardless; users can flip between cards before Continue. */
+const pickedChoice = ref<'cloud' | 'local' | null>('local')
 
 // Capacity-protection switch for Cloud (PostHog flag
 // `desktop-cloud-capacity`). At first-use, we follow the flag
@@ -127,22 +136,27 @@ const capacityReady = ref(false)
 /** What the picker rendered as default before the user could interact —
  *  used to split `fork_chosen` conversion by signal-vs-defaulting: a
  *  user keeping the default pick is different from a user actively
- *  flipping the card. Updated post-mount once the experiment flag and
- *  capacity status resolve. */
-const initialDefaultChoice = ref<'cloud' | 'local'>('local')
+ *  flipping the card. `null` for the `'no-default'` variant, where
+ *  Continue is gated on an explicit pick so every commit is signal. */
+const initialDefaultChoice = ref<'cloud' | 'local' | null>('local')
 
 /** Read the experiment variant (boot-time cache, sync once main is
- *  ready) and decide whether Cloud should be the pre-selected default.
+ *  ready) and decide which card should be the pre-selected default.
  *  Capacity-disabled and Legacy-Desktop branches still force Local
  *  ahead of the experiment — see `applyForkExperimentDefault` below. */
-async function loadForkExperimentVariant(): Promise<'control' | 'treatment'> {
+function mapFlagToVariant(flagValue: string | boolean | null | undefined): ForkVariant {
+  if (flagValue === 'cloud') return 'cloud-default'
+  if (flagValue === 'none') return 'no-default'
+  return 'control'
+}
+async function loadForkExperimentVariant(): Promise<ForkVariant> {
   let flagValue: string | boolean | null | undefined
   try {
     flagValue = await window.api.telemetryGetExperimentFlag(FORK_DEFAULT_EXPERIMENT_KEY)
   } catch {
     flagValue = undefined
   }
-  const variant = flagValue === 'cloud' ? 'treatment' : 'control'
+  const variant = mapFlagToVariant(flagValue)
   // Fire exposure exactly once per process via main's per-session dedup.
   // Source: 'cache' when the on-disk experiment-flags.json had a value
   // we recognised, 'fallback' when nothing usable came back (first-ever
@@ -160,15 +174,38 @@ async function loadForkExperimentVariant(): Promise<'control' | 'treatment'> {
 }
 
 /** Apply the resolved variant to the picker state, respecting the
- *  hard precedence rules (capacity-disabled > legacy-desktop >
+ *  hard precedence rules (legacy-desktop > capacity-disabled >
  *  experiment). Idempotent — safe to call from `onMounted` and from
- *  `open()` on takeover replay. */
-function applyForkExperimentDefault(variant: 'control' | 'treatment'): void {
-  if (cloudCapacity.isDisabled()) return
-  if (hasLegacyDesktop.value) return
-  if (variant === 'treatment') {
+ *  `open()` on takeover replay. Always lands on a terminal state for
+ *  both refs so the caller doesn't need to seed defaults first. */
+function applyForkExperimentDefault(variant: ForkVariant): void {
+  // Migration flow always wins. Returning Desktop-1 users land on
+  // Local with the migrate-existing checkbox pre-ticked — that's the
+  // whole point of the legacy-detection branch. The experiment never
+  // overrides it.
+  if (hasLegacyDesktop.value) {
+    pickedChoice.value = 'local'
+    initialDefaultChoice.value = 'local'
+    return
+  }
+  // Capacity kill-switch also forces Local: cloud can't be booked, so
+  // there's no point pre-selecting it.
+  if (cloudCapacity.isDisabled()) {
+    pickedChoice.value = 'local'
+    initialDefaultChoice.value = 'local'
+    return
+  }
+  if (variant === 'cloud-default') {
     pickedChoice.value = 'cloud'
     initialDefaultChoice.value = 'cloud'
+  } else if (variant === 'no-default') {
+    // Neither card pre-selected. Continue stays disabled until the
+    // user clicks one, so every commit is an explicit signal pick.
+    pickedChoice.value = null
+    initialDefaultChoice.value = null
+  } else {
+    pickedChoice.value = 'local'
+    initialDefaultChoice.value = 'local'
   }
 }
 
@@ -320,6 +357,10 @@ async function onContinue(): Promise<void> {
     nudgeTos()
     return
   }
+  // No-default experiment arm: until the user clicks a card, there's
+  // no pick to commit. The button is already :disabled in this state,
+  // but guard defensively so a programmatic click can't bypass.
+  if (pickedChoice.value === null) return
   // Keep `isContinuing` true past `routePostStart()` because the chain
   // handlers (express prep, cloud auto-launch, new-install swap) all
   // either unmount this takeover or swap to a sub-step within ms. The
@@ -471,22 +512,22 @@ function chooseMigrate(): void {
   emit('chain-migrate', { express: false })
 }
 
-/** Radiogroup arrow-key handler for the Cloud / Local / Migrate cards.
+/** Radiogroup arrow-key handler for the Cloud / Local cards.
  *  WAI-ARIA APG §3.15: arrow keys cycle the checked radio and move DOM
- *  focus along with it. The Migrate card is only present when
- *  `hasLegacyDesktop` is true, so the cycle order is built dynamically
- *  to match what's actually rendered. */
+ *  focus along with it. When `pickedChoice` is `null` (the no-default
+ *  experiment arm before the user has touched the picker), arrow-down
+ *  enters at Cloud and arrow-up enters at Local so keyboard users can
+ *  make a pick without reaching for the mouse. */
 function onStartCardsKeydown(e: KeyboardEvent): void {
   const target = e.target as HTMLElement | null
   if (!target?.closest('[role="radio"]')) return
   const order = ['cloud', 'local'] as const
-  const currentIndex = order.indexOf(pickedChoice.value)
-  if (currentIndex < 0) return
+  const currentIndex = pickedChoice.value === null ? -1 : order.indexOf(pickedChoice.value)
   let next: number
   if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
-    next = (currentIndex + 1) % order.length
+    next = currentIndex < 0 ? 0 : (currentIndex + 1) % order.length
   } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
-    next = (currentIndex - 1 + order.length) % order.length
+    next = currentIndex < 0 ? order.length - 1 : (currentIndex - 1 + order.length) % order.length
   } else {
     return
   }
@@ -532,11 +573,12 @@ async function open(opts: OpenOpts = {}): Promise<void> {
   whyCloudOpen.value = false
   termsDoc.value = null
   acceptedTos.value = false
-  // Local is the shipped baseline. The experiment may flip both refs
-  // to Cloud below when the variant is `'treatment'` and neither hard
-  // gate (capacity-disabled, legacy-desktop) applies. Reset to Local
-  // unconditionally first so the variant-aware apply call has a clean
-  // slate after a takeover replay.
+  // Safe baseline: Local pre-selected. The variant-aware apply call
+  // below overrides to Cloud (`'cloud-default'` arm) or null
+  // (`'no-default'` arm) when neither hard gate (legacy-desktop,
+  // capacity-disabled) applies. Reset unconditionally first so the
+  // takeover-replay path lands on a clean slate even if the variant
+  // hasn't resolved yet on first mount.
   pickedChoice.value = 'local'
   initialDefaultChoice.value = 'local'
   // Re-apply the experiment variant on every replay so a user who
@@ -820,7 +862,7 @@ defineExpose({ open, resetContinue })
             class="brand-primary start-continue"
             type="button"
             data-testid="first-use-continue"
-            :disabled="isContinuing"
+            :disabled="isContinuing || pickedChoice === null"
             :aria-busy="isContinuing"
             @click="onContinue"
           >

--- a/src/renderer/src/views/FirstUseTakeover.vue
+++ b/src/renderer/src/views/FirstUseTakeover.vue
@@ -95,11 +95,24 @@ const emit = defineEmits<{
 const step = ref<Step>('start')
 const telemetryEnabled = ref(true)
 const locale = ref('en')
+
+/** A/B experiment that varies the pre-selected fork on the merged start
+ *  screen. Multivariate PostHog flag — variant strings come straight
+ *  from the server (`'local'` = control, `'cloud'` = treatment). Any
+ *  other value (missing cache entry, unrecognised string, network
+ *  failure on first-ever boot) falls back to `'local'` so the default
+ *  remains the Download-Local intent we shipped. */
+const FORK_DEFAULT_EXPERIMENT_KEY = 'desktop-first-use-fork-default'
+/** Variant assigned to this install. `null` until the boot-time fetch
+ *  resolves; treat as `'control'` for default-rendering purposes. */
+const forkExperimentVariant = ref<'control' | 'treatment' | null>(null)
+
 /** Cloud-vs-Local selection picked on the merged start screen. Local
- *  is the default everywhere — the user got here by clicking
- *  "Download Local" upstream, so honor that intent. Cloud is still
- *  rendered as an equal-weight peer card; users can flip to it before
- *  pressing Continue. */
+ *  is the shipped default — the user got here by clicking
+ *  "Download Local" upstream, so honor that intent unless the
+ *  experiment flips the variant to `'treatment'` (Cloud-default).
+ *  Cloud is rendered as an equal-weight peer card regardless; users
+ *  can flip to it before pressing Continue. */
 const pickedChoice = ref<'cloud' | 'local'>('local')
 
 // Capacity-protection switch for Cloud (PostHog flag
@@ -113,11 +126,61 @@ const cloudCapacity = useCloudCapacity()
 const capacityReady = ref(false)
 /** What the picker rendered as default before the user could interact —
  *  used to split `fork_chosen` conversion by signal-vs-defaulting: a
- *  user keeping the default Local pick is different from a user
- *  actively flipping to Cloud. */
+ *  user keeping the default pick is different from a user actively
+ *  flipping the card. Updated post-mount once the experiment flag and
+ *  capacity status resolve. */
 const initialDefaultChoice = ref<'cloud' | 'local'>('local')
+
+/** Read the experiment variant (boot-time cache, sync once main is
+ *  ready) and decide whether Cloud should be the pre-selected default.
+ *  Capacity-disabled and Legacy-Desktop branches still force Local
+ *  ahead of the experiment — see `applyForkExperimentDefault` below. */
+async function loadForkExperimentVariant(): Promise<'control' | 'treatment'> {
+  let flagValue: string | boolean | null | undefined
+  try {
+    flagValue = await window.api.telemetryGetExperimentFlag(FORK_DEFAULT_EXPERIMENT_KEY)
+  } catch {
+    flagValue = undefined
+  }
+  const variant = flagValue === 'cloud' ? 'treatment' : 'control'
+  // Fire exposure exactly once per process via main's per-session dedup.
+  // Source: 'cache' when the on-disk experiment-flags.json had a value
+  // we recognised, 'fallback' when nothing usable came back (first-ever
+  // boot with no network, network failure, or unrecognised payload).
+  try {
+    window.api.telemetryRecordExposure({
+      experimentKey: FORK_DEFAULT_EXPERIMENT_KEY,
+      variant,
+      source: typeof flagValue === 'string' ? 'cache' : 'fallback'
+    })
+  } catch {
+    // best-effort
+  }
+  return variant
+}
+
+/** Apply the resolved variant to the picker state, respecting the
+ *  hard precedence rules (capacity-disabled > legacy-desktop >
+ *  experiment). Idempotent — safe to call from `onMounted` and from
+ *  `open()` on takeover replay. */
+function applyForkExperimentDefault(variant: 'control' | 'treatment'): void {
+  if (cloudCapacity.isDisabled()) return
+  if (hasLegacyDesktop.value) return
+  if (variant === 'treatment') {
+    pickedChoice.value = 'cloud'
+    initialDefaultChoice.value = 'cloud'
+  }
+}
+
 onMounted(async () => {
-  await cloudCapacity.whenReady()
+  // Capacity + experiment in parallel; both are best-effort and
+  // fail-closed so the picker still works if either errors.
+  const [variant] = await Promise.all([
+    loadForkExperimentVariant(),
+    cloudCapacity.whenReady()
+  ])
+  forkExperimentVariant.value = variant
+  applyForkExperimentDefault(variant)
   capacityReady.value = true
 })
 // Defensive: if the user manually flipped to Cloud and the kill-switch
@@ -179,7 +242,13 @@ function emitCompleted(exitPath: 'cloud' | 'local-new' | 'local-migrate' | 'skip
     duration_ms: durationMs,
     duration_seconds: Math.round(durationMs / 1000),
     had_legacy: hasLegacyDesktop.value,
-    had_existing_install: skipPick.value
+    had_existing_install: skipPick.value,
+    // A/B attribution: completion rate IS the experiment's primary
+    // guardrail — if Cloud-default makes users bounce, this drops
+    // even when fork_chosen rate looks better. Carry the same
+    // variant tag through so the funnel can be sliced per arm.
+    experiment_key: FORK_DEFAULT_EXPERIMENT_KEY,
+    experiment_variant: forkExperimentVariant.value
   })
 }
 /** When the host detects prior usage of the launcher (any
@@ -280,7 +349,13 @@ async function onContinue(): Promise<void> {
     // tier the user would have hit on dashboard / IPP.
     capacity_status: cloudCapacity.status.value,
     was_default: pickedChoice.value === initialDefaultChoice.value,
-    user_tier: cloudCapacity.tier.value
+    user_tier: cloudCapacity.tier.value,
+    // A/B attribution: identify which experiment arm this pick belongs
+    // to so PostHog can compute cloud-pick rate, subscription rate, and
+    // bounce-after-cloud rate per variant. The key is captured too so
+    // future experiments running concurrently can be split apart.
+    experiment_key: FORK_DEFAULT_EXPERIMENT_KEY,
+    experiment_variant: forkExperimentVariant.value
   })
 
   if (isChinese.value) {
@@ -457,11 +532,22 @@ async function open(opts: OpenOpts = {}): Promise<void> {
   whyCloudOpen.value = false
   termsDoc.value = null
   acceptedTos.value = false
-  // Local is the default everywhere. Cloud-disabled and Legacy-Desktop-
-  // detected used to flip the default to Local; both now collapse into
-  // the same default, so the reset is unconditional.
+  // Local is the shipped baseline. The experiment may flip both refs
+  // to Cloud below when the variant is `'treatment'` and neither hard
+  // gate (capacity-disabled, legacy-desktop) applies. Reset to Local
+  // unconditionally first so the variant-aware apply call has a clean
+  // slate after a takeover replay.
   pickedChoice.value = 'local'
   initialDefaultChoice.value = 'local'
+  // Re-apply the experiment variant on every replay so a user who
+  // cancelled mid-flow lands back on the same default they saw the
+  // first time. `forkExperimentVariant.value` is locked at boot — on
+  // first mount it may still be null if `loadForkExperimentVariant`
+  // hasn't resolved yet, which is fine: onMounted applies it once it
+  // does.
+  if (forkExperimentVariant.value) {
+    applyForkExperimentDefault(forkExperimentVariant.value)
+  }
   expressInstall.value = true
   migrateExisting.value = true
   // `onContinue` keeps `isContinuing` true past `routePostStart()`


### PR DESCRIPTION
## Summary

Wires a multivariate PostHog feature flag into the first-use start screen so the pre-selected fork can be served as **control (Local)** or **treatment (Cloud)**, with downstream events tagged for per-arm attribution.

Hypothesis: pre-selecting Cloud increases the cloud-pick rate AND drives more cloud arrivals to subscription, without dropping first-use completion rate.

## What the code does

- Reads the multivariate flag at mount via ``window.api.telemetryGetExperimentFlag('desktop-first-use-fork-default')`` (existing IPC bridge into ``experiments.ts``'s boot-time cache — no new infra).
- Variant mapping:
  - ``'cloud'`` → **treatment**, Cloud pre-selected
  - ``'control'`` / unknown string / boolean / null / undefined → **control**, Local pre-selected (shipped baseline)
- Hard precedence preserved: capacity-disabled and Legacy-Desktop-detected branches still force Local on both arms (``disabled > legacy > experiment``).
- Records exposure via ``window.api.telemetryRecordExposure({ experimentKey, variant, source })`` so the PostHog experiment can attribute downstream events. ``source: 'cache' | 'fallback'`` matches whether the boot cache had a recognised value.
- ``fork_chosen`` and ``first_use.completed`` payloads now carry ``experiment_key`` + ``experiment_variant`` so the funnel can be sliced per arm without joining on the exposure event.
- ``open()`` re-applies the variant on takeover replay so a mid-flow cancel-and-return lands on the same default.

## PostHog side (already created via MCP)

- **Feature flag**: ``desktop-first-use-fork-default`` (multivariate, 50/50 control vs cloud, 100% rollout)
- **Experiment**: ``Desktop first-use: Cloud-vs-Local default`` (draft)
  - **Exposure**: ``comfy.desktop.experiment.exposed`` filtered by ``experiment_key = 'desktop-first-use-fork-default'``
  - **Primary metric**: Cloud-pick rate — mean of ``comfy.desktop.first_use.fork_chosen`` filtered by ``choice = 'cloud'``
  - **Secondary metrics**:
    - Cloud subscription rate — mean of ``billing:subscription_created``
    - First-use completion rate (guardrail) — mean of ``comfy.desktop.first_use.completed``
    - Cloud-pick + paywall hit — mean of ``app:subscription_required_modal_opened``
  - Minimum detectable effect: 25%, Bayesian stats

## Test plan

- [x] ``pnpm test`` — 1770/1770 green (4 new cases: control/fallback, treatment, recognised-control string, legacy-precedence)
- [x] ``pnpm typecheck:web`` — clean
- [x] ``pnpm exec eslint`` — clean on changed files
- [ ] Manual QA on dev install: force-set flag to ``'cloud'`` via PostHog UI override, restart, verify Cloud is pre-selected
- [ ] Manual QA: force-set to ``'control'``, verify Local is pre-selected and exposure fires
- [ ] Manual QA: with a legacy Desktop install present, verify Local stays selected even when flag is ``'cloud'``
- [ ] PostHog after rollout: confirm ``experiment.exposed`` events flow with both ``variant`` values
- [ ] PostHog after rollout: confirm ``fork_chosen`` events carry ``experiment_variant``

## Rollout plan

1. Merge this PR.
2. Ship the next Desktop release.
3. Once meaningful traffic reaches the new build, launch the draft experiment in PostHog (UI button — not done in this PR).
4. Watch the primary metric + guardrail for the first 24-48h; pause if completion rate drops materially on treatment.

## Out of scope

- No UI copy changes — both arms render the same picker, only the pre-selection differs.
- Datadog dashboard tiles for the experiment can land separately once we have data flowing.