### PR TITLE
ci(release): accept bare -rc suffix in version-bump regex

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -73,16 +73,22 @@ jobs:
           const channel = process.env.CHANNEL
           const pkgPath = 'package.json'
           const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'))
-          const match = String(pkg.version).match(/^(\d+)\.(\d+)\.(\d+)(?:-rc\.(\d+))?$/)
+          // Accept X.Y.Z, X.Y.Z-rc, or X.Y.Z-rc.N. Bare `-rc` (no `.N`)
+          // shows up when an earlier manual bump landed without the
+          // numeric suffix — treat it as `-rc.0` so the next rc bump
+          // produces `-rc.1` and a stable bump drops the suffix.
+          const match = String(pkg.version).match(/^(\d+)\.(\d+)\.(\d+)(-rc(?:\.(\d+))?)?$/)
 
           if (!match) {
-            throw new Error(`Unsupported version format: ${pkg.version} (expected X.Y.Z or X.Y.Z-rc.N)`)
+            throw new Error(`Unsupported version format: ${pkg.version} (expected X.Y.Z, X.Y.Z-rc, or X.Y.Z-rc.N)`)
           }
 
           let major = Number(match[1])
           let minor = Number(match[2])
           let patch = Number(match[3])
-          const currentRc = match[4] === undefined ? null : Number(match[4])
+          // match[4] is the whole suffix (e.g. "-rc", "-rc.3", or undefined).
+          // match[5] is the explicit N. Missing N on a present suffix → 0.
+          const currentRc = match[4] === undefined ? null : (match[5] === undefined ? 0 : Number(match[5]))
 
           const applyBaseBump = () => {
             if (bumpType === 'major') {


### PR DESCRIPTION
## Summary

[Run #26978677271](https://github.com/Comfy-Org/Comfy-Desktop/actions/runs/26978677271/job/79612114671) failed because `package.json` was `1.0.3-rc` (no `.N`) and the regex only accepted `X.Y.Z` or `X.Y.Z-rc.N`. Loosen the regex to also accept bare `-rc` and treat it as `-rc.0`.

## Before / after

| Current version | Channel | Before | After |
|---|---|---|---|
| `1.0.3-rc` | `rc` | throws | `1.0.3-rc.1` |
| `1.0.3-rc` | `stable` | throws | `1.0.3` |
| `1.0.3-rc.2` | `rc` | `1.0.3-rc.3` | `1.0.3-rc.3` (unchanged) |
| `1.0.3-rc.2` | `stable` | `1.0.3` | `1.0.3` (unchanged) |
| `1.0.3` | `rc` | `1.0.4-rc.1` | `1.0.4-rc.1` (unchanged) |

The bump-logic branches still read `currentRc === null` vs a number, so no other code changes. The `1.0.3` manual cut shipped via [#890](https://github.com/Comfy-Org/Comfy-Desktop/pull/890); this PR just makes sure the workflow doesn't trip again the next time someone lands a bare `-rc` version.