### PR TITLE
fix(installer): force install-directory page via NSH define (unblocks ToDesktop builds + delivers the path-select page)

### DIFF
--- a/scripts/installer.nsh
+++ b/scripts/installer.nsh
@@ -28,6 +28,21 @@
 ; blocks (the source BMPs are still at resources/installerHeader.bmp,
 ; resources/installerSidebar.bmp, resources/uninstallerSidebar.bmp).
 
+; Force the install-directory page into the installer flow. electron-builder's
+; template (assistedInstaller.nsh) gates `!insertmacro MUI_PAGE_DIRECTORY` on
+; `!ifdef allowToChangeInstallationDirectory`. ToDesktop's todesktop.json CLI
+; schema rejects the matching `windows.allowToChangeInstallationDirectory`
+; key (confirmed by run #27005979459 — same gate that bit the installer-art
+; keys in #810/#817), so we set the NSIS define directly here instead — same
+; nsisInclude mechanism ToDesktop already accepts. Our sharedHeader is
+; prepended ahead of installer.nsi line 40 (`!include "assistedInstaller.nsh"`),
+; so this define is in scope before the page macro runs. Guarded with
+; !ifndef so if electron-builder/ToDesktop ever set it from above us, we
+; won't trip the -WX "macro redefined" failure.
+!ifndef allowToChangeInstallationDirectory
+  !define allowToChangeInstallationDirectory
+!endif
+
 ; Friendlier install-mode page strings. electron-builder's defaults read like
 ; internals ("There is already a per-user installation." / "Will reinstall/
 ; upgrade."). electron-builder !includes its own message lang file AFTER this

--- a/todesktop.json
+++ b/todesktop.json
@@ -31,8 +31,7 @@
   ],
   "windows": {
     "icon": "./assets/Comfy_Logo_x256.png",
-    "nsisInclude": "./scripts/installer.nsh",
-    "allowToChangeInstallationDirectory": true
+    "nsisInclude": "./scripts/installer.nsh"
   },
   "mac": {
     "icon": "./assets/Comfy_Logo_mac_x1024.png",


### PR DESCRIPTION
## Why this is urgent

**Main is currently un-buildable on ToDesktop.** #931 added \`allowToChangeInstallationDirectory: true\` to \`todesktop.json\`'s \`windows\` block. ToDesktop CLI 1.22.0 rejects that key at config validation in <30s (CI run [27005979459](https://github.com/Comfy-Org/Comfy-Desktop/actions/runs/27005979459/job/79697522835)):

\`\`\`
todesktop.json invalid.
ADDTIONAL PROPERTY must NOT have additional properties
 33 |     "icon": "./assets/Comfy_Logo_x256.png",
\`\`\`

Same architectural gate that bit the installer-art keys in #810 → #817.

## The fix

Two-part, both in one commit:

1. **Revert \`todesktop.json\`** — drop the rejected \`allowToChangeInstallationDirectory\` line so the CLI stops rejecting the config.
2. **Set the NSIS define in \`scripts/installer.nsh\`** — \`!define allowToChangeInstallationDirectory\`, \`!ifndef\`-guarded.

## Why the NSH path works (where the JSON one doesn't)

\`node_modules/app-builder-lib/templates/nsis/assistedInstaller.nsh:22\`:

\`\`\`nsis
!ifdef allowToChangeInstallationDirectory
  !include StrContains.nsh
  !insertmacro skipPageIfUpdated
  !insertmacro MUI_PAGE_DIRECTORY
\`\`\`

That's a plain NSIS preprocessor define-check. \`installer.nsi\` includes \`assistedInstaller.nsh\` at **line 40**, but electron-builder *prepends* our \`sharedHeader\` (which \`!include\`s our \`installer.nsh\`) ahead of the entire template. So the define we set in \`installer.nsh\` is in scope before the page macro runs — the conditional fires, \`MUI_PAGE_DIRECTORY\` gets inserted, the user sees the path-select page.

The \`!ifndef\` guard means electron-builder's local builds (which set the define from \`electron-builder.yml\`'s \`nsis.allowToChangeInstallationDirectory: true\`) won't trip the \`-WX\` \"macro redefined\" failure. ToDesktop's pipeline doesn't set it (rejected the key) → our \`!define\` is what enables the page there.

## Test plan

- [x] **Local \`pnpm run build:win\`** — exit 0, NSIS compiles clean, installer + uninstaller signed (artifact: \`dist/Comfy-Desktop-1.0.5-win-x64.exe\`). Confirms NSH syntax and the \`!ifndef\` guard work under \`-WX\`.
- [ ] **ToDesktop ephemeral build** — should clear config validation (no offending keys) and produce an installer with the directory page. Real check.
- [ ] **Visual smoke test** — run the produced .exe, confirm the Directory page (with Browse…) shows between Install Mode and the progress screen.

Refs: #931 (the JSON attempt that broke main), #810/#817 (prior identical schema-rejection cycle for the BMP keys).