### PR TITLE
fix(launcher): lock Continue until ToS accepted + neutral zoom pill 

### DIFF
--- a/src/renderer/src/comfyTitleBar/TitleBarApp.vue
+++ b/src/renderer/src/comfyTitleBar/TitleBarApp.vue
@@ -1124,9 +1124,10 @@ onUnmounted(() => {
   gap: 4px;
   padding: 3px 8px;
   border-radius: 999px;
-  border: 1px solid color-mix(in srgb, var(--comfy-yellow) 45%, transparent);
-  background: color-mix(in srgb, var(--comfy-yellow) 12%, transparent);
-  color: var(--comfy-yellow);
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--titlebar-icon);
+  opacity: 0.85;
   font: inherit;
   font-size: 11px;
   line-height: 14px;
@@ -1134,14 +1135,21 @@ onUnmounted(() => {
   cursor: pointer;
   transition:
     background-color 0.12s,
-    border-color 0.12s;
+    opacity 0.12s,
+    border-color 0.12s,
+    color 0.12s;
 }
 .title-zoom-reset-percent {
   letter-spacing: 0.01em;
 }
 .title-bar.is-hover-active .title-zoom-reset:hover {
-  background: color-mix(in srgb, var(--comfy-yellow) 20%, transparent);
-  border-color: var(--comfy-yellow);
+  opacity: 1;
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+.title-bar.is-light.is-hover-active .title-zoom-reset:hover {
+  background: rgba(0, 0, 0, 0.06);
+  border-color: rgba(0, 0, 0, 0.18);
 }
 .title-zoom-reset:focus-visible {
   outline: 2px solid var(--focus-ring);

--- a/src/renderer/src/views/FirstUseTakeover.vue
+++ b/src/renderer/src/views/FirstUseTakeover.vue
@@ -860,10 +860,12 @@ defineExpose({ open, resetContinue })
           </div>
           <button
             class="brand-primary start-continue"
+            :class="{ 'start-continue--locked': !acceptedTos }"
             type="button"
             data-testid="first-use-continue"
             :disabled="isContinuing || pickedChoice === null"
             :aria-busy="isContinuing"
+            :aria-disabled="!acceptedTos"
             @click="onContinue"
           >
             <Loader2
@@ -1283,6 +1285,15 @@ defineExpose({ open, resetContinue })
   align-items: center;
   justify-content: center;
   gap: 8px;
+}
+
+.start-continue--locked {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.start-continue--locked:hover {
+  background: var(--comfy-yellow);
+  border-color: var(--comfy-yellow);
 }
 .start-continue__spinner {
   animation: start-continue-spin 750ms linear infinite;


### PR DESCRIPTION
## Summary

Two style-only launcher-chrome fixes. The first-use **Continue** CTA now reads as locked (dimmed "disabled yellow") until the EULA/ToS box is checked, and the title-bar zoom-reset pill no longer looks permanently highlighted next to the refresh icon.

## Changes

**What**
- `FirstUseTakeover.vue` — Continue button gains `:class="{ 'start-continue--locked': !acceptedTos }"` + `:aria-disabled="!acceptedTos"`. New `.start-continue--locked` rule dims it (`opacity: 0.45`, `cursor: not-allowed`) with a hover override that cancels the `brand-primary` darken, so it reads as not-yet-available. Deliberately **not** wired through the `disabled` attribute — the button stays clickable so the existing `onContinue` → `nudgeTos()` consent-row shake still fires.
- `TitleBarApp.vue` — `.title-zoom-reset` resting state rewritten to mirror the inactive refresh icon (`.title-menu-button`): transparent background/border, `color: var(--titlebar-icon)`, `opacity: 0.85`. Hover moves from a brand-yellow tint to the neutral white wash, plus a `.is-light` hover variant. Pill geometry, `:focus-visible`, and the fade transition are untouched.

**Breaking**
- None. No logic, IPC, telemetry, or gating behavior changed — `acceptedTos` gating and `onContinue` routing are exactly as before; the zoom pill's click-to-reset and fade-in conditions are unchanged.

## Review Focus

- Confirm the locked Continue stays clickable (so the nudge fires) — i.e. that we did **not** reach for `disabled`/`pointer-events: none` for the ToS gate.
- Zoom pill: verify resting state now matches the refresh icon in both dark and light title-bar themes; yellow should appear only on hover.
- Scope is visual only; the pre-existing Prettier warnings in `FirstUseTakeover.vue` (lines ~146 and ~634) are untouched and out of scope.

## Testing

Style-only change with no user-visible behavior change beyond the intended visuals, so verification is manual + the repo pre-commit gate.

- `pnpm typecheck` (node/web/e2e/integration) and `pnpm lint` — pass clean (ran via pre-commit hook).
- Manual — **Continue**: on the first-use start screen with ToS unchecked, button renders dimmed yellow; clicking it shakes the consent row (no navigation); checking the box restores full yellow and Continue proceeds; async busy spinner/`:disabled` state during the IPC pre-roll still works.
- Manual — **Zoom pill**: zoom the comfyView off 100% so the pill fades in; resting look matches the refresh icon (not yellow); hover gives the neutral white wash; click resets to 100% and fades out. Checked in dark and light themes.

Screen Recording (ZOOM + EULA)

https://github.com/user-attachments/assets/27e252e0-2b1c-49e3-a9e3-7a173fb4bd62


https://github.com/user-attachments/assets/b5d9f09a-d6c5-4f6d-849d-a850e6525c3f


closes #913  closes #914 