### PR TITLE
feat: rename to Comfy Desktop via todesktop.json productName (fixes macOS auto-update)

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -111,7 +111,7 @@ jobs:
         run: pnpm run datadog:sourcemaps:upload
 
       - name: Install ToDesktop CLI
-        run: npm install --location=global @todesktop/cli@1.22.0
+        run: npm install --location=global @todesktop/cli@1.25.2
 
       - name: Pre-fetch bootstrap-python for all platforms
         # @todesktop/cli now eagerly validates the `extraResources` paths in

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "comfyui-desktop-2",
-  "version": "1.0.3",
+  "productName": "ComfyUI",
+  "version": "1.0.4-rc.1",
   "description": "Comfy Desktop",
   "author": {
     "name": "Comfy Org",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "comfyui-desktop-2",
+  "name": "@comfyorg/comfyui-electron",
   "productName": "ComfyUI",
-  "version": "1.0.4-rc.1",
+  "version": "1.0.4-rc.2",
   "description": "Comfy Desktop",
   "author": {
     "name": "Comfy Org",

--- a/todesktop.json
+++ b/todesktop.json
@@ -9,12 +9,12 @@
     "!bootstrap-python/**"
   ],
   "appId": "com.todesktop.241012ess7yxs0e",
+  "productName": "Comfy Desktop",
   "icon": "./assets/Comfy_Logo_x512.png",
   "packageManager": "pnpm",
   "pnpmVersion": "10.28.1",
   "packageJson": {
     "extends": "package.json",
-    "productName": "Comfy Desktop",
     "devDependencies": {
       "electron": "40.4.1",
       "electron-builder": null


### PR DESCRIPTION
Fixes the macOS in-place auto-update failure caused by the bundle rename, using ToDesktop's new top-level `productName` support (per Dave / ToDesktop).

## The fix
The previous rename set the macOS bundle name to `Comfy Desktop`, which broke Squirrel.Mac's in-place update for App 1 (`com.todesktop.241012ess7yxs0e`, installed as `ComfyUI.app`). Windows was unaffected. ToDesktop shipped first-class rename support: keep the **identity** stable in `package.json`, set the **display name** in `todesktop.json`.

| File | Change |
|------|--------|
| `package.json` | add `productName: "ComfyUI"` — runtime app identity / data path / auto-update identity, matching App 1 |
| `todesktop.json` | add top-level `productName: "Comfy Desktop"`; remove nested `packageJson.productName` override |
| `build-release.yml` | `@todesktop/cli` `1.22.0` → `1.25.2` (required for the rename feature) |

Docs: https://www.npmjs.com/package/@todesktop/cli#productname---optional-string

## ⚠️ Data-path implication (needs Jedrzej's eyes)
Adding `productName: "ComfyUI"` changes `app.getName()`, which moves the Electron userData dir:
- macOS: `~/Library/Application Support/Comfy Desktop` → `.../ComfyUI`
- Windows: `%APPDATA%\Comfy Desktop` → `...\ComfyUI`

For **App 1 (0.9.x) users** this is the goal — the migrated build inherits their existing `ComfyUI` data dir. For users **already on a 1.0.x build** (data under `Comfy Desktop`), this needs migration handling. Note `src/main/lib/paths.ts` hardcodes `APP_NAME = "comfyui-desktop-2"` for Linux XDG paths only; Mac/Win follow `app.getName()`. Worth confirming the migration path before stable release.

## Testing
Version `1.0.4-rc.1` cut as a prerelease test build (ephemeral, not on the auto-update channel). Verify on a real Mac that the in-place update from App 1 applies, the bundle shows as `Comfy Desktop`, and data carries over.

Not for merge until the rc test passes (and bump to stable `1.0.4` before merge).