### PR TITLE
feat: editable remote connection URL in Instance Picker Preview

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1004,6 +1004,7 @@
   },
 
   "errors": {
+    "invalidUrl": "Enter a valid URL (e.g. http://localhost:8188).",
     "noLaunchSupport": "This source does not support launching yet.",
     "noEnvFound": "Cannot launch: no Python environment found. Create one first.",
     "alreadyRunning": "ComfyUI is already running. Stop it before launching again.",

--- a/src/main/lib/ipc/registerInstallationHandlers.ts
+++ b/src/main/lib/ipc/registerInstallationHandlers.ts
@@ -34,6 +34,7 @@ import * as releaseCache from '../release-cache'
 import { runStartupReleaseChecks } from '../release-cache-startup'
 import { _broadcastToRenderer } from './shared'
 import { hasGitDir } from '../git'
+import { parseUrl } from '../util'
 import { restoreSnapshotIntoInstallation } from '../standaloneMigration'
 import * as mainTelemetry from '../telemetry'
 import { recordIpcInvocation } from '../e2eOverrides'
@@ -411,9 +412,16 @@ export function registerInstallationHandlers(): void {
       }
       const filtered: Record<string, unknown> = {}
       for (const key of Object.keys(data)) {
-        if (allowedIds.has(key)) {
-          filtered[key] = key === 'envVars' ? sanitizeEnvVars(data[key]) : data[key]
+        if (!allowedIds.has(key)) continue
+        if (key === 'remoteUrl') {
+          const parsed = parseUrl(data[key] as string)
+          if (!parsed) return { ok: false, message: i18n.t('errors.invalidUrl') }
+          // Store the normalized href (scheme-completed, trailing slash
+          // stripped) so it matches creation's `buildInstallation`.
+          filtered[key] = parsed.href
+          continue
         }
+        filtered[key] = key === 'envVars' ? sanitizeEnvVars(data[key]) : data[key]
       }
       if (filtered.name && filtered.name !== inst.name) {
         if (await installations.hasNameConflict(installationId, filtered.name as string)) {

--- a/src/main/sources/common/urlSource.ts
+++ b/src/main/sources/common/urlSource.ts
@@ -80,7 +80,7 @@ export function createUrlSource(config: UrlSourceConfig): SourcePlugin {
 
     getDetailSections(installation: InstallationRecord): Record<string, unknown>[] {
       const urlField: Record<string, unknown> = editableUrl
-        ? { id: 'remoteUrl', label: t('remote.url'), value: (installation.remoteUrl as string) || '—', editable: true }
+        ? { id: 'remoteUrl', label: t('remote.url'), value: (installation.remoteUrl as string) || '—', editable: true, requiresRestart: true }
         : { label: t('remote.url'), value: (installation.remoteUrl as string) || '—' }
 
       const actions: Record<string, unknown>[] = [

--- a/src/renderer/src/components/settings/ComfyUISettingsContent.vue
+++ b/src/renderer/src/components/settings/ComfyUISettingsContent.vue
@@ -114,6 +114,7 @@ const {
   updateField,
   renameInstallation,
   pendingRestartFieldIds,
+  clearPendingRestart,
   fieldErrorMessages,
   runAction,
   runningActionIds,
@@ -414,6 +415,26 @@ function handleArgsUpdate(value: string): void {
   if (f) void updateField(f, value)
 }
 
+/** Live `remoteUrl` field from the status sections (remote connections only). */
+const remoteUrlField = computed<DetailField | null>(() => {
+  for (const s of sectionsForTab('status').value) {
+    for (const f of s.fields ?? []) {
+      if (f.id === 'remoteUrl') return f
+    }
+  }
+  return null
+})
+
+/** Commit a remote-URL edit through `updateField` (optimistic write, rollback,
+ *  error pill, restart-dirty + telemetry). Resolves `false` on rejection so
+ *  StatusFactPanel reverts; success is read back from the field-error map. */
+async function handleUrlUpdate(value: string): Promise<boolean> {
+  const field = remoteUrlField.value
+  if (!field) return false
+  await updateField(field, value)
+  return !fieldErrorMessages.value.has(field.id)
+}
+
 function handleSnapshotAction(action: ActionDef): void {
   void runAction(action)
 }
@@ -449,7 +470,14 @@ const primaryActionLabel = computed(() => {
 })
 
 function handlePrimaryAction(): void {
-  if (!installation.value) return
+  const selectedInstall = installation.value
+  if (!selectedInstall) return
+  // The restart-in-place click IS the restart: main stops + relaunches with the
+  // freshly-saved values, so consume the pending-restart state now. A remote
+  // relaunch surfaces no observable lifecycle dip, so the watchers can't clear it.
+  if (installCta.restartInPlace.value && pendingRestartFieldIds.value.size > 0) {
+    clearPendingRestart(selectedInstall.id)
+  }
   emit('primary-action', installCta.restartInPlace.value)
 }
 
@@ -695,6 +723,8 @@ defineExpose({
                 :sections="statusSections"
                 :disk-usage="diskUsageItem"
                 :on-rename="renameInstallation"
+                :on-update-url="handleUrlUpdate"
+                :url-restart-pending="pendingRestartFieldIds.has('remoteUrl')"
               />
             </div>
             <div

--- a/src/renderer/src/composables/useComfyUISettings.ts
+++ b/src/renderer/src/composables/useComfyUISettings.ts
@@ -80,6 +80,11 @@ export interface UseComfyUISettingsApi {
    *  drives the "Restart to apply" pill. Held per-install. */
   pendingRestartFieldIds: ComputedRef<Set<string>>
 
+  /** Consume the pending-restart + error state for an install. Called when the
+   *  user initiates the restart, since a remote relaunch surfaces no observable
+   *  lifecycle dip to clear it automatically. */
+  clearPendingRestart: (installId: string) => void
+
   /** Per-install field error messages from failed `updateField` IPCs. */
   fieldErrorMessages: ComputedRef<Map<string, string>>
 
@@ -673,8 +678,21 @@ export function useComfyUISettings(opts: UseComfyUISettingsOpts): UseComfyUISett
     if (noticeTimer) clearTimeout(noticeTimer)
   })
 
-  // Drop the per-install dirty + error entries when the install stops; it
-  // picks up new values on next launch, so nothing is left to apply.
+  // Drop the per-install dirty + error entries once a (re)launch has consumed
+  // the new values, so the "Restart to apply" state clears after the restart.
+  function clearRestartAndErrors(installId: string): void {
+    if (restartBaselines.value.has(installId)) {
+      const next = new Map(restartBaselines.value)
+      next.delete(installId)
+      restartBaselines.value = next
+    }
+    if (errorMessages.value.has(installId)) {
+      const next = new Map(errorMessages.value)
+      next.delete(installId)
+      errorMessages.value = next
+    }
+  }
+
   watch(
     () => {
       const inst = toValue(opts.installation)
@@ -686,18 +704,25 @@ export function useComfyUISettings(opts: UseComfyUISettingsOpts): UseComfyUISett
       // Refetch so the "Running details" port row (sourced from main) appears
       // on launch and clears on stop. Race-safe via reload()'s requestSeq.
       void reload()
-      if (wasRunning && !running) {
-        if (restartBaselines.value.has(inst.id)) {
-          const next = new Map(restartBaselines.value)
-          next.delete(inst.id)
-          restartBaselines.value = next
-        }
-        if (errorMessages.value.has(inst.id)) {
-          const next = new Map(errorMessages.value)
-          next.delete(inst.id)
-          errorMessages.value = next
-        }
-      }
+      // Stop edge: nothing is left to apply (next launch picks up new values).
+      if (wasRunning && !running) clearRestartAndErrors(inst.id)
+    }
+  )
+
+  // A restart may not surface a running→stopped dip (e.g. a remote connection
+  // has no process to kill, so the snapshot can coalesce stop+relaunch into one
+  // running broadcast). Catch the relaunch via the launching edge instead: any
+  // (re)launch re-reads the persisted values, so the pending-restart state is
+  // satisfied the moment a new launch begins.
+  watch(
+    () => {
+      const inst = toValue(opts.installation)
+      return inst ? sessionStore.isLaunching(inst.id) : false
+    },
+    (launching, wasLaunching) => {
+      const inst = toValue(opts.installation)
+      if (!inst) return
+      if (launching && !wasLaunching) clearRestartAndErrors(inst.id)
     }
   )
 
@@ -718,6 +743,7 @@ export function useComfyUISettings(opts: UseComfyUISettingsOpts): UseComfyUISett
     updateField,
     renameInstallation,
     pendingRestartFieldIds,
+    clearPendingRestart: clearRestartAndErrors,
     fieldErrorMessages,
     runAction,
     runningActionIds,

--- a/src/renderer/src/lib/i18nMessages.ts
+++ b/src/renderer/src/lib/i18nMessages.ts
@@ -34,7 +34,12 @@ export const en = {
       'Restart the application (or close and reopen) for these changes to take effect.'
   },
   statusFactPanel: {
-    editName: 'Edit installation name'
+    editName: 'Edit installation name',
+    editUrl: 'Edit connection URL',
+    restartToApply: 'Restart to apply'
+  },
+  errors: {
+    invalidUrl: 'Enter a valid URL (e.g. http://localhost:8188).'
   },
   models: {
     addDir: 'Add directory',

--- a/src/renderer/src/views/comfyUISettings/StatusFactPanel.vue
+++ b/src/renderer/src/views/comfyUISettings/StatusFactPanel.vue
@@ -16,6 +16,10 @@ interface Props {
   diskUsage: { label: string; value: string } | null
   /** Commit a rename, resolving `true` on success; a function prop (not an emit) so blur can await and revert only on failure. */
   onRename?: (newName: string) => Promise<boolean>
+  /** Commit a remote-URL change, resolving `true` on success. Same function-prop rationale as `onRename`: blur awaits and reverts only on failure. */
+  onUpdateUrl?: (newUrl: string) => Promise<boolean>
+  /** True when the remote URL was edited while running and a reconnect is pending. Owned by the composable so it clears on stop/restart like the footer button. */
+  urlRestartPending?: boolean
 }
 
 const props = defineProps<Props>()
@@ -82,6 +86,107 @@ async function handleNameBlur(event: FocusEvent): Promise<void> {
   }
   // Empty / whitespace-only / unchanged: restore the canonical name now.
   syncName()
+}
+
+// --- Remote connection URL: inline-editable, mirroring the name-edit pattern above. ---
+
+// Only the Remote Connection source exposes an editable `remoteUrl`; Cloud's URL stays read-only.
+const urlEditable = computed(() => props.installation?.sourceCategory === 'remote')
+
+// Mirrors main's `parseUrl`: a scheme-less value is tried as `http://<value>` and must yield a hostname.
+function isValidConnectionUrl(raw: string): boolean {
+  const trimmed = raw.trim()
+  if (!trimmed) return false
+  try {
+    const parsed = new URL(trimmed.includes('://') ? trimmed : `http://${trimmed}`)
+    return parsed.hostname.length > 0
+  } catch {
+    return false
+  }
+}
+
+// The live session is pinned to the launch-time URL, so an edit while running
+// only takes effect on restart. Visibility is owned by the composable's
+// restart-dirty state (via `urlRestartPending`), which clears on stop/restart —
+// gated here on `isRunning` so the tag hides the instant the instance stops.
+const showUrlRestart = computed(() => {
+  const id = props.installation?.id
+  return !!props.urlRestartPending && !!id && sessionStore.isRunning(id)
+})
+
+// Same imperative-sync rationale as the name hero (pencil sibling can't live inside the contenteditable).
+// A `ref` on an element inside `v-for` resolves to an array; the URL row renders at most once, so unwrap to the single node.
+const urlElRaw = useTemplateRef<HTMLElement | HTMLElement[]>('urlEl')
+const urlEl = computed<HTMLElement | null>(() =>
+  Array.isArray(urlElRaw.value) ? (urlElRaw.value[0] ?? null) : (urlElRaw.value ?? null),
+)
+// Source the canonical URL from the `remoteUrl` detail field (always present in
+// the sections) rather than `installation.remoteUrl`, which the picker snapshot
+// may omit. Falls back to the installation field if the section value is a placeholder.
+function currentUrl(): string {
+  for (const section of props.sections) {
+    for (const field of section.fields ?? []) {
+      if (field.id === 'remoteUrl') {
+        const v = typeof field.value === 'string' ? field.value : ''
+        if (v && v !== '—') return v
+      }
+    }
+  }
+  const fallback = props.installation?.remoteUrl
+  return typeof fallback === 'string' ? fallback : ''
+}
+function syncUrl(): void {
+  const el = urlEl.value
+  if (!el) return
+  const url = currentUrl()
+  if (el.textContent !== url) el.textContent = url
+}
+// Repaint the canonical URL when it changes externally (e.g. main re-normalised
+// it), without stomping the caret mid-edit.
+watch(
+  [() => currentUrl(), urlEl],
+  () => {
+    if (document.activeElement !== urlEl.value) syncUrl()
+  },
+  { immediate: true, flush: 'post' },
+)
+
+function handleUrlEscape(): void {
+  syncUrl()
+  urlEl.value?.blur()
+}
+
+// Pencil click: focus the URL field and drop the caret at the end so the user can edit immediately.
+function focusUrlField(): void {
+  const el = urlEl.value
+  if (!el) return
+  el.focus()
+  const range = document.createRange()
+  range.selectNodeContents(el)
+  range.collapse(false)
+  const sel = window.getSelection()
+  sel?.removeAllRanges()
+  sel?.addRange(range)
+}
+
+// The editable URL row is the remote source's `remoteUrl` fact (matched on the field id carried into the row).
+function isUrlRow(row: { id: string }): boolean {
+  return urlEditable.value && row.id === 'remoteUrl'
+}
+
+async function handleUrlBlur(event: FocusEvent): Promise<void> {
+  const el = event.target as HTMLElement
+  const current = currentUrl()
+  const next = el.textContent?.trim() ?? ''
+  if (!next || next === current || !isValidConnectionUrl(next)) {
+    // Empty / unchanged / invalid: restore the canonical value, no commit.
+    syncUrl()
+    return
+  }
+  // On rejection, revert; on success the composable sets the restart-pending
+  // state (when running) and main normalises the URL — the watcher repaints it.
+  const committed = await props.onUpdateUrl?.(next)
+  if (committed === false) syncUrl()
 }
 
 interface FactRow {
@@ -278,7 +383,35 @@ const groups = computed<FactGroup[]>(() => {
       <dl class="status-fact-list">
         <div v-for="row in group.rows" :key="row.id" class="status-fact-row">
           <dt>{{ row.label }}</dt>
-          <dd>
+          <dd v-if="isUrlRow(row)" class="status-fact-url-dd">
+            <span class="status-fact-url-edit">
+              <span
+                ref="urlEl"
+                class="status-fact-value status-fact-url-editable"
+                role="textbox"
+                :aria-label="t('statusFactPanel.editUrl', 'Edit connection URL')"
+                contenteditable="plaintext-only"
+                spellcheck="false"
+                :title="row.value"
+                @blur="handleUrlBlur"
+                @keydown.enter.prevent="($event.target as HTMLElement).blur()"
+                @keydown.esc.prevent="handleUrlEscape"
+              />
+              <button
+                type="button"
+                class="status-fact-url-edit-btn"
+                :aria-label="t('statusFactPanel.editUrl', 'Edit connection URL')"
+                :title="t('statusFactPanel.editUrl', 'Edit connection URL')"
+                @click="focusUrlField"
+              >
+                <Pencil :size="12" aria-hidden="true" />
+              </button>
+            </span>
+            <span v-if="showUrlRestart" class="status-fact-restart-tag" role="status">
+              {{ t('statusFactPanel.restartToApply', 'Restart to apply') }}
+            </span>
+          </dd>
+          <dd v-else>
             <span
               class="status-fact-value"
               :class="{ 'is-truncate-start': row.truncate === 'start' }"
@@ -451,5 +584,93 @@ const groups = computed<FactGroup[]>(() => {
 .status-fact-value.is-truncate-start {
   direction: rtl;
   text-align: left;
+}
+
+/* Editable URL row: stack the field over the reconnect hint, keeping the right alignment of the fact list. */
+.status-fact-url-dd {
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  row-gap: 4px;
+}
+
+/* Name + pencil as siblings (the pencil can't live inside the contenteditable — `textContent =` would wipe it). */
+.status-fact-url-edit {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.status-fact-url-editable {
+  padding: 2px 6px;
+  margin-right: -6px;
+  border-radius: 6px;
+  outline: none;
+  cursor: text;
+  text-align: right;
+  transition: background-color 120ms ease;
+}
+
+.status-fact-url-editable:hover {
+  background: var(--brand-surface-bg-hover);
+}
+
+.status-fact-url-editable:focus-visible {
+  background: var(--brand-surface-bg-hover);
+  box-shadow: 0 0 0 2px var(--focus-ring, var(--neutral-50));
+  /* Let the full URL show while editing rather than ellipsizing. */
+  overflow: visible;
+  text-overflow: clip;
+}
+
+.status-fact-url-edit-btn {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    opacity 120ms ease,
+    background-color 120ms ease,
+    color 120ms ease;
+}
+
+/* Reveal on row hover or whenever the field/button itself has focus, so keyboard users can find it. */
+.status-fact-url-edit:hover .status-fact-url-edit-btn,
+.status-fact-url-edit:focus-within .status-fact-url-edit-btn {
+  opacity: 0.6;
+}
+
+.status-fact-url-edit-btn:hover,
+.status-fact-url-edit-btn:focus-visible {
+  opacity: 1;
+  background: var(--brand-surface-bg-hover);
+  color: var(--text);
+  outline: none;
+}
+
+/* Reconnect hint: restart-tag shape in the warning ramp (mirrors SettingsSectionList's `.settings-v2-restart-tag`). */
+.status-fact-restart-tag {
+  flex: 0 0 auto;
+  padding: 1px 6px;
+  border-radius: 9999px;
+  font-size: 10px;
+  font-weight: 500;
+  line-height: 14px;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--warning);
+  background: color-mix(in srgb, var(--warning) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--warning) 36%, transparent);
+  white-space: nowrap;
 }
 </style>


### PR DESCRIPTION
## Summary

Lets users edit a Remote Connection instance's URL/port inline on the **About** tab. The change persists to the underlying `remoteUrl` (not just the display), is validated + normalized on save, and surfaces a "Restart to apply" affordance when edited while connected.

## Changes

**What**
- `src/main/sources/common/urlSource.ts` — mark the `remoteUrl` detail field `requiresRestart: true` (already `editable`), so editing it while connected drives the "Restart to apply" pill. Remote only; Cloud's URL stays read-only.
- `src/main/lib/ipc/registerInstallationHandlers.ts` — in `update-installation`, validate `remoteUrl` with `parseUrl` and store the normalized `href` (scheme-completed, trailing-slash-stripped), matching how creation persists it; reject invalid input with `errors.invalidUrl`.
- `src/renderer/src/views/comfyUISettings/StatusFactPanel.vue` — make the URL fact row inline-editable (contenteditable + clickable/keyboard-accessible pencil button), mirroring the existing name-edit pattern; client-side `isValidConnectionUrl` guard; inline "Restart to apply" tag gated on `isRunning`.
- `src/renderer/src/components/settings/ComfyUISettingsContent.vue` — wire `:on-update-url` (commits through `updateField` for optimistic write / rollback / error pill); clear pending-restart state on the restart-in-place CTA click.
- `src/renderer/src/composables/useComfyUISettings.ts` — expose `clearPendingRestart`. A remote relaunch surfaces no observable lifecycle dip (instant stop+relaunch, snapshot broadcast coalesces, no launching state), so the restart click itself consumes the pending-restart state.
- `locales/en.json` + `src/renderer/src/lib/i18nMessages.ts` — add `errors.invalidUrl`, `statusFactPanel.editUrl`, `statusFactPanel.restartToApply` (popup catalog mirrored for the title-popup picker).

**Breaking**
- None. Cloud URL remains read-only; the `update-installation` editable-field whitelist, IPC channels, and existing `requiresRestart` machinery are reused unchanged. Editing the URL while disconnected shows no restart prompt — the next Connect uses the new URL (launch reads `remoteUrl` fresh).

## Review Focus

- **Why clear on the CTA click, not a lifecycle watcher:** a remote session has `proc: null`, so restart does an instant `stopRunning` + relaunch; the picker snapshot broadcast (`broadcastInstancePickerSnapshotToTitlePopups`) has a sequence guard that coalesces the stop snapshot away, and the remote launch path never sets the launching state — so neither the `isRunning` stop edge nor the `isLaunching` edge is observable. The restart click is the reliable, host-agnostic clear point (both `ChooserView` and `InstancePickerView` consume the same `primary-action` emit).
- **Scope:** remote URL editing only. Cloud URL editability and a true "reconnect now" (vs. restart-to-apply) are out of scope.

## Testing

Unit + existing suites only — behavior is renderer-wiring plus a main-side validation branch, both covered by current specs (the `primary-action` emit is unchanged; the clear call is additive). Manual verification covers the live edit/restart flow that unit tests can't exercise.
- `pnpm typecheck` (node/web/e2e/integration), `pnpm lint`, `pnpm build`, `pnpm test` (131 files, 1866 tests) all green.
- Manual: edit URL while disconnected → no pill, next Connect uses it; edit while connected → pill + footer button appear; click "Restart to apply changes" → clears immediately and reconnects to the new URL; invalid URL → inline error, no persist; scheme-less `host:port` → stored as `http://host:port`; Cloud URL stays read-only; verified from both the dashboard drawer and the title-popup picker.

Screen Recording


https://github.com/user-attachments/assets/4c4dc08f-60c0-4958-80e7-eff56a66d62d



Closes #947 