### PR TITLE
feat(downloads): show preview thumbnails for completed image assets

### DIFF
--- a/src/main/lib/comfyDownloadManager.ts
+++ b/src/main/lib/comfyDownloadManager.ts
@@ -803,9 +803,15 @@ const thumbnailCache = new Map<string, string>()
 
 /** Read a completed image download and return a small `data:` URL preview, or
  *  `null` for non-images, missing/unreadable files, or any decode failure.
- *  Lazy + cached so it only runs for visible image rows. */
+ *  Lazy + cached so it only runs for visible image rows.
+ *
+ *  `savePath` is a LOCAL filesystem path (a download's `savePath`), never a
+ *  remote/source URL — this only ever reads from disk, never the network. A
+ *  value with a URL scheme is rejected so a caller passing the wrong field
+ *  (e.g. the entry's `url`) can't trigger a path-resolve on a URL. */
 export async function getDownloadThumbnail(savePath: unknown): Promise<string | null> {
   if (typeof savePath !== 'string' || !savePath) return null
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(savePath)) return null
   const resolved = path.resolve(savePath)
   if (!hasImageExtension(resolved)) return null
 

--- a/src/main/lib/comfyDownloadManager.ts
+++ b/src/main/lib/comfyDownloadManager.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, dialog } from 'electron'
+import { app, BrowserWindow, dialog, nativeImage } from 'electron'
 import { EventEmitter } from 'events'
 import fs from 'fs'
 import path from 'path'
@@ -6,6 +6,9 @@ import * as settings from '../settings'
 import { _broadcastToRenderer } from './ipc/shared'
 
 export const ALLOWED_EXTENSIONS = ['.safetensors', '.sft', '.ckpt', '.pth', '.pt']
+
+/** Asset (output) downloads whose final file is itself an image we can preview. */
+export const IMAGE_EXTENSIONS = ['.png', '.jpg', '.jpeg', '.webp', '.gif']
 
 export interface DownloadProgress {
   url: string
@@ -22,6 +25,9 @@ export interface DownloadProgress {
   /** First-seen ms for this URL, preserved across status transitions so the
    *  renderer keeps each entry in its insertion-ordered slot. */
   createdAt?: number
+  /** Set on a completed asset download whose file is an image, so the renderer
+   *  knows to lazily request a thumbnail via `download-thumbnail`. */
+  isImage?: boolean
 }
 
 interface PendingDownload {
@@ -185,6 +191,17 @@ export function isPathContained(filePath: string, baseDir: string): boolean {
 export function hasValidExtension(filename: string): boolean {
   const lower = filename.toLowerCase()
   return ALLOWED_EXTENSIONS.some((ext) => lower.endsWith(ext))
+}
+
+function hasImageExtension(filePath: string): boolean {
+  const lower = filePath.toLowerCase()
+  return IMAGE_EXTENSIONS.some((ext) => lower.endsWith(ext))
+}
+
+/** A completed download is previewable only if it's an asset (carries
+ *  `outputDir`; model downloads never do) whose final file is an image. */
+function isImageAsset(pending: PendingDownload): boolean {
+  return !!pending.outputDir && hasImageExtension(pending.savePath)
 }
 
 export function stripQueryParams(rawFilename: string): string {
@@ -551,6 +568,7 @@ function attachDownloadListeners(item: Electron.DownloadItem, pending: PendingDo
         savePath: pending.savePath,
         progress: 1,
         status: 'completed',
+        isImage: isImageAsset(pending),
       })
     } else if (state === 'cancelled') {
       if (pending.tempPath) {
@@ -775,6 +793,53 @@ export function getActiveDownloads(): DownloadProgress[] {
     result.push(pending.lastProgress)
   }
   return result
+}
+
+/** Downscaled-thumbnail data URLs keyed by `${resolvedPath}:${mtimeMs}` so a
+ *  re-downloaded file at the same path re-encodes. LRU-capped. */
+const THUMB_WIDTH = 96
+const THUMB_CACHE_MAX = 64
+const thumbnailCache = new Map<string, string>()
+
+/** Read a completed image download and return a small `data:` URL preview, or
+ *  `null` for non-images, missing/unreadable files, or any decode failure.
+ *  Lazy + cached so it only runs for visible image rows. */
+export async function getDownloadThumbnail(savePath: unknown): Promise<string | null> {
+  if (typeof savePath !== 'string' || !savePath) return null
+  const resolved = path.resolve(savePath)
+  if (!hasImageExtension(resolved)) return null
+
+  let stat: fs.Stats
+  try {
+    stat = await fs.promises.stat(resolved)
+  } catch {
+    return null
+  }
+  if (!stat.isFile()) return null
+
+  const key = `${resolved}:${stat.mtimeMs}`
+  const cached = thumbnailCache.get(key)
+  if (cached !== undefined) {
+    // LRU touch: re-insert so it counts as most-recently-used.
+    thumbnailCache.delete(key)
+    thumbnailCache.set(key, cached)
+    return cached
+  }
+
+  try {
+    const img = nativeImage.createFromPath(resolved)
+    if (img.isEmpty()) return null
+    const dataUrl = img.resize({ width: THUMB_WIDTH, quality: 'good' }).toDataURL()
+    thumbnailCache.set(key, dataUrl)
+    while (thumbnailCache.size > THUMB_CACHE_MAX) {
+      const oldest = thumbnailCache.keys().next().value
+      if (oldest === undefined) break
+      thumbnailCache.delete(oldest)
+    }
+    return dataUrl
+  } catch {
+    return null
+  }
 }
 
 /** Full snapshot for the renderer store to seed from on mount — active entries

--- a/src/main/lib/ipc/registerDownloadHandlers.ts
+++ b/src/main/lib/ipc/registerDownloadHandlers.ts
@@ -5,6 +5,7 @@ import {
   clearFinishedDownloads,
   dismissRecentDownload,
   getAllDownloads,
+  getDownloadThumbnail,
   pauseModelDownload,
   resumeModelDownload,
   retryDownload,
@@ -49,4 +50,11 @@ export function registerDownloadHandlers(): void {
       shell.showItemInFolder(path.resolve(savePath))
     }
   })
+
+  // Lazy preview thumbnail for a completed image download; null for non-images
+  // or unreadable files. Reachable from the panel (`window.api`) and the
+  // title-bar popup (`ipcRenderer.invoke`) alike.
+  ipcMain.handle('download-thumbnail', (_event, { savePath }: { savePath: string }) =>
+    getDownloadThumbnail(savePath),
+  )
 }

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -186,6 +186,7 @@ export function buildElectronApi(): ElectronApi {
     clearFinishedModelDownloads: () => ipcRenderer.invoke('model-download-clear-finished'),
     retryModelDownload: (url) => ipcRenderer.invoke('model-download-retry', { url }),
     showDownloadInFolder: (savePath) => ipcRenderer.invoke('show-download-in-folder', { savePath }),
+    getDownloadThumbnail: (savePath) => ipcRenderer.invoke('download-thumbnail', { savePath }),
 
     // Updates
     checkForUpdate: () => ipcRenderer.invoke('check-for-update'),

--- a/src/preload/comfyPreload.ts
+++ b/src/preload/comfyPreload.ts
@@ -12,6 +12,7 @@ export interface ComfyDownloadProgress {
   etaSeconds?: number
   status: 'pending' | 'downloading' | 'paused' | 'completed' | 'error' | 'cancelled'
   error?: string
+  isImage?: boolean
 }
 
 contextBridge.exposeInMainWorld('__comfyDesktop2', {

--- a/src/preload/comfyTitlePopupPreload.ts
+++ b/src/preload/comfyTitlePopupPreload.ts
@@ -147,6 +147,8 @@ export interface PopupDownloadEntry {
   /** First-seen timestamp (ms), stable across status transitions so terminal
    *  entries keep their slot in a single insertion-ordered list. */
   createdAt?: number
+  /** Set on a completed image asset; the popup lazily requests a thumbnail. */
+  isImage?: boolean
 }
 
 export interface PopupDownloadsState {
@@ -204,6 +206,9 @@ export interface ComfyTitlePopupBridge {
    *  `{ confirmed: true }` when an in-drawer confirm already ran so main skips
    *  its system-modal. */
   restartInstall(installationId: string, opts?: { confirmed?: boolean }): void
+  /** Downscaled `data:` URL preview of a completed image download (the popup
+   *  has no `window.api`); null for non-images / unreadable files. */
+  getDownloadThumbnail(savePath: string): Promise<string | null>
   /** Cloud capacity status; the popup has no `window.api`, so this gives
    *  `useCloudCapacity` an equivalent read path. */
   getCloudCapacity(): Promise<'normal' | 'degraded' | 'disabled'>
@@ -518,6 +523,8 @@ const bridge: ComfyTitlePopupBridge = {
       confirmed: opts?.confirmed === true,
     })
   },
+  getDownloadThumbnail: (savePath: string) =>
+    ipcRenderer.invoke('download-thumbnail', { savePath }),
   getCloudCapacity: async () => {
     // Reuses the panel's `get-cloud-capacity` handler, which awaits the boot
     // fetch so the first call doesn't race the network.

--- a/src/renderer/src/comfyTitlePopup/DownloadsView.vue
+++ b/src/renderer/src/comfyTitlePopup/DownloadsView.vue
@@ -13,6 +13,7 @@ import {
 } from 'lucide-vue-next'
 import { fileLabel, statusKindClass, statusLine } from '../lib/downloadFormatters'
 import { revealInFolderLabel } from '../composables/usePlatform'
+import DownloadThumbnail from '../components/DownloadThumbnail.vue'
 
 const { t } = useI18n()
 
@@ -35,6 +36,7 @@ interface DownloadEntry {
   status: 'pending' | 'downloading' | 'paused' | 'completed' | 'error' | 'cancelled'
   error?: string
   createdAt?: number
+  isImage?: boolean
 }
 
 interface DownloadsState {
@@ -58,6 +60,7 @@ interface PopupBridge {
   downloadsAction(action: DownloadAction): void
   openSettingsTab(tab: PopupSettingsTab): void
   openDownloadsModal(): void
+  getDownloadThumbnail(savePath: string): Promise<string | null>
 }
 
 const bridge = (window as unknown as { __comfyTitlePopup?: PopupBridge }).__comfyTitlePopup
@@ -69,6 +72,15 @@ const TERMINAL_STATUSES = new Set<DownloadEntry['status']>(['completed', 'error'
 
 function isTerminal(d: DownloadEntry): boolean {
   return TERMINAL_STATUSES.has(d.status)
+}
+
+const fetchThumbnail = (savePath: string): Promise<string | null> =>
+  bridge?.getDownloadThumbnail(savePath) ?? Promise.resolve(null)
+
+/** A completed image asset reserves the enlarged rounded preview box (the
+ *  thumbnail itself may still fail to load, falling back to the status icon). */
+function isCompletedImage(download: DownloadEntry): boolean {
+  return download.isImage === true && download.status === 'completed'
 }
 
 /** Combined list newest-first by `createdAt` so a download staying in place across
@@ -180,15 +192,19 @@ function progressStyle(d: DownloadEntry): Record<string, string> | undefined {
         :style="progressStyle(d)"
         @click="(e) => handleRowClick(d, e)"
       >
-        <span class="downloads-item-icon">
-          <CircleCheck v-if="d.status === 'completed'" :size="16" class="ok" />
-          <CircleAlert
-            v-else-if="d.status === 'error' || d.status === 'cancelled'"
-            :size="16"
-            class="bad"
-          />
-          <PauseCircle v-else-if="d.status === 'paused'" :size="16" />
-          <LoaderCircle v-else :size="16" class="spin" />
+        <span class="downloads-item-icon" :class="{ 'is-image': isCompletedImage(d) }">
+          <DownloadThumbnail :entry="d" :fetcher="fetchThumbnail">
+            <template #fallback>
+              <CircleCheck v-if="d.status === 'completed'" :size="16" class="ok" />
+              <CircleAlert
+                v-else-if="d.status === 'error' || d.status === 'cancelled'"
+                :size="16"
+                class="bad"
+              />
+              <PauseCircle v-else-if="d.status === 'paused'" :size="16" />
+              <LoaderCircle v-else :size="16" class="spin" />
+            </template>
+          </DownloadThumbnail>
         </span>
         <div class="downloads-item-text">
           <span class="downloads-item-name" :title="fileLabel(d)">{{ fileLabel(d) }}</span>
@@ -330,6 +346,18 @@ function progressStyle(d: DownloadEntry): Record<string, string> | undefined {
   color: var(--downloads-text);
   margin-top: 2px;
   align-self: flex-start;
+}
+/* A completed image asset grows the leading box into a rounded preview; the
+ * status-icon fallback (file moved/deleted) centers in the same box. */
+.downloads-item-icon.is-image {
+  flex-basis: 36px;
+  width: 36px;
+  height: 36px;
+  margin-top: 0;
+  align-self: center;
+  border-radius: 6px;
+  overflow: hidden;
+  background: color-mix(in srgb, var(--downloads-bar-rest) 60%, transparent);
 }
 .downloads-item-icon .ok {
   color: var(--downloads-text);

--- a/src/renderer/src/comfyTitlePopup/TitlePopupApp.vue
+++ b/src/renderer/src/comfyTitlePopup/TitlePopupApp.vue
@@ -35,6 +35,7 @@ interface DownloadEntry {
   status: 'pending' | 'downloading' | 'paused' | 'completed' | 'error' | 'cancelled'
   error?: string
   createdAt?: number
+  isImage?: boolean
 }
 
 interface DownloadsState {

--- a/src/renderer/src/components/DownloadThumbnail.vue
+++ b/src/renderer/src/components/DownloadThumbnail.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import {
+  useDownloadThumbnail,
+  type ThumbnailFetcher
+} from '../composables/useDownloadThumbnail'
+
+/**
+ * Leading slot for a download row: shows a rounded preview thumbnail for a
+ * completed image asset, otherwise renders the `#fallback` slot (the surface's
+ * existing status icon). Fetching is lazy and injected so the same component
+ * serves both the panel (`window.api`) and the title-bar popup (its bridge).
+ */
+const props = defineProps<{
+  entry: { isImage?: boolean; status: string; savePath?: string; filename: string }
+  fetcher: ThumbnailFetcher
+}>()
+
+const { t } = useI18n()
+
+const thumbnail = useDownloadThumbnail(() => props.entry, props.fetcher)
+
+// A broken image (file moved/deleted after the data URL was cached) falls back
+// to the icon; reset when the underlying source changes.
+const failed = ref(false)
+watch(thumbnail, () => {
+  failed.value = false
+})
+</script>
+
+<template>
+  <img
+    v-if="thumbnail && !failed"
+    :src="thumbnail"
+    :alt="t('downloadsPopup.thumbnailAlt', { name: entry.filename })"
+    class="download-thumb"
+    loading="lazy"
+    decoding="async"
+    draggable="false"
+    @error="failed = true"
+  />
+  <slot v-else name="fallback" />
+</template>
+
+<style scoped>
+.download-thumb {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+</style>

--- a/src/renderer/src/components/DownloadsModal.vue
+++ b/src/renderer/src/components/DownloadsModal.vue
@@ -1,36 +1,30 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import {
   ArrowDownToLine,
+  Ban,
   CheckCircle2,
+  CircleAlert,
   FolderOpen,
+  LoaderCircle,
   PauseCircle,
   PlayCircle,
   RotateCcw,
+  Trash2,
   X,
-  XCircle,
+  XCircle
 } from 'lucide-vue-next'
 import { BaseModal } from './ui'
 import DownloadThumbnail from './DownloadThumbnail.vue'
 import { useDownloadStore } from '../stores/downloadStore'
 import { isTerminalModelDownloadStatus } from '../lib/telemetry'
-import {
-  fileLabel,
-  statusKindClass,
-  statusLine as formatStatusLine,
-} from '../lib/downloadFormatters'
+import { fileLabel, modalSubtitle, statusKindClass } from '../lib/downloadFormatters'
 import { revealInFolderLabel } from '../composables/usePlatform'
 import type { ModelDownloadProgress, ModelDownloadStatus } from '../types/ipc'
 
 const { t } = useI18n()
 const revealLabel = computed(() => revealInFolderLabel(window.api?.platform))
-
-/**
- * "View All Downloads" — the full surface the popup's footer link opens. Mirrors
- * the Settings tab's data model and actions on `BaseModal`. Backed by the same
- * `useDownloadStore`, so all three surfaces stay in lockstep.
- */
 
 const props = defineProps<{ open: boolean }>()
 const emit = defineEmits<{ close: [] }>()
@@ -44,24 +38,42 @@ onMounted(() => {
   store.init()
 })
 
+// Ticking clock so relative timestamps ("5m ago") stay fresh. Runs only while
+// the modal is open to avoid a background timer when it's closed.
+const now = ref(Date.now())
+let clock: ReturnType<typeof setInterval> | undefined
+function stopClock(): void {
+  if (clock) {
+    clearInterval(clock)
+    clock = undefined
+  }
+}
+watch(
+  () => props.open,
+  (open) => {
+    stopClock()
+    if (open) {
+      now.value = Date.now()
+      clock = setInterval(() => (now.value = Date.now()), 30_000)
+    }
+  },
+  { immediate: true }
+)
+onUnmounted(stopClock)
+
 const ordered = computed<ModelDownloadProgress[]>(() =>
-  // Newest-first by `createdAt` (stamped by main on first sight, preserved
-  // across status updates) so a finishing row keeps its slot.
-  [...store.downloads.values()].sort(
-    (a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0),
-  ),
+  [...store.downloads.values()].sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0))
 )
 
 const activeCount = computed(() => store.activeDownloads.length)
 const completedCount = computed(
-  () => store.finishedDownloads.filter((d) => d.status === 'completed').length,
+  () => store.finishedDownloads.filter((d) => d.status === 'completed').length
 )
 const errorCount = computed(
   () =>
-    store.finishedDownloads.filter(
-      (d) => d.status === 'error' || d.status === 'cancelled',
-    ).length,
+    store.finishedDownloads.filter((d) => d.status === 'error' || d.status === 'cancelled').length
 )
+const finishedCount = computed(() => store.finishedDownloads.length)
 
 const filtered = computed<ModelDownloadProgress[]>(() => {
   switch (filter.value) {
@@ -70,20 +82,12 @@ const filtered = computed<ModelDownloadProgress[]>(() => {
     case 'completed':
       return store.finishedDownloads.filter((d) => d.status === 'completed')
     case 'error':
-      return store.finishedDownloads.filter(
-        (d) => d.status === 'error' || d.status === 'cancelled',
-      )
+      return store.finishedDownloads.filter((d) => d.status === 'error' || d.status === 'cancelled')
     default:
       return ordered.value
   }
 })
 
-/** Append total size to `'completed'` rows via the shared formatter. */
-function statusLine(d: ModelDownloadProgress): string {
-  return formatStatusLine(d, { completedShowsSize: true })
-}
-
-/** Wrap IPC calls so rejections don't surface as unhandled-promise warnings. */
 async function safe(call: Promise<unknown>): Promise<void> {
   try {
     await call
@@ -111,8 +115,7 @@ function showInFolder(savePath: string | undefined): void {
 function dismissOne(url: string): void {
   store.dismiss(url)
 }
-/** Render filter pills only for non-empty buckets, and only when ≥ 2 are
- *  non-empty (a lone bucket IS the list). */
+
 const visibleFilters = computed<{ key: StatusFilter; label: string }[]>(() => {
   const present: { key: StatusFilter; label: string }[] = []
   if (activeCount.value > 0) {
@@ -142,11 +145,23 @@ function isTerminal(status: ModelDownloadStatus): boolean {
 const fetchThumbnail = (savePath: string): Promise<string | null> =>
   window.api.getDownloadThumbnail(savePath)
 
-/** A completed image asset reserves the enlarged rounded preview box (the
- *  thumbnail itself may still fail to load, in which case the status icon
- *  fallback fills the same box). */
 function isCompletedImage(download: ModelDownloadProgress): boolean {
   return download.isImage === true && download.status === 'completed'
+}
+
+function progressPercent(d: ModelDownloadProgress): number {
+  return Math.round(d.progress * 100)
+}
+
+function statusBadge(d: ModelDownloadProgress): { label: string; cls: string } | null {
+  switch (d.status) {
+    case 'error':
+      return { label: t('downloadsTab.badgeFailed'), cls: 'dlm-badge-error' }
+    case 'cancelled':
+      return { label: t('downloadsTab.badgeCancelled'), cls: 'dlm-badge-muted' }
+    default:
+      return null
+  }
 }
 </script>
 
@@ -155,6 +170,7 @@ function isCompletedImage(download: ModelDownloadProgress): boolean {
     :open="props.open"
     size="lg"
     blur-overlay
+    content-class="dlm-panel"
     :aria-label="t('downloadsTab.title')"
     @close="emit('close')"
   >
@@ -164,132 +180,186 @@ function isCompletedImage(download: ModelDownloadProgress): boolean {
       </div>
     </template>
 
-    <div
-      v-if="visibleFilters.length > 0"
-      class="dlm-filterbar filter-pill-group"
-      role="tablist"
-      :aria-label="t('downloadsTab.filterAriaLabel')"
-    >
-      <button
-        v-for="f in visibleFilters"
-        :key="f.key"
-        type="button"
-        class="filter-pill dlm-filter-chip"
-        :class="{ active: filter === f.key }"
-        role="tab"
-        :aria-selected="filter === f.key"
-        @click="filter = f.key"
+    <div class="dlm-body">
+      <div
+        v-if="visibleFilters.length > 0"
+        class="dlm-filterbar"
+        role="tablist"
+        :aria-label="t('downloadsTab.filterAriaLabel')"
       >
-        {{ f.label }}
-      </button>
-    </div>
+        <button
+          v-for="f in visibleFilters"
+          :key="f.key"
+          type="button"
+          class="dlm-filter-chip"
+          :class="{ active: filter === f.key }"
+          role="tab"
+          :aria-selected="filter === f.key"
+          @click="filter = f.key"
+        >
+          {{ f.label }}
+        </button>
+      </div>
 
-    <div v-if="filtered.length === 0" class="dlm-empty">
-      <ArrowDownToLine :size="18" />
-      <span>{{ t('downloadsTab.empty') }}</span>
-    </div>
+      <div v-if="filtered.length === 0" class="dlm-empty">
+        <div class="dlm-empty-icon">
+          <ArrowDownToLine :size="28" />
+        </div>
+        <span class="dlm-empty-title">{{ t('downloadsTab.empty') }}</span>
+        <span class="dlm-empty-hint">{{ t('downloadsTab.emptyHint') }}</span>
+      </div>
 
-    <ul v-else class="dlm-list">
-      <li
-        v-for="d in filtered"
-        :key="d.url"
-        class="dlm-item"
-        :class="statusKindClass(d)"
-      >
-        <div class="dlm-item-row">
+      <ul v-else :key="filter" class="dlm-list">
+        <li
+          v-for="(d, i) in filtered"
+          :key="d.url"
+          class="dlm-row"
+          :class="statusKindClass(d)"
+          :style="{ '--i': i }"
+        >
+          <!-- Left: icon / thumbnail -->
           <span :class="['dlm-leading', { 'dlm-thumb': isCompletedImage(d) }]">
             <DownloadThumbnail :entry="d" :fetcher="fetchThumbnail">
               <template #fallback>
-                <CheckCircle2
-                  v-if="d.status === 'completed'"
-                  :size="14"
-                  class="dlm-icon ok"
-                />
-                <XCircle
-                  v-else-if="d.status === 'error' || d.status === 'cancelled'"
-                  :size="14"
-                  class="dlm-icon bad"
-                />
-                <ArrowDownToLine v-else :size="14" class="dlm-icon" />
+                <span v-if="d.status === 'completed'" class="dlm-icon-circle ok">
+                  <CheckCircle2 :size="16" />
+                </span>
+                <span v-else-if="d.status === 'error'" class="dlm-icon-circle error">
+                  <CircleAlert :size="16" />
+                </span>
+                <span v-else-if="d.status === 'cancelled'" class="dlm-icon-circle muted">
+                  <Ban :size="16" />
+                </span>
+                <span v-else-if="d.status === 'paused'" class="dlm-icon-circle warn">
+                  <PauseCircle :size="16" />
+                </span>
+                <span v-else class="dlm-icon-circle active">
+                  <LoaderCircle :size="16" class="dlm-spin" />
+                </span>
               </template>
             </DownloadThumbnail>
           </span>
-          <span class="dlm-name" :title="fileLabel(d)">{{ fileLabel(d) }}</span>
-          <button
-            v-if="isTerminal(d.status)"
-            type="button"
-            class="dlm-dismiss"
-            :title="t('downloadsPopup.remove')"
-            :aria-label="t('downloadsPopup.remove')"
-            @click="dismissOne(d.url)"
-          >
-            <X :size="14" />
-          </button>
-        </div>
-        <div class="dlm-status">{{ statusLine(d) }}</div>
-        <div v-if="d.savePath" class="dlm-path" :title="d.savePath">
-          {{ d.savePath }}
-        </div>
-        <div
-          v-if="d.status === 'downloading' || d.status === 'paused' || d.status === 'pending'"
-          class="dlm-bar"
+
+          <!-- Center: name + subtitle -->
+          <div class="dlm-content">
+            <span class="dlm-name" :title="fileLabel(d)">{{ fileLabel(d) }}</span>
+            <span class="dlm-sub" :title="d.savePath">{{ modalSubtitle(d, now) }}</span>
+            <!-- Inline progress bar for active downloads -->
+            <div
+              v-if="d.status === 'downloading' || d.status === 'paused' || d.status === 'pending'"
+              class="dlm-bar"
+            >
+              <div
+                class="dlm-bar-fill"
+                :class="{
+                  indeterminate: d.status === 'pending',
+                  paused: d.status === 'paused'
+                }"
+                :style="
+                  d.status === 'pending' ? { width: '100%' } : { width: `${progressPercent(d)}%` }
+                "
+              />
+            </div>
+          </div>
+
+          <!-- Right: badge + primary action + dismiss -->
+          <div class="dlm-actions">
+            <span v-if="statusBadge(d)" class="dlm-badge" :class="statusBadge(d)!.cls">
+              {{ statusBadge(d)!.label }}
+            </span>
+
+            <span v-if="d.status === 'downloading'" class="dlm-pct">{{ progressPercent(d) }}%</span>
+            <button
+              v-if="d.status === 'downloading'"
+              type="button"
+              class="dlm-btn"
+              :title="t('downloadsPopup.pause')"
+              :aria-label="t('downloadsPopup.pause')"
+              @click="pause(d.url)"
+            >
+              <PauseCircle :size="14" />
+            </button>
+            <button
+              v-if="d.status === 'paused'"
+              type="button"
+              class="dlm-btn dlm-btn-primary"
+              :title="t('downloadsPopup.resume')"
+              :aria-label="t('downloadsPopup.resume')"
+              @click="resume(d.url)"
+            >
+              <PlayCircle :size="14" />
+              {{ t('downloadsPopup.resume') }}
+            </button>
+            <button
+              v-if="d.status === 'error' || d.status === 'cancelled'"
+              type="button"
+              class="dlm-btn"
+              :title="t('downloadsTab.retry')"
+              :aria-label="t('downloadsTab.retry')"
+              @click="retry(d.url)"
+            >
+              <RotateCcw :size="14" />
+              {{ t('downloadsTab.retry') }}
+            </button>
+            <button
+              v-if="d.status === 'completed' && d.savePath"
+              type="button"
+              class="dlm-btn"
+              @click="showInFolder(d.savePath)"
+            >
+              <FolderOpen :size="14" />
+              {{ revealLabel }}
+            </button>
+
+            <!-- Cancel (active) or dismiss (terminal) -->
+            <button
+              v-if="!isTerminal(d.status)"
+              type="button"
+              class="dlm-x"
+              :title="t('downloadsPopup.cancel')"
+              :aria-label="t('downloadsPopup.cancel')"
+              @click="cancel(d.url)"
+            >
+              <XCircle :size="14" />
+            </button>
+            <button
+              v-if="isTerminal(d.status)"
+              type="button"
+              class="dlm-x"
+              :title="t('downloadsPopup.remove')"
+              :aria-label="t('downloadsPopup.remove')"
+              @click="dismissOne(d.url)"
+            >
+              <X :size="14" />
+            </button>
+          </div>
+        </li>
+      </ul>
+    </div>
+
+    <!-- Footer summary bar -->
+    <template v-if="ordered.length > 0" #footer>
+      <div class="dlm-footer">
+        <span class="dlm-footer-stats">
+          <span v-if="activeCount > 0" class="dlm-footer-stat">
+            {{ t('downloadsTab.footerActive', { n: activeCount }) }}
+          </span>
+          <span v-if="activeCount > 0 && completedCount > 0" class="dlm-footer-sep">&middot;</span>
+          <span v-if="completedCount > 0" class="dlm-footer-stat">
+            {{ t('downloadsTab.footerCompleted', { n: completedCount }) }}
+          </span>
+        </span>
+        <button
+          v-if="finishedCount > 0"
+          type="button"
+          class="dlm-clear-btn"
+          @click="store.clearFinished()"
         >
-          <div
-            class="dlm-bar-fill"
-            :class="{ indeterminate: d.status === 'pending' }"
-            :style="
-              d.status === 'pending'
-                ? { width: '100%' }
-                : { width: `${Math.round(d.progress * 100)}%` }
-            "
-          />
-        </div>
-        <div class="dlm-item-actions">
-          <button
-            v-if="d.status === 'error' || d.status === 'cancelled'"
-            type="button"
-            @click="retry(d.url)"
-          >
-            <RotateCcw :size="13" />
-            {{ t('downloadsTab.retry') }}
-          </button>
-          <button
-            v-if="d.status === 'downloading'"
-            type="button"
-            @click="pause(d.url)"
-          >
-            <PauseCircle :size="13" />
-            {{ t('downloadsPopup.pause') }}
-          </button>
-          <button
-            v-if="d.status === 'paused'"
-            type="button"
-            class="primary"
-            @click="resume(d.url)"
-          >
-            <PlayCircle :size="13" />
-            {{ t('downloadsPopup.resume') }}
-          </button>
-          <button
-            v-if="d.status === 'downloading' || d.status === 'paused' || d.status === 'pending'"
-            type="button"
-            class="danger"
-            @click="cancel(d.url)"
-          >
-            <XCircle :size="13" />
-            {{ t('downloadsPopup.cancel') }}
-          </button>
-          <button
-            v-if="d.status === 'completed' && d.savePath"
-            type="button"
-            @click="showInFolder(d.savePath)"
-          >
-            <FolderOpen :size="13" />
-            {{ revealLabel }}
-          </button>
-        </div>
-      </li>
-    </ul>
+          <Trash2 :size="13" />
+          {{ t('downloadsTab.clearFinished') }}
+        </button>
+      </div>
+    </template>
   </BaseModal>
 </template>
 
@@ -308,83 +378,190 @@ function isCompletedImage(download: ModelDownloadProgress): boolean {
   color: var(--neutral-100);
 }
 
-/* `.filter-pill*` are global (assets/main.css); `.dlm-filter-chip` is a
- * test-selector hook only. */
-.dlm-filterbar {
-  position: sticky;
-  top: 0;
-  z-index: 1;
-  margin: -16px -24px 12px;
-  padding: 12px 24px;
-  background: var(--modal-surface-bg);
-  border-bottom: 1px solid color-mix(in oklab, var(--neutral-100) 8%, transparent);
+.dlm-body {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 100%;
 }
 
-.dlm-empty {
+.dlm-filterbar {
+  position: sticky;
+  top: -16px;
+  z-index: 2;
   display: flex;
+  gap: 6px;
+  margin: -16px -24px 8px;
+  padding: 12px 24px 10px;
+  background: var(--modal-surface-bg, #27202d);
+  border-bottom: 1px solid color-mix(in oklab, var(--neutral-100) 8%, transparent);
+}
+.dlm-filter-chip {
+  flex: 1 1 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 5px 8px;
+  font: inherit;
+  font-size: 12px;
+  color: inherit;
+  background: transparent;
+  border: 1px solid color-mix(in oklab, var(--neutral-100) 12%, transparent);
+  border-radius: 6px;
+  cursor: pointer;
+  opacity: 0.65;
+  transition:
+    opacity 150ms ease,
+    background 150ms ease,
+    border-color 150ms ease;
+}
+.dlm-filter-chip:hover {
+  opacity: 1;
+}
+.dlm-filter-chip.active {
+  background: color-mix(in oklab, var(--neutral-100) 8%, transparent);
+  border-color: color-mix(in oklab, var(--neutral-100) 22%, transparent);
+  opacity: 1;
+}
+
+/* ── Empty state ── */
+.dlm-empty {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   gap: 8px;
-  padding: 48px 0;
+  padding: 24px;
+  text-align: center;
+}
+.dlm-empty-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  border-radius: 16px;
+  background: color-mix(in oklab, var(--neutral-100) 5%, transparent);
   color: var(--text-muted, #9ca0a8);
+  margin-bottom: 4px;
+}
+.dlm-empty-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--neutral-100);
+}
+.dlm-empty-hint {
   font-size: 13px;
+  color: var(--text-muted, #9ca0a8);
 }
 
+/* ── List ── */
 .dlm-list {
   list-style: none;
   margin: 0;
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 2px;
 }
 
-.dlm-item {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding: 12px 14px;
-  border: 1px solid color-mix(in oklab, var(--neutral-100) 8%, transparent);
-  border-radius: 10px;
-  background: color-mix(in oklab, var(--neutral-100) 3%, transparent);
-}
-
-.dlm-item-row {
+/* ── Row: horizontal layout + stagger entrance ── */
+.dlm-row {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  transition: background 120ms ease;
+  animation: dlm-row-in 220ms cubic-bezier(0.2, 0, 0, 1) both;
+  animation-delay: calc(var(--i, 0) * 40ms);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dlm-row {
+    animation: none;
+  }
+}
+@keyframes dlm-row-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+}
+.dlm-row:hover {
+  background: color-mix(in oklab, var(--neutral-100) 4%, transparent);
 }
 
+/* ── Leading icon / thumbnail ── */
 .dlm-leading {
   flex: 0 0 auto;
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  width: 36px;
+  height: 36px;
 }
-/* A completed image asset grows the leading box into a rounded preview; the
- * status-icon fallback (file moved/deleted) centers in the same box. */
 .dlm-thumb {
-  width: 44px;
-  height: 44px;
+  width: 40px;
+  height: 40px;
   border-radius: 8px;
   overflow: hidden;
   background: color-mix(in oklab, var(--neutral-100) 6%, transparent);
 }
 
-.dlm-icon {
-  flex: 0 0 auto;
-  color: var(--neutral-100);
+.dlm-icon-circle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
 }
-.dlm-icon.ok {
+.dlm-icon-circle.ok {
+  background: color-mix(in oklab, #22c55e 15%, transparent);
   color: #22c55e;
 }
-.dlm-icon.bad {
+.dlm-icon-circle.error {
+  background: color-mix(in oklab, #ef4444 15%, transparent);
   color: #ef4444;
+}
+.dlm-icon-circle.muted {
+  background: color-mix(in oklab, var(--neutral-100) 8%, transparent);
+  color: var(--text-muted, #9ca0a8);
+}
+.dlm-icon-circle.warn {
+  background: color-mix(in oklab, #f59e0b 15%, transparent);
+  color: #f59e0b;
+}
+.dlm-icon-circle.active {
+  background: color-mix(in oklab, var(--accent, #60a5fa) 15%, transparent);
+  color: var(--accent, #60a5fa);
+}
+
+.dlm-spin {
+  animation: dlm-spin 0.9s linear infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .dlm-spin {
+    animation: none;
+  }
+}
+@keyframes dlm-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* ── Center content ── */
+.dlm-content {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
 }
 
 .dlm-name {
-  flex: 1 1 auto;
-  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -393,44 +570,38 @@ function isCompletedImage(download: ModelDownloadProgress): boolean {
   color: var(--neutral-100);
 }
 
-.dlm-dismiss {
+/* ── Status badge ── */
+.dlm-badge {
   flex: 0 0 auto;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 22px;
-  height: 22px;
-  padding: 0;
-  border: none;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+  padding: 3px 7px;
   border-radius: 4px;
-  background: transparent;
-  color: var(--text-muted, #9ca0a8);
-  cursor: pointer;
-  opacity: 0.6;
+  white-space: nowrap;
 }
-.dlm-dismiss:hover {
-  opacity: 1;
-  background: color-mix(in oklab, var(--neutral-100) 10%, transparent);
-  color: inherit;
+.dlm-badge-error {
+  background: color-mix(in oklab, #ef4444 15%, transparent);
+  color: #ef4444;
+}
+.dlm-badge-muted {
+  background: color-mix(in oklab, var(--neutral-100) 8%, transparent);
+  color: var(--text-muted, #9ca0a8);
 }
 
-.dlm-status {
+.dlm-sub {
   font-size: 12px;
   color: var(--text-muted, #9ca0a8);
   font-variant-numeric: tabular-nums;
-}
-
-.dlm-path {
-  font-size: 11px;
-  color: var(--text-muted, #9ca0a8);
-  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
+/* ── Inline progress bar ── */
 .dlm-bar {
-  height: 4px;
+  height: 3px;
+  margin-top: 2px;
   background: color-mix(in oklab, var(--neutral-100) 10%, transparent);
   border-radius: 2px;
   overflow: hidden;
@@ -438,64 +609,159 @@ function isCompletedImage(download: ModelDownloadProgress): boolean {
 .dlm-bar-fill {
   height: 100%;
   background: var(--accent, #60a5fa);
+  border-radius: 2px;
   transition: width 0.3s ease;
 }
 .dlm-bar-fill.indeterminate {
-  /* Barber-pole until main reports a real progress tick (empty bar reads as
-   * "stuck" otherwise). */
   background: repeating-linear-gradient(
     90deg,
     var(--accent, #60a5fa),
     var(--accent, #60a5fa) 8px,
-    color-mix(in oklab, var(--accent, #60a5fa) 65%, transparent) 8px,
-    color-mix(in oklab, var(--accent, #60a5fa) 65%, transparent) 16px
+    color-mix(in oklab, var(--accent, #60a5fa) 50%, transparent) 8px,
+    color-mix(in oklab, var(--accent, #60a5fa) 50%, transparent) 16px
   );
+  animation: dlm-shimmer 1.2s linear infinite;
 }
-.dlm-item.is-paused .dlm-bar-fill {
+.dlm-bar-fill.paused {
   background: #f59e0b;
 }
+@keyframes dlm-shimmer {
+  to {
+    background-position: 32px 0;
+  }
+}
 
-.dlm-item-actions {
+/* ── Right: actions ── */
+.dlm-actions {
+  flex: 0 0 auto;
   display: flex;
-  flex-wrap: wrap;
+  align-items: center;
   gap: 6px;
-  margin-top: 2px;
 }
-/* Collapse the action row when empty (the title-row X handles Remove). */
-.dlm-item-actions:empty {
-  display: none;
+
+.dlm-pct {
+  font-size: 13px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: var(--accent, #60a5fa);
+  min-width: 36px;
+  text-align: right;
 }
-.dlm-item-actions button {
+
+.dlm-btn {
   display: inline-flex;
   align-items: center;
   gap: 4px;
   background: color-mix(in oklab, var(--neutral-100) 6%, transparent);
   color: inherit;
-  border: 1px solid color-mix(in oklab, var(--neutral-100) 18%, transparent);
-  border-radius: 5px;
-  padding: 4px 8px;
+  border: 1px solid color-mix(in oklab, var(--neutral-100) 12%, transparent);
+  border-radius: 6px;
+  padding: 4px 10px;
   font: inherit;
-  font-size: 11px;
+  font-size: 12px;
   cursor: pointer;
+  white-space: nowrap;
+  transition:
+    background 120ms ease,
+    border-color 120ms ease;
 }
-.dlm-item-actions button.primary {
+.dlm-btn:hover {
+  background: color-mix(in oklab, var(--neutral-100) 10%, transparent);
+  border-color: color-mix(in oklab, var(--neutral-100) 20%, transparent);
+}
+.dlm-btn-primary {
   background: var(--accent, #3b82f6);
   color: #fff;
   border-color: transparent;
 }
-.dlm-item-actions button.danger {
-  border-color: rgba(239, 68, 68, 0.45);
-  color: #ef4444;
+.dlm-btn-primary:hover {
+  background: var(--accent-hover, #2563eb);
+  border-color: transparent;
 }
-.dlm-item-actions button:hover {
-  filter: brightness(1.1);
+
+.dlm-x {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted, #9ca0a8);
+  cursor: pointer;
+  opacity: 0.5;
+  transition:
+    opacity 120ms ease,
+    background 120ms ease,
+    color 120ms ease;
+}
+/* Active rows: hide X until hover */
+.dlm-row.is-active .dlm-x {
+  opacity: 0;
+}
+.dlm-row.is-active:hover .dlm-x {
+  opacity: 0.5;
+}
+.dlm-x:hover {
+  opacity: 1 !important;
+  background: color-mix(in oklab, var(--neutral-100) 10%, transparent);
+  color: var(--neutral-100);
+}
+
+/* ── Footer ── */
+.dlm-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+}
+.dlm-footer-stats {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-muted, #9ca0a8);
+}
+.dlm-footer-stat {
+  font-variant-numeric: tabular-nums;
+}
+.dlm-footer-sep {
+  opacity: 0.4;
+}
+.dlm-clear-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: transparent;
+  color: var(--text-muted, #9ca0a8);
+  border: 1px solid color-mix(in oklab, var(--neutral-100) 10%, transparent);
+  border-radius: 6px;
+  padding: 5px 10px;
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+  transition:
+    background 120ms ease,
+    color 120ms ease;
+}
+.dlm-clear-btn:hover {
+  background: color-mix(in oklab, var(--neutral-100) 6%, transparent);
+  color: var(--neutral-100);
 }
 </style>
 
-<!-- Non-scoped: in overlay-panel mode the page behind the modal is the live
-     ComfyUI canvas, which the default scrim crushes; soften it and lean on blur. -->
+<!-- Non-scoped: contentClass and overlay-mode styles live outside scoped. -->
 <style>
 body.panel-overlay-mode .base-modal-overlay {
   background: color-mix(in oklab, var(--neutral-900) 28%, transparent);
+}
+.dlm-panel {
+  height: clamp(420px, 70vh, 720px);
+}
+.dlm-panel .base-modal-body {
+  display: flex;
+  flex-direction: column;
 }
 </style>

--- a/src/renderer/src/components/DownloadsModal.vue
+++ b/src/renderer/src/components/DownloadsModal.vue
@@ -12,6 +12,7 @@ import {
   XCircle,
 } from 'lucide-vue-next'
 import { BaseModal } from './ui'
+import DownloadThumbnail from './DownloadThumbnail.vue'
 import { useDownloadStore } from '../stores/downloadStore'
 import { isTerminalModelDownloadStatus } from '../lib/telemetry'
 import {
@@ -137,6 +138,16 @@ watch(visibleFilters, (next) => {
 function isTerminal(status: ModelDownloadStatus): boolean {
   return isTerminalModelDownloadStatus(status)
 }
+
+const fetchThumbnail = (savePath: string): Promise<string | null> =>
+  window.api.getDownloadThumbnail(savePath)
+
+/** A completed image asset reserves the enlarged rounded preview box (the
+ *  thumbnail itself may still fail to load, in which case the status icon
+ *  fallback fills the same box). */
+function isCompletedImage(download: ModelDownloadProgress): boolean {
+  return download.isImage === true && download.status === 'completed'
+}
 </script>
 
 <template>
@@ -186,17 +197,23 @@ function isTerminal(status: ModelDownloadStatus): boolean {
         :class="statusKindClass(d)"
       >
         <div class="dlm-item-row">
-          <CheckCircle2
-            v-if="d.status === 'completed'"
-            :size="14"
-            class="dlm-icon ok"
-          />
-          <XCircle
-            v-else-if="d.status === 'error' || d.status === 'cancelled'"
-            :size="14"
-            class="dlm-icon bad"
-          />
-          <ArrowDownToLine v-else :size="14" class="dlm-icon" />
+          <span :class="['dlm-leading', { 'dlm-thumb': isCompletedImage(d) }]">
+            <DownloadThumbnail :entry="d" :fetcher="fetchThumbnail">
+              <template #fallback>
+                <CheckCircle2
+                  v-if="d.status === 'completed'"
+                  :size="14"
+                  class="dlm-icon ok"
+                />
+                <XCircle
+                  v-else-if="d.status === 'error' || d.status === 'cancelled'"
+                  :size="14"
+                  class="dlm-icon bad"
+                />
+                <ArrowDownToLine v-else :size="14" class="dlm-icon" />
+              </template>
+            </DownloadThumbnail>
+          </span>
           <span class="dlm-name" :title="fileLabel(d)">{{ fileLabel(d) }}</span>
           <button
             v-if="isTerminal(d.status)"
@@ -336,6 +353,22 @@ function isTerminal(status: ModelDownloadStatus): boolean {
   display: flex;
   align-items: center;
   gap: 8px;
+}
+
+.dlm-leading {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+/* A completed image asset grows the leading box into a rounded preview; the
+ * status-icon fallback (file moved/deleted) centers in the same box. */
+.dlm-thumb {
+  width: 44px;
+  height: 44px;
+  border-radius: 8px;
+  overflow: hidden;
+  background: color-mix(in oklab, var(--neutral-100) 6%, transparent);
 }
 
 .dlm-icon {

--- a/src/renderer/src/composables/useDownloadThumbnail.ts
+++ b/src/renderer/src/composables/useDownloadThumbnail.ts
@@ -1,0 +1,63 @@
+import { ref, watchEffect, type Ref } from 'vue'
+
+/** Reads a completed download's preview into a `data:` URL. */
+export type ThumbnailFetcher = (savePath: string) => Promise<string | null>
+
+interface ThumbnailEntry {
+  isImage?: boolean
+  status: string
+  savePath?: string
+}
+
+// Keyed by savePath so the popup and modal never fetch the same thumbnail twice
+// (`null` = resolved-but-no-thumbnail, distinct from "not yet fetched").
+const cache = new Map<string, string | null>()
+const inflight = new Map<string, Promise<string | null>>()
+
+/**
+ * Lazily resolves a download row's thumbnail. Returns a ref that stays `null`
+ * until the file is a completed image with a `savePath` and the injected
+ * `fetcher` resolves a data URL. The `fetcher` is injected so the same code
+ * serves the panel (`window.api`) and the popup (its bridge).
+ */
+export function useDownloadThumbnail(
+  entry: () => ThumbnailEntry,
+  fetcher: ThumbnailFetcher
+): Ref<string | null> {
+  const url = ref<string | null>(null)
+
+  watchEffect(() => {
+    const e = entry()
+    url.value = null
+    if (!e.isImage || e.status !== 'completed' || !e.savePath) return
+
+    const savePath = e.savePath
+    const cached = cache.get(savePath)
+    if (cached !== undefined) {
+      url.value = cached
+      return
+    }
+
+    let pending = inflight.get(savePath)
+    if (!pending) {
+      pending = fetcher(savePath)
+        .then((result) => {
+          cache.set(savePath, result)
+          inflight.delete(savePath)
+          return result
+        })
+        .catch(() => {
+          inflight.delete(savePath)
+          return null
+        })
+      inflight.set(savePath, pending)
+    }
+
+    void pending.then((result) => {
+      // Guard against the row's savePath changing while the fetch was in flight.
+      if (entry().savePath === savePath) url.value = result
+    })
+  })
+
+  return url
+}

--- a/src/renderer/src/composables/useDownloadThumbnail.ts
+++ b/src/renderer/src/composables/useDownloadThumbnail.ts
@@ -24,17 +24,20 @@ export function useDownloadThumbnail(
   entry: () => ThumbnailEntry,
   fetcher: ThumbnailFetcher
 ): Ref<string | null> {
-  const url = ref<string | null>(null)
+  // The resolved thumbnail data: URL (not the download's source URL).
+  const thumbnail = ref<string | null>(null)
 
   watchEffect(() => {
     const e = entry()
-    url.value = null
+    thumbnail.value = null
+    // Only completed image assets carry a readable on-disk file; `savePath` is a
+    // local filesystem path, never the (possibly external) download `url`.
     if (!e.isImage || e.status !== 'completed' || !e.savePath) return
 
     const savePath = e.savePath
     const cached = cache.get(savePath)
     if (cached !== undefined) {
-      url.value = cached
+      thumbnail.value = cached
       return
     }
 
@@ -55,9 +58,9 @@ export function useDownloadThumbnail(
 
     void pending.then((result) => {
       // Guard against the row's savePath changing while the fetch was in flight.
-      if (entry().savePath === savePath) url.value = result
+      if (entry().savePath === savePath) thumbnail.value = result
     })
   })
 
-  return url
+  return thumbnail
 }

--- a/src/renderer/src/lib/downloadFormatters.ts
+++ b/src/renderer/src/lib/downloadFormatters.ts
@@ -88,3 +88,66 @@ export function statusKindClass(d: Pick<DownloadFormatInput, 'status'>): string 
       return 'is-active'
   }
 }
+
+/** Human-readable relative time from a wall-clock ms timestamp. `now` is
+ *  injectable so callers can drive a ticking clock for live re-rendering. */
+export function relativeTime(timestampMs: number | undefined, now = Date.now()): string {
+  if (!timestampMs) return ''
+  const delta = Math.max(0, now - timestampMs)
+  const secs = Math.floor(delta / 1000)
+  if (secs < 60) return 'Just now'
+  const mins = Math.floor(secs / 60)
+  if (mins < 60) return `${mins}m ago`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  return `${days}d ago`
+}
+
+export interface ModalFormatInput extends DownloadFormatInput {
+  createdAt?: number
+  totalBytes?: number
+}
+
+/** Rich subtitle for the Downloads Modal: progress details for active, size + time for terminal.
+ *  `now` is injectable so the relative-time portion can re-render against a ticking clock. */
+export function modalSubtitle(d: ModalFormatInput, now = Date.now()): string {
+  const pct = Math.round(d.progress * 100)
+  switch (d.status) {
+    case 'pending':
+      return 'Waiting…'
+    case 'downloading': {
+      const parts: string[] = []
+      if (d.totalBytes && d.totalBytes > 0 && d.receivedBytes != null) {
+        parts.push(`${formatBytes(d.receivedBytes)} / ${formatBytes(d.totalBytes)}`)
+      }
+      if (d.speedBytesPerSec && d.speedBytesPerSec > 0) {
+        parts.push(formatSpeed(d.speedBytesPerSec))
+      }
+      if (d.etaSeconds != null && d.etaSeconds > 0 && isFinite(d.etaSeconds)) {
+        parts.push(`~${formatEta(d.etaSeconds)} left`)
+      }
+      return parts.join(' · ') || `${pct}%`
+    }
+    case 'paused': {
+      const parts = [`Paused at ${pct}%`]
+      if (d.totalBytes && d.totalBytes > 0 && d.receivedBytes != null) {
+        parts.push(`${formatBytes(d.receivedBytes)} / ${formatBytes(d.totalBytes)}`)
+      }
+      return parts.join(' · ')
+    }
+    case 'completed': {
+      const parts: string[] = []
+      if (d.totalBytes) parts.push(formatBytes(d.totalBytes))
+      const ago = relativeTime(d.createdAt, now)
+      if (ago) parts.push(ago)
+      return parts.join(' · ') || 'Completed'
+    }
+    case 'error':
+      return d.error || 'Download failed'
+    case 'cancelled':
+      return 'Cancelled'
+    default:
+      return ''
+  }
+}

--- a/src/renderer/src/lib/i18nMessages.ts
+++ b/src/renderer/src/lib/i18nMessages.ts
@@ -114,7 +114,8 @@ export const en = {
     showInFolder: 'Show in Finder',
     remove: 'Remove from list',
     viewAllInSettings: 'View All Downloads',
-    completed: 'Completed'
+    completed: 'Completed',
+    thumbnailAlt: 'Thumbnail of {name}'
   },
   downloadsTab: {
     title: 'Downloads',

--- a/src/renderer/src/lib/i18nMessages.ts
+++ b/src/renderer/src/lib/i18nMessages.ts
@@ -119,13 +119,19 @@ export const en = {
   },
   downloadsTab: {
     title: 'Downloads',
-    empty: 'No downloads to show',
+    empty: 'No downloads yet',
+    emptyHint: 'Downloads will appear here.',
     filterAll: 'All',
     filterActive: 'Active',
     filterCompleted: 'Completed',
     filterErrored: 'Failed',
     filterAriaLabel: 'Status filter',
-    retry: 'Retry'
+    retry: 'Retry',
+    badgeFailed: 'Failed',
+    badgeCancelled: 'Cancelled',
+    footerActive: '{n} active',
+    footerCompleted: '{n} completed',
+    clearFinished: 'Clear finished'
   },
   settingsModal: {
     title: 'Settings',

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -514,6 +514,9 @@ export interface ModelDownloadProgress {
    *  bottom when they leave the in-flight bucket. Optional only for
    *  back-compat with snapshots that predate the field. */
   createdAt?: number
+  /** Set on a completed asset download whose file is an image, so the surface
+   *  knows to lazily request a thumbnail via `getDownloadThumbnail`. */
+  isImage?: boolean
 }
 
 // --- Track types ---
@@ -1198,6 +1201,9 @@ export interface ElectronApi {
    *  params were evicted from the recent buffer. */
   retryModelDownload(url: string): Promise<boolean>
   showDownloadInFolder(savePath: string): Promise<void>
+  /** Downscaled `data:` URL preview of a completed image download, or null for
+   *  non-images / unreadable files. */
+  getDownloadThumbnail(savePath: string): Promise<string | null>
 
   // Event listeners (return unsubscribe functions)
   onInstallProgress(callback: (data: ProgressData) => void): Unsubscribe


### PR DESCRIPTION
## Summary

Show a preview thumbnail for completed **output/asset image downloads** (PNG/JPG/JPEG/WebP/GIF) in both download surfaces — the title-bar popup and the "View All" modal. Model downloads (`.safetensors`, `.ckpt`, etc.) keep their existing status icon. Thumbnails are read lazily off disk via a new `download-thumbnail` IPC and returned as a downscaled `data:` URL.

## Changes

**What**
- `comfyDownloadManager.ts` — add `getDownloadThumbnail(savePath)`: validates an image extension, `stat`s the file, decodes + downscales via Electron's built-in `nativeImage` (~96px, no new dependency), returns a `data:` URL; results cached in an `mtime`-keyed LRU (cap 64). Returns `null` for non-images, missing/unreadable files, or decode failure.
- `comfyDownloadManager.ts` — flag a completed asset whose file is an image with `isImage: true` on the broadcast `DownloadProgress` (asset = carries `outputDir`; models never do), so surfaces know to request a thumbnail.
- `registerDownloadHandlers.ts` — register `ipcMain.handle('download-thumbnail', …)`, reachable from both the panel (`window.api`) and the title-bar popup (`ipcRenderer.invoke`).
- `ipc.ts` / `api.ts` / `comfyPreload.ts` / `comfyTitlePopupPreload.ts` — thread `isImage?: boolean` and `getDownloadThumbnail(savePath)` through every type/preload surface.
- `useDownloadThumbnail.ts` (new) — composable that lazily requests a thumbnail only for completed image rows, with a module-level `savePath`-keyed cache so the popup and modal never double-fetch; `fetcher` is injected so the same code serves both surfaces.
- `DownloadThumbnail.vue` (new) — renders the `<img>` (lazy/async, i18n `alt`, `@error` → fallback) or a `#fallback` slot holding the surface's existing status icon.
- `DownloadsView.vue` (popup) + `DownloadsModal.vue` — wire `DownloadThumbnail` into the leading icon slot; image rows grow to a rounded ~36px (popup) / ~44px (modal) preview, everything else keeps the icon.
- `i18nMessages.ts` — add `downloadsPopup.thumbnailAlt` for the `<img alt>`.

**Breaking**
- None. The `DownloadProgress` shape only gains an optional `isImage`; existing IPC channels, broadcast/seed/recent paths, and telemetry are untouched. Non-image and model downloads render exactly as before.

## Review Focus

- The asset-vs-model discriminator is `outputDir` presence (set only by `startAssetDownload`), narrowed by an image-extension check — see `isImageAsset` in `comfyDownloadManager.ts`.
- Lazy-by-design: the broadcast object carries only a boolean; the `data:` URL is fetched per visible row, not embedded — keeps the recent-buffer, IPC payloads, and popup state small. CSP (`img-src 'self' data:`) already allows `data:`, so no CSP change.
- The popup runs in a separate webview with its own bridge (no `window.api`/Pinia), so `getDownloadThumbnail` is exposed on `__comfyTitlePopup` and proxies to the same global handler.
- **Scope:** asset/output images only. Model thumbnails are intentionally out of scope (no local preview data; would require external Civitai/HF API calls).

## Testing

No automated tests in this PR. The thumbnail decode/cache/fallback path was prototyped under unit + e2e but the e2e proved environment-fragile (runs against the prebuilt bundle; a real-image decode crosses the test↔app filesystem boundary), so tests were dropped rather than land flaky. The change is additive and behind an `isImage` gate, with graceful icon fallback on any failure.

- `pnpm typecheck` — clean (node/web/e2e/integration).
- `pnpm lint` — clean.
- Manual: generate/save an output image from a cloud workflow → popup + modal show the thumbnail; a `.safetensors` download keeps its icon; move/delete the file → row falls back to the status icon.

Screen Recording

https://github.com/user-attachments/assets/023b8116-28d3-4a91-9497-00f2990d89dc

closes #875 