### PR TITLE
fix(instance-picker): make rename pencil clickable + stop long names from truncating

### DIFF
--- a/src/renderer/src/comfyTitlePopup/InstancePickerView.vue
+++ b/src/renderer/src/comfyTitlePopup/InstancePickerView.vue
@@ -859,6 +859,7 @@ async function handleExpandedPrimaryAction(restartInPlace: boolean): Promise<voi
 .picker-detail {
   position: relative;
   flex: 1 1 0;
+  min-width: 0;
   min-height: 0;
   display: flex;
   flex-direction: column;

--- a/src/renderer/src/views/comfyUISettings/StatusFactPanel.vue
+++ b/src/renderer/src/views/comfyUISettings/StatusFactPanel.vue
@@ -47,6 +47,19 @@ watch(
   { immediate: true, flush: 'post' },
 )
 
+// Clicking the pencil should behave like clicking into the field: focus the editable name and place the caret at the end.
+function focusName(): void {
+  const el = nameEl.value
+  if (!el) return
+  el.focus()
+  const range = document.createRange()
+  range.selectNodeContents(el)
+  range.collapse(false)
+  const sel = window.getSelection()
+  sel?.removeAllRanges()
+  sel?.addRange(range)
+}
+
 function handleNameSelectAll(event: KeyboardEvent): void {
   event.preventDefault()
   const el = event.currentTarget as HTMLElement
@@ -244,6 +257,7 @@ const groups = computed<FactGroup[]>(() => {
         <span class="status-fact-hero-name-wrap">
           <span
             v-if="nameEditable"
+            id="status-fact-hero-name"
             ref="nameEl"
             class="status-fact-hero-name"
             role="textbox"
@@ -260,12 +274,16 @@ const groups = computed<FactGroup[]>(() => {
           <span v-else class="status-fact-hero-name status-fact-hero-name-static">{{
             installation.name
           }}</span>
-          <Pencil
+          <button
             v-if="nameEditable"
-            :size="13"
-            class="status-fact-hero-edit-hint"
-            aria-hidden="true"
-          />
+            type="button"
+            class="status-fact-hero-edit-btn"
+            :aria-label="t('statusFactPanel.editName', 'Edit installation name')"
+            aria-controls="status-fact-hero-name"
+            @click="focusName"
+          >
+            <Pencil :size="13" class="status-fact-hero-edit-hint" aria-hidden="true" />
+          </button>
         </span>
         <span v-if="installation.sourceLabel" class="status-fact-hero-badge">
           {{ installation.sourceLabel }}
@@ -355,18 +373,49 @@ const groups = computed<FactGroup[]>(() => {
   box-shadow: 0 0 0 2px var(--focus-ring, var(--neutral-50));
 }
 
-/* Pencil hint fades up on hover/focus. */
+.status-fact-hero-edit-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 0;
+  margin-left: -6px;
+  padding: 0;
+  overflow: hidden;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition:
+    width 120ms ease,
+    margin-left 120ms ease;
+}
+
+.status-fact-hero-edit-btn:focus-visible {
+  outline: 2px solid var(--focus-ring, var(--neutral-50));
+  outline-offset: 1px;
+}
+
+
+.status-fact-hero-name-wrap:hover .status-fact-hero-edit-btn,
+.status-fact-hero-edit-btn:focus-visible,
+.status-fact-hero-name:focus-visible ~ .status-fact-hero-edit-btn {
+  width: 17px;
+  margin-left: 0;
+}
+
+
 .status-fact-hero-edit-hint {
   flex-shrink: 0;
   color: var(--text-muted);
   opacity: 0;
   transition: opacity 120ms ease;
   user-select: none;
-  pointer-events: none;
 }
 
 .status-fact-hero-name-wrap:hover .status-fact-hero-edit-hint,
-.status-fact-hero-name:focus-visible ~ .status-fact-hero-edit-hint {
+.status-fact-hero-edit-btn:focus-visible .status-fact-hero-edit-hint,
+.status-fact-hero-name:focus-visible ~ .status-fact-hero-edit-btn .status-fact-hero-edit-hint {
   opacity: 0.6;
 }
 


### PR DESCRIPTION
## Summary

The rename pencil in the instance picker's **About** tab did nothing on click, and a long instance name overflowed the entire right pane (clipping every row at the right edge). This makes the pencil focus the name like a normal field click and stops long names from stretching the pane.

## Changes

**What**
- `StatusFactPanel.vue` — wrapped the `Pencil` hint in a real `<button>` that calls a new `focusName()`: it focuses the `contenteditable` name and drops the caret at the end, mirroring a click into the field. Wired `aria-controls` to the name's id.
- `StatusFactPanel.vue` — collapsed the pencil button to `width: 0` (with a `-6px` margin cancelling the wrap's gap) at rest, expanding to `17px` on hover / keyboard focus, so it leaves no dead space between the name and the source badge when the icon is hidden.
- `InstancePickerView.vue` — added `min-width: 0` to `.picker-detail`. As a `flex: 1 1 0` item it defaulted to `min-width: auto` (its content's intrinsic width), so the longest line — a long instance name — pushed it past the `minmax(0, 1fr)` grid column and the pane's `overflow: hidden` clipped everything. With `min-width: 0` the pane honours its column and the name's existing `overflow: hidden; text-overflow: ellipsis` clamps it.

**Breaking**
- None. No IPC, rename logic, or `onRename` contract changed — purely the pencil affordance and pane width constraint. Non-renamable (Cloud) installs still render a static name with no pencil.

## Review Focus

- The real overflow fix is the single `min-width: 0` on `.picker-detail`; the symptom (the long name) was a red herring — the whole pane was overflowing the grid column, not just the name span. No container restructuring was needed.
- Scope is the About-tab rename hero + the picker detail pane width only. The pencil keeps its hover/focus fade; it now also occupies zero layout space at rest.

## Testing

Unit + template only — no user-visible IPC/behavior change, so existing component specs cover the affordance and the static-vs-editable branching; the layout fix is CSS-only and verified manually against a pathologically long name.

- `StatusFactPanel.test.ts` — asserts the pencil is absent for non-renamable installs and the rename commit path; 10 passing.
- `ComfyUISettingsContent.test.ts` — host wiring of the status pane; 31 passing.
- `pnpm typecheck` ✅, `pnpm lint` ✅, `vitest` 41/41 ✅.
- Manual: long name now ellipsizes inside the box; badge sits flush at rest; clicking the pencil focuses the field with caret at the end.

closes #927 