### PR TITLE
feat: restore last-used instance on startup (allow closing last window without forced dashboard) (#902)

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -396,6 +396,7 @@
     "closeQuitDownloads": "Downloading",
     "autoUpdate": "Check for updates on startup",
     "autoInstallUpdates": "Automatically install Desktop updates",
+    "reopenLastInstanceOnLaunch": "Reopen last instance on launch",
     "checkForUpdates": "Check for updates",
     "checkingForUpdates": "Checking…",
     "telemetry": "Telemetry",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -267,6 +267,7 @@
     "closeQuitConfirm": "退出",
     "autoUpdate": "启动时检查更新",
     "autoInstallUpdates": "自动安装桌面更新",
+    "reopenLastInstanceOnLaunch": "启动时重新打开上次的实例",
     "checkForUpdates": "检查更新",
     "checkingForUpdates": "检查中…",
     "telemetry": "遥测",

--- a/src/main/host/attach.ts
+++ b/src/main/host/attach.ts
@@ -7,6 +7,8 @@ import { TITLEBAR_BG } from '../lib/theme'
 import * as mainTelemetry from '../lib/telemetry'
 import { refreshCloudUserTier } from '../lib/userTier'
 import { forwardDatadogError } from '../lib/processErrorHandlers'
+import { isQuitInProgress } from '../lib/quit-state'
+import { recordInstanceSurface } from '../lib/lastSession'
 import { installationEvents, type InstallationRecord } from '../installations'
 import {
   dropInstallationIndex,
@@ -137,6 +139,10 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
   // null) install on the next dock-icon click.
   if (comfyWindow.isFocused()) {
     setLastFocusedInstallationId(installationId)
+    // An attach onto the focused host makes this install the active surface;
+    // persist it so the next boot restores this instance (no fresh focus
+    // event fires for an in-place attach).
+    if (!isQuitInProgress()) recordInstanceSurface(installationId)
   }
 
   // OS-level window title is rebuilt whenever the page title or the

--- a/src/main/host/attach.ts
+++ b/src/main/host/attach.ts
@@ -7,7 +7,6 @@ import { TITLEBAR_BG } from '../lib/theme'
 import * as mainTelemetry from '../lib/telemetry'
 import { refreshCloudUserTier } from '../lib/userTier'
 import { forwardDatadogError } from '../lib/processErrorHandlers'
-import { isQuitInProgress } from '../lib/quit-state'
 import { recordInstanceSurface } from '../lib/lastSession'
 import { installationEvents, type InstallationRecord } from '../installations'
 import {
@@ -141,8 +140,9 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
     setLastFocusedInstallationId(installationId)
     // An attach onto the focused host makes this install the active surface;
     // persist it so the next boot restores this instance (no fresh focus
-    // event fires for an in-place attach).
-    if (!isQuitInProgress()) recordInstanceSurface(installationId)
+    // event fires for an in-place attach). The record helper no-ops while
+    // quitting.
+    recordInstanceSurface(installationId)
   }
 
   // OS-level window title is rebuilt whenever the page title or the

--- a/src/main/host/createHostWindow.test.ts
+++ b/src/main/host/createHostWindow.test.ts
@@ -21,7 +21,7 @@ import type { InstallationRecord } from '../installations'
 import {
   cascadeOffsetForCollisions,
   expectedPartitionFor,
-  shouldBailAfterCloseConfirm,
+  shouldBailAfterCloseChoice,
   shouldBailAfterConsult,
   shouldDetachLastInstallWindowToDashboard,
   shouldShowInstallCloseConfirm,
@@ -118,40 +118,44 @@ describe('shouldBailAfterConsult', () => {
 
 describe('shouldShowInstallCloseConfirm', () => {
   it('shows the modal for a host that would kill a local session on a defer consult', () => {
-    expect(shouldShowInstallCloseConfirm('defer', true, false)).toBe(true)
+    expect(shouldShowInstallCloseConfirm('defer', true, false, false)).toBe(true)
+  })
+
+  it('shows the modal for the last install window even with no local session at risk (closing quits)', () => {
+    expect(shouldShowInstallCloseConfirm('defer', false, false, true)).toBe(true)
   })
 
   it('skips the modal when the caller pre-cleared the close', () => {
     // Force-close paths must not block on an extra user prompt.
-    expect(shouldShowInstallCloseConfirm('defer', true, true)).toBe(false)
+    expect(shouldShowInstallCloseConfirm('defer', true, true, true)).toBe(false)
   })
 
-  it('skips the modal for a chooser host or a cloud/remote-backed host (no local session at risk)', () => {
-    expect(shouldShowInstallCloseConfirm('defer', false, false)).toBe(false)
+  it('skips the modal for a non-last cloud/remote-backed host (no local session at risk)', () => {
+    expect(shouldShowInstallCloseConfirm('defer', false, false, false)).toBe(false)
   })
 
   it('skips the modal on a cleared or aborted consult', () => {
     // `cleared` → renderer already handled it; `aborted` → we already
     // bailed in the prior check (this case is unreachable in practice).
-    expect(shouldShowInstallCloseConfirm('cleared', true, false)).toBe(false)
-    expect(shouldShowInstallCloseConfirm('aborted', true, false)).toBe(false)
+    expect(shouldShowInstallCloseConfirm('cleared', true, false, true)).toBe(false)
+    expect(shouldShowInstallCloseConfirm('aborted', true, false, true)).toBe(false)
   })
 })
 
-describe('shouldBailAfterCloseConfirm', () => {
-  it('bails when the user dismissed the close-confirm modal', () => {
-    expect(shouldBailAfterCloseConfirm(false, false)).toBe(true)
+describe('shouldBailAfterCloseChoice', () => {
+  it('bails when the user cancelled the close-confirm modal', () => {
+    expect(shouldBailAfterCloseChoice('cancel', false)).toBe(true)
   })
 
-  it('does not bail when the user confirmed the close-confirm modal', () => {
-    expect(shouldBailAfterCloseConfirm(true, false)).toBe(false)
-    expect(shouldBailAfterCloseConfirm(true, true)).toBe(false)
+  it('does not bail when the user chose to close or return to the dashboard', () => {
+    expect(shouldBailAfterCloseChoice('close', false)).toBe(false)
+    expect(shouldBailAfterCloseChoice('return-to-dashboard', false)).toBe(false)
   })
 
-  it('does not bail when a force-close lands mid-modal even on user dismiss', () => {
+  it('does not bail when a force-close lands mid-modal even on user cancel', () => {
     // Mirrors the consult re-check: a caller-side force-close that
     // arrives while the modal is open must override the user's cancel.
-    expect(shouldBailAfterCloseConfirm(false, true)).toBe(false)
+    expect(shouldBailAfterCloseChoice('cancel', true)).toBe(false)
   })
 })
 

--- a/src/main/host/createHostWindow.ts
+++ b/src/main/host/createHostWindow.ts
@@ -1333,7 +1333,18 @@ export function applyChooserHostThemeToAll(): void {
  *  The comfyView still exists so `layoutViews` doesn't have to
  *  special-case its absence, but is sized to zero and never made
  *  visible. */
-export function openChooserHostWindow(initialPanel: ComfyPanelKey = 'comfy'): BrowserWindow {
+export interface OpenChooserHostWindowOptions {
+  /** Hold the window hidden after construction: skip the titlebar/panel/backstop
+   *  cold-start reveal and leave `coldStartPendingReveal` off, so only an
+   *  explicit `forceRevealHostWindow()` shows it. Used by startup restore to
+   *  keep the dashboard from flashing before the launch takeover is up. */
+  deferColdStartReveal?: boolean
+}
+
+export function openChooserHostWindow(
+  initialPanel: ComfyPanelKey = 'comfy',
+  opts: OpenChooserHostWindowOptions = {},
+): BrowserWindow {
   // Install-less wrapper. The shared `createHostWindow()` builds
   // the BrowserWindow + 2 views skeleton, layoutViews, macOS
   // fullscreen, bounds-save listeners, close / closed handlers,
@@ -1393,7 +1404,9 @@ export function openChooserHostWindow(initialPanel: ComfyPanelKey = 'comfy'): Br
     initiallyHidden: true,
   })
 
-  entry.coldStartPendingReveal = true
+  // Startup restore holds the window hidden (no pending cold-start reveal) until
+  // its launch takeover is up; everyone else reveals on first paint.
+  entry.coldStartPendingReveal = !opts.deferColdStartReveal
 
   // Seed the requested initial panel (default 'comfy' → chooser body for
   // an install-less host). "+ New Instance" passes 'new-install' so the
@@ -1404,6 +1417,10 @@ export function openChooserHostWindow(initialPanel: ComfyPanelKey = 'comfy'): Br
   entry.layoutViews()
 
   const revealKey = entry.windowKey
+
+  // Deferred reveal: the caller owns the timing (it will call
+  // `forceRevealHostWindow`), so skip the auto-reveal hooks entirely.
+  if (opts.deferColdStartReveal) return comfyWindow
 
   // Fast-path reveal: the title-bar bundle is ~25 KB and finishes its
   // first paint in well under 200 ms even on a Windows cold start,

--- a/src/main/host/createHostWindow.ts
+++ b/src/main/host/createHostWindow.ts
@@ -40,6 +40,7 @@ import {
   comfyWindows,
   computeBodyMode,
   dropAttachClaimsForWindow,
+  hasRunningSessionForEntry,
   isChooserHost,
   isInstallHost,
   nextWindowKey,
@@ -751,11 +752,13 @@ export function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowRe
       setLastFocusedInstallationId(entry.installationId)
     }
     // Persist which surface was last active so the next boot can restore it.
-    // The record helpers no-op while quitting: windows can take focus as
-    // siblings are destroyed, which would otherwise clobber the surface the
-    // user actually left from.
+    // Only a *running* instance is a healthy restore target — a stopped or
+    // crashed install-backed window shows the lifecycle panel, so record it as
+    // the dashboard to avoid relaunching straight into a crash next boot. The
+    // record helpers no-op while quitting: windows can take focus as siblings
+    // are destroyed, which would otherwise clobber the surface the user left.
     if (entry) {
-      if (entry.installationId) recordInstanceSurface(entry.installationId)
+      if (hasRunningSessionForEntry(entry)) recordInstanceSurface(entry.installationId)
       else recordDashboardSurface()
     }
   })

--- a/src/main/host/createHostWindow.ts
+++ b/src/main/host/createHostWindow.ts
@@ -751,9 +751,10 @@ export function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowRe
       setLastFocusedInstallationId(entry.installationId)
     }
     // Persist which surface was last active so the next boot can restore it.
-    // Skip while quitting: windows can take focus as siblings are destroyed,
-    // which would clobber the surface the user actually left from.
-    if (entry && !isQuitInProgress()) {
+    // The record helpers no-op while quitting: windows can take focus as
+    // siblings are destroyed, which would otherwise clobber the surface the
+    // user actually left from.
+    if (entry) {
       if (entry.installationId) recordInstanceSurface(entry.installationId)
       else recordDashboardSurface()
     }

--- a/src/main/host/createHostWindow.ts
+++ b/src/main/host/createHostWindow.ts
@@ -29,6 +29,7 @@ import {
 import * as mainTelemetry from '../lib/telemetry'
 import { forwardDatadogError } from '../lib/processErrorHandlers'
 import { isQuitInProgress } from '../lib/quit-state'
+import { recordDashboardSurface, recordInstanceSurface } from '../lib/lastSession'
 import * as updater from '../lib/updater'
 import { getSavedBounds, getWindowOptions, saveWindowBounds } from '../lib/windowState'
 import { ensureSystemModal } from '../popups/systemModal'
@@ -62,6 +63,13 @@ const DEFAULT_HOST_HEIGHT = 900
  *  {@link HostWindowFactories.consultPanelRendererClose}. */
 export type CloseConsultResult = 'cleared' | 'aborted' | 'defer'
 
+/** User's pick from the close-window confirm:
+ *   - `close`               — tear the window down (last window → app quits)
+ *   - `cancel`              — keep the window open
+ *   - `return-to-dashboard` — flip the window in place to the dashboard (only
+ *     offered on the last window, so the user isn't forced to quit) */
+export type CloseWindowChoice = 'close' | 'cancel' | 'return-to-dashboard'
+
 /** Should the close handler bail after the renderer consult?
  *
  *  A `forceClose` snapshot (caller pre-cleared via `preClearedClose`)
@@ -73,37 +81,46 @@ export function shouldBailAfterConsult(consult: CloseConsultResult, forceClose: 
   return consult === 'aborted' && !forceClose
 }
 
-/** Should the install-host close-confirm modal run? Only fires when
- *  the renderer deferred (no overlay), the host would kill a local
- *  process, and the caller hasn't pre-cleared. Cloud/remote-backed
- *  windows skip the modal (issue #654) — closing them never kills a
- *  local ComfyUI. The "entry still exists" check is folded into
- *  `killsLocalSession` (its `shouldConfirmKillForEntry` source rejects
- *  a missing entry). */
+/** Should the install-host close-confirm modal run? Fires when the renderer
+ *  deferred (no overlay), the caller hasn't pre-cleared, AND either the host
+ *  would kill a local process OR this is the last install window (closing it
+ *  quits the app, so the user must get the confirm + the dashboard escape).
+ *  Cloud/remote non-last windows skip the modal (issue #654) — closing them
+ *  never kills a local ComfyUI and the app stays alive. The "entry still
+ *  exists" check is folded into `killsLocalSession` (its
+ *  `shouldConfirmKillForEntry` source rejects a missing entry); the
+ *  last-install-window branch carries its own entry check at the call site. */
 export function shouldShowInstallCloseConfirm(
   consult: CloseConsultResult,
   killsLocalSession: boolean,
   forceClose: boolean,
+  isLastInstallWindow: boolean,
 ): boolean {
-  return consult === 'defer' && killsLocalSession && !forceClose
+  return consult === 'defer' && !forceClose && (killsLocalSession || isLastInstallWindow)
 }
 
 /** Should the close handler bail after the install-host close-confirm
- *  modal? Same force-close override as {@link shouldBailAfterConsult}
- *  — a pre-cleared close lands mid-modal must still proceed. */
-export function shouldBailAfterCloseConfirm(confirmed: boolean, forceClose: boolean): boolean {
-  return !confirmed && !forceClose
+ *  modal? `cancel` keeps the window open, but a force-close override
+ *  (the caller pre-cleared mid-modal) must still proceed — same override
+ *  as {@link shouldBailAfterConsult}. */
+export function shouldBailAfterCloseChoice(choice: CloseWindowChoice, forceClose: boolean): boolean {
+  return choice === 'cancel' && !forceClose
 }
 
 /** Should the close handler detach the last install-backed window to
- *  the dashboard instead of tearing it down?
+ *  the dashboard instead of tearing it down — as the FALLBACK when no
+ *  explicit close choice was made (the confirm was skipped)?
  *
- *  The OS ✕ on the last install window flips the host to chooser mode
- *  in place so the app stays alive on the dashboard — that's why
- *  `isLastWindow` exists. A force-close (launch-guard eviction, bulk
- *  Exit-All) is a different intent: the caller already wants the
- *  window gone, and leaving a stray dashboard window behind after a
- *  swap-installs flow is noise. Force-close therefore skips the
+ *  The normal close of the last install window now shows a three-way
+ *  confirm (Quit Desktop / Return to Dashboard / Cancel); the user's
+ *  pick drives the outcome directly. This guard only covers the paths
+ *  that reach teardown WITHOUT that confirm (e.g. a rare overlay-cancel
+ *  consult that cleared) — there, defaulting the last install window to
+ *  the dashboard preserves the invariant that we never quit the last
+ *  window without an explicit user choice. A force-close (launch-guard
+ *  eviction, bulk Exit-All) is a different intent: the caller already
+ *  wants the window gone, and leaving a stray dashboard window behind
+ *  after a swap-installs flow is noise. Force-close therefore skips the
  *  detach branch and falls through to the normal teardown.
  *
  *  Same logic applies when `app.quit()` is in flight (Cmd+Q, app menu
@@ -160,12 +177,15 @@ export interface HostWindowFactories {
     panelView: WebContentsView | null | undefined,
   ) => Promise<'cleared' | 'aborted' | 'defer'>
   /** Shell-level "Close Window" confirm, owned by main so a hidden panel
-   *  renderer can't swallow it. Shared with the Close Window menu entry. */
+   *  renderer can't swallow it. Shared with the Close Window menu entry.
+   *  The last window adds a "Return to Dashboard" option so closing it
+   *  isn't a forced quit; `stopsLocalComfy` tailors the copy. */
   confirmCloseInstanceWindow: (
     window: BrowserWindow,
     isLastWindow: boolean,
+    stopsLocalComfy: boolean,
     theme: { bg: string; text: string },
-  ) => Promise<boolean>
+  ) => Promise<CloseWindowChoice>
   /** Detach the install currently bound to a host entry (in-place flip). */
   detachInstallImpl: (entry: ComfyWindowEntry) => void
   /** WeakSet of host windows whose close was pre-cleared by the
@@ -730,6 +750,13 @@ export function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowRe
     if (entry?.installationId) {
       setLastFocusedInstallationId(entry.installationId)
     }
+    // Persist which surface was last active so the next boot can restore it.
+    // Skip while quitting: windows can take focus as siblings are destroyed,
+    // which would clobber the surface the user actually left from.
+    if (entry && !isQuitInProgress()) {
+      if (entry.installationId) recordInstanceSurface(entry.installationId)
+      else recordDashboardSurface()
+    }
   })
 
   // Push the initial state once the title bar's preload signals readiness.
@@ -854,24 +881,32 @@ export function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowRe
           : await fx.consultPanelRendererClose(entry?.panelView)
         if (shouldBailAfterConsult(consult, fx.preClearedClose.has(comfyWindow))) return
         // Step 2 — for an install-backed host with no overlay, main shows
-        // the same Close Window confirm as the menu item. The dashboard
-        // closes with no prompt.
+        // the same Close Window confirm as the menu item. The last window
+        // gets a three-way choice (Quit Desktop / Return to Dashboard /
+        // Cancel) so closing it isn't a forced quit; non-last windows get
+        // the plain Close/Cancel confirm. The dashboard closes with no
+        // prompt.
         const entryForClose = comfyWindows.get(windowKey)
         const isInstallHostWindow = !!entryForClose && !isChooserHost(entryForClose)
+        const isLastInstallWindow = isLastWindow && isInstallHostWindow
+        // `null` = no confirm was shown (so no explicit user choice).
+        let closeChoice: CloseWindowChoice | null = null
         if (
           shouldShowInstallCloseConfirm(
             consult,
             shouldConfirmKillForEntry(entryForClose),
             fx.preClearedClose.has(comfyWindow),
+            isLastInstallWindow,
           )
           && entryForClose
         ) {
-          const confirmed = await fx.confirmCloseInstanceWindow(
+          closeChoice = await fx.confirmCloseInstanceWindow(
             comfyWindow,
             isLastWindow,
+            shouldConfirmKillForEntry(entryForClose),
             entryForClose.lastTheme,
           )
-          if (shouldBailAfterCloseConfirm(confirmed, fx.preClearedClose.has(comfyWindow))) return
+          if (shouldBailAfterCloseChoice(closeChoice, fx.preClearedClose.has(comfyWindow))) return
         }
         // Capture the force-close intent before we drain the flag.
         // Either the initial snapshot (`skipConsult`) or a late-arriving
@@ -880,15 +915,21 @@ export function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowRe
         const forceClose = skipConsult || fx.preClearedClose.has(comfyWindow)
         fx.preClearedClose.delete(comfyWindow)
         if (comfyWindow.isDestroyed()) return
-        // Last install-backed window → return to the dashboard rather
-        // than tear down + quit. `detachInstall` runs the same
-        // `_installCleanup` (stopRunning, listeners off) the teardown
-        // below would, then flips the window to chooser mode in place.
-        // Force-close skips this — the caller wants the window gone
-        // (e.g. launch-guard swapping installs shouldn't leave a stray
-        // dashboard window behind).
+        // Explicit "Return to Dashboard" pick → flip in place rather than
+        // tearing down. `detachInstall` runs the same `_installCleanup`
+        // (stopRunning, listeners off) the teardown below would, then
+        // flips the window to chooser mode. Force-close ignores the pick —
+        // the caller wants the window gone.
+        if (closeChoice === 'return-to-dashboard' && !forceClose && isInstallHostWindow && entryForClose) {
+          entryForClose.detachInstall()
+          return
+        }
+        // No explicit choice (the confirm was skipped) → keep the last
+        // install window on the dashboard rather than quitting silently,
+        // so the app never exits without the user deciding to.
         if (
-          shouldDetachLastInstallWindowToDashboard(
+          closeChoice === null
+          && shouldDetachLastInstallWindowToDashboard(
             isInstallHostWindow,
             !!entryForClose,
             isLastWindow,

--- a/src/main/host/detach.ts
+++ b/src/main/host/detach.ts
@@ -4,8 +4,10 @@ import * as ipc from '../lib/ipc'
 import { _runningSessions } from '../lib/ipc/shared'
 import { COMFY_BG } from '../lib/theme'
 import { destroyPanelView, ensurePanelView } from './panelView'
-import { openSystemModalAsync } from '../popups/systemModal'
+import { openSystemModalAsync, openSystemModalChoiceAsync } from '../popups/systemModal'
 import type { SystemModalDetailGroup } from '../popups/systemModal'
+import { isQuitInProgress } from '../lib/quit-state'
+import { recordDashboardSurface } from '../lib/lastSession'
 import { comfyWindows, isChooserHost, isInstallHost, shouldConfirmKillForEntry } from './registry'
 import type { ComfyWindowEntry } from './registry'
 import {
@@ -13,6 +15,7 @@ import {
   CHOOSER_HOST_TITLE_TEXT,
   CHOOSER_HOST_WINDOW_TITLE,
 } from './createHostWindow'
+import type { CloseWindowChoice } from './createHostWindow'
 
 /**
  * Host windows whose `close` should skip the panel-renderer consult and tear down
@@ -252,31 +255,58 @@ export async function confirmAndCloseAllHostWindows(
  * Shared "Close Window" confirm, used by both the menu entry and the OS ✕ handler. Lives in
  * main, not the panel renderer, because the renderer is hidden behind ComfyUI while an
  * instance runs and can't be relied on to surface a prompt.
+ *
+ * The last window adds a "Return to Dashboard" middle option so closing it isn't a forced
+ * quit — the primary action quits Desktop, the secondary keeps the app on the dashboard.
+ * `stopsLocalComfy` tailors the copy (a stopped / cloud window has no local process to stop).
  */
 export async function confirmCloseInstanceWindow(
   window: BrowserWindow,
   isLastWindow: boolean,
+  stopsLocalComfy: boolean,
   theme: { bg: string; text: string },
-): Promise<boolean> {
-  return openSystemModalAsync({
+): Promise<CloseWindowChoice> {
+  if (!isLastWindow) {
+    const confirmed = await openSystemModalAsync({
+      parent: window,
+      spec: {
+        title: 'Close Window',
+        message: stopsLocalComfy
+          ? 'Close this window? This stops the running ComfyUI instance.'
+          : 'Close this window?',
+        confirmLabel: 'Close Window',
+        cancelLabel: 'Cancel',
+        confirmStyle: 'danger',
+        theme,
+      },
+    })
+    return confirmed ? 'close' : 'cancel'
+  }
+  const action = await openSystemModalChoiceAsync({
     parent: window,
     spec: {
       title: 'Close Window',
-      message: isLastWindow
-        ? 'Close this window? This stops ComfyUI and returns you to the dashboard.'
-        : 'Close this window? This stops the running ComfyUI instance.',
-      confirmLabel: isLastWindow ? 'Return to Dashboard' : 'Close Window',
+      message: stopsLocalComfy
+        ? 'This is the last window. Closing it stops ComfyUI and quits Desktop, or you can return to the dashboard.'
+        : 'This is the last window. Closing it quits Desktop, or you can return to the dashboard.',
+      confirmLabel: 'Quit Desktop',
+      secondaryLabel: 'Return to Dashboard',
+      secondaryStyle: 'primary',
       cancelLabel: 'Cancel',
       confirmStyle: 'danger',
       theme,
     },
   })
+  if (action === 'confirm') return 'close'
+  if (action === 'secondary') return 'return-to-dashboard'
+  return 'cancel'
 }
 
 /**
  * Confirm + close a single install-backed host window. Model downloads are owned by the
  * desktop app, not the instance, so they keep running after a close (no active-download
- * list here). As the last window, flip in place to the dashboard rather than quitting.
+ * list here). Closing the last window quits Desktop; the confirm offers "Return to
+ * Dashboard" so the user isn't forced to quit.
  */
 export async function confirmAndCloseHostWindow(parentWindow: BrowserWindow): Promise<void> {
   if (parentWindow.isDestroyed()) return
@@ -289,20 +319,26 @@ export async function confirmAndCloseHostWindow(parentWindow: BrowserWindow): Pr
     (e) => !e.window.isDestroyed(),
   ).length
   const isLastWindow = liveWindowCount <= 1
-  // Confirm only when closing kills a local ComfyUI process; cloud/remote and chooser hosts
-  // close immediately.
-  if (shouldConfirmKillForEntry(entry)) {
-    const confirmed = await confirmCloseInstanceWindow(entry.window, isLastWindow, entry.lastTheme)
-    if (!confirmed) return
+  // Confirm when closing kills a local ComfyUI process OR when this is the last install
+  // window (closing it quits the app, so the user gets the prompt + the dashboard escape).
+  // Cloud/remote non-last windows and chooser hosts close immediately.
+  if (shouldConfirmKillForEntry(entry) || (isLastWindow && isInstallHost(entry))) {
+    const choice = await confirmCloseInstanceWindow(
+      entry.window,
+      isLastWindow,
+      shouldConfirmKillForEntry(entry),
+      entry.lastTheme,
+    )
+    if (choice === 'cancel') return
+    if (choice === 'return-to-dashboard') {
+      // Flip the last window to the dashboard rather than closing it (which would quit).
+      entry.detachInstall()
+      return
+    }
   }
-  if (isLastWindow && isInstallHost(entry)) {
-    // Flip the last window to the dashboard rather than closing it (which would quit).
-    entry.detachInstall()
-  } else {
-    // Skip the close handler's consult: the user already confirmed via this prompt.
-    preClearedClose.add(entry.window)
-    entry.window.close()
-  }
+  // Skip the close handler's consult: the user already confirmed via this prompt.
+  preClearedClose.add(entry.window)
+  entry.window.close()
 }
 
 /**
@@ -315,6 +351,11 @@ export async function confirmAndCloseHostWindow(parentWindow: BrowserWindow): Pr
 export function _detachInstallImpl(entry: ComfyWindowEntry): void {
   if (isChooserHost(entry)) return
   if (entry.window.isDestroyed()) return
+
+  // Returning to the dashboard makes it the active surface — persist so the
+  // next boot opens the dashboard, not the install we just detached. Skipped
+  // while quitting (the user's last surface is whatever they left from).
+  if (!isQuitInProgress()) recordDashboardSurface()
 
   // Symmetric undo of attachInstall (listeners, maps, stopRunning, etc).
   entry._installCleanup?.()

--- a/src/main/host/detach.ts
+++ b/src/main/host/detach.ts
@@ -6,7 +6,6 @@ import { COMFY_BG } from '../lib/theme'
 import { destroyPanelView, ensurePanelView } from './panelView'
 import { openSystemModalAsync, openSystemModalChoiceAsync } from '../popups/systemModal'
 import type { SystemModalDetailGroup } from '../popups/systemModal'
-import { isQuitInProgress } from '../lib/quit-state'
 import { recordDashboardSurface } from '../lib/lastSession'
 import { comfyWindows, isChooserHost, isInstallHost, shouldConfirmKillForEntry } from './registry'
 import type { ComfyWindowEntry } from './registry'
@@ -353,9 +352,10 @@ export function _detachInstallImpl(entry: ComfyWindowEntry): void {
   if (entry.window.isDestroyed()) return
 
   // Returning to the dashboard makes it the active surface — persist so the
-  // next boot opens the dashboard, not the install we just detached. Skipped
-  // while quitting (the user's last surface is whatever they left from).
-  if (!isQuitInProgress()) recordDashboardSurface()
+  // next boot opens the dashboard, not the install we just detached. The
+  // record helper no-ops while quitting (the user's last surface is whatever
+  // they left from).
+  recordDashboardSurface()
 
   // Symmetric undo of attachInstall (listeners, maps, stopRunning, etc).
   entry._installCleanup?.()

--- a/src/main/host/registry.test.ts
+++ b/src/main/host/registry.test.ts
@@ -29,6 +29,7 @@ import {
   hostInstallEvents,
   indexInstallationId,
   nextWindowKey,
+  hasRunningSessionForEntry,
   raiseAllHostWindows,
   registerHostEntry,
   setHostFactories,
@@ -214,6 +215,39 @@ describe('shouldConfirmKillForEntry', () => {
   it('returns false for null/undefined entries', () => {
     expect(shouldConfirmKillForEntry(null)).toBe(false)
     expect(shouldConfirmKillForEntry(undefined)).toBe(false)
+  })
+})
+
+describe('hasRunningSessionForEntry', () => {
+  // Rule: "is this an install-backed window showing a live ComfyUI view?" — true only when
+  // the install has a session in `_runningSessions` (local OR cloud/remote). Drives whether
+  // the window is a healthy "last active surface" worth restoring on next boot.
+  it('returns true for an install-backed host with a running session', () => {
+    const entry = makeEntry({ installationId: 'inst-A', sourceCategory: 'local' })
+    _runningSessions.set('inst-A', {} as never)
+    expect(hasRunningSessionForEntry(entry)).toBe(true)
+  })
+
+  it('returns true for a running cloud/remote-backed host', () => {
+    _runningSessions.set('inst-cloud', {} as never)
+    expect(
+      hasRunningSessionForEntry(makeEntry({ installationId: 'inst-cloud', sourceCategory: 'cloud' })),
+    ).toBe(true)
+  })
+
+  it('returns false for an install-backed host with no running session (stopped/crashed)', () => {
+    expect(
+      hasRunningSessionForEntry(makeEntry({ installationId: 'inst-A', sourceCategory: 'local' })),
+    ).toBe(false)
+  })
+
+  it('returns false for a chooser/install-less host', () => {
+    expect(hasRunningSessionForEntry(makeEntry({ installationId: null }))).toBe(false)
+  })
+
+  it('returns false for null/undefined entries', () => {
+    expect(hasRunningSessionForEntry(null)).toBe(false)
+    expect(hasRunningSessionForEntry(undefined)).toBe(false)
   })
 })
 

--- a/src/main/host/registry.test.ts
+++ b/src/main/host/registry.test.ts
@@ -29,6 +29,7 @@ import {
   hostInstallEvents,
   indexInstallationId,
   nextWindowKey,
+  forceRevealHostWindow,
   hasRunningSessionForEntry,
   raiseAllHostWindows,
   registerHostEntry,
@@ -248,6 +249,30 @@ describe('hasRunningSessionForEntry', () => {
   it('returns false for null/undefined entries', () => {
     expect(hasRunningSessionForEntry(null)).toBe(false)
     expect(hasRunningSessionForEntry(undefined)).toBe(false)
+  })
+})
+
+describe('forceRevealHostWindow', () => {
+  it('reveals a deferred host regardless of the coldStartPendingReveal flag', () => {
+    const entry = makeEntry({ installationId: null })
+    entry.coldStartPendingReveal = false // deferred restore leaves the flag off
+    registerHostEntry(entry)
+
+    forceRevealHostWindow(entry.windowKey)
+
+    expect(entry.coldStartPendingReveal).toBe(false)
+    expect((entry.window as unknown as FakeWindow).raised).toContain('show')
+  })
+
+  it('no-ops for a destroyed window', () => {
+    const entry = makeEntry({ installationId: null, destroyed: true })
+    registerHostEntry(entry)
+    forceRevealHostWindow(entry.windowKey)
+    expect((entry.window as unknown as FakeWindow).raised).not.toContain('show')
+  })
+
+  it('no-ops for an unknown window key', () => {
+    expect(() => forceRevealHostWindow(999_999)).not.toThrow()
   })
 })
 

--- a/src/main/host/registry.ts
+++ b/src/main/host/registry.ts
@@ -353,6 +353,18 @@ export function revealColdStartHostIfPending(windowKey: number): void {
   bringToFront(entry.window)
 }
 
+/** Reveal a host whose cold-start reveal was deferred by the caller (the
+ *  startup-restore flow holds the window hidden until its launch takeover is
+ *  up, so the dashboard never flashes). Reveals regardless of the
+ *  `coldStartPendingReveal` flag — the caller owns the timing. */
+export function forceRevealHostWindow(windowKey: number): void {
+  const entry = comfyWindows.get(windowKey)
+  if (!entry || entry.window.isDestroyed()) return
+  entry.coldStartPendingReveal = false
+  entry.layoutViews()
+  bringToFront(entry.window)
+}
+
 /** Late-bound host-window factories, set by `index.ts` so the registry can
  *  spawn a chooser host without importing host-construction code (cycle). */
 interface HostFactories {

--- a/src/main/host/registry.ts
+++ b/src/main/host/registry.ts
@@ -244,6 +244,17 @@ export function shouldConfirmKillForEntry(
 }
 
 /**
+ * Predicate: this entry has a live ComfyUI session (i.e. its body shows the
+ * running ComfyUI view, not the lifecycle/crash panel). Used to decide whether
+ * the install is a healthy "last active surface" worth restoring on next boot.
+ */
+export function hasRunningSessionForEntry(
+  entry: ComfyWindowEntry | null | undefined,
+): entry is ComfyWindowEntry & { installationId: string } {
+  return !!entry && isInstallHost(entry) && _runningSessions.has(entry.installationId)
+}
+
+/**
  * Decide what fills a comfy window's body. Install-backed: the Comfy pill →
  * live ComfyUI view (running) or lifecycle panel (stopped). Install-less: the
  * Comfy pill → chooser. Centralised so layout and body swaps can't disagree.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -87,6 +87,7 @@ import {
   dropAttachClaimsForWindow,
   findEntryByTitleBarSender,
   findEntryByHostWindow,
+  forceRevealHostWindow,
   getEntryByInstallationId,
   isChooserHost,
   isInstallHost,
@@ -200,14 +201,35 @@ function quitApp(): void {
   app.quit()
 }
 
+/** Restore windows are opened hidden and revealed only once their launch
+ *  takeover is up (or a fallback fires); this guards against a renderer that
+ *  never reaches the restore handler, so the window can't stay invisible. */
+const STARTUP_RESTORE_REVEAL_BACKSTOP_MS = 10_000
+const pendingStartupRestoreRevealTimers = new Map<number, ReturnType<typeof setTimeout>>()
+
+function clearStartupRestoreRevealTimer(windowKey: number): void {
+  const timer = pendingStartupRestoreRevealTimers.get(windowKey)
+  if (timer) clearTimeout(timer)
+  pendingStartupRestoreRevealTimers.delete(windowKey)
+}
+
+/** Give up on the in-place restore and just show the dashboard: the surface the
+ *  user lands on is now the dashboard, so persist that and reveal the window. */
+function revealStartupRestoreDashboard(windowKey: number): void {
+  clearStartupRestoreRevealTimer(windowKey)
+  recordDashboardSurface()
+  forceRevealHostWindow(windowKey)
+}
+
 /**
- * Boot surface: always open the chooser host, then — when the reopen setting is
- * on and the user last left an instance window — restore that instance in place
- * on top of it. Restore reuses the dashboard's own launch path (the
- * `picker-pick-install` deep link → `handleChooserPick`), so it gets the same
- * progress overlay, claim, and in-place attach the user sees when clicking an
- * install card. Any failure (install gone, launch error, console/external mode)
- * just leaves the dashboard up.
+ * Boot surface. Normally just opens the chooser host (dashboard). When the
+ * reopen setting is on and the user last left an instance window, instead open
+ * the chooser host HIDDEN and restore that instance on top of it via the
+ * dashboard's own launch path (the `picker-pick-install` deep link →
+ * `performChooserLaunch`), revealing the window only once its launch takeover is
+ * showing — so the dashboard never flashes. Any failure (install gone, launch
+ * error, console/external mode, slow/absent renderer) falls back to revealing
+ * the dashboard.
  */
 function openStartupSurface(): void {
   // Read the persisted surface BEFORE opening the chooser host: showing the
@@ -217,31 +239,58 @@ function openStartupSurface(): void {
   const restoreEnabled =
     settings.get('reopenLastInstanceOnLaunch') !== false &&
     settings.get('firstUseCompleted') === true
+  const shouldRestore = restoreEnabled && surface?.kind === 'instance'
 
-  const chooserWindow = openOrFocusChooserHostWindow()
+  // Restore opens hidden (revealed on takeover-ready / fallback); the plain
+  // dashboard boot reveals on first paint as before.
+  const chooserWindow = shouldRestore
+    ? openChooserHostWindow('comfy', { deferColdStartReveal: true })
+    : openOrFocusChooserHostWindow()
 
-  if (!restoreEnabled || surface?.kind !== 'instance') return
+  if (!shouldRestore) return
   const installationId = surface.installationId
 
   void (async () => {
-    const inst = await getInstallation(installationId)
-    if (!inst) {
-      // The remembered install was deleted — fall back to the dashboard and
-      // drop the stale state so we don't retry forever.
-      clearLastActiveSurface()
+    const entry = findEntryByHostWindow(chooserWindow)
+    if (!entry || entry.window.isDestroyed() || !isChooserHost(entry)) {
+      // Lost the entry right after creating it (shouldn't happen) — reveal the
+      // raw window so a hidden restore window can't get stranded invisible.
+      if (!chooserWindow.isDestroyed()) chooserWindow.show()
       return
     }
-    const entry = findEntryByHostWindow(chooserWindow)
-    if (!entry || entry.window.isDestroyed() || !isChooserHost(entry)) return
+
+    // Backstop: if the renderer never resolves the reveal (failed load, hung
+    // guard), show the dashboard rather than leaving the window invisible.
+    const timer = setTimeout(
+      () => revealStartupRestoreDashboard(entry.windowKey),
+      STARTUP_RESTORE_REVEAL_BACKSTOP_MS,
+    )
+    pendingStartupRestoreRevealTimers.set(entry.windowKey, timer)
+
+    const inst = await getInstallation(installationId)
+    if (!inst) {
+      // The remembered install was deleted — drop the stale state so we don't
+      // retry forever, and reveal the dashboard.
+      clearLastActiveSurface()
+      revealStartupRestoreDashboard(entry.windowKey)
+      return
+    }
     const panelView =
       entry.panelView ?? ensurePanelView(entry.windowKey, entry, computeBodyMode(entry))
-    if (panelView.webContents.isDestroyed()) return
+    if (panelView.webContents.isDestroyed()) {
+      revealStartupRestoreDashboard(entry.windowKey)
+      return
+    }
     // `sendToPanelDeferred` holds the IPC until the panel renderer's
     // `did-finish-load`; the deep-link handler then awaits its own bootstrap
-    // before launching, so this is safe to fire immediately after open.
+    // before launching, so this is safe to fire immediately after open. The
+    // `startupRestore` flag tells the renderer to (a) take the dashboard-
+    // fallback path on a missing launch action instead of opening new-install,
+    // and (b) resolve the reveal once the launch takeover is up.
     sendToPanelDeferred(panelView, 'panel-trigger-overlay', {
       kind: 'picker-pick-install',
-      installationId
+      installationId,
+      startupRestore: true
     })
   })()
 }
@@ -652,6 +701,31 @@ ipcMain.handle('app:relaunch', () => {
 ipcMain.handle('reset-zoom', () => {
   // no-op
 })
+
+/**
+ * Startup-restore reveal handshake. The boot flow opens the restore window
+ * hidden and asks the panel renderer to launch the remembered instance; the
+ * renderer fires this once it knows the outcome:
+ *   - `'takeover-ready'`     → the launch takeover is up, reveal the window so
+ *     the user lands on the launching surface (no dashboard flash).
+ *   - `'dashboard-fallback'` → the launch didn't produce a takeover (already
+ *     running, missing action, console/external mode, error), so reveal the
+ *     dashboard instead.
+ * Resolved by sender so we reveal the exact hidden host that asked.
+ */
+ipcMain.on(
+  'comfy-window:startup-restore-reveal',
+  (event, payload: { result?: unknown }) => {
+    const result = payload?.result === 'dashboard-fallback' ? 'dashboard-fallback' : 'takeover-ready'
+    for (const [windowKey, entry] of comfyWindows) {
+      if (entry.panelView?.webContents !== event.sender) continue
+      clearStartupRestoreRevealTimer(windowKey)
+      if (result === 'dashboard-fallback') recordDashboardSurface()
+      forceRevealHostWindow(windowKey)
+      return
+    }
+  }
+)
 
 /**
  * First-use takeover step plumbing.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -9,6 +9,7 @@ import type { ChildProcess } from 'child_process'
 import todesktop from '@todesktop/runtime'
 import * as ipc from './lib/ipc'
 import { getAppVersion } from './lib/ipc'
+import type { ExitCallbackInfo } from './lib/ipc'
 import * as updater from './lib/updater'
 import * as settings from './settings'
 import { installAppMenu } from './menu'
@@ -18,7 +19,8 @@ import { saveWindowBounds } from './lib/windowState'
 import {
   clearLastActiveSurface,
   flushLastSessionSync,
-  getLastActiveSurface
+  getLastActiveSurface,
+  recordDashboardSurface
 } from './lib/lastSession'
 import { registerProcessErrorHandlers } from './lib/processErrorHandlers'
 import { registerTitleTooltipIpc } from './popups/titleTooltip'
@@ -244,8 +246,14 @@ function openStartupSurface(): void {
   })()
 }
 
-function onComfyExited({ installationId }: { installationId?: string } = {}): void {
+function onComfyExited({ installationId, crashed }: ExitCallbackInfo = {}): void {
   if (!installationId) return
+  // A crashed instance is no longer a healthy restore target: drop it back to
+  // the dashboard so the next boot doesn't relaunch straight into the crash.
+  // `recordDashboardSurface` only overwrites when this install is still the
+  // recorded surface's intent (it's a simple last-writer), which is correct
+  // here — the crashed window is the one the user was on.
+  if (crashed) recordDashboardSurface()
   // The window stays alive — exit (clean or crash) just swaps the body to the
   // lifecycle panel so the user can re-launch, look at logs, or close the
   // window themselves. Window destruction only happens via explicit close

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -17,7 +17,7 @@ import { migrateXdgPaths } from './lib/paths'
 import { saveWindowBounds } from './lib/windowState'
 import {
   clearLastActiveSurface,
-  flushLastSession,
+  flushLastSessionSync,
   getLastActiveSurface
 } from './lib/lastSession'
 import { registerProcessErrorHandlers } from './lib/processErrorHandlers'
@@ -1965,8 +1965,9 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
       _stopPeriodicReleaseChecks = null
     }
     // Persist any pending last-active-surface write so the next boot can
-    // restore it (best-effort; in-session writes are already debounce-flushed).
-    void flushLastSession()
+    // restore it. Synchronous: the app exits without awaiting promises, so an
+    // async write would be torn down mid-flight and lose a just-made change.
+    flushLastSessionSync()
     cleanupTempDownloads()
   })
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -15,6 +15,11 @@ import { installAppMenu } from './menu'
 import * as i18n from './lib/i18n'
 import { migrateXdgPaths } from './lib/paths'
 import { saveWindowBounds } from './lib/windowState'
+import {
+  clearLastActiveSurface,
+  flushLastSession,
+  getLastActiveSurface
+} from './lib/lastSession'
 import { registerProcessErrorHandlers } from './lib/processErrorHandlers'
 import { registerTitleTooltipIpc } from './popups/titleTooltip'
 import { registerTitleCoachmarkIpc } from './popups/titleCoachmark'
@@ -191,6 +196,52 @@ function quitApp(): void {
     tray = null
   }
   app.quit()
+}
+
+/**
+ * Boot surface: always open the chooser host, then — when the reopen setting is
+ * on and the user last left an instance window — restore that instance in place
+ * on top of it. Restore reuses the dashboard's own launch path (the
+ * `picker-pick-install` deep link → `handleChooserPick`), so it gets the same
+ * progress overlay, claim, and in-place attach the user sees when clicking an
+ * install card. Any failure (install gone, launch error, console/external mode)
+ * just leaves the dashboard up.
+ */
+function openStartupSurface(): void {
+  // Read the persisted surface BEFORE opening the chooser host: showing the
+  // chooser fires its `focus` handler, which would record 'dashboard' and
+  // clobber the instance we're about to restore.
+  const surface = getLastActiveSurface()
+  const restoreEnabled =
+    settings.get('reopenLastInstanceOnLaunch') !== false &&
+    settings.get('firstUseCompleted') === true
+
+  const chooserWindow = openOrFocusChooserHostWindow()
+
+  if (!restoreEnabled || surface?.kind !== 'instance') return
+  const installationId = surface.installationId
+
+  void (async () => {
+    const inst = await getInstallation(installationId)
+    if (!inst) {
+      // The remembered install was deleted — fall back to the dashboard and
+      // drop the stale state so we don't retry forever.
+      clearLastActiveSurface()
+      return
+    }
+    const entry = findEntryByHostWindow(chooserWindow)
+    if (!entry || entry.window.isDestroyed() || !isChooserHost(entry)) return
+    const panelView =
+      entry.panelView ?? ensurePanelView(entry.windowKey, entry, computeBodyMode(entry))
+    if (panelView.webContents.isDestroyed()) return
+    // `sendToPanelDeferred` holds the IPC until the panel renderer's
+    // `did-finish-load`; the deep-link handler then awaits its own bootstrap
+    // before launching, so this is safe to fire immediately after open.
+    sendToPanelDeferred(panelView, 'panel-trigger-overlay', {
+      kind: 'picker-pick-install',
+      installationId
+    })
+  })()
 }
 
 function onComfyExited({ installationId }: { installationId?: string } = {}): void {
@@ -1833,8 +1884,10 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
     // The install-less chooser host is the primary surface. Each
     // install gets its own ComfyUI window via openComfyWindow()
     // when launched, and the chooser host is the entry-point for
-    // picking / creating installs.
-    openOrFocusChooserHostWindow()
+    // picking / creating installs. When the user last left an instance
+    // window (and the reopen setting is on), restore that instance
+    // in-place on top of the freshly-opened chooser host.
+    openStartupSurface()
 
     // Single subscription rebroadcasts every install-list mutation
     // (add/remove/update/markLaunched/reorder/...) to all renderers as
@@ -1911,6 +1964,9 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
       _stopPeriodicReleaseChecks()
       _stopPeriodicReleaseChecks = null
     }
+    // Persist any pending last-active-surface write so the next boot can
+    // restore it (best-effort; in-session writes are already debounce-flushed).
+    void flushLastSession()
     cleanupTempDownloads()
   })
 

--- a/src/main/lib/ipc/index.ts
+++ b/src/main/lib/ipc/index.ts
@@ -37,7 +37,7 @@ export {
   getActiveDetails,
   cancelAll
 } from './shared'
-export type { RegisterCallbacks } from './shared'
+export type { RegisterCallbacks, ExitCallbackInfo } from './shared'
 
 // Idempotent guard so a re-run (tests/hot-reload) doesn't double-subscribe.
 let _releaseCacheBridgeWired = false

--- a/src/main/lib/ipc/registerSettingsHandlers.ts
+++ b/src/main/lib/ipc/registerSettingsHandlers.ts
@@ -55,6 +55,12 @@ export function buildSettingsSections(): SettingsSection[] {
           type: 'boolean',
           value: s.autoInstallUpdates !== false
         },
+        {
+          id: 'reopenLastInstanceOnLaunch',
+          label: i18n.t('settings.reopenLastInstanceOnLaunch'),
+          type: 'boolean',
+          value: s.reopenLastInstanceOnLaunch !== false
+        },
         // onAppClose field hidden while docking-to-tray is disabled.
         ...(isChinese ? [chineseMirrorsField] : [])
       ]

--- a/src/main/lib/ipc/sessionActions/launch.ts
+++ b/src/main/lib/ipc/sessionActions/launch.ts
@@ -270,7 +270,7 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
       if (!sender.isDestroyed()) {
         sender.send('comfy-exited', exitedPayload)
       }
-      if (_onComfyExited) _onComfyExited({ installationId })
+      if (_onComfyExited) _onComfyExited({ installationId, crashed })
     })
 
     if (_onLaunch) {
@@ -671,7 +671,7 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
       if (!sender.isDestroyed()) {
         sender.send('comfy-exited', exitedPayload)
       }
-      if (_onComfyExited) _onComfyExited({ installationId })
+      if (_onComfyExited) _onComfyExited({ installationId, crashed })
     })
   }
   attachExitHandler(proc)

--- a/src/main/lib/ipc/shared.ts
+++ b/src/main/lib/ipc/shared.ts
@@ -123,6 +123,9 @@ export interface StopCallbackInfo {
 
 export interface ExitCallbackInfo {
   installationId?: string
+  /** True when the process exited unexpectedly (non-zero code or a signal),
+   *  as opposed to a clean user-initiated stop. */
+  crashed?: boolean
 }
 
 export interface RestartCallbackInfo {

--- a/src/main/lib/lastSession.test.ts
+++ b/src/main/lib/lastSession.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+let testStateDir = ''
+
+// Mock paths.ts directly: stateDir() reads XDG_STATE_HOME on Linux, bypassing
+// the electron.app.getPath mock and breaking CI.
+vi.mock('./paths', () => ({
+  stateDir: () => testStateDir
+}))
+
+vi.mock('electron', () => ({
+  app: { getPath: () => testStateDir }
+}))
+
+import {
+  _resetLastSessionCacheForTest,
+  clearLastActiveSurface,
+  flushLastSession,
+  getLastActiveSurface,
+  recordDashboardSurface,
+  recordInstanceSurface
+} from './lastSession'
+
+const statePath = (): string => path.join(testStateDir, 'last-session.json')
+
+beforeEach(() => {
+  testStateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'last-session-'))
+  _resetLastSessionCacheForTest()
+})
+
+afterEach(() => {
+  fs.rmSync(testStateDir, { recursive: true, force: true })
+})
+
+describe('getLastActiveSurface', () => {
+  it('returns null when no state file exists', () => {
+    expect(getLastActiveSurface()).toBeNull()
+  })
+
+  it('reads a persisted instance surface from disk', () => {
+    fs.writeFileSync(statePath(), JSON.stringify({ kind: 'instance', installationId: 'inst-A' }))
+    expect(getLastActiveSurface()).toEqual({ kind: 'instance', installationId: 'inst-A' })
+  })
+
+  it('reads a persisted dashboard surface from disk', () => {
+    fs.writeFileSync(statePath(), JSON.stringify({ kind: 'dashboard' }))
+    expect(getLastActiveSurface()).toEqual({ kind: 'dashboard' })
+  })
+
+  it('returns null for a malformed instance record (missing id)', () => {
+    fs.writeFileSync(statePath(), JSON.stringify({ kind: 'instance' }))
+    expect(getLastActiveSurface()).toBeNull()
+  })
+
+  it('returns null for unparseable JSON', () => {
+    fs.writeFileSync(statePath(), 'not json')
+    expect(getLastActiveSurface()).toBeNull()
+  })
+})
+
+describe('recordInstanceSurface / recordDashboardSurface', () => {
+  it('records and flushes an instance surface to disk', async () => {
+    recordInstanceSurface('inst-B')
+    expect(getLastActiveSurface()).toEqual({ kind: 'instance', installationId: 'inst-B' })
+    await flushLastSession()
+    expect(JSON.parse(fs.readFileSync(statePath(), 'utf-8'))).toEqual({
+      kind: 'instance',
+      installationId: 'inst-B'
+    })
+  })
+
+  it('records and flushes a dashboard surface to disk', async () => {
+    recordDashboardSurface()
+    expect(getLastActiveSurface()).toEqual({ kind: 'dashboard' })
+    await flushLastSession()
+    expect(JSON.parse(fs.readFileSync(statePath(), 'utf-8'))).toEqual({ kind: 'dashboard' })
+  })
+
+  it('overwrites a prior surface', () => {
+    recordInstanceSurface('inst-C')
+    recordDashboardSurface()
+    expect(getLastActiveSurface()).toEqual({ kind: 'dashboard' })
+    recordInstanceSurface('inst-D')
+    expect(getLastActiveSurface()).toEqual({ kind: 'instance', installationId: 'inst-D' })
+  })
+})
+
+describe('clearLastActiveSurface', () => {
+  it('drops in-memory state and removes the file on flush', async () => {
+    recordInstanceSurface('inst-E')
+    await flushLastSession()
+    expect(fs.existsSync(statePath())).toBe(true)
+
+    clearLastActiveSurface()
+    expect(getLastActiveSurface()).toBeNull()
+    await flushLastSession()
+    expect(fs.existsSync(statePath())).toBe(false)
+  })
+})

--- a/src/main/lib/lastSession.test.ts
+++ b/src/main/lib/lastSession.test.ts
@@ -15,10 +15,16 @@ vi.mock('electron', () => ({
   app: { getPath: () => testStateDir }
 }))
 
+let quitInProgress = false
+vi.mock('./quit-state', () => ({
+  isQuitInProgress: () => quitInProgress
+}))
+
 import {
   _resetLastSessionCacheForTest,
   clearLastActiveSurface,
   flushLastSession,
+  flushLastSessionSync,
   getLastActiveSurface,
   recordDashboardSurface,
   recordInstanceSurface
@@ -28,6 +34,7 @@ const statePath = (): string => path.join(testStateDir, 'last-session.json')
 
 beforeEach(() => {
   testStateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'last-session-'))
+  quitInProgress = false
   _resetLastSessionCacheForTest()
 })
 
@@ -85,6 +92,38 @@ describe('recordInstanceSurface / recordDashboardSurface', () => {
     expect(getLastActiveSurface()).toEqual({ kind: 'dashboard' })
     recordInstanceSurface('inst-D')
     expect(getLastActiveSurface()).toEqual({ kind: 'instance', installationId: 'inst-D' })
+  })
+
+  it('skips recording while a quit is in progress', () => {
+    quitInProgress = true
+    recordInstanceSurface('inst-Q')
+    recordDashboardSurface()
+    expect(getLastActiveSurface()).toBeNull()
+  })
+})
+
+describe('flushLastSessionSync', () => {
+  it('synchronously persists a recorded instance surface', () => {
+    recordInstanceSurface('inst-F')
+    flushLastSessionSync()
+    expect(JSON.parse(fs.readFileSync(statePath(), 'utf-8'))).toEqual({
+      kind: 'instance',
+      installationId: 'inst-F'
+    })
+  })
+
+  it('synchronously removes the file when state was cleared', () => {
+    recordInstanceSurface('inst-G')
+    flushLastSessionSync()
+    expect(fs.existsSync(statePath())).toBe(true)
+    clearLastActiveSurface()
+    flushLastSessionSync()
+    expect(fs.existsSync(statePath())).toBe(false)
+  })
+
+  it('is a no-op when nothing was recorded', () => {
+    flushLastSessionSync()
+    expect(fs.existsSync(statePath())).toBe(false)
   })
 })
 

--- a/src/main/lib/lastSession.ts
+++ b/src/main/lib/lastSession.ts
@@ -1,0 +1,96 @@
+import path from 'path'
+import fs from 'fs'
+import { stateDir } from './paths'
+
+/**
+ * The surface the user last had active, persisted across quits so the next
+ * boot can reopen it. `instance` carries the installation id so the boot flow
+ * can re-launch that specific install; `dashboard` opens the chooser host.
+ */
+export type LastActiveSurface =
+  | { kind: 'dashboard' }
+  | { kind: 'instance'; installationId: string }
+
+const lastSessionPath = (): string => path.join(stateDir(), 'last-session.json')
+
+let cache: LastActiveSurface | null | undefined
+let flushTimer: ReturnType<typeof setTimeout> | null = null
+
+function isSurface(value: unknown): value is LastActiveSurface {
+  if (!value || typeof value !== 'object') return false
+  const v = value as { kind?: unknown; installationId?: unknown }
+  if (v.kind === 'dashboard') return true
+  if (v.kind === 'instance') return typeof v.installationId === 'string' && v.installationId.length > 0
+  return false
+}
+
+function load(): LastActiveSurface | null {
+  if (cache !== undefined) return cache
+  try {
+    const parsed: unknown = JSON.parse(fs.readFileSync(lastSessionPath(), 'utf-8'))
+    cache = isSurface(parsed) ? parsed : null
+  } catch {
+    cache = null
+  }
+  return cache
+}
+
+function scheduleFlush(): void {
+  if (flushTimer) clearTimeout(flushTimer)
+  flushTimer = setTimeout(() => void flushLastSession(), 250)
+}
+
+/** Persist the in-memory surface to disk. Safe to call when nothing changed. */
+export async function flushLastSession(): Promise<void> {
+  if (cache === undefined) return
+  try {
+    const p = lastSessionPath()
+    await fs.promises.mkdir(path.dirname(p), { recursive: true })
+    if (cache === null) {
+      await fs.promises.rm(p, { force: true })
+    } else {
+      await fs.promises.writeFile(p, JSON.stringify(cache, null, 2))
+    }
+  } catch {
+    // Best-effort: a failed write just means the next boot falls back to the
+    // dashboard, which is the safe default.
+  }
+}
+
+/** The persisted surface from the previous session, or `null` if none. */
+export function getLastActiveSurface(): LastActiveSurface | null {
+  return load()
+}
+
+/** Record that the dashboard (chooser host) is the active surface. Deduped so
+ *  focus churn doesn't spam writes. */
+export function recordDashboardSurface(): void {
+  const current = load()
+  if (current?.kind === 'dashboard') return
+  cache = { kind: 'dashboard' }
+  scheduleFlush()
+}
+
+/** Record that an instance window is the active surface. Deduped per id. */
+export function recordInstanceSurface(installationId: string): void {
+  const current = load()
+  if (current?.kind === 'instance' && current.installationId === installationId) return
+  cache = { kind: 'instance', installationId }
+  scheduleFlush()
+}
+
+/** Drop the persisted surface (e.g. the restore target install was deleted). */
+export function clearLastActiveSurface(): void {
+  if (cache === null) return
+  cache = null
+  scheduleFlush()
+}
+
+/** Test-only reset of the in-memory cache. */
+export function _resetLastSessionCacheForTest(): void {
+  cache = undefined
+  if (flushTimer) {
+    clearTimeout(flushTimer)
+    flushTimer = null
+  }
+}

--- a/src/main/lib/lastSession.ts
+++ b/src/main/lib/lastSession.ts
@@ -1,6 +1,7 @@
 import path from 'path'
 import fs from 'fs'
 import { stateDir } from './paths'
+import { isQuitInProgress } from './quit-state'
 
 /**
  * The surface the user last had active, persisted across quits so the next
@@ -46,10 +47,42 @@ export async function flushLastSession(): Promise<void> {
   try {
     const p = lastSessionPath()
     await fs.promises.mkdir(path.dirname(p), { recursive: true })
-    if (cache === null) {
+    const data = serialize()
+    if (data === null) {
       await fs.promises.rm(p, { force: true })
     } else {
-      await fs.promises.writeFile(p, JSON.stringify(cache, null, 2))
+      await fs.promises.writeFile(p, data)
+    }
+  } catch {
+    // Best-effort: a failed write just means the next boot falls back to the
+    // dashboard, which is the safe default.
+  }
+}
+
+/** Build the bytes to persist, or `null` to remove the file. */
+function serialize(): string | null {
+  return cache == null ? null : JSON.stringify(cache, null, 2)
+}
+
+/**
+ * Persist the in-memory surface synchronously. Used on `will-quit`, where
+ * Electron exits without awaiting promises — an async write would be torn down
+ * mid-flight and lose a surface change made right before quitting.
+ */
+export function flushLastSessionSync(): void {
+  if (cache === undefined) return
+  if (flushTimer) {
+    clearTimeout(flushTimer)
+    flushTimer = null
+  }
+  try {
+    const p = lastSessionPath()
+    fs.mkdirSync(path.dirname(p), { recursive: true })
+    const data = serialize()
+    if (data === null) {
+      fs.rmSync(p, { force: true })
+    } else {
+      fs.writeFileSync(p, data)
     }
   } catch {
     // Best-effort: a failed write just means the next boot falls back to the
@@ -63,16 +96,20 @@ export function getLastActiveSurface(): LastActiveSurface | null {
 }
 
 /** Record that the dashboard (chooser host) is the active surface. Deduped so
- *  focus churn doesn't spam writes. */
+ *  focus churn doesn't spam writes. Skipped while quitting: the user's last
+ *  surface is whatever they left from, not focus churn during teardown. */
 export function recordDashboardSurface(): void {
+  if (isQuitInProgress()) return
   const current = load()
   if (current?.kind === 'dashboard') return
   cache = { kind: 'dashboard' }
   scheduleFlush()
 }
 
-/** Record that an instance window is the active surface. Deduped per id. */
+/** Record that an instance window is the active surface. Deduped per id.
+ *  Skipped while quitting (see {@link recordDashboardSurface}). */
 export function recordInstanceSurface(installationId: string): void {
+  if (isQuitInProgress()) return
   const current = load()
   if (current?.kind === 'instance' && current.installationId === installationId) return
   cache = { kind: 'instance', installationId }

--- a/src/main/popups/systemModal.ts
+++ b/src/main/popups/systemModal.ts
@@ -4,6 +4,7 @@ import { TITLEBAR_HEIGHT } from '../lib/titleBarOverlay'
 import { EmbeddedPopupView } from './embeddedPopupView'
 
 type SystemModalConfirmStyle = 'primary' | 'danger'
+type SystemModalSecondaryStyle = 'primary' | 'danger' | 'default'
 
 export interface SystemModalDetailGroup {
   label: string
@@ -19,10 +20,14 @@ export interface SystemModalSpec {
   confirmLabel: string
   cancelLabel: string
   confirmStyle?: SystemModalConfirmStyle
+  /** Optional middle action (rendered between Cancel and the primary). When set,
+   *  the modal becomes a three-way choice and resolves `'secondary'`. */
+  secondaryLabel?: string
+  secondaryStyle?: SystemModalSecondaryStyle
   theme: { bg: string; text: string }
 }
 
-type SystemModalAction = 'confirm' | 'cancel'
+type SystemModalAction = 'confirm' | 'cancel' | 'secondary'
 
 export type SystemModalCallback = (action: SystemModalAction) => void
 
@@ -169,6 +174,26 @@ export function openSystemModalAsync(opts: OpenSystemModalOpts): Promise<boolean
   })
 }
 
+/** Three-way variant of `openSystemModalAsync`. Resolves the raw action so a
+ *  caller offering a middle option (`secondaryLabel`) can branch on it. Cancel
+ *  / superseded / parent-destroyed all resolve `'cancel'`. */
+export function openSystemModalChoiceAsync(
+  opts: OpenSystemModalOpts,
+): Promise<'confirm' | 'cancel' | 'secondary'> {
+  return new Promise((resolve) => {
+    openSystemModal({
+      parent: opts.parent,
+      spec: opts.spec,
+      callback: (action) => {
+        if (opts.callback) {
+          try { opts.callback(action) } catch {}
+        }
+        resolve(action)
+      },
+    })
+  })
+}
+
 /** Wire the IPC handlers that drive the system-modal popup. Called once at app ready. */
 export function registerSystemModalIpc(): void {
   ipcMain.on('comfy-systemmodal:ready', (event) => {
@@ -204,7 +229,7 @@ export function registerSystemModalIpc(): void {
       // Stale ack — the modal was already replaced by a newer open.
       if (payload?.modalId !== spec.id) return
       const action = payload?.action
-      if (action !== 'confirm' && action !== 'cancel') return
+      if (action !== 'confirm' && action !== 'cancel' && action !== 'secondary') return
       entry.currentSpec = null
       entry.currentCallback = null
       entry.view.hide({ focusParent: true })

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -22,6 +22,9 @@ export interface KnownSettings {
   /** When true (default), Desktop updates download and install silently; when
    *  false, the user is prompted before any download/install. */
   autoInstallUpdates?: boolean
+  /** When true (default), boot reopens the last-used instance window instead of
+   *  the dashboard, when the last active surface was an instance. */
+  reopenLastInstanceOnLaunch?: boolean
   pypiMirror?: string
   useChineseMirrors?: boolean
   chineseMirrorsPrompted?: boolean
@@ -61,6 +64,7 @@ const SETTINGS_SCHEMA = {
   theme: { nullable: false },
   autoUpdate: { nullable: false },
   autoInstallUpdates: { nullable: false },
+  reopenLastInstanceOnLaunch: { nullable: false },
   pypiMirror: { nullable: false },
   useChineseMirrors: { nullable: false },
   chineseMirrorsPrompted: { nullable: false },

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -65,6 +65,8 @@ export function buildElectronApi(): ElectronApi {
     closeHostWindow: () => ipcRenderer.invoke('close-host-window'),
     returnToDashboard: () => ipcRenderer.invoke('return-to-dashboard'),
     closeCurrentPanel: () => ipcRenderer.send('comfy-window:close-current-panel'),
+    resolveStartupRestoreReveal: (result) =>
+      ipcRenderer.send('comfy-window:startup-restore-reveal', { result }),
     openGlobalSettings: () => ipcRenderer.send('comfy-titlepopup:open-global-settings'),
     openInstancePicker: (opts) =>
       ipcRenderer.send('comfy-window:open-instance-picker-for-install', {
@@ -443,6 +445,7 @@ export function buildElectronApi(): ElectronApi {
             actionId?: string
             version?: string | null
             settingsTab?: 'comfy' | 'directories' | 'downloads' | 'global'
+            startupRestore?: boolean
           }
         )
       ipcRenderer.on('panel-trigger-overlay', handler)

--- a/src/preload/comfySystemModalPreload.ts
+++ b/src/preload/comfySystemModalPreload.ts
@@ -8,6 +8,7 @@ import type { IpcRendererEvent } from 'electron'
  */
 
 export type SystemModalConfirmStyle = 'primary' | 'danger'
+export type SystemModalSecondaryStyle = 'primary' | 'danger' | 'default'
 
 export interface SystemModalDetailGroup {
   label: string
@@ -23,10 +24,13 @@ export interface SystemModalSpec {
   confirmLabel: string
   cancelLabel: string
   confirmStyle?: SystemModalConfirmStyle
+  /** Optional middle action; when present the modal renders a third button. */
+  secondaryLabel?: string
+  secondaryStyle?: SystemModalSecondaryStyle
   theme: { bg: string; text: string }
 }
 
-export type SystemModalAction = 'confirm' | 'cancel'
+export type SystemModalAction = 'confirm' | 'cancel' | 'secondary'
 
 export interface SystemModalActionPayload {
   modalId: string
@@ -80,7 +84,13 @@ function isModalSpec(value: unknown): value is SystemModalSpec {
 const bridge: ComfySystemModalBridge = {
   action: (payload) => {
     if (!payload || typeof payload.modalId !== 'string') return
-    if (payload.action !== 'confirm' && payload.action !== 'cancel') return
+    if (
+      payload.action !== 'confirm' &&
+      payload.action !== 'cancel' &&
+      payload.action !== 'secondary'
+    ) {
+      return
+    }
     ipcRenderer.send('comfy-systemmodal:action', payload)
   },
   ready: () => {

--- a/src/renderer/src/comfySystemModal/SystemModalApp.vue
+++ b/src/renderer/src/comfySystemModal/SystemModalApp.vue
@@ -11,6 +11,8 @@ import BaseAlert from '../components/ui/BaseAlert.vue'
  */
 
 type SystemModalConfirmStyle = 'primary' | 'danger'
+type SystemModalSecondaryStyle = 'primary' | 'danger' | 'default'
+type SystemModalAction = 'confirm' | 'cancel' | 'secondary'
 
 interface SystemModalDetailGroup {
   label: string
@@ -25,11 +27,13 @@ interface SystemModalSpec {
   confirmLabel: string
   cancelLabel: string
   confirmStyle?: SystemModalConfirmStyle
+  secondaryLabel?: string
+  secondaryStyle?: SystemModalSecondaryStyle
   theme: { bg: string; text: string }
 }
 
 interface Bridge {
-  action(payload: { modalId: string; action: 'confirm' | 'cancel' }): void
+  action(payload: { modalId: string; action: SystemModalAction }): void
   ready(): void
   notifyRendered(): void
   onModal(cb: (spec: SystemModalSpec) => void): () => void
@@ -43,7 +47,7 @@ const tone = computed<'primary' | 'danger'>(() =>
   spec.value?.confirmStyle === 'danger' ? 'danger' : 'primary',
 )
 
-function ack(action: 'confirm' | 'cancel'): void {
+function ack(action: SystemModalAction): void {
   const current = spec.value
   if (!current) return
   bridge?.action({ modalId: current.id, action })
@@ -79,9 +83,12 @@ onUnmounted(() => {
     :button-label="spec?.confirmLabel ?? ''"
     :cancel-label="spec?.cancelLabel ?? ''"
     :tone="tone"
+    :secondary-label="spec?.secondaryLabel"
+    :secondary-tone="spec?.secondaryStyle ?? 'default'"
     show-cancel
     @close="ack('confirm')"
     @cancel="ack('cancel')"
+    @secondary="ack('secondary')"
   >
     <!-- When the spec carries `details`, render `message` then each group as a bulleted list. -->
     <template v-if="spec?.details && spec.details.length > 0" #default>

--- a/src/renderer/src/composables/useDeepLinkRouter.ts
+++ b/src/renderer/src/composables/useDeepLinkRouter.ts
@@ -19,8 +19,13 @@ interface DeepLinkRouterOpts {
   showAppUpdateRestartPrompt: (version: string | null) => Promise<void>
   showAppUpdateDownloadPrompt: (version: string | null) => Promise<void>
   /** Picker picked a non-running install; runs the chooser's launch flow
-   *  without the attach-claim that would swap this host's install out. */
-  pickInstallFromPicker?: (installation: Installation) => Promise<void> | void
+   *  without the attach-claim that would swap this host's install out.
+   *  `startupRestore` marks the boot-time restore path (dashboard fallback on
+   *  missing action + reveal handshake). */
+  pickInstallFromPicker?: (
+    installation: Installation,
+    opts?: { startupRestore?: boolean },
+  ) => Promise<void> | void
   /** Picker "More" menu selected an install-level action; dispatches
    *  through the same `useInstallContextMenu` path the dashboard kebab uses. */
   runInstallActionFromPicker?: (installation: Installation, actionId: string) => Promise<void> | void
@@ -93,8 +98,17 @@ export function useDeepLinkRouter(opts: DeepLinkRouterOpts): void {
           const id = payload.installationId
           if (!id) return
           const inst = installationStore.getById(id)
-          if (!inst) return
-          await opts.pickInstallFromPicker?.(inst)
+          if (!inst) {
+            // Boot restore against a now-missing install: tell main to reveal
+            // the dashboard rather than leaving the hidden window stuck.
+            if (payload.startupRestore) {
+              window.api.resolveStartupRestoreReveal('dashboard-fallback')
+            }
+            return
+          }
+          await opts.pickInstallFromPicker?.(inst, {
+            startupRestore: payload.startupRestore === true,
+          })
           return
         }
         if (payload.kind === 'picker-install-action') {

--- a/src/renderer/src/panel/PanelApp.vue
+++ b/src/renderer/src/panel/PanelApp.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import ProgressModal from '../views/ProgressModal.vue'
 import ModalDialog from '../components/ModalDialog.vue'
@@ -184,6 +184,23 @@ chooserHandoff = useChooserHandoff({
 })
 const { handleChooserPick, handleChooserShowNewInstall } = chooserHandoff
 
+// Boot-time restore: the host window is hidden until we tell main the outcome.
+// Use `performChooserLaunch` (NOT `handleChooserPick`) so a missing launch
+// action falls back to the dashboard instead of opening the new-install wizard.
+// Reveal the launching takeover when it comes up; otherwise (already running,
+// missing action, console/external mode, error) fall back to the dashboard.
+async function handleStartupRestorePick(inst: Installation): Promise<void> {
+  try {
+    const outcome = await chooserHandoff.performChooserLaunch(inst)
+    await nextTick()
+    const takeoverReady = outcome === 'launched' && currentOverlay.value?.kind === 'takeover'
+    window.api.resolveStartupRestoreReveal(takeoverReady ? 'takeover-ready' : 'dashboard-fallback')
+  } catch (err) {
+    console.error('startup restore launch failed', err)
+    window.api.resolveStartupRestoreReveal('dashboard-fallback')
+  }
+}
+
 // When an overlay closes on a chooser host without producing an attach
 // (cancel / error / dismiss), revert the install identity preview that
 // `claimAttachHost` pushed to the title bar — otherwise the chooser host
@@ -233,7 +250,7 @@ useDeepLinkRouter({
   openOverlay,
   showAppUpdateRestartPrompt,
   showAppUpdateDownloadPrompt,
-  pickInstallFromPicker: async (inst) => {
+  pickInstallFromPicker: async (inst, pickOpts) => {
     // Chooser-host pick (no installationId backing this host) → swap
     // in-place via the same path the dashboard chooser uses, so the
     // dashboard window becomes the picked install. Install-backed
@@ -243,7 +260,11 @@ useDeepLinkRouter({
     // window before this IPC fires, so we only ever see launches
     // here for installs that aren't running yet).
     if (!installationId) {
-      await chooserHandoff.handleChooserPick(inst)
+      if (pickOpts?.startupRestore) {
+        await handleStartupRestorePick(inst)
+      } else {
+        await chooserHandoff.handleChooserPick(inst)
+      }
     } else {
       await chooserHandoff.performPickerLaunch(inst)
     }

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -972,6 +972,12 @@ export interface ElectronApi {
    *  the comfy/chooser root. Fire-and-forget; the panel will receive
    *  the resulting `panel-switch` like any other navigation. */
   closeCurrentPanel(): void
+  /** Boot-time restore reveal handshake. The restore window is opened
+   *  hidden; the panel calls this once it knows whether its launch
+   *  takeover came up (`'takeover-ready'` → reveal the launching surface)
+   *  or it fell back to the dashboard (`'dashboard-fallback'`). Main
+   *  reveals the sender's hidden host either way. Fire-and-forget. */
+  resolveStartupRestoreReveal(result: 'takeover-ready' | 'dashboard-fallback'): void
   /** Open the Global Settings popup for the panel's host window. Used
    *  by the panel-side file-menu "Settings" item and the
    *  `comfy://open-settings?tab=global` deep link. Main reuses the
@@ -1408,6 +1414,10 @@ export interface ElectronApi {
       settingsTab?: 'comfy' | 'directories' | 'downloads' | 'global'
       title?: string
       cancellable?: boolean
+      /** Picker-only (`picker-pick-install`): set on boot-time restore. The
+       *  panel takes the dashboard-fallback path on a missing launch action
+       *  (instead of opening new-install) and resolves the reveal handshake. */
+      startupRestore?: boolean
       triggersInstanceStart?: boolean
       opKind?: 'launch' | 'install' | 'update' | 'destructive' | 'snapshot' | 'generic'
       isRestart?: boolean


### PR DESCRIPTION
## Summary

Implements #902: on startup, restore the **last-used ComfyUI instance window** instead of always opening the dashboard — and, as the prerequisite, allow **closing the last instance window without being forced back to the dashboard**.

Previously, pressing ✕ on the last instance window always detached it back to the dashboard, so the window could never truly "go away" and we couldn't remember that the user last left an instance window.

## Behavior changes

### Closing the last window
- Closing the last instance window now **quits Desktop**, but the confirm is a **three-way choice** so quitting is never the only option:
  - **Quit Desktop** (primary/danger) → tear down + quit
  - **Return to Dashboard** (secondary) → flip the window in place to the chooser (old behavior, still available)
  - **Cancel** → keep the window open
- Applies to both the OS ✕ and the File-menu **Close Window**. The picker **Home** icon still returns to the dashboard as before.
- Non-last windows are unchanged (plain Close/Cancel confirm).

### Restore on startup
- New setting **"Reopen last instance on launch"** (Global Settings → General), **on by default**.
- The last active surface (dashboard vs. a specific instance) is persisted to a small state file in `stateDir()`, updated on window focus / attach / detach (skipped while quitting).
- On boot, when the setting is on and the user last left an instance window, that instance is **auto-launched and restored in place** on top of the freshly-opened chooser host — by reusing the dashboard's own launch path (the `picker-pick-install` deep link → `handleChooserPick`). That means it gets the same progress overlay, attach-claim, and in-place attach the user sees when clicking an install card.
- Falls back to the dashboard when: the setting is off, the remembered install was deleted, first-use isn't complete, or the launch fails.

## Open questions from the issue, resolved
- **Auto-launch vs. open-stopped-window** → auto-launch (reuses the existing launch path; no new host-construction surface).
- **Behind a setting / default?** → yes, `reopenLastInstanceOnLaunch`, default on.
- **X semantics** → ✕ on the last window quits, with an explicit "Return to Dashboard" escape in the confirm; Home icon unchanged.
- **Multi-window "last used"** → most-recently-focused surface wins.

## Implementation notes
- `src/main/lib/lastSession.ts` — new persisted last-active-surface state (mirrors `windowState.ts`).
- `systemModal` (main + preload + `SystemModalApp.vue`) — extended with an optional middle ("secondary") action, rendered via the existing `BaseAlert` three-button footer; new `openSystemModalChoiceAsync`.
- `createHostWindow.ts` / `detach.ts` — close handler + `confirmAndCloseHostWindow` now drive a `CloseWindowChoice` (`close` / `cancel` / `return-to-dashboard`); the old "always detach last window" branch is now only a fallback for paths that reach teardown without an explicit choice.
- `index.ts` — `openStartupSurface()` replaces the unconditional chooser open at boot.

## Validation
- `pnpm run typecheck`, `pnpm run lint`, `pnpm run build`, `pnpm run test` all pass (1842 tests, incl. new `lastSession.test.ts` and updated close-handler unit tests).
