### PR TITLE
i18n(track): rename "Track Existing Install" → "Add Existing Install"

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -301,8 +301,8 @@
   },
 
   "track": {
-    "title": "Track Existing Install",
-    "grandTitle": "Track Existing Install",
+    "title": "Add Existing Install",
+    "grandTitle": "Add Existing Install",
     "grandSubtitle": "Add an existing local ComfyUI checkout to Desktop without reinstalling it.",
     "installDir": "Install Directory",
     "selectDir": "Select a directory…",

--- a/src/renderer/src/views/TrackModal.test.ts
+++ b/src/renderer/src/views/TrackModal.test.ts
@@ -24,7 +24,7 @@ const messages = {
     },
     git: { venv: 'Virtual Environment', venvNotFound: 'Not found' },
     track: {
-      grandTitle: 'Track Existing Install',
+      grandTitle: 'Add Existing Install',
       grandSubtitle: 'Add an existing local ComfyUI checkout.',
       installDir: 'Install Directory',
       selectDir: 'Select a directory',


### PR DESCRIPTION
## Summary
Renames the user-facing label for the existing-install flow from `Track Existing Install` to `Add Existing Install`. Copy-only — no behavior, IPC, or component changes.

## Changes
**What**
- `locales/en.json` — update `track.title` and `track.grandTitle` to `Add Existing Install`. `grandSubtitle` already reads "Add an existing local ComfyUI checkout…", so the new title aligns with the existing supporting copy.
- `src/renderer/src/views/TrackModal.test.ts` — mirror the new `grandTitle` in the test's i18n message fixture so the modal's title assertion stays in sync with `en.json`.

closes #859 