### PR TITLE
feat(mirrors): seed Manager config with CDN channel when useChineseMirrors is on

### DIFF
--- a/src/main/lib/ipc/sessionActions/launch.ts
+++ b/src/main/lib/ipc/sessionActions/launch.ts
@@ -26,6 +26,7 @@ import { rotateLogFiles, getLogDir } from '../../logRotation'
 import { createExecutionTap } from '../../executionTap'
 import { clearCrash, recordCrash } from '../../crashBuffer'
 import * as telemetry from '../../telemetry'
+import { ensureManagerMirrorConfig } from '../../managerConfig'
 import type { WriteStream } from 'fs'
 
 // Feature flags injected on every spawned ComfyUI, gated by the running
@@ -115,6 +116,14 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
       } catch {
         // Schema not available — pass args as-is.
       }
+    }
+  }
+
+  if (settings.get('useChineseMirrors') === true) {
+    try {
+      await ensureManagerMirrorConfig(inst.installPath)
+    } catch (err) {
+      console.warn('Failed to seed ComfyUI-Manager mirror config:', err)
     }
   }
 

--- a/src/main/lib/managerConfig.test.ts
+++ b/src/main/lib/managerConfig.test.ts
@@ -1,0 +1,52 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { _internals, ensureManagerMirrorConfig } from './managerConfig'
+
+describe('ensureManagerMirrorConfig', () => {
+  let tmpRoot: string
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'manager-config-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+  })
+
+  it('writes the mirror config at the modern Manager config path', async () => {
+    await ensureManagerMirrorConfig(tmpRoot)
+    const target = _internals.managerConfigPath(tmpRoot)
+    expect(fs.existsSync(target)).toBe(true)
+    const written = fs.readFileSync(target, 'utf-8')
+    expect(written).toContain('[default]')
+    expect(written).toContain(`channel_url = ${_internals.MANAGER_MIRROR_CHANNEL_URL}`)
+    expect(written).toContain('bypass_ssl = true')
+    expect(written).toContain('network_mode = public')
+  })
+
+  it('creates intermediate directories when they do not exist', async () => {
+    const target = _internals.managerConfigPath(tmpRoot)
+    expect(fs.existsSync(path.dirname(target))).toBe(false)
+    await ensureManagerMirrorConfig(tmpRoot)
+    expect(fs.existsSync(target)).toBe(true)
+  })
+
+  it('does not overwrite an existing config (preserves user customizations)', async () => {
+    const target = _internals.managerConfigPath(tmpRoot)
+    fs.mkdirSync(path.dirname(target), { recursive: true })
+    const original = '[default]\nchannel_url = https://my.custom.mirror/\n'
+    fs.writeFileSync(target, original, 'utf-8')
+
+    await ensureManagerMirrorConfig(tmpRoot)
+
+    expect(fs.readFileSync(target, 'utf-8')).toBe(original)
+  })
+
+  it('targets <installPath>/ComfyUI/user/__manager/config.ini', () => {
+    const target = _internals.managerConfigPath('/some/install')
+    expect(target).toBe(path.join('/some/install', 'ComfyUI', 'user', '__manager', 'config.ini'))
+  })
+})

--- a/src/main/lib/managerConfig.ts
+++ b/src/main/lib/managerConfig.ts
@@ -1,0 +1,39 @@
+import fs from 'fs'
+import path from 'path'
+
+// Reachable from regions where raw.githubusercontent.com fails and serves
+// arbitrary github paths via /gh/<owner>/<repo>@<ref>/<file>.
+const MANAGER_MIRROR_CHANNEL_URL = 'https://cdn.jsdelivr.net/gh/ltdrdata/ComfyUI-Manager@main'
+
+const MANAGER_MIRROR_CONFIG = `[default]
+channel_url = ${MANAGER_MIRROR_CHANNEL_URL}
+bypass_ssl = true
+network_mode = public
+`
+
+// Modern ComfyUI's system-user-api path. Older ComfyUI uses a different layout
+// (user/default/ComfyUI-Manager) — Desktop ships a modern bundle so we target
+// the modern path only; if a migrated install ends up on old ComfyUI the
+// untouched legacy config simply keeps Manager's current behavior.
+function managerConfigPath(installPath: string): string {
+  return path.join(installPath, 'ComfyUI', 'user', '__manager', 'config.ini')
+}
+
+/**
+ * Seed ComfyUI-Manager's config.ini with mirror-friendly defaults for users
+ * who opted into the China mirror flow. Writes only when the file doesn't
+ * already exist — a returning user with their own customized config keeps
+ * full control.
+ */
+export async function ensureManagerMirrorConfig(installPath: string): Promise<void> {
+  const target = managerConfigPath(installPath)
+  if (fs.existsSync(target)) return
+  await fs.promises.mkdir(path.dirname(target), { recursive: true })
+  await fs.promises.writeFile(target, MANAGER_MIRROR_CONFIG, 'utf-8')
+}
+
+export const _internals = {
+  MANAGER_MIRROR_CHANNEL_URL,
+  MANAGER_MIRROR_CONFIG,
+  managerConfigPath,
+}


### PR DESCRIPTION
## Summary

When a user opts into the China mirror flow (\`useChineseMirrors=true\`), seed ComfyUI-Manager's \`config.ini\` with a mirror-friendly channel URL and SSL bypass, so its node-list fetch at boot doesn't hang or fail on \`raw.githubusercontent.com\`.

Writes only when no \`config.ini\` exists at the target path — returning users with their own customized config keep full control.

## Why

Cohort analysis over a 24h launch window:

| Cohort | Users | Users hitting external-network errors |
|---|---|---|
| opted_in (mirror on) | 1,225 | 61 (5.0%) |
| no_prompt | 1,461 | 17 (1.2%) |

For the opted-in cohort, 83% of those network errors are \`aiohttp ... raw.githubusercontent.com\` — ComfyUI-Manager's node-list fetch. The existing mirror flow rewrites pip's index and the Comfy-Org git remotes, but Manager hardcodes the GitHub raw channel and bypasses any other mirror config. When that DNS hangs, boot stalls and users quit — strongly correlated with the boot→view drop in the activation funnel.

## How

\`ComfyUI-Manager\` already supports \`channel_url\` and \`bypass_ssl\` in its config.ini. This PR seeds those values for opted-in users:

- \`channel_url = https://cdn.jsdelivr.net/gh/ltdrdata/ComfyUI-Manager@main\` — jsdelivr's CDN proxy serves arbitrary GitHub raw paths and is reachable from regions where raw.githubusercontent.com is not. Keeps fresh node-list updates (no offline mode), just routes them through a working CDN.
- \`bypass_ssl = true\` — kills SSL cert chain failures from corporate proxies / outdated CA bundles (next-biggest error category after DNS).
- \`network_mode = public\` — explicit default, makes the config self-documenting.

The config is written at launch time, gated on \`settings.get('useChineseMirrors') === true\`, only when the target file doesn't already exist. Idempotent — the file-exists guard short-circuits every subsequent launch.

Targets the modern ComfyUI system-user-api path: \`<installPath>/ComfyUI/user/__manager/config.ini\`.

## Test plan

- [x] \`pnpm vitest run managerConfig.test.ts\` — 4/4 pass (writes config, creates intermediate dirs, does not overwrite existing config, correct path)
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm lint\` — clean
- [ ] Manual: build, opt into mirrors at first-use, launch an instance, confirm \`<installPath>/ComfyUI/user/__manager/config.ini\` exists and Manager pulls node-list from jsdelivr instead of github