### PR TITLE
feat: interactive Console in install Settings (supports_terminal)

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -19,6 +19,7 @@ extraResources:
     to: lib
 asarUnpack:
   - node_modules/7zip-bin/**/*
+  - node_modules/node-pty/**/*
 afterPack: ./scripts/afterPack.mjs
 publish:
   provider: github

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -17,6 +17,11 @@ export default defineConfig({
   main: {
     build: {
       sourcemap: 'hidden',
+      rollupOptions: {
+        // node-pty is a native addon; it must stay external (its .node binary
+        // can't be bundled) and is loaded from the unpacked node_modules.
+        external: ['node-pty'],
+      },
     },
   },
   preload: {

--- a/locales/en.json
+++ b/locales/en.json
@@ -72,6 +72,7 @@
     "tabUpdate": "Update",
     "tabSnapshots": "Snapshots",
     "tabStorage": "Storage",
+    "tabConsole": "Console",
     "relaunch": "Relaunch",
     "more": "More",
     "diskUsage": "Disk Usage",
@@ -362,7 +363,9 @@
     "disconnect": "Disconnect",
     "connectedTo": "Connected to {url}",
     "processExited": "Process exited",
-    "processCrashed": "Process crashed (exit code {code})"
+    "processCrashed": "Process crashed (exit code {code})",
+    "sessionEnded": "This console session ended. Restart it to keep using the shell.",
+    "restartSession": "Restart console"
   },
 
   "settingsModal": {
@@ -1032,6 +1035,7 @@
   "tooltips": {
     "instances": "A separate ComfyUI installation with its own version, models, and settings.",
     "snapshots": "A saved point-in-time state of an installation (versions + custom nodes) you can restore later.",
+    "console": "An interactive shell running in this installation's folder. Works whether ComfyUI is running or stopped.",
     "standalone": "A self-contained install with its own bundled Python and dependencies. Easy to update and manage.",
     "portable": "The official portable Windows build with embedded Python. Runs from a single folder without a system-wide install.",
     "git": "A git-based install cloned from the ComfyUI repository. Requires git and Python to be installed on your system.",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,8 @@
     "7zip-bin": "^5.2.0",
     "@datadog/browser-rum": "6.28.1",
     "@todesktop/runtime": "^2.1.3",
+    "@xterm/addon-fit": "^0.10.0",
+    "@xterm/xterm": "^5.5.0",
     "electron-updater": "^6.7.3",
     "node-pty": "^1.1.0",
     "posthog-node": "^5.30.7",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@datadog/browser-rum": "6.28.1",
     "@todesktop/runtime": "^2.1.3",
     "electron-updater": "^6.7.3",
+    "node-pty": "^1.1.0",
     "posthog-node": "^5.30.7",
     "smol-toml": "^1.6.1",
     "systeminformation": "^5.31.5",
@@ -104,7 +105,8 @@
     "onlyBuiltDependencies": [
       "electron",
       "electron-winstaller",
-      "esbuild"
+      "esbuild",
+      "node-pty"
     ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,12 @@ importers:
       '@todesktop/runtime':
         specifier: ^2.1.3
         version: 2.1.3
+      '@xterm/addon-fit':
+        specifier: ^0.10.0
+        version: 0.10.0(@xterm/xterm@5.5.0)
+      '@xterm/xterm':
+        specifier: ^5.5.0
+        version: 5.5.0
       electron-updater:
         specifier: ^6.7.3
         version: 6.8.3
@@ -1322,6 +1328,14 @@ packages:
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
+
+  '@xterm/addon-fit@0.10.0':
+    resolution: {integrity: sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==}
+    peerDependencies:
+      '@xterm/xterm': ^5.0.0
+
+  '@xterm/xterm@5.5.0':
+    resolution: {integrity: sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==}
 
   abbrev@2.0.0:
     resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
@@ -4766,6 +4780,12 @@ snapshots:
       vue: 3.5.29(typescript@5.9.3)
 
   '@xmldom/xmldom@0.8.11': {}
+
+  '@xterm/addon-fit@0.10.0(@xterm/xterm@5.5.0)':
+    dependencies:
+      '@xterm/xterm': 5.5.0
+
+  '@xterm/xterm@5.5.0': {}
 
   abbrev@2.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       electron-updater:
         specifier: ^6.7.3
         version: 6.8.3
+      node-pty:
+        specifier: ^1.1.0
+        version: 1.1.0
       posthog-node:
         specifier: ^5.30.7
         version: 5.30.7(rxjs@7.8.2)
@@ -2713,6 +2716,9 @@ packages:
   node-addon-api@1.7.2:
     resolution: {integrity: sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==}
 
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
   node-api-version@0.2.1:
     resolution: {integrity: sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==}
 
@@ -2720,6 +2726,9 @@ packages:
     resolution: {integrity: sha512-ra7Kvlhxn5V9Slyus0ygMa2h+UqExPqUIkfk7Pc8QTLT956JLSy51uWFwHtIYy0vI8cB4BDhc/S03+880My/LQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
     hasBin: true
+
+  node-pty@1.1.0:
+    resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
@@ -6295,6 +6304,8 @@ snapshots:
   node-addon-api@1.7.2:
     optional: true
 
+  node-addon-api@7.1.1: {}
+
   node-api-version@0.2.1:
     dependencies:
       semver: 7.7.4
@@ -6313,6 +6324,10 @@ snapshots:
       which: 5.0.0
     transitivePeerDependencies:
       - supports-color
+
+  node-pty@1.1.0:
+    dependencies:
+      node-addon-api: 7.1.1
 
   node-releases@2.0.27: {}
 

--- a/src/main/host/attach.ts
+++ b/src/main/host/attach.ts
@@ -2,6 +2,8 @@ import * as ipc from '../lib/ipc'
 import { getAppVersion } from '../lib/ipc'
 import { attachSessionDownloadHandler } from '../lib/comfyDownloadManager'
 import { getModelDownloadContentScript } from '../lib/comfyContentScript'
+import { getComfyTerminalContentScript } from '../lib/comfyTerminalContentScript'
+import { isCachedFeatureFlagAvailable } from '../lib/comfy-feature-flags'
 import { _operationAborts, sourceMap } from '../lib/ipc/shared'
 import { TITLEBAR_BG } from '../lib/theme'
 import * as mainTelemetry from '../lib/telemetry'
@@ -377,6 +379,18 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
     comfyContents.executeJavaScript(COMFY_THEME_OBSERVER_JS).catch(() => {})
     const preamble = isLocal ? '' : 'window.__comfyDesktop2Remote = true;\n'
     comfyContents.executeJavaScript(preamble + getModelDownloadContentScript()).catch(() => {})
+    // Stopgap: inject a fallback bottom-panel Terminal tab for standalone
+    // installs whose ComfyUI doesn't advertise `supports_terminal`, the exact
+    // case where the real flag-gated frontend tab can't appear. The transport
+    // (__comfyDesktop2.Terminal) exists regardless of the flag. Remove once the
+    // official tab ships in a stable release.
+    if (
+      isLocal &&
+      installation.sourceId === 'standalone' &&
+      !isCachedFeatureFlagAvailable(installationId, 'supports_terminal')
+    ) {
+      comfyContents.executeJavaScript(getComfyTerminalContentScript()).catch(() => {})
+    }
     // Cloud-only patches (popup-blocked toast suppression + post-signin
     // flicker hide). Skipped for local installs — they don't load cloud
     // frontend, never see the toast or the redirect flash.

--- a/src/main/host/registry.ts
+++ b/src/main/host/registry.ts
@@ -271,6 +271,16 @@ export function findEntryByTitleBarSender(wc: WebContents): { id: number; entry:
   return null
 }
 
+/** Resolve the installationId backing the comfyView whose webContents sent an
+ *  IPC message. Used by the terminal bridge so the served ComfyUI frontend
+ *  (which has no idea which install it belongs to) reaches the right shell. */
+export function findInstallationIdByComfySender(wc: WebContents): string | null {
+  for (const entry of comfyWindows.values()) {
+    if (entry.comfyView.webContents === wc) return entry.installationId
+  }
+  return null
+}
+
 /** Resolve a host BrowserWindow back to its registry entry. */
 export function findEntryByHostWindow(window: BrowserWindow): ComfyWindowEntry | null {
   for (const entry of comfyWindows.values()) {

--- a/src/main/lib/comfy-feature-flags.test.ts
+++ b/src/main/lib/comfy-feature-flags.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect } from 'vitest'
-import { parseFeatureFlagOutput } from './comfy-feature-flags'
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  parseFeatureFlagOutput,
+  getCachedFeatureFlagRegistry,
+  isCachedFeatureFlagAvailable,
+  clearFeatureFlagRegistryCache,
+  getComfyFeatureFlagRegistry,
+} from './comfy-feature-flags'
 
 describe('parseFeatureFlagOutput', () => {
   it('parses valid JSON output', () => {
@@ -45,5 +51,41 @@ describe('parseFeatureFlagOutput', () => {
     const reg = parseFeatureFlagOutput(stdout)
     expect(Object.keys(reg)).toEqual(['flag_a', 'flag_b'])
     expect(reg['flag_b']?.default).toBe(10)
+  })
+})
+
+describe('feature-flag registry cache accessors', () => {
+  const installationId = 'cache-test-install'
+  // A path that can't be executed, so discovery fails and caches {} —
+  // exercising the spawn-free accessors without needing a real Python.
+  const badPython = '/nonexistent/python-binary'
+
+  beforeEach(() => {
+    clearFeatureFlagRegistryCache(installationId)
+  })
+
+  it('returns null before any discovery has run', () => {
+    expect(getCachedFeatureFlagRegistry(installationId)).toBeNull()
+    expect(isCachedFeatureFlagAvailable(installationId, 'supports_terminal')).toBe(false)
+  })
+
+  it('caches an empty registry after a failed discovery and reports flags absent', async () => {
+    await getComfyFeatureFlagRegistry(badPython, 'main.py', process.cwd(), installationId, '1.0.0')
+    expect(getCachedFeatureFlagRegistry(installationId)).toEqual({})
+    expect(isCachedFeatureFlagAvailable(installationId, 'supports_terminal')).toBe(false)
+  })
+
+  it('matches a cached version and rejects a mismatched one', async () => {
+    await getComfyFeatureFlagRegistry(badPython, 'main.py', process.cwd(), installationId, '1.0.0')
+    expect(getCachedFeatureFlagRegistry(installationId, '1.0.0')).toEqual({})
+    expect(getCachedFeatureFlagRegistry(installationId, '2.0.0')).toBeNull()
+    // A version-less query always hits the cache.
+    expect(getCachedFeatureFlagRegistry(installationId)).toEqual({})
+  })
+
+  it('clears the cache back to a miss', async () => {
+    await getComfyFeatureFlagRegistry(badPython, 'main.py', process.cwd(), installationId, '1.0.0')
+    clearFeatureFlagRegistryCache(installationId)
+    expect(getCachedFeatureFlagRegistry(installationId)).toBeNull()
   })
 })

--- a/src/main/lib/comfy-feature-flags.ts
+++ b/src/main/lib/comfy-feature-flags.ts
@@ -57,10 +57,36 @@ export async function getComfyFeatureFlagRegistry(
     console.warn('[comfy-feature-flags] Could not get registry:', (err as Error).message)
   }
 
-  if (version) {
-    registryCache.set(installationId, { registry, version })
-  }
+  registryCache.set(installationId, { registry, version: version ?? '' })
   return registry
+}
+
+/**
+ * Read the cached registry without ever spawning Python. Returns `null` when
+ * nothing is cached for the install (e.g. discovery hasn't run, or failed).
+ * A blank cached version matches any requested version so launches that lacked
+ * a version string still hit.
+ */
+export function getCachedFeatureFlagRegistry(
+  installationId: string,
+  version?: string,
+): FeatureFlagRegistry | null {
+  const cached = registryCache.get(installationId)
+  if (!cached) return null
+  if (version !== undefined && cached.version !== '' && cached.version !== version) {
+    return null
+  }
+  return cached.registry
+}
+
+/** Whether a CLI feature flag is known to the install's ComfyUI, read from the
+ *  cache only (no spawn). Treats an absent cache as "not available". */
+export function isCachedFeatureFlagAvailable(
+  installationId: string,
+  key: string,
+  version?: string,
+): boolean {
+  return key in (getCachedFeatureFlagRegistry(installationId, version) ?? {})
 }
 
 function runListFeatureFlags(pythonPath: string, mainPyPath: string, cwd: string): Promise<string> {

--- a/src/main/lib/comfyTerminalContentScript.test.ts
+++ b/src/main/lib/comfyTerminalContentScript.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { getComfyTerminalContentScript } from './comfyTerminalContentScript'
+
+describe('getComfyTerminalContentScript', () => {
+  const script = getComfyTerminalContentScript()
+
+  it('returns a syntactically valid, self-contained IIFE', () => {
+    expect(script.startsWith('(function () {')).toBe(true)
+    // Throws on a syntax error in the assembled string (escaping bugs, etc.).
+    expect(() => new Function(script)).not.toThrow()
+  })
+
+  it('bails when the desktop terminal bridge is absent', () => {
+    expect(script).toContain('!window.__comfyDesktop2.Terminal')
+  })
+
+  it('guards against double injection', () => {
+    expect(script).toContain('window.__comfyDesktopTerminalStopgap')
+  })
+
+  it('inlines the xterm UMD build and its fit addon', () => {
+    expect(script).toContain('__xt.exports')
+    expect(script).toContain('__fit.exports')
+    expect(script).toContain('var XTerm =')
+    expect(script).toContain('var FitAddon =')
+  })
+
+  it('injects the xterm stylesheet exactly once via a stable id', () => {
+    expect(script).toContain('__comfyDesktopXtermCss')
+    expect(script).toContain('.xterm')
+  })
+
+  it('registers a custom bottom-panel tab through the extension API', () => {
+    expect(script).toContain('registerExtension')
+    expect(script).toContain('bottomPanelTabs')
+    expect(script).toContain(`type: 'custom'`)
+    expect(script).toContain(`id: 'command-terminal'`)
+    expect(script).toContain(`title: 'Terminal'`)
+  })
+
+  it('uses the shared desktop terminal transport', () => {
+    for (const member of ['subscribe', 'write', 'resize', 'restart', 'onOutput', 'onExited']) {
+      expect(script).toContain(member)
+    }
+  })
+
+  it('memoizes the assembled script', () => {
+    expect(getComfyTerminalContentScript()).toBe(script)
+  })
+})

--- a/src/main/lib/comfyTerminalContentScript.ts
+++ b/src/main/lib/comfyTerminalContentScript.ts
@@ -1,0 +1,228 @@
+/**
+ * Stopgap injection of an interactive "Terminal" bottom-panel tab into the
+ * served ComfyUI frontend, for the window between our frontend/backend terminal
+ * PRs landing and a stable release shipping them.
+ *
+ * It is injected (via `webContents.executeJavaScript`) only for STANDALONE
+ * installs whose ComfyUI does not yet advertise the `supports_terminal` feature
+ * flag — i.e. exactly when the real, flag-gated frontend tab cannot appear, so
+ * there is never a duplicate. Delete this module (and its call site in
+ * `attach.ts`) once stable ships the official tab.
+ *
+ * The transport is the already-injected `window.__comfyDesktop2.Terminal`
+ * bridge (see `comfyPreload.ts`). xterm isn't exposed on `window.comfyAPI`, so
+ * we inline the installed `@xterm/xterm` + `@xterm/addon-fit` UMD builds (read
+ * from node_modules at runtime; works in dev and inside asar) and register a
+ * `type: 'custom'` tab that renders a vanilla xterm view mirroring the real
+ * CommandTerminal behavior (focus-reclaims the shared PTY size, restart banner,
+ * clear-on-output revives the session, refit-after-restore).
+ */
+
+import { createRequire } from 'module'
+import { readFileSync } from 'fs'
+
+// The main bundle is CommonJS, so `__filename` is the right anchor for
+// require.resolve (import.meta.url is unavailable there).
+const require = createRequire(__filename)
+
+let cachedScript: string | null = null
+
+function readPackageFile(id: string): string {
+  return readFileSync(require.resolve(id), 'utf8')
+}
+
+function stripSourceMapComment(source: string): string {
+  return source.replace(/\n?\/\/# sourceMappingURL=.*$/u, '')
+}
+
+/**
+ * Vanilla browser code that registers and renders the stopgap terminal tab.
+ * Runs in the ComfyUI page main world; `XTerm` and `FitAddon` are the UMD
+ * exports captured above it, and `window.__comfyDesktop2.Terminal` is the host
+ * bridge. Kept as a string (not a stringified function) to stay consistent with
+ * the other injected scripts and to avoid bundler/`toString` surprises.
+ */
+const TERMINAL_TAB_MAIN_JS = `
+var STATE = window.__comfyDesktopTerminalStopgap;
+var mounted = null;
+
+function destroyTerminal() {
+  if (!mounted) return;
+  var m = mounted;
+  mounted = null;
+  m.disposed = true;
+  try { if (m.onData) m.onData.dispose(); } catch (e) {}
+  try { if (m.offOutput) m.offOutput(); } catch (e) {}
+  try { if (m.offExited) m.offExited(); } catch (e) {}
+  try { if (m.host && m.onFocus) m.host.removeEventListener('focusin', m.onFocus); } catch (e) {}
+  try { if (m.ro) m.ro.disconnect(); } catch (e) {}
+  if (m.resizeTimer) { clearTimeout(m.resizeTimer); }
+  try { window.__comfyDesktop2.Terminal.unsubscribe(); } catch (e) {}
+  try { if (m.term) m.term.dispose(); } catch (e) {}
+  try { if (m.container) m.container.innerHTML = ''; } catch (e) {}
+}
+
+function renderTerminal(container) {
+  destroyTerminal();
+  var bridge = window.__comfyDesktop2 && window.__comfyDesktop2.Terminal;
+  if (!bridge) return;
+
+  container.style.position = 'relative';
+  container.style.width = '100%';
+  container.style.height = '100%';
+  container.style.minWidth = '0';
+  container.style.overflow = 'hidden';
+  container.style.background = '#171717';
+
+  var host = document.createElement('div');
+  host.style.position = 'absolute';
+  host.style.inset = '0';
+  host.style.padding = '8px';
+  container.appendChild(host);
+
+  var banner = document.createElement('div');
+  banner.style.cssText = 'position:absolute;left:0;right:0;bottom:0;display:none;align-items:center;justify-content:space-between;gap:12px;padding:8px 12px;background:#262626;color:#e5e5e5;font-size:13px;';
+  var bannerText = document.createElement('span');
+  bannerText.textContent = 'This terminal session ended.';
+  var restartBtn = document.createElement('button');
+  restartBtn.textContent = 'Restart';
+  restartBtn.style.cssText = 'cursor:pointer;border:0;border-radius:6px;padding:4px 12px;background:#3b82f6;color:#fff;font-size:12px;';
+  banner.appendChild(bannerText);
+  banner.appendChild(restartBtn);
+  container.appendChild(banner);
+
+  var term = new XTerm({ convertEol: true, theme: { background: '#171717' } });
+  var fitAddon = new FitAddon();
+  term.loadAddon(fitAddon);
+  term.open(host);
+
+  var m = {
+    disposed: false, container: container, host: host, term: term,
+    fitAddon: fitAddon, exited: false, resizeTimer: 0,
+    onData: null, offOutput: null, offExited: null, onFocus: null, ro: null
+  };
+  mounted = m;
+
+  function updateBanner() { banner.style.display = m.exited ? 'flex' : 'none'; }
+
+  // Re-fit to our own container and (re)claim the shared PTY size. forceReclaim
+  // pushes even when our dims are unchanged, because the launcher settings
+  // console may have resized the one PTY out from under us.
+  function doFit(forceReclaim) {
+    if (m.disposed || !host.offsetParent) return;
+    var dims = fitAddon.proposeDimensions();
+    if (!dims || !dims.cols || !dims.rows) return;
+    var changed = dims.cols !== term.cols || dims.rows !== term.rows;
+    if (changed) term.resize(dims.cols, dims.rows);
+    if (changed || forceReclaim) { try { bridge.resize(term.cols, term.rows); } catch (e) {} }
+  }
+
+  function applyRestore(restore) {
+    if (m.disposed || !restore) return;
+    if (restore.buffer && restore.buffer.length) {
+      term.resize(restore.size.cols, restore.size.rows);
+      term.write(restore.buffer.join(''));
+    }
+    m.exited = !!restore.exited;
+    updateBanner();
+    window.requestAnimationFrame(function () { doFit(true); });
+  }
+
+  m.onData = term.onData(function (d) { try { bridge.write(d); } catch (e) {} });
+  m.offOutput = bridge.onOutput(function (msg) {
+    if (m.disposed) return;
+    if (m.exited) { m.exited = false; updateBanner(); }
+    term.write(msg);
+  });
+  m.offExited = bridge.onExited(function () {
+    if (m.disposed) return;
+    m.exited = true; updateBanner();
+  });
+  m.onFocus = function () { doFit(true); };
+  host.addEventListener('focusin', m.onFocus);
+
+  m.ro = new ResizeObserver(function () {
+    if (m.resizeTimer) clearTimeout(m.resizeTimer);
+    m.resizeTimer = setTimeout(function () { doFit(false); }, 50);
+  });
+  m.ro.observe(container);
+
+  function doRestart() {
+    if (m.disposed) return;
+    term.reset();
+    m.exited = false; updateBanner();
+    bridge.restart().then(applyRestore).catch(function () {});
+  }
+  restartBtn.addEventListener('click', doRestart);
+
+  bridge.subscribe().then(function (restore) {
+    if (m.disposed) return;
+    if (restore && restore.exited) doRestart();
+    else applyRestore(restore);
+  }).catch(function () {});
+}
+
+function waitForRegister(timeoutMs) {
+  var startedAt = Date.now();
+  (function tick() {
+    if (STATE.registered) return;
+    var app = window.comfyAPI && window.comfyAPI.app && window.comfyAPI.app.app;
+    var reg = app && app.registerExtension;
+    if (typeof reg === 'function') {
+      try {
+        reg.call(app, {
+          name: 'Comfy.Desktop.TerminalStopgap',
+          bottomPanelTabs: [{
+            id: 'command-terminal',
+            title: 'Terminal',
+            type: 'custom',
+            render: renderTerminal,
+            destroy: destroyTerminal
+          }]
+        });
+        STATE.registered = true;
+      } catch (e) {}
+      return;
+    }
+    if (Date.now() - startedAt > timeoutMs) return;
+    setTimeout(tick, 100);
+  })();
+}
+
+waitForRegister(30000);
+`
+
+/**
+ * Build the self-contained injection script. Memoized: the UMD payloads are
+ * large and never change at runtime.
+ */
+export function getComfyTerminalContentScript(): string {
+  if (cachedScript) return cachedScript
+
+  const xtermJs = stripSourceMapComment(readPackageFile('@xterm/xterm/lib/xterm.js'))
+  const fitJs = stripSourceMapComment(readPackageFile('@xterm/addon-fit/lib/addon-fit.js'))
+  const css = readPackageFile('@xterm/xterm/css/xterm.css')
+
+  cachedScript =
+    `(function () {\n` +
+    `'use strict';\n` +
+    `if (typeof window === 'undefined' || !window.__comfyDesktop2 || !window.__comfyDesktop2.Terminal) return;\n` +
+    `if (window.__comfyDesktopTerminalStopgap) return;\n` +
+    `window.__comfyDesktopTerminalStopgap = { started: true, registered: false };\n` +
+    // Capture the UMD modules into locals so we never touch window.Terminal.
+    `var __xt = { exports: {} };\n` +
+    `(function () { var module = __xt; var exports = __xt.exports;\n${xtermJs}\n}).call(window);\n` +
+    `var __fit = { exports: {} };\n` +
+    `(function () { var module = __fit; var exports = __fit.exports; var self = window;\n${fitJs}\n}).call(window);\n` +
+    `var XTerm = __xt.exports && __xt.exports.Terminal;\n` +
+    `var FitAddon = __fit.exports && __fit.exports.FitAddon;\n` +
+    `if (!XTerm || !FitAddon) return;\n` +
+    `(function () {\n` +
+    `var s = document.getElementById('__comfyDesktopXtermCss');\n` +
+    `if (!s) { s = document.createElement('style'); s.id = '__comfyDesktopXtermCss'; s.textContent = ${JSON.stringify(css)}; (document.head || document.documentElement).appendChild(s); }\n` +
+    `})();\n` +
+    TERMINAL_TAB_MAIN_JS +
+    `})();\n`
+
+  return cachedScript
+}

--- a/src/main/lib/ipc/index.ts
+++ b/src/main/lib/ipc/index.ts
@@ -25,6 +25,7 @@ import { registerInstallationHandlers } from './registerInstallationHandlers'
 import { registerSnapshotHandlers } from './registerSnapshotHandlers'
 import { registerSettingsHandlers } from './registerSettingsHandlers'
 import { registerSessionHandlers } from './registerSessionHandlers'
+import { registerTerminalHandlers } from './registerTerminalHandlers'
 import { registerCrashHandlers } from './registerCrashHandlers'
 import { registerTelemetryHandlers } from './registerTelemetryHandlers'
 
@@ -205,6 +206,7 @@ export function register(callbacks: RegisterCallbacks = {}): void {
   registerSnapshotHandlers()
   registerSettingsHandlers()
   registerSessionHandlers()
+  registerTerminalHandlers()
   registerCrashHandlers()
   registerTelemetryHandlers()
 }

--- a/src/main/lib/ipc/registerTerminalHandlers.ts
+++ b/src/main/lib/ipc/registerTerminalHandlers.ts
@@ -1,0 +1,86 @@
+import { ipcMain } from 'electron'
+import type { IpcMainInvokeEvent } from 'electron'
+import { findInstallationIdByComfySender } from '../../host/registry'
+import {
+  subscribeTerminal,
+  unsubscribeTerminal,
+  writeTerminal,
+  resizeTerminal,
+  restartTerminal,
+  getTerminalRestore,
+  type TerminalRestore,
+} from '../terminal'
+
+/**
+ * IPC for the interactive per-installation console.
+ *
+ * Two kinds of caller share these channels:
+ *   - The desktop renderer (Settings "Console" tab), which knows the
+ *     installationId and passes it explicitly.
+ *   - The served ComfyUI frontend inside a comfyView, which does NOT know its
+ *     installationId — we resolve it from the sender via the host registry.
+ *
+ * Output/exit are pushed straight to the subscribing webContents, so the
+ * frontend never needs to know its own installationId.
+ */
+
+const EMPTY_RESTORE: TerminalRestore = {
+  buffer: [],
+  size: { cols: 80, rows: 30 },
+  exited: true,
+}
+
+function resolveInstallationId(
+  event: IpcMainInvokeEvent,
+  explicit: string | null | undefined,
+): string | null {
+  if (explicit) return explicit
+  return findInstallationIdByComfySender(event.sender)
+}
+
+export function registerTerminalHandlers(): void {
+  ipcMain.handle(
+    'terminal-subscribe',
+    async (event, installationId?: string | null): Promise<TerminalRestore> => {
+      const id = resolveInstallationId(event, installationId)
+      if (!id) return EMPTY_RESTORE
+      return subscribeTerminal(id, event.sender)
+    },
+  )
+
+  ipcMain.handle('terminal-unsubscribe', (event, installationId?: string | null) => {
+    const id = resolveInstallationId(event, installationId)
+    if (id) unsubscribeTerminal(id, event.sender)
+  })
+
+  ipcMain.handle('terminal-write', (event, installationId: string | null, data: string) => {
+    const id = resolveInstallationId(event, installationId)
+    if (id) writeTerminal(id, data)
+  })
+
+  ipcMain.handle(
+    'terminal-resize',
+    (event, installationId: string | null, cols: number, rows: number) => {
+      const id = resolveInstallationId(event, installationId)
+      if (id) resizeTerminal(id, cols, rows)
+    },
+  )
+
+  ipcMain.handle(
+    'terminal-restart',
+    async (event, installationId?: string | null): Promise<TerminalRestore> => {
+      const id = resolveInstallationId(event, installationId)
+      if (!id) return EMPTY_RESTORE
+      return restartTerminal(id)
+    },
+  )
+
+  ipcMain.handle(
+    'terminal-restore',
+    (event, installationId?: string | null): TerminalRestore => {
+      const id = resolveInstallationId(event, installationId)
+      if (!id) return EMPTY_RESTORE
+      return getTerminalRestore(id) ?? EMPTY_RESTORE
+    },
+  )
+}

--- a/src/main/lib/ipc/sessionActions/launch.ts
+++ b/src/main/lib/ipc/sessionActions/launch.ts
@@ -33,6 +33,10 @@ import type { WriteStream } from 'fs'
 // install's --list-feature-flags registry so we never inject unrecognized keys.
 const DESKTOP_FEATURE_FLAGS: Record<string, string> = {
   show_signin_button: 'true',
+  // Advertises that an interactive terminal host is available, so the frontend
+  // may surface its bottom-panel terminal. The actual transport is the
+  // __comfyDesktop2.Terminal bridge; the flag only gates visibility.
+  supports_terminal: 'true',
 }
 
 // A clean exit is code 0 with no signal; anything else (non-zero code or a

--- a/src/main/lib/terminal.test.ts
+++ b/src/main/lib/terminal.test.ts
@@ -173,6 +173,24 @@ describe('terminal manager', () => {
     expect(ptyAt(1).written).toContain('echo hi\r')
   })
 
+  it('clears stale scrollback when respawning after exit', async () => {
+    const wc = makeWebContents()
+    await subscribeTerminal('inst-a', asWc(wc))
+    ptyAt(0).emitData('old-session-output')
+    expect(getTerminalRestore('inst-a')?.buffer.join('')).toContain(
+      'old-session-output',
+    )
+
+    ptyAt(0).emitExit()
+
+    // Re-subscribing respawns the shell; the dead session's scrollback is gone.
+    const restore = await subscribeTerminal('inst-a', asWc(wc))
+
+    expect(spawn).toHaveBeenCalledTimes(2)
+    expect(restore.exited).toBe(false)
+    expect(restore.buffer.join('')).not.toContain('old-session-output')
+  })
+
   it('does not fire a spurious exit when restarting a live shell', async () => {
     const wc = makeWebContents()
     await subscribeTerminal('inst-a', asWc(wc))

--- a/src/main/lib/terminal.test.ts
+++ b/src/main/lib/terminal.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+/**
+ * Fake node-pty machinery. Defined inside vi.hoisted so the (also hoisted)
+ * vi.mock factory can reference it. Lets a test drive output/exit and inspect
+ * what was written, without spawning a real shell.
+ */
+const { spawned, spawn } = vi.hoisted(() => {
+  class FakePty {
+    dataCb: ((d: string) => void) | undefined
+    exitCb: (() => void) | undefined
+    written: string[] = []
+    killed = false
+    cols: number
+    rows: number
+
+    constructor(cols: number, rows: number) {
+      this.cols = cols
+      this.rows = rows
+    }
+
+    onData(cb: (d: string) => void) {
+      this.dataCb = cb
+      return { dispose() {} }
+    }
+    onExit(cb: () => void) {
+      this.exitCb = cb
+      return { dispose() {} }
+    }
+    write(d: string) {
+      this.written.push(d)
+    }
+    resize(cols: number, rows: number) {
+      this.cols = cols
+      this.rows = rows
+    }
+    kill() {
+      this.killed = true
+      // node-pty fires onExit asynchronously after kill().
+      queueMicrotask(() => this.exitCb?.())
+    }
+
+    emitData(d: string) {
+      this.dataCb?.(d)
+    }
+    emitExit() {
+      this.exitCb?.()
+    }
+  }
+
+  const spawnedList: FakePty[] = []
+  const spawnFn = vi.fn(
+    (_file: string, _args: string[], opts: { cols: number; rows: number }) => {
+      const p = new FakePty(opts.cols, opts.rows)
+      spawnedList.push(p)
+      return p
+    },
+  )
+  return { spawned: spawnedList, spawn: spawnFn }
+})
+
+vi.mock('node-pty', () => ({ default: { spawn } }))
+
+vi.mock('../installations', () => ({
+  get: vi.fn(async (id: string) => ({ id, name: id, installPath: `/installs/${id}` })),
+}))
+
+import {
+  subscribeTerminal,
+  writeTerminal,
+  restartTerminal,
+  getTerminalRestore,
+  _resetTerminalsForTest,
+} from './terminal'
+
+interface FakeWebContents {
+  sent: { channel: string; payload: unknown }[]
+  destroyedCb?: () => void
+  send: (channel: string, payload: unknown) => void
+  once: (event: string, cb: () => void) => void
+  isDestroyed: () => boolean
+}
+
+function makeWebContents(): FakeWebContents {
+  const wc: FakeWebContents = {
+    sent: [],
+    send(channel, payload) {
+      this.sent.push({ channel, payload })
+    },
+    once(event, cb) {
+      if (event === 'destroyed') this.destroyedCb = cb
+    },
+    isDestroyed: () => false,
+  }
+  return wc
+}
+
+// The manager only uses WebContents.send/once/isDestroyed, so the fake is enough.
+function asWc(wc: FakeWebContents) {
+  return wc as unknown as Parameters<typeof subscribeTerminal>[1]
+}
+
+/** Nth spawned fake pty, asserting it exists (satisfies noUncheckedIndexedAccess). */
+function ptyAt(i: number) {
+  const p = spawned[i]
+  if (!p) throw new Error(`No pty spawned at index ${i}`)
+  return p
+}
+
+describe('terminal manager', () => {
+  beforeEach(() => {
+    _resetTerminalsForTest()
+    spawned.length = 0
+    spawn.mockClear()
+  })
+
+  it('spawns a shell on first subscribe and reports it alive', async () => {
+    const wc = makeWebContents()
+    const restore = await subscribeTerminal('inst-a', asWc(wc))
+
+    expect(spawn).toHaveBeenCalledTimes(1)
+    expect(restore.exited).toBe(false)
+    // Init commands (venv activate + pip alias) are written into the shell.
+    expect(ptyAt(0).written.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('streams output to subscribers and retains scrollback', async () => {
+    const wc = makeWebContents()
+    await subscribeTerminal('inst-a', asWc(wc))
+
+    ptyAt(0).emitData('hello ')
+    ptyAt(0).emitData('world')
+
+    const outputs = wc.sent.filter((m) => m.channel === 'terminal-output')
+    expect(outputs.map((m) => (m.payload as { data: string }).data)).toEqual([
+      'hello ',
+      'world',
+    ])
+    expect(getTerminalRestore('inst-a')?.buffer.join('')).toBe('hello world')
+  })
+
+  it('marks the session exited and notifies subscribers when the shell is killed', async () => {
+    const wc = makeWebContents()
+    await subscribeTerminal('inst-a', asWc(wc))
+
+    ptyAt(0).emitExit()
+
+    expect(wc.sent.some((m) => m.channel === 'terminal-exited')).toBe(true)
+    expect(getTerminalRestore('inst-a')?.exited).toBe(true)
+  })
+
+  it('drops writes after exit instead of throwing (the legacy dead-pty bug)', async () => {
+    const wc = makeWebContents()
+    await subscribeTerminal('inst-a', asWc(wc))
+    ptyAt(0).emitExit()
+
+    expect(() => writeTerminal('inst-a', 'ls\r')).not.toThrow()
+    // Nothing reached the dead shell.
+    expect(ptyAt(0).written.filter((w) => w === 'ls\r')).toHaveLength(0)
+  })
+
+  it('respawns a fresh shell on restart after the user killed it', async () => {
+    const wc = makeWebContents()
+    await subscribeTerminal('inst-a', asWc(wc))
+    ptyAt(0).emitExit()
+
+    const restore = await restartTerminal('inst-a')
+
+    expect(spawn).toHaveBeenCalledTimes(2)
+    expect(restore.exited).toBe(false)
+    // The new shell accepts input.
+    writeTerminal('inst-a', 'echo hi\r')
+    expect(ptyAt(1).written).toContain('echo hi\r')
+  })
+
+  it('does not fire a spurious exit when restarting a live shell', async () => {
+    const wc = makeWebContents()
+    await subscribeTerminal('inst-a', asWc(wc))
+
+    await restartTerminal('inst-a')
+    // Let the killed old pty's async onExit microtask run.
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(wc.sent.some((m) => m.channel === 'terminal-exited')).toBe(false)
+    expect(getTerminalRestore('inst-a')?.exited).toBe(false)
+  })
+
+  it('keeps sessions isolated per installation', async () => {
+    const wcA = makeWebContents()
+    const wcB = makeWebContents()
+    await subscribeTerminal('inst-a', asWc(wcA))
+    await subscribeTerminal('inst-b', asWc(wcB))
+
+    ptyAt(0).emitData('from-a')
+
+    expect(wcA.sent.some((m) => m.channel === 'terminal-output')).toBe(true)
+    expect(wcB.sent.some((m) => m.channel === 'terminal-output')).toBe(false)
+  })
+})

--- a/src/main/lib/terminal.ts
+++ b/src/main/lib/terminal.ts
@@ -39,17 +39,20 @@ function getDefaultShell(): string {
 }
 
 /** Commands written into a fresh shell: activate the install's venv and make
- *  `pip` route through the bundled uv, mirroring legacy desktop. */
+ *  `pip` route through the bundled uv, mirroring legacy desktop. A final clear
+ *  hides the activation echo so the session opens on a clean prompt. */
 function initCommands(venvDir: string, uvPath: string): string[] {
   if (process.platform === 'win32') {
     return [
       `& "${venvDir}\\Scripts\\Activate.ps1"`,
       `function pip { & "${uvPath}" pip $args }`,
+      'Clear-Host',
     ]
   }
   return [
     `source "${venvDir}/bin/activate"`,
     `alias pip='"${uvPath}" pip'`,
+    'clear',
   ]
 }
 
@@ -78,7 +81,6 @@ class InstallTerminal {
   /** Kill any existing shell and start a fresh one. Clears scrollback. */
   async restart(): Promise<void> {
     this.#killPty()
-    this.sessionBuffer.length = 0
     await this.#spawn()
   }
 
@@ -128,6 +130,9 @@ class InstallTerminal {
     if (!inst || !inst.installPath) {
       throw new Error(`Installation not found: ${this.installationId}`)
     }
+    // A fresh shell starts with a fresh scrollback; otherwise a respawn after
+    // the user typed `exit` would leak the dead session's buffer into restore.
+    this.sessionBuffer.length = 0
     const venvDir = getActiveVenvDir(inst)
     const uvPath = getActiveUvPath(inst)
     const instance = pty.spawn(getDefaultShell(), [], {

--- a/src/main/lib/terminal.ts
+++ b/src/main/lib/terminal.ts
@@ -1,0 +1,246 @@
+import pty from 'node-pty'
+import type { WebContents } from 'electron'
+import * as installations from '../installations'
+import { getActiveVenvDir, getActiveUvPath } from './pythonEnv'
+
+/**
+ * Interactive per-installation shell sessions.
+ *
+ * Each installation gets at most one long-lived PTY, shared across every
+ * surface that subscribes to it: the desktop Settings "Console" tab and the
+ * ComfyUI frontend's bottom-panel terminal (across all of an install's
+ * windows). One shell, one scrollback — so the same session is visible
+ * everywhere and there's no confusion about which terminal is which.
+ *
+ * The session is independent of the ComfyUI server: it stays usable whether
+ * ComfyUI is running or stopped (e.g. to pip-install something before a
+ * reboot). When the user kills the shell (typing `exit`), the session is
+ * marked exited and subscribers are notified; it is NOT silently respawned.
+ * Callers restart it explicitly via {@link restartTerminal} (the desktop
+ * Restart button, or the frontend re-opening the tab).
+ */
+
+const MAX_BUFFER_CHUNKS = 1000
+const DEFAULT_SIZE = { cols: 80, rows: 30 }
+
+export interface TerminalRestore {
+  buffer: string[]
+  size: { cols: number; rows: number }
+  exited: boolean
+}
+
+function getDefaultShell(): string {
+  if (process.platform === 'win32') {
+    return process.env.COMSPEC?.toLowerCase().includes('cmd')
+      ? 'powershell.exe'
+      : process.env.COMSPEC || 'powershell.exe'
+  }
+  return process.env.SHELL || '/bin/bash'
+}
+
+/** Commands written into a fresh shell: activate the install's venv and make
+ *  `pip` route through the bundled uv, mirroring legacy desktop. */
+function initCommands(venvDir: string, uvPath: string): string[] {
+  if (process.platform === 'win32') {
+    return [
+      `& "${venvDir}\\Scripts\\Activate.ps1"`,
+      `function pip { & "${uvPath}" pip $args }`,
+    ]
+  }
+  return [
+    `source "${venvDir}/bin/activate"`,
+    `alias pip='"${uvPath}" pip'`,
+  ]
+}
+
+class InstallTerminal {
+  readonly installationId: string
+  #pty: pty.IPty | undefined
+  #exited = true
+  readonly sessionBuffer: string[] = []
+  readonly size = { ...DEFAULT_SIZE }
+  readonly subscribers = new Set<WebContents>()
+
+  constructor(installationId: string) {
+    this.installationId = installationId
+  }
+
+  get exited(): boolean {
+    return this.#exited || this.#pty === undefined
+  }
+
+  /** Spawn the shell if it isn't alive. Safe to call repeatedly. */
+  async ensureAlive(): Promise<void> {
+    if (this.#pty && !this.#exited) return
+    await this.#spawn()
+  }
+
+  /** Kill any existing shell and start a fresh one. Clears scrollback. */
+  async restart(): Promise<void> {
+    this.#killPty()
+    this.sessionBuffer.length = 0
+    await this.#spawn()
+  }
+
+  write(data: string): void {
+    if (this.#exited || !this.#pty) return
+    this.#pty.write(data)
+  }
+
+  resize(cols: number, rows: number): void {
+    if (!Number.isFinite(cols) || !Number.isFinite(rows)) return
+    this.size.cols = Math.max(1, Math.floor(cols))
+    this.size.rows = Math.max(1, Math.floor(rows))
+    if (this.#exited || !this.#pty) return
+    try {
+      this.#pty.resize(this.size.cols, this.size.rows)
+    } catch {
+      // pty may have died between the exited check and here; ignore.
+    }
+  }
+
+  restore(): TerminalRestore {
+    return {
+      buffer: [...this.sessionBuffer],
+      size: { ...this.size },
+      exited: this.exited,
+    }
+  }
+
+  subscribe(wc: WebContents): void {
+    if (this.subscribers.has(wc)) return
+    this.subscribers.add(wc)
+    wc.once('destroyed', () => this.subscribers.delete(wc))
+  }
+
+  unsubscribe(wc: WebContents): void {
+    this.subscribers.delete(wc)
+  }
+
+  dispose(): void {
+    this.#killPty()
+    this.subscribers.clear()
+    this.sessionBuffer.length = 0
+  }
+
+  async #spawn(): Promise<void> {
+    const inst = await installations.get(this.installationId)
+    if (!inst || !inst.installPath) {
+      throw new Error(`Installation not found: ${this.installationId}`)
+    }
+    const venvDir = getActiveVenvDir(inst)
+    const uvPath = getActiveUvPath(inst)
+    const instance = pty.spawn(getDefaultShell(), [], {
+      name: 'xterm-256color',
+      cols: this.size.cols,
+      rows: this.size.rows,
+      cwd: inst.installPath,
+      env: process.env as Record<string, string>,
+    })
+
+    this.#pty = instance
+    this.#exited = false
+
+    instance.onData((data) => {
+      // Ignore stray output from a shell we've already replaced (restart race).
+      if (this.#pty !== instance) return
+      this.sessionBuffer.push(data)
+      if (this.sessionBuffer.length > MAX_BUFFER_CHUNKS) this.sessionBuffer.shift()
+      this.#broadcast('terminal-output', { installationId: this.installationId, data })
+    })
+
+    instance.onExit(() => {
+      // A restart kills the old pty and spawns a new one; the old pty's async
+      // exit must not clobber the live session or fire a spurious "exited".
+      if (this.#pty !== instance) return
+      this.#exited = true
+      this.#pty = undefined
+      this.#broadcast('terminal-exited', { installationId: this.installationId })
+    })
+
+    for (const cmd of initCommands(venvDir, uvPath)) {
+      instance.write(`${cmd}\r`)
+    }
+  }
+
+  #killPty(): void {
+    const instance = this.#pty
+    this.#pty = undefined
+    this.#exited = true
+    if (!instance) return
+    try {
+      instance.kill()
+    } catch {
+      // Already dead; nothing to do.
+    }
+  }
+
+  #broadcast(channel: string, payload: unknown): void {
+    for (const wc of this.subscribers) {
+      if (wc.isDestroyed()) {
+        this.subscribers.delete(wc)
+        continue
+      }
+      wc.send(channel, payload)
+    }
+  }
+}
+
+const terminals = new Map<string, InstallTerminal>()
+
+function getOrCreate(installationId: string): InstallTerminal {
+  let term = terminals.get(installationId)
+  if (!term) {
+    term = new InstallTerminal(installationId)
+    terminals.set(installationId, term)
+  }
+  return term
+}
+
+/** Subscribe a renderer to an install's shell, spawning it if needed, and
+ *  return the scrollback/size/exited state so the caller can repaint. */
+export async function subscribeTerminal(
+  installationId: string,
+  wc: WebContents,
+): Promise<TerminalRestore> {
+  const term = getOrCreate(installationId)
+  await term.ensureAlive()
+  term.subscribe(wc)
+  return term.restore()
+}
+
+export function unsubscribeTerminal(installationId: string, wc: WebContents): void {
+  terminals.get(installationId)?.unsubscribe(wc)
+}
+
+export function writeTerminal(installationId: string, data: string): void {
+  terminals.get(installationId)?.write(data)
+}
+
+export function resizeTerminal(installationId: string, cols: number, rows: number): void {
+  terminals.get(installationId)?.resize(cols, rows)
+}
+
+export async function restartTerminal(installationId: string): Promise<TerminalRestore> {
+  const term = getOrCreate(installationId)
+  await term.restart()
+  return term.restore()
+}
+
+export function getTerminalRestore(installationId: string): TerminalRestore | null {
+  return terminals.get(installationId)?.restore() ?? null
+}
+
+/** Tear down an install's shell entirely (e.g. when it's deleted). */
+export function disposeTerminal(installationId: string): void {
+  const term = terminals.get(installationId)
+  if (!term) return
+  term.dispose()
+  terminals.delete(installationId)
+}
+
+/** Test-only: drop all sessions without spawning anything. */
+export function _resetTerminalsForTest(): void {
+  for (const term of terminals.values()) term.dispose()
+  terminals.clear()
+}

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -58,6 +58,16 @@ export function buildElectronApi(): ElectronApi {
     // Running
     stopComfyUI: (installationId) => ipcRenderer.invoke('stop-comfyui', installationId),
     focusComfyWindow: (installationId) => ipcRenderer.invoke('focus-comfy-window', installationId),
+
+    // Interactive console
+    terminalSubscribe: (installationId) => ipcRenderer.invoke('terminal-subscribe', installationId),
+    terminalUnsubscribe: (installationId) =>
+      ipcRenderer.invoke('terminal-unsubscribe', installationId),
+    terminalWrite: (installationId, data) =>
+      ipcRenderer.invoke('terminal-write', installationId, data),
+    terminalResize: (installationId, cols, rows) =>
+      ipcRenderer.invoke('terminal-resize', installationId, cols, rows),
+    terminalRestart: (installationId) => ipcRenderer.invoke('terminal-restart', installationId),
     openInstallWindow: (installationId) =>
       ipcRenderer.invoke('open-install-window', installationId),
     closeComfyWindow: (installationId, opts) =>
@@ -213,6 +223,18 @@ export function buildElectronApi(): ElectronApi {
         callback(data as Parameters<typeof callback>[0])
       ipcRenderer.on('comfy-exited', handler)
       return () => ipcRenderer.removeListener('comfy-exited', handler)
+    },
+    onTerminalOutput: (callback) => {
+      const handler = (_event: IpcRendererEvent, data: unknown) =>
+        callback(data as Parameters<typeof callback>[0])
+      ipcRenderer.on('terminal-output', handler)
+      return () => ipcRenderer.removeListener('terminal-output', handler)
+    },
+    onTerminalExited: (callback) => {
+      const handler = (_event: IpcRendererEvent, data: unknown) =>
+        callback(data as Parameters<typeof callback>[0])
+      ipcRenderer.on('terminal-exited', handler)
+      return () => ipcRenderer.removeListener('terminal-exited', handler)
     },
     onComfyBootLog: (callback) => {
       const handler = (_event: IpcRendererEvent, data: unknown) =>

--- a/src/preload/comfyPreload.ts
+++ b/src/preload/comfyPreload.ts
@@ -15,6 +15,42 @@ export interface ComfyDownloadProgress {
   isImage?: boolean
 }
 
+export interface TerminalRestore {
+  buffer: string[]
+  size: { cols: number; rows: number }
+  exited: boolean
+}
+
+/**
+ * Interactive terminal bridge for the served ComfyUI frontend.
+ *
+ * The frontend has no idea which installation it belongs to; the main process
+ * resolves that from the sending webContents, so every call here omits the
+ * installationId. The session is per-install and shared across windows.
+ */
+const Terminal = {
+  /** Spawn the shell if needed, register this view as a subscriber, and
+   *  return the current scrollback/size/exited state. */
+  subscribe: (): Promise<TerminalRestore> => ipcRenderer.invoke('terminal-subscribe', null),
+  unsubscribe: (): Promise<void> => ipcRenderer.invoke('terminal-unsubscribe', null),
+  write: (data: string): Promise<void> => ipcRenderer.invoke('terminal-write', null, data),
+  resize: (cols: number, rows: number): Promise<void> =>
+    ipcRenderer.invoke('terminal-resize', null, cols, rows),
+  /** Kill the current shell (if any) and start a fresh one. */
+  restart: (): Promise<TerminalRestore> => ipcRenderer.invoke('terminal-restart', null),
+  onOutput: (callback: (data: string) => void): (() => void) => {
+    const handler = (_event: IpcRendererEvent, payload: { data: string }) =>
+      callback(payload.data)
+    ipcRenderer.on('terminal-output', handler)
+    return () => ipcRenderer.removeListener('terminal-output', handler)
+  },
+  onExited: (callback: () => void): (() => void) => {
+    const handler = () => callback()
+    ipcRenderer.on('terminal-exited', handler)
+    return () => ipcRenderer.removeListener('terminal-exited', handler)
+  },
+}
+
 contextBridge.exposeInMainWorld('__comfyDesktop2', {
   downloadModel: (url: string, filename: string, directory: string): Promise<boolean> => {
     return ipcRenderer.invoke('desktop2-download-model', { url, filename, directory })
@@ -42,4 +78,5 @@ contextBridge.exposeInMainWorld('__comfyDesktop2', {
   reportTheme: (bg: string, text: string): void => {
     ipcRenderer.send('desktop2-theme-report', { bg, text })
   },
+  Terminal,
 })

--- a/src/preload/comfyTitlePopupPreload.ts
+++ b/src/preload/comfyTitlePopupPreload.ts
@@ -1,6 +1,7 @@
 import { contextBridge, ipcRenderer } from 'electron'
 import type { IpcRendererEvent } from 'electron'
 import { PICKER_SETTINGS_CHANNELS as CH } from '../types/ipc'
+import type { TerminalRestore } from '../types/ipc'
 
 /** Bridge for the title-bar dropdown popup (waffle menu, downloads tray,
  *  instance-picker, global-settings), which share one reused child
@@ -328,6 +329,17 @@ export interface ComfyTitlePopupBridge {
   pickerSettingsPreviewLocalMigration(
     installationId: string,
   ): Promise<Record<string, unknown>>
+  /** Interactive per-install console. The popup's settings UI hits the same
+   *  generic `terminal-*` IPC the panel does, with an explicit installationId. */
+  terminalSubscribe(installationId: string): Promise<TerminalRestore>
+  terminalUnsubscribe(installationId: string): Promise<void>
+  terminalWrite(installationId: string, data: string): Promise<void>
+  terminalResize(installationId: string, cols: number, rows: number): Promise<void>
+  terminalRestart(installationId: string): Promise<TerminalRestore>
+  onTerminalOutput(
+    callback: (data: { installationId: string; data: string }) => void,
+  ): () => void
+  onTerminalExited(callback: (data: { installationId: string }) => void): () => void
   /** Relaunch the app (`app.relaunch()` main-side). */
   pickerSettingsRelaunchApp(): void
   /** Pull the panel-side i18n catalog; the popup boots with a minimal static
@@ -649,6 +661,28 @@ const bridge: ComfyTitlePopupBridge = {
     ipcRenderer.invoke(CH.previewDesktopMigration, { installationId, desktopId }),
   pickerSettingsPreviewLocalMigration: (installationId) =>
     ipcRenderer.invoke(CH.previewLocalMigration, { installationId }),
+  terminalSubscribe: (installationId) =>
+    ipcRenderer.invoke('terminal-subscribe', installationId),
+  terminalUnsubscribe: (installationId) =>
+    ipcRenderer.invoke('terminal-unsubscribe', installationId),
+  terminalWrite: (installationId, data) =>
+    ipcRenderer.invoke('terminal-write', installationId, data),
+  terminalResize: (installationId, cols, rows) =>
+    ipcRenderer.invoke('terminal-resize', installationId, cols, rows),
+  terminalRestart: (installationId) =>
+    ipcRenderer.invoke('terminal-restart', installationId),
+  onTerminalOutput: (callback) => {
+    const handler = (_event: IpcRendererEvent, data: unknown): void =>
+      callback(data as { installationId: string; data: string })
+    ipcRenderer.on('terminal-output', handler)
+    return () => ipcRenderer.removeListener('terminal-output', handler)
+  },
+  onTerminalExited: (callback) => {
+    const handler = (_event: IpcRendererEvent, data: unknown): void =>
+      callback(data as { installationId: string })
+    ipcRenderer.on('terminal-exited', handler)
+    return () => ipcRenderer.removeListener('terminal-exited', handler)
+  },
   pickerSettingsRelaunchApp: () => {
     ipcRenderer.send(CH.relaunchApp)
   },

--- a/src/renderer/src/comfyTitlePopup/InstancePickerView.test.ts
+++ b/src/renderer/src/comfyTitlePopup/InstancePickerView.test.ts
@@ -6,6 +6,16 @@ import { createPinia, setActivePinia } from 'pinia'
 import { en } from '../lib/i18nMessages.ts'
 import type { SnapshotListData } from '../types/ipc'
 
+// The interactive console pane drives a real xterm terminal (needs a canvas);
+// stub it so the picker's detail pane renders without a terminal host.
+vi.mock('../views/comfyUISettings/ConsoleTerminalPane.vue', () => ({
+  default: {
+    name: 'ConsoleTerminalPane',
+    props: ['installationId'],
+    template: '<div data-testid="console-terminal-pane-stub" />',
+  },
+}))
+
 const emptySnapshotListPayload: SnapshotListData = {
   snapshots: [],
   copyEvents: [],

--- a/src/renderer/src/comfyTitlePopup/pickerSettingsApiShim.test.ts
+++ b/src/renderer/src/comfyTitlePopup/pickerSettingsApiShim.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { installPickerSettingsApiShim } from './pickerSettingsApiShim'
+
+// The settings UI runs inside the title-popup WebContents, which has the
+// `__comfyTitlePopup` bridge instead of `window.api`. The shim must forward
+// every method the settings UI calls — including the interactive console —
+// or the Console tab mounts xterm against undefined APIs and wedges the tab
+// transition (regression: the whole settings UI appeared to freeze).
+
+afterEach(() => {
+  delete (window as unknown as { api?: unknown }).api
+  delete (window as unknown as { __comfyTitlePopup?: unknown }).__comfyTitlePopup
+})
+
+function installBridge(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const explicit: Record<string, unknown> = {
+    terminalSubscribe: vi.fn().mockResolvedValue({
+      buffer: [],
+      size: { cols: 80, rows: 30 },
+      exited: false
+    }),
+    terminalUnsubscribe: vi.fn().mockResolvedValue(undefined),
+    terminalWrite: vi.fn().mockResolvedValue(undefined),
+    terminalResize: vi.fn().mockResolvedValue(undefined),
+    terminalRestart: vi.fn().mockResolvedValue({
+      buffer: [],
+      size: { cols: 80, rows: 30 },
+      exited: false
+    }),
+    onTerminalOutput: vi.fn(() => () => {}),
+    onTerminalExited: vi.fn(() => () => {}),
+    ...overrides
+  }
+  // Auto-stub any other mapped bridge method the shim binds, so the test only
+  // has to declare the terminal methods it asserts on.
+  const bridge = new Proxy(explicit, {
+    get(target, prop: string) {
+      if (!(prop in target)) target[prop] = vi.fn()
+      return target[prop]
+    },
+    has() {
+      return true
+    }
+  })
+  ;(window as unknown as { __comfyTitlePopup?: unknown }).__comfyTitlePopup = bridge
+  return bridge
+}
+
+describe('installPickerSettingsApiShim — terminal forwarding', () => {
+  const terminalMethods = [
+    'terminalSubscribe',
+    'terminalUnsubscribe',
+    'terminalWrite',
+    'terminalResize',
+    'terminalRestart',
+    'onTerminalOutput',
+    'onTerminalExited'
+  ] as const
+
+  it('exposes every terminal method on window.api', () => {
+    installBridge()
+    installPickerSettingsApiShim()
+
+    const api = (window as unknown as { api: Record<string, unknown> }).api
+    for (const method of terminalMethods) {
+      expect(typeof api[method]).toBe('function')
+    }
+  })
+
+  it('forwards terminal calls to the bridge', async () => {
+    const bridge = installBridge()
+    installPickerSettingsApiShim()
+
+    const api = (window as unknown as {
+      api: {
+        terminalSubscribe: (id: string) => Promise<unknown>
+        terminalWrite: (id: string, data: string) => Promise<void>
+        onTerminalOutput: (cb: () => void) => () => void
+      }
+    }).api
+
+    await api.terminalSubscribe('install-A')
+    expect(bridge.terminalSubscribe).toHaveBeenCalledWith('install-A')
+
+    await api.terminalWrite('install-A', 'ls\r')
+    expect(bridge.terminalWrite).toHaveBeenCalledWith('install-A', 'ls\r')
+
+    const cb = vi.fn()
+    api.onTerminalOutput(cb)
+    expect(bridge.onTerminalOutput).toHaveBeenCalledWith(cb)
+  })
+})

--- a/src/renderer/src/comfyTitlePopup/pickerSettingsApiShim.ts
+++ b/src/renderer/src/comfyTitlePopup/pickerSettingsApiShim.ts
@@ -31,6 +31,13 @@ const API_MAP = {
   previewDesktopMigration: 'pickerSettingsPreviewDesktopMigration',
   previewLocalMigration: 'pickerSettingsPreviewLocalMigration',
   onReleaseCacheEnriched: 'pickerSettingsOnReleaseCacheEnriched',
+  terminalSubscribe: 'terminalSubscribe',
+  terminalUnsubscribe: 'terminalUnsubscribe',
+  terminalWrite: 'terminalWrite',
+  terminalResize: 'terminalResize',
+  terminalRestart: 'terminalRestart',
+  onTerminalOutput: 'onTerminalOutput',
+  onTerminalExited: 'onTerminalExited',
 } as const satisfies Record<string, keyof ComfyTitlePopupBridge>
 
 type ShimApi = {

--- a/src/renderer/src/components/settings/ComfyUISettingsContent.test.ts
+++ b/src/renderer/src/components/settings/ComfyUISettingsContent.test.ts
@@ -24,12 +24,15 @@ const messages = {
       tabUpdate: 'Update',
       tabSnapshots: 'Snapshots',
       tabStorage: 'Storage',
+      tabConsole: 'Console',
       relaunch: 'Relaunch',
       more: 'More',
     },
     tooltips: {
       snapshots:
         'A saved point-in-time state of an installation (versions + custom nodes) you can restore later.',
+      console:
+        "An interactive shell running in this installation's folder. Works whether ComfyUI is running or stopped.",
     },
     instancePicker: {
       open: 'Start',
@@ -114,6 +117,9 @@ vi.mock('../../views/comfyUISettings/StatusFactPanel.vue', () => ({
 }))
 vi.mock('../../views/comfyUISettings/StoragePane.vue', () => ({
   default: { template: '<div />' },
+}))
+vi.mock('../../views/comfyUISettings/ConsoleTerminalPane.vue', () => ({
+  default: { name: 'ConsoleTerminalPane', props: ['installationId'], template: '<div data-testid="console-terminal-pane-stub" />' },
 }))
 vi.mock('../../views/comfyUISettings/ArgsBuilderPage.vue', () => ({
   default: { template: '<div />' },
@@ -374,13 +380,16 @@ describe('ComfyUISettingsContent', () => {
 
     const SNAPSHOTS_TOOLTIP =
       'A saved point-in-time state of an installation (versions + custom nodes) you can restore later.'
+    const CONSOLE_TOOLTIP =
+      "An interactive shell running in this installation's folder. Works whether ComfyUI is running or stopped."
+    const CONCEPT_TOOLTIPS = new Set([SNAPSHOTS_TOOLTIP, CONSOLE_TOOLTIP])
 
-    /** Disabled flags for tabs that only echo their label (excludes Snapshots,
-     *  which carries a real concept tooltip). */
+    /** Disabled flags for tabs that only echo their label (excludes Snapshots
+     *  and Console, which carry real concept tooltips). */
     function labelEchoDisabledFlags(w: VueWrapper): boolean[] {
       return w
         .findAllComponents({ name: 'Tooltip' })
-        .filter((tt) => tt.props('text') !== SNAPSHOTS_TOOLTIP)
+        .filter((tt) => !CONCEPT_TOOLTIPS.has(tt.props('text') as string))
         .map((tt) => tt.props('disabled') as boolean)
     }
 

--- a/src/renderer/src/components/settings/ComfyUISettingsContent.vue
+++ b/src/renderer/src/components/settings/ComfyUISettingsContent.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref, toRef, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { CheckCircle, XCircle, ChevronUp, HardDrive, SlidersHorizontal, Info, RefreshCw, History } from 'lucide-vue-next'
+import { CheckCircle, XCircle, ChevronUp, HardDrive, SlidersHorizontal, Info, RefreshCw, History, SquareTerminal } from 'lucide-vue-next'
 import { useComfyUISettings } from '../../composables/useComfyUISettings'
 import { useInstallCta } from '../../composables/useInstallCta'
 import { useCloudCapacity } from '../../composables/useCloudCapacity'
@@ -12,6 +12,7 @@ import SnapshotsView from '../../views/comfyUISettings/SnapshotsView.vue'
 import StatusFactPanel from '../../views/comfyUISettings/StatusFactPanel.vue'
 import SettingsSectionList from '../../views/comfyUISettings/SettingsSectionList.vue'
 import StoragePane, { type StorageSnapshot } from '../../views/comfyUISettings/StoragePane.vue'
+import ConsoleTerminalPane from '../../views/comfyUISettings/ConsoleTerminalPane.vue'
 import Tooltip from '../ui/Tooltip.vue'
 import type { PickerTab, SectionTab } from '../../lib/pickerTabs'
 import { humanizeOpStatus, operationInflightLabel, operationSuccessLabel } from '../../lib/progressStatusLabel'
@@ -251,17 +252,36 @@ const ALL_TABS: TabDef[] = [
     icon: HardDrive
   },
   {
+    key: 'console',
+    sectionTab: 'console',
+    label: t('comfyUISettings.tabConsole', 'Console'),
+    icon: SquareTerminal,
+    tooltip: t('tooltips.console')
+  },
+  {
     key: 'status',
     sectionTab: 'status',
     label: t('comfyUISettings.tabStatus', 'About'),
     icon: Info
   }
 ]
+
+// The console tab has no backend `sections` — it's a live PTY view — so it
+// can't be section-gated like the others. Show it for any local install
+// (cloud installs run no local process to attach a shell to).
+const showConsoleTab = computed(
+  () => installation.value != null && installation.value.sourceCategory !== 'cloud'
+)
+
 const tabs = computed<TabDef[]>(() => {
   // Cloud runs no local process, so the `config` tab carries no real
   // startup args — relabel it "Storage" to match its contents.
   const isCloud = installation.value?.sourceCategory === 'cloud'
-  return ALL_TABS.filter((tab) => sectionsForTab(tab.sectionTab).value.length > 0).map((tab) =>
+  return ALL_TABS.filter((tab) =>
+    tab.key === 'console'
+      ? showConsoleTab.value
+      : sectionsForTab(tab.sectionTab).value.length > 0
+  ).map((tab) =>
     isCloud && tab.key === 'config'
       ? { ...tab, label: t('comfyUISettings.tabStorage', 'Storage'), icon: HardDrive }
       : tab
@@ -598,13 +618,13 @@ defineExpose({
         {{ t('comfyUISettings.emptyInstallLess', 'Open a ComfyUI install to view its settings.') }}
       </p>
       <p
-        v-else-if="loading && !visibleSections.length"
+        v-else-if="loading && !visibleSections.length && activeTab !== 'console'"
         class="empty"
         :data-testid="TID.pickerSettingsLoading"
       >
         {{ t('common.loading', 'Loading…') }}
       </p>
-      <p v-else-if="error" class="empty error">{{ error }}</p>
+      <p v-else-if="error && activeTab !== 'console'" class="empty error">{{ error }}</p>
 
       <Transition v-else :name="subPageTransition" mode="out-in">
         <ArgsBuilderPage
@@ -681,6 +701,13 @@ defineExpose({
                 :running-action-ids="runningActionIds"
                 @update-field="updateField"
               />
+            </div>
+            <div
+              v-else-if="activeTab === 'console' && installation"
+              :key="`tab-console-${paneInstallKey}`"
+              class="settings-v2-tab-pane settings-v2-tab-pane--console"
+            >
+              <ConsoleTerminalPane :installation-id="installation.id" />
             </div>
             <div v-else :key="`tab-${activeTab}-${paneInstallKey}`" class="settings-v2-tab-pane">
               <Transition name="op-overlay" mode="out-in">

--- a/src/renderer/src/lib/pickerTabs.ts
+++ b/src/renderer/src/lib/pickerTabs.ts
@@ -1,7 +1,19 @@
-export type PickerTab = 'config' | 'status' | 'update' | 'snapshots' | 'storage'
+export type PickerTab =
+  | 'config'
+  | 'status'
+  | 'update'
+  | 'snapshots'
+  | 'storage'
+  | 'console'
 
 /** Narrowing of `DetailSection.tab`. Uses 'settings' where PickerTab uses 'config'. */
-export type SectionTab = 'settings' | 'status' | 'update' | 'snapshots' | 'storage'
+export type SectionTab =
+  | 'settings'
+  | 'status'
+  | 'update'
+  | 'snapshots'
+  | 'storage'
+  | 'console'
 
 const PICKER_TABS: ReadonlySet<PickerTab> = new Set([
   'config',
@@ -9,6 +21,7 @@ const PICKER_TABS: ReadonlySet<PickerTab> = new Set([
   'update',
   'snapshots',
   'storage',
+  'console',
 ])
 
 export function isPickerTab(tab: string | null | undefined): tab is PickerTab {

--- a/src/renderer/src/views/comfyUISettings/ConsoleTerminalPane.test.ts
+++ b/src/renderer/src/views/comfyUISettings/ConsoleTerminalPane.test.ts
@@ -18,6 +18,10 @@ const fakeTerminal = {
   resize: vi.fn(),
   reset: vi.fn(),
   dispose: vi.fn(),
+  element: {
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn()
+  },
   cols: 80,
   rows: 30
 }
@@ -48,6 +52,9 @@ function createTestI18n() {
 }
 
 let exitCallbacks: Array<(data: { installationId: string }) => void> = []
+let outputCallbacks: Array<
+  (data: { installationId: string; data: string }) => void
+> = []
 
 function makeRestore(overrides: Partial<TerminalRestore> = {}): TerminalRestore {
   return { buffer: [], size: { cols: 80, rows: 30 }, exited: false, ...overrides }
@@ -60,7 +67,12 @@ function setupApi(subscribeRestore: TerminalRestore = makeRestore()): void {
     terminalWrite: vi.fn().mockResolvedValue(undefined),
     terminalResize: vi.fn().mockResolvedValue(undefined),
     terminalRestart: vi.fn().mockResolvedValue(makeRestore()),
-    onTerminalOutput: vi.fn(() => () => {}),
+    onTerminalOutput: vi.fn(
+      (cb: (data: { installationId: string; data: string }) => void) => {
+        outputCallbacks.push(cb)
+        return () => {}
+      }
+    ),
     onTerminalExited: vi.fn((cb: (data: { installationId: string }) => void) => {
       exitCallbacks.push(cb)
       return () => {}
@@ -78,6 +90,7 @@ function mountPane(): VueWrapper {
 describe('comfyUISettings/ConsoleTerminalPane', () => {
   beforeEach(() => {
     exitCallbacks = []
+    outputCallbacks = []
     vi.clearAllMocks()
     ;(globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
       observe() {}
@@ -109,6 +122,41 @@ describe('comfyUISettings/ConsoleTerminalPane', () => {
     await flushPromises()
     expect(window.api.terminalRestart).toHaveBeenCalledWith('install-A')
     expect(w.find(`[data-testid="${TID.consoleSessionEnded}"]`).exists()).toBe(false)
+  })
+
+  it('clears the session-ended banner when output resumes', async () => {
+    const w = mountPane()
+    await flushPromises()
+
+    exitCallbacks.forEach((cb) => cb({ installationId: 'install-A' }))
+    await flushPromises()
+    expect(w.find(`[data-testid="${TID.consoleSessionEnded}"]`).exists()).toBe(true)
+
+    outputCallbacks.forEach((cb) =>
+      cb({ installationId: 'install-A', data: 'fresh prompt' })
+    )
+    await flushPromises()
+    expect(w.find(`[data-testid="${TID.consoleSessionEnded}"]`).exists()).toBe(false)
+  })
+
+  it('re-asserts its size to the shared PTY on focus even when local dims are unchanged', async () => {
+    const w = mountPane()
+    await flushPromises()
+
+    const host = w.find(`[data-testid="${TID.consoleTerminal}"]`)
+      .element as HTMLElement
+    Object.defineProperty(host, 'offsetParent', {
+      value: document.body,
+      configurable: true
+    })
+    vi.mocked(window.api.terminalResize).mockClear()
+
+    const focusHandler = fakeTerminal.element.addEventListener.mock.calls.find(
+      ([event]) => event === 'focusin'
+    )?.[1] as () => void
+    focusHandler()
+
+    expect(window.api.terminalResize).toHaveBeenCalledWith('install-A', 80, 30)
   })
 
   it('ignores exit events for other installations', async () => {

--- a/src/renderer/src/views/comfyUISettings/ConsoleTerminalPane.test.ts
+++ b/src/renderer/src/views/comfyUISettings/ConsoleTerminalPane.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+
+import { TID } from '../../../../shared/testIds'
+import type { TerminalRestore } from '../../types/ipc'
+import ConsoleTerminalPane from './ConsoleTerminalPane.vue'
+
+// The PTY lives in main; this pane is a thin xterm view. We mock xterm so the
+// tests assert the wiring (subscribe on mount, exit banner + restart) rather
+// than terminal rendering, which needs a real canvas.
+
+const fakeTerminal = {
+  loadAddon: vi.fn(),
+  open: vi.fn(),
+  onData: vi.fn(() => ({ dispose: vi.fn() })),
+  write: vi.fn(),
+  resize: vi.fn(),
+  reset: vi.fn(),
+  dispose: vi.fn(),
+  cols: 80,
+  rows: 30
+}
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: vi.fn(function (this: unknown) {
+    return fakeTerminal
+  })
+}))
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: vi.fn(function (this: unknown) {
+    return { fit: vi.fn(), proposeDimensions: vi.fn() }
+  })
+}))
+vi.mock('@xterm/xterm/css/xterm.css', () => ({}))
+
+const messages = {
+  en: {
+    console: {
+      sessionEnded: 'Console session ended',
+      restartSession: 'Restart console'
+    }
+  }
+} as const
+
+function createTestI18n() {
+  return createI18n({ legacy: false, locale: 'en', messages })
+}
+
+let exitCallbacks: Array<(data: { installationId: string }) => void> = []
+
+function makeRestore(overrides: Partial<TerminalRestore> = {}): TerminalRestore {
+  return { buffer: [], size: { cols: 80, rows: 30 }, exited: false, ...overrides }
+}
+
+function setupApi(subscribeRestore: TerminalRestore = makeRestore()): void {
+  ;(window as unknown as { api: Record<string, unknown> }).api = {
+    terminalSubscribe: vi.fn().mockResolvedValue(subscribeRestore),
+    terminalUnsubscribe: vi.fn().mockResolvedValue(undefined),
+    terminalWrite: vi.fn().mockResolvedValue(undefined),
+    terminalResize: vi.fn().mockResolvedValue(undefined),
+    terminalRestart: vi.fn().mockResolvedValue(makeRestore()),
+    onTerminalOutput: vi.fn(() => () => {}),
+    onTerminalExited: vi.fn((cb: (data: { installationId: string }) => void) => {
+      exitCallbacks.push(cb)
+      return () => {}
+    })
+  }
+}
+
+function mountPane(): VueWrapper {
+  return mount(ConsoleTerminalPane, {
+    props: { installationId: 'install-A' },
+    global: { plugins: [createTestI18n()] }
+  }) as VueWrapper
+}
+
+describe('comfyUISettings/ConsoleTerminalPane', () => {
+  beforeEach(() => {
+    exitCallbacks = []
+    vi.clearAllMocks()
+    ;(globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+      observe() {}
+      disconnect() {}
+    }
+    setupApi()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('subscribes to the install console on mount', async () => {
+    const w = mountPane()
+    await flushPromises()
+    expect(window.api.terminalSubscribe).toHaveBeenCalledWith('install-A')
+    expect(w.find(`[data-testid="${TID.consoleSessionEnded}"]`).exists()).toBe(false)
+  })
+
+  it('shows the restart banner on exit and respawns on click', async () => {
+    const w = mountPane()
+    await flushPromises()
+
+    exitCallbacks.forEach((cb) => cb({ installationId: 'install-A' }))
+    await flushPromises()
+    expect(w.find(`[data-testid="${TID.consoleSessionEnded}"]`).exists()).toBe(true)
+
+    await w.find(`[data-testid="${TID.consoleRestart}"]`).trigger('click')
+    await flushPromises()
+    expect(window.api.terminalRestart).toHaveBeenCalledWith('install-A')
+    expect(w.find(`[data-testid="${TID.consoleSessionEnded}"]`).exists()).toBe(false)
+  })
+
+  it('ignores exit events for other installations', async () => {
+    const w = mountPane()
+    await flushPromises()
+
+    exitCallbacks.forEach((cb) => cb({ installationId: 'other-install' }))
+    await flushPromises()
+    expect(w.find(`[data-testid="${TID.consoleSessionEnded}"]`).exists()).toBe(false)
+  })
+
+  it('shows the banner immediately when restored session was already exited', async () => {
+    setupApi(makeRestore({ exited: true }))
+    const w = mountPane()
+    await flushPromises()
+    expect(w.find(`[data-testid="${TID.consoleSessionEnded}"]`).exists()).toBe(true)
+  })
+})

--- a/src/renderer/src/views/comfyUISettings/ConsoleTerminalPane.vue
+++ b/src/renderer/src/views/comfyUISettings/ConsoleTerminalPane.vue
@@ -92,6 +92,7 @@ async function attach(id: string): Promise<void> {
 
   pushSize()
   applyRestore(await api.terminalSubscribe(id))
+  requestAnimationFrame(pushSize)
 }
 
 async function restart(): Promise<void> {
@@ -162,6 +163,19 @@ onBeforeUnmount(teardown)
   inset: 0;
   padding: 8px;
   overflow: hidden;
+}
+
+/* xterm injects its own DOM at runtime, outside Vue's scoped templates, so
+ * `:deep()` is required to reach it. Without clamping these layers they
+ * overflow the host and capture pointer events across the settings window,
+ * which reads as the whole UI freezing. */
+.console-host :deep(.xterm) {
+  overflow: hidden;
+}
+
+.console-host :deep(.xterm-screen) {
+  overflow: hidden;
+  background-color: #171717;
 }
 
 .console-ended {

--- a/src/renderer/src/views/comfyUISettings/ConsoleTerminalPane.vue
+++ b/src/renderer/src/views/comfyUISettings/ConsoleTerminalPane.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useDebounceFn } from '@vueuse/core'
 import { useI18n } from 'vue-i18n'
 import { FitAddon } from '@xterm/addon-fit'
 import { Terminal } from '@xterm/xterm'
@@ -21,6 +22,7 @@ const props = defineProps<Props>()
 const { t } = useI18n()
 const api = window.api
 
+const paneRef = ref<HTMLDivElement | null>(null)
 const hostRef = ref<HTMLDivElement | null>(null)
 const exited = ref(false)
 
@@ -55,9 +57,14 @@ function applyRestore(restore: TerminalRestore): void {
 function pushSize(): void {
   if (!terminal || !fitAddon || !currentId) return
   if (!hostRef.value?.offsetParent) return
-  fitAddon.fit()
-  void api.terminalResize(currentId, terminal.cols, terminal.rows)
+  const dims = fitAddon.proposeDimensions()
+  if (!dims || !dims.cols || !dims.rows) return
+  if (dims.cols === terminal.cols && dims.rows === terminal.rows) return
+  terminal.resize(dims.cols, dims.rows)
+  void api.terminalResize(currentId, dims.cols, dims.rows)
 }
+
+const debouncedPushSize = useDebounceFn(pushSize, 50)
 
 async function attach(id: string): Promise<void> {
   if (!hostRef.value) return
@@ -80,8 +87,8 @@ async function attach(id: string): Promise<void> {
     })
   )
 
-  resizeObserver = new ResizeObserver(() => pushSize())
-  resizeObserver.observe(hostRef.value)
+  resizeObserver = new ResizeObserver(() => void debouncedPushSize())
+  if (paneRef.value) resizeObserver.observe(paneRef.value)
 
   pushSize()
   applyRestore(await api.terminalSubscribe(id))
@@ -112,7 +119,7 @@ onBeforeUnmount(teardown)
 </script>
 
 <template>
-  <div class="console-pane">
+  <div ref="paneRef" class="console-pane">
     <div ref="hostRef" class="console-host" :data-testid="TID.consoleTerminal" />
     <div
       v-if="exited"

--- a/src/renderer/src/views/comfyUISettings/ConsoleTerminalPane.vue
+++ b/src/renderer/src/views/comfyUISettings/ConsoleTerminalPane.vue
@@ -1,0 +1,178 @@
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { FitAddon } from '@xterm/addon-fit'
+import { Terminal } from '@xterm/xterm'
+import '@xterm/xterm/css/xterm.css'
+import type { TerminalRestore } from '../../../../types/ipc'
+import { TID } from '../../../../shared/testIds'
+
+/** Interactive per-install console. The shell lives in main (one PTY per
+ *  installation, shared across windows) and survives ComfyUI being stopped,
+ *  so this pane is purely a view onto it. Typing `exit` ends the session;
+ *  the restart banner respawns a fresh shell. */
+
+interface Props {
+  installationId: string | null
+}
+
+const props = defineProps<Props>()
+
+const { t } = useI18n()
+const api = window.api
+
+const hostRef = ref<HTMLDivElement | null>(null)
+const exited = ref(false)
+
+let terminal: Terminal | null = null
+let fitAddon: FitAddon | null = null
+let resizeObserver: ResizeObserver | null = null
+const disposers: Array<() => void> = []
+
+function teardown(): void {
+  for (const dispose of disposers.splice(0)) dispose()
+  resizeObserver?.disconnect()
+  resizeObserver = null
+  const id = currentId
+  if (id) void api.terminalUnsubscribe(id)
+  terminal?.dispose()
+  terminal = null
+  fitAddon = null
+  currentId = null
+}
+
+let currentId: string | null = null
+
+function applyRestore(restore: TerminalRestore): void {
+  if (!terminal) return
+  if (restore.size.cols > 0 && restore.size.rows > 0) {
+    terminal.resize(restore.size.cols, restore.size.rows)
+  }
+  if (restore.buffer.length) terminal.write(restore.buffer.join(''))
+  exited.value = restore.exited
+}
+
+function pushSize(): void {
+  if (!terminal || !fitAddon || !currentId) return
+  if (!hostRef.value?.offsetParent) return
+  fitAddon.fit()
+  void api.terminalResize(currentId, terminal.cols, terminal.rows)
+}
+
+async function attach(id: string): Promise<void> {
+  if (!hostRef.value) return
+  currentId = id
+
+  terminal = new Terminal({ convertEol: true, theme: { background: '#171717' } })
+  fitAddon = new FitAddon()
+  terminal.loadAddon(fitAddon)
+  terminal.open(hostRef.value)
+
+  disposers.push(terminal.onData((data) => void api.terminalWrite(id, data)).dispose)
+  disposers.push(
+    api.onTerminalOutput((payload) => {
+      if (payload.installationId === id) terminal?.write(payload.data)
+    })
+  )
+  disposers.push(
+    api.onTerminalExited((payload) => {
+      if (payload.installationId === id) exited.value = true
+    })
+  )
+
+  resizeObserver = new ResizeObserver(() => pushSize())
+  resizeObserver.observe(hostRef.value)
+
+  pushSize()
+  applyRestore(await api.terminalSubscribe(id))
+}
+
+async function restart(): Promise<void> {
+  if (!currentId || !terminal) return
+  terminal.reset()
+  exited.value = false
+  applyRestore(await api.terminalRestart(currentId))
+  pushSize()
+}
+
+onMounted(() => {
+  if (props.installationId) void attach(props.installationId)
+})
+
+watch(
+  () => props.installationId,
+  (next) => {
+    teardown()
+    exited.value = false
+    if (next) void attach(next)
+  }
+)
+
+onBeforeUnmount(teardown)
+</script>
+
+<template>
+  <div class="console-pane">
+    <div ref="hostRef" class="console-host" :data-testid="TID.consoleTerminal" />
+    <div
+      v-if="exited"
+      class="console-ended"
+      role="status"
+      :data-testid="TID.consoleSessionEnded"
+    >
+      <span class="console-ended-text">{{ t('console.sessionEnded') }}</span>
+      <button
+        type="button"
+        class="accent console-ended-restart"
+        :data-testid="TID.consoleRestart"
+        @click="restart"
+      >
+        {{ t('console.restartSession') }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.console-pane {
+  position: relative;
+  width: 100%;
+  flex: 1 1 auto;
+  min-height: 240px;
+  background: #171717;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.console-host {
+  width: 100%;
+  height: 100%;
+  padding: 8px;
+}
+
+.console-ended {
+  position: absolute;
+  inset-inline: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 14px;
+  background: var(--modal-surface-bg, #1f1f1f);
+  border-top: 1px solid var(--chooser-surface-border, rgba(255, 255, 255, 0.1));
+}
+
+.console-ended-text {
+  font-size: 13px;
+  color: var(--text-muted, var(--neutral-100));
+}
+
+.console-ended-restart {
+  height: 30px;
+  padding: 0 14px;
+  font-size: 12px;
+  font-weight: 500;
+  flex-shrink: 0;
+}
+</style>

--- a/src/renderer/src/views/comfyUISettings/ConsoleTerminalPane.vue
+++ b/src/renderer/src/views/comfyUISettings/ConsoleTerminalPane.vue
@@ -64,6 +64,16 @@ function pushSize(): void {
   void api.terminalResize(currentId, dims.cols, dims.rows)
 }
 
+/** Force the shared PTY to this view's size. Unlike {@link pushSize}, this skips
+ *  the "local dims unchanged" guard: another window may have resized the PTY out
+ *  from under us, so on focus we must re-assert our size even if our own xterm
+ *  hasn't changed, or the shell's cursor stays misaligned. */
+function reclaimPtySize(): void {
+  if (!terminal || !currentId) return
+  if (!hostRef.value?.offsetParent) return
+  void api.terminalResize(currentId, terminal.cols, terminal.rows)
+}
+
 const debouncedPushSize = useDebounceFn(pushSize, 50)
 
 async function attach(id: string): Promise<void> {
@@ -78,8 +88,20 @@ async function attach(id: string): Promise<void> {
   disposers.push(terminal.onData((data) => void api.terminalWrite(id, data)).dispose)
   disposers.push(
     api.onTerminalOutput((payload) => {
-      if (payload.installationId === id) terminal?.write(payload.data)
+      if (payload.installationId !== id) return
+      // Output only flows from a live shell, so a restart triggered from
+      // another window (no exit/start event reaches us) revives the session:
+      // clear the "session ended" banner so input works again.
+      if (exited.value) exited.value = false
+      terminal?.write(payload.data)
     })
+  )
+  // The PTY is shared with the ComfyUI window's terminal and holds one size.
+  // Reclaim it for this view on focus so the shell's cursor matches what we
+  // render here.
+  terminal.element?.addEventListener('focusin', reclaimPtySize)
+  disposers.push(() =>
+    terminal?.element?.removeEventListener('focusin', reclaimPtySize)
   )
   disposers.push(
     api.onTerminalExited((payload) => {

--- a/src/renderer/src/views/comfyUISettings/ConsoleTerminalPane.vue
+++ b/src/renderer/src/views/comfyUISettings/ConsoleTerminalPane.vue
@@ -137,6 +137,10 @@ onBeforeUnmount(teardown)
 .console-pane {
   position: relative;
   width: 100%;
+  /* Without min-width:0 the xterm host's intrinsic ~80-col width propagates up
+   * the flex chain and blows out the settings pane (overflowing buttons, broken
+   * tab strip). */
+  min-width: 0;
   flex: 1 1 auto;
   min-height: 240px;
   background: #171717;
@@ -144,10 +148,13 @@ onBeforeUnmount(teardown)
   overflow: hidden;
 }
 
+/* Absolutely positioned so xterm's content size never contributes to the
+ * layout's intrinsic width — the pane is sized by the flex container only. */
 .console-host {
-  width: 100%;
-  height: 100%;
+  position: absolute;
+  inset: 0;
   padding: 8px;
+  overflow: hidden;
 }
 
 .console-ended {

--- a/src/shared/testIds.ts
+++ b/src/shared/testIds.ts
@@ -46,6 +46,10 @@ export const TID = {
   snapshotsOpCardRetry: 'snapshots-op-card-retry',
   snapshotsOpCardDismiss: 'snapshots-op-card-dismiss',
 
+  consoleTerminal: 'console-terminal',
+  consoleSessionEnded: 'console-session-ended',
+  consoleRestart: 'console-restart',
+
   progressErrorMessage: 'progress-error-message',
   progressLogs: 'progress-logs',
   progressReboot: 'progress-reboot',

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -434,6 +434,14 @@ export interface ComfyOutputData {
   text: string
 }
 
+/** Snapshot for repainting an interactive console: the retained scrollback,
+ *  the shell's current size, and whether the session has been killed. */
+export interface TerminalRestore {
+  buffer: string[]
+  size: { cols: number; rows: number }
+  exited: boolean
+}
+
 export interface ComfyExitedData {
   installationId: string
   installationName: string
@@ -934,6 +942,16 @@ export interface ElectronApi {
   // Running
   stopComfyUI(installationId: string): Promise<void>
   focusComfyWindow(installationId: string): Promise<void>
+
+  // Interactive console (per-installation shell, shared across windows)
+  /** Spawn the install's shell if needed, subscribe this surface, and return
+   *  the current scrollback/size/exited state to repaint. */
+  terminalSubscribe(installationId: string): Promise<TerminalRestore>
+  terminalUnsubscribe(installationId: string): Promise<void>
+  terminalWrite(installationId: string, data: string): Promise<void>
+  terminalResize(installationId: string, cols: number, rows: number): Promise<void>
+  /** Kill the current shell (if any) and start a fresh one. */
+  terminalRestart(installationId: string): Promise<TerminalRestore>
   /** Open a window for the install backing `installationId`. Focuses
    *  any existing install-backed window; otherwise opens a fresh
    *  chooser host so the user can pick the install from the dashboard.
@@ -1209,6 +1227,10 @@ export interface ElectronApi {
   onInstallProgress(callback: (data: ProgressData) => void): Unsubscribe
   onComfyOutput(callback: (data: ComfyOutputData) => void): Unsubscribe
   onComfyExited(callback: (data: ComfyExitedData) => void): Unsubscribe
+  onTerminalOutput(
+    callback: (data: { installationId: string; data: string }) => void
+  ): Unsubscribe
+  onTerminalExited(callback: (data: { installationId: string }) => void): Unsubscribe
   onComfyBootLog(callback: (data: ComfyBootLogData) => void): Unsubscribe
   onInstanceLaunching(
     callback: (data: { installationId: string; installationName: string }) => void

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -1006,7 +1006,7 @@ export interface ElectronApi {
    *  `comfy://open-settings?tab=comfy`). */
   openInstancePicker(opts?: {
     installationId?: string | null
-    initialTab?: 'config' | 'status' | 'update' | 'snapshots' | 'storage'
+    initialTab?: 'config' | 'status' | 'update' | 'snapshots' | 'storage' | 'console'
     autoAction?: string | null
   }): void
   /** Push the first-use takeover's current step to main so it can


### PR DESCRIPTION
Adds an interactive **Console** tab to each install's Settings, plus the backend that powers it.

## What this does
- New **Console** tab in the per-install Settings surface, backed by an `xterm` view.
- One shared shell **per installation** (keyed by `installationId`), visible from every window attached to that install, so the same session is never duplicated or confused across windows.
- The shell is **independent of the ComfyUI process** — it works whether ComfyUI is running or stopped (most console use happens while ComfyUI is off, since changes usually need a reboot to take effect).

## Fixes the legacy "typed `exit` and the console is dead" bug
In legacy Desktop, typing `exit` killed the PTY and it stayed dead until the app restarted. Now:
- `onExit` marks the session ended and notifies every subscriber instead of caching a dead PTY.
- Writes after exit are dropped.
- The pane shows a **"session ended"** banner with a **Restart console** button that respawns a fresh shell.
- Guards against the restart race where an old PTY's async exit could clobber the new session.

## Frontend feature flag (served frontend bottom panel)
So the served ComfyUI frontend can also surface its bottom-panel terminal, the launcher injects the `supports_terminal` CLI feature flag (validated against the install's `--list-feature-flags` registry). The interactive transport is the existing `__comfyDesktop2.Terminal` preload bridge; the flag only gates visibility.

This piece depends on two not-yet-merged PRs (branches pushed, PRs intentionally not opened yet):
- **ComfyUI** `feat/supports-terminal-flag` — registers `supports_terminal` as a bool CLI feature flag.
- **ComfyUI_frontend** `feat/desktop-terminal-feature-flag` — gates the bottom-panel terminal on `supports_terminal` and adds host-agnostic terminal transport + auto-restart.

The desktop Console tab in this PR works on its own (via `window.api.terminal*`) and does not require those to land first; they only enable the served frontend's bottom panel.

## Packaging
`node-pty` is externalized in the main build and `asar`-unpacked for distribution.

## Validation
`typecheck`, `lint`, `build`, and the full unit suite (1808 tests) pass.

Fixes #888
