### PR TITLE
fix(menu): restore fullscreen accelerator across all OSes

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1145,6 +1145,15 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
       }
     })
 
+    // Hide the bar on every window (incl. window.open popups) while keeping
+    // its accelerators live — the app uses a custom title bar throughout.
+    if (process.platform !== 'darwin') {
+      app.on('browser-window-created', (_event, window) => {
+        window.setMenuBarVisibility(false)
+        window.autoHideMenuBar = true
+      })
+    }
+
     // Bring up main-process telemetry as early as possible so install/migrate
     // sub-step events can fire even before the renderer mounts.
     //

--- a/src/main/menu.test.ts
+++ b/src/main/menu.test.ts
@@ -21,18 +21,26 @@ beforeEach(() => {
 })
 
 describe('installAppMenu', () => {
-  it('clears the application menu on win32 without dev overrides', () => {
-    installAppMenu('win32')
+  const winLinuxFullscreenOnly = (platform: 'win32' | 'linux'): void => {
+    installAppMenu(platform)
     expect(setApplicationMenu).toHaveBeenCalledTimes(1)
-    expect(setApplicationMenu).toHaveBeenCalledWith(null)
-    expect(buildFromTemplate).not.toHaveBeenCalled()
+    expect(buildFromTemplate).toHaveBeenCalledTimes(1)
+
+    const template = buildFromTemplate.mock.calls[0]?.[0] as Array<{
+      label?: string
+      submenu?: Array<{ role?: string; label?: string }>
+    }>
+    expect(template).toEqual([
+      { label: 'View', submenu: [{ role: 'togglefullscreen' }] },
+    ])
+  }
+
+  it('installs a fullscreen-only View menu on win32 without dev overrides', () => {
+    winLinuxFullscreenOnly('win32')
   })
 
-  it('clears the application menu on linux without dev overrides', () => {
-    installAppMenu('linux')
-    expect(setApplicationMenu).toHaveBeenCalledTimes(1)
-    expect(setApplicationMenu).toHaveBeenCalledWith(null)
-    expect(buildFromTemplate).not.toHaveBeenCalled()
+  it('installs a fullscreen-only View menu on linux without dev overrides', () => {
+    winLinuxFullscreenOnly('linux')
   })
 
   it('installs a View submenu on win32 when dev overrides wire Toggle DevTools', () => {
@@ -50,6 +58,7 @@ describe('installAppMenu', () => {
       expect.objectContaining({
         label: 'View',
         submenu: expect.arrayContaining([
+          expect.objectContaining({ role: 'togglefullscreen' }),
           expect.objectContaining({ role: 'reload' }),
           expect.objectContaining({ label: 'Toggle Developer Tools', click: expect.any(Function) }),
         ]),
@@ -77,6 +86,7 @@ describe('installAppMenu', () => {
     const windowRoles = (windowEntry?.submenu ?? []).map((item) => item.role)
     expect(windowRoles).toContain('minimize')
     expect(windowRoles).toContain('zoom')
+    expect(windowRoles).toContain('togglefullscreen')
     expect(windowRoles).toContain('front')
     expect(windowRoles).not.toContain('close')
     expect(windowRoles).not.toContain('closeAllWindows')
@@ -142,8 +152,14 @@ describe('installAppMenu', () => {
   it('does not add the app menu item on non-darwin platforms', () => {
     const onCheckForUpdates = vi.fn()
     installAppMenu('win32', undefined, { onCheckForUpdates })
-    // win32 with no dev overrides strips the menu entirely.
-    expect(setApplicationMenu).toHaveBeenCalledWith(null)
+    // The "Check for Updates…" item is macOS-only; win32 gets just the
+    // fullscreen-carrying View menu and never wires the handler.
+    const template = buildFromTemplate.mock.calls[0]?.[0] as Array<{
+      label?: string
+      submenu?: Array<{ role?: string; label?: string }>
+    }>
+    const labels = template.flatMap((e) => (e.submenu ?? []).map((i) => i.label))
+    expect(labels).not.toContain('Check for Updates…')
     expect(onCheckForUpdates).not.toHaveBeenCalled()
   })
 

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -34,28 +34,22 @@ export function installAppMenu(
       : undefined
 
   if (platform !== 'darwin') {
-    if (!routedDevTools) {
-      Menu.setApplicationMenu(null)
-      return
-    }
-    Menu.setApplicationMenu(
-      Menu.buildFromTemplate([
+    const viewSubmenu: MenuItemConstructorOptions[] = [{ role: 'togglefullscreen' }]
+    if (routedDevTools) {
+      viewSubmenu.push(
+        { type: 'separator' },
+        { role: 'reload' },
+        { role: 'forceReload' },
         {
-          label: 'View',
-          submenu: [
-            { role: 'reload' },
-            { role: 'forceReload' },
-            {
-              label: 'Toggle Developer Tools',
-              accelerator: 'Control+Shift+I',
-              click: (_menuItem, bw) => {
-                routedDevTools(bw)
-              },
-            },
-          ],
+          label: 'Toggle Developer Tools',
+          accelerator: 'Control+Shift+I',
+          click: (_menuItem, bw) => {
+            routedDevTools(bw)
+          },
         },
-      ]),
-    )
+      )
+    }
+    Menu.setApplicationMenu(Menu.buildFromTemplate([{ label: 'View', submenu: viewSubmenu }]))
     return
   }
   const onCheckForUpdates =
@@ -111,6 +105,7 @@ export function installAppMenu(
       submenu: [
         { role: 'minimize' },
         { role: 'zoom' },
+        { role: 'togglefullscreen' },
         { type: 'separator' },
         { role: 'front' },
       ],


### PR DESCRIPTION
## Fix fullscreen accelerator across all OSes

### Problem
Users reported **F11 does nothing** in the new build. The custom title bar
(`titleBarStyle: 'hidden'`) ships with the native app menu stripped — on
Win/Linux production the menu was set to `null`. That menu carried the
`togglefullscreen` role, whose default accelerator (F11 on Win/Linux,
Ctrl+Cmd+F on macOS) vanished with it. No menu → no accelerator → no
fullscreen. macOS only ever worked via the green traffic-light button, so
the breakage read as OS-specific.

### Fix
Restore fullscreen the canonical way (how VS Code/Chrome do it): keep the
role in the menu and let Electron bind the right key per platform. Works
window-globally regardless of focus, and is discoverable in the macOS
Window menu.

- **menu.ts** — add `{ role: 'togglefullscreen' }`; Win/Linux now install a
  minimal `View` menu (was `null`) so the accelerator has a carrier.
- **index.ts** — `browser-window-created` hook hides the menu bar on *every*
  window (incl. `window.open` checkout/OAuth popups) while keeping
  accelerators live, so no visible bar regresses anywhere.
- **menu.test.ts** — assert the fullscreen role per platform; drop the two
  tests that locked in the old `null`-menu (buggy) contract.

### Result
| Platform | Key | Status |
|---|---|---|
| Windows | F11 | ✅ fixed |
| Linux | F11 | ✅ fixed |
| macOS | Ctrl+Cmd+F | ✅ confirmed (F11 is OS-reserved) |

The existing `enter/leave-full-screen` handlers already keep the custom
title bar in sync, so no renderer changes were needed.

### Test plan
- [x] `pnpm test` (menu suite, 8 pass) · typecheck · lint
- [ ] Windows: F11 toggles fullscreen; Alt shows no menu bar; checkout/OAuth popups barless
- [ ] Linux: F11 toggles fullscreen
- [ ] macOS: Ctrl+Cmd+F toggles; traffic lights reflow correctly

closes #952 