### PR TITLE
feat(installer): allow user to choose install path on Windows

### DIFF
--- a/todesktop.json
+++ b/todesktop.json
@@ -31,7 +31,8 @@
   ],
   "windows": {
     "icon": "./assets/Comfy_Logo_x256.png",
-    "nsisInclude": "./scripts/installer.nsh"
+    "nsisInclude": "./scripts/installer.nsh",
+    "allowToChangeInstallationDirectory": true
   },
   "mac": {
     "icon": "./assets/Comfy_Logo_mac_x1024.png",


### PR DESCRIPTION
## What

Adds `\"allowToChangeInstallationDirectory\": true` to `todesktop.json`'s \`windows\` block. With this, the Windows installer surfaces a directory-select page so the user can pick where ComfyUI Desktop lands, instead of forcing the default per-user path.

## Why this lives in todesktop.json (not electron-builder.yml)

\`electron-builder.yml\` has \`nsis.allowToChangeInstallationDirectory: true\` already — that's why a **local** \`pnpm run build:win\` produces an installer with the directory page. But ToDesktop reads \`todesktop.json\`, not \`electron-builder.yml\`, so its pipeline has been falling back to its own default (no directory selection). Same architectural gap that bit us on the installer art (#810 → #817).

## Risk (and why this is draft until a ToDesktop ephemeral runs)

ToDesktop CLI 1.22.0 has a strict schema for \`todesktop.json\`. It rejected the installer-art keys (\`installerHeader\`, \`installerSidebar\`, \`uninstallerSidebar\`) in #810 with:

\`\`\`
todesktop.json invalid.
ADDITIONAL PROPERTY must NOT have additional properties
  > installerHeader is not expected to be here!
\`\`\`

\`allowToChangeInstallationDirectory\` is a core NSIS *behavior* key (not artwork), so it's more likely to be in their schema than the art keys were — but **the only way to know is an ephemeral build**. If it's rejected, we'd see the same pattern at config validation in <30s and the obvious fallback is forcing the directory page via the existing \`scripts/installer.nsh\` (which the CLI does accept via \`nsisInclude\`).

<img width="495" height="388" alt="image" src="https://github.com/user-attachments/assets/ea8fda53-78ff-4dcd-b4d2-5f6db93cd036" />


## What's not changing

- \`electron-builder.yml\` — unchanged, local builds keep working as today.
- \`scripts/installer.nsh\` — unchanged. No NSIS gymnastics yet.
- Other windows-block keys — left alone to keep the diff minimal and isolate which key the CLI accepts.

## Test plan

- [x] JSON validity (\`python -m json.tool\` clean, see commit message).
- [ ] **ToDesktop ephemeral build** — this is the real check. Either:
  - Build clears config validation → installer now has the directory-select page (verify visually by running the produced \`.exe\`).
  - Build dies at validation with \`\"allowToChangeInstallationDirectory\" is not expected to be here\` → revert this PR and switch to an NSH-side workaround in a follow-up.