### PR TITLE
test: revert productName to isolate macOS auto-update failure

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,5 +1,5 @@
 appId: com.todesktop.241012ess7yxs0e
-productName: Comfy Desktop
+productName: ComfyUI Desktop 2.0
 directories:
   buildResources: resources
 files:

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,5 +1,5 @@
 appId: com.todesktop.241012ess7yxs0e
-productName: ComfyUI Desktop 2.0
+productName: ComfyUI
 directories:
   buildResources: resources
 files:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-desktop-2",
-  "version": "1.0.2",
+  "version": "1.0.2-mactest.1",
   "description": "Comfy Desktop",
   "author": {
     "name": "Comfy Org",

--- a/todesktop.json
+++ b/todesktop.json
@@ -14,7 +14,7 @@
   "pnpmVersion": "10.28.1",
   "packageJson": {
     "extends": "package.json",
-    "productName": "Comfy Desktop",
+    "productName": "ComfyUI",
     "devDependencies": {
       "electron": "40.4.1",
       "electron-builder": null


### PR DESCRIPTION
**Test build, not for merge.**

## Why
Windows migrates App 1 (`com.todesktop.241012ess7yxs0e`, 0.9.x) to the new build in place cleanly; macOS does not. Dave's hunch is the `productName` change from #616 (`ComfyUI Desktop 2.0` → `Comfy Desktop`), which renames the `.app` bundle / CFBundleName and could break Squirrel.Mac's in-place replace.

## What
Reverts **only** `productName` back to the pre-#616 value (`ComfyUI Desktop 2.0`). Everything else is held constant:
- `appId` stays App 1's `com.todesktop.241012ess7yxs0e`
- signing / notarization unchanged
- userData path unaffected either way (runtime app name is package.json `name` = `comfyui-desktop-2`, no `productName` in package.json)

So this is a clean single-variable isolation.

## How to read the result
Build this branch in ToDesktop, offer it as an update to a Mac sitting on App 1:
- **Updates cleanly** → the rename is the cause; we decide bundle name vs Mac auto-update.
- **Still fails** → it's not productName. Next suspect is signing (same Apple Team ID between App 1 and the new build?). Pull the ShipIt log to confirm: `~/Library/Caches/com.todesktop.241012ess7yxs0e.ShipIt/ShipIt_stderr.log`.

## Caveat
This reverts to the beta's pre-rename value (`ComfyUI Desktop 2.0`). If App 1 actually shipped under a different bundle name (e.g. `ComfyUI`), the truest Squirrel.Mac continuity test should match that instead. Worth confirming App 1's installed productName with Dave.