### PR TITLE
fix(install): Latest on GitHub actually pulls master HEAD (follow-up to #832)

### DIFF
--- a/src/main/sources/standalone/index.test.ts
+++ b/src/main/sources/standalone/index.test.ts
@@ -74,24 +74,25 @@ describe('standalone.buildInstallation', () => {
     } as unknown as Record<string, unknown>,
   })
 
-  it('Stable: sets autoUpdateComfyUI (post-install update-to-stable), updateChannel left undefined', () => {
+  it('Stable: sets autoUpdateComfyUI + updateChannel="stable" so post-install checks out the latest stable tag', () => {
     const result = standalone.buildInstallation({
       release: makeRelease('stable', 'v0.18.2-env1'),
       variant: makeVariant(VENDOR_ID),
     })
     expect(result.autoUpdateComfyUI).toBe(true)
-    // updateChannel stays falsy: `getEffectiveChannel` defaults to
-    // 'stable' so the IPP picker still opens on Stable.
-    expect(result.updateChannel).toBeUndefined()
+    expect(result.updateChannel).toBe('stable')
   })
 
-  it('Latest on GitHub: persists updateChannel="latest", no autoUpdate', () => {
+  it('Latest on GitHub: sets autoUpdateComfyUI + updateChannel="latest" so post-install fast-forwards to master HEAD', () => {
     const result = standalone.buildInstallation({
       release: makeRelease('latest', 'v0.18.2-env1'),
       variant: makeVariant(VENDOR_ID),
     })
-    expect(result.autoUpdateComfyUI).toBeUndefined()
-    // Persisted so the IPP Update tab opens on Latest on GitHub.
+    // Both channels run the post-install update step — the bundle's
+    // checked-in commit is necessarily behind both stable AND master,
+    // so picking "Latest on GitHub" without an update would leave the
+    // user on an OLD master commit, not the actual latest one.
+    expect(result.autoUpdateComfyUI).toBe(true)
     expect(result.updateChannel).toBe('latest')
   })
 

--- a/src/main/sources/standalone/index.ts
+++ b/src/main/sources/standalone/index.ts
@@ -93,11 +93,18 @@ export const standalone: SourcePlugin = {
     const r2Release = vd?.r2Release
     const variantId = vd?.variantId || ''
     const isCpu = stripPlatform(variantId) === 'cpu' || stripPlatform(variantId).startsWith('cpu-')
-    // The release dropdown values now match the IPP channel ids:
-    // 'stable' triggers the post-install update-to-stable step;
-    // 'latest' (master HEAD) leaves the bundle's checked-in commit
-    // alone and only persists `updateChannel` so the IPP Update tab
-    // opens on the picked channel.
+    // The release dropdown values now match the IPP channel ids.
+    // BOTH options trigger the post-install update step — the bundle
+    // ships with whatever commit was current when the R2 artefact was
+    // built, which is necessarily behind master AND usually behind the
+    // latest stable tag too. So:
+    //   - 'stable' → autoUpdateComfyUI + updateChannel='stable' →
+    //     post-install checks out the latest stable tag.
+    //   - 'latest' → autoUpdateComfyUI + updateChannel='latest' →
+    //     post-install fast-forwards to master HEAD ('Latest on GitHub'
+    //     means actually-on-GitHub, not bundle-time).
+    // The same `updateChannel` is consumed by the IPP Update tab so
+    // future channel-switches stay consistent with the install-time pick.
     const isStable = selections.release?.value === 'stable'
     const isLatest = selections.release?.value === 'latest'
     const releaseTag = r2Release?.tag || (selections.release?.value || 'unknown')
@@ -118,7 +125,8 @@ export const standalone: SourcePlugin = {
       launchArgs: isCpu ? `${DEFAULT_LAUNCH_ARGS} --cpu` : DEFAULT_LAUNCH_ARGS,
       launchMode: 'window',
       browserPartition: 'unique',
-      ...(isStable ? { autoUpdateComfyUI: true } : {}),
+      ...(isStable || isLatest ? { autoUpdateComfyUI: true } : {}),
+      ...(isStable ? { updateChannel: 'stable' } : {}),
       ...(isLatest ? { updateChannel: 'latest' } : {}),
     }
   },

--- a/src/main/sources/standalone/install.ts
+++ b/src/main/sources/standalone/install.ts
@@ -137,16 +137,23 @@ export async function postInstall(installation: InstallationRecord, { sendProgre
     console.warn('Initial snapshot failed:', err)
   }
 
-  // Auto-update to latest stable if the user selected "Latest Stable".
+  // Auto-update to the channel the user picked on the install wizard.
+  // `installation.updateChannel` is set by `buildInstallation`:
+  // 'stable' → check out the latest stable tag; 'latest' → fast-forward
+  // to master HEAD. Defaults to 'stable' for installs created before
+  // the channel split, where `autoUpdateComfyUI` implicitly meant stable.
   if (installation.autoUpdateComfyUI && fs.existsSync(path.join(comfyuiDir, '.git'))) {
     if (signal?.aborted) throw new Error('Cancelled')
-    sendProgress('update', { percent: -1, status: 'Fetching latest stable version' })
+    const channel: 'stable' | 'latest' =
+      (installation.updateChannel as 'stable' | 'latest' | undefined) ?? 'stable'
+    const channelLabel = channel === 'latest' ? 'latest version' : 'latest stable version'
+    sendProgress('update', { percent: -1, status: `Fetching ${channelLabel}` })
 
     try {
       // Bypass the in-memory tag cache, which can be poisoned with `null` at
       // startup before any git backend is configured. `tryConfigurePygit2Fallback`
       // above has since configured pygit2, so the refreshed lookup fires.
-      const latestRelease = await fetchLatestRelease('stable', { refresh: true })
+      const latestRelease = await fetchLatestRelease(channel, { refresh: true })
       const latestTag = latestRelease?.tag_name as string | undefined
       const current = installation.comfyVersion as ComfyVersion | undefined
       const onLatestTag = !!latestTag && tagsEqual(current?.baseTag, latestTag) && current?.commitsAhead === 0
@@ -154,14 +161,14 @@ export async function postInstall(installation: InstallationRecord, { sendProgre
       if (!latestTag) {
         // A network flake must not masquerade as "up to date" — that stranded
         // first installs on the bundled version.
-        sendProgress('update', { percent: 100, status: 'Skipped — could not verify latest version' })
+        sendProgress('update', { percent: 100, status: `Skipped — could not verify ${channelLabel}` })
       } else if (onLatestTag) {
         sendProgress('update', { percent: 100, status: 'Already up to date' })
       } else {
         const result = await runComfyUIUpdate({
           installPath: installation.installPath,
           installation,
-          channel: 'stable',
+          channel,
           update,
           sendProgress: sendProgress as (step: string, data: Record<string, unknown>) => void,
           signal,
@@ -175,7 +182,7 @@ export async function postInstall(installation: InstallationRecord, { sendProgre
       }
     } catch (err) {
       if ((err as Error).message === 'Cancelled') throw err
-      console.warn('Auto-update to latest stable failed:', err)
+      console.warn(`Auto-update to ${channel} failed:`, err)
       sendProgress('update', { percent: 100, status: 'Skipped' })
     }
   }


### PR DESCRIPTION
## Summary
Follow-up to PR #832 (which collapsed the install-wizard release dropdown to the same two IPP channels — Stable + Latest on GitHub).

That cut persisted `updateChannel: 'latest'` for the **Latest on GitHub** option but *didn't* set `autoUpdateComfyUI`, so the post-install update step was skipped. The user landed on whatever commit the R2 standalone bundle was built with — necessarily *behind* master, sometimes by weeks — and had to manually flip the IPP Update tab to actually get HEAD. That defeats the channel's name.

## Fix
- **`buildInstallation`**: set `autoUpdateComfyUI: true` for **both** channels, and persist `updateChannel: 'stable'` for Stable (was previously left undefined and relied on `getEffectiveChannel`'s default).
- **`postInstall`** in `install.ts`: was hardcoded to `channel: 'stable'` for the `runComfyUIUpdate` call. Switched to read `installation.updateChannel` (default `'stable'` for back-compat with installs created before the channel split). Status copy + log line also pick up the channel-specific wording (`"latest version"` vs `"latest stable version"`).

## Behaviour matrix (after this PR)

| Pick | `autoUpdateComfyUI` | `updateChannel` | Post-install action | IPP Update tab opens on |
|---|---|---|---|---|
| **Stable** | `true` | `'stable'` | `runComfyUIUpdate({ channel: 'stable' })` — checks out latest stable tag | Stable |
| **Latest on GitHub** | `true` | `'latest'` | `runComfyUIUpdate({ channel: 'latest' })` — fast-forwards to master HEAD | Latest on GitHub |

Same code path the IPP Update tab's "Latest" channel takes (`runComfyUIUpdate` with `channel: 'latest'`), so install-time and post-install behaviour stay consistent.

## Tests
- `src/main/sources/standalone/index.test.ts` updated:
  - Stable asserts both `autoUpdateComfyUI: true` and `updateChannel: 'stable'`.
  - Latest on GitHub asserts both `autoUpdateComfyUI: true` and `updateChannel: 'latest'`.
- All 47 standalone tests pass. `pnpm run typecheck` clean.

## Back-compat
Installs created before the channel split don't carry `updateChannel`. The post-install code defaults to `'stable'` when the field is missing, so those installs continue to land on the same code path they used to (update-to-stable on first launch). No migration needed.
