### PR TITLE
chore: bump version to 1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-desktop-2",
-  "version": "1.0.3-rc",
+  "version": "1.0.3",
   "description": "Comfy Desktop",
   "author": {
     "name": "Comfy Org",


### PR DESCRIPTION
## Summary
- bump `package.json` version from `1.0.3-rc` to `1.0.3` (promotes the rc to stable)
- channel: `stable` → GitHub Release marked **Latest**, ToDesktop builds + waits for human Release click

> Manual replacement for the [Version Bump PR run](https://github.com/Comfy-Org/Comfy-Desktop/actions/runs/26978677271/job/79612114671) that failed because the workflow's regex didn't accept `1.0.3-rc` (no `.N` suffix). Follow-up PR will relax the regex.

## How merging this PR ships the build
1. Merge — `Release From Version PR` workflow tags `v1.0.3` on the merge commit
2. Tag triggers `Publish All / build-release`, which creates the GitHub Release using **this PR body as the release notes**
3. ToDesktop picks up the new build; click **Release** in the ToDesktop dashboard to push to users

## What's in 1.0.3 (since v1.0.2)

### Features
- **A/B/C: Cloud-vs-Local-vs-NoDefault first-use experiment** (#869) — three equal cohorts (33-33-33): Local pre-selected (control), Cloud pre-selected, or neither (forced explicit pick). Migration flow always wins regardless of variant.
- **Manager channel + R2 mirror fallback for restricted regions** (#884) — falls back to the China-friendly mirror when the primary endpoint is unreachable.
- **Download preview thumbnails** (#876) — completed image asset downloads now render a preview thumbnail in the Downloads panel.
- **Cluster rises as installs grow + tile filter animation** (#877) — visual polish on the chooser.

### Fixes
- **Snapshot pill + path truncation** (#873) — fixes the package pill layout and truncates long snapshot paths instead of overflowing.
- **Settings modal instant open** (#879) — snappier first paint on Settings.

### Polish
- **DMG background + icon layout in todesktop.json** (#882) — Comfy-branded mac DMG (was using ToDesktop's default template).
- **i18n: "Track Existing Install" → "Add Existing Install"** (#871) — clearer label.

## Install
- 👉 [comfy.org/download](https://comfy.org/download)