### PR TITLE
Fix/settings modal instant open

### DIFF
--- a/src/main/lib/githubStars.ts
+++ b/src/main/lib/githubStars.ts
@@ -22,10 +22,8 @@ export function getCachedGithubStarCount(repo: string): number | null {
 }
 
 export async function getGithubStarCount(repo: string): Promise<number | null> {
-  const cached = cache.get(repo)
-  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
-    return cached.count
-  }
+  const fresh = getCachedGithubStarCount(repo)
+  if (fresh != null) return fresh
 
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)

--- a/src/main/lib/githubStars.ts
+++ b/src/main/lib/githubStars.ts
@@ -10,6 +10,17 @@ const FETCH_TIMEOUT_MS = 6000
 
 const cache = new Map<string, CacheEntry>()
 
+// Synchronous, network-free read of the cached count. Returns null when the
+// entry is missing or stale, so callers can open instantly off the cache and
+// warm it in the background via getGithubStarCount().
+export function getCachedGithubStarCount(repo: string): number | null {
+  const cached = cache.get(repo)
+  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+    return cached.count
+  }
+  return null
+}
+
 export async function getGithubStarCount(repo: string): Promise<number | null> {
   const cached = cache.get(repo)
   if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {

--- a/src/main/popups/titlePopup.ts
+++ b/src/main/popups/titlePopup.ts
@@ -30,7 +30,7 @@ import {
   buildModelsPayload
 } from '../lib/ipc/registerSettingsHandlers'
 import { globalSettingsEvents } from '../lib/globalSettingsEvents'
-import { getGithubStarCount } from '../lib/githubStars'
+import { getCachedGithubStarCount, getGithubStarCount } from '../lib/githubStars'
 import {
   comfyWindows,
   findEntryByTitleBarSender,
@@ -205,6 +205,7 @@ export interface GlobalSettingsSnapshot {
   }
   githubUrl: string
   githubStars: number | null
+  githubStarsLoading: boolean
   i18n: {
     overview: string
     updates: string
@@ -1623,22 +1624,27 @@ export interface TitlePopupHostBindings {
 function openGlobalSettingsForHost(
   parentEntry: ComfyWindowEntry,
   parentEntryId: number,
-  _bindings: TitlePopupHostBindings,
+  bindings: TitlePopupHostBindings,
   titleBarSender: Electron.WebContents
 ): void {
   if (parentEntry.window.isDestroyed()) return
+  // Open instantly off the cached snapshot — like the instance picker — so the
+  // popup never waits on the GitHub-stars network fetch. Warm the cache in the
+  // background and broadcast the result so the star count fills in afterwards.
+  openTitlePopup({
+    parent: parentEntry.window,
+    parentEntryId,
+    kind: 'global-settings',
+    snapshot: buildGlobalSettingsSnapshot(),
+    anchor: { x: 0, y: TITLEBAR_HEIGHT },
+    theme: parentEntry.lastTheme,
+    titleBarSender
+  })
   void (async () => {
-    const snapshot = await buildGlobalSettingsSnapshot()
+    await getGithubStarCount('comfy-org/ComfyUI').catch(() => null)
+    githubStarsFetchAttempted = true
     if (parentEntry.window.isDestroyed()) return
-    openTitlePopup({
-      parent: parentEntry.window,
-      parentEntryId,
-      kind: 'global-settings',
-      snapshot,
-      anchor: { x: 0, y: TITLEBAR_HEIGHT },
-      theme: parentEntry.lastTheme,
-      titleBarSender
-    })
+    await broadcastGlobalSettingsSnapshotToTitlePopups(bindings)
   })()
 }
 
@@ -1854,8 +1860,14 @@ function activateTitlePopupMenuItem(
     // Open the Global Settings popup. The host's active installation
     // (null on chooser hosts) drives the install-scoped Update Channel
     // + Copy & Update controls.
+    //
+    // `openGlobalSettingsForHost` now opens synchronously (it no longer
+    // awaits the GitHub-stars fetch), reusing this popup's view via the
+    // kind-switch in `openTitlePopup` — which already dismisses the menu.
+    // Returning here skips the trailing `hideTitlePopup(entry)` below,
+    // which would otherwise immediately hide the settings popup we just
+    // opened on the same shared view.
     if (parentEntry && !parentEntry.window.isDestroyed()) {
-      releaseFocusToParent = false
       openGlobalSettingsForHost(
         parentEntry,
         entry.parentEntryId,
@@ -1863,6 +1875,7 @@ function activateTitlePopupMenuItem(
         parentEntry.titleBarView.webContents
       )
     }
+    return
   } else if (id === 'skip-onboarding') {
     // Forward to the panel renderer so it runs the same
     // `markFirstUseCompleted` + dismiss sequence the Cloud-branch
@@ -1939,6 +1952,13 @@ let lastAppUpdateProgress: Record<string, unknown> | null = null
  *  another IPC round-trip. */
 let globalSettingsLastCheckedAt: number | null = null
 
+/*  Flips true once the first background GitHub-stars fetch of the session
+ *  resolves (success or failure). Until then a null count means "still
+ *  loading" and the renderer shows a skeleton; afterwards a null count means
+ *  "unavailable" and the badge is hidden. Prevents an infinite shimmer when
+ *  offline. */
+let githubStarsFetchAttempted = false
+
 const SETTINGS_TYPE_TO_DETAIL_EDIT_TYPE: Record<string, string | undefined> = {
   text: 'text',
   number: 'number',
@@ -1986,7 +2006,7 @@ function findSettingsFields(
   return src.map(toDetailField)
 }
 
-async function buildGlobalSettingsSnapshot(): Promise<GlobalSettingsSnapshot> {
+function buildGlobalSettingsSnapshot(): GlobalSettingsSnapshot {
   const settingsSections = buildSettingsSections()
   const mediaSections = buildMediaSections()
   const modelsPayload = buildModelsPayload()
@@ -2002,7 +2022,8 @@ async function buildGlobalSettingsSnapshot(): Promise<GlobalSettingsSnapshot> {
   const appUpdateState = updater.getCurrentUpdateState() as unknown as Record<string, unknown>
   const isDownloading = appUpdateState['kind'] === 'downloading'
   if (!isDownloading) lastAppUpdateProgress = null
-  const githubStars = await getGithubStarCount('comfy-org/ComfyUI').catch(() => null)
+  const githubStars = getCachedGithubStarCount('comfy-org/ComfyUI')
+  const githubStarsLoading = githubStars == null && !githubStarsFetchAttempted
   return {
     generalFields,
     telemetryFields,
@@ -2030,6 +2051,7 @@ async function buildGlobalSettingsSnapshot(): Promise<GlobalSettingsSnapshot> {
     },
     githubUrl: GLOBAL_SETTINGS_GITHUB_URL,
     githubStars,
+    githubStarsLoading,
     i18n: {
       overview: i18n.t('settings.general'),
       updates: i18n.t('settings.updatesTab'),
@@ -2052,7 +2074,7 @@ async function broadcastGlobalSettingsSnapshotToTitlePopups(
     if (entry.kind !== 'global-settings') continue
     if (!entry.view.isOpen && entry.view.pendingShowTimer === null) continue
     if (entry.view.popup.webContents.isDestroyed()) continue
-    const snapshot = await buildGlobalSettingsSnapshot()
+    const snapshot = buildGlobalSettingsSnapshot()
     const snapshotJson = JSON.stringify(snapshot)
     if (entry.lastGlobalSettingsBroadcastJson === snapshotJson) continue
     entry.lastGlobalSettingsBroadcastJson = snapshotJson

--- a/src/preload/comfyTitlePopupPreload.ts
+++ b/src/preload/comfyTitlePopupPreload.ts
@@ -100,6 +100,7 @@ export interface PopupGlobalSettingsSnapshot {
   }
   githubUrl: string
   githubStars: number | null
+  githubStarsLoading: boolean
   i18n: {
     overview: string
     updates: string

--- a/src/renderer/src/comfyTitlePopup/GlobalSettingsView.vue
+++ b/src/renderer/src/comfyTitlePopup/GlobalSettingsView.vue
@@ -49,6 +49,7 @@ interface Snapshot {
   }
   githubUrl: string
   githubStars: number | null
+  githubStarsLoading: boolean
   i18n: {
     overview: string
     updates: string
@@ -240,6 +241,7 @@ onMounted(() => {
             <GitHubLinkCard
               :url="snapshot.githubUrl"
               :stars="snapshot.githubStars"
+              :loading="snapshot.githubStarsLoading"
               @open="handleOpenExternal"
             />
           </GlobalSettingsMicroSection>

--- a/src/renderer/src/comfyTitlePopup/TitlePopupApp.vue
+++ b/src/renderer/src/comfyTitlePopup/TitlePopupApp.vue
@@ -110,6 +110,7 @@ interface GlobalSettingsSnapshot {
   }
   githubUrl: string
   githubStars: number | null
+  githubStarsLoading: boolean
   i18n: {
     overview: string
     updates: string
@@ -200,6 +201,7 @@ const globalSettingsSnapshot = ref<GlobalSettingsSnapshot>({
   },
   githubUrl: '',
   githubStars: null,
+  githubStarsLoading: false,
   i18n: {
     overview: 'General',
     updates: 'Updates',

--- a/src/renderer/src/comfyTitlePopup/globalSettings/GitHubLinkCard.vue
+++ b/src/renderer/src/comfyTitlePopup/globalSettings/GitHubLinkCard.vue
@@ -8,9 +8,11 @@ const props = withDefaults(
   defineProps<{
     url: string
     stars: number | null
+    loading?: boolean
     label?: string
   }>(),
   {
+    loading: false,
     label: 'Comfy Desktop',
   },
 )
@@ -35,7 +37,14 @@ const starCountLabel = computed(() => {
       <span class="github-link-label">{{ label }}</span>
       <ExternalLink :size="12" class="github-link-external" aria-hidden="true" />
     </span>
-    <span v-if="stars != null" class="github-link-stars" :aria-label="`${stars} GitHub stars`">
+    <span v-if="loading" class="github-link-stars github-link-stars--skeleton" aria-hidden="true">
+      <span class="github-link-skeleton-bar" />
+    </span>
+    <span
+      v-else-if="stars != null"
+      class="github-link-stars"
+      :aria-label="`${stars} GitHub stars`"
+    >
       <Star :size="12" class="github-link-stars-icon" aria-hidden="true" />
       <span>{{ starCountLabel }}</span>
     </span>
@@ -100,5 +109,39 @@ const starCountLabel = computed(() => {
 .github-link-stars-icon {
   color: var(--warning);
   fill: currentColor;
+}
+
+.github-link-stars--skeleton {
+  min-width: 44px;
+  justify-content: center;
+}
+
+.github-link-skeleton-bar {
+  width: 32px;
+  height: 10px;
+  border-radius: 999px;
+  background: linear-gradient(
+    90deg,
+    color-mix(in oklab, var(--neutral-100) 6%, transparent) 0%,
+    color-mix(in oklab, var(--neutral-100) 16%, transparent) 50%,
+    color-mix(in oklab, var(--neutral-100) 6%, transparent) 100%
+  );
+  background-size: 200% 100%;
+  animation: github-stars-shimmer 1.4s linear infinite;
+}
+
+@keyframes github-stars-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .github-link-skeleton-bar {
+    animation: none;
+  }
 }
 </style>


### PR DESCRIPTION
## Summary

The global Desktop Settings popup had an abrupt delay on its **first** open after launch — unlike the instance picker, hamburger menu, and downloads popup, which open instantly. `openGlobalSettingsForHost` was `await`ing a GitHub-stars network fetch inside `buildGlobalSettingsSnapshot` before showing the popup, so the very first open (empty cache) paid full network latency (up to the 6s fetch timeout). This opens the popup synchronously off the cached snapshot and fetches the star count in the background, mirroring the instance picker's open-then-refresh pattern.

## Changes

**What**
- `titlePopup.ts` / `openGlobalSettingsForHost` — open the popup synchronously off `buildGlobalSettingsSnapshot()` instead of awaiting the fetch; kick off a background IIFE that warms the stars cache via `getGithubStarCount()` then `broadcastGlobalSettingsSnapshotToTitlePopups()` so the count fills in afterwards.
- `titlePopup.ts` / `buildGlobalSettingsSnapshot` — made synchronous; reads the cached count via the new `getCachedGithubStarCount()` and derives `githubStarsLoading`.
- `githubStars.ts` — added `getCachedGithubStarCount()`, a network-free read of the 24h cache (returns `null` when missing/stale). `getGithubStarCount()` is unchanged.
- `titlePopup.ts` / `activateTitlePopupMenuItem` — the `settings` branch now `return`s after opening. The open reuses the shared popup view via the kind-switch in `openTitlePopup` (which already dismisses the menu); the trailing `hideTitlePopup(entry)` was otherwise hiding the just-opened popup now that the open is synchronous.
- `GlobalSettingsSnapshot` — added `githubStarsLoading: boolean` to all four mirrored definitions (`titlePopup.ts`, `comfyTitlePopupPreload.ts`, `TitlePopupApp.vue`, `GlobalSettingsView.vue`) to distinguish "still loading" from "unavailable" (offline/failed) so the skeleton never shimmers forever. A module-level `githubStarsFetchAttempted` flag flips to not-loading once the first background fetch resolves.
- `GitHubLinkCard.vue` — added a `loading` prop; renders a skeleton shimmer in the star-pill slot while loading (reusing the existing pill shape + the codebase's `background-position` shimmer convention), then swaps to the real count. `prefers-reduced-motion` disables the animation.

**Breaking**
None. IPC channels (`comfy-titlepopup:global-settings-changed`, `set-config`), the live-update path, and the renderer's existing null-stars handling are untouched. Behavior is purely additive: the popup shows sooner and the count arrives via the same broadcast it already used.

## Review Focus

- The crux is `openGlobalSettingsForHost` going sync — confirm the background IIFE's `broadcastGlobalSettingsSnapshotToTitlePopups` correctly pushes the count to the open popup (it does; the dedupe seed in `openTitlePopup` is keyed off the initial `githubStarsLoading: true` snapshot, so the post-fetch snapshot differs and isn't skipped).
- The `return` in the menu `settings` branch — this is the regression fix; without it the synchronous open is immediately hidden by the trailing `hideTitlePopup`. Verify focus handling is acceptable (the popup keeps focus, same as the picker).
- Scope is the Desktop Settings open path only; the picker/menu/downloads paths are unchanged.

## Testing

No new automated tests — this is a timing/lifecycle change with no new pure logic to unit-test, and the existing 1766-test suite covers the snapshot/IPC contracts. Verified via the full pre-commit gauntlet and manual run.

- `pnpm typecheck` ✓ (node + web + e2e + integration)
- `pnpm lint` ✓
- `pnpm build` ✓
- `pnpm test` ✓ (1766 passed / 126 files)
- Manual: cold first-open → popup appears instantly with a skeleton in the star slot, count pops in ~1s later; offline → opens instantly, skeleton clears to no badge (no infinite shimmer); warm reopen → real count shows immediately, no skeleton flash.

closes #872 