### PR TITLE
feat(mirrors): inject HF_ENDPOINT mirror when useChineseMirrors is on

### DIFF
--- a/src/main/lib/ipc/buildLaunchEnv.test.ts
+++ b/src/main/lib/ipc/buildLaunchEnv.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getPath: () => '/tmp',
+    getVersion: () => '0.0.0-test',
+    getLocale: () => 'en',
+  },
+  ipcMain: { handle: vi.fn(), on: vi.fn(), off: vi.fn() },
+  dialog: {},
+  shell: {},
+  BrowserWindow: { getAllWindows: () => [] },
+  nativeTheme: { on: vi.fn(), shouldUseDarkColors: false },
+}))
+
+const settingsState: Record<string, unknown> = {}
+vi.mock('../../settings', () => ({
+  get: (key: string) => settingsState[key],
+  set: (key: string, value: unknown) => {
+    settingsState[key] = value
+  },
+}))
+
+import * as settingsModule from '../../settings'
+import type { InstallationRecord } from '../../installations'
+import { buildLaunchEnv } from './shared'
+
+function fakeInst(sourceId: InstallationRecord['sourceId'] = 'standalone'): InstallationRecord {
+  return { sourceId } as InstallationRecord
+}
+
+describe('buildLaunchEnv mirror injection', () => {
+  let originalHfEndpoint: string | undefined
+
+  beforeEach(() => {
+    originalHfEndpoint = process.env.HF_ENDPOINT
+    delete process.env.HF_ENDPOINT
+    for (const k of Object.keys(settingsState)) delete settingsState[k]
+  })
+
+  afterEach(() => {
+    if (originalHfEndpoint === undefined) delete process.env.HF_ENDPOINT
+    else process.env.HF_ENDPOINT = originalHfEndpoint
+  })
+
+  it('omits HF_ENDPOINT when mirrors are off', () => {
+    settingsModule.set('useChineseMirrors', false)
+    const env = buildLaunchEnv(fakeInst())
+    expect(env.HF_ENDPOINT).toBeUndefined()
+  })
+
+  it('omits HF_ENDPOINT when the setting is unset', () => {
+    const env = buildLaunchEnv(fakeInst())
+    expect(env.HF_ENDPOINT).toBeUndefined()
+  })
+
+  it('injects the HF mirror when mirrors are on and no user override exists', () => {
+    settingsModule.set('useChineseMirrors', true)
+    const env = buildLaunchEnv(fakeInst())
+    expect(env.HF_ENDPOINT).toBe('https://hf-mirror.com')
+  })
+
+  it('respects a user-provided HF_ENDPOINT and does not override it', () => {
+    settingsModule.set('useChineseMirrors', true)
+    process.env.HF_ENDPOINT = 'https://my-private-hf.example.com'
+    const env = buildLaunchEnv(fakeInst())
+    expect(env.HF_ENDPOINT).toBe('https://my-private-hf.example.com')
+  })
+
+  it('keeps other env keys untouched alongside the mirror', () => {
+    settingsModule.set('useChineseMirrors', true)
+    const env = buildLaunchEnv(fakeInst())
+    expect(env.PYTHONIOENCODING).toBe('utf-8')
+    expect(env.CM_USE_PYGIT2).toBe('1')
+  })
+})

--- a/src/main/lib/ipc/shared.ts
+++ b/src/main/lib/ipc/shared.ts
@@ -434,12 +434,21 @@ export function sanitizeEnvVars(raw: unknown): Record<string, string> {
   return result
 }
 
+// Well-known HuggingFace mirror used by the community for regions with restricted GitHub/HF
+// access. Keeps the user-set `HF_ENDPOINT` (if any) wins; only injected when the user opted
+// into mirrors and has no explicit override.
+const HF_MIRROR_URL = 'https://hf-mirror.com'
+
 export function buildLaunchEnv(inst: InstallationRecord, sessionPath?: string): Record<string, string | undefined> {
   const userEnvVars = sanitizeEnvVars(inst.envVars)
+  const useChineseMirrors = settings.get('useChineseMirrors') === true
+  const hasUserHfEndpoint =
+    typeof process.env.HF_ENDPOINT === 'string' && process.env.HF_ENDPOINT.length > 0
   return {
     ...process.env,
     ...userEnvVars,
     PYTHONIOENCODING: 'utf-8',
+    ...(useChineseMirrors && !hasUserHfEndpoint ? { HF_ENDPOINT: HF_MIRROR_URL } : {}),
     ...(sessionPath ? { __COMFY_CLI_SESSION__: sessionPath } : {}),
     ...(inst.sourceId === 'standalone' ? { CM_USE_PYGIT2: '1' } : {}),
   }


### PR DESCRIPTION
## Summary

When a user opts into the China mirror flow (\`useChineseMirrors=true\`), inject \`HF_ENDPOINT=https://hf-mirror.com\` into every spawned ComfyUI process so HuggingFace downloads route through the mirror.

Current behaviour: opt-in only rewrites pip's \`--index-url\` and the Comfy-Org git clone URL. HuggingFace, the second-largest external dependency (model downloads, hub API), still points at huggingface.co with no fallback. This PR closes that gap.

## Why

Cohort analysis over a 24h launch window:

| Cohort | Users | Users hitting external-network errors |
|---|---|---|
| opted_in (mirror on) | 1,225 | 61 (5.0%) |
| no_prompt | 1,461 | 17 (1.2%) |

Even users who explicitly opt into the mirror still hit network failures at ~4x the baseline rate. The errors trace to dependencies the mirror doesn't currently cover — HuggingFace is one. \`HF_ENDPOINT\` is the documented hub env var (https://huggingface.co/docs/huggingface_hub/package_reference/environment_variables) and \`hf-mirror.com\` is the standard community mirror.

## Behaviour

- \`useChineseMirrors=true\` and no user override → injects \`HF_ENDPOINT=https://hf-mirror.com\`
- \`useChineseMirrors=true\` but the user already set \`HF_ENDPOINT\` in their shell → keeps the user value, no override
- \`useChineseMirrors=false\` or unset → no-op

## Test plan

- [x] \`pnpm vitest run buildLaunchEnv.test.ts\` — 5/5 pass (covers off/unset/on-default/user-override/other-keys)
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm lint\` — clean
- [ ] Manual: build, set \`useChineseMirrors=true\`, start an instance, attach to the Python process and confirm \`os.environ['HF_ENDPOINT'] == 'https://hf-mirror.com'\`