### PR TITLE
fix(migration): honor legacy Server Config values when deriving launch args

### DIFF
--- a/src/main/lib/desktopAdopt.test.ts
+++ b/src/main/lib/desktopAdopt.test.ts
@@ -401,6 +401,81 @@ describe('deriveLaunchArgs', () => {
     expect(launchArgs).not.toContain('1234')
   })
 
+  it('honors Comfy.Server.ServerConfigValues (authoritative legacy store)', () => {
+    // ServerConfigValues keeps native types: number port, boolean flags.
+    const { launchArgs } = deriveLaunchArgs({
+      'Comfy.Server.ServerConfigValues': { port: 8192, 'enable-manager-legacy-ui': true }
+    })
+    expect(launchArgs).toContain('--port 8192')
+    expect(launchArgs).toContain('--enable-manager-legacy-ui')
+  })
+
+  it('keeps a custom port from ServerConfigValues (no --port 8000 override)', () => {
+    const { launchArgs } = deriveLaunchArgs({
+      'Comfy.Server.ServerConfigValues': { port: 8192 }
+    })
+    expect(launchArgs).toContain('--port 8192')
+    expect(launchArgs).not.toContain('--port 8000')
+  })
+
+  it('carries enable-manager-legacy-ui and does NOT add --enable-manager', () => {
+    const { launchArgs } = deriveLaunchArgs({
+      'Comfy.Server.ServerConfigValues': { 'enable-manager-legacy-ui': true }
+    })
+    expect(launchArgs).toContain('--enable-manager-legacy-ui')
+    expect(launchArgs).not.toContain('--enable-manager ')
+    expect(launchArgs.endsWith('--enable-manager')).toBe(false)
+    expect(launchArgs.split(' ')).not.toContain('--enable-manager')
+  })
+
+  it('lets LaunchArgs override ServerConfigValues on a conflicting key', () => {
+    const { launchArgs } = deriveLaunchArgs({
+      'Comfy.Server.ServerConfigValues': { port: 8192 },
+      'Comfy.Server.LaunchArgs': { port: '7860' }
+    })
+    expect(launchArgs).toContain('--port 7860')
+    expect(launchArgs).not.toContain('8192')
+  })
+
+  it('synthesizes --port 8000 when neither store sets a port', () => {
+    const { launchArgs } = deriveLaunchArgs({
+      'Comfy.Server.ServerConfigValues': { 'cpu-vae': true },
+      'Comfy.Server.LaunchArgs': { lowvram: '' }
+    })
+    expect(launchArgs).toContain('--port 8000')
+  })
+
+  it('drops ServerConfigValues entries explicitly set to false', () => {
+    const { launchArgs } = deriveLaunchArgs({
+      'Comfy.Server.ServerConfigValues': { 'enable-manager-legacy-ui': false }
+    })
+    expect(launchArgs).not.toContain('--enable-manager-legacy-ui')
+    // legacy disabled -> new Manager is force-added as usual
+    expect(launchArgs).toContain('--enable-manager')
+  })
+
+  it('leaves LaunchArgs-only --enable-manager behavior unchanged', () => {
+    const { launchArgs } = deriveLaunchArgs({
+      'Comfy.Server.LaunchArgs': { 'enable-manager': '', lowvram: '' }
+    })
+    expect((launchArgs.match(/--enable-manager\b/g) ?? []).length).toBe(1)
+    expect(launchArgs).toContain('--lowvram')
+  })
+
+  it('is idempotent: re-deriving from its own output keys yields stable args', () => {
+    const first = deriveLaunchArgs({
+      'Comfy.Server.ServerConfigValues': { port: 8192, 'enable-manager-legacy-ui': true }
+    })
+    // Feed the derived flags back through both stores; result must not grow.
+    const second = deriveLaunchArgs({
+      'Comfy.Server.ServerConfigValues': { port: 8192, 'enable-manager-legacy-ui': true },
+      'Comfy.Server.LaunchArgs': { port: '8192', 'enable-manager-legacy-ui': '' }
+    })
+    expect(second.launchArgs).toBe(first.launchArgs)
+    expect((second.launchArgs.match(/--enable-manager-legacy-ui/g) ?? []).length).toBe(1)
+    expect((second.launchArgs.match(/--port/g) ?? []).length).toBe(1)
+  })
+
   it('does NOT synthesize --listen (legacy implicit matches ComfyUI native)', () => {
     const { launchArgs } = deriveLaunchArgs({ 'Comfy.Server.LaunchArgs': {} })
     expect(launchArgs).not.toContain('--listen')

--- a/src/main/lib/desktopAdopt.ts
+++ b/src/main/lib/desktopAdopt.ts
@@ -325,16 +325,49 @@ export interface DerivedLaunchArgs {
 }
 
 /**
+ * Coerce a raw legacy settings value into the flag→value convention used
+ * when emitting the launchArgs string: booleans become `''` (flag with no
+ * value) when truthy and are dropped when `false`; everything else is
+ * stringified. Returns `null` when the entry should be skipped entirely.
+ *
+ * This normalizes the two legacy stores into one shape. `LaunchArgs`
+ * already stores boolean flags as `''` and numbers as strings, while
+ * `ServerConfigValues` keeps native `true`/`false`/number values, so a
+ * raw `true` here means "emit the bare flag" and a raw `false` means
+ * "the user explicitly disabled it — emit nothing".
+ */
+function normalizeLaunchValue(value: unknown): string | null {
+  if (value === undefined || value === null) return null
+  if (typeof value === 'boolean') return value ? '' : null
+  return String(value)
+}
+
+/**
  * Build the user-facing `launchArgs` string for an adopted install from
- * the legacy `comfy.settings.json` blob (a flat dotted-key map). Reads
- * **only** `Comfy.Server.LaunchArgs` — the actual source of legacy launch
- * flags. Legacy `server_config.{listen,port}` keys are baked into
- * defaults by the legacy app itself and never appear here.
+ * the legacy `comfy.settings.json` blob (a flat dotted-key map).
+ *
+ * Merges both legacy server-config stores, keyed by config id (which is
+ * the CLI flag name):
+ *  - `Comfy.Server.ServerConfigValues` is the AUTHORITATIVE store of the
+ *    user's server-config choices and forms the BASE of the merge. The
+ *    legacy frontend already filters out values equal to their default,
+ *    so whatever is present here is a deliberate non-default choice.
+ *  - `Comfy.Server.LaunchArgs` is a lazily-synced derived copy that only
+ *    gets written while the Server-Config settings panel is open, so it
+ *    is frequently stale or empty. It OVERRIDES `ServerConfigValues` on
+ *    key conflicts (it is the more-recent edit when both are present),
+ *    but never erases a value that lives only in `ServerConfigValues`.
+ *
+ * Legacy `server_config.{listen,port}` keys are baked into defaults by
+ * the legacy app itself and never appear here.
  *
  * The synthesized output preserves legacy implicit defaults users notice:
- *  - `--port 8000` when the user hasn't overridden it (legacy default;
- *    matters because legacy users have it bookmarked).
- *  - `--enable-manager` always included (legacy always did).
+ *  - `--port 8000` when the user hasn't overridden it in EITHER store
+ *    (legacy default; matters because legacy users have it bookmarked).
+ *  - `--enable-manager` included by default, EXCEPT when the user opted
+ *    into the legacy Manager UI (`enable-manager-legacy-ui`). The two
+ *    Manager UIs are mutually exclusive, so honoring the legacy choice
+ *    must not also inject the new Manager.
  *  - `--listen` is NOT synthesized — legacy's implicit `127.0.0.1`
  *    matches ComfyUI's native default, so emitting it would only add
  *    noise to the editable string. Explicit user-set `listen` values
@@ -345,19 +378,24 @@ export interface DerivedLaunchArgs {
  * them into the per-install `inputDir` / `outputDir` fields.
  */
 export function deriveLaunchArgs(comfySettings: Record<string, unknown>): DerivedLaunchArgs {
-  const raw = comfySettings['Comfy.Server.LaunchArgs']
-  const launchArgsMap: Record<string, unknown> =
+  const asMap = (raw: unknown): Record<string, unknown> =>
     raw && typeof raw === 'object' && !Array.isArray(raw) ? (raw as Record<string, unknown>) : {}
+
+  const serverConfigValues = asMap(comfySettings['Comfy.Server.ServerConfigValues'])
+  const launchArgsMap = asMap(comfySettings['Comfy.Server.LaunchArgs'])
+
+  // ServerConfigValues is the base; LaunchArgs overrides on key conflicts.
+  const mergedMap: Record<string, unknown> = { ...serverConfigValues, ...launchArgsMap }
 
   const parts: string[] = []
   const pathOverrides: DerivedLaunchArgs['pathOverrides'] = {}
   let hasPort = false
 
-  for (const [key, value] of Object.entries(launchArgsMap)) {
+  for (const [key, value] of Object.entries(mergedMap)) {
     if (!key) continue
     if (STRIPPED_LAUNCH_KEYS.has(key)) continue
-    if (value === undefined || value === null) continue
-    const strVal = String(value)
+    const strVal = normalizeLaunchValue(value)
+    if (strVal === null) continue
     if (PROMOTED_LAUNCH_KEYS.has(key)) {
       if (strVal === '') continue
       if (key === 'input-directory') pathOverrides.inputDir = strVal
@@ -377,7 +415,10 @@ export function deriveLaunchArgs(comfySettings: Record<string, unknown>): Derive
   // because its legacy implicit `127.0.0.1` matches ComfyUI's native
   // default — writing it adds noise without effect.
   if (!hasPort) parts.unshift('--port', '8000')
-  if (!parts.includes('--enable-manager')) parts.push('--enable-manager')
+  // The new Manager and the legacy Manager UI are mutually exclusive, so
+  // don't force the new Manager on when the user opted into the legacy UI.
+  const usesLegacyManager = parts.includes('--enable-manager-legacy-ui')
+  if (!usesLegacyManager && !parts.includes('--enable-manager')) parts.push('--enable-manager')
 
   return { launchArgs: parts.join(' '), pathOverrides }
 }


### PR DESCRIPTION
https://github.com/Comfy-Org/Comfy-Desktop/issues/937
## Summary

Fixes the 0.9.x -> 1.0.x adoption silently rewriting a user's ComfyUI launch args. `deriveLaunchArgs` previously read **only** `Comfy.Server.LaunchArgs`, which is a lazily-synced derived copy of the user's server-config choices: the legacy frontend only writes it while the Server-Config settings panel is open, and it filters out any value equal to its default. So for most users it is stale or empty.

The authoritative store is `Comfy.Server.ServerConfigValues` (keyed by config id, which is the CLI flag name, with defaults already filtered out by the legacy store). Ignoring it caused three regressions on migration:

- a custom port (e.g. `8192`) was reset to `--port 8000`
- a deliberate `--enable-manager-legacy-ui` preference was dropped
- `--enable-manager` (new Manager UI) was force-added unconditionally, even for legacy-Manager users (the two UIs are mutually exclusive)

## Changes

- `deriveLaunchArgs` now merges both legacy stores: `ServerConfigValues` is the base, `Comfy.Server.LaunchArgs` overrides on key conflicts. LaunchArgs still wins on any conflict; we only add values that exist solely in `ServerConfigValues`, so nothing already-correct changes.
- A small `normalizeLaunchValue` helper reconciles the two stores' value conventions: `ServerConfigValues` keeps native `true`/`false`/number values, so truthy booleans become a bare flag, explicit `false` is dropped, numbers are stringified. `LaunchArgs` already uses the `''`/string shape.
- The `--enable-manager` force-add is now conditional: skipped when the merged args contain `--enable-manager-legacy-ui`.
- The custom-port fix falls out of the merge (a port from `ServerConfigValues` now sets `hasPort`), no special-casing.
- Existing stripping/promotion behavior and idempotency are preserved.

## Tests

Inverted the assumption that `ServerConfigValues` is ignored and added cases: custom port survives, legacy-manager flag carried with no `--enable-manager`, LaunchArgs overrides on conflict, default `--port 8000` still synthesized when neither store sets a port, explicit `false` dropped, LaunchArgs-only `--enable-manager` unchanged, and idempotency.

- `pnpm typecheck`: pass
- `pnpm lint`: pass
- `pnpm test`: 1863 passed / 131 files (desktopAdopt suite: 61 passed)
