### PR TITLE
feat(settings): configurable default install location

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -122,8 +122,7 @@
   "media": {
     "sharedDirs": "Media",
     "inputDir": "Input Directory",
-    "outputDir": "Output Directory",
-    "installDir": "Install Location"
+    "outputDir": "Output Directory"
   },
 
   "directories": {
@@ -417,7 +416,7 @@
     "community": "Community",
     "storageTab": "Storage",
     "sharedDirectories": "Shared Directories",
-    "installLocation": "Install Location",
+    "installLocation": "Default Install Location",
     "updatesTab": "Updates"
   },
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -122,7 +122,8 @@
   "media": {
     "sharedDirs": "Media",
     "inputDir": "Input Directory",
-    "outputDir": "Output Directory"
+    "outputDir": "Output Directory",
+    "installDir": "Install Location"
   },
 
   "directories": {
@@ -416,6 +417,7 @@
     "community": "Community",
     "storageTab": "Storage",
     "sharedDirectories": "Shared Directories",
+    "installLocation": "Install Location",
     "updatesTab": "Updates"
   },
 
@@ -1050,6 +1052,7 @@
     "perInstallOutputDir": "Folder this install writes generated output files to. Leave blank to use this install's own internal output folder.",
     "inputDir": "Shared folder for input files (images, masks, etc.) accessible to all installations.",
     "outputDir": "Shared folder where ComfyUI saves generated outputs, accessible to all installations.",
+    "installDir": "Default parent folder suggested when creating new installations. Existing installs aren't moved.",
     "autoDownloadOutputs": "Automatically download output files (images, videos) from this remote instance to a local directory after each workflow run.",
     "useSharedOutputDir": "When enabled, downloaded outputs are saved to the shared output directory. Disable to use a custom output folder for this install.",
     "outputDirPerInstall": "Custom local folder where outputs from this remote instance will be saved.",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -74,7 +74,8 @@
   "media": {
     "sharedDirs": "媒体",
     "inputDir": "输入目录",
-    "outputDir": "输出目录"
+    "outputDir": "输出目录",
+    "installDir": "安装位置"
   },
 
   "directories": {
@@ -287,6 +288,7 @@
     "community": "社区",
     "storageTab": "存储",
     "sharedDirectories": "共享目录",
+    "installLocation": "安装位置",
     "updatesTab": "更新"
   },
 
@@ -663,6 +665,7 @@
     "useSharedModels": "启用后，此安装可以看到您全局共享模型文件夹中的所有模型。关闭后将隐藏这些模型——大多数用户应保持启用。",
     "useSharedInputOutput": "启用后，此安装将从全局共享文件夹读取和写入输入与输出文件。关闭后可在下方将此安装指向自己的文件夹。",
     "perInstallInputDir": "此安装读取输入文件的文件夹。留空则使用该安装自带的内部输入文件夹。",
-    "perInstallOutputDir": "此安装写入生成的输出文件的文件夹。留空则使用该安装自带的内部输出文件夹。"
+    "perInstallOutputDir": "此安装写入生成的输出文件的文件夹。留空则使用该安装自带的内部输出文件夹。",
+    "installDir": "创建新安装时建议使用的默认上级文件夹。现有安装不会被移动。"
   }
 }

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -74,8 +74,7 @@
   "media": {
     "sharedDirs": "媒体",
     "inputDir": "输入目录",
-    "outputDir": "输出目录",
-    "installDir": "安装位置"
+    "outputDir": "输出目录"
   },
 
   "directories": {
@@ -288,7 +287,7 @@
     "community": "社区",
     "storageTab": "存储",
     "sharedDirectories": "共享目录",
-    "installLocation": "安装位置",
+    "installLocation": "默认安装位置",
     "updatesTab": "更新"
   },
 

--- a/src/main/lib/ipc/registerSettingsHandlers.ts
+++ b/src/main/lib/ipc/registerSettingsHandlers.ts
@@ -160,6 +160,7 @@ export function buildModelsPayload(): { systemDefault: string; sections: Setting
 
 // Default suggested install location (global-only; intentionally NOT part of
 // buildMediaSections so it doesn't leak into the per-instance Storage tab).
+// Label/tooltip live on the section header, so the field itself is unlabelled.
 export function buildInstallLocationFields(): SettingsSection[] {
   const s = settings.getAll()
   return [
@@ -167,11 +168,10 @@ export function buildInstallLocationFields(): SettingsSection[] {
       fields: [
         {
           id: 'installDir',
-          label: i18n.t('media.installDir'),
+          label: '',
           type: 'path' as const,
           value: s.installDir || settings.defaults.installDir,
-          openable: true,
-          tooltip: i18n.t('tooltips.installDir')
+          openable: true
         }
       ]
     }

--- a/src/main/lib/ipc/registerSettingsHandlers.ts
+++ b/src/main/lib/ipc/registerSettingsHandlers.ts
@@ -158,6 +158,26 @@ export function buildModelsPayload(): { systemDefault: string; sections: Setting
   }
 }
 
+// Default suggested install location (global-only; intentionally NOT part of
+// buildMediaSections so it doesn't leak into the per-instance Storage tab).
+export function buildInstallLocationFields(): SettingsSection[] {
+  const s = settings.getAll()
+  return [
+    {
+      fields: [
+        {
+          id: 'installDir',
+          label: i18n.t('media.installDir'),
+          type: 'path' as const,
+          value: s.installDir || settings.defaults.installDir,
+          openable: true,
+          tooltip: i18n.t('tooltips.installDir')
+        }
+      ]
+    }
+  ]
+}
+
 // Shared input/output directories.
 export function buildMediaSections(): SettingsSection[] {
   const s = settings.getAll()

--- a/src/main/lib/paths.ts
+++ b/src/main/lib/paths.ts
@@ -49,8 +49,31 @@ export function stateDir(): string {
   return app.getPath("userData");
 }
 
-export function defaultInstallDir(): string {
+/** Built-in fallback when no `installDir` setting is configured. */
+export function builtinDefaultInstallDir(): string {
   return path.join(app.getPath("home"), "ComfyUI-Installs");
+}
+
+/** Resolver for the user's configured install location, injected by settings.ts.
+ *  Kept as injected state (not a direct `import`) so paths.ts has no dependency
+ *  on settings — settings → models → paths is the only allowed direction, and
+ *  importing settings here would re-enter paths before its top-level consts
+ *  (e.g. `isLinux`) initialize. */
+let installDirResolver: (() => string | undefined) | null = null;
+
+export function setInstallDirResolver(resolver: () => string | undefined): void {
+  installDirResolver = resolver;
+}
+
+/** Parent directory suggested for new installations. Honors the user's
+ *  `installDir` Desktop Setting so every new-install path stays consistent;
+ *  falls back to the built-in default. */
+export function defaultInstallDir(): string {
+  const configured = installDirResolver?.();
+  if (typeof configured === "string" && configured.trim() !== "") {
+    return configured;
+  }
+  return builtinDefaultInstallDir();
 }
 
 /** Migrate a file/dir to a new location (only if old exists and new doesn't). Uses

--- a/src/main/popups/titlePopup.ts
+++ b/src/main/popups/titlePopup.ts
@@ -27,7 +27,8 @@ import {
   applySettingSet,
   buildSettingsSections,
   buildMediaSections,
-  buildModelsPayload
+  buildModelsPayload,
+  buildInstallLocationFields
 } from '../lib/ipc/registerSettingsHandlers'
 import { globalSettingsEvents } from '../lib/globalSettingsEvents'
 import { getCachedGithubStarCount, getGithubStarCount } from '../lib/githubStars'
@@ -192,6 +193,9 @@ export interface GlobalSettingsSnapshot {
   cacheFields: Record<string, unknown>[]
   advancedFields: Record<string, unknown>[]
   sharedDirectoriesFields: Record<string, unknown>[]
+  /** Default suggested install location — global-only; not in the
+   *  per-instance picker storage slice. */
+  installLocationFields: Record<string, unknown>[]
   modelsDirs: GlobalSettingsModelsDir[]
   modelsSystemDefault: string
   appUpdate: {
@@ -2017,6 +2021,7 @@ function buildGlobalSettingsSnapshot(): GlobalSettingsSnapshot {
   const cache = findSettingsFields(settingsSections, 'settings.cache', 2)
   const advanced = findSettingsFields(settingsSections, 'settings.advanced', 3)
   const shared = (mediaSections[0]?.fields ?? []).map(toDetailField)
+  const installLocationFields = (buildInstallLocationFields()[0]?.fields ?? []).map(toDetailField)
   const modelsDirsRaw = (modelsPayload.sections[0]?.fields[0]?.value as string[] | undefined) ?? []
   const modelsDefault = modelsPayload.systemDefault
   const appUpdateState = updater.getCurrentUpdateState() as unknown as Record<string, unknown>
@@ -2031,6 +2036,7 @@ function buildGlobalSettingsSnapshot(): GlobalSettingsSnapshot {
     cacheFields: cache,
     advancedFields: advanced,
     sharedDirectoriesFields: shared,
+    installLocationFields,
     modelsDirs: modelsDirsRaw.map((p, i) => ({
       path: p,
       isPrimary: i === 0,

--- a/src/main/settings.test.ts
+++ b/src/main/settings.test.ts
@@ -129,6 +129,20 @@ describe('settings unset/default semantics', () => {
     expect(readPersistedSettings()['customKey']).toBeNull()
   })
 
+  it('defaults installDir to ~/ComfyUI-Installs and persists overrides', () => {
+    const builtinDefault = path.join(homePath, 'ComfyUI-Installs')
+    expect(settings.get('installDir')).toBe(builtinDefault)
+
+    const custom = path.join(homePath, 'Custom', 'Installs')
+    settings.set('installDir', custom)
+    expect(settings.get('installDir')).toBe(custom)
+    expect(readPersistedSettings()['installDir']).toBe(custom)
+
+    settings.set('installDir', undefined)
+    expect(settings.get('installDir')).toBe(builtinDefault)
+    expect(readPersistedSettings()).not.toHaveProperty('installDir')
+  })
+
   it('treats empty and whitespace-only strings as unset for pypiMirror', () => {
     settings.set('pypiMirror', 'https://mirrors.aliyun.com/pypi/simple/')
     expect(settings.get('pypiMirror')).toBe('https://mirrors.aliyun.com/pypi/simple/')

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 import fs from 'fs'
 import { app } from 'electron'
-import { configDir, cacheDir, homeDir } from './lib/paths'
+import { configDir, cacheDir, homeDir, setInstallDirResolver } from './lib/paths'
 import { MODEL_FOLDER_TYPES } from './lib/models'
 import { readFileSafe, writeFileSafe } from './lib/safe-file'
 
@@ -12,6 +12,8 @@ export interface KnownSettings {
   modelsDirs: string[]
   inputDir: string
   outputDir: string
+  /** Default suggested parent directory for new installations. */
+  installDir: string
   language?: string
   theme?: string
   /** Legacy "check for updates on startup" toggle. No longer gated on a setting;
@@ -40,6 +42,7 @@ type DefaultedSettingKey =
   | 'modelsDirs'
   | 'inputDir'
   | 'outputDir'
+  | 'installDir'
 type SettingsDefaults = Pick<KnownSettings, DefaultedSettingKey>
 
 const dataPath = path.join(configDir(), "settings.json")
@@ -53,6 +56,7 @@ const SETTINGS_SCHEMA = {
   modelsDirs: { nullable: false },
   inputDir: { nullable: false },
   outputDir: { nullable: false },
+  installDir: { nullable: false },
   language: { nullable: false },
   theme: { nullable: false },
   autoUpdate: { nullable: false },
@@ -89,6 +93,7 @@ export const defaults: SettingsDefaults = {
   modelsDirs: [path.join(SHARED_ROOT, "models")],
   inputDir: path.join(SHARED_ROOT, "input"),
   outputDir: path.join(SHARED_ROOT, "output"),
+  installDir: path.join(homeDir(), "ComfyUI-Installs"),
 }
 
 const systemDefault = defaults.modelsDirs[0]!
@@ -246,6 +251,12 @@ function load(): Settings {
       result.outputDir = nextOutputDir
       changed = true
     }
+
+    const nextInstallDir = sanitizeUserDefaultPath(result.installDir, defaults.installDir)
+    if (nextInstallDir !== result.installDir) {
+      result.installDir = nextInstallDir
+      changed = true
+    }
   }
 
   // Keep modelsDirs a valid array of non-empty strings; inject system default as fallback.
@@ -355,3 +366,7 @@ export function has(key: string): boolean {
 export function getMirrorConfig(): { pypiMirror?: string; useChineseMirrors?: boolean } {
   return { pypiMirror: get('pypiMirror'), useChineseMirrors: get('useChineseMirrors') === true }
 }
+
+// Let paths.defaultInstallDir() honor the user's configured location without
+// paths.ts importing this module (which would create an init cycle).
+setInstallDirResolver(() => get('installDir'))

--- a/src/preload/comfyTitlePopupPreload.ts
+++ b/src/preload/comfyTitlePopupPreload.ts
@@ -87,6 +87,7 @@ export interface PopupGlobalSettingsSnapshot {
   cacheFields: Record<string, unknown>[]
   advancedFields: Record<string, unknown>[]
   sharedDirectoriesFields: Record<string, unknown>[]
+  installLocationFields: Record<string, unknown>[]
   modelsDirs: PopupGlobalSettingsModelsDir[]
   modelsSystemDefault: string
   appUpdate: {
@@ -402,6 +403,7 @@ function isGlobalSettingsSnapshot(value: unknown): value is PopupGlobalSettingsS
   if (!Array.isArray(v['cacheFields'])) return false
   if (!Array.isArray(v['advancedFields'])) return false
   if (!Array.isArray(v['sharedDirectoriesFields'])) return false
+  if (!Array.isArray(v['installLocationFields'])) return false
   if (!Array.isArray(v['modelsDirs'])) return false
   if (typeof v['modelsSystemDefault'] !== 'string') return false
   if (!v['appUpdate'] || typeof v['appUpdate'] !== 'object') return false

--- a/src/renderer/src/comfyTitlePopup/GlobalSettingsView.test.ts
+++ b/src/renderer/src/comfyTitlePopup/GlobalSettingsView.test.ts
@@ -73,6 +73,17 @@ function makeSnapshot(overrides: Partial<Record<string, unknown>> = {}) {
     cacheFields: [],
     advancedFields: [],
     sharedDirectoriesFields: [],
+    installLocationFields: [
+      {
+        id: 'installDir',
+        label: 'Install Location',
+        value: '/home/u/ComfyUI-Installs',
+        editable: true,
+        editType: 'path',
+        openable: true,
+        browseOnly: true,
+      },
+    ],
     modelsDirs: [
       { path: '/home/u/ComfyUI/models', isPrimary: true, isDefault: true },
       { path: '/mnt/extra/models', isPrimary: false, isDefault: false },
@@ -181,6 +192,16 @@ describe('GlobalSettingsView', () => {
     await toggle.trigger('click')
     await flushPromises()
     expect(bridge.updateFieldCalls).toEqual([{ id: 'sharedOutputDir', value: true }])
+  })
+
+  it('Storage tab renders the global Install Location section', async () => {
+    installMockBridge()
+    const wrapper = mountView()
+    await wrapper.findAll('.gs-tab').find((t) => t.text() === 'Storage')!.trigger('click')
+    await nextTick()
+    expect(wrapper.text()).toContain('Install Location')
+    const inputValues = wrapper.findAll('input').map((i) => (i.element as HTMLInputElement).value)
+    expect(inputValues).toContain('/home/u/ComfyUI-Installs')
   })
 
   it('close button routes to bridge.close', async () => {

--- a/src/renderer/src/comfyTitlePopup/GlobalSettingsView.test.ts
+++ b/src/renderer/src/comfyTitlePopup/GlobalSettingsView.test.ts
@@ -194,14 +194,22 @@ describe('GlobalSettingsView', () => {
     expect(bridge.updateFieldCalls).toEqual([{ id: 'sharedOutputDir', value: true }])
   })
 
-  it('Storage tab renders the global Install Location section', async () => {
+  it('Advanced tab renders the global Default Install Location section', async () => {
+    installMockBridge()
+    const wrapper = mountView()
+    await wrapper.findAll('.gs-tab').find((t) => t.text() === 'Advanced')!.trigger('click')
+    await nextTick()
+    expect(wrapper.text()).toContain('Default Install Location')
+    const inputValues = wrapper.findAll('input').map((i) => (i.element as HTMLInputElement).value)
+    expect(inputValues).toContain('/home/u/ComfyUI-Installs')
+  })
+
+  it('does not render the Install Location section in the Storage tab', async () => {
     installMockBridge()
     const wrapper = mountView()
     await wrapper.findAll('.gs-tab').find((t) => t.text() === 'Storage')!.trigger('click')
     await nextTick()
-    expect(wrapper.text()).toContain('Install Location')
-    const inputValues = wrapper.findAll('input').map((i) => (i.element as HTMLInputElement).value)
-    expect(inputValues).toContain('/home/u/ComfyUI-Installs')
+    expect(wrapper.text()).not.toContain('Install Location')
   })
 
   it('close button routes to bridge.close', async () => {

--- a/src/renderer/src/comfyTitlePopup/GlobalSettingsView.vue
+++ b/src/renderer/src/comfyTitlePopup/GlobalSettingsView.vue
@@ -36,6 +36,7 @@ interface Snapshot {
   cacheFields: Record<string, unknown>[]
   advancedFields: Record<string, unknown>[]
   sharedDirectoriesFields: Record<string, unknown>[]
+  installLocationFields: Record<string, unknown>[]
   modelsDirs: ModelsDir[]
   modelsSystemDefault: string
   appUpdate: {
@@ -94,6 +95,7 @@ const tabs = computed(() => [
 
 const storageSnapshot = computed(() => ({
   sharedDirectoriesFields: props.snapshot.sharedDirectoriesFields,
+  installLocationFields: props.snapshot.installLocationFields,
   modelsDirs: props.snapshot.modelsDirs,
   modelsSystemDefault: props.snapshot.modelsSystemDefault,
 }))

--- a/src/renderer/src/comfyTitlePopup/GlobalSettingsView.vue
+++ b/src/renderer/src/comfyTitlePopup/GlobalSettingsView.vue
@@ -95,7 +95,6 @@ const tabs = computed(() => [
 
 const storageSnapshot = computed(() => ({
   sharedDirectoriesFields: props.snapshot.sharedDirectoriesFields,
-  installLocationFields: props.snapshot.installLocationFields,
   modelsDirs: props.snapshot.modelsDirs,
   modelsSystemDefault: props.snapshot.modelsSystemDefault,
 }))
@@ -114,6 +113,9 @@ const cacheSections = computed<DetailSection[]>(() => [
 ])
 const advancedSections = computed<DetailSection[]>(() => [
   { fields: props.snapshot.advancedFields as unknown as DetailField[] }
+])
+const installLocationSections = computed<DetailSection[]>(() => [
+  { fields: props.snapshot.installLocationFields as unknown as DetailField[] }
 ])
 const appUpdateState = computed<AppUpdateState>(
   () => props.snapshot.appUpdate.state as unknown as AppUpdateState
@@ -270,6 +272,16 @@ onMounted(() => {
         </template>
 
         <template v-else>
+          <GlobalSettingsMicroSection
+            :title="t('settings.installLocation', 'Default Install Location')"
+            :tooltip="t('tooltips.installDir')"
+          >
+            <SettingsSectionList
+              :sections="installLocationSections"
+              @update-field="handleUpdateField"
+            />
+          </GlobalSettingsMicroSection>
+
           <GlobalSettingsMicroSection :title="snapshot.i18n.advanced">
             <SettingsSectionList :sections="advancedSections" @update-field="handleUpdateField" />
           </GlobalSettingsMicroSection>

--- a/src/renderer/src/comfyTitlePopup/TitlePopupApp.vue
+++ b/src/renderer/src/comfyTitlePopup/TitlePopupApp.vue
@@ -98,6 +98,7 @@ interface GlobalSettingsSnapshot {
   cacheFields: Record<string, unknown>[]
   advancedFields: Record<string, unknown>[]
   sharedDirectoriesFields: Record<string, unknown>[]
+  installLocationFields: Record<string, unknown>[]
   modelsDirs: GlobalSettingsModelsDir[]
   modelsSystemDefault: string
   appUpdate: {
@@ -189,6 +190,7 @@ const globalSettingsSnapshot = ref<GlobalSettingsSnapshot>({
   cacheFields: [],
   advancedFields: [],
   sharedDirectoriesFields: [],
+  installLocationFields: [],
   modelsDirs: [],
   modelsSystemDefault: '',
   appUpdate: {

--- a/src/renderer/src/comfyTitlePopup/globalSettings/GlobalStorageSections.vue
+++ b/src/renderer/src/comfyTitlePopup/globalSettings/GlobalStorageSections.vue
@@ -19,8 +19,6 @@ interface ModelsDir {
 
 export interface GlobalStorageSnapshot {
   sharedDirectoriesFields: Record<string, unknown>[]
-  /** Default suggested install location — global-only (not shown per-instance). */
-  installLocationFields: Record<string, unknown>[]
   modelsDirs: ModelsDir[]
   modelsSystemDefault: string
 }
@@ -63,10 +61,6 @@ const bridge = (window as unknown as { __comfyTitlePopup?: GlobalSettingsBridge 
 
 const sharedDirsSections = computed<DetailSection[]>(() => [
   { fields: props.snapshot.sharedDirectoriesFields as unknown as DetailField[] },
-])
-
-const installLocationSections = computed<DetailSection[]>(() => [
-  { fields: props.snapshot.installLocationFields as unknown as DetailField[] },
 ])
 
 async function handleAddModelsDir(): Promise<void> {
@@ -117,20 +111,6 @@ async function handleUpdateSharedDirField(field: DetailField, value: unknown): P
 </script>
 
 <template>
-  <GlobalSettingsMicroSection
-    :title="t('settings.installLocation', 'Install Location')"
-    :tooltip="t('tooltips.installDir')"
-  >
-    <SettingsSectionList
-      :sections="installLocationSections"
-      :installation-id="installationId"
-      :running-action-ids="runningActionIds"
-      :pending-restart-field-ids="pendingRestartFieldIds"
-      :field-error-messages="fieldErrorMessages"
-      @update-field="handleUpdateSharedDirField"
-    />
-  </GlobalSettingsMicroSection>
-
   <GlobalSettingsMicroSection
     :title="t('settings.models', 'Shared Models')"
     :tooltip="t('tooltips.sharedModels')"

--- a/src/renderer/src/comfyTitlePopup/globalSettings/GlobalStorageSections.vue
+++ b/src/renderer/src/comfyTitlePopup/globalSettings/GlobalStorageSections.vue
@@ -19,6 +19,8 @@ interface ModelsDir {
 
 export interface GlobalStorageSnapshot {
   sharedDirectoriesFields: Record<string, unknown>[]
+  /** Default suggested install location — global-only (not shown per-instance). */
+  installLocationFields: Record<string, unknown>[]
   modelsDirs: ModelsDir[]
   modelsSystemDefault: string
 }
@@ -61,6 +63,10 @@ const bridge = (window as unknown as { __comfyTitlePopup?: GlobalSettingsBridge 
 
 const sharedDirsSections = computed<DetailSection[]>(() => [
   { fields: props.snapshot.sharedDirectoriesFields as unknown as DetailField[] },
+])
+
+const installLocationSections = computed<DetailSection[]>(() => [
+  { fields: props.snapshot.installLocationFields as unknown as DetailField[] },
 ])
 
 async function handleAddModelsDir(): Promise<void> {
@@ -111,6 +117,20 @@ async function handleUpdateSharedDirField(field: DetailField, value: unknown): P
 </script>
 
 <template>
+  <GlobalSettingsMicroSection
+    :title="t('settings.installLocation', 'Install Location')"
+    :tooltip="t('tooltips.installDir')"
+  >
+    <SettingsSectionList
+      :sections="installLocationSections"
+      :installation-id="installationId"
+      :running-action-ids="runningActionIds"
+      :pending-restart-field-ids="pendingRestartFieldIds"
+      :field-error-messages="fieldErrorMessages"
+      @update-field="handleUpdateSharedDirField"
+    />
+  </GlobalSettingsMicroSection>
+
   <GlobalSettingsMicroSection
     :title="t('settings.models', 'Shared Models')"
     :tooltip="t('tooltips.sharedModels')"

--- a/src/renderer/src/lib/i18nMessages.ts
+++ b/src/renderer/src/lib/i18nMessages.ts
@@ -21,6 +21,7 @@ export const en = {
     platform: 'Platform',
     storageTab: 'Storage',
     sharedDirectories: 'Shared Directories',
+    installLocation: 'Install Location',
     models: 'Shared Models',
     updatesTab: 'Updates',
     checkForUpdates: 'Check for updates',
@@ -56,7 +57,9 @@ export const en = {
     modelsPrimary:
       'The primary directory is where ComfyUI saves newly downloaded models by default.',
     modelsDefault:
-      'The system default directory. This path is created automatically and cannot be removed.'
+      'The system default directory. This path is created automatically and cannot be removed.',
+    installDir:
+      "Default parent folder suggested when creating new installations. Existing installs aren't moved."
   },
   installType: {
     standalone: 'Standalone',

--- a/src/renderer/src/lib/i18nMessages.ts
+++ b/src/renderer/src/lib/i18nMessages.ts
@@ -21,7 +21,7 @@ export const en = {
     platform: 'Platform',
     storageTab: 'Storage',
     sharedDirectories: 'Shared Directories',
-    installLocation: 'Install Location',
+    installLocation: 'Default Install Location',
     models: 'Shared Models',
     updatesTab: 'Updates',
     checkForUpdates: 'Check for updates',

--- a/src/renderer/src/views/comfyUISettings/PathField.vue
+++ b/src/renderer/src/views/comfyUISettings/PathField.vue
@@ -39,7 +39,7 @@ function handleChange(value: string): void {
   <BaseInput
     :model-value="stringValue"
     :readonly="isBrowseOnly"
-    :aria-label="field.label"
+    :aria-label="field.label || undefined"
     @change="handleChange"
   >
     <template #trailing>

--- a/src/renderer/src/views/comfyUISettings/SettingsSectionList.vue
+++ b/src/renderer/src/views/comfyUISettings/SettingsSectionList.vue
@@ -242,7 +242,7 @@ function fieldOwnsLabel(field: DetailField): boolean {
         </div>
 
         <template v-else>
-          <label v-if="!fieldOwnsLabel(field)" class="settings-v2-field-label">
+          <label v-if="!fieldOwnsLabel(field) && field.label" class="settings-v2-field-label">
             <span class="settings-v2-field-label-text">{{ field.label }}</span>
             <InfoTooltip v-if="field.tooltip" :text="field.tooltip" />
             <span v-if="needsRestartTag(field)" class="settings-v2-restart-tag" role="status">

--- a/src/renderer/src/views/comfyUISettings/StoragePane.test.ts
+++ b/src/renderer/src/views/comfyUISettings/StoragePane.test.ts
@@ -83,6 +83,15 @@ describe('StoragePane', () => {
     expect(rows[1]!.find('.tag-primary').exists()).toBe(false)
   })
 
+  // The global default install location is intentionally NOT shown in the
+  // per-instance Storage tab — it only belongs in Global Desktop Settings.
+  it('does not render the global Install Location section', async () => {
+    installMockBridge()
+    const wrapper = mountPane()
+    await nextTick()
+    expect(wrapper.text()).not.toContain('Install Location')
+  })
+
   it('writes reordered dirs through the bridge when make-primary is invoked', async () => {
     const bridge = installMockBridge()
     const wrapper = mountPane()


### PR DESCRIPTION
## Summary

Closes #887.

Adds an `installDir` Global Desktop Setting that controls the **suggested default install location** for new installations. Previously this was hardcoded to `~/ComfyUI-Installs`.

The configured value is honored by **every** new-install code path — install wizards, first-use chain, quick install, desktop adoption, standalone migration, and snapshot restore — because they all route through `paths.defaultInstallDir()`, which now resolves the setting (falling back to the built-in default).

## UX

The field is exposed in **Global Settings → Storage** as a new `Install Location` section. It is intentionally **not** shown in the per-instance Storage tab (it is a global default, not a per-install path), achieved by carrying it on a dedicated global-only snapshot field (`installLocationFields`) rather than the shared media sections that both surfaces render.

## Implementation notes

- `installDir` added to the settings schema as a defaulted, non-nullable key (default `~/ComfyUI-Installs`), including the Win32 foreign-default sanitization the other path settings use.
- `paths.ts` obtains the configured value via an **injected resolver** (`setInstallDirResolver`) that `settings.ts` registers. A direct import would create a `settings → models → paths` init cycle (re-entering `paths` before its top-level consts initialize), and a runtime `require` breaks once the main process is bundled into a single file. The injection avoids both and was verified in the built `out/main/index.js`.
- i18n strings added to `locales/en.json`, `locales/zh.json`, and the hand-maintained popup catalog `i18nMessages.ts`.

## Tests

- `settings.test.ts`: default value + override persistence/unset for `installDir`.
- `GlobalSettingsView.test.ts`: Install Location section renders in the global Storage tab.
- `StoragePane.test.ts`: regression guard that it is **not** rendered per-instance.

## Validation

`pnpm run typecheck`, `lint`, `test` (1800 passing), and `build` all pass.