### PR TITLE
fix(picker): switch to op's progress tab when tabs lock

### DIFF
--- a/src/renderer/src/components/settings/ComfyUISettingsContent.test.ts
+++ b/src/renderer/src/components/settings/ComfyUISettingsContent.test.ts
@@ -231,7 +231,7 @@ describe('ComfyUISettingsContent', () => {
       expect(w.find('.op-overlay').exists()).toBe(false)
     })
 
-    it('renders the overlay for snapshot-restore on a NON-snapshots tab', async () => {
+    it('auto-switches to the snapshots tab when a snapshot-restore op starts on another tab', async () => {
       const w = await mountContent({
         initialTab: 'update',
         activeOperation: {
@@ -241,8 +241,47 @@ describe('ComfyUISettingsContent', () => {
           percent: 30, status: 'Loading snapshot…', cancellable: true, title: '',
         },
       })
+      // Routed to the snapshots tab so its dedicated rail shows progress;
+      // the generic overlay must stay hidden to avoid double progress UI.
+      expect(w.find('[data-testid="snapshots-view-stub"]').exists()).toBe(true)
+      expect(w.find('.op-overlay').exists()).toBe(false)
+    })
+
+    it('auto-switches to the Update tab when a non-snapshot op starts on the snapshots tab', async () => {
+      const w = await mountContent({
+        initialTab: 'snapshots',
+        activeOperation: {
+          actionId: 'copy', actionData: {},
+          done: false, ok: null, error: null,
+          percent: 30, status: '', cancellable: true, title: '',
+        },
+      })
+      // The snapshots pane can't render a non-snapshot op's progress, so the
+      // host moves to the Update tab where the overlay is shown.
+      expect(w.find('[data-testid="snapshots-view-stub"]').exists()).toBe(false)
       expect(w.find('.op-overlay').exists()).toBe(true)
-      expect(w.find('.op-title').text()).toBe('Restoring snapshot…')
+      expect(w.find('.op-title').text()).toBe('Copying…')
+    })
+
+    it('switches to the op home tab when selecting an already-operating install', async () => {
+      // Viewing an idle install on the snapshots tab...
+      const w = await mountContent({ initialTab: 'snapshots', activeOperation: null })
+      expect(w.find('[data-testid="snapshots-view-stub"]').exists()).toBe(true)
+
+      // ...then selecting a different install that already has an in-flight op
+      // (e.g. one updating from another window's shelf) routes to its progress.
+      await w.setProps({
+        installation: { ...SAMPLE_INSTALL, id: 'inst-2' },
+        activeOperation: {
+          actionId: 'release-update', actionData: {},
+          done: false, ok: null, error: null,
+          percent: 30, status: '', cancellable: true, title: '',
+        },
+      })
+      await flushPromises()
+      expect(w.find('[data-testid="snapshots-view-stub"]').exists()).toBe(false)
+      expect(w.find('.op-overlay').exists()).toBe(true)
+      expect(w.find('.op-title').text()).toBe('Updating…')
     })
 
     it('renders the overlay on the Update tab when a copy op is in flight', async () => {
@@ -265,7 +304,8 @@ describe('ComfyUISettingsContent', () => {
       ['copy-update',           { actionData: {} }, 'Copying & updating…', 'Copy complete'],
       ['delete',                { actionData: {} }, 'Deleting…',          'Deleted'],
       ['release-update',        { actionData: {} }, 'Updating…',          'Update complete'],
-      ['snapshot-restore',      { actionData: {} }, 'Restoring snapshot…', 'Snapshot restored'],
+      // snapshot-restore is intentionally absent: it renders in the snapshots
+      // tab's dedicated rail, not the generic overlay (see "overlay routing").
       ['migrate-to-standalone', { actionData: {} }, 'Migrating…',         'Migration complete'],
     ])('actionId=%s → in-flight %s / success %s', async (actionId, extras, inflight, success) => {
       const wIn = await mountContent({

--- a/src/renderer/src/components/settings/ComfyUISettingsContent.vue
+++ b/src/renderer/src/components/settings/ComfyUISettingsContent.vue
@@ -501,13 +501,14 @@ const showOpOverlay = computed(() => {
 
 const opBlocksFooter = computed(() => opInflight.value)
 
-// The tab that renders progress for the active op. Snapshot ops have
-// their own timeline rail in SnapshotsView; everything else surfaces in
-// the Update tab's inline overlay.
+// The tab that renders progress for the active op. Only snapshot-restore
+// has its own rail in SnapshotsView (matching `showOpOverlay`); every
+// other op — including snapshot-save/delete — surfaces in the Update
+// tab's inline overlay.
 const opHomeTab = computed<ComfyUISettingsTab | null>(() => {
   const op = props.activeOperation
   if (!op) return null
-  return op.actionId.startsWith('snapshot-') ? 'snapshots' : 'update'
+  return op.actionId === 'snapshot-restore' ? 'snapshots' : 'update'
 })
 
 // Locking the other tabs during an op is meant to force the user onto
@@ -520,7 +521,7 @@ watch(
   [
     () => opInflight.value,
     () => props.installation?.id ?? null,
-    () => tabs.value.length
+    () => tabs.value.map((tab) => tab.key).join(',')
   ],
   () => {
     if (!opInflight.value) return

--- a/src/renderer/src/components/settings/ComfyUISettingsContent.vue
+++ b/src/renderer/src/components/settings/ComfyUISettingsContent.vue
@@ -501,6 +501,37 @@ const showOpOverlay = computed(() => {
 
 const opBlocksFooter = computed(() => opInflight.value)
 
+// The tab that renders progress for the active op. Snapshot ops have
+// their own timeline rail in SnapshotsView; everything else surfaces in
+// the Update tab's inline overlay.
+const opHomeTab = computed<ComfyUISettingsTab | null>(() => {
+  const op = props.activeOperation
+  if (!op) return null
+  return op.actionId.startsWith('snapshot-') ? 'snapshots' : 'update'
+})
+
+// Locking the other tabs during an op is meant to force the user onto
+// the progress view, but the lock alone doesn't move them there. Switch
+// to the op's home tab whenever the selected install has an in-flight op
+// so progress is always visible. Covers op-start, mount, async tab load,
+// and selecting an already-operating install (e.g. from another window's
+// shelf). Sets `activeTab` directly because `selectTab` is locked mid-op.
+watch(
+  [
+    () => opInflight.value,
+    () => props.installation?.id ?? null,
+    () => tabs.value.length
+  ],
+  () => {
+    if (!opInflight.value) return
+    const home = opHomeTab.value
+    if (!home || activeTab.value === home) return
+    if (!tabs.value.some((tab) => tab.key === home)) return
+    activeTab.value = home
+  },
+  { immediate: true }
+)
+
 const successCountdown = ref(0)
 let countdownTimer: ReturnType<typeof setInterval> | null = null
 


### PR DESCRIPTION
## Problem

Fixes #889.

Active operations in the instance-picker shelf correctly lock the other tabs (to signal "you can't interact, watch progress"), **but nothing actually moves the user to the tab that shows progress**. Example: while on the **Snapshots** tab, clicking *Update* on the central ComfyUI pill locks the tabs — yet you stay on Snapshots, whose pane renders no progress for an update op. The lock's whole purpose (force you to view progress) is defeated.

### Root cause

In `ComfyUISettingsContent.vue` two pieces of logic never coordinated:

- **Tab locking** is driven by `opInflight` — disables every tab except the *currently active* one.
- **Progress display** only renders in the `update`/`config` pane (inline overlay) or, for `snapshot-restore`, in the Snapshots tab's dedicated rail. The `snapshots`/`status`/`storage` panes show no overlay.

Nothing switched `activeTab` when an op began, so a non-snapshot op started from any of those tabs locked the UI with zero visible progress.

## Fix

When the selected install has an in-flight op, switch `activeTab` to the op's **home tab**:

- snapshot ops (`snapshot-*`) → **Snapshots** tab (its dedicated rail)
- everything else → **Update** tab (inline overlay)

The watcher covers op-start, mount, async tab load, and **selecting an already-operating install** (e.g. from another window's shelf — operation state is global main-process state broadcast to all picker popups). It sets `activeTab` directly because `selectTab` is locked mid-op, and only switches to a tab that's actually present.

Scope is per-selected-install: other instance cards remain fully interactable.

## Tests

- Updated the two `overlay routing` / per-action-label tests that encoded the old "snapshot-restore shows the generic overlay on a non-snapshots tab" behavior.
- Added coverage: non-snapshot op on Snapshots → switches to Update + overlay; snapshot op on another tab → switches to Snapshots rail; selecting an already-operating install → switches to its progress tab.

`pnpm run typecheck && pnpm run lint && pnpm run build && pnpm run test` all green (1798 tests pass).
