### PR TITLE
chore(release): 1.0.3-rc

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-desktop-2",
-  "version": "1.0.2",
+  "version": "1.0.3-rc",
   "description": "Comfy Desktop",
   "author": {
     "name": "Comfy Org",

--- a/src/main/lib/installer.test.ts
+++ b/src/main/lib/installer.test.ts
@@ -2,6 +2,21 @@ import { describe, it, expect, vi } from 'vitest'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
+
+// `installer.ts` -> `download.ts` -> `../settings` -> `models.ts` -> `paths.ts`
+// pulls in electron's `app.getPath` at module-load time. The download function
+// here is dependency-injected through `ctx`, so none of that code actually
+// runs in this suite — but the import chain still has to resolve, so stub
+// the surface used by `paths.ts`.
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getPath: () => '/tmp',
+    getVersion: () => '0.0.0-test',
+    getLocale: () => 'en',
+  },
+}))
+
 import { downloadAndExtract, downloadAndExtractMulti } from './installer'
 import type { Cache } from './cache'
 import type { DownloadProgress } from './download'


### PR DESCRIPTION
Bump to **1.0.3-rc** to release the China-network fallback work that landed in #884.

## What's shipping in 1.0.3-rc

Net-new since 1.0.2:

- **Mirror fallback for R2 manifest fetches** — install wizard release dropdown no longer dead-ends when \`desktop-assets.comfy.org\` connection-resets from restricted regions. Auto-retries against a GCS Hong Kong mirror, then the persisted ETag cache.
- **Mirror fallback for the standalone binary download** — same auto-retry, scoped to \`useChineseMirrors=true\` users so a brief R2 hiccup can't drag the global user base into the GCS bucket.
- **ComfyUI-Manager mirror channel** — when the user opts into the China mirror flow, seed Manager's \`config.ini\` with a jsdelivr-CDN \`channel_url\` plus \`bypass_ssl=true\` so boot doesn't hang ~60s on \`raw.githubusercontent.com\`. Skipped when a legacy Manager config exists so the legacy-migration path is never silently triggered.

All three fallbacks are no-ops for users outside their failure modes — no behaviour change for the existing happy path.

## Why RC

Soft-launching to validate the fallbacks against real China traffic before promoting to stable. The fallbacks are gated and unit-tested, but the GCS bucket reachability + Manager CDN reach is observable only from inside the restricted regions.

## How to validate while this is on RC

- Watch \`comfy.desktop.manager.mirror_seed_failed\` event rate (should be near 0)
- Re-run the 24h cohort error query for \`raw.githubusercontent.com\` (should drop sharply for opted-in users)
- Watch \`desktop-assets.comfy.org\` connection_reset rate in CN locale (should drop)

If those move the right way after a day of RC traffic, promote to stable. If anything regresses, hotfix or roll back via a follow-up version bump.

## Auto-update channel

Tags as \`v1.0.3-rc\` via the existing release-from-pr-label workflow once this merges with the \`Release\` label. ToDesktop publishes to the same channel as 1.0.x.