### PR TITLE
feat(install): wire mirror-URL fallback for R2 manifest fetches

### DIFF
--- a/src/main/lib/fetch.test.ts
+++ b/src/main/lib/fetch.test.ts
@@ -1,0 +1,100 @@
+import { EventEmitter } from 'events'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./paths', () => ({
+  cacheDir: () => '/tmp/desktop-test-cache',
+}))
+
+vi.mock('./safe-file', () => ({
+  writeFileSafe: vi.fn(),
+}))
+
+interface FakeRequest extends EventEmitter {
+  setHeader: ReturnType<typeof vi.fn>
+  end: ReturnType<typeof vi.fn>
+  __resolvedUrl: string
+}
+
+const requests: FakeRequest[] = []
+
+vi.mock('electron', () => ({
+  net: {
+    request: vi.fn((opts: { url: string }) => {
+      const req = Object.assign(new EventEmitter(), {
+        setHeader: vi.fn(),
+        end: vi.fn(),
+        __resolvedUrl: opts.url,
+      }) as FakeRequest
+      requests.push(req)
+      return req
+    }),
+  },
+}))
+
+import { fetchJSON } from './fetch'
+
+function makeResponse(statusCode: number, body: string, headers: Record<string, string> = {}): EventEmitter & { statusCode: number; headers: Record<string, string> } {
+  const res = Object.assign(new EventEmitter(), { statusCode, headers })
+  setImmediate(() => {
+    res.emit('data', body)
+    res.emit('end')
+  })
+  return res
+}
+
+describe('fetchJSON mirror fallback', () => {
+  beforeEach(() => {
+    requests.length = 0
+  })
+
+  it('returns the primary response when the primary succeeds (mirror untouched)', async () => {
+    const promise = fetchJSON('https://primary.example/x.json', {
+      mirrorUrl: 'https://mirror.example/x.json',
+    })
+    // First request is the primary
+    const req = requests[0]!
+    expect(req.__resolvedUrl).toBe('https://primary.example/x.json')
+    req.emit('response', makeResponse(200, '{"ok":true}'))
+    await expect(promise).resolves.toEqual({ ok: true })
+    expect(requests.length).toBe(1)
+  })
+
+  it('retries the mirror when the primary connection errors', async () => {
+    const promise = fetchJSON('https://primary.example/x.json', {
+      mirrorUrl: 'https://mirror.example/x.json',
+    })
+    const primary = requests[0]!
+    primary.emit('error', new Error('ECONNRESET'))
+    // Second request is the mirror
+    await new Promise((r) => setImmediate(r))
+    const mirror = requests[1]!
+    expect(mirror.__resolvedUrl).toBe('https://mirror.example/x.json')
+    mirror.emit('response', makeResponse(200, '{"from":"mirror"}'))
+    await expect(promise).resolves.toEqual({ from: 'mirror' })
+  })
+
+  it('rejects with the primary error when both primary and mirror fail and no cache exists', async () => {
+    const promise = fetchJSON('https://primary.example/y.json', {
+      mirrorUrl: 'https://mirror.example/y.json',
+    })
+    requests[0]!.emit('error', new Error('PRIMARY_DOWN'))
+    await new Promise((r) => setImmediate(r))
+    requests[1]!.emit('error', new Error('MIRROR_DOWN'))
+    await expect(promise).rejects.toThrow(/PRIMARY_DOWN/)
+  })
+
+  it('does not retry the mirror when none is supplied', async () => {
+    const promise = fetchJSON('https://primary.example/z.json')
+    requests[0]!.emit('error', new Error('NETWORK_DOWN'))
+    await expect(promise).rejects.toThrow(/NETWORK_DOWN/)
+    expect(requests.length).toBe(1)
+  })
+
+  it('does not retry the mirror when it equals the primary URL', async () => {
+    const url = 'https://primary.example/same.json'
+    const promise = fetchJSON(url, { mirrorUrl: url })
+    requests[0]!.emit('error', new Error('SAME_URL_FAIL'))
+    await expect(promise).rejects.toThrow(/SAME_URL_FAIL/)
+    expect(requests.length).toBe(1)
+  })
+})

--- a/src/main/lib/fetch.ts
+++ b/src/main/lib/fetch.ts
@@ -68,15 +68,16 @@ function _headerString(value: string | string[] | undefined): string | undefined
   return Array.isArray(value) ? value[0] : value
 }
 
-export function fetchJSON(url: string, opts?: { refresh?: boolean }): Promise<unknown> {
-  _ensureLoaded()
-  // `refresh` ignores the persisted ETag so the response is never served from cache. Used
-  // for R2 manifests where a stale value would strand users on an old release.
-  const cached = opts?.refresh ? undefined : _cache.get(url)
+interface FetchJSONOpts {
+  refresh?: boolean
+  // Tried once if the primary URL fails with a network/connection error. The
+  // primary URL stays the cache key, so subsequent revalidation continues to
+  // negotiate against the primary's ETag.
+  mirrorUrl?: string
+}
 
+function fetchJSONOnce(url: string, cached: CacheEntry | undefined, cacheKey: string): Promise<unknown> {
   return new Promise((resolve, reject) => {
-    // "no-cache" forces Chromium to revalidate (send If-None-Match) instead of serving from
-    // its disk cache. GitHub returns 304 for free when the ETag matches.
     const request = net.request({ url, cache: "no-cache" })
     request.setHeader("User-Agent", "ComfyUI-Desktop-2")
 
@@ -102,11 +103,6 @@ export function fetchJSON(url: string, opts?: { refresh?: boolean }): Promise<un
           return
         }
         if (response.statusCode !== 200) {
-          // On error, fall back to cached data if available
-          if (cached) {
-            resolve(structuredClone(cached.data))
-            return
-          }
           let msg = `HTTP ${response.statusCode}`
           if (response.statusCode === 403 || response.statusCode === 429) {
             const resetHeader = _headerString(response.headers["x-ratelimit-reset"])
@@ -131,28 +127,38 @@ export function fetchJSON(url: string, opts?: { refresh?: boolean }): Promise<un
         try {
           parsed = JSON.parse(data)
         } catch {
-          if (cached) {
-            resolve(structuredClone(cached.data))
-            return
-          }
           reject(new Error(`Invalid JSON response from ${url}`))
           return
         }
         const etag = _headerString(response.headers["etag"])
         if (etag) {
-          _cacheSet(url, { etag, data: parsed })
+          _cacheSet(cacheKey, { etag, data: parsed })
         }
         resolve(parsed)
       })
     })
-    request.on("error", (err) => {
-      // Network error — fall back to cached data if available
-      if (cached) {
-        resolve(structuredClone(cached.data))
-        return
-      }
-      reject(err)
-    })
+    request.on("error", (err) => reject(err))
     request.end()
   })
+}
+
+export async function fetchJSON(url: string, opts?: FetchJSONOpts): Promise<unknown> {
+  _ensureLoaded()
+  // `refresh` ignores the persisted ETag so the response is never served from cache. Used
+  // for R2 manifests where a stale value would strand users on an old release.
+  const cached = opts?.refresh ? undefined : _cache.get(url)
+
+  try {
+    return await fetchJSONOnce(url, cached, url)
+  } catch (primaryErr) {
+    if (opts?.mirrorUrl && opts.mirrorUrl !== url) {
+      try {
+        return await fetchJSONOnce(opts.mirrorUrl, cached, url)
+      } catch {
+        // fall through to cache / primary error
+      }
+    }
+    if (cached) return structuredClone(cached.data)
+    throw primaryErr
+  }
 }

--- a/src/main/lib/ipc/index.ts
+++ b/src/main/lib/ipc/index.ts
@@ -17,6 +17,7 @@ import {
   isEffectivelyEmptyInstallDir,
   UPDATE_CHECK_INTERVAL
 } from './shared'
+import { r2MirrorUrl } from '../../sources/standalone/updateSections'
 import * as releaseCache from '../release-cache'
 import type { RegisterCallbacks } from './shared'
 import { registerAppHandlers } from './registerAppHandlers'
@@ -190,7 +191,8 @@ export function register(callbacks: RegisterCallbacks = {}): void {
   // Pre-warm the ETag cache
   void (async () => {
     try {
-      await fetchJSON('https://desktop-assets.comfy.org/standalone-environments/latest.json')
+      const prewarmUrl = 'https://desktop-assets.comfy.org/standalone-environments/latest.json'
+      await fetchJSON(prewarmUrl, { mirrorUrl: r2MirrorUrl(prewarmUrl) })
     } catch {}
   })()
 

--- a/src/main/sources/standalone/index.ts
+++ b/src/main/sources/standalone/index.ts
@@ -12,7 +12,7 @@ import {
   getVenvDir, recommendVariant, writeComfyEnvironment,
 } from './envPaths'
 import { install, postInstall, probeInstallation } from './install'
-import { getListPreview, getStatusTag, getDetailSections, R2_BASE_URL } from './updateSections'
+import { getListPreview, getStatusTag, getDetailSections, R2_BASE_URL, r2MirrorUrl } from './updateSections'
 import { handleAction } from './actions'
 import type { InstallationRecord } from '../../installations'
 import type {
@@ -284,13 +284,15 @@ export const standalone: SourcePlugin = {
       // Always revalidate R2 manifests when populating the install wizard —
       // a stale persisted ETag can otherwise hide a freshly-shipped standalone
       // release and strand new installs on whatever the previous run cached.
-      const latest = await fetchJSON(`${R2_BASE_URL}/latest.json`, { refresh: true }) as R2Latest
+      const latestUrl = `${R2_BASE_URL}/latest.json`
+      const latest = await fetchJSON(latestUrl, { refresh: true, mirrorUrl: r2MirrorUrl(latestUrl) }) as R2Latest
       const vendorIds = Object.keys(latest).filter((id) => id.startsWith(prefix))
       if (vendorIds.length === 0) return []
 
       const vendorReleases = Object.fromEntries(
         await Promise.all(vendorIds.map(async (id) => {
-          const data = await fetchJSON(`${R2_BASE_URL}/${id}/releases.json`, { refresh: true }) as R2VendorReleases
+          const releasesUrl = `${R2_BASE_URL}/${id}/releases.json`
+          const data = await fetchJSON(releasesUrl, { refresh: true, mirrorUrl: r2MirrorUrl(releasesUrl) }) as R2VendorReleases
           return [id, data.releases] as const
         }))
       )

--- a/src/main/sources/standalone/updateSections.test.ts
+++ b/src/main/sources/standalone/updateSections.test.ts
@@ -30,7 +30,7 @@ vi.mock('../../lib/git', () => ({
 }))
 
 import * as releaseCache from '../../lib/release-cache'
-import { getDetailSections, getEffectiveChannel } from './updateSections'
+import { getDetailSections, getEffectiveChannel, R2_BASE_URL, R2_MIRROR_BASE_URL, r2MirrorUrl } from './updateSections'
 
 interface UpdateAction {
   id: string
@@ -186,5 +186,17 @@ describe('updateSections — channel picker reflects de-facto channel', () => {
     } as Partial<InstallationRecord>)) as unknown as UpdateSection[]
     const field = sections.find((s) => s.tab === 'update')?.fields?.find((f) => f.id === 'updateChannel')
     expect((field as unknown as { value: string }).value).toBe('latest')
+  })
+})
+
+describe('r2MirrorUrl', () => {
+  it('returns undefined when R2_MIRROR_BASE_URL is empty (default)', () => {
+    expect(R2_MIRROR_BASE_URL).toBe('')
+    expect(r2MirrorUrl(`${R2_BASE_URL}/latest.json`)).toBeUndefined()
+  })
+
+  it('returns undefined for URLs outside the R2 namespace, even if a mirror is set', () => {
+    expect(r2MirrorUrl('https://api.github.com/repos/Comfy-Org/ComfyUI/releases')).toBeUndefined()
+    expect(r2MirrorUrl('https://example.com/standalone-environments/latest.json')).toBeUndefined()
   })
 })

--- a/src/main/sources/standalone/updateSections.ts
+++ b/src/main/sources/standalone/updateSections.ts
@@ -17,6 +17,19 @@ export const COMFYUI_REPO = 'Comfy-Org/ComfyUI'
 export const RELEASE_REPO = 'Comfy-Org/ComfyUI-Standalone-Environments'
 export const R2_BASE_URL = 'https://desktop-assets.comfy.org/standalone-environments'
 
+// Fallback host for regions where the primary R2 edge is throttled (e.g. mainland China
+// without an ICP-licensed CDN). Wired into the install-wizard JSON fetches as a single
+// retry — primary is still the source of truth and stays the ETag cache key. Empty string
+// disables the fallback. Infra populates this once an Aliyun OSS (or equivalent) mirror
+// of the same manifest files is provisioned.
+export const R2_MIRROR_BASE_URL = ''
+
+export function r2MirrorUrl(primaryUrl: string): string | undefined {
+  if (!R2_MIRROR_BASE_URL) return undefined
+  if (!primaryUrl.startsWith(R2_BASE_URL)) return undefined
+  return R2_MIRROR_BASE_URL + primaryUrl.slice(R2_BASE_URL.length)
+}
+
 function getChannelDefs(): ChannelDef[] {
   return [
     { value: 'stable', label: t('standalone.channelStable'), description: t('standalone.channelStableDesc'), recommended: true },


### PR DESCRIPTION
## Summary

When the primary R2 host is unreachable (connection-reset, throttling, regional blocks), retry the install-wizard JSON fetches once against a configured mirror host before falling back to the on-disk cache. Primary stays the source of truth and the ETag cache key — the mirror only catches the network-fail case.

\`R2_MIRROR_BASE_URL\` is empty by default; the fallback activates with zero further code change once infra populates it with a mirror bucket URL.

## Why

A user testing without VPN cannot load the install-wizard release dropdown — \`get-field-options\` fails with \`net::ERR_CONNECTION_RESET\`. The failing URL is \`https://desktop-assets.comfy.org/standalone-environments/latest.json\` (Cloudflare R2, no ICP-licensed CDN in front), which means the install wizard never populates and fresh installs are blocked.

This affects every JSON manifest fetch in the install path:
- Boot ETag pre-warm (\`fetchJSON\` in \`registerIpcHandlers\`)
- Release dropdown population (\`R2_BASE_URL/latest.json\`)
- Per-vendor release list (\`R2_BASE_URL/<vendor>/releases.json\`)

## How

- \`fetchJSON\` now accepts an optional \`mirrorUrl\`. On a primary network failure, it retries once against the mirror. Both paths share the same ETag cache key so subsequent revalidation continues to negotiate against the primary.
- New helper \`r2MirrorUrl(primaryUrl)\` builds the mirror URL by swapping the base prefix. Returns \`undefined\` when no mirror is configured or the URL isn't in the R2 namespace.
- Three call sites updated to pass \`mirrorUrl: r2MirrorUrl(url)\`.
- \`R2_MIRROR_BASE_URL\` is currently empty — no behavior change at runtime until infra populates it.

## Out of scope

Binary standalone bundles (the multi-GB \`.7z\` / \`.tar.gz\` files) go through a different download path, not \`fetchJSON\`. Those continue to hit the primary host only. Mirroring them is a follow-up that depends on the same mirror bucket being available.

## Test plan

- [x] \`pnpm vitest run fetch.test.ts updateSections.test.ts\` — 19/19 pass (5 new fetch-fallback tests + 14 existing)
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm lint\` — clean
- [ ] Once infra provisions a mirror, set \`R2_MIRROR_BASE_URL\` and verify on a network that connection-resets the primary