### PR TITLE
chore: bump version to 1.0.5-rc.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-desktop-2",
-  "version": "1.0.4",
+  "version": "1.0.5-rc.1",
   "description": "Comfy Desktop",
   "author": {
     "name": "Comfy Org",


### PR DESCRIPTION
## Summary
- bump `package.json` version from `1.0.4` to `1.0.5-rc.1`
- channel: `rc` (rc → GitHub pre-release, stable → Latest)
- commits since `v1.0.3` were auto-grouped below

## How merging this PR ships the build
1. Merge — `Release From Version PR` workflow tags `v1.0.5-rc.1` on the merge commit
2. Tag triggers `Publish All / build-release`, which creates the GitHub Release using **this PR body as the release notes**
3. ToDesktop picks up the new build and rolls it out

> **Polish the sections below before merge.** The auto-fill is a starting point — rewrite for users, not for the changelog.

## Features
- configurable default install location (#895)

## Fixes
- refresh button on local instances (#886) + restore portable/git migrate fires (#905)
- don't recreate ~/ComfyUI-Shared when user has custom paths (#699) (#815)
- labeled status pill + readable, window-owned error recovery (#874)
- switch to op's progress tab when tabs lock (#896)
- rebuild Finish-page 'Add a desktop shortcut' as an explicit nsDialogs checkbox (#893)

## Install
- 👉 [comfy.org/download](https://comfy.org/download)
