### PR TITLE
fix(macos): declare Local Network usage so remote LAN servers connect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-desktop-2",
-  "version": "1.0.9",
+  "version": "1.0.10-rc.1",
   "description": "Comfy Desktop",
   "author": {
     "name": "Comfy Org",

--- a/todesktop.json
+++ b/todesktop.json
@@ -35,7 +35,13 @@
   },
   "mac": {
     "icon": "./assets/Comfy_Logo_mac_x1024.png",
-    "category": "public.app-category.graphics-design"
+    "category": "public.app-category.graphics-design",
+    "extendInfo": {
+      "NSLocalNetworkUsageDescription": "Comfy Desktop connects to ComfyUI servers running on your local network.",
+      "NSAppTransportSecurity": {
+        "NSAllowsLocalNetworking": true
+      }
+    }
   },
   "dmg": {
     "title": "Comfy Desktop",


### PR DESCRIPTION
## Problem
Packaged macOS builds fail to connect to a remote ComfyUI on a private LAN address (e.g. `http://192.168.0.134:8188`) with "Could not connect…", even though the same URL works in a browser and in `pnpm dev`.

## Root cause (proven, not a code bug)
Controlled test, **same 1.0.9 code**, only the app identity varies:
- `pnpm dev` (Electron identity, already granted Local Network) → `probe OK, reachable` ✅
- packaged "Comfy Desktop" (identity not granted) → "Could not connect" ❌

The main-process reachability probe (`waitForUrl` → Node `http.get`) opens a socket to the LAN IP. macOS gates Local Network access **per app identity**. The app declares **no** `NSLocalNetworkUsageDescription`, so the packaged app was never prompted for or granted access — and the rename changed the bundle identity, so any prior grant (the old `Comfy Desktop 2.0 Beta` entry) doesn't carry over. Result: every LAN socket the packaged app opens is blocked. (Confirmed in System Settings → Privacy → Local Network: old name present, `Comfy Desktop` absent.) Loopback/`localhost` keeps working because it's exempt.

## Fix
Add to `todesktop.json` `mac.extendInfo` (ToDesktop injects it into `Info.plist`; it ignores `electron-builder.yml`):
- `NSLocalNetworkUsageDescription` — so macOS prompts for and lists the app under Local Network.
- `NSAppTransportSecurity.NSAllowsLocalNetworking: true` — so plaintext **http** to LAN addresses is allowed by ATS.

## Verify
Needs a ToDesktop build: install it on a Mac, connect to a remote LAN ComfyUI, confirm the OS prompt appears and the connection succeeds. (Existing installs that were silently denied may need a `tccutil reset "Local Network"` once.)

## Not covered
Windows uses no Local Network TCC, so this is macOS-only. If Windows packaged builds also fail (dev works, packaged doesn't), that's a separate firewall/identity issue tracked independently.