### PR TITLE
feat(settings): add "Hide Cloud from Instance Picker" opt-out

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -397,6 +397,8 @@
     "closeQuitDownloads": "Downloading",
     "autoUpdate": "Check for updates on startup",
     "autoInstallUpdates": "Automatically install Desktop updates",
+    "hideCloudFromPicker": "Hide Cloud from the Instance Picker",
+    "hideCloudFromPickerDescription": "For local-only users — hides the Cloud tile (and the Try Cloud CTA) from the Dashboard. Cloud remains fully functional; you can re-enable this any time.",
     "checkForUpdates": "Check for updates",
     "checkingForUpdates": "Checking…",
     "telemetry": "Telemetry",

--- a/src/main/lib/ipc/registerSettingsHandlers.ts
+++ b/src/main/lib/ipc/registerSettingsHandlers.ts
@@ -55,6 +55,16 @@ export function buildSettingsSections(): SettingsSection[] {
           type: 'boolean',
           value: s.autoInstallUpdates !== false
         },
+        // Local-only users have asked us to make the Cloud tile go away.
+        // Cloud is still a first-class peer; this is an opt-out, not a
+        // removal — default off, surface as a plain toggle.
+        {
+          id: 'hideCloudFromPicker',
+          label: i18n.t('settings.hideCloudFromPicker'),
+          type: 'boolean',
+          value: s.hideCloudFromPicker === true,
+          tooltip: i18n.t('settings.hideCloudFromPickerDescription')
+        },
         // onAppClose field hidden while docking-to-tray is disabled.
         ...(isChinese ? [chineseMirrorsField] : [])
       ]

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -31,6 +31,11 @@ export interface KnownSettings {
   /** `true` once the first-use takeover is finished. Mid-flow cancel does NOT
    *  flip this, so the takeover replays from step 1 next launch. */
   firstUseCompleted?: boolean
+  /** When true, hide the Cloud tile (and the Try-Cloud CTA) from the
+   *  Dashboard / Instance Picker. Local-only users who never use Cloud
+   *  can opt out of seeing it without us removing the feature. Default
+   *  false — Cloud stays visible. */
+  hideCloudFromPicker?: boolean
   oemManagedModelDirs?: string[]
   oemWorkflowImportVersion?: number
 }
@@ -68,6 +73,7 @@ const SETTINGS_SCHEMA = {
   chineseMirrorsPrompted: { nullable: false },
   telemetryEnabled: { nullable: false },
   firstUseCompleted: { nullable: false },
+  hideCloudFromPicker: { nullable: false },
   oemManagedModelDirs: { nullable: false },
   oemWorkflowImportVersion: { nullable: false },
 } as const satisfies Record<keyof KnownSettings, { nullable: boolean }>

--- a/src/renderer/src/composables/useInstallList.ts
+++ b/src/renderer/src/composables/useInstallList.ts
@@ -49,12 +49,22 @@ export interface UseInstallListApi {
 // Shared install-list state for the dashboard and the instance picker.
 // Pure-data (no IPC/Pinia/DOM); Cloud is always split out as its own surface.
 // Owns a 60s `now` tick so relative time labels stay fresh.
+//
+// The `hideCloudFromPicker` setting is read once on mount; subsequent
+// toggles in Global Settings take effect on the next dashboard render
+// (no live IPC broadcast for it — settings updates already trigger a
+// re-render via the snapshot pipeline).
 export function useInstallList(opts: UseInstallListOpts): UseInstallListApi {
   const { t } = useI18n()
   const { installations } = opts
 
   const searchQuery = ref('')
   const activeFilter = ref<FilterKey>('all')
+  // Module-local copy of the `hideCloudFromPicker` setting. `false` while
+  // the IPC fetch is in flight so Cloud renders by default and only
+  // disappears if the user actually opted in. Re-fetched on mount so
+  // the Settings toggle applies after a dashboard reload.
+  const hideCloudFromPicker = ref<boolean>(false)
 
   function matchesQuery(name: string): boolean {
     const q = searchQuery.value.trim().toLowerCase()
@@ -97,6 +107,10 @@ export function useInstallList(opts: UseInstallListOpts): UseInstallListApi {
   })
 
   const showCloudCard = computed<boolean>(() => {
+    // Opt-out: user toggled "Hide Cloud from picker" in Global Settings.
+    // Gates BOTH the per-install tile (when a cloud install exists) and
+    // the generic Try-Cloud CTA so the user truly never sees it.
+    if (hideCloudFromPicker.value) return false
     const inCategory = activeFilter.value === 'all' || activeFilter.value === 'cloud'
     if (!inCategory) return false
     // When a real cloud install exists, gate visibility on the query —
@@ -120,6 +134,17 @@ export function useInstallList(opts: UseInstallListOpts): UseInstallListApi {
     nowTimer = setInterval(() => {
       now.value = Date.now()
     }, 60_000)
+    // Best-effort read of the "Hide Cloud from picker" opt-out. Failures
+    // resolve to `false` so Cloud renders by default — never silently
+    // hide on a missing IPC bridge (e.g. tests or pre-attach mounts).
+    void (async () => {
+      try {
+        const value = await window.api.getSetting('hideCloudFromPicker')
+        hideCloudFromPicker.value = value === true
+      } catch {
+        hideCloudFromPicker.value = false
+      }
+    })()
   })
   onBeforeUnmount(() => {
     if (nowTimer) clearInterval(nowTimer)


### PR DESCRIPTION
## Summary

Day-3 launch feedback has a clear drumbeat from local-only users asking for a way to make the Cloud tile go away (Reddit, Typeform, Discord). Cloud stays a first-class peer of local installs — this is opt-out, not removal.

Default: **Cloud visible** (no behavior change for the 99%). Toggle: **Global Settings → General → "Hide Cloud from the Instance Picker"**.

## Changes

| File | What |
|---|---|
| `src/main/settings.ts` | New `hideCloudFromPicker?: boolean` in `KnownSettings`, schema entry |
| `src/main/lib/ipc/registerSettingsHandlers.ts` | Boolean toggle in the General settings section, next to `autoInstallUpdates` |
| `src/renderer/src/composables/useInstallList.ts` | `useInstallList` reads the setting once on mount and ANDs it into `showCloudCard`. Failure resolves to `false` so Cloud is never silently hidden on a missing IPC bridge |
| `locales/en.json` | New `settings.hideCloudFromPicker` + description strings |

## Behavior

- **Default (off)**: Cloud tile renders exactly like today — both the Try-Cloud CTA tile and the per-install cloud tile when a cloud install exists.
- **On**: `showCloudCard` always returns `false`. Both the CTA and the per-install tile disappear from the chooser. Cloud webview / login flow / IPP routing are untouched — re-enabling the toggle restores everything immediately on next dashboard render.
- **No live broadcast**: the setting is fetched once per dashboard mount. Toggling in Global Settings takes effect on the next dashboard load (matches the snapshot-update pipeline pattern already in use).

## Why we're shipping this

From the Day-3 Typeform raw quotes (paraphrasing — sample):

> "Fuck Comfy Cloud / Dashboard is a nuisance / cannot be disabled"
> "When I close the program, I want it to CLOSE, not return to Dashboard"
> "stop forcing cloud version, nothing works today after update"

These users aren't going to ever click Cloud. Giving them a settings toggle is cheap, keeps Cloud first-class for everyone else, and removes the loudest source of "Comfy is becoming SaaS" sentiment.

## Test plan

- [x] `pnpm typecheck:web` passes
- [x] `pnpm vitest run src/renderer/src/composables/useInstallList.test.ts` passes (28/28)
- [ ] Manual: toggle the new setting in Global Settings → close + reopen dashboard → Cloud tile gone
- [ ] Manual: toggle off → reopen dashboard → Cloud tile back, no other behavior change

(Node-side typecheck has a pre-existing `Cannot find module 'yaml'` error in `desktopAdopt.ts` that's unrelated to this change.)