### PR TITLE
fix(settings): shared models folder icon browses to re-point dir

### DIFF
--- a/src/renderer/src/comfyTitlePopup/GlobalSettingsView.test.ts
+++ b/src/renderer/src/comfyTitlePopup/GlobalSettingsView.test.ts
@@ -160,14 +160,18 @@ describe('GlobalSettingsView', () => {
     ])
   })
 
-  it('Storage tab opens a models dir through the bridge', async () => {
+  it('Storage tab browses and re-points a models dir through the bridge', async () => {
     const bridge = installMockBridge()
+    bridge.browseFolderReturn = '/mnt/new/models'
     const wrapper = mountView()
     await wrapper.findAll('.gs-tab').find((t) => t.text() === 'Storage')!.trigger('click')
     await nextTick()
-    const openBtns = wrapper.findAll('.models-dir-row .models-dir-action')
-    await openBtns[0]!.trigger('click')
-    expect(bridge.openPathCalls).toEqual(['/home/u/ComfyUI/models'])
+    const browseBtns = wrapper.findAll('.models-dir-row .models-dir-action')
+    await browseBtns[0]!.trigger('click')
+    await flushPromises()
+    expect(bridge.setModelsDirsCalls).toEqual([
+      ['/mnt/new/models', '/mnt/extra/models'],
+    ])
   })
 
   // Covers the Shared Directories field-write path, not just the model-dir actions.

--- a/src/renderer/src/comfyTitlePopup/globalSettings/GlobalStorageSections.vue
+++ b/src/renderer/src/comfyTitlePopup/globalSettings/GlobalStorageSections.vue
@@ -99,8 +99,14 @@ async function handleMakePrimary(index: number): Promise<void> {
   await bridge?.globalSettingsSetModelsDirs(dirs)
 }
 
-function handleOpenModelsDir(path: string): void {
-  bridge?.globalSettingsOpenPath(path)
+async function handleChangeModelsDir(index: number): Promise<void> {
+  const current = props.snapshot.modelsDirs[index]?.path
+  const picked = await bridge?.globalSettingsBrowseFolder(current)
+  if (!picked || picked === current) return
+  emit('touched')
+  const dirs = props.snapshot.modelsDirs.map((d) => d.path)
+  dirs[index] = picked
+  await bridge?.globalSettingsSetModelsDirs(dirs)
 }
 
 async function handleUpdateSharedDirField(field: DetailField, value: unknown): Promise<void> {
@@ -116,7 +122,7 @@ async function handleUpdateSharedDirField(field: DetailField, value: unknown): P
   >
     <ModelsDirList
       :dirs="snapshot.modelsDirs"
-      @open="handleOpenModelsDir"
+      @change="handleChangeModelsDir"
       @remove="handleRemoveModelsDir"
       @make-primary="handleMakePrimary"
       @add="handleAddModelsDir"

--- a/src/renderer/src/comfyTitlePopup/globalSettings/ModelsDirList.vue
+++ b/src/renderer/src/comfyTitlePopup/globalSettings/ModelsDirList.vue
@@ -16,7 +16,7 @@ interface Props {
 const props = defineProps<Props>()
 
 const emit = defineEmits<{
-  open: [path: string]
+  change: [index: number]
   remove: [index: number]
   'make-primary': [index: number]
   add: []
@@ -76,9 +76,9 @@ function handleMenuArrow(index: number, direction: 1 | -1, event: KeyboardEvent)
   items[next]?.focus()
 }
 
-function handleOpen(path: string): void {
+function handleChange(index: number): void {
   closeMenu()
-  emit('open', path)
+  emit('change', index)
 }
 
 function handleRemove(index: number): void {
@@ -144,9 +144,9 @@ const rows = computed(() =>
         <button
           type="button"
           class="models-dir-action"
-          :aria-label="t('settings.open', 'Open')"
-          :title="t('settings.open', 'Open')"
-          @click.stop="handleOpen(row.path)"
+          :aria-label="t('common.browse', 'Browse')"
+          :title="t('common.browse', 'Browse')"
+          @click.stop="handleChange(row.index)"
         >
           <FolderOpen :size="14" aria-hidden="true" />
         </button>

--- a/src/renderer/src/views/comfyUISettings/StoragePane.test.ts
+++ b/src/renderer/src/views/comfyUISettings/StoragePane.test.ts
@@ -123,13 +123,28 @@ describe('StoragePane', () => {
     expect(document.activeElement).toBe(toggle.element)
   })
 
-  it('opens a models dir through the bridge when the open icon is clicked', async () => {
+  it('browses and re-points the dir through the bridge when the browse icon is clicked', async () => {
     const bridge = installMockBridge()
+    bridge.browseFolderReturn = '/mnt/new/models'
     const wrapper = mountPane()
     await nextTick()
-    const openBtns = wrapper.findAll('.models-dir-row .models-dir-action')
-    await openBtns[0]!.trigger('click')
-    expect(bridge.openPathCalls).toEqual(['/home/u/ComfyUI/models'])
+    const browseBtns = wrapper.findAll('.models-dir-row .models-dir-action')
+    await browseBtns[0]!.trigger('click')
+    await flushPromises()
+    expect(bridge.setModelsDirsCalls).toEqual([
+      ['/mnt/new/models', '/mnt/extra/models'],
+    ])
+  })
+
+  it('leaves dirs unchanged when the browse picker is canceled', async () => {
+    const bridge = installMockBridge()
+    bridge.browseFolderReturn = null
+    const wrapper = mountPane()
+    await nextTick()
+    const browseBtns = wrapper.findAll('.models-dir-row .models-dir-action')
+    await browseBtns[0]!.trigger('click')
+    await flushPromises()
+    expect(bridge.setModelsDirsCalls).toEqual([])
   })
 
   // make-primary is a "touched" action; the note bar must flip to the
@@ -147,12 +162,14 @@ describe('StoragePane', () => {
     expect(wrapper.find('.storage-note.is-warning').exists()).toBe(true)
   })
 
-  it('does not flip the storage note when only opening a dir', async () => {
-    installMockBridge()
+  it('flips the storage note to the warning state after browsing to a new dir', async () => {
+    const bridge = installMockBridge()
+    bridge.browseFolderReturn = '/mnt/new/models'
     const wrapper = mountPane()
     await nextTick()
+    expect(wrapper.find('.storage-note.is-warning').exists()).toBe(false)
     await wrapper.findAll('.models-dir-row .models-dir-action')[0]!.trigger('click')
     await flushPromises()
-    expect(wrapper.find('.storage-note.is-warning').exists()).toBe(false)
+    expect(wrapper.find('.storage-note.is-warning').exists()).toBe(true)
   })
 })

--- a/src/renderer/src/views/comfyUISettings/StoragePane.vue
+++ b/src/renderer/src/views/comfyUISettings/StoragePane.vue
@@ -153,8 +153,14 @@ async function handleMakePrimary(index: number): Promise<void> {
   await bridge?.globalSettingsSetModelsDirs(dirs)
 }
 
-function handleOpenModelsDir(path: string): void {
-  bridge?.globalSettingsOpenPath(path)
+async function handleChangeModelsDir(index: number): Promise<void> {
+  const current = props.snapshot.modelsDirs[index]?.path
+  const picked = await bridge?.globalSettingsBrowseFolder(current)
+  if (!picked || picked === current) return
+  globalTouched.value = true
+  const dirs = props.snapshot.modelsDirs.map((d) => d.path)
+  dirs[index] = picked
+  await bridge?.globalSettingsSetModelsDirs(dirs)
 }
 
 async function handleUpdateSharedDirField(field: DetailField, value: unknown): Promise<void> {
@@ -234,7 +240,7 @@ function handleUpdatePerInstallField(field: DetailField, value: unknown): void {
     >
       <ModelsDirList
         :dirs="snapshot.modelsDirs"
-        @open="handleOpenModelsDir"
+        @change="handleChangeModelsDir"
         @remove="handleRemoveModelsDir"
         @make-primary="handleMakePrimary"
         @add="handleAddModelsDir"


### PR DESCRIPTION
## Summary

In **Desktop Settings → Storage → Shared Models**, the folder icon on each directory row now opens a native folder picker and re-points that row, instead of revealing the folder in Finder/Explorer. A folder icon beside a directory path reads as "browse and change" — which is exactly what the **Input Directory** / **Output Directory** rows in the same panel already do, so this makes the Storage tab internally consistent.

## Changes

**What**
- `ModelsDirList.vue` — row folder icon emits `change(index)` instead of `open(path)`; tooltip/`aria-label` switched from `t('settings.open', 'Open')` to `t('common.browse', 'Browse')` (the same key the Input/Output trailing button uses). Icon stays `FolderOpen`.
- `StoragePane.vue` — replaced `handleOpenModelsDir(path)` (`globalSettingsOpenPath`) with `handleChangeModelsDir(index)`: browses from the row's current path via `globalSettingsBrowseFolder`, splices the picked dir into `modelsDirs`, and persists with `globalSettingsSetModelsDirs`. Cancel / same-path is a no-op.
- `GlobalStorageSections.vue` — identical change applied here too, since `ModelsDirList` is shared by both the per-install Storage tab and the Global Settings popup; patching only one would let them drift.

**Breaking**
- None. No main-process changes — reused the existing `globalSettingsBrowseFolder` and `globalSettingsSetModelsDirs` IPC. The `globalSettingsOpenPath` bridge/IPC/preload plumbing is left intact (now unused by the renderer, no dangling refs). No locale catalog edit needed — `common.browse` already resolves.

## Review Focus

- The crux: `ModelsDirList` has **two** consumers (`StoragePane` and `GlobalStorageSections`) that duplicate the same handler logic rather than sharing it. Both are updated here; the underlying duplication is a pre-existing smell.
- **Scope boundaries:** this PR only changes the folder-icon behavior. The `...` more-actions menu (Make primary / Remove) and the Input/Output pickers are untouched. Duplicate/overlapping-path guards are *not* added — parity with existing `add` behavior; a follow-up if wanted. De-duplicating `StoragePane` to reuse `GlobalStorageSections` is also a separate follow-up.

## Testing

Unit-only by design — the change is renderer wiring over existing IPC, and the two affected specs already cover the model-dir action surface, so updating them to the new behavior is the precise regression net.

- `StoragePane.test.ts` — replaced the old "open icon" spec with: browses-and-re-points through the bridge, leaves dirs unchanged when the picker is canceled, and flips the storage note to the warning state after a successful re-point.
- `GlobalSettingsView.test.ts` — Storage-tab spec updated to assert browse-and-re-point through the bridge.
- `pnpm typecheck && pnpm lint && pnpm test` all green: 131 files / 1856 tests passing.
- Manual: open Desktop Settings → Storage → click a Shared Models row's folder icon → picker opens at the row's current path → choosing a folder updates and persists the row (reopen to confirm); cancel is a no-op; icon no longer opens Finder. Input/Output and the `...` menu verified unchanged.

Screen Recording


https://github.com/user-attachments/assets/22009483-8c26-4b58-becc-041507f1ce13



closes #944 