### PR TITLE
fix: lock Comfy Cloud install name (#922)

### DIFF
--- a/src/main/installations.test.ts
+++ b/src/main/installations.test.ts
@@ -525,3 +525,49 @@ describe('installations.hasNameConflict', () => {
     expect(await installations.hasNameConflict(a.id, 'Self')).toBe(false)
   })
 })
+
+describe('installations.enforceCloudName', () => {
+  it('resets a renamed Cloud entry back to the canonical name', async () => {
+    const installations = await loadInstallations()
+    const cloud = await installations.add({
+      name: 'My Renamed Cloud',
+      installPath: path.join(tmpRoot, 'cloud'),
+      sourceId: installations.CLOUD_SOURCE_ID,
+      status: 'installed',
+    })
+    await installations.enforceCloudName()
+    const rec = (await installations.list()).find((r) => r.id === cloud.id)!
+    expect(rec.name).toBe(installations.CLOUD_INSTALL_NAME)
+  })
+
+  it('leaves a Cloud entry that already has the canonical name untouched', async () => {
+    const installations = await loadInstallations()
+    const cloud = await installations.add({
+      name: installations.CLOUD_INSTALL_NAME,
+      installPath: path.join(tmpRoot, 'cloud'),
+      sourceId: installations.CLOUD_SOURCE_ID,
+      status: 'installed',
+    })
+    await installations.enforceCloudName()
+    const rec = (await installations.list()).find((r) => r.id === cloud.id)!
+    expect(rec.name).toBe(installations.CLOUD_INSTALL_NAME)
+  })
+
+  it('does not touch non-Cloud installs', async () => {
+    const installations = await loadInstallations()
+    const local = await installations.add({
+      name: 'My Local',
+      installPath: path.join(tmpRoot, 'local'),
+      sourceId: 'standalone',
+      status: 'installed',
+    })
+    await installations.enforceCloudName()
+    const rec = (await installations.list()).find((r) => r.id === local.id)!
+    expect(rec.name).toBe('My Local')
+  })
+
+  it('is a no-op when there is no Cloud entry', async () => {
+    const installations = await loadInstallations()
+    await expect(installations.enforceCloudName()).resolves.toBeUndefined()
+  })
+})

--- a/src/main/installations.ts
+++ b/src/main/installations.ts
@@ -10,6 +10,11 @@ import type { ComfyVersion } from './lib/version'
  *  list-affecting mutation and is rebroadcast as `installations-changed`. */
 export const installationEvents = new EventEmitter()
 
+/** Source id of the always-seeded Comfy Cloud entry. */
+export const CLOUD_SOURCE_ID = 'cloud'
+/** Canonical, non-user-editable name of the Comfy Cloud entry (issue #922). */
+export const CLOUD_INSTALL_NAME = 'Comfy Cloud'
+
 export interface InstallationRecord {
   id: string
   name: string
@@ -196,6 +201,27 @@ export async function ensureExists(sourceId: string, data: Record<string, unknow
     return true
   })
   if (added) installationEvents.emit('changed')
+}
+
+/** Force the seeded Cloud entry back to its canonical name. The Cloud install
+ *  is not user-renamable (issue #922); this self-heals any entry that a prior
+ *  build let the user rename. No-op when the name already matches or no Cloud
+ *  entry exists. */
+export async function enforceCloudName(): Promise<void> {
+  const updated = await enqueue(async () => {
+    const all = await load()
+    const index = all.findIndex((i) => i.sourceId === CLOUD_SOURCE_ID)
+    if (index === -1) return null
+    const existing = all[index]!
+    if (existing.name === CLOUD_INSTALL_NAME) return null
+    all[index] = { ...existing, name: CLOUD_INSTALL_NAME } as InstallationRecord
+    await save(all)
+    return all[index]!
+  })
+  if (updated) {
+    installationEvents.emit('updated', updated)
+    installationEvents.emit('changed')
+  }
 }
 
 /**

--- a/src/main/lib/ipc/index.ts
+++ b/src/main/lib/ipc/index.ts
@@ -55,21 +55,25 @@ export function register(callbacks: RegisterCallbacks = {}): void {
 
   installations.seedDefaults([
     {
-      name: 'Comfy Cloud',
-      sourceId: 'cloud',
+      name: installations.CLOUD_INSTALL_NAME,
+      sourceId: installations.CLOUD_SOURCE_ID,
       remoteUrl: 'https://cloud.comfy.org/',
       launchMode: 'window',
       browserPartition: 'shared'
     }
   ])
-  installations.ensureExists('cloud', {
-    name: 'Comfy Cloud',
-    sourceId: 'cloud',
+  installations.ensureExists(installations.CLOUD_SOURCE_ID, {
+    name: installations.CLOUD_INSTALL_NAME,
+    sourceId: installations.CLOUD_SOURCE_ID,
     remoteUrl: 'https://cloud.comfy.org/',
     launchMode: 'window',
     browserPartition: 'shared',
     status: 'installed'
   })
+  // The Cloud entry is not user-renamable; reset any entry a prior build
+  // let the user rename back to the canonical name (issue #922). Runs after
+  // ensureExists via the shared FIFO write queue.
+  void installations.enforceCloudName()
 
   // Auto-track a detected Legacy Desktop install.
   {

--- a/src/main/lib/ipc/registerInstallationHandlers.ts
+++ b/src/main/lib/ipc/registerInstallationHandlers.ts
@@ -403,6 +403,11 @@ export function registerInstallationHandlers(): void {
           }
         }
       }
+      // The Comfy Cloud entry is not user-renamable (issue #922); drop any
+      // attempted name change so the canonical name is preserved.
+      if (inst.sourceId === installations.CLOUD_SOURCE_ID) {
+        allowedIds.delete('name')
+      }
       const filtered: Record<string, unknown> = {}
       for (const key of Object.keys(data)) {
         if (allowedIds.has(key)) {

--- a/src/main/sources/common/urlSource.test.ts
+++ b/src/main/sources/common/urlSource.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: { getPath: () => '' },
+}))
+
+import { createUrlSource } from './urlSource'
+import type { InstallationRecord } from '../../installations'
+
+function makeInstall(): InstallationRecord {
+  return {
+    id: 'inst-1',
+    name: 'My Connection',
+    createdAt: new Date().toISOString(),
+    sourceId: 'x',
+    remoteUrl: 'https://example.com/',
+    status: 'installed',
+  } as unknown as InstallationRecord
+}
+
+function detailActionIds(source: ReturnType<typeof createUrlSource>): string[] {
+  const sections = source.getDetailSections(makeInstall()) as Record<string, unknown>[]
+  const ids: string[] = []
+  for (const section of sections) {
+    const actions = section.actions as Record<string, unknown>[] | undefined
+    if (!actions) continue
+    for (const a of actions) if (a.id) ids.push(a.id as string)
+  }
+  return ids
+}
+
+describe('createUrlSource â€” rename action', () => {
+  it('omits the rename action for the cloud category (issue #922)', () => {
+    const cloud = createUrlSource({
+      id: 'cloud',
+      labelKey: 'cloud.label',
+      descKey: 'cloud.desc',
+      category: 'cloud',
+      defaultUrl: 'https://cloud.comfy.org/',
+    })
+    expect(detailActionIds(cloud)).not.toContain('rename')
+  })
+
+  it('keeps the rename action for the remote category', () => {
+    const remote = createUrlSource({
+      id: 'remote',
+      labelKey: 'remote.label',
+      descKey: 'remote.desc',
+      category: 'remote',
+      defaultUrl: 'http://localhost:8188',
+    })
+    expect(detailActionIds(remote)).toContain('rename')
+  })
+})

--- a/src/main/sources/common/urlSource.ts
+++ b/src/main/sources/common/urlSource.ts
@@ -86,8 +86,11 @@ export function createUrlSource(config: UrlSourceConfig): SourcePlugin {
       const actions: Record<string, unknown>[] = [
         { id: 'launch', label: t('actions.connect'), style: 'primary', enabled: installation.status === 'installed',
           showProgress: true, progressTitle: t('actions.connecting'), cancellable: true },
-        renameAction(installation.name),
       ]
+      // The Comfy Cloud entry is not user-renamable (issue #922).
+      if (category !== 'cloud') {
+        actions.push(renameAction(installation.name))
+      }
       if (includeUntrack) {
         actions.push(untrackAction())
       }

--- a/src/renderer/src/views/comfyUISettings/StatusFactPanel.test.ts
+++ b/src/renderer/src/views/comfyUISettings/StatusFactPanel.test.ts
@@ -22,6 +22,16 @@ function makeInstall(name: string): Installation {
   } as Installation
 }
 
+function makeCloudInstall(name: string): Installation {
+  return {
+    id: 'cloud-1',
+    name,
+    sourceLabel: 'Cloud',
+    sourceCategory: 'cloud',
+    status: 'installed',
+  } as Installation
+}
+
 function mountPanel(props: {
   installation: Installation | null
   onRename?: (newName: string) => Promise<boolean>
@@ -77,6 +87,24 @@ describe('StatusFactPanel — hero name', () => {
 
     expect(onRename).toHaveBeenCalledWith('Duplicate')
     expect((el.element as HTMLElement).textContent).toBe('Original')
+  })
+
+  it('renders the Cloud name as static, non-editable text (issue #922)', async () => {
+    const onRename = vi.fn().mockResolvedValue(true)
+    const wrapper = mountPanel({ installation: makeCloudInstall('Comfy Cloud'), onRename })
+    await nextTick()
+
+    const name = wrapper.find('.status-fact-hero-name')
+    expect(name.exists()).toBe(true)
+    expect(name.text()).toBe('Comfy Cloud')
+    // No contenteditable affordance and no pencil hint.
+    expect(name.attributes('contenteditable')).toBeUndefined()
+    expect(wrapper.find('.status-fact-hero-name-static').exists()).toBe(true)
+    expect(wrapper.find('.status-fact-hero-edit-hint').exists()).toBe(false)
+
+    // Blur must not commit a rename for the Cloud entry.
+    await name.trigger('blur')
+    expect(onRename).not.toHaveBeenCalled()
   })
 
   it('repaints the hero when the installation name prop changes', async () => {

--- a/src/renderer/src/views/comfyUISettings/StatusFactPanel.vue
+++ b/src/renderer/src/views/comfyUISettings/StatusFactPanel.vue
@@ -21,6 +21,10 @@ const props = defineProps<Props>()
 
 const { t } = useI18n()
 
+// The Comfy Cloud entry is not user-renamable (issue #922): render its name as
+// static text with no contenteditable / pencil affordance.
+const nameEditable = computed(() => props.installation?.sourceCategory !== 'cloud')
+
 // Drive the hero name imperatively: mixing `{{ }}` with the inline pencil icon left Vue unable to patch the edited text node, so a committed rename painted everywhere except here.
 const nameEl = useTemplateRef<HTMLElement>('nameEl')
 
@@ -241,6 +245,7 @@ const groups = computed<FactGroup[]>(() => {
       <div class="status-fact-hero-title-row">
         <span class="status-fact-hero-name-wrap">
           <span
+            v-if="nameEditable"
             ref="nameEl"
             class="status-fact-hero-name"
             role="textbox"
@@ -254,7 +259,15 @@ const groups = computed<FactGroup[]>(() => {
             @keydown.meta.a.prevent="handleNameSelectAll"
             @paste="handleNamePaste"
           />
-          <Pencil :size="13" class="status-fact-hero-edit-hint" aria-hidden="true" />
+          <span v-else class="status-fact-hero-name status-fact-hero-name-static">{{
+            installation.name
+          }}</span>
+          <Pencil
+            v-if="nameEditable"
+            :size="13"
+            class="status-fact-hero-edit-hint"
+            aria-hidden="true"
+          />
         </span>
         <span v-if="installation.sourceLabel" class="status-fact-hero-badge">
           {{ installation.sourceLabel }}
@@ -331,7 +344,12 @@ const groups = computed<FactGroup[]>(() => {
   transition: background-color 120ms ease;
 }
 
-.status-fact-hero-name:hover {
+/* Static (non-renamable) name, e.g. Comfy Cloud: no edit affordance. */
+.status-fact-hero-name-static {
+  cursor: default;
+}
+
+.status-fact-hero-name:not(.status-fact-hero-name-static):hover {
   background: var(--brand-surface-bg-hover);
 }
 


### PR DESCRIPTION
## Summary

Fixes #922. The Comfy Cloud install entry must always be named **"Comfy Cloud"** and must not be user-renamable. Previously it could be renamed, and renamed entries stayed renamed across restarts.

## Changes

- **Authoritative backend guard** â€” the `update-installation` IPC handler now drops `name` from the editable fields when `sourceId === 'cloud'`, so no rename path (inline hero edit, rename action, or direct IPC) can change the Cloud name.
- **Self-heal on boot** â€” new `enforceCloudName()` resets any Cloud entry that a prior build let the user rename back to the canonical name. It runs after `ensureExists` via the shared FIFO write queue.
- **Remove rename affordances for Cloud (UI)**:
  - `urlSource` no longer emits the `rename` action for the `cloud` category (the shared `remote` source keeps it).
  - `StatusFactPanel` renders the Cloud hero name as static text (no `contenteditable`, no pencil hint, no hover affordance).
- **Shared constants** â€” `CLOUD_SOURCE_ID` / `CLOUD_INSTALL_NAME` so the seed, repair, and guard cannot drift.

## Tests

- `installations.enforceCloudName`: resets a renamed Cloud entry, leaves a canonical one untouched, ignores non-Cloud installs, and no-ops when no Cloud entry exists.
- `urlSource`: omits the rename action for `cloud`, keeps it for `remote`.
- `StatusFactPanel`: renders the Cloud name as static, non-editable text and does not commit a rename on blur.

## Verification

`pnpm run typecheck`, `pnpm run lint`, `pnpm run build`, and `pnpm run test` (1839 tests) all pass.
