### PR TITLE
fix(downloads): remember last-used Save dialog directory

### DIFF
--- a/src/main/lib/comfyDownloadManager.ts
+++ b/src/main/lib/comfyDownloadManager.ts
@@ -650,6 +650,10 @@ export function attachSessionDownloadHandler(sess: Electron.Session): void {
       // General download — browser-like save dialog
       const suggestedName = item.getFilename()
       const downloadsDir = app.getPath('downloads')
+      // Seed the dialog with the directory the user last saved to, matching
+      // browser behavior. Fall back to Downloads if unset or no longer present.
+      const remembered = settings.get('lastSaveDialogDir')
+      const startDir = remembered && fs.existsSync(remembered) ? remembered : downloadsDir
       // `webContents` is null for `session.downloadURL(...)`-initiated downloads
       // (Electron only sets it for page-initiated ones), so fall back to the
       // focused window for the Save dialog parent.
@@ -659,22 +663,23 @@ export function attachSessionDownloadHandler(sess: Electron.Session): void {
       let savePath: string | undefined
       if (win) {
         const filePath = dialog.showSaveDialogSync(win, {
-          defaultPath: path.join(downloadsDir, suggestedName),
+          defaultPath: path.join(startDir, suggestedName),
         })
         if (filePath) {
           savePath = filePath
+          settings.set('lastSaveDialogDir', path.dirname(filePath))
         } else {
           item.cancel()
           return
         }
       } else {
         // setSavePath must be synchronous within will-download
-        let candidate = path.join(downloadsDir, suggestedName)
+        let candidate = path.join(startDir, suggestedName)
         let i = 1
         while (fs.existsSync(candidate)) {
           const ext = path.extname(suggestedName)
           const base = path.basename(suggestedName, ext)
-          candidate = path.join(downloadsDir, `${base} (${i})${ext}`)
+          candidate = path.join(startDir, `${base} (${i})${ext}`)
           i++
         }
         savePath = candidate

--- a/src/main/settings.test.ts
+++ b/src/main/settings.test.ts
@@ -80,6 +80,17 @@ describe('settings unset/default semantics', () => {
     expect(persisted).not.toHaveProperty('onAppClose')
   })
 
+  it('persists and clears the nullable lastSaveDialogDir', () => {
+    const dir = path.join(homePath, 'Pictures', 'renders')
+    settings.set('lastSaveDialogDir', dir)
+    expect(settings.get('lastSaveDialogDir')).toBe(dir)
+    expect(readPersistedSettings()['lastSaveDialogDir']).toBe(dir)
+
+    settings.set('lastSaveDialogDir', undefined)
+    expect(settings.get('lastSaveDialogDir')).toBeUndefined()
+    expect(readPersistedSettings()).not.toHaveProperty('lastSaveDialogDir')
+  })
+
   it('normalizes legacy null values to unset on write', () => {
     fs.mkdirSync(path.dirname(settingsPath), { recursive: true })
     fs.writeFileSync(

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -33,6 +33,9 @@ export interface KnownSettings {
   firstUseCompleted?: boolean
   oemManagedModelDirs?: string[]
   oemWorkflowImportVersion?: number
+  /** Directory the user last chose in the general "Save image/file" dialog.
+   *  Used to seed the dialog's defaultPath so it matches browser behavior. */
+  lastSaveDialogDir?: string
 }
 
 export type Settings = KnownSettings & Record<string, unknown>
@@ -70,6 +73,7 @@ const SETTINGS_SCHEMA = {
   firstUseCompleted: { nullable: false },
   oemManagedModelDirs: { nullable: false },
   oemWorkflowImportVersion: { nullable: false },
+  lastSaveDialogDir: { nullable: true },
 } as const satisfies Record<keyof KnownSettings, { nullable: boolean }>
 
 export type KnownSettingKey = keyof typeof SETTINGS_SCHEMA


### PR DESCRIPTION
## Remember last-used Save dialog directory

### Problem
In Comfy Desktop (1.0.9), right-clicking an image (e.g. Preview Image node) → **Save** always opens the native dialog in **Downloads**, ignoring the folder you last saved to. The same ComfyUI instance over Chrome/localhost remembers it correctly — because that's a browser feature. In Desktop, ComfyUI runs inside Electron and our own `will-download` handler shows the dialog with `defaultPath` hardcoded to `app.getPath('downloads')`, with no persistence.

### Fix
- Persist the chosen directory as a new nullable setting `lastSaveDialogDir`.
- Seed the Save dialog's `defaultPath` from it, so it reopens where you last saved.
- Fall back to OS Downloads when nothing is stored **or** the remembered folder no longer exists (`fs.existsSync` guard — handles deleted/unmounted dirs without crashing).

### Before / After
| | Before | After |
|---|---|---|
| First save | Opens in Downloads | Opens in Downloads |
| Next save (after choosing a custom folder) | **Resets to Downloads** | **Opens in the last-used folder** |
| Across app restarts | n/a | Persists |

### Changes
- `src/main/settings.ts` — declare `lastSaveDialogDir` (interface + schema, `nullable: true`).
- `src/main/lib/comfyDownloadManager.ts` — read/seed + persist in the general-download branch of `attachSessionDownloadHandler`.
- `src/main/settings.test.ts` — set/get/clear test for the new key.

### Testing
- `pnpm run typecheck` — passes (all 4 tsconfigs).
- `pnpm exec vitest run src/main/settings.test.ts` — 21/21 pass.
- Manual: Save an image → pick a custom folder → save another → dialog opens in that folder; persists across restart; falls back to Downloads if the folder is removed.

closes #954 