### PR TITLE
test: use realistic Legacy Desktop fixtures (category local + desktop sourceId)

### DIFF
--- a/src/renderer/src/comfyTitleBar/TitleBarApp.test.ts
+++ b/src/renderer/src/comfyTitleBar/TitleBarApp.test.ts
@@ -457,9 +457,9 @@ describe('TitleBarApp', () => {
     bridgeState.sourceCategoryChangedCallbacks.forEach((cb) => cb('cloud'))
     await flushPromises()
     expect(wrapper.find('.title-install-type-icon').attributes('title')).toBe('Cloud')
-    bridgeState.sourceCategoryChangedCallbacks.forEach((cb) => cb('desktop'))
+    bridgeState.sourceCategoryChangedCallbacks.forEach((cb) => cb('remote'))
     await flushPromises()
-    expect(wrapper.find('.title-install-type-icon').attributes('title')).toBe('Legacy Desktop')
+    expect(wrapper.find('.title-install-type-icon').attributes('title')).toBe('Remote')
   })
 
   it('suppresses the install-type icon on install-less host windows even when a category arrives', async () => {

--- a/src/renderer/src/composables/useInstallList.test.ts
+++ b/src/renderer/src/composables/useInstallList.test.ts
@@ -117,7 +117,8 @@ describe('useInstallList', () => {
       const installations = ref<Installation[]>([
         makeInstall({ id: 'l', sourceCategory: 'local' }),
         makeInstall({ id: 'r', sourceCategory: 'remote' }),
-        makeInstall({ id: 'd', sourceCategory: 'desktop' }),
+        // Legacy Desktop reports category `local`; sourceId is the marker.
+        makeInstall({ id: 'd', sourceCategory: 'local', sourceId: 'desktop' } as Partial<Installation>),
         makeInstall({ id: 'c', sourceCategory: 'cloud' }),
       ])
       const list = withI18nScope(i18n, () => useInstallList({ installations }))

--- a/src/renderer/src/composables/useInstallList.test.ts
+++ b/src/renderer/src/composables/useInstallList.test.ts
@@ -118,7 +118,7 @@ describe('useInstallList', () => {
         makeInstall({ id: 'l', sourceCategory: 'local' }),
         makeInstall({ id: 'r', sourceCategory: 'remote' }),
         // Legacy Desktop reports category `local`; sourceId is the marker.
-        makeInstall({ id: 'd', sourceCategory: 'local', sourceId: 'desktop' } as Partial<Installation>),
+        makeInstall({ id: 'd', sourceCategory: 'local', sourceId: 'desktop' }),
         makeInstall({ id: 'c', sourceCategory: 'cloud' }),
       ])
       const list = withI18nScope(i18n, () => useInstallList({ installations }))

--- a/src/renderer/src/composables/useListAction.test.ts
+++ b/src/renderer/src/composables/useListAction.test.ts
@@ -54,7 +54,8 @@ function makeInstall(overrides: Partial<Installation> = {}): Installation {
     id: 'inst-1',
     name: 'Legacy Desktop',
     sourceLabel: 'Legacy Desktop',
-    sourceCategory: 'desktop',
+    // Legacy Desktop reports category `local`; the `desktop` sourceId is the marker.
+    sourceCategory: 'local',
     sourceId: 'desktop',
     status: 'installed',
     ...overrides,

--- a/src/renderer/src/views/ChooserView.test.ts
+++ b/src/renderer/src/views/ChooserView.test.ts
@@ -195,7 +195,8 @@ describe('ChooserView', () => {
   it('filters install tiles by source category when a filter chip is active', async () => {
     installMockApi([
       makeInstall({ id: 'l', name: 'LocalThing', sourceCategory: 'local' }),
-      makeInstall({ id: 'd', name: 'DesktopThing', sourceCategory: 'desktop' }),
+      // Legacy Desktop reports category `local`; sourceId is the marker.
+      makeInstall({ id: 'd', name: 'LegacyDesktopThing', sourceCategory: 'local', sourceId: 'desktop' }),
       makeInstall({ id: 'r', name: 'RemoteThing', sourceCategory: 'remote' }),
     ])
     const wrapper = mountChooser()


### PR DESCRIPTION
Follow-up cleanup stacked on top of #905.

Several test fixtures used `sourceCategory: 'desktop'` — a value that **never occurs in production**. The desktop source plugin reports `category: 'local'` and is distinguished by `sourceId: 'desktop'`. These fixtures are updated to mirror the real runtime data model so the tests can't drift from reality.

### Files
- `useListAction.test.ts` — `sourceCategory: 'desktop'` -> `'local'` (interceptor already keys on `sourceId`)
- `useInstallList.test.ts` (all-filter test) -> `'local'` + `sourceId: 'desktop'`
- `ChooserView.test.ts` (category-filter test) -> `'local'` + `sourceId: 'desktop'`
- `TitleBarApp.test.ts` — the tooltip-switch test now uses a realistic `'remote'` category (the title bar never receives a `'desktop'` category in production)

No behavior change. `typecheck` / `lint` / `build` / `test` (1809) all pass.

> Note: stacked on `fix/local-refresh-button-and-migrate-fires` (#905). Retarget to `main` once #905 merges.