### PR TITLE
chore(release): v1.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-desktop-2",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Comfy Desktop",
   "author": {
     "name": "Comfy Org",


### PR DESCRIPTION
Release 1.0.4 off current main. Bundles the two fixes that landed after v1.0.3:
- #893 fix(installer): Finish-page 'Add a desktop shortcut' as an explicit nsDialogs checkbox
- #894 fix(install): make 'Latest on GitHub' actually pull master HEAD post-install

No productName/rename change (that's parked in #897). `v1.0.4` tag pushed to trigger the ToDesktop build.

Note: build was triggered by the manual tag, so merge this **without** the Release label to avoid a duplicate tag.