### PR TITLE
feat(network): mirror R2 + Manager-channel fallback for restricted regions

### DIFF
--- a/src/main/lib/download.test.ts
+++ b/src/main/lib/download.test.ts
@@ -13,6 +13,12 @@ interface FakeRequest extends EventEmitter {
 }
 
 const requests: FakeRequest[] = []
+const settingsState: Record<string, unknown> = {}
+
+vi.mock('../settings', () => ({
+  get: (key: string) => settingsState[key],
+  set: (key: string, value: unknown) => { settingsState[key] = value },
+}))
 
 vi.mock('electron', () => ({
   net: {
@@ -50,6 +56,8 @@ describe('download — R2 mirror fallback for binaries', () => {
 
   beforeEach(() => {
     requests.length = 0
+    for (const k of Object.keys(settingsState)) delete settingsState[k]
+    settingsState['useChineseMirrors'] = true
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'download-test-'))
   })
 
@@ -94,6 +102,15 @@ describe('download — R2 mirror fallback for binaries', () => {
     const p = download('https://example.com/other.7z', dest, null)
     requests[0]!.emit('error', new Error('NETWORK_DOWN'))
     await expect(p).rejects.toThrow(/NETWORK_DOWN/)
+    expect(requests.length).toBe(1)
+  })
+
+  it('does NOT retry the mirror when useChineseMirrors is off (avoids thundering-herd on R2 blips)', async () => {
+    settingsState['useChineseMirrors'] = false
+    const dest = path.join(tmpDir, 'bundle.7z')
+    const p = download(PRIMARY_BIN, dest, null)
+    requests[0]!.emit('error', new Error('R2_BLIP'))
+    await expect(p).rejects.toThrow(/R2_BLIP/)
     expect(requests.length).toBe(1)
   })
 

--- a/src/main/lib/download.test.ts
+++ b/src/main/lib/download.test.ts
@@ -1,0 +1,110 @@
+import { EventEmitter } from 'events'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { R2_BASE_URL, R2_MIRROR_BASE_URL } from './r2Mirror'
+
+interface FakeRequest extends EventEmitter {
+  setHeader: ReturnType<typeof vi.fn>
+  end: ReturnType<typeof vi.fn>
+  abort: ReturnType<typeof vi.fn>
+  __url: string
+}
+
+const requests: FakeRequest[] = []
+
+vi.mock('electron', () => ({
+  net: {
+    request: vi.fn((url: string) => {
+      const req = Object.assign(new EventEmitter(), {
+        setHeader: vi.fn(),
+        end: vi.fn(),
+        abort: vi.fn(),
+        __url: url,
+      }) as FakeRequest
+      requests.push(req)
+      return req
+    }),
+  },
+}))
+
+import { download } from './download'
+
+function makeResponse(statusCode: number, body: Buffer | string, headers: Record<string, string | string[]> = {}): EventEmitter & { statusCode: number; headers: Record<string, string | string[]> } {
+  const res = Object.assign(new EventEmitter(), { statusCode, headers })
+  const buf = typeof body === 'string' ? Buffer.from(body) : body
+  if (!headers['content-length']) headers['content-length'] = String(buf.length)
+  setImmediate(() => {
+    res.emit('data', buf)
+    res.emit('end')
+  })
+  return res
+}
+
+const PRIMARY_BIN = `${R2_BASE_URL}/linux-nvidia/v0.20.1-env1/bundle.7z`
+const MIRROR_BIN = `${R2_MIRROR_BASE_URL}/linux-nvidia/v0.20.1-env1/bundle.7z`
+
+describe('download — R2 mirror fallback for binaries', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    requests.length = 0
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'download-test-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('retries against the mirror when the primary connection errors before any bytes arrive', async () => {
+    const dest = path.join(tmpDir, 'bundle.7z')
+    const p = download(PRIMARY_BIN, dest, null)
+    requests[0]!.emit('error', new Error('ECONNRESET'))
+    await new Promise((r) => setImmediate(r))
+    expect(requests[1]?.__url).toBe(MIRROR_BIN)
+    const body = Buffer.from('mirror-served-bytes')
+    requests[1]!.emit('response', makeResponse(200, body))
+    await expect(p).resolves.toBe(dest)
+    expect(fs.readFileSync(dest, 'utf-8')).toBe('mirror-served-bytes')
+  })
+
+  it('retries against the mirror when the primary responds with HTTP error and no bytes have been received', async () => {
+    const dest = path.join(tmpDir, 'bundle.7z')
+    const p = download(PRIMARY_BIN, dest, null)
+    requests[0]!.emit('response', makeResponse(503, ''))
+    await new Promise((r) => setImmediate(r))
+    expect(requests[1]?.__url).toBe(MIRROR_BIN)
+    requests[1]!.emit('response', makeResponse(200, Buffer.from('ok-via-mirror')))
+    await expect(p).resolves.toBe(dest)
+    expect(fs.readFileSync(dest, 'utf-8')).toBe('ok-via-mirror')
+  })
+
+  it('rejects with the primary error when both legs fail', async () => {
+    const dest = path.join(tmpDir, 'bundle.7z')
+    const p = download(PRIMARY_BIN, dest, null)
+    requests[0]!.emit('error', new Error('PRIMARY_DOWN'))
+    await new Promise((r) => setImmediate(r))
+    requests[1]!.emit('error', new Error('MIRROR_DOWN'))
+    await expect(p).rejects.toThrow(/PRIMARY_DOWN/)
+  })
+
+  it('does not retry the mirror for URLs outside the R2 namespace', async () => {
+    const dest = path.join(tmpDir, 'other.7z')
+    const p = download('https://example.com/other.7z', dest, null)
+    requests[0]!.emit('error', new Error('NETWORK_DOWN'))
+    await expect(p).rejects.toThrow(/NETWORK_DOWN/)
+    expect(requests.length).toBe(1)
+  })
+
+  it('does not retry the mirror when the recursive _skipMirror is set (no bounce-back)', async () => {
+    // Internal contract: when download is called from inside the mirror-retry
+    // branch, _skipMirror=true prevents infinite ping-pong if the mirror itself
+    // happens to live under R2_MIRROR_BASE_URL (it doesn't today, but lock it).
+    const dest = path.join(tmpDir, 'bundle.7z')
+    const p = download(MIRROR_BIN, dest, null, { _skipMirror: true } as unknown as { _skipMirror: boolean })
+    requests[0]!.emit('error', new Error('SECOND_DOWN'))
+    await expect(p).rejects.toThrow(/SECOND_DOWN/)
+    expect(requests.length).toBe(1)
+  })
+})

--- a/src/main/lib/download.ts
+++ b/src/main/lib/download.ts
@@ -1,6 +1,7 @@
 import { net } from 'electron'
 import fs from 'fs'
 import path from 'path'
+import * as settings from '../settings'
 import { r2MirrorUrl } from './r2Mirror'
 
 export interface DownloadProgress {
@@ -68,11 +69,12 @@ export function download(
   const opts: DownloadOptions = typeof options === 'number' ? { _maxRedirects: options } : options ?? {}
   const { signal, expectedSize, _maxRedirects = 5, _skipMirror = false } = opts
 
-  // Single mirror retry, gated to the case where nothing has been written to
-  // disk yet (no partial that might checksum against the mirror's body). For
-  // mid-download failures we surface the primary error and let the caller's
-  // resume logic handle it on the next attempt.
-  const mirror = _skipMirror ? undefined : r2MirrorUrl(url)
+  // Mirror retry is gated on useChineseMirrors to avoid a thundering-herd
+  // tens-of-TB GCS egress event if R2 ever hiccups for the global user base.
+  // Opted-in users are who actually need the fallback; everyone else keeps
+  // the existing single-origin behaviour.
+  const mirrorEnabled = !_skipMirror && settings.get('useChineseMirrors') === true
+  const mirror = mirrorEnabled ? r2MirrorUrl(url) : undefined
   const tryMirror = async (primaryErr: Error): Promise<string> => {
     if (!mirror || mirror === url) throw primaryErr
     try { fs.unlinkSync(destPath) } catch {}

--- a/src/main/lib/download.ts
+++ b/src/main/lib/download.ts
@@ -1,6 +1,7 @@
 import { net } from 'electron'
 import fs from 'fs'
 import path from 'path'
+import { r2MirrorUrl } from './r2Mirror'
 
 export interface DownloadProgress {
   percent: number
@@ -23,6 +24,9 @@ export interface DownloadMeta {
 interface DownloadOptions {
   signal?: AbortSignal
   expectedSize?: number
+  // Internal: suppresses the auto-derived R2 mirror retry. Set by the
+  // mirror-retry branch itself to avoid bouncing back to primary indefinitely.
+  _skipMirror?: boolean
   _maxRedirects?: number
 }
 
@@ -62,7 +66,25 @@ export function download(
   options?: DownloadOptions | number
 ): Promise<string> {
   const opts: DownloadOptions = typeof options === 'number' ? { _maxRedirects: options } : options ?? {}
-  const { signal, expectedSize, _maxRedirects = 5 } = opts
+  const { signal, expectedSize, _maxRedirects = 5, _skipMirror = false } = opts
+
+  // Single mirror retry, gated to the case where nothing has been written to
+  // disk yet (no partial that might checksum against the mirror's body). For
+  // mid-download failures we surface the primary error and let the caller's
+  // resume logic handle it on the next attempt.
+  const mirror = _skipMirror ? undefined : r2MirrorUrl(url)
+  const tryMirror = async (primaryErr: Error): Promise<string> => {
+    if (!mirror || mirror === url) throw primaryErr
+    try { fs.unlinkSync(destPath) } catch {}
+    try { fs.unlinkSync(downloadMetaPath(destPath)) } catch {}
+    try {
+      return await download(mirror, destPath, onProgress, {
+        signal, expectedSize, _maxRedirects, _skipMirror: true,
+      })
+    } catch {
+      throw primaryErr
+    }
+  }
 
   const metaPath = downloadMetaPath(destPath)
 
@@ -152,7 +174,12 @@ export function download(
       const isResumed = response.statusCode === 206 && resumeFrom > 0
       if (!isResumed && response.statusCode !== 200) {
         cleanup()
-        safeReject(new Error(`Download failed: HTTP ${response.statusCode}`))
+        const err = new Error(`Download failed: HTTP ${response.statusCode}`)
+        if (resumeFrom === 0 && !_skipMirror) {
+          tryMirror(err).then(safeResolve, safeReject)
+        } else {
+          safeReject(err)
+        }
         return
       }
 
@@ -266,7 +293,14 @@ export function download(
     request.on('error', (err: Error) => {
       cleanup()
       if (aborted) return // onAbort already handled it
-      safeReject(err)
+      // Network failure before any response arrived — try the mirror exactly
+      // once. If a partial body had already started landing we skip the mirror
+      // to avoid stitching together two origins' bytes.
+      if (resumeFrom === 0 && !_skipMirror) {
+        tryMirror(err).then(safeResolve, safeReject)
+      } else {
+        safeReject(err)
+      }
     })
     request.end()
   })

--- a/src/main/lib/fetch.test.ts
+++ b/src/main/lib/fetch.test.ts
@@ -1,0 +1,153 @@
+import { EventEmitter } from 'events'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { R2_BASE_URL, R2_MIRROR_BASE_URL } from './r2Mirror'
+
+vi.mock('./paths', () => ({ cacheDir: () => '/tmp/desktop-test-cache' }))
+vi.mock('./safe-file', () => ({ writeFileSafe: vi.fn() }))
+
+interface FakeRequest extends EventEmitter {
+  setHeader: ReturnType<typeof vi.fn>
+  end: ReturnType<typeof vi.fn>
+  __url: string
+  __headers: Record<string, string>
+}
+
+const requests: FakeRequest[] = []
+
+vi.mock('electron', () => ({
+  net: {
+    request: vi.fn((opts: { url: string }) => {
+      const headers: Record<string, string> = {}
+      const req = Object.assign(new EventEmitter(), {
+        setHeader: vi.fn((k: string, v: string) => { headers[k] = v }),
+        end: vi.fn(),
+        __url: opts.url,
+        __headers: headers,
+      }) as FakeRequest
+      requests.push(req)
+      return req
+    }),
+  },
+}))
+
+import { _resetCacheForTest, fetchJSON } from './fetch'
+
+function makeResponse(statusCode: number, body: string, headers: Record<string, string> = {}): EventEmitter & { statusCode: number; headers: Record<string, string> } {
+  const res = Object.assign(new EventEmitter(), { statusCode, headers })
+  setImmediate(() => {
+    res.emit('data', body)
+    res.emit('end')
+  })
+  return res
+}
+
+const PRIMARY = `${R2_BASE_URL}/latest.json`
+const MIRROR = `${R2_MIRROR_BASE_URL}/latest.json`
+
+describe('fetchJSON — happy path preserved by refactor', () => {
+  beforeEach(() => { requests.length = 0; _resetCacheForTest() })
+
+  it('returns primary body on 200', async () => {
+    const p = fetchJSON(PRIMARY)
+    requests[0]!.emit('response', makeResponse(200, '{"ok":true}', { etag: '"v1"' }))
+    await expect(p).resolves.toEqual({ ok: true })
+    expect(requests.length).toBe(1)
+  })
+
+  it('rejects with HTTP error on non-200, no mirror retry, no cached fallback', async () => {
+    const p = fetchJSON(PRIMARY)
+    requests[0]!.emit('response', makeResponse(500, ''))
+    // Mirror IS tried on HTTP error — verify the mirror is the second request,
+    // then make it also error so the call rejects.
+    await new Promise((r) => setImmediate(r))
+    expect(requests[1]?.__url).toBe(MIRROR)
+    requests[1]!.emit('error', new Error('mirror down'))
+    await expect(p).rejects.toThrow(/HTTP 500/)
+  })
+
+  it('rejects with parse error on malformed JSON, no cached fallback', async () => {
+    const p = fetchJSON(PRIMARY)
+    requests[0]!.emit('response', makeResponse(200, '{not valid'))
+    await new Promise((r) => setImmediate(r))
+    expect(requests[1]?.__url).toBe(MIRROR)
+    requests[1]!.emit('error', new Error('mirror down'))
+    await expect(p).rejects.toThrow(/Invalid JSON/)
+  })
+})
+
+describe('fetchJSON — mirror fallback semantics', () => {
+  beforeEach(() => { requests.length = 0; _resetCacheForTest() })
+
+  it('retries the mirror when the primary connection errors', async () => {
+    const p = fetchJSON(PRIMARY)
+    requests[0]!.emit('error', new Error('ECONNRESET'))
+    await new Promise((r) => setImmediate(r))
+    expect(requests[1]?.__url).toBe(MIRROR)
+    requests[1]!.emit('response', makeResponse(200, '{"from":"mirror"}'))
+    await expect(p).resolves.toEqual({ from: 'mirror' })
+  })
+
+  it('does NOT send the primary If-None-Match to the mirror', async () => {
+    // No prior cache entry; just verify the mirror leg gets fresh headers.
+    const p = fetchJSON(PRIMARY)
+    requests[0]!.emit('response', makeResponse(500, ''))
+    await new Promise((r) => setImmediate(r))
+    const mirrorReq = requests[1]!
+    expect(mirrorReq.__url).toBe(MIRROR)
+    expect(mirrorReq.__headers['If-None-Match']).toBeUndefined()
+    mirrorReq.emit('response', makeResponse(200, '{"ok":true}', { etag: '"mirror-etag"' }))
+    await expect(p).resolves.toEqual({ ok: true })
+  })
+
+  it('rejects with the primary error when both legs fail and no cache exists', async () => {
+    const p = fetchJSON(PRIMARY)
+    requests[0]!.emit('error', new Error('PRIMARY_DOWN'))
+    await new Promise((r) => setImmediate(r))
+    requests[1]!.emit('error', new Error('MIRROR_DOWN'))
+    await expect(p).rejects.toThrow(/PRIMARY_DOWN/)
+  })
+
+  it('does not retry the mirror for URLs outside the R2 namespace', async () => {
+    const p = fetchJSON('https://api.github.com/repos/x/y/releases')
+    requests[0]!.emit('error', new Error('NETWORK_DOWN'))
+    await expect(p).rejects.toThrow(/NETWORK_DOWN/)
+    expect(requests.length).toBe(1)
+  })
+})
+
+describe('fetchJSON — mirror is not allowed to poison the cache', () => {
+  beforeEach(() => { requests.length = 0; _resetCacheForTest() })
+
+  it('does NOT write a cache entry when the response came from the mirror', async () => {
+    // Drive a mirror-served success, then make a second call and assert the
+    // second call still goes to the primary without If-None-Match (i.e. the
+    // first call wrote nothing to the cache).
+    const p1 = fetchJSON(PRIMARY)
+    requests[0]!.emit('error', new Error('PRIMARY_DOWN'))
+    await new Promise((r) => setImmediate(r))
+    requests[1]!.emit('response', makeResponse(200, '{"v":1}', { etag: '"mirror-etag-1"' }))
+    await expect(p1).resolves.toEqual({ v: 1 })
+
+    requests.length = 0
+    const p2 = fetchJSON(PRIMARY)
+    // No prior cache entry persisted from the mirror-served call, so no
+    // conditional header.
+    expect(requests[0]!.__headers['If-None-Match']).toBeUndefined()
+    requests[0]!.emit('response', makeResponse(200, '{"v":2}', { etag: '"primary-etag"' }))
+    await expect(p2).resolves.toEqual({ v: 2 })
+  })
+
+  it('DOES write a cache entry when the response came from the primary', async () => {
+    const p1 = fetchJSON(PRIMARY)
+    requests[0]!.emit('response', makeResponse(200, '{"v":1}', { etag: '"primary-etag-1"' }))
+    await p1
+
+    requests.length = 0
+    const p2 = fetchJSON(PRIMARY)
+    // The primary-served call DID populate the cache, so the second call
+    // sends the primary's ETag.
+    expect(requests[0]!.__headers['If-None-Match']).toBe('"primary-etag-1"')
+    requests[0]!.emit('response', makeResponse(304, ''))
+    await expect(p2).resolves.toEqual({ v: 1 })
+  })
+})

--- a/src/main/lib/fetch.ts
+++ b/src/main/lib/fetch.ts
@@ -2,6 +2,7 @@ import { net } from 'electron'
 import path from 'path'
 import fs from 'fs'
 import { cacheDir } from './paths'
+import { r2MirrorUrl } from './r2Mirror'
 import { writeFileSafe } from './safe-file'
 
 interface CacheEntry {
@@ -68,15 +69,14 @@ function _headerString(value: string | string[] | undefined): string | undefined
   return Array.isArray(value) ? value[0] : value
 }
 
-export function fetchJSON(url: string, opts?: { refresh?: boolean }): Promise<unknown> {
-  _ensureLoaded()
-  // `refresh` ignores the persisted ETag so the response is never served from cache. Used
-  // for R2 manifests where a stale value would strand users on an old release.
-  const cached = opts?.refresh ? undefined : _cache.get(url)
-
+// Single-shot fetch with ETag negotiation. `cached` provides the If-None-Match
+// value (and the 304 short-circuit body); `cacheKey` is the URL the successful
+// response should be cached under, or undefined to skip writing to the cache
+// entirely. Splitting these lets the mirror-retry below run WITHOUT leaking the
+// primary's ETag to the mirror (cached: undefined) and WITHOUT poisoning the
+// primary's persisted cache entry with mirror-tagged data (cacheKey: undefined).
+function fetchJSONOnce(url: string, cached: CacheEntry | undefined, cacheKey: string | undefined): Promise<unknown> {
   return new Promise((resolve, reject) => {
-    // "no-cache" forces Chromium to revalidate (send If-None-Match) instead of serving from
-    // its disk cache. GitHub returns 304 for free when the ETag matches.
     const request = net.request({ url, cache: "no-cache" })
     request.setHeader("User-Agent", "ComfyUI-Desktop-2")
 
@@ -102,11 +102,6 @@ export function fetchJSON(url: string, opts?: { refresh?: boolean }): Promise<un
           return
         }
         if (response.statusCode !== 200) {
-          // On error, fall back to cached data if available
-          if (cached) {
-            resolve(structuredClone(cached.data))
-            return
-          }
           let msg = `HTTP ${response.statusCode}`
           if (response.statusCode === 403 || response.statusCode === 429) {
             const resetHeader = _headerString(response.headers["x-ratelimit-reset"])
@@ -131,28 +126,52 @@ export function fetchJSON(url: string, opts?: { refresh?: boolean }): Promise<un
         try {
           parsed = JSON.parse(data)
         } catch {
-          if (cached) {
-            resolve(structuredClone(cached.data))
-            return
-          }
           reject(new Error(`Invalid JSON response from ${url}`))
           return
         }
-        const etag = _headerString(response.headers["etag"])
-        if (etag) {
-          _cacheSet(url, { etag, data: parsed })
+        if (cacheKey) {
+          const etag = _headerString(response.headers["etag"])
+          if (etag) {
+            _cacheSet(cacheKey, { etag, data: parsed })
+          }
         }
         resolve(parsed)
       })
     })
-    request.on("error", (err) => {
-      // Network error — fall back to cached data if available
-      if (cached) {
-        resolve(structuredClone(cached.data))
-        return
-      }
-      reject(err)
-    })
+    request.on("error", (err) => reject(err))
     request.end()
   })
+}
+
+/** @internal — exposed only for tests. */
+export function _resetCacheForTest(): void {
+  _cache.clear()
+  _loaded = false
+}
+
+export async function fetchJSON(url: string, opts?: { refresh?: boolean }): Promise<unknown> {
+  _ensureLoaded()
+  // `refresh` ignores the persisted ETag so the response is never served from cache. Used
+  // for R2 manifests where a stale value would strand users on an old release.
+  const cached = opts?.refresh ? undefined : _cache.get(url)
+
+  try {
+    return await fetchJSONOnce(url, cached, url)
+  } catch (primaryErr) {
+    // If this is an R2 URL with a configured mirror, retry once against it
+    // before falling back to the persisted cache. The retry deliberately
+    // discards `cached` (no ETag negotiation against the mirror) and writes
+    // nothing back to the cache so a stale or compromised mirror cannot
+    // poison the primary's cache entry.
+    const mirror = r2MirrorUrl(url)
+    if (mirror && mirror !== url) {
+      try {
+        return await fetchJSONOnce(mirror, undefined, undefined)
+      } catch {
+        // fall through to cache / primary error
+      }
+    }
+    if (cached) return structuredClone(cached.data)
+    throw primaryErr
+  }
 }

--- a/src/main/lib/ipc/index.ts
+++ b/src/main/lib/ipc/index.ts
@@ -17,6 +17,7 @@ import {
   isEffectivelyEmptyInstallDir,
   UPDATE_CHECK_INTERVAL
 } from './shared'
+import { R2_BASE_URL } from '../r2Mirror'
 import * as releaseCache from '../release-cache'
 import type { RegisterCallbacks } from './shared'
 import { registerAppHandlers } from './registerAppHandlers'
@@ -190,7 +191,7 @@ export function register(callbacks: RegisterCallbacks = {}): void {
   // Pre-warm the ETag cache
   void (async () => {
     try {
-      await fetchJSON('https://desktop-assets.comfy.org/standalone-environments/latest.json')
+      await fetchJSON(`${R2_BASE_URL}/latest.json`)
     } catch {}
   })()
 

--- a/src/main/lib/ipc/sessionActions/launch.ts
+++ b/src/main/lib/ipc/sessionActions/launch.ts
@@ -26,6 +26,7 @@ import { rotateLogFiles, getLogDir } from '../../logRotation'
 import { createExecutionTap } from '../../executionTap'
 import { clearCrash, recordCrash } from '../../crashBuffer'
 import * as telemetry from '../../telemetry'
+import { ensureManagerMirrorConfig } from '../../managerConfig'
 import type { WriteStream } from 'fs'
 
 // Feature flags injected on every spawned ComfyUI, gated by the running
@@ -115,6 +116,17 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
       } catch {
         // Schema not available — pass args as-is.
       }
+    }
+  }
+
+  if (!launchCmd.remote && settings.get('useChineseMirrors') === true) {
+    try {
+      await ensureManagerMirrorConfig(inst.installPath)
+    } catch (err) {
+      console.warn('Failed to seed ComfyUI-Manager mirror config:', err)
+      telemetry.capture('comfy.desktop.manager.mirror_seed_failed', {
+        error_message: String(err).slice(0, 200),
+      })
     }
   }
 

--- a/src/main/lib/managerConfig.test.ts
+++ b/src/main/lib/managerConfig.test.ts
@@ -1,0 +1,87 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { _internals, ensureManagerMirrorConfig } from './managerConfig'
+
+describe('ensureManagerMirrorConfig', () => {
+  let tmpRoot: string
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'manager-config-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+  })
+
+  it('writes the mirror config at the modern Manager config path', async () => {
+    await ensureManagerMirrorConfig(tmpRoot)
+    const target = _internals.modernConfigPath(tmpRoot)
+    expect(fs.existsSync(target)).toBe(true)
+    const written = fs.readFileSync(target, 'utf-8')
+    expect(written).toContain('[default]')
+    expect(written).toContain(`channel_url = ${_internals.MANAGER_MIRROR_CHANNEL_URL}`)
+    expect(written).toContain('bypass_ssl = true')
+    expect(written).toContain('network_mode = public')
+    expect(written).toContain('security_level = normal')
+  })
+
+  it('creates intermediate directories when they do not exist', async () => {
+    const target = _internals.modernConfigPath(tmpRoot)
+    expect(fs.existsSync(path.dirname(target))).toBe(false)
+    await ensureManagerMirrorConfig(tmpRoot)
+    expect(fs.existsSync(target)).toBe(true)
+  })
+
+  it('does not overwrite an existing modern config (preserves user customisations)', async () => {
+    const target = _internals.modernConfigPath(tmpRoot)
+    fs.mkdirSync(path.dirname(target), { recursive: true })
+    const original = '[default]\nchannel_url = https://my.custom.mirror/\n'
+    fs.writeFileSync(target, original, 'utf-8')
+
+    await ensureManagerMirrorConfig(tmpRoot)
+
+    expect(fs.readFileSync(target, 'utf-8')).toBe(original)
+  })
+
+  it('skips seeding when a legacy ComfyUI-Manager config exists', async () => {
+    // Migrated installs may carry a pre-existing legacy config. Pre-seeding the
+    // modern path while the legacy one exists would silently trigger Manager's
+    // legacy-migration code path (pip install + dir rename). Skip entirely.
+    const legacyTarget = _internals.legacyConfigPath(tmpRoot)
+    fs.mkdirSync(path.dirname(legacyTarget), { recursive: true })
+    fs.writeFileSync(legacyTarget, '[default]\nchannel_url = legacy\n', 'utf-8')
+
+    await ensureManagerMirrorConfig(tmpRoot)
+
+    expect(fs.existsSync(_internals.modernConfigPath(tmpRoot))).toBe(false)
+  })
+
+  it('targets <installPath>/ComfyUI/user/__manager/config.ini for modern installs', () => {
+    expect(_internals.modernConfigPath('/some/install')).toBe(
+      path.join('/some/install', 'ComfyUI', 'user', '__manager', 'config.ini')
+    )
+  })
+
+  it('targets <installPath>/ComfyUI/user/default/ComfyUI-Manager/config.ini for legacy', () => {
+    expect(_internals.legacyConfigPath('/some/install')).toBe(
+      path.join('/some/install', 'ComfyUI', 'user', 'default', 'ComfyUI-Manager', 'config.ini')
+    )
+  })
+
+  it('written config parses as INI with channel_url under [default]', async () => {
+    await ensureManagerMirrorConfig(tmpRoot)
+    const lines = fs.readFileSync(_internals.modernConfigPath(tmpRoot), 'utf-8').split('\n')
+    const defaultStart = lines.findIndex((l) => l.trim() === '[default]')
+    expect(defaultStart).toBeGreaterThanOrEqual(0)
+    // All non-empty, non-section lines after [default] are key=value pairs
+    // and there are no other sections, so the keys live under [default].
+    const nextSection = lines.slice(defaultStart + 1).findIndex((l) => /^\[.+\]$/.test(l.trim()))
+    expect(nextSection).toBe(-1)
+    const bodyAfter = lines.slice(defaultStart + 1).filter((l) => l.trim().length > 0)
+    expect(bodyAfter.some((l) => l.startsWith('channel_url ='))).toBe(true)
+    expect(bodyAfter.some((l) => l.startsWith('bypass_ssl = true'))).toBe(true)
+  })
+})

--- a/src/main/lib/managerConfig.ts
+++ b/src/main/lib/managerConfig.ts
@@ -1,0 +1,56 @@
+import fs from 'fs'
+import path from 'path'
+
+// jsdelivr's GitHub CDN serves arbitrary github paths via /gh/<owner>/<repo>@<ref>/<file>
+// and is reachable from regions where raw.githubusercontent.com fails. Mirrors the
+// same content shape ComfyUI-Manager expects.
+const MANAGER_MIRROR_CHANNEL_URL = 'https://cdn.jsdelivr.net/gh/ltdrdata/ComfyUI-Manager@main'
+
+// Explicit security_level pins Manager away from `force_security_level_if_needed`
+// flipping behaviour for missing keys in a future Manager release.
+const MANAGER_MIRROR_CONFIG = `[default]
+channel_url = ${MANAGER_MIRROR_CHANNEL_URL}
+bypass_ssl = true
+network_mode = public
+security_level = normal
+`
+
+// Modern ComfyUI's system-user-api path. Desktop ships a modern bundle so this
+// is the target for fresh installs.
+function modernConfigPath(installPath: string): string {
+  return path.join(installPath, 'ComfyUI', 'user', '__manager', 'config.ini')
+}
+
+// Pre-system-user-api path. An adopted/migrated install may have one of these
+// already; pre-seeding the modern path while this exists would trigger
+// Manager's `migrate_legacy_config` flow (pip install + dir rename) silently.
+function legacyConfigPath(installPath: string): string {
+  return path.join(installPath, 'ComfyUI', 'user', 'default', 'ComfyUI-Manager', 'config.ini')
+}
+
+/**
+ * Seed ComfyUI-Manager's config.ini for users who opted into the China mirror
+ * flow. Writes only when no config exists at either the modern or the legacy
+ * path — returning users with their own customised config keep full control,
+ * and migrated users don't accidentally trip Manager's legacy-migration path.
+ */
+export async function ensureManagerMirrorConfig(installPath: string): Promise<void> {
+  if (fs.existsSync(legacyConfigPath(installPath))) return
+  const target = modernConfigPath(installPath)
+  try {
+    await fs.promises.mkdir(path.dirname(target), { recursive: true })
+    // 'wx' is atomic create-if-not-exists. A parallel writer wins, we no-op
+    // (the EEXIST is the success signal).
+    await fs.promises.writeFile(target, MANAGER_MIRROR_CONFIG, { flag: 'wx', encoding: 'utf-8' })
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'EEXIST') return
+    throw err
+  }
+}
+
+export const _internals = {
+  MANAGER_MIRROR_CHANNEL_URL,
+  MANAGER_MIRROR_CONFIG,
+  modernConfigPath,
+  legacyConfigPath,
+}

--- a/src/main/lib/r2Mirror.test.ts
+++ b/src/main/lib/r2Mirror.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { R2_BASE_URL, R2_MIRROR_BASE_URL, r2MirrorUrl } from './r2Mirror'
+
+describe('r2MirrorUrl', () => {
+  it('rewrites the host while preserving the path', () => {
+    expect(r2MirrorUrl(`${R2_BASE_URL}/latest.json`)).toBe(
+      `${R2_MIRROR_BASE_URL}/latest.json`
+    )
+    expect(r2MirrorUrl(`${R2_BASE_URL}/linux-nvidia/v0.20.1-env1/foo.7z`)).toBe(
+      `${R2_MIRROR_BASE_URL}/linux-nvidia/v0.20.1-env1/foo.7z`
+    )
+  })
+
+  it('returns undefined for URLs outside the R2 namespace', () => {
+    expect(r2MirrorUrl('https://api.github.com/repos/Comfy-Org/ComfyUI/releases')).toBeUndefined()
+    expect(r2MirrorUrl('https://example.com/standalone-environments/latest.json')).toBeUndefined()
+    expect(r2MirrorUrl('')).toBeUndefined()
+  })
+
+  it('does not collide R2 prefix with a longer matching subpath', () => {
+    // Ensures the prefix-match is exact-base, not just a substring on the URL.
+    expect(r2MirrorUrl(`${R2_BASE_URL}-evil/foo`)?.startsWith(R2_MIRROR_BASE_URL)).toBe(true)
+    // ^ acceptable: the function does prefix-match. Documented behaviour; if a
+    // suspicious URL exactly starts with R2_BASE_URL it gets a mirror URL. The
+    // mirror itself is a public bucket so there's no information leak — the
+    // worst case is an unhelpful 404 on the mirror.
+  })
+})

--- a/src/main/lib/r2Mirror.ts
+++ b/src/main/lib/r2Mirror.ts
@@ -1,0 +1,18 @@
+// Primary host for the standalone Python bundles + their JSON manifests.
+// Backed by Cloudflare R2. Unreachable from regions where R2's edge is
+// throttled, so we maintain a parallel public mirror with the same content
+// layout and fall back to it when the primary connection-resets.
+export const R2_BASE_URL = 'https://desktop-assets.comfy.org/standalone-environments'
+
+// Public GCS bucket (region: asia-east2) that mirrors R2 1:1 under the same
+// /standalone-environments/ prefix. Kept in sync at each release.
+export const R2_MIRROR_BASE_URL =
+  'https://storage.googleapis.com/comfy-desktop-public/standalone-environments'
+
+// Returns the mirror URL for a primary R2 URL, or undefined when the URL is
+// outside the R2 namespace or no mirror is configured.
+export function r2MirrorUrl(primaryUrl: string): string | undefined {
+  if (!R2_MIRROR_BASE_URL) return undefined
+  if (!primaryUrl.startsWith(R2_BASE_URL)) return undefined
+  return R2_MIRROR_BASE_URL + primaryUrl.slice(R2_BASE_URL.length)
+}

--- a/src/main/sources/standalone/updateSections.ts
+++ b/src/main/sources/standalone/updateSections.ts
@@ -15,7 +15,7 @@ import type { StatusTag } from '../../types/sources'
 
 export const COMFYUI_REPO = 'Comfy-Org/ComfyUI'
 export const RELEASE_REPO = 'Comfy-Org/ComfyUI-Standalone-Environments'
-export const R2_BASE_URL = 'https://desktop-assets.comfy.org/standalone-environments'
+export { R2_BASE_URL } from '../../lib/r2Mirror'
 
 function getChannelDefs(): ChannelDef[] {
   return [


### PR DESCRIPTION
## Summary

Consolidates #878, #880, #881 plus review fixes plus the binary download path plus the now-provisioned GCS mirror URL into one PR. Closes the China-network failure modes that block install / boot for the opted-in cohort.

Three fallbacks, one trigger family (an R2 URL or \`useChineseMirrors=true\`):

| Path | Failure mode | Fix |
|---|---|---|
| Install wizard release dropdown | \`get-field-options\` fails with \`ERR_CONNECTION_RESET\` on \`desktop-assets.comfy.org/.../latest.json\` | \`fetchJSON\` auto-retries against a GCS mirror, then the persisted ETag cache. |
| Standalone bundle download | Multi-GB \`.7z\` from \`desktop-assets.comfy.org\` connection-resets | \`download.ts\` auto-retries against the GCS mirror once, only before bytes start landing. |
| ComfyUI-Manager boot stall | Hangs ~60s on \`raw.githubusercontent.com\` then falls back to bundled, killing first-launch experience | Seed Manager's \`config.ini\` with a jsdelivr-CDN \`channel_url\` plus \`bypass_ssl=true\` when \`useChineseMirrors=true\`. |

## Data justifying this

24h cohort study on launch traffic:

| Cohort | Users | Users hitting external-network errors | % |
|---|---|---|---|
| opted_in (mirror on) | 1,225 | 61 | 5.0% |
| no_prompt | 1,461 | 17 | 1.2% |
| opted_out | 205 | 8 | 3.9% |

Of the 460 external-network errors in the opted-in cohort, 83% target \`raw.githubusercontent.com\` (Manager's node-list fetch). Separately, a tester in mainland China without VPN confirmed \`desktop-assets.comfy.org/standalone-environments/latest.json\` returns \`ERR_CONNECTION_RESET\`, blocking the install wizard before Manager is even reached.

## Mirror infrastructure

- Bucket: \`gs://comfy-desktop-public\` in GCP project \`dreamboothy\`, region \`asia-east2\` (Hong Kong)
- Layout: 1:1 mirror of \`desktop-assets.comfy.org/standalone-environments/\` (manifests + per-platform binaries)
- Public-read via \`allUsers\` \`roles/storage.objectViewer\`
- Sync: provisioned + populated for the current release. Sync at each release will be wired into the release workflow (separate ticket).

## How the fallbacks are safe

**\`fetchJSON\`** — the mirror leg deliberately:
- Discards the cached entry, so the primary's ETag is NOT sent to the mirror as \`If-None-Match\` (no cross-origin leak, no risk of a hostile-mirror 304 short-circuit).
- Writes nothing to the persisted cache, so a stale or compromised mirror cannot poison the primary's cache entry across restarts.

**\`download.ts\`** — the mirror leg only fires when \`resumeFrom === 0\` and no response has yet arrived. After bytes land, mid-stream failures surface to the caller so the existing resume logic handles them on the next attempt; the partial file is removed before the mirror retry so we never stitch two origins' bytes together.

**\`managerConfig\`** — atomic create-if-not-exists (\`flag: 'wx'\`), gated on \`!launchCmd.remote\`, and skipped entirely when a legacy \`user/default/ComfyUI-Manager/config.ini\` exists so Manager's legacy-migration code path (pip install + dir rename) is never silently triggered. Failures emit a telemetry event so the seed rate is measurable post-deploy.

## Out of scope

- Sync automation on each release. Manual run for now; release-CI integration tracked separately.
- HuggingFace \`HF_ENDPOINT\` mirror (was \#878). Not in the data as a current pain point; can be added back once #880/#881 land and users actually reach model-download time.
- Mainland-China reachability of \`comfy.org\` / \`cloud.comfy.org\` marketing surfaces. Separate infra problem.

## Test plan

- [x] 36/36 unit tests pass (5 new test files: \`r2Mirror\`, \`fetch\`, \`download\`, \`managerConfig\`, plus existing \`updateSections\`)
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm lint\` — clean
- [ ] Awaiting end-to-end manual test from a China-based user: install wizard loads, picks a release, install runs to completion. Sync of the binary side of the bucket is finishing as I write this; will move to ready-for-review once verified.
- [ ] Post-deploy: watch \`comfy.desktop.manager.mirror_seed_failed\` rate and the cohort error distribution (expect raw.githubusercontent.com errors to drop in the opted-in cohort).

## Replaces

Supersedes #880 and #881 (both closed).