### PR TITLE
feat(telemetry): tag execution events with source_layer="comfyui"

### DIFF
--- a/src/main/lib/executionTap.test.ts
+++ b/src/main/lib/executionTap.test.ts
@@ -176,6 +176,34 @@ describe('executionTap', () => {
     expect(events).toContain('comfy.desktop.execution.completed')
   })
 
+  it('tags every emission with source_layer="comfyui" so engine-origin events are filterable in PostHog', () => {
+    const tap = createExecutionTap({ installationId: 'inst-1' })
+    tap.ingest(
+      [
+        'got prompt',
+        'Prompt executed in 1.0 seconds',
+        'Failed to validate prompt for output 7:',
+        'Traceback (most recent call last):',
+        '  File "x.py", line 1, in <module>',
+        '    raise RuntimeError("boom")',
+        'RuntimeError: boom',
+        '',
+        'next-line'
+      ].join('\n'),
+      'stderr'
+    )
+    tap.flushSummary()
+    // Cover every event family this tap emits — none should leak without the tag.
+    const families = new Set(captured.map((c) => c.event))
+    expect(families).toContain('comfy.desktop.execution.started')
+    expect(families).toContain('comfy.desktop.execution.completed')
+    expect(families).toContain('comfy.desktop.execution.error')
+    expect(families).toContain('comfy.desktop.execution.session_summary')
+    for (const c of captured) {
+      expect(c.ctx['source_layer']).toBe('comfyui')
+    }
+  })
+
   it('redacts Bearer tokens and api keys from traceback messages (secret scrub)', () => {
     const bearer = 'Bearer ' + 'a'.repeat(30)
     const apiKey = 's' + 'k-' + 'a'.repeat(24)

--- a/src/main/lib/executionTap.ts
+++ b/src/main/lib/executionTap.ts
@@ -83,10 +83,15 @@ export function createExecutionTap(opts: {
     tracebackPhase: 'none'
   }
 
+  // Every event emitted from this tap originates in the ComfyUI Python
+  // subprocess (parsed from its stdout/stderr). Tagging at the baseContext
+  // level lets PostHog separate engine-origin errors from any future
+  // shell-origin emissions without renaming the event family.
   const baseContext = {
     installation_id: state.installationId,
     variant: state.variant,
-    release: state.release
+    release: state.release,
+    source_layer: 'comfyui' as const
   }
 
   function pushPromptStart(): void {


### PR DESCRIPTION
## Summary

Every event emitted from `src/main/lib/executionTap.ts` (the 6 `comfy.desktop.execution.*` event families) originates in the **ComfyUI Python subprocess** — `executionTap` exists purely to parse `proc.stdout` / `proc.stderr`. Today they all land in PostHog without any way to filter engine-origin from shell-origin.

This PR adds `source_layer: 'comfyui'` to the shared `baseContext`, so the tag is present on every emission with zero risk of any event family being missed.

PostHog filter for triage becomes:

```
event = 'comfy.desktop.execution.error'
  AND properties.source_layer = 'comfyui'
```

## Why a property and not a new event-name namespace?

Considered renaming to `comfy.desktop.comfyui.execution.*` (matches the existing `comfy.desktop.comfyui.boot_started` / `boot_log` / `exited` namespace). Decided against for now because:

- Every existing dashboard, funnel, and saved insight filters on the current event names — rename breaks all of them simultaneously
- The 1-SDK-in-main consolidation (#789) is still rolling out; stacking event-name churn on top makes regression triage harder
- Filtering by property gets the same triage outcome with no migration window

If we later want the cleaner namespace, the property tag makes a backfill migration easy.

## Scope

Covers all 6 emissions in `executionTap.ts`:
- `comfy.desktop.execution.started`
- `comfy.desktop.execution.completed`
- `comfy.desktop.execution.first_completed`
- `comfy.desktop.execution.error` (validation path)
- `comfy.desktop.execution.error` (traceback path)
- `comfy.desktop.execution.session_summary`

Diff is 2 files, +34/-1.

## Test plan

- [x] New test asserts `source_layer === 'comfyui'` on every event family this tap emits (`executionTap.test.ts`)
- [x] All 11 existing `executionTap` tests still green
- [x] Full unit suite: 1867/1867 pass
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [ ] After merge: confirm in PostHog that `properties.source_layer` is populated on new events and the triage filter above returns expected volume

## Follow-ups (not in this PR)

- Investigate the `error_bucket = 'other'` win32 cluster — 1,454 users producing ~21.5 errors/user each in the last 24h suggests a single common failure pattern that isn't being classified. Worth a sample-and-fingerprint pass.