### PR TITLE
Fix/snapshot pkg pill and path truncation

### DIFF
--- a/src/renderer/src/lib/i18nMessages.ts
+++ b/src/renderer/src/lib/i18nMessages.ts
@@ -240,6 +240,8 @@ export const en = {
     // Row meta + chips.
     nodesCount: '{count} nodes',
     packagesCount: '{count} packages',
+    nodesLabel: 'nodes',
+    pkgsLabel: 'pkgs',
     nodeChanges: '{count} node changes',
     pipChanges: '{count} pkg changes',
     comfyuiUpdated: 'ComfyUI updated',

--- a/src/renderer/src/lib/snapshots.ts
+++ b/src/renderer/src/lib/snapshots.ts
@@ -108,7 +108,7 @@ export function changeSummary(s: SnapshotSummary, t: Translator): string[] {
   }
   const pipChanges = d.pipsAdded + d.pipsRemoved + d.pipsChanged
   if (pipChanges > 0) {
-    parts.push(`${pipChanges} pkg changes`)
+    parts.push(t('snapshots.pipChanges', { count: pipChanges }))
   }
   return parts
 }

--- a/src/renderer/src/views/comfyUISettings/SnapshotRow.vue
+++ b/src/renderer/src/views/comfyUISettings/SnapshotRow.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { ChevronDown, Tag, Boxes } from 'lucide-vue-next'
+import { ChevronDown, Tag, Boxes, Package } from 'lucide-vue-next'
 import type { SnapshotSummary } from '../../types/ipc'
 import {
   triggerLabel as _triggerLabel,
@@ -64,6 +64,19 @@ const hasNodeChanges = computed(
   () => nodeDelta.value.added + nodeDelta.value.removed + nodeDelta.value.changed > 0
 )
 
+// Pip-package deltas vs the previous snapshot, driving a second collapsed-header pill.
+const pipDelta = computed(() => {
+  const diff = props.snapshot.diffVsPrevious
+  return {
+    added: diff?.pipsAdded ?? 0,
+    removed: diff?.pipsRemoved ?? 0,
+    changed: diff?.pipsChanged ?? 0,
+  }
+})
+const hasPipChanges = computed(
+  () => pipDelta.value.added + pipDelta.value.removed + pipDelta.value.changed > 0
+)
+
 // Title pill: manual label, else a version transition `prev → this`, else the resulting version.
 const isManualWithLabel = computed(
   () => props.snapshot.trigger === 'manual' && !!props.snapshot.label
@@ -102,7 +115,7 @@ const hasTitlePill = computed(() => !!titlePillText.value)
         </div>
       </div>
       <!-- At-a-glance pills: version/name pill + node deltas vs previous. -->
-      <div v-if="hasTitlePill || hasNodeChanges" class="snapshot-row-pills">
+      <div v-if="hasTitlePill || hasNodeChanges || hasPipChanges" class="snapshot-row-pills">
         <span
           v-if="hasTitlePill"
           class="snap-pill snap-pill--version"
@@ -118,6 +131,13 @@ const hasTitlePill = computed(() => !!titlePillText.value)
           <span v-if="nodeDelta.removed" class="snap-delta is-remove">−{{ nodeDelta.removed }}</span>
           <span v-if="nodeDelta.changed" class="snap-delta is-change">~{{ nodeDelta.changed }}</span>
           <span class="snap-pill-label">{{ t('snapshots.nodesLabel', 'nodes') }}</span>
+        </span>
+        <span v-if="hasPipChanges" class="snap-pill snap-pill--pkgs">
+          <Package :size="11" aria-hidden="true" />
+          <span v-if="pipDelta.added" class="snap-delta is-add">+{{ pipDelta.added }}</span>
+          <span v-if="pipDelta.removed" class="snap-delta is-remove">−{{ pipDelta.removed }}</span>
+          <span v-if="pipDelta.changed" class="snap-delta is-change">~{{ pipDelta.changed }}</span>
+          <span class="snap-pill-label">{{ t('snapshots.pkgsLabel', 'pkgs') }}</span>
         </span>
       </div>
     </button>

--- a/src/renderer/src/views/comfyUISettings/StatusFactPanel.vue
+++ b/src/renderer/src/views/comfyUISettings/StatusFactPanel.vue
@@ -401,7 +401,7 @@ const groups = computed<FactGroup[]>(() => {
 
 .status-fact-row {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1.2fr);
+  grid-template-columns: minmax(0, auto) minmax(0, 1fr);
   align-items: center;
   gap: 12px;
   padding: 10px 0;


### PR DESCRIPTION
## Summary

Two fixes for the instance picker / settings UI: snapshot rows now surface package changes at a glance, and file paths in the About tab no longer truncate early.

## Changes

**What**

- `SnapshotRow.vue` — added a `pkgs` delta pill (`Package` icon + `+/−/~` counts) beside the existing nodes pill, driven by a new `pipDelta`/`hasPipChanges` mirroring the node-delta computeds. Package changes were previously only visible inside the expandable diff; now they show on the collapsed row in both the picker accordion and the settings-drawer timeline (shared component).
- `snapshots.ts` — `changeSummary()` now pushes the `snapshots.pipChanges` i18n key instead of a hardcoded English `"N pkg changes"` string.
- `i18nMessages.ts` — backfilled `nodesLabel` and `pkgsLabel` in the popup i18n catalog; both were missing, leaving the picker's pill and `RestoreModal`'s pkg badges on inline fallbacks.
- `StatusFactPanel.vue` — changed the row grid from `minmax(0, 1fr) minmax(0, 1.2fr)` to `minmax(0, auto) minmax(0, 1fr)` so the value column fills the pane before ellipsizing. Fixes paths like `ComfyUI-Installs\ComfyUI` clipping halfway across the modal.

**Breaking**

None. Renderer/display only — snapshot capture and diff computation in `src/main/lib/snapshots/` already recorded and diffed `pipPackages`. The path tooltip, `is-truncate-start` start-truncation, and `BaseCopyButton` are unchanged.

## Review Focus

- The `pkgs` pill reuses the shared `.snap-pill` / `.snap-delta` styles — no new CSS, no `.snap-pill--pkgs` rule needed. Worth a glance that it reads distinctly from the nodes pill.
- Like the nodes pill, the pkg pill only renders when the diff *vs the previous snapshot* is non-zero, so the oldest snapshot shows neither — intentional.
- Scope is the three at-a-glance surfaces (collapsed row + picker summary) plus the truncation grid. The full expandable diff (`SnapshotDiffView.vue`) already listed package names + versions and is untouched.
- Pre-existing catalog naming inconsistency (`pkgsLabel`/"pkgs" vs `packagesCount`/"packages") left alone to avoid touching `RestoreModal`; flagged as a possible follow-up.

## Testing

Display-only change with no IPC or data-flow impact, so verification is typecheck/lint + manual UI check rather than new specs.

- `pnpm typecheck` ✅ · `pnpm lint` ✅
- Manual: instance picker → Snapshots → confirm the `pkgs` pill on a snapshot whose predecessor changed packages, in both the picker accordion and the settings drawer; expand → summary line renders localized text (not a raw key).
- Manual: About tab with a real install path under `ComfyUI-Installs` → Location fills the pane, ellipsizes only when genuinely too long, tooltip + copy intact.


### **Snapshot Packages**
<img width="971" height="750" alt="image" src="https://github.com/user-attachments/assets/66df2884-2dd5-453e-8a45-178c40534f12" />


### **Stop Truncating Path Early**
<img width="1003" height="765" alt="image" src="https://github.com/user-attachments/assets/8fad6e40-aea1-4731-8505-5a604b82e5d4" />

closes #854 closes #852 