### PR TITLE
chore: bump version to 1.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-desktop-2",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Comfy Desktop",
   "author": {
     "name": "Comfy Org",


### PR DESCRIPTION
## Summary
- bump `package.json` version from `1.0.8` to `1.0.9`
- channel: `stable` (rc → GitHub pre-release, stable → Latest)
- commits since `v1.0.8` were auto-grouped below

## How merging this PR ships the build
1. Merge — `Release From Version PR` workflow tags `v1.0.9` on the merge commit
2. Tag triggers `Publish All / build-release`, which creates the GitHub Release using **this PR body as the release notes**
3. ToDesktop picks up the new build and rolls it out

> **Polish the sections below before merge.** The auto-fill is a starting point — rewrite for users, not for the changelog.

## Features
- _(no `feat:` commits since v1.0.8 — add highlights here)_

## Fixes
- honor legacy Server Config values when deriving launch args (#941)
- shared models folder icon browses to re-point dir (#948)

## Install
- 👉 [comfy.org/download](https://comfy.org/download)
