### PR TITLE
feat(launch-week): bundle close-modal + restore-last + always-on terminal + hide-cloud

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -19,6 +19,7 @@ extraResources:
     to: lib
 asarUnpack:
   - node_modules/7zip-bin/**/*
+  - node_modules/node-pty/**/*
 afterPack: ./scripts/afterPack.mjs
 publish:
   provider: github

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -17,6 +17,11 @@ export default defineConfig({
   main: {
     build: {
       sourcemap: 'hidden',
+      rollupOptions: {
+        // node-pty is a native addon; it must stay external (its .node binary
+        // can't be bundled) and is loaded from the unpacked node_modules.
+        external: ['node-pty'],
+      },
     },
   },
   preload: {

--- a/locales/en.json
+++ b/locales/en.json
@@ -72,6 +72,7 @@
     "tabUpdate": "Update",
     "tabSnapshots": "Snapshots",
     "tabStorage": "Storage",
+    "tabConsole": "Console",
     "relaunch": "Relaunch",
     "more": "More",
     "diskUsage": "Disk Usage",
@@ -362,7 +363,9 @@
     "disconnect": "Disconnect",
     "connectedTo": "Connected to {url}",
     "processExited": "Process exited",
-    "processCrashed": "Process crashed (exit code {code})"
+    "processCrashed": "Process crashed (exit code {code})",
+    "sessionEnded": "This console session ended. Restart it to keep using the shell.",
+    "restartSession": "Restart console"
   },
 
   "settingsModal": {
@@ -1032,6 +1035,7 @@
   "tooltips": {
     "instances": "A separate ComfyUI installation with its own version, models, and settings.",
     "snapshots": "A saved point-in-time state of an installation (versions + custom nodes) you can restore later.",
+    "console": "An interactive shell running in this installation's folder. Works whether ComfyUI is running or stopped.",
     "standalone": "A self-contained install with its own bundled Python and dependencies. Easy to update and manage.",
     "portable": "The official portable Windows build with embedded Python. Runs from a single folder without a system-wide install.",
     "git": "A git-based install cloned from the ComfyUI repository. Requires git and Python to be installed on your system.",

--- a/locales/en.json
+++ b/locales/en.json
@@ -384,7 +384,7 @@
 
   "settings": {
     "title": "Settings",
-    "general": "General",
+    "general": "Preferences",
     "theme": "Theme",
     "themeSystem": "Match system",
     "themeDark": "Dark",
@@ -400,7 +400,10 @@
     "closeQuitDownloads": "Downloading",
     "autoUpdate": "Check for updates on startup",
     "autoInstallUpdates": "Automatically install Desktop updates",
-    "reopenLastInstanceOnLaunch": "Reopen last instance on launch",
+    "appBehavior": "App Behavior",
+    "reopenLastInstanceOnLaunch": "Auto-restart last instance on launch",
+    "closeDirectlyOnLastWindow": "Close Comfy Desktop on last window (don't return to Dashboard)",
+    "closeDirectlyOnLastWindowDescription": "When you close the last ComfyUI instance window, quit Comfy Desktop immediately instead of returning to the Dashboard.",
     "hideCloudFromPicker": "Hide Cloud from the Instance Picker",
     "hideCloudFromPickerDescription": "For local-only users — hides the Cloud tile (and the Try Cloud CTA) from the Dashboard. Cloud remains fully functional; you can re-enable this any time.",
     "checkForUpdates": "Check for updates",
@@ -678,7 +681,7 @@
 
   "cloud": {
     "label": "Cloud",
-    "desc": "Connect to Comfy Cloud for remote GPU-powered workflows.",
+    "desc": "Run workflows on managed GPUs.",
     "signInBanner": {
       "message": "We opened your browser to sign in. Didn’t open?",
       "copy": "Copy link",

--- a/locales/en.json
+++ b/locales/en.json
@@ -396,6 +396,7 @@
     "closeQuitDownloads": "Downloading",
     "autoUpdate": "Check for updates on startup",
     "autoInstallUpdates": "Automatically install Desktop updates",
+    "reopenLastInstanceOnLaunch": "Reopen last instance on launch",
     "checkForUpdates": "Check for updates",
     "checkingForUpdates": "Checking…",
     "telemetry": "Telemetry",

--- a/locales/en.json
+++ b/locales/en.json
@@ -397,6 +397,8 @@
     "closeQuitDownloads": "Downloading",
     "autoUpdate": "Check for updates on startup",
     "autoInstallUpdates": "Automatically install Desktop updates",
+    "hideCloudFromPicker": "Hide Cloud from the Instance Picker",
+    "hideCloudFromPickerDescription": "For local-only users — hides the Cloud tile (and the Try Cloud CTA) from the Dashboard. Cloud remains fully functional; you can re-enable this any time.",
     "checkForUpdates": "Check for updates",
     "checkingForUpdates": "Checking…",
     "telemetry": "Telemetry",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -267,6 +267,7 @@
     "closeQuitConfirm": "退出",
     "autoUpdate": "启动时检查更新",
     "autoInstallUpdates": "自动安装桌面更新",
+    "reopenLastInstanceOnLaunch": "启动时重新打开上次的实例",
     "checkForUpdates": "检查更新",
     "checkingForUpdates": "检查中…",
     "telemetry": "遥测",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,8 @@
     "7zip-bin": "^5.2.0",
     "@datadog/browser-rum": "6.28.1",
     "@todesktop/runtime": "^2.1.3",
+    "@xterm/addon-fit": "^0.10.0",
+    "@xterm/xterm": "^5.5.0",
     "electron-updater": "^6.7.3",
     "node-pty": "^1.1.0",
     "posthog-node": "^5.30.7",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
   },
   "devDependencies": {
     "@datadog/datadog-ci": "^5.9.0",
+    "@electron/rebuild": "^3.7.2",
     "@eslint/js": "^10.0.1",
     "@pinia/testing": "^1.0.3",
     "@playwright/test": "^1.58.2",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@datadog/browser-rum": "6.28.1",
     "@todesktop/runtime": "^2.1.3",
     "electron-updater": "^6.7.3",
+    "node-pty": "^1.1.0",
     "posthog-node": "^5.30.7",
     "smol-toml": "^1.6.1",
     "systeminformation": "^5.31.5",
@@ -104,7 +105,8 @@
     "onlyBuiltDependencies": [
       "electron",
       "electron-winstaller",
-      "esbuild"
+      "esbuild",
+      "node-pty"
     ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@datadog/datadog-ci':
         specifier: ^5.9.0
         version: 5.9.0(@types/node@22.19.12)
+      '@electron/rebuild':
+        specifier: ^3.7.2
+        version: 3.7.2
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.0.2(jiti@2.6.1))
@@ -352,6 +355,12 @@ packages:
     resolution: {integrity: sha512-F+nKc0xW+kVbBRhFzaMgPy3KwmuNTYX1fx6+FxxoSnNgwYX6LD7AKBTWkU0MQ6IBoe7dz069CNkR673sPAgkCQ==}
     engines: {node: '>=14'}
 
+  '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2':
+    resolution: {tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
+    version: 10.2.0-electron.1
+    engines: {node: '>=12.13.0'}
+    hasBin: true
+
   '@electron/notarize@2.5.0':
     resolution: {integrity: sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A==}
     engines: {node: '>= 10.0.0'}
@@ -359,6 +368,11 @@ packages:
   '@electron/osx-sign@1.3.3':
     resolution: {integrity: sha512-KZ8mhXvWv2rIEgMbWZ4y33bDHyUKMXnx4M0sTyPNK/vcB81ImdeY9Ggdqy0SWbMDgmbqyQ+phgejh6V3R2QuSg==}
     engines: {node: '>=12.0.0'}
+    hasBin: true
+
+  '@electron/rebuild@3.7.2':
+    resolution: {integrity: sha512-19/KbIR/DAxbsCkiaGMXIdPnMCJLkcf8AvGnduJtWBs/CBwiAjY1apCqOLVxrXg+rtXFCngbXhBanWjxLUt1Mg==}
+    engines: {node: '>=12.13.0'}
     hasBin: true
 
   '@electron/rebuild@4.0.3':
@@ -726,6 +740,9 @@ packages:
     resolution: {integrity: sha512-bIZEUzOI1jkhviX2cp5vNyXQc6olzb2ohewQubuYlMXZ2Q/XjBO0x0XhGPvc9fjSIiUN0vw+0hq53BJ4eQSJKQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  '@gar/promisify@1.1.3':
+    resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -829,9 +846,18 @@ packages:
     resolution: {integrity: sha512-S79NdEgDQd/NGCay6TCoVzXSj74skRZIKJcpJjC5lOq34SZzyI6MqtiiWoiVWoVrTcGjNeC4ipbh1VIHlpfF5Q==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  '@npmcli/fs@2.1.2':
+    resolution: {integrity: sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
   '@npmcli/fs@4.0.0':
     resolution: {integrity: sha512-/xGlezI6xfGO9NwuJlnwz/K14qD1kCSAGtacBHnGzeAIuJGazcp45KP5NuyARXoKb7cwulAGWVsbeSxdG/cb0Q==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  '@npmcli/move-file@2.0.1':
+    resolution: {integrity: sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    deprecated: This functionality has been moved to @npmcli/fs
 
   '@one-ini/wasm@0.1.1':
     resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
@@ -1095,6 +1121,10 @@ packages:
   '@todesktop/runtime@2.1.3':
     resolution: {integrity: sha512-dtC/BwpW5k0kJN/aSxHRznkjwCNcvPRUQ1AeZ/OeBszvdYrAmdGtw8mb4Ztk/6Z/2jzlCJ6mPtf4jtujXMpIHg==}
 
+  '@tootallnate/once@2.0.1':
+    resolution: {integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==}
+    engines: {node: '>= 10'}
+
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
@@ -1340,6 +1370,9 @@ packages:
   '@xterm/xterm@5.5.0':
     resolution: {integrity: sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==}
 
+  abbrev@1.1.1:
+    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
+
   abbrev@2.0.0:
     resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -1358,9 +1391,17 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  agentkeepalive@4.6.0:
+    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
+    engines: {node: '>= 8.0.0'}
 
   aggregate-error@3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
@@ -1539,6 +1580,10 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
+  cacache@16.1.3:
+    resolution: {integrity: sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
   cacache@19.0.1:
     resolution: {integrity: sha512-hdsUxulXCi5STId78vRVYEtDAjq99ICAUktLTeTYsLoTE6Z8dS0c8pWNCxwdrk9YfJeobDZc2Y186hD/5ZQgFQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -1572,6 +1617,10 @@ packages:
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+
+  chownr@2.0.0:
+    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
+    engines: {node: '>=10'}
 
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
@@ -2125,6 +2174,10 @@ packages:
     resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
     engines: {node: '>=10'}
 
+  fs-minipass@2.1.0:
+    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
+    engines: {node: '>= 8'}
+
   fs-minipass@3.0.3:
     resolution: {integrity: sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -2194,6 +2247,11 @@ packages:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
+  glob@8.1.0:
+    resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
+    engines: {node: '>=12'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
   global-agent@3.0.0:
     resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
     engines: {node: '>=10.0'}
@@ -2254,6 +2312,10 @@ packages:
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
 
+  http-proxy-agent@5.0.0:
+    resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
+    engines: {node: '>= 6'}
+
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
@@ -2262,6 +2324,10 @@ packages:
     resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
     engines: {node: '>=10.19.0'}
 
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
@@ -2269,6 +2335,9 @@ packages:
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
+
+  humanize-ms@1.2.1:
+    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
@@ -2310,6 +2379,9 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
+  infer-owner@1.0.4:
+    resolution: {integrity: sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==}
+
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
@@ -2343,6 +2415,9 @@ packages:
   is-interactive@1.0.0:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
     engines: {node: '>=8'}
+
+  is-lambda@1.0.1:
+    resolution: {integrity: sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==}
 
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
@@ -2589,6 +2664,10 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  make-fetch-happen@10.2.1:
+    resolution: {integrity: sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
   make-fetch-happen@14.0.3:
     resolution: {integrity: sha512-QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -2659,9 +2738,17 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  minipass-collect@1.0.2:
+    resolution: {integrity: sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==}
+    engines: {node: '>= 8'}
+
   minipass-collect@2.0.1:
     resolution: {integrity: sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass-fetch@2.1.2:
+    resolution: {integrity: sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
   minipass-fetch@4.0.1:
     resolution: {integrity: sha512-j7U11C5HXigVuutxebFadoYBbd7VSdZWggSe64NVdvWNBqGAiXPL2QVCehjmw7lY1oF9gOllYbORh+hiNgfPgQ==}
@@ -2683,9 +2770,17 @@ packages:
     resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
     engines: {node: '>=8'}
 
+  minipass@5.0.0:
+    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
+    engines: {node: '>=8'}
+
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  minizlib@2.1.2:
+    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
+    engines: {node: '>= 8'}
 
   minizlib@3.1.0:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
@@ -2696,6 +2791,11 @@ packages:
 
   mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
+    hasBin: true
+
+  mkdirp@1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
     hasBin: true
 
   ms@2.0.0:
@@ -2718,6 +2818,10 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  negotiator@0.6.4:
+    resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
+    engines: {node: '>= 0.6'}
+
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
@@ -2725,6 +2829,10 @@ packages:
   netmask@2.0.2:
     resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
     engines: {node: '>= 0.4.0'}
+
+  node-abi@3.92.0:
+    resolution: {integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==}
+    engines: {node: '>=10'}
 
   node-abi@4.26.0:
     resolution: {integrity: sha512-8QwIZqikRvDIkXS2S93LjzhsSPJuIbfaMETWH+Bx8oOT9Sa9UsUtBFQlc3gBNd1+QINjaTloitXr1W3dQLi9Iw==}
@@ -2749,6 +2857,11 @@ packages:
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
+
+  nopt@6.0.0:
+    resolution: {integrity: sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    hasBin: true
 
   nopt@7.2.1:
     resolution: {integrity: sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==}
@@ -2942,6 +3055,10 @@ packages:
     resolution: {integrity: sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  proc-log@2.0.1:
+    resolution: {integrity: sha512-Kcmo2FhfDTXdcbfDH76N7uBYHINxc/8GW7UAVuVP9I+Va3uHSerrnKV6dLooga/gh7GlgzuCCr/eoldnL1muGw==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
   proc-log@5.0.0:
     resolution: {integrity: sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -2952,6 +3069,14 @@ packages:
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
+
+  promise-inflight@1.0.1:
+    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
+    peerDependencies:
+      bluebird: '*'
+    peerDependenciesMeta:
+      bluebird:
+        optional: true
 
   promise-retry@2.0.1:
     resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
@@ -3144,6 +3269,10 @@ packages:
     resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
     engines: {node: '>= 18'}
 
+  socks-proxy-agent@7.0.0:
+    resolution: {integrity: sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==}
+    engines: {node: '>= 10'}
+
   socks-proxy-agent@8.0.5:
     resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
     engines: {node: '>= 14'}
@@ -3173,6 +3302,10 @@ packages:
   ssri@12.0.0:
     resolution: {integrity: sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  ssri@9.0.1:
+    resolution: {integrity: sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -3245,6 +3378,11 @@ packages:
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
+
+  tar@6.2.1:
+    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
+    engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tar@7.5.11:
     resolution: {integrity: sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==}
@@ -3344,9 +3482,17 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
+  unique-filename@2.0.1:
+    resolution: {integrity: sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
   unique-filename@4.0.0:
     resolution: {integrity: sha512-XSnEewXmQ+veP7xX2dS5Q4yZAvO40cBN2MWkJ7D/6sW4Dg6wYBNwM1Vrnz1FhH5AdeLIlUXRI9e28z1YZi71NQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  unique-slug@3.0.0:
+    resolution: {integrity: sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
   unique-slug@5.0.0:
     resolution: {integrity: sha512-9OdaqO5kwqR+1kVgHAhsp5vPNU0hnxRa26rBFNfNgM7M6pNtgzeBn3s/xbyCQL3dcjzOatcef6UUHpB/6MaETg==}
@@ -3906,6 +4052,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2':
+    dependencies:
+      env-paths: 2.2.1
+      exponential-backoff: 3.1.3
+      glob: 8.1.0
+      graceful-fs: 4.2.11
+      make-fetch-happen: 10.2.1
+      nopt: 6.0.0
+      proc-log: 2.0.1
+      semver: 7.7.4
+      tar: 6.2.1
+      which: 2.0.2
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
+
   '@electron/notarize@2.5.0':
     dependencies:
       debug: 4.4.3
@@ -3923,6 +4085,26 @@ snapshots:
       minimist: 1.2.8
       plist: 3.1.0
     transitivePeerDependencies:
+      - supports-color
+
+  '@electron/rebuild@3.7.2':
+    dependencies:
+      '@electron/node-gyp': https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2
+      '@malept/cross-spawn-promise': 2.0.0
+      chalk: 4.1.2
+      debug: 4.4.3
+      detect-libc: 2.1.2
+      fs-extra: 10.1.0
+      got: 11.8.6
+      node-abi: 3.92.0
+      node-api-version: 0.2.1
+      ora: 5.4.1
+      read-binary-file-arch: 1.0.6
+      semver: 7.7.4
+      tar: 6.2.1
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bluebird
       - supports-color
 
   '@electron/rebuild@4.0.3':
@@ -4156,6 +4338,8 @@ snapshots:
       '@eslint/core': 1.1.0
       levn: 0.4.1
 
+  '@gar/promisify@1.1.3': {}
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -4269,9 +4453,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@npmcli/fs@2.1.2':
+    dependencies:
+      '@gar/promisify': 1.1.3
+      semver: 7.7.4
+
   '@npmcli/fs@4.0.0':
     dependencies:
       semver: 7.7.4
+
+  '@npmcli/move-file@2.0.1':
+    dependencies:
+      mkdirp: 1.0.4
+      rimraf: 3.0.2
 
   '@one-ini/wasm@0.1.1': {}
 
@@ -4460,6 +4654,8 @@ snapshots:
       semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
+
+  '@tootallnate/once@2.0.1': {}
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
@@ -4795,6 +4991,8 @@ snapshots:
 
   '@xterm/xterm@5.5.0': {}
 
+  abbrev@1.1.1: {}
+
   abbrev@2.0.0: {}
 
   abbrev@3.0.1: {}
@@ -4805,7 +5003,17 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   agent-base@7.1.4: {}
+
+  agentkeepalive@4.6.0:
+    dependencies:
+      humanize-ms: 1.2.1
 
   aggregate-error@3.1.0:
     dependencies:
@@ -5022,6 +5230,29 @@ snapshots:
 
   cac@6.7.14: {}
 
+  cacache@16.1.3:
+    dependencies:
+      '@npmcli/fs': 2.1.2
+      '@npmcli/move-file': 2.0.1
+      chownr: 2.0.0
+      fs-minipass: 2.1.0
+      glob: 8.1.0
+      infer-owner: 1.0.4
+      lru-cache: 7.18.3
+      minipass: 3.3.6
+      minipass-collect: 1.0.2
+      minipass-flush: 1.0.5
+      minipass-pipeline: 1.2.4
+      mkdirp: 1.0.4
+      p-map: 4.0.0
+      promise-inflight: 1.0.1
+      rimraf: 3.0.2
+      ssri: 9.0.1
+      tar: 6.2.1
+      unique-filename: 2.0.1
+    transitivePeerDependencies:
+      - bluebird
+
   cacache@19.0.1:
     dependencies:
       '@npmcli/fs': 4.0.0
@@ -5069,6 +5300,8 @@ snapshots:
       supports-color: 7.2.0
 
   chardet@2.1.1: {}
+
+  chownr@2.0.0: {}
 
   chownr@3.0.0: {}
 
@@ -5747,6 +5980,10 @@ snapshots:
       jsonfile: 6.2.0
       universalify: 2.0.1
 
+  fs-minipass@2.1.0:
+    dependencies:
+      minipass: 3.3.6
+
   fs-minipass@3.0.3:
     dependencies:
       minipass: 7.1.3
@@ -5828,6 +6065,14 @@ snapshots:
       minimatch: 3.1.5
       once: 1.4.0
       path-is-absolute: 1.0.1
+
+  glob@8.1.0:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 5.1.9
+      once: 1.4.0
 
   global-agent@3.0.0:
     dependencies:
@@ -5911,6 +6156,14 @@ snapshots:
 
   http-cache-semantics@4.2.0: {}
 
+  http-proxy-agent@5.0.0:
+    dependencies:
+      '@tootallnate/once': 2.0.1
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
@@ -5923,6 +6176,13 @@ snapshots:
       quick-lru: 5.1.1
       resolve-alpn: 1.2.1
 
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
@@ -5931,6 +6191,10 @@ snapshots:
       - supports-color
 
   human-signals@2.1.0: {}
+
+  humanize-ms@1.2.1:
+    dependencies:
+      ms: 2.1.3
 
   husky@9.1.7: {}
 
@@ -5959,6 +6223,8 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
+
+  infer-owner@1.0.4: {}
 
   inflight@1.0.6:
     dependencies:
@@ -6000,6 +6266,8 @@ snapshots:
       is-extglob: 2.1.1
 
   is-interactive@1.0.0: {}
+
+  is-lambda@1.0.1: {}
 
   is-number@7.0.0: {}
 
@@ -6201,6 +6469,28 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  make-fetch-happen@10.2.1:
+    dependencies:
+      agentkeepalive: 4.6.0
+      cacache: 16.1.3
+      http-cache-semantics: 4.2.0
+      http-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.1
+      is-lambda: 1.0.1
+      lru-cache: 7.18.3
+      minipass: 3.3.6
+      minipass-collect: 1.0.2
+      minipass-fetch: 2.1.2
+      minipass-flush: 1.0.5
+      minipass-pipeline: 1.2.4
+      negotiator: 0.6.4
+      promise-retry: 2.0.1
+      socks-proxy-agent: 7.0.0
+      ssri: 9.0.1
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
+
   make-fetch-happen@14.0.3:
     dependencies:
       '@npmcli/agent': 3.0.0
@@ -6269,9 +6559,21 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  minipass-collect@1.0.2:
+    dependencies:
+      minipass: 3.3.6
+
   minipass-collect@2.0.1:
     dependencies:
       minipass: 7.1.3
+
+  minipass-fetch@2.1.2:
+    dependencies:
+      minipass: 3.3.6
+      minipass-sized: 1.0.3
+      minizlib: 2.1.2
+    optionalDependencies:
+      encoding: 0.1.13
 
   minipass-fetch@4.0.1:
     dependencies:
@@ -6297,7 +6599,14 @@ snapshots:
     dependencies:
       yallist: 4.0.0
 
+  minipass@5.0.0: {}
+
   minipass@7.1.3: {}
+
+  minizlib@2.1.2:
+    dependencies:
+      minipass: 3.3.6
+      yallist: 4.0.0
 
   minizlib@3.1.0:
     dependencies:
@@ -6308,6 +6617,8 @@ snapshots:
   mkdirp@0.5.6:
     dependencies:
       minimist: 1.2.8
+
+  mkdirp@1.0.4: {}
 
   ms@2.0.0: {}
 
@@ -6321,9 +6632,15 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  negotiator@0.6.4: {}
+
   negotiator@1.0.0: {}
 
   netmask@2.0.2: {}
+
+  node-abi@3.92.0:
+    dependencies:
+      semver: 7.7.4
 
   node-abi@4.26.0:
     dependencies:
@@ -6358,6 +6675,10 @@ snapshots:
       node-addon-api: 7.1.1
 
   node-releases@2.0.27: {}
+
+  nopt@6.0.0:
+    dependencies:
+      abbrev: 1.1.1
 
   nopt@7.2.1:
     dependencies:
@@ -6540,11 +6861,15 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 18.3.1
 
+  proc-log@2.0.1: {}
+
   proc-log@5.0.0: {}
 
   process-nextick-args@2.0.1: {}
 
   progress@2.0.3: {}
+
+  promise-inflight@1.0.1: {}
 
   promise-retry@2.0.1:
     dependencies:
@@ -6765,6 +7090,14 @@ snapshots:
 
   smol-toml@1.6.1: {}
 
+  socks-proxy-agent@7.0.0:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+      socks: 2.8.7
+    transitivePeerDependencies:
+      - supports-color
+
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.4
@@ -6795,6 +7128,10 @@ snapshots:
   ssri@12.0.0:
     dependencies:
       minipass: 7.1.3
+
+  ssri@9.0.1:
+    dependencies:
+      minipass: 3.3.6
 
   stackback@0.0.2: {}
 
@@ -6860,6 +7197,15 @@ snapshots:
   tailwindcss@4.2.1: {}
 
   tapable@2.3.0: {}
+
+  tar@6.2.1:
+    dependencies:
+      chownr: 2.0.0
+      fs-minipass: 2.1.0
+      minipass: 5.0.0
+      minizlib: 2.1.2
+      mkdirp: 1.0.4
+      yallist: 4.0.0
 
   tar@7.5.11:
     dependencies:
@@ -6953,9 +7299,17 @@ snapshots:
 
   undici-types@7.16.0: {}
 
+  unique-filename@2.0.1:
+    dependencies:
+      unique-slug: 3.0.0
+
   unique-filename@4.0.0:
     dependencies:
       unique-slug: 5.0.0
+
+  unique-slug@3.0.0:
+    dependencies:
+      imurmurhash: 0.1.4
 
   unique-slug@5.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,12 @@ importers:
       '@todesktop/runtime':
         specifier: ^2.1.3
         version: 2.1.3
+      '@xterm/addon-fit':
+        specifier: ^0.10.0
+        version: 0.10.0(@xterm/xterm@5.5.0)
+      '@xterm/xterm':
+        specifier: ^5.5.0
+        version: 5.5.0
       electron-updater:
         specifier: ^6.7.3
         version: 6.8.3
@@ -1322,6 +1328,14 @@ packages:
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
+
+  '@xterm/addon-fit@0.10.0':
+    resolution: {integrity: sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==}
+    peerDependencies:
+      '@xterm/xterm': ^5.0.0
+
+  '@xterm/xterm@5.5.0':
+    resolution: {integrity: sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==}
 
   abbrev@2.0.0:
     resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
@@ -4766,6 +4780,12 @@ snapshots:
       vue: 3.5.29(typescript@5.9.3)
 
   '@xmldom/xmldom@0.8.11': {}
+
+  '@xterm/addon-fit@0.10.0(@xterm/xterm@5.5.0)':
+    dependencies:
+      '@xterm/xterm': 5.5.0
+
+  '@xterm/xterm@5.5.0': {}
 
   abbrev@2.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       electron-updater:
         specifier: ^6.7.3
         version: 6.8.3
+      node-pty:
+        specifier: ^1.1.0
+        version: 1.1.0
       posthog-node:
         specifier: ^5.30.7
         version: 5.30.7(rxjs@7.8.2)
@@ -2713,6 +2716,9 @@ packages:
   node-addon-api@1.7.2:
     resolution: {integrity: sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==}
 
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
   node-api-version@0.2.1:
     resolution: {integrity: sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==}
 
@@ -2720,6 +2726,9 @@ packages:
     resolution: {integrity: sha512-ra7Kvlhxn5V9Slyus0ygMa2h+UqExPqUIkfk7Pc8QTLT956JLSy51uWFwHtIYy0vI8cB4BDhc/S03+880My/LQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
     hasBin: true
+
+  node-pty@1.1.0:
+    resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
@@ -6295,6 +6304,8 @@ snapshots:
   node-addon-api@1.7.2:
     optional: true
 
+  node-addon-api@7.1.1: {}
+
   node-api-version@0.2.1:
     dependencies:
       semver: 7.7.4
@@ -6313,6 +6324,10 @@ snapshots:
       which: 5.0.0
     transitivePeerDependencies:
       - supports-color
+
+  node-pty@1.1.0:
+    dependencies:
+      node-addon-api: 7.1.1
 
   node-releases@2.0.27: {}
 

--- a/src/main/host/attach.ts
+++ b/src/main/host/attach.ts
@@ -7,6 +7,8 @@ import { TITLEBAR_BG } from '../lib/theme'
 import * as mainTelemetry from '../lib/telemetry'
 import { refreshCloudUserTier } from '../lib/userTier'
 import { forwardDatadogError } from '../lib/processErrorHandlers'
+import { isQuitInProgress } from '../lib/quit-state'
+import { recordInstanceSurface } from '../lib/lastSession'
 import { installationEvents, type InstallationRecord } from '../installations'
 import {
   dropInstallationIndex,
@@ -137,6 +139,10 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
   // null) install on the next dock-icon click.
   if (comfyWindow.isFocused()) {
     setLastFocusedInstallationId(installationId)
+    // An attach onto the focused host makes this install the active surface;
+    // persist it so the next boot restores this instance (no fresh focus
+    // event fires for an in-place attach).
+    if (!isQuitInProgress()) recordInstanceSurface(installationId)
   }
 
   // OS-level window title is rebuilt whenever the page title or the

--- a/src/main/host/attach.ts
+++ b/src/main/host/attach.ts
@@ -7,7 +7,6 @@ import { TITLEBAR_BG } from '../lib/theme'
 import * as mainTelemetry from '../lib/telemetry'
 import { refreshCloudUserTier } from '../lib/userTier'
 import { forwardDatadogError } from '../lib/processErrorHandlers'
-import { isQuitInProgress } from '../lib/quit-state'
 import { recordInstanceSurface } from '../lib/lastSession'
 import { installationEvents, type InstallationRecord } from '../installations'
 import {
@@ -141,8 +140,9 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
     setLastFocusedInstallationId(installationId)
     // An attach onto the focused host makes this install the active surface;
     // persist it so the next boot restores this instance (no fresh focus
-    // event fires for an in-place attach).
-    if (!isQuitInProgress()) recordInstanceSurface(installationId)
+    // event fires for an in-place attach). The record helper no-ops while
+    // quitting.
+    recordInstanceSurface(installationId)
   }
 
   // OS-level window title is rebuilt whenever the page title or the

--- a/src/main/host/attach.ts
+++ b/src/main/host/attach.ts
@@ -2,6 +2,8 @@ import * as ipc from '../lib/ipc'
 import { getAppVersion } from '../lib/ipc'
 import { attachSessionDownloadHandler } from '../lib/comfyDownloadManager'
 import { getModelDownloadContentScript } from '../lib/comfyContentScript'
+import { getComfyTerminalContentScript } from '../lib/comfyTerminalContentScript'
+import { isCachedFeatureFlagAvailable } from '../lib/comfy-feature-flags'
 import { _operationAborts, sourceMap } from '../lib/ipc/shared'
 import { TITLEBAR_BG } from '../lib/theme'
 import * as mainTelemetry from '../lib/telemetry'
@@ -377,6 +379,18 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
     comfyContents.executeJavaScript(COMFY_THEME_OBSERVER_JS).catch(() => {})
     const preamble = isLocal ? '' : 'window.__comfyDesktop2Remote = true;\n'
     comfyContents.executeJavaScript(preamble + getModelDownloadContentScript()).catch(() => {})
+    // Stopgap: inject a fallback bottom-panel Terminal tab for standalone
+    // installs whose ComfyUI doesn't advertise `supports_terminal`, the exact
+    // case where the real flag-gated frontend tab can't appear. The transport
+    // (__comfyDesktop2.Terminal) exists regardless of the flag. Remove once the
+    // official tab ships in a stable release.
+    if (
+      isLocal &&
+      installation.sourceId === 'standalone' &&
+      !isCachedFeatureFlagAvailable(installationId, 'supports_terminal')
+    ) {
+      comfyContents.executeJavaScript(getComfyTerminalContentScript()).catch(() => {})
+    }
     // Cloud-only patches (popup-blocked toast suppression + post-signin
     // flicker hide). Skipped for local installs — they don't load cloud
     // frontend, never see the toast or the redirect flash.

--- a/src/main/host/attach.ts
+++ b/src/main/host/attach.ts
@@ -3,7 +3,6 @@ import { getAppVersion } from '../lib/ipc'
 import { attachSessionDownloadHandler } from '../lib/comfyDownloadManager'
 import { getModelDownloadContentScript } from '../lib/comfyContentScript'
 import { getComfyTerminalContentScript } from '../lib/comfyTerminalContentScript'
-import { isCachedFeatureFlagAvailable } from '../lib/comfy-feature-flags'
 import { _operationAborts, sourceMap } from '../lib/ipc/shared'
 import { TITLEBAR_BG } from '../lib/theme'
 import * as mainTelemetry from '../lib/telemetry'
@@ -385,16 +384,18 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
     comfyContents.executeJavaScript(COMFY_THEME_OBSERVER_JS).catch(() => {})
     const preamble = isLocal ? '' : 'window.__comfyDesktop2Remote = true;\n'
     comfyContents.executeJavaScript(preamble + getModelDownloadContentScript()).catch(() => {})
-    // Stopgap: inject a fallback bottom-panel Terminal tab for standalone
-    // installs whose ComfyUI doesn't advertise `supports_terminal`, the exact
-    // case where the real flag-gated frontend tab can't appear. The transport
-    // (__comfyDesktop2.Terminal) exists regardless of the flag. Remove once the
-    // official tab ships in a stable release.
-    if (
-      isLocal &&
-      installation.sourceId === 'standalone' &&
-      !isCachedFeatureFlagAvailable(installationId, 'supports_terminal')
-    ) {
+    // Always inject the Terminal bottom-panel tab on standalone installs.
+    //
+    // Originally gated on `!supports_terminal` to avoid duplicating the
+    // flag-gated frontend tab. Day-3 launch feedback put terminal
+    // discoverability ("Why u delete cmd?") in the top tier of complaints,
+    // and the companion ComfyUI / ComfyUI_frontend PRs that would deliver
+    // the native tab are still in flight. So we ship the injection
+    // always-on now and dedupe in JS instead: the injected script checks
+    // `bottomPanelTabs` for an existing `command-terminal` entry and
+    // bails out before registering a second copy. See
+    // `comfyTerminalContentScript.ts` for the dedupe guard.
+    if (isLocal && installation.sourceId === 'standalone') {
       comfyContents.executeJavaScript(getComfyTerminalContentScript()).catch(() => {})
     }
     // Cloud-only patches (popup-blocked toast suppression + post-signin

--- a/src/main/host/createHostWindow.test.ts
+++ b/src/main/host/createHostWindow.test.ts
@@ -21,7 +21,7 @@ import type { InstallationRecord } from '../installations'
 import {
   cascadeOffsetForCollisions,
   expectedPartitionFor,
-  shouldBailAfterCloseConfirm,
+  shouldBailAfterCloseChoice,
   shouldBailAfterConsult,
   shouldDetachLastInstallWindowToDashboard,
   shouldShowInstallCloseConfirm,
@@ -118,40 +118,44 @@ describe('shouldBailAfterConsult', () => {
 
 describe('shouldShowInstallCloseConfirm', () => {
   it('shows the modal for a host that would kill a local session on a defer consult', () => {
-    expect(shouldShowInstallCloseConfirm('defer', true, false)).toBe(true)
+    expect(shouldShowInstallCloseConfirm('defer', true, false, false)).toBe(true)
+  })
+
+  it('shows the modal for the last install window even with no local session at risk (closing quits)', () => {
+    expect(shouldShowInstallCloseConfirm('defer', false, false, true)).toBe(true)
   })
 
   it('skips the modal when the caller pre-cleared the close', () => {
     // Force-close paths must not block on an extra user prompt.
-    expect(shouldShowInstallCloseConfirm('defer', true, true)).toBe(false)
+    expect(shouldShowInstallCloseConfirm('defer', true, true, true)).toBe(false)
   })
 
-  it('skips the modal for a chooser host or a cloud/remote-backed host (no local session at risk)', () => {
-    expect(shouldShowInstallCloseConfirm('defer', false, false)).toBe(false)
+  it('skips the modal for a non-last cloud/remote-backed host (no local session at risk)', () => {
+    expect(shouldShowInstallCloseConfirm('defer', false, false, false)).toBe(false)
   })
 
   it('skips the modal on a cleared or aborted consult', () => {
     // `cleared` → renderer already handled it; `aborted` → we already
     // bailed in the prior check (this case is unreachable in practice).
-    expect(shouldShowInstallCloseConfirm('cleared', true, false)).toBe(false)
-    expect(shouldShowInstallCloseConfirm('aborted', true, false)).toBe(false)
+    expect(shouldShowInstallCloseConfirm('cleared', true, false, true)).toBe(false)
+    expect(shouldShowInstallCloseConfirm('aborted', true, false, true)).toBe(false)
   })
 })
 
-describe('shouldBailAfterCloseConfirm', () => {
-  it('bails when the user dismissed the close-confirm modal', () => {
-    expect(shouldBailAfterCloseConfirm(false, false)).toBe(true)
+describe('shouldBailAfterCloseChoice', () => {
+  it('bails when the user cancelled the close-confirm modal', () => {
+    expect(shouldBailAfterCloseChoice('cancel', false)).toBe(true)
   })
 
-  it('does not bail when the user confirmed the close-confirm modal', () => {
-    expect(shouldBailAfterCloseConfirm(true, false)).toBe(false)
-    expect(shouldBailAfterCloseConfirm(true, true)).toBe(false)
+  it('does not bail when the user chose to close or return to the dashboard', () => {
+    expect(shouldBailAfterCloseChoice('close', false)).toBe(false)
+    expect(shouldBailAfterCloseChoice('return-to-dashboard', false)).toBe(false)
   })
 
-  it('does not bail when a force-close lands mid-modal even on user dismiss', () => {
+  it('does not bail when a force-close lands mid-modal even on user cancel', () => {
     // Mirrors the consult re-check: a caller-side force-close that
     // arrives while the modal is open must override the user's cancel.
-    expect(shouldBailAfterCloseConfirm(false, true)).toBe(false)
+    expect(shouldBailAfterCloseChoice('cancel', true)).toBe(false)
   })
 })
 

--- a/src/main/host/createHostWindow.ts
+++ b/src/main/host/createHostWindow.ts
@@ -1333,7 +1333,18 @@ export function applyChooserHostThemeToAll(): void {
  *  The comfyView still exists so `layoutViews` doesn't have to
  *  special-case its absence, but is sized to zero and never made
  *  visible. */
-export function openChooserHostWindow(initialPanel: ComfyPanelKey = 'comfy'): BrowserWindow {
+export interface OpenChooserHostWindowOptions {
+  /** Hold the window hidden after construction: skip the titlebar/panel/backstop
+   *  cold-start reveal and leave `coldStartPendingReveal` off, so only an
+   *  explicit `forceRevealHostWindow()` shows it. Used by startup restore to
+   *  keep the dashboard from flashing before the launch takeover is up. */
+  deferColdStartReveal?: boolean
+}
+
+export function openChooserHostWindow(
+  initialPanel: ComfyPanelKey = 'comfy',
+  opts: OpenChooserHostWindowOptions = {},
+): BrowserWindow {
   // Install-less wrapper. The shared `createHostWindow()` builds
   // the BrowserWindow + 2 views skeleton, layoutViews, macOS
   // fullscreen, bounds-save listeners, close / closed handlers,
@@ -1393,7 +1404,9 @@ export function openChooserHostWindow(initialPanel: ComfyPanelKey = 'comfy'): Br
     initiallyHidden: true,
   })
 
-  entry.coldStartPendingReveal = true
+  // Startup restore holds the window hidden (no pending cold-start reveal) until
+  // its launch takeover is up; everyone else reveals on first paint.
+  entry.coldStartPendingReveal = !opts.deferColdStartReveal
 
   // Seed the requested initial panel (default 'comfy' → chooser body for
   // an install-less host). "+ New Instance" passes 'new-install' so the
@@ -1404,6 +1417,10 @@ export function openChooserHostWindow(initialPanel: ComfyPanelKey = 'comfy'): Br
   entry.layoutViews()
 
   const revealKey = entry.windowKey
+
+  // Deferred reveal: the caller owns the timing (it will call
+  // `forceRevealHostWindow`), so skip the auto-reveal hooks entirely.
+  if (opts.deferColdStartReveal) return comfyWindow
 
   // Fast-path reveal: the title-bar bundle is ~25 KB and finishes its
   // first paint in well under 200 ms even on a Windows cold start,

--- a/src/main/host/createHostWindow.ts
+++ b/src/main/host/createHostWindow.ts
@@ -40,6 +40,7 @@ import {
   comfyWindows,
   computeBodyMode,
   dropAttachClaimsForWindow,
+  hasRunningSessionForEntry,
   isChooserHost,
   isInstallHost,
   nextWindowKey,
@@ -751,11 +752,13 @@ export function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowRe
       setLastFocusedInstallationId(entry.installationId)
     }
     // Persist which surface was last active so the next boot can restore it.
-    // The record helpers no-op while quitting: windows can take focus as
-    // siblings are destroyed, which would otherwise clobber the surface the
-    // user actually left from.
+    // Only a *running* instance is a healthy restore target — a stopped or
+    // crashed install-backed window shows the lifecycle panel, so record it as
+    // the dashboard to avoid relaunching straight into a crash next boot. The
+    // record helpers no-op while quitting: windows can take focus as siblings
+    // are destroyed, which would otherwise clobber the surface the user left.
     if (entry) {
-      if (entry.installationId) recordInstanceSurface(entry.installationId)
+      if (hasRunningSessionForEntry(entry)) recordInstanceSurface(entry.installationId)
       else recordDashboardSurface()
     }
   })

--- a/src/main/host/createHostWindow.ts
+++ b/src/main/host/createHostWindow.ts
@@ -751,9 +751,10 @@ export function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowRe
       setLastFocusedInstallationId(entry.installationId)
     }
     // Persist which surface was last active so the next boot can restore it.
-    // Skip while quitting: windows can take focus as siblings are destroyed,
-    // which would clobber the surface the user actually left from.
-    if (entry && !isQuitInProgress()) {
+    // The record helpers no-op while quitting: windows can take focus as
+    // siblings are destroyed, which would otherwise clobber the surface the
+    // user actually left from.
+    if (entry) {
       if (entry.installationId) recordInstanceSurface(entry.installationId)
       else recordDashboardSurface()
     }

--- a/src/main/host/createHostWindow.ts
+++ b/src/main/host/createHostWindow.ts
@@ -30,6 +30,7 @@ import * as mainTelemetry from '../lib/telemetry'
 import { forwardDatadogError } from '../lib/processErrorHandlers'
 import { isQuitInProgress } from '../lib/quit-state'
 import { recordDashboardSurface, recordInstanceSurface } from '../lib/lastSession'
+import * as settings from '../settings'
 import * as updater from '../lib/updater'
 import { getSavedBounds, getWindowOptions, saveWindowBounds } from '../lib/windowState'
 import { ensureSystemModal } from '../popups/systemModal'
@@ -904,13 +905,26 @@ export function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowRe
           )
           && entryForClose
         ) {
-          closeChoice = await fx.confirmCloseInstanceWindow(
-            comfyWindow,
-            isLastWindow,
-            shouldConfirmKillForEntry(entryForClose),
-            entryForClose.lastTheme,
-          )
-          if (shouldBailAfterCloseChoice(closeChoice, fx.preClearedClose.has(comfyWindow))) return
+          // Last install window: skip the three-way modal entirely and
+          // pick the outcome from the user's setting.
+          //  - `closeDirectlyOnLastWindow` true  → quit Desktop ('close')
+          //  - false (default)                   → return to dashboard
+          // Non-last windows still go through the existing 2-way confirm
+          // because running processes / pending downloads need an "are
+          // you sure" gate.
+          if (isLastInstallWindow) {
+            const closeDirectly =
+              (settings.get('closeDirectlyOnLastWindow') as boolean | undefined) === true
+            closeChoice = closeDirectly ? 'close' : 'return-to-dashboard'
+          } else {
+            closeChoice = await fx.confirmCloseInstanceWindow(
+              comfyWindow,
+              isLastWindow,
+              shouldConfirmKillForEntry(entryForClose),
+              entryForClose.lastTheme,
+            )
+            if (shouldBailAfterCloseChoice(closeChoice, fx.preClearedClose.has(comfyWindow))) return
+          }
         }
         // Capture the force-close intent before we drain the flag.
         // Either the initial snapshot (`skipConsult`) or a late-arriving
@@ -928,9 +942,12 @@ export function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowRe
           entryForClose.detachInstall()
           return
         }
-        // No explicit choice (the confirm was skipped) → keep the last
-        // install window on the dashboard rather than quitting silently,
-        // so the app never exits without the user deciding to.
+        // No explicit choice (the confirm was skipped — consult cleared
+        // or pre-cleared close). Default: keep the last install window
+        // on the dashboard rather than quitting silently. EXCEPT when
+        // the user has opted into `closeDirectlyOnLastWindow`, in which
+        // case the consult-cleared path must still honor that intent
+        // and let the teardown run.
         if (
           closeChoice === null
           && shouldDetachLastInstallWindowToDashboard(
@@ -942,8 +959,13 @@ export function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowRe
           )
           && entryForClose
         ) {
-          entryForClose.detachInstall()
-          return
+          const closeDirectly =
+            isLastInstallWindow &&
+            (settings.get('closeDirectlyOnLastWindow') as boolean | undefined) === true
+          if (!closeDirectly) {
+            entryForClose.detachInstall()
+            return
+          }
         }
         // Each cleanup step is wrapped via `safeTeardown` so a single
         // throw can't skip the BrowserWindow.destroy() at the end.

--- a/src/main/host/createHostWindow.ts
+++ b/src/main/host/createHostWindow.ts
@@ -29,6 +29,7 @@ import {
 import * as mainTelemetry from '../lib/telemetry'
 import { forwardDatadogError } from '../lib/processErrorHandlers'
 import { isQuitInProgress } from '../lib/quit-state'
+import { recordDashboardSurface, recordInstanceSurface } from '../lib/lastSession'
 import * as updater from '../lib/updater'
 import { getSavedBounds, getWindowOptions, saveWindowBounds } from '../lib/windowState'
 import { ensureSystemModal } from '../popups/systemModal'
@@ -62,6 +63,13 @@ const DEFAULT_HOST_HEIGHT = 900
  *  {@link HostWindowFactories.consultPanelRendererClose}. */
 export type CloseConsultResult = 'cleared' | 'aborted' | 'defer'
 
+/** User's pick from the close-window confirm:
+ *   - `close`               — tear the window down (last window → app quits)
+ *   - `cancel`              — keep the window open
+ *   - `return-to-dashboard` — flip the window in place to the dashboard (only
+ *     offered on the last window, so the user isn't forced to quit) */
+export type CloseWindowChoice = 'close' | 'cancel' | 'return-to-dashboard'
+
 /** Should the close handler bail after the renderer consult?
  *
  *  A `forceClose` snapshot (caller pre-cleared via `preClearedClose`)
@@ -73,37 +81,46 @@ export function shouldBailAfterConsult(consult: CloseConsultResult, forceClose: 
   return consult === 'aborted' && !forceClose
 }
 
-/** Should the install-host close-confirm modal run? Only fires when
- *  the renderer deferred (no overlay), the host would kill a local
- *  process, and the caller hasn't pre-cleared. Cloud/remote-backed
- *  windows skip the modal (issue #654) — closing them never kills a
- *  local ComfyUI. The "entry still exists" check is folded into
- *  `killsLocalSession` (its `shouldConfirmKillForEntry` source rejects
- *  a missing entry). */
+/** Should the install-host close-confirm modal run? Fires when the renderer
+ *  deferred (no overlay), the caller hasn't pre-cleared, AND either the host
+ *  would kill a local process OR this is the last install window (closing it
+ *  quits the app, so the user must get the confirm + the dashboard escape).
+ *  Cloud/remote non-last windows skip the modal (issue #654) — closing them
+ *  never kills a local ComfyUI and the app stays alive. The "entry still
+ *  exists" check is folded into `killsLocalSession` (its
+ *  `shouldConfirmKillForEntry` source rejects a missing entry); the
+ *  last-install-window branch carries its own entry check at the call site. */
 export function shouldShowInstallCloseConfirm(
   consult: CloseConsultResult,
   killsLocalSession: boolean,
   forceClose: boolean,
+  isLastInstallWindow: boolean,
 ): boolean {
-  return consult === 'defer' && killsLocalSession && !forceClose
+  return consult === 'defer' && !forceClose && (killsLocalSession || isLastInstallWindow)
 }
 
 /** Should the close handler bail after the install-host close-confirm
- *  modal? Same force-close override as {@link shouldBailAfterConsult}
- *  — a pre-cleared close lands mid-modal must still proceed. */
-export function shouldBailAfterCloseConfirm(confirmed: boolean, forceClose: boolean): boolean {
-  return !confirmed && !forceClose
+ *  modal? `cancel` keeps the window open, but a force-close override
+ *  (the caller pre-cleared mid-modal) must still proceed — same override
+ *  as {@link shouldBailAfterConsult}. */
+export function shouldBailAfterCloseChoice(choice: CloseWindowChoice, forceClose: boolean): boolean {
+  return choice === 'cancel' && !forceClose
 }
 
 /** Should the close handler detach the last install-backed window to
- *  the dashboard instead of tearing it down?
+ *  the dashboard instead of tearing it down — as the FALLBACK when no
+ *  explicit close choice was made (the confirm was skipped)?
  *
- *  The OS ✕ on the last install window flips the host to chooser mode
- *  in place so the app stays alive on the dashboard — that's why
- *  `isLastWindow` exists. A force-close (launch-guard eviction, bulk
- *  Exit-All) is a different intent: the caller already wants the
- *  window gone, and leaving a stray dashboard window behind after a
- *  swap-installs flow is noise. Force-close therefore skips the
+ *  The normal close of the last install window now shows a three-way
+ *  confirm (Quit Desktop / Return to Dashboard / Cancel); the user's
+ *  pick drives the outcome directly. This guard only covers the paths
+ *  that reach teardown WITHOUT that confirm (e.g. a rare overlay-cancel
+ *  consult that cleared) — there, defaulting the last install window to
+ *  the dashboard preserves the invariant that we never quit the last
+ *  window without an explicit user choice. A force-close (launch-guard
+ *  eviction, bulk Exit-All) is a different intent: the caller already
+ *  wants the window gone, and leaving a stray dashboard window behind
+ *  after a swap-installs flow is noise. Force-close therefore skips the
  *  detach branch and falls through to the normal teardown.
  *
  *  Same logic applies when `app.quit()` is in flight (Cmd+Q, app menu
@@ -160,12 +177,15 @@ export interface HostWindowFactories {
     panelView: WebContentsView | null | undefined,
   ) => Promise<'cleared' | 'aborted' | 'defer'>
   /** Shell-level "Close Window" confirm, owned by main so a hidden panel
-   *  renderer can't swallow it. Shared with the Close Window menu entry. */
+   *  renderer can't swallow it. Shared with the Close Window menu entry.
+   *  The last window adds a "Return to Dashboard" option so closing it
+   *  isn't a forced quit; `stopsLocalComfy` tailors the copy. */
   confirmCloseInstanceWindow: (
     window: BrowserWindow,
     isLastWindow: boolean,
+    stopsLocalComfy: boolean,
     theme: { bg: string; text: string },
-  ) => Promise<boolean>
+  ) => Promise<CloseWindowChoice>
   /** Detach the install currently bound to a host entry (in-place flip). */
   detachInstallImpl: (entry: ComfyWindowEntry) => void
   /** WeakSet of host windows whose close was pre-cleared by the
@@ -730,6 +750,13 @@ export function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowRe
     if (entry?.installationId) {
       setLastFocusedInstallationId(entry.installationId)
     }
+    // Persist which surface was last active so the next boot can restore it.
+    // Skip while quitting: windows can take focus as siblings are destroyed,
+    // which would clobber the surface the user actually left from.
+    if (entry && !isQuitInProgress()) {
+      if (entry.installationId) recordInstanceSurface(entry.installationId)
+      else recordDashboardSurface()
+    }
   })
 
   // Push the initial state once the title bar's preload signals readiness.
@@ -854,24 +881,32 @@ export function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowRe
           : await fx.consultPanelRendererClose(entry?.panelView)
         if (shouldBailAfterConsult(consult, fx.preClearedClose.has(comfyWindow))) return
         // Step 2 — for an install-backed host with no overlay, main shows
-        // the same Close Window confirm as the menu item. The dashboard
-        // closes with no prompt.
+        // the same Close Window confirm as the menu item. The last window
+        // gets a three-way choice (Quit Desktop / Return to Dashboard /
+        // Cancel) so closing it isn't a forced quit; non-last windows get
+        // the plain Close/Cancel confirm. The dashboard closes with no
+        // prompt.
         const entryForClose = comfyWindows.get(windowKey)
         const isInstallHostWindow = !!entryForClose && !isChooserHost(entryForClose)
+        const isLastInstallWindow = isLastWindow && isInstallHostWindow
+        // `null` = no confirm was shown (so no explicit user choice).
+        let closeChoice: CloseWindowChoice | null = null
         if (
           shouldShowInstallCloseConfirm(
             consult,
             shouldConfirmKillForEntry(entryForClose),
             fx.preClearedClose.has(comfyWindow),
+            isLastInstallWindow,
           )
           && entryForClose
         ) {
-          const confirmed = await fx.confirmCloseInstanceWindow(
+          closeChoice = await fx.confirmCloseInstanceWindow(
             comfyWindow,
             isLastWindow,
+            shouldConfirmKillForEntry(entryForClose),
             entryForClose.lastTheme,
           )
-          if (shouldBailAfterCloseConfirm(confirmed, fx.preClearedClose.has(comfyWindow))) return
+          if (shouldBailAfterCloseChoice(closeChoice, fx.preClearedClose.has(comfyWindow))) return
         }
         // Capture the force-close intent before we drain the flag.
         // Either the initial snapshot (`skipConsult`) or a late-arriving
@@ -880,15 +915,21 @@ export function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowRe
         const forceClose = skipConsult || fx.preClearedClose.has(comfyWindow)
         fx.preClearedClose.delete(comfyWindow)
         if (comfyWindow.isDestroyed()) return
-        // Last install-backed window → return to the dashboard rather
-        // than tear down + quit. `detachInstall` runs the same
-        // `_installCleanup` (stopRunning, listeners off) the teardown
-        // below would, then flips the window to chooser mode in place.
-        // Force-close skips this — the caller wants the window gone
-        // (e.g. launch-guard swapping installs shouldn't leave a stray
-        // dashboard window behind).
+        // Explicit "Return to Dashboard" pick → flip in place rather than
+        // tearing down. `detachInstall` runs the same `_installCleanup`
+        // (stopRunning, listeners off) the teardown below would, then
+        // flips the window to chooser mode. Force-close ignores the pick —
+        // the caller wants the window gone.
+        if (closeChoice === 'return-to-dashboard' && !forceClose && isInstallHostWindow && entryForClose) {
+          entryForClose.detachInstall()
+          return
+        }
+        // No explicit choice (the confirm was skipped) → keep the last
+        // install window on the dashboard rather than quitting silently,
+        // so the app never exits without the user deciding to.
         if (
-          shouldDetachLastInstallWindowToDashboard(
+          closeChoice === null
+          && shouldDetachLastInstallWindowToDashboard(
             isInstallHostWindow,
             !!entryForClose,
             isLastWindow,

--- a/src/main/host/detach.ts
+++ b/src/main/host/detach.ts
@@ -4,8 +4,10 @@ import * as ipc from '../lib/ipc'
 import { _runningSessions } from '../lib/ipc/shared'
 import { COMFY_BG } from '../lib/theme'
 import { destroyPanelView, ensurePanelView } from './panelView'
-import { openSystemModalAsync } from '../popups/systemModal'
+import { openSystemModalAsync, openSystemModalChoiceAsync } from '../popups/systemModal'
 import type { SystemModalDetailGroup } from '../popups/systemModal'
+import { isQuitInProgress } from '../lib/quit-state'
+import { recordDashboardSurface } from '../lib/lastSession'
 import { comfyWindows, isChooserHost, isInstallHost, shouldConfirmKillForEntry } from './registry'
 import type { ComfyWindowEntry } from './registry'
 import {
@@ -13,6 +15,7 @@ import {
   CHOOSER_HOST_TITLE_TEXT,
   CHOOSER_HOST_WINDOW_TITLE,
 } from './createHostWindow'
+import type { CloseWindowChoice } from './createHostWindow'
 
 /**
  * Host windows whose `close` should skip the panel-renderer consult and tear down
@@ -252,31 +255,58 @@ export async function confirmAndCloseAllHostWindows(
  * Shared "Close Window" confirm, used by both the menu entry and the OS ✕ handler. Lives in
  * main, not the panel renderer, because the renderer is hidden behind ComfyUI while an
  * instance runs and can't be relied on to surface a prompt.
+ *
+ * The last window adds a "Return to Dashboard" middle option so closing it isn't a forced
+ * quit — the primary action quits Desktop, the secondary keeps the app on the dashboard.
+ * `stopsLocalComfy` tailors the copy (a stopped / cloud window has no local process to stop).
  */
 export async function confirmCloseInstanceWindow(
   window: BrowserWindow,
   isLastWindow: boolean,
+  stopsLocalComfy: boolean,
   theme: { bg: string; text: string },
-): Promise<boolean> {
-  return openSystemModalAsync({
+): Promise<CloseWindowChoice> {
+  if (!isLastWindow) {
+    const confirmed = await openSystemModalAsync({
+      parent: window,
+      spec: {
+        title: 'Close Window',
+        message: stopsLocalComfy
+          ? 'Close this window? This stops the running ComfyUI instance.'
+          : 'Close this window?',
+        confirmLabel: 'Close Window',
+        cancelLabel: 'Cancel',
+        confirmStyle: 'danger',
+        theme,
+      },
+    })
+    return confirmed ? 'close' : 'cancel'
+  }
+  const action = await openSystemModalChoiceAsync({
     parent: window,
     spec: {
       title: 'Close Window',
-      message: isLastWindow
-        ? 'Close this window? This stops ComfyUI and returns you to the dashboard.'
-        : 'Close this window? This stops the running ComfyUI instance.',
-      confirmLabel: isLastWindow ? 'Return to Dashboard' : 'Close Window',
+      message: stopsLocalComfy
+        ? 'This is the last window. Closing it stops ComfyUI and quits Desktop, or you can return to the dashboard.'
+        : 'This is the last window. Closing it quits Desktop, or you can return to the dashboard.',
+      confirmLabel: 'Quit Desktop',
+      secondaryLabel: 'Return to Dashboard',
+      secondaryStyle: 'primary',
       cancelLabel: 'Cancel',
       confirmStyle: 'danger',
       theme,
     },
   })
+  if (action === 'confirm') return 'close'
+  if (action === 'secondary') return 'return-to-dashboard'
+  return 'cancel'
 }
 
 /**
  * Confirm + close a single install-backed host window. Model downloads are owned by the
  * desktop app, not the instance, so they keep running after a close (no active-download
- * list here). As the last window, flip in place to the dashboard rather than quitting.
+ * list here). Closing the last window quits Desktop; the confirm offers "Return to
+ * Dashboard" so the user isn't forced to quit.
  */
 export async function confirmAndCloseHostWindow(parentWindow: BrowserWindow): Promise<void> {
   if (parentWindow.isDestroyed()) return
@@ -289,20 +319,26 @@ export async function confirmAndCloseHostWindow(parentWindow: BrowserWindow): Pr
     (e) => !e.window.isDestroyed(),
   ).length
   const isLastWindow = liveWindowCount <= 1
-  // Confirm only when closing kills a local ComfyUI process; cloud/remote and chooser hosts
-  // close immediately.
-  if (shouldConfirmKillForEntry(entry)) {
-    const confirmed = await confirmCloseInstanceWindow(entry.window, isLastWindow, entry.lastTheme)
-    if (!confirmed) return
+  // Confirm when closing kills a local ComfyUI process OR when this is the last install
+  // window (closing it quits the app, so the user gets the prompt + the dashboard escape).
+  // Cloud/remote non-last windows and chooser hosts close immediately.
+  if (shouldConfirmKillForEntry(entry) || (isLastWindow && isInstallHost(entry))) {
+    const choice = await confirmCloseInstanceWindow(
+      entry.window,
+      isLastWindow,
+      shouldConfirmKillForEntry(entry),
+      entry.lastTheme,
+    )
+    if (choice === 'cancel') return
+    if (choice === 'return-to-dashboard') {
+      // Flip the last window to the dashboard rather than closing it (which would quit).
+      entry.detachInstall()
+      return
+    }
   }
-  if (isLastWindow && isInstallHost(entry)) {
-    // Flip the last window to the dashboard rather than closing it (which would quit).
-    entry.detachInstall()
-  } else {
-    // Skip the close handler's consult: the user already confirmed via this prompt.
-    preClearedClose.add(entry.window)
-    entry.window.close()
-  }
+  // Skip the close handler's consult: the user already confirmed via this prompt.
+  preClearedClose.add(entry.window)
+  entry.window.close()
 }
 
 /**
@@ -315,6 +351,11 @@ export async function confirmAndCloseHostWindow(parentWindow: BrowserWindow): Pr
 export function _detachInstallImpl(entry: ComfyWindowEntry): void {
   if (isChooserHost(entry)) return
   if (entry.window.isDestroyed()) return
+
+  // Returning to the dashboard makes it the active surface — persist so the
+  // next boot opens the dashboard, not the install we just detached. Skipped
+  // while quitting (the user's last surface is whatever they left from).
+  if (!isQuitInProgress()) recordDashboardSurface()
 
   // Symmetric undo of attachInstall (listeners, maps, stopRunning, etc).
   entry._installCleanup?.()

--- a/src/main/host/detach.ts
+++ b/src/main/host/detach.ts
@@ -6,7 +6,6 @@ import { COMFY_BG } from '../lib/theme'
 import { destroyPanelView, ensurePanelView } from './panelView'
 import { openSystemModalAsync, openSystemModalChoiceAsync } from '../popups/systemModal'
 import type { SystemModalDetailGroup } from '../popups/systemModal'
-import { isQuitInProgress } from '../lib/quit-state'
 import { recordDashboardSurface } from '../lib/lastSession'
 import { comfyWindows, isChooserHost, isInstallHost, shouldConfirmKillForEntry } from './registry'
 import type { ComfyWindowEntry } from './registry'
@@ -353,9 +352,10 @@ export function _detachInstallImpl(entry: ComfyWindowEntry): void {
   if (entry.window.isDestroyed()) return
 
   // Returning to the dashboard makes it the active surface — persist so the
-  // next boot opens the dashboard, not the install we just detached. Skipped
-  // while quitting (the user's last surface is whatever they left from).
-  if (!isQuitInProgress()) recordDashboardSurface()
+  // next boot opens the dashboard, not the install we just detached. The
+  // record helper no-ops while quitting (the user's last surface is whatever
+  // they left from).
+  recordDashboardSurface()
 
   // Symmetric undo of attachInstall (listeners, maps, stopRunning, etc).
   entry._installCleanup?.()

--- a/src/main/host/registry.test.ts
+++ b/src/main/host/registry.test.ts
@@ -29,6 +29,7 @@ import {
   hostInstallEvents,
   indexInstallationId,
   nextWindowKey,
+  hasRunningSessionForEntry,
   raiseAllHostWindows,
   registerHostEntry,
   setHostFactories,
@@ -214,6 +215,39 @@ describe('shouldConfirmKillForEntry', () => {
   it('returns false for null/undefined entries', () => {
     expect(shouldConfirmKillForEntry(null)).toBe(false)
     expect(shouldConfirmKillForEntry(undefined)).toBe(false)
+  })
+})
+
+describe('hasRunningSessionForEntry', () => {
+  // Rule: "is this an install-backed window showing a live ComfyUI view?" — true only when
+  // the install has a session in `_runningSessions` (local OR cloud/remote). Drives whether
+  // the window is a healthy "last active surface" worth restoring on next boot.
+  it('returns true for an install-backed host with a running session', () => {
+    const entry = makeEntry({ installationId: 'inst-A', sourceCategory: 'local' })
+    _runningSessions.set('inst-A', {} as never)
+    expect(hasRunningSessionForEntry(entry)).toBe(true)
+  })
+
+  it('returns true for a running cloud/remote-backed host', () => {
+    _runningSessions.set('inst-cloud', {} as never)
+    expect(
+      hasRunningSessionForEntry(makeEntry({ installationId: 'inst-cloud', sourceCategory: 'cloud' })),
+    ).toBe(true)
+  })
+
+  it('returns false for an install-backed host with no running session (stopped/crashed)', () => {
+    expect(
+      hasRunningSessionForEntry(makeEntry({ installationId: 'inst-A', sourceCategory: 'local' })),
+    ).toBe(false)
+  })
+
+  it('returns false for a chooser/install-less host', () => {
+    expect(hasRunningSessionForEntry(makeEntry({ installationId: null }))).toBe(false)
+  })
+
+  it('returns false for null/undefined entries', () => {
+    expect(hasRunningSessionForEntry(null)).toBe(false)
+    expect(hasRunningSessionForEntry(undefined)).toBe(false)
   })
 })
 

--- a/src/main/host/registry.test.ts
+++ b/src/main/host/registry.test.ts
@@ -29,6 +29,7 @@ import {
   hostInstallEvents,
   indexInstallationId,
   nextWindowKey,
+  forceRevealHostWindow,
   hasRunningSessionForEntry,
   raiseAllHostWindows,
   registerHostEntry,
@@ -248,6 +249,30 @@ describe('hasRunningSessionForEntry', () => {
   it('returns false for null/undefined entries', () => {
     expect(hasRunningSessionForEntry(null)).toBe(false)
     expect(hasRunningSessionForEntry(undefined)).toBe(false)
+  })
+})
+
+describe('forceRevealHostWindow', () => {
+  it('reveals a deferred host regardless of the coldStartPendingReveal flag', () => {
+    const entry = makeEntry({ installationId: null })
+    entry.coldStartPendingReveal = false // deferred restore leaves the flag off
+    registerHostEntry(entry)
+
+    forceRevealHostWindow(entry.windowKey)
+
+    expect(entry.coldStartPendingReveal).toBe(false)
+    expect((entry.window as unknown as FakeWindow).raised).toContain('show')
+  })
+
+  it('no-ops for a destroyed window', () => {
+    const entry = makeEntry({ installationId: null, destroyed: true })
+    registerHostEntry(entry)
+    forceRevealHostWindow(entry.windowKey)
+    expect((entry.window as unknown as FakeWindow).raised).not.toContain('show')
+  })
+
+  it('no-ops for an unknown window key', () => {
+    expect(() => forceRevealHostWindow(999_999)).not.toThrow()
   })
 })
 

--- a/src/main/host/registry.ts
+++ b/src/main/host/registry.ts
@@ -271,6 +271,16 @@ export function findEntryByTitleBarSender(wc: WebContents): { id: number; entry:
   return null
 }
 
+/** Resolve the installationId backing the comfyView whose webContents sent an
+ *  IPC message. Used by the terminal bridge so the served ComfyUI frontend
+ *  (which has no idea which install it belongs to) reaches the right shell. */
+export function findInstallationIdByComfySender(wc: WebContents): string | null {
+  for (const entry of comfyWindows.values()) {
+    if (entry.comfyView.webContents === wc) return entry.installationId
+  }
+  return null
+}
+
 /** Resolve a host BrowserWindow back to its registry entry. */
 export function findEntryByHostWindow(window: BrowserWindow): ComfyWindowEntry | null {
   for (const entry of comfyWindows.values()) {

--- a/src/main/host/registry.ts
+++ b/src/main/host/registry.ts
@@ -353,6 +353,18 @@ export function revealColdStartHostIfPending(windowKey: number): void {
   bringToFront(entry.window)
 }
 
+/** Reveal a host whose cold-start reveal was deferred by the caller (the
+ *  startup-restore flow holds the window hidden until its launch takeover is
+ *  up, so the dashboard never flashes). Reveals regardless of the
+ *  `coldStartPendingReveal` flag — the caller owns the timing. */
+export function forceRevealHostWindow(windowKey: number): void {
+  const entry = comfyWindows.get(windowKey)
+  if (!entry || entry.window.isDestroyed()) return
+  entry.coldStartPendingReveal = false
+  entry.layoutViews()
+  bringToFront(entry.window)
+}
+
 /** Late-bound host-window factories, set by `index.ts` so the registry can
  *  spawn a chooser host without importing host-construction code (cycle). */
 interface HostFactories {

--- a/src/main/host/registry.ts
+++ b/src/main/host/registry.ts
@@ -244,6 +244,17 @@ export function shouldConfirmKillForEntry(
 }
 
 /**
+ * Predicate: this entry has a live ComfyUI session (i.e. its body shows the
+ * running ComfyUI view, not the lifecycle/crash panel). Used to decide whether
+ * the install is a healthy "last active surface" worth restoring on next boot.
+ */
+export function hasRunningSessionForEntry(
+  entry: ComfyWindowEntry | null | undefined,
+): entry is ComfyWindowEntry & { installationId: string } {
+  return !!entry && isInstallHost(entry) && _runningSessions.has(entry.installationId)
+}
+
+/**
  * Decide what fills a comfy window's body. Install-backed: the Comfy pill →
  * live ComfyUI view (running) or lifecycle panel (stopped). Install-less: the
  * Comfy pill → chooser. Centralised so layout and body swaps can't disagree.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -87,6 +87,7 @@ import {
   dropAttachClaimsForWindow,
   findEntryByTitleBarSender,
   findEntryByHostWindow,
+  forceRevealHostWindow,
   getEntryByInstallationId,
   isChooserHost,
   isInstallHost,
@@ -200,14 +201,35 @@ function quitApp(): void {
   app.quit()
 }
 
+/** Restore windows are opened hidden and revealed only once their launch
+ *  takeover is up (or a fallback fires); this guards against a renderer that
+ *  never reaches the restore handler, so the window can't stay invisible. */
+const STARTUP_RESTORE_REVEAL_BACKSTOP_MS = 10_000
+const pendingStartupRestoreRevealTimers = new Map<number, ReturnType<typeof setTimeout>>()
+
+function clearStartupRestoreRevealTimer(windowKey: number): void {
+  const timer = pendingStartupRestoreRevealTimers.get(windowKey)
+  if (timer) clearTimeout(timer)
+  pendingStartupRestoreRevealTimers.delete(windowKey)
+}
+
+/** Give up on the in-place restore and just show the dashboard: the surface the
+ *  user lands on is now the dashboard, so persist that and reveal the window. */
+function revealStartupRestoreDashboard(windowKey: number): void {
+  clearStartupRestoreRevealTimer(windowKey)
+  recordDashboardSurface()
+  forceRevealHostWindow(windowKey)
+}
+
 /**
- * Boot surface: always open the chooser host, then — when the reopen setting is
- * on and the user last left an instance window — restore that instance in place
- * on top of it. Restore reuses the dashboard's own launch path (the
- * `picker-pick-install` deep link → `handleChooserPick`), so it gets the same
- * progress overlay, claim, and in-place attach the user sees when clicking an
- * install card. Any failure (install gone, launch error, console/external mode)
- * just leaves the dashboard up.
+ * Boot surface. Normally just opens the chooser host (dashboard). When the
+ * reopen setting is on and the user last left an instance window, instead open
+ * the chooser host HIDDEN and restore that instance on top of it via the
+ * dashboard's own launch path (the `picker-pick-install` deep link →
+ * `performChooserLaunch`), revealing the window only once its launch takeover is
+ * showing — so the dashboard never flashes. Any failure (install gone, launch
+ * error, console/external mode, slow/absent renderer) falls back to revealing
+ * the dashboard.
  */
 function openStartupSurface(): void {
   // Read the persisted surface BEFORE opening the chooser host: showing the
@@ -217,31 +239,58 @@ function openStartupSurface(): void {
   const restoreEnabled =
     settings.get('reopenLastInstanceOnLaunch') !== false &&
     settings.get('firstUseCompleted') === true
+  const shouldRestore = restoreEnabled && surface?.kind === 'instance'
 
-  const chooserWindow = openOrFocusChooserHostWindow()
+  // Restore opens hidden (revealed on takeover-ready / fallback); the plain
+  // dashboard boot reveals on first paint as before.
+  const chooserWindow = shouldRestore
+    ? openChooserHostWindow('comfy', { deferColdStartReveal: true })
+    : openOrFocusChooserHostWindow()
 
-  if (!restoreEnabled || surface?.kind !== 'instance') return
+  if (!shouldRestore) return
   const installationId = surface.installationId
 
   void (async () => {
-    const inst = await getInstallation(installationId)
-    if (!inst) {
-      // The remembered install was deleted — fall back to the dashboard and
-      // drop the stale state so we don't retry forever.
-      clearLastActiveSurface()
+    const entry = findEntryByHostWindow(chooserWindow)
+    if (!entry || entry.window.isDestroyed() || !isChooserHost(entry)) {
+      // Lost the entry right after creating it (shouldn't happen) — reveal the
+      // raw window so a hidden restore window can't get stranded invisible.
+      if (!chooserWindow.isDestroyed()) chooserWindow.show()
       return
     }
-    const entry = findEntryByHostWindow(chooserWindow)
-    if (!entry || entry.window.isDestroyed() || !isChooserHost(entry)) return
+
+    // Backstop: if the renderer never resolves the reveal (failed load, hung
+    // guard), show the dashboard rather than leaving the window invisible.
+    const timer = setTimeout(
+      () => revealStartupRestoreDashboard(entry.windowKey),
+      STARTUP_RESTORE_REVEAL_BACKSTOP_MS,
+    )
+    pendingStartupRestoreRevealTimers.set(entry.windowKey, timer)
+
+    const inst = await getInstallation(installationId)
+    if (!inst) {
+      // The remembered install was deleted — drop the stale state so we don't
+      // retry forever, and reveal the dashboard.
+      clearLastActiveSurface()
+      revealStartupRestoreDashboard(entry.windowKey)
+      return
+    }
     const panelView =
       entry.panelView ?? ensurePanelView(entry.windowKey, entry, computeBodyMode(entry))
-    if (panelView.webContents.isDestroyed()) return
+    if (panelView.webContents.isDestroyed()) {
+      revealStartupRestoreDashboard(entry.windowKey)
+      return
+    }
     // `sendToPanelDeferred` holds the IPC until the panel renderer's
     // `did-finish-load`; the deep-link handler then awaits its own bootstrap
-    // before launching, so this is safe to fire immediately after open.
+    // before launching, so this is safe to fire immediately after open. The
+    // `startupRestore` flag tells the renderer to (a) take the dashboard-
+    // fallback path on a missing launch action instead of opening new-install,
+    // and (b) resolve the reveal once the launch takeover is up.
     sendToPanelDeferred(panelView, 'panel-trigger-overlay', {
       kind: 'picker-pick-install',
-      installationId
+      installationId,
+      startupRestore: true
     })
   })()
 }
@@ -652,6 +701,31 @@ ipcMain.handle('app:relaunch', () => {
 ipcMain.handle('reset-zoom', () => {
   // no-op
 })
+
+/**
+ * Startup-restore reveal handshake. The boot flow opens the restore window
+ * hidden and asks the panel renderer to launch the remembered instance; the
+ * renderer fires this once it knows the outcome:
+ *   - `'takeover-ready'`     → the launch takeover is up, reveal the window so
+ *     the user lands on the launching surface (no dashboard flash).
+ *   - `'dashboard-fallback'` → the launch didn't produce a takeover (already
+ *     running, missing action, console/external mode, error), so reveal the
+ *     dashboard instead.
+ * Resolved by sender so we reveal the exact hidden host that asked.
+ */
+ipcMain.on(
+  'comfy-window:startup-restore-reveal',
+  (event, payload: { result?: unknown }) => {
+    const result = payload?.result === 'dashboard-fallback' ? 'dashboard-fallback' : 'takeover-ready'
+    for (const [windowKey, entry] of comfyWindows) {
+      if (entry.panelView?.webContents !== event.sender) continue
+      clearStartupRestoreRevealTimer(windowKey)
+      if (result === 'dashboard-fallback') recordDashboardSurface()
+      forceRevealHostWindow(windowKey)
+      return
+    }
+  }
+)
 
 /**
  * First-use takeover step plumbing.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -9,6 +9,7 @@ import type { ChildProcess } from 'child_process'
 import todesktop from '@todesktop/runtime'
 import * as ipc from './lib/ipc'
 import { getAppVersion } from './lib/ipc'
+import type { ExitCallbackInfo } from './lib/ipc'
 import * as updater from './lib/updater'
 import * as settings from './settings'
 import { installAppMenu } from './menu'
@@ -18,7 +19,8 @@ import { saveWindowBounds } from './lib/windowState'
 import {
   clearLastActiveSurface,
   flushLastSessionSync,
-  getLastActiveSurface
+  getLastActiveSurface,
+  recordDashboardSurface
 } from './lib/lastSession'
 import { registerProcessErrorHandlers } from './lib/processErrorHandlers'
 import { registerTitleTooltipIpc } from './popups/titleTooltip'
@@ -244,8 +246,14 @@ function openStartupSurface(): void {
   })()
 }
 
-function onComfyExited({ installationId }: { installationId?: string } = {}): void {
+function onComfyExited({ installationId, crashed }: ExitCallbackInfo = {}): void {
   if (!installationId) return
+  // A crashed instance is no longer a healthy restore target: drop it back to
+  // the dashboard so the next boot doesn't relaunch straight into the crash.
+  // `recordDashboardSurface` only overwrites when this install is still the
+  // recorded surface's intent (it's a simple last-writer), which is correct
+  // here — the crashed window is the one the user was on.
+  if (crashed) recordDashboardSurface()
   // The window stays alive — exit (clean or crash) just swaps the body to the
   // lifecycle panel so the user can re-launch, look at logs, or close the
   // window themselves. Window destruction only happens via explicit close

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -17,7 +17,7 @@ import { migrateXdgPaths } from './lib/paths'
 import { saveWindowBounds } from './lib/windowState'
 import {
   clearLastActiveSurface,
-  flushLastSession,
+  flushLastSessionSync,
   getLastActiveSurface
 } from './lib/lastSession'
 import { registerProcessErrorHandlers } from './lib/processErrorHandlers'
@@ -1965,8 +1965,9 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
       _stopPeriodicReleaseChecks = null
     }
     // Persist any pending last-active-surface write so the next boot can
-    // restore it (best-effort; in-session writes are already debounce-flushed).
-    void flushLastSession()
+    // restore it. Synchronous: the app exits without awaiting promises, so an
+    // async write would be torn down mid-flight and lose a just-made change.
+    flushLastSessionSync()
     cleanupTempDownloads()
   })
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -15,6 +15,11 @@ import { installAppMenu } from './menu'
 import * as i18n from './lib/i18n'
 import { migrateXdgPaths } from './lib/paths'
 import { saveWindowBounds } from './lib/windowState'
+import {
+  clearLastActiveSurface,
+  flushLastSession,
+  getLastActiveSurface
+} from './lib/lastSession'
 import { registerProcessErrorHandlers } from './lib/processErrorHandlers'
 import { registerTitleTooltipIpc } from './popups/titleTooltip'
 import { registerTitleCoachmarkIpc } from './popups/titleCoachmark'
@@ -191,6 +196,52 @@ function quitApp(): void {
     tray = null
   }
   app.quit()
+}
+
+/**
+ * Boot surface: always open the chooser host, then — when the reopen setting is
+ * on and the user last left an instance window — restore that instance in place
+ * on top of it. Restore reuses the dashboard's own launch path (the
+ * `picker-pick-install` deep link → `handleChooserPick`), so it gets the same
+ * progress overlay, claim, and in-place attach the user sees when clicking an
+ * install card. Any failure (install gone, launch error, console/external mode)
+ * just leaves the dashboard up.
+ */
+function openStartupSurface(): void {
+  // Read the persisted surface BEFORE opening the chooser host: showing the
+  // chooser fires its `focus` handler, which would record 'dashboard' and
+  // clobber the instance we're about to restore.
+  const surface = getLastActiveSurface()
+  const restoreEnabled =
+    settings.get('reopenLastInstanceOnLaunch') !== false &&
+    settings.get('firstUseCompleted') === true
+
+  const chooserWindow = openOrFocusChooserHostWindow()
+
+  if (!restoreEnabled || surface?.kind !== 'instance') return
+  const installationId = surface.installationId
+
+  void (async () => {
+    const inst = await getInstallation(installationId)
+    if (!inst) {
+      // The remembered install was deleted — fall back to the dashboard and
+      // drop the stale state so we don't retry forever.
+      clearLastActiveSurface()
+      return
+    }
+    const entry = findEntryByHostWindow(chooserWindow)
+    if (!entry || entry.window.isDestroyed() || !isChooserHost(entry)) return
+    const panelView =
+      entry.panelView ?? ensurePanelView(entry.windowKey, entry, computeBodyMode(entry))
+    if (panelView.webContents.isDestroyed()) return
+    // `sendToPanelDeferred` holds the IPC until the panel renderer's
+    // `did-finish-load`; the deep-link handler then awaits its own bootstrap
+    // before launching, so this is safe to fire immediately after open.
+    sendToPanelDeferred(panelView, 'panel-trigger-overlay', {
+      kind: 'picker-pick-install',
+      installationId
+    })
+  })()
 }
 
 function onComfyExited({ installationId }: { installationId?: string } = {}): void {
@@ -1833,8 +1884,10 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
     // The install-less chooser host is the primary surface. Each
     // install gets its own ComfyUI window via openComfyWindow()
     // when launched, and the chooser host is the entry-point for
-    // picking / creating installs.
-    openOrFocusChooserHostWindow()
+    // picking / creating installs. When the user last left an instance
+    // window (and the reopen setting is on), restore that instance
+    // in-place on top of the freshly-opened chooser host.
+    openStartupSurface()
 
     // Single subscription rebroadcasts every install-list mutation
     // (add/remove/update/markLaunched/reorder/...) to all renderers as
@@ -1911,6 +1964,9 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
       _stopPeriodicReleaseChecks()
       _stopPeriodicReleaseChecks = null
     }
+    // Persist any pending last-active-surface write so the next boot can
+    // restore it (best-effort; in-session writes are already debounce-flushed).
+    void flushLastSession()
     cleanupTempDownloads()
   })
 

--- a/src/main/lib/comfy-feature-flags.test.ts
+++ b/src/main/lib/comfy-feature-flags.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect } from 'vitest'
-import { parseFeatureFlagOutput } from './comfy-feature-flags'
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  parseFeatureFlagOutput,
+  getCachedFeatureFlagRegistry,
+  isCachedFeatureFlagAvailable,
+  clearFeatureFlagRegistryCache,
+  getComfyFeatureFlagRegistry,
+} from './comfy-feature-flags'
 
 describe('parseFeatureFlagOutput', () => {
   it('parses valid JSON output', () => {
@@ -45,5 +51,41 @@ describe('parseFeatureFlagOutput', () => {
     const reg = parseFeatureFlagOutput(stdout)
     expect(Object.keys(reg)).toEqual(['flag_a', 'flag_b'])
     expect(reg['flag_b']?.default).toBe(10)
+  })
+})
+
+describe('feature-flag registry cache accessors', () => {
+  const installationId = 'cache-test-install'
+  // A path that can't be executed, so discovery fails and caches {} —
+  // exercising the spawn-free accessors without needing a real Python.
+  const badPython = '/nonexistent/python-binary'
+
+  beforeEach(() => {
+    clearFeatureFlagRegistryCache(installationId)
+  })
+
+  it('returns null before any discovery has run', () => {
+    expect(getCachedFeatureFlagRegistry(installationId)).toBeNull()
+    expect(isCachedFeatureFlagAvailable(installationId, 'supports_terminal')).toBe(false)
+  })
+
+  it('caches an empty registry after a failed discovery and reports flags absent', async () => {
+    await getComfyFeatureFlagRegistry(badPython, 'main.py', process.cwd(), installationId, '1.0.0')
+    expect(getCachedFeatureFlagRegistry(installationId)).toEqual({})
+    expect(isCachedFeatureFlagAvailable(installationId, 'supports_terminal')).toBe(false)
+  })
+
+  it('matches a cached version and rejects a mismatched one', async () => {
+    await getComfyFeatureFlagRegistry(badPython, 'main.py', process.cwd(), installationId, '1.0.0')
+    expect(getCachedFeatureFlagRegistry(installationId, '1.0.0')).toEqual({})
+    expect(getCachedFeatureFlagRegistry(installationId, '2.0.0')).toBeNull()
+    // A version-less query always hits the cache.
+    expect(getCachedFeatureFlagRegistry(installationId)).toEqual({})
+  })
+
+  it('clears the cache back to a miss', async () => {
+    await getComfyFeatureFlagRegistry(badPython, 'main.py', process.cwd(), installationId, '1.0.0')
+    clearFeatureFlagRegistryCache(installationId)
+    expect(getCachedFeatureFlagRegistry(installationId)).toBeNull()
   })
 })

--- a/src/main/lib/comfy-feature-flags.ts
+++ b/src/main/lib/comfy-feature-flags.ts
@@ -57,10 +57,36 @@ export async function getComfyFeatureFlagRegistry(
     console.warn('[comfy-feature-flags] Could not get registry:', (err as Error).message)
   }
 
-  if (version) {
-    registryCache.set(installationId, { registry, version })
-  }
+  registryCache.set(installationId, { registry, version: version ?? '' })
   return registry
+}
+
+/**
+ * Read the cached registry without ever spawning Python. Returns `null` when
+ * nothing is cached for the install (e.g. discovery hasn't run, or failed).
+ * A blank cached version matches any requested version so launches that lacked
+ * a version string still hit.
+ */
+export function getCachedFeatureFlagRegistry(
+  installationId: string,
+  version?: string,
+): FeatureFlagRegistry | null {
+  const cached = registryCache.get(installationId)
+  if (!cached) return null
+  if (version !== undefined && cached.version !== '' && cached.version !== version) {
+    return null
+  }
+  return cached.registry
+}
+
+/** Whether a CLI feature flag is known to the install's ComfyUI, read from the
+ *  cache only (no spawn). Treats an absent cache as "not available". */
+export function isCachedFeatureFlagAvailable(
+  installationId: string,
+  key: string,
+  version?: string,
+): boolean {
+  return key in (getCachedFeatureFlagRegistry(installationId, version) ?? {})
 }
 
 function runListFeatureFlags(pythonPath: string, mainPyPath: string, cwd: string): Promise<string> {

--- a/src/main/lib/comfyTerminalContentScript.test.ts
+++ b/src/main/lib/comfyTerminalContentScript.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { getComfyTerminalContentScript } from './comfyTerminalContentScript'
+
+describe('getComfyTerminalContentScript', () => {
+  const script = getComfyTerminalContentScript()
+
+  it('returns a syntactically valid, self-contained IIFE', () => {
+    expect(script.startsWith('(function () {')).toBe(true)
+    // Throws on a syntax error in the assembled string (escaping bugs, etc.).
+    expect(() => new Function(script)).not.toThrow()
+  })
+
+  it('bails when the desktop terminal bridge is absent', () => {
+    expect(script).toContain('!window.__comfyDesktop2.Terminal')
+  })
+
+  it('guards against double injection', () => {
+    expect(script).toContain('window.__comfyDesktopTerminalStopgap')
+  })
+
+  it('inlines the xterm UMD build and its fit addon', () => {
+    expect(script).toContain('__xt.exports')
+    expect(script).toContain('__fit.exports')
+    expect(script).toContain('var XTerm =')
+    expect(script).toContain('var FitAddon =')
+  })
+
+  it('injects the xterm stylesheet exactly once via a stable id', () => {
+    expect(script).toContain('__comfyDesktopXtermCss')
+    expect(script).toContain('.xterm')
+  })
+
+  it('registers a custom bottom-panel tab through the extension API', () => {
+    expect(script).toContain('registerExtension')
+    expect(script).toContain('bottomPanelTabs')
+    expect(script).toContain(`type: 'custom'`)
+    expect(script).toContain(`id: 'command-terminal'`)
+    expect(script).toContain(`title: 'Terminal'`)
+  })
+
+  it('uses the shared desktop terminal transport', () => {
+    for (const member of ['subscribe', 'write', 'resize', 'restart', 'onOutput', 'onExited']) {
+      expect(script).toContain(member)
+    }
+  })
+
+  it('memoizes the assembled script', () => {
+    expect(getComfyTerminalContentScript()).toBe(script)
+  })
+})

--- a/src/main/lib/comfyTerminalContentScript.ts
+++ b/src/main/lib/comfyTerminalContentScript.ts
@@ -1,0 +1,228 @@
+/**
+ * Stopgap injection of an interactive "Terminal" bottom-panel tab into the
+ * served ComfyUI frontend, for the window between our frontend/backend terminal
+ * PRs landing and a stable release shipping them.
+ *
+ * It is injected (via `webContents.executeJavaScript`) only for STANDALONE
+ * installs whose ComfyUI does not yet advertise the `supports_terminal` feature
+ * flag — i.e. exactly when the real, flag-gated frontend tab cannot appear, so
+ * there is never a duplicate. Delete this module (and its call site in
+ * `attach.ts`) once stable ships the official tab.
+ *
+ * The transport is the already-injected `window.__comfyDesktop2.Terminal`
+ * bridge (see `comfyPreload.ts`). xterm isn't exposed on `window.comfyAPI`, so
+ * we inline the installed `@xterm/xterm` + `@xterm/addon-fit` UMD builds (read
+ * from node_modules at runtime; works in dev and inside asar) and register a
+ * `type: 'custom'` tab that renders a vanilla xterm view mirroring the real
+ * CommandTerminal behavior (focus-reclaims the shared PTY size, restart banner,
+ * clear-on-output revives the session, refit-after-restore).
+ */
+
+import { createRequire } from 'module'
+import { readFileSync } from 'fs'
+
+// The main bundle is CommonJS, so `__filename` is the right anchor for
+// require.resolve (import.meta.url is unavailable there).
+const require = createRequire(__filename)
+
+let cachedScript: string | null = null
+
+function readPackageFile(id: string): string {
+  return readFileSync(require.resolve(id), 'utf8')
+}
+
+function stripSourceMapComment(source: string): string {
+  return source.replace(/\n?\/\/# sourceMappingURL=.*$/u, '')
+}
+
+/**
+ * Vanilla browser code that registers and renders the stopgap terminal tab.
+ * Runs in the ComfyUI page main world; `XTerm` and `FitAddon` are the UMD
+ * exports captured above it, and `window.__comfyDesktop2.Terminal` is the host
+ * bridge. Kept as a string (not a stringified function) to stay consistent with
+ * the other injected scripts and to avoid bundler/`toString` surprises.
+ */
+const TERMINAL_TAB_MAIN_JS = `
+var STATE = window.__comfyDesktopTerminalStopgap;
+var mounted = null;
+
+function destroyTerminal() {
+  if (!mounted) return;
+  var m = mounted;
+  mounted = null;
+  m.disposed = true;
+  try { if (m.onData) m.onData.dispose(); } catch (e) {}
+  try { if (m.offOutput) m.offOutput(); } catch (e) {}
+  try { if (m.offExited) m.offExited(); } catch (e) {}
+  try { if (m.host && m.onFocus) m.host.removeEventListener('focusin', m.onFocus); } catch (e) {}
+  try { if (m.ro) m.ro.disconnect(); } catch (e) {}
+  if (m.resizeTimer) { clearTimeout(m.resizeTimer); }
+  try { window.__comfyDesktop2.Terminal.unsubscribe(); } catch (e) {}
+  try { if (m.term) m.term.dispose(); } catch (e) {}
+  try { if (m.container) m.container.innerHTML = ''; } catch (e) {}
+}
+
+function renderTerminal(container) {
+  destroyTerminal();
+  var bridge = window.__comfyDesktop2 && window.__comfyDesktop2.Terminal;
+  if (!bridge) return;
+
+  container.style.position = 'relative';
+  container.style.width = '100%';
+  container.style.height = '100%';
+  container.style.minWidth = '0';
+  container.style.overflow = 'hidden';
+  container.style.background = '#171717';
+
+  var host = document.createElement('div');
+  host.style.position = 'absolute';
+  host.style.inset = '0';
+  host.style.padding = '8px';
+  container.appendChild(host);
+
+  var banner = document.createElement('div');
+  banner.style.cssText = 'position:absolute;left:0;right:0;bottom:0;display:none;align-items:center;justify-content:space-between;gap:12px;padding:8px 12px;background:#262626;color:#e5e5e5;font-size:13px;';
+  var bannerText = document.createElement('span');
+  bannerText.textContent = 'This terminal session ended.';
+  var restartBtn = document.createElement('button');
+  restartBtn.textContent = 'Restart';
+  restartBtn.style.cssText = 'cursor:pointer;border:0;border-radius:6px;padding:4px 12px;background:#3b82f6;color:#fff;font-size:12px;';
+  banner.appendChild(bannerText);
+  banner.appendChild(restartBtn);
+  container.appendChild(banner);
+
+  var term = new XTerm({ convertEol: true, theme: { background: '#171717' } });
+  var fitAddon = new FitAddon();
+  term.loadAddon(fitAddon);
+  term.open(host);
+
+  var m = {
+    disposed: false, container: container, host: host, term: term,
+    fitAddon: fitAddon, exited: false, resizeTimer: 0,
+    onData: null, offOutput: null, offExited: null, onFocus: null, ro: null
+  };
+  mounted = m;
+
+  function updateBanner() { banner.style.display = m.exited ? 'flex' : 'none'; }
+
+  // Re-fit to our own container and (re)claim the shared PTY size. forceReclaim
+  // pushes even when our dims are unchanged, because the launcher settings
+  // console may have resized the one PTY out from under us.
+  function doFit(forceReclaim) {
+    if (m.disposed || !host.offsetParent) return;
+    var dims = fitAddon.proposeDimensions();
+    if (!dims || !dims.cols || !dims.rows) return;
+    var changed = dims.cols !== term.cols || dims.rows !== term.rows;
+    if (changed) term.resize(dims.cols, dims.rows);
+    if (changed || forceReclaim) { try { bridge.resize(term.cols, term.rows); } catch (e) {} }
+  }
+
+  function applyRestore(restore) {
+    if (m.disposed || !restore) return;
+    if (restore.buffer && restore.buffer.length) {
+      term.resize(restore.size.cols, restore.size.rows);
+      term.write(restore.buffer.join(''));
+    }
+    m.exited = !!restore.exited;
+    updateBanner();
+    window.requestAnimationFrame(function () { doFit(true); });
+  }
+
+  m.onData = term.onData(function (d) { try { bridge.write(d); } catch (e) {} });
+  m.offOutput = bridge.onOutput(function (msg) {
+    if (m.disposed) return;
+    if (m.exited) { m.exited = false; updateBanner(); }
+    term.write(msg);
+  });
+  m.offExited = bridge.onExited(function () {
+    if (m.disposed) return;
+    m.exited = true; updateBanner();
+  });
+  m.onFocus = function () { doFit(true); };
+  host.addEventListener('focusin', m.onFocus);
+
+  m.ro = new ResizeObserver(function () {
+    if (m.resizeTimer) clearTimeout(m.resizeTimer);
+    m.resizeTimer = setTimeout(function () { doFit(false); }, 50);
+  });
+  m.ro.observe(container);
+
+  function doRestart() {
+    if (m.disposed) return;
+    term.reset();
+    m.exited = false; updateBanner();
+    bridge.restart().then(applyRestore).catch(function () {});
+  }
+  restartBtn.addEventListener('click', doRestart);
+
+  bridge.subscribe().then(function (restore) {
+    if (m.disposed) return;
+    if (restore && restore.exited) doRestart();
+    else applyRestore(restore);
+  }).catch(function () {});
+}
+
+function waitForRegister(timeoutMs) {
+  var startedAt = Date.now();
+  (function tick() {
+    if (STATE.registered) return;
+    var app = window.comfyAPI && window.comfyAPI.app && window.comfyAPI.app.app;
+    var reg = app && app.registerExtension;
+    if (typeof reg === 'function') {
+      try {
+        reg.call(app, {
+          name: 'Comfy.Desktop.TerminalStopgap',
+          bottomPanelTabs: [{
+            id: 'command-terminal',
+            title: 'Terminal',
+            type: 'custom',
+            render: renderTerminal,
+            destroy: destroyTerminal
+          }]
+        });
+        STATE.registered = true;
+      } catch (e) {}
+      return;
+    }
+    if (Date.now() - startedAt > timeoutMs) return;
+    setTimeout(tick, 100);
+  })();
+}
+
+waitForRegister(30000);
+`
+
+/**
+ * Build the self-contained injection script. Memoized: the UMD payloads are
+ * large and never change at runtime.
+ */
+export function getComfyTerminalContentScript(): string {
+  if (cachedScript) return cachedScript
+
+  const xtermJs = stripSourceMapComment(readPackageFile('@xterm/xterm/lib/xterm.js'))
+  const fitJs = stripSourceMapComment(readPackageFile('@xterm/addon-fit/lib/addon-fit.js'))
+  const css = readPackageFile('@xterm/xterm/css/xterm.css')
+
+  cachedScript =
+    `(function () {\n` +
+    `'use strict';\n` +
+    `if (typeof window === 'undefined' || !window.__comfyDesktop2 || !window.__comfyDesktop2.Terminal) return;\n` +
+    `if (window.__comfyDesktopTerminalStopgap) return;\n` +
+    `window.__comfyDesktopTerminalStopgap = { started: true, registered: false };\n` +
+    // Capture the UMD modules into locals so we never touch window.Terminal.
+    `var __xt = { exports: {} };\n` +
+    `(function () { var module = __xt; var exports = __xt.exports;\n${xtermJs}\n}).call(window);\n` +
+    `var __fit = { exports: {} };\n` +
+    `(function () { var module = __fit; var exports = __fit.exports; var self = window;\n${fitJs}\n}).call(window);\n` +
+    `var XTerm = __xt.exports && __xt.exports.Terminal;\n` +
+    `var FitAddon = __fit.exports && __fit.exports.FitAddon;\n` +
+    `if (!XTerm || !FitAddon) return;\n` +
+    `(function () {\n` +
+    `var s = document.getElementById('__comfyDesktopXtermCss');\n` +
+    `if (!s) { s = document.createElement('style'); s.id = '__comfyDesktopXtermCss'; s.textContent = ${JSON.stringify(css)}; (document.head || document.documentElement).appendChild(s); }\n` +
+    `})();\n` +
+    TERMINAL_TAB_MAIN_JS +
+    `})();\n`
+
+  return cachedScript
+}

--- a/src/main/lib/comfyTerminalContentScript.ts
+++ b/src/main/lib/comfyTerminalContentScript.ts
@@ -159,6 +159,10 @@ function renderTerminal(container) {
     if (m.disposed) return;
     if (restore && restore.exited) doRestart();
     else applyRestore(restore);
+    // Force an immediate fit; ResizeObserver may not fire on first mount if
+    // the container's layout was already settled before we attached. Decides
+    // whether the user sees a 0×0 invisible xterm or an actual 80×24 prompt.
+    window.requestAnimationFrame(function () { doFit(true); });
   }).catch(function () {});
 }
 
@@ -211,12 +215,178 @@ function waitForRegister(timeoutMs) {
           }]
         });
         STATE.registered = true;
+        startTerminalTabPopoutInjector();
       } catch (e) {}
       return;
     }
     if (Date.now() - startedAt > timeoutMs) return;
     setTimeout(tick, 100);
   })();
+}
+
+// Inject a small ↗ "open in new window" button onto the Terminal tab's
+// header (the bottom-panel tab strip), positioned right after the
+// "Terminal" label. Vue re-renders that strip on tab switches, so we
+// keep a MutationObserver running for the page's lifetime and re-add
+// the button whenever the previous one disappears. Idempotent: each
+// pass checks for our existing button before re-injecting.
+function startTerminalTabPopoutInjector() {
+  if (STATE.tabBarInjectorStarted) return;
+  STATE.tabBarInjectorStarted = true;
+
+  // Find the bottom-panel header strip — the row that contains both
+  // "Terminal" and "Logs" tab labels. Lock onto its close (✕) button
+  // (the only unique landmark with a stable accessibility label), then
+  // walk up to the smallest ancestor that ALSO has both tabs as leaf
+  // descendants. From there we can enumerate the tab buttons.
+  function findBottomPanelHeader() {
+    var closes = document.querySelectorAll(
+      'button[aria-label="Close"], [role="button"][aria-label="Close"], button[title="Close"]'
+    );
+    for (var i = 0; i < closes.length; i++) {
+      var close = closes[i];
+      if (!close) continue;
+      if (close.classList && close.classList.contains('__comfy-desktop-popout-btn')) continue;
+      var testid = (close.getAttribute && close.getAttribute('data-testid')) || '';
+      if (/minimap/i.test(testid)) continue;
+      var anc = close.parentElement;
+      for (var depth = 0; depth < 6 && anc; depth++) {
+        if (containsLeafText(anc, 'Terminal') && containsLeafText(anc, 'Logs')) {
+          return anc;
+        }
+        anc = anc.parentElement;
+      }
+    }
+    return null;
+  }
+
+  function containsLeafText(root, target) {
+    if (!root || !root.querySelectorAll) return false;
+    var leaves = root.querySelectorAll('*');
+    var pattern = new RegExp('^' + target + '$', 'i');
+    for (var i = 0; i < leaves.length; i++) {
+      var e = leaves[i];
+      if (!e || e.children.length > 0) continue;
+      var txt = (e.textContent || '').trim();
+      if (pattern.test(txt)) return true;
+    }
+    return false;
+  }
+
+  // Inside the bottom-panel header, find each tab BUTTON by walking up
+  // from the leaf that holds the label text. We want the smallest
+  // interactive ancestor (button / role=tab / clickable div) so the
+  // popout icon sits in the same row as the label without disrupting
+  // the tab's own hit area.
+  function findTabButton(headerRoot, labelText) {
+    if (!headerRoot) return null;
+    var leaves = headerRoot.querySelectorAll('*');
+    var pattern = new RegExp('^' + labelText + '$', 'i');
+    for (var i = 0; i < leaves.length; i++) {
+      var leaf = leaves[i];
+      if (!leaf || leaf.children.length > 0) continue;
+      if (leaf.classList && leaf.classList.contains('__comfy-desktop-popout-btn')) continue;
+      var txt = (leaf.textContent || '').trim();
+      if (!pattern.test(txt)) continue;
+      var cur = leaf;
+      for (var d = 0; d < 6 && cur && cur.parentElement; d++) {
+        var p = cur.parentElement;
+        if (p === headerRoot) break;
+        var role = p.getAttribute && p.getAttribute('role');
+        var tag = (p.tagName || '').toLowerCase();
+        var cls = (p.className && p.className.baseVal != null ? p.className.baseVal : p.className) || '';
+        if (role === 'tab' || tag === 'button' || tag === 'a' || /tab/i.test(String(cls))) {
+          return p;
+        }
+        cur = p;
+      }
+      // Fall back to the leaf's parent — better than nothing.
+      return leaf.parentElement || leaf;
+    }
+    return null;
+  }
+
+  function findInsertionPoint() {
+    var close = findCloseButtonNearTerminalAndLogs();
+    if (close && close.parentElement) {
+      return { parent: close.parentElement, before: close };
+    }
+    return null;
+  }
+
+  function makePopoutButton(kind) {
+    var btn = document.createElement('button');
+    btn.className = '__comfy-desktop-popout-btn';
+    btn.setAttribute('data-popout-kind', kind);
+    btn.type = 'button';
+    var ariaLabel = kind === 'terminal'
+      ? 'Open terminal in a new window'
+      : 'Open logs in a new window';
+    btn.title = 'Open in a new window';
+    btn.setAttribute('aria-label', ariaLabel);
+    btn.style.cssText =
+      'display:inline-flex;align-items:center;justify-content:center;' +
+      'width:18px;height:18px;margin-left:6px;padding:0;border:0;' +
+      'background:transparent;color:currentColor;cursor:pointer;' +
+      'opacity:0.55;border-radius:4px;transition:opacity 120ms ease, background 120ms ease;' +
+      'vertical-align:middle;';
+    btn.innerHTML =
+      '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" ' +
+      'stroke="currentColor" stroke-width="2.4" stroke-linecap="round" ' +
+      'stroke-linejoin="round" aria-hidden="true">' +
+      '<path d="M14 3h7v7"/><path d="M21 3l-9 9"/>' +
+      '<path d="M21 14v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5"/>' +
+      '</svg>';
+    btn.addEventListener('mouseenter', function () {
+      btn.style.opacity = '1';
+      btn.style.background = 'rgba(255,255,255,0.08)';
+    });
+    btn.addEventListener('mouseleave', function () {
+      btn.style.opacity = '0.55';
+      btn.style.background = 'transparent';
+    });
+    btn.addEventListener('click', function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+      if (kind === 'terminal') {
+        try { window.__comfyDesktop2.Terminal.openPopout(); } catch (err) {}
+      } else {
+        try { window.__comfyDesktop2.Logs.openPopout(); } catch (err) {}
+      }
+    });
+    return btn;
+  }
+
+  function injectIntoTab(headerRoot, label, kind) {
+    var tab = findTabButton(headerRoot, label);
+    if (!tab) return false;
+    // Don't double-inject if our previous pass already added a button.
+    var existing = tab.querySelector('.__comfy-desktop-popout-btn[data-popout-kind="' + kind + '"]');
+    if (existing) return true;
+    tab.appendChild(makePopoutButton(kind));
+    return true;
+  }
+
+  function tryInject() {
+    var header = findBottomPanelHeader();
+    if (!header) return;
+    injectIntoTab(header, 'Terminal', 'terminal');
+    injectIntoTab(header, 'Logs', 'logs');
+  }
+
+  // Initial attempt + periodic retry while the page is settling.
+  tryInject();
+  var settleTries = 0;
+  var settleInterval = setInterval(function () {
+    settleTries++;
+    tryInject();
+    if (settleTries > 50) clearInterval(settleInterval);
+  }, 200);
+
+  // Persistent observer — re-add the button whenever Vue re-renders
+  // the tab strip. Throttled by re-checking inside tryInject().
+  var observer = new MutationObserver(function () { tryInject(); });
+  observer.observe(document.body, { childList: true, subtree: true });
 }
 
 waitForRegister(30000);
@@ -238,7 +408,7 @@ export function getComfyTerminalContentScript(): string {
     `'use strict';\n` +
     `if (typeof window === 'undefined' || !window.__comfyDesktop2 || !window.__comfyDesktop2.Terminal) return;\n` +
     `if (window.__comfyDesktopTerminalStopgap) return;\n` +
-    `window.__comfyDesktopTerminalStopgap = { started: true, registered: false };\n` +
+    `window.__comfyDesktopTerminalStopgap = { started: true, registered: false, tabBarInjectorStarted: false };\n` +
     // Capture the UMD modules into locals so we never touch window.Terminal.
     `var __xt = { exports: {} };\n` +
     `(function () { var module = __xt; var exports = __xt.exports;\n${xtermJs}\n}).call(window);\n` +

--- a/src/main/lib/comfyTerminalContentScript.ts
+++ b/src/main/lib/comfyTerminalContentScript.ts
@@ -162,6 +162,31 @@ function renderTerminal(container) {
   }).catch(function () {});
 }
 
+// Dedupe guard. The frontend ships a native flag-gated 'command-terminal'
+// bottom-panel tab via the companion ComfyUI_frontend PR; when that lands
+// it registers itself before we tick. Bail out if we see it so the user
+// never gets two tabs with the same id. Defensive over both shapes that
+// ComfyUI exposes (an extensions array, and a future-proof tab registry).
+function alreadyHasTerminalTab(app) {
+  try {
+    var exts = (app && app.extensions) || [];
+    for (var i = 0; i < exts.length; i++) {
+      var ext = exts[i] || {};
+      if (ext.name === 'Comfy.Desktop.TerminalStopgap') continue;
+      var tabs = ext.bottomPanelTabs || [];
+      for (var j = 0; j < tabs.length; j++) {
+        if (tabs[j] && tabs[j].id === 'command-terminal') return true;
+      }
+    }
+  } catch (e) {}
+  try {
+    var registry =
+      app && (app.bottomPanelTabRegistry || (app.workbench && app.workbench.bottomPanelTabRegistry));
+    if (registry && typeof registry.get === 'function' && registry.get('command-terminal')) return true;
+  } catch (e) {}
+  return false;
+}
+
 function waitForRegister(timeoutMs) {
   var startedAt = Date.now();
   (function tick() {
@@ -169,6 +194,11 @@ function waitForRegister(timeoutMs) {
     var app = window.comfyAPI && window.comfyAPI.app && window.comfyAPI.app.app;
     var reg = app && app.registerExtension;
     if (typeof reg === 'function') {
+      // Native frontend tab already mounted — leave it alone.
+      if (alreadyHasTerminalTab(app)) {
+        STATE.registered = true;
+        return;
+      }
       try {
         reg.call(app, {
           name: 'Comfy.Desktop.TerminalStopgap',

--- a/src/main/lib/ipc/index.ts
+++ b/src/main/lib/ipc/index.ts
@@ -37,7 +37,7 @@ export {
   getActiveDetails,
   cancelAll
 } from './shared'
-export type { RegisterCallbacks } from './shared'
+export type { RegisterCallbacks, ExitCallbackInfo } from './shared'
 
 // Idempotent guard so a re-run (tests/hot-reload) doesn't double-subscribe.
 let _releaseCacheBridgeWired = false

--- a/src/main/lib/ipc/index.ts
+++ b/src/main/lib/ipc/index.ts
@@ -25,6 +25,7 @@ import { registerInstallationHandlers } from './registerInstallationHandlers'
 import { registerSnapshotHandlers } from './registerSnapshotHandlers'
 import { registerSettingsHandlers } from './registerSettingsHandlers'
 import { registerSessionHandlers } from './registerSessionHandlers'
+import { registerTerminalHandlers } from './registerTerminalHandlers'
 import { registerCrashHandlers } from './registerCrashHandlers'
 import { registerTelemetryHandlers } from './registerTelemetryHandlers'
 
@@ -205,6 +206,7 @@ export function register(callbacks: RegisterCallbacks = {}): void {
   registerSnapshotHandlers()
   registerSettingsHandlers()
   registerSessionHandlers()
+  registerTerminalHandlers()
   registerCrashHandlers()
   registerTelemetryHandlers()
 }

--- a/src/main/lib/ipc/index.ts
+++ b/src/main/lib/ipc/index.ts
@@ -26,6 +26,7 @@ import { registerSnapshotHandlers } from './registerSnapshotHandlers'
 import { registerSettingsHandlers } from './registerSettingsHandlers'
 import { registerSessionHandlers } from './registerSessionHandlers'
 import { registerTerminalHandlers } from './registerTerminalHandlers'
+import { registerLogsHandlers } from './registerLogsHandlers'
 import { registerCrashHandlers } from './registerCrashHandlers'
 import { registerTelemetryHandlers } from './registerTelemetryHandlers'
 
@@ -211,6 +212,7 @@ export function register(callbacks: RegisterCallbacks = {}): void {
   registerSettingsHandlers()
   registerSessionHandlers()
   registerTerminalHandlers()
+  registerLogsHandlers()
   registerCrashHandlers()
   registerTelemetryHandlers()
 }

--- a/src/main/lib/ipc/registerInstallationHandlers.ts
+++ b/src/main/lib/ipc/registerInstallationHandlers.ts
@@ -36,6 +36,7 @@ import { _broadcastToRenderer } from './shared'
 import { hasGitDir } from '../git'
 import { restoreSnapshotIntoInstallation } from '../standaloneMigration'
 import * as mainTelemetry from '../telemetry'
+import { appendLog } from '../logsBroadcast'
 import { recordIpcInvocation } from '../e2eOverrides'
 
 /** Fire-and-forget: refresh the shared ComfyUI release cache for the
@@ -270,6 +271,7 @@ export function registerInstallationHandlers(): void {
             try {
               if (!sender.isDestroyed()) sender.send('comfy-output', { installationId, text })
             } catch {}
+            appendLog(installationId, text)
           }
           const update = (data: Record<string, unknown>): Promise<void> =>
             installations.update(installationId, data).then(() => {})

--- a/src/main/lib/ipc/registerLogsHandlers.ts
+++ b/src/main/lib/ipc/registerLogsHandlers.ts
@@ -1,0 +1,58 @@
+import { ipcMain } from 'electron'
+import type { IpcMainInvokeEvent } from 'electron'
+import { findInstallationIdByComfySender } from '../../host/registry'
+import { subscribeLogs, unsubscribeLogs, type LogsRestore } from '../logsBroadcast'
+import { openLogsPopout } from '../logsPopoutWindow'
+
+/**
+ * IPC for the logs broadcast — the read-only counterpart of the
+ * interactive terminal channels.
+ *
+ * Callers come in two shapes, same as the terminal IPC:
+ *   - The desktop renderer (Console tab, future Logs panel) passes its
+ *     installationId explicitly.
+ *   - The injected ComfyUI bottom-panel Logs tab does not know its
+ *     installationId; we resolve it from the sender via the comfyView
+ *     registry.
+ *
+ * Subscribe returns the current ring-buffer contents so the caller can
+ * paint immediately. Subsequent broadcasts arrive on `logs-output`.
+ */
+
+const EMPTY_RESTORE: LogsRestore = { installationId: '', buffer: [] }
+
+function resolveInstallationId(
+  event: IpcMainInvokeEvent,
+  explicit: string | null | undefined,
+): string | null {
+  if (explicit) return explicit
+  return findInstallationIdByComfySender(event.sender)
+}
+
+export function registerLogsHandlers(): void {
+  ipcMain.handle(
+    'logs-subscribe',
+    (event, installationId?: string | null): LogsRestore => {
+      const id = resolveInstallationId(event, installationId)
+      if (!id) return EMPTY_RESTORE
+      return subscribeLogs(id, event.sender)
+    },
+  )
+
+  ipcMain.handle('logs-unsubscribe', (event, installationId?: string | null) => {
+    const id = resolveInstallationId(event, installationId)
+    if (id) unsubscribeLogs(id, event.sender)
+  })
+
+  // Pop the inline logs out into a standalone Electron window. Same
+  // sender-resolution path as terminal-popout-open so the caller
+  // (inline injection in the comfyView) never has to know its own id.
+  ipcMain.handle(
+    'logs-popout-open',
+    async (event, installationId?: string | null): Promise<void> => {
+      const id = resolveInstallationId(event, installationId)
+      if (!id) return
+      await openLogsPopout(id)
+    },
+  )
+}

--- a/src/main/lib/ipc/registerSettingsHandlers.ts
+++ b/src/main/lib/ipc/registerSettingsHandlers.ts
@@ -55,6 +55,16 @@ export function buildSettingsSections(): SettingsSection[] {
           type: 'boolean',
           value: s.autoInstallUpdates !== false
         },
+        // Local-only users have asked us to make the Cloud tile go away.
+        // Cloud is still a first-class peer; this is an opt-out, not a
+        // removal — default off, surface as a plain toggle.
+        {
+          id: 'hideCloudFromPicker',
+          label: i18n.t('settings.hideCloudFromPicker'),
+          type: 'boolean',
+          value: s.hideCloudFromPicker === true,
+          tooltip: i18n.t('settings.hideCloudFromPickerDescription')
+        },
         // onAppClose field hidden while docking-to-tray is disabled.
         ...(isChinese ? [chineseMirrorsField] : [])
       ]

--- a/src/main/lib/ipc/registerSettingsHandlers.ts
+++ b/src/main/lib/ipc/registerSettingsHandlers.ts
@@ -38,6 +38,9 @@ export function buildSettingsSections(): SettingsSection[] {
     {
       title: i18n.t('settings.general'),
       fields: [
+        // Locale picker first — most users only ever touch this once and
+        // then forget the panel exists. Keeping it at the top so it's
+        // discoverable.
         {
           id: 'language',
           label: i18n.t('settings.language'),
@@ -47,31 +50,46 @@ export function buildSettingsSections(): SettingsSection[] {
         },
         // Theme picker hidden (app is dark-only); the theme plumbing stays
         // wired so re-adding this field is the only change needed to restore it.
-        // autoInstallUpdates toggles silent-install vs prompt; the auto-check
-        // loop itself always runs.
-        {
-          id: 'autoInstallUpdates',
-          label: i18n.t('settings.autoInstallUpdates'),
-          type: 'boolean',
-          value: s.autoInstallUpdates !== false
-        },
-        // Restore the last-used instance window on launch (Jedrzej #939)
-        // so power users don't need to reopen the picker every cold start.
+
+        // Window-behavior block — these two travel together:
+        //   reopenLastInstanceOnLaunch + closeDirectlyOnLastWindow
+        // together implement the "feel like a single-app workspace" flow
+        // (quit closes the instance, next launch boots straight back in).
         {
           id: 'reopenLastInstanceOnLaunch',
           label: i18n.t('settings.reopenLastInstanceOnLaunch'),
           type: 'boolean',
           value: s.reopenLastInstanceOnLaunch !== false
         },
-        // Local-only users have asked us to make the Cloud tile go away.
-        // Cloud is still a first-class peer; this is an opt-out, not a
-        // removal — default off, surface as a plain toggle.
+        {
+          id: 'closeDirectlyOnLastWindow',
+          label: i18n.t('settings.closeDirectlyOnLastWindow'),
+          type: 'boolean',
+          value: s.closeDirectlyOnLastWindow === true,
+          tooltip: i18n.t('settings.closeDirectlyOnLastWindowDescription')
+        },
+
+        // Cloud opt-out — pure visibility toggle, doesn't affect any
+        // running behavior. Kept after the window-behavior block so
+        // users who don't care about Cloud find it without scrolling
+        // past the more invasive ones.
         {
           id: 'hideCloudFromPicker',
           label: i18n.t('settings.hideCloudFromPicker'),
           type: 'boolean',
           value: s.hideCloudFromPicker === true,
           tooltip: i18n.t('settings.hideCloudFromPickerDescription')
+        },
+
+        // autoInstallUpdates is filtered out of generalFields by
+        // buildGlobalSettingsSnapshot — it renders inside the Updates
+        // tab. Keeping the field definition here so the schema stays
+        // single-source.
+        {
+          id: 'autoInstallUpdates',
+          label: i18n.t('settings.autoInstallUpdates'),
+          type: 'boolean',
+          value: s.autoInstallUpdates !== false
         },
         // onAppClose field hidden while docking-to-tray is disabled.
         ...(isChinese ? [chineseMirrorsField] : [])

--- a/src/main/lib/ipc/registerSettingsHandlers.ts
+++ b/src/main/lib/ipc/registerSettingsHandlers.ts
@@ -55,6 +55,12 @@ export function buildSettingsSections(): SettingsSection[] {
           type: 'boolean',
           value: s.autoInstallUpdates !== false
         },
+        {
+          id: 'reopenLastInstanceOnLaunch',
+          label: i18n.t('settings.reopenLastInstanceOnLaunch'),
+          type: 'boolean',
+          value: s.reopenLastInstanceOnLaunch !== false
+        },
         // onAppClose field hidden while docking-to-tray is disabled.
         ...(isChinese ? [chineseMirrorsField] : [])
       ]

--- a/src/main/lib/ipc/registerTerminalHandlers.ts
+++ b/src/main/lib/ipc/registerTerminalHandlers.ts
@@ -1,0 +1,86 @@
+import { ipcMain } from 'electron'
+import type { IpcMainInvokeEvent } from 'electron'
+import { findInstallationIdByComfySender } from '../../host/registry'
+import {
+  subscribeTerminal,
+  unsubscribeTerminal,
+  writeTerminal,
+  resizeTerminal,
+  restartTerminal,
+  getTerminalRestore,
+  type TerminalRestore,
+} from '../terminal'
+
+/**
+ * IPC for the interactive per-installation console.
+ *
+ * Two kinds of caller share these channels:
+ *   - The desktop renderer (Settings "Console" tab), which knows the
+ *     installationId and passes it explicitly.
+ *   - The served ComfyUI frontend inside a comfyView, which does NOT know its
+ *     installationId — we resolve it from the sender via the host registry.
+ *
+ * Output/exit are pushed straight to the subscribing webContents, so the
+ * frontend never needs to know its own installationId.
+ */
+
+const EMPTY_RESTORE: TerminalRestore = {
+  buffer: [],
+  size: { cols: 80, rows: 30 },
+  exited: true,
+}
+
+function resolveInstallationId(
+  event: IpcMainInvokeEvent,
+  explicit: string | null | undefined,
+): string | null {
+  if (explicit) return explicit
+  return findInstallationIdByComfySender(event.sender)
+}
+
+export function registerTerminalHandlers(): void {
+  ipcMain.handle(
+    'terminal-subscribe',
+    async (event, installationId?: string | null): Promise<TerminalRestore> => {
+      const id = resolveInstallationId(event, installationId)
+      if (!id) return EMPTY_RESTORE
+      return subscribeTerminal(id, event.sender)
+    },
+  )
+
+  ipcMain.handle('terminal-unsubscribe', (event, installationId?: string | null) => {
+    const id = resolveInstallationId(event, installationId)
+    if (id) unsubscribeTerminal(id, event.sender)
+  })
+
+  ipcMain.handle('terminal-write', (event, installationId: string | null, data: string) => {
+    const id = resolveInstallationId(event, installationId)
+    if (id) writeTerminal(id, data)
+  })
+
+  ipcMain.handle(
+    'terminal-resize',
+    (event, installationId: string | null, cols: number, rows: number) => {
+      const id = resolveInstallationId(event, installationId)
+      if (id) resizeTerminal(id, cols, rows)
+    },
+  )
+
+  ipcMain.handle(
+    'terminal-restart',
+    async (event, installationId?: string | null): Promise<TerminalRestore> => {
+      const id = resolveInstallationId(event, installationId)
+      if (!id) return EMPTY_RESTORE
+      return restartTerminal(id)
+    },
+  )
+
+  ipcMain.handle(
+    'terminal-restore',
+    (event, installationId?: string | null): TerminalRestore => {
+      const id = resolveInstallationId(event, installationId)
+      if (!id) return EMPTY_RESTORE
+      return getTerminalRestore(id) ?? EMPTY_RESTORE
+    },
+  )
+}

--- a/src/main/lib/ipc/registerTerminalHandlers.ts
+++ b/src/main/lib/ipc/registerTerminalHandlers.ts
@@ -10,6 +10,7 @@ import {
   getTerminalRestore,
   type TerminalRestore,
 } from '../terminal'
+import { openTerminalPopout } from '../terminalPopoutWindow'
 
 /**
  * IPC for the interactive per-installation console.
@@ -81,6 +82,19 @@ export function registerTerminalHandlers(): void {
       const id = resolveInstallationId(event, installationId)
       if (!id) return EMPTY_RESTORE
       return getTerminalRestore(id) ?? EMPTY_RESTORE
+    },
+  )
+
+  // Pop the inline terminal out into a standalone Electron window.
+  // Caller (the inline injection in the comfyView) doesn't pass an
+  // installationId — we resolve it from the sender's registered
+  // comfyView so the popout always targets the right shell.
+  ipcMain.handle(
+    'terminal-popout-open',
+    async (event, installationId?: string | null): Promise<void> => {
+      const id = resolveInstallationId(event, installationId)
+      if (!id) return
+      await openTerminalPopout(id)
     },
   )
 }

--- a/src/main/lib/ipc/sessionActions/delegate.ts
+++ b/src/main/lib/ipc/sessionActions/delegate.ts
@@ -4,6 +4,7 @@ import {
   _operationAborts,
 } from '../shared'
 import type { ActionContext, ActionResult } from './types'
+import { appendLog } from '../../logsBroadcast'
 
 export async function handleDelegateToSource({ event, installationId, inst, actionData }: ActionContext, actionId: string): Promise<ActionResult> {
   const abort = new AbortController()
@@ -14,6 +15,7 @@ export async function handleDelegateToSource({ event, installationId, inst, acti
   }
   const sendOutput = (text: string): void => {
     try { if (!sender.isDestroyed()) sender.send('comfy-output', { installationId, text }) } catch {}
+    appendLog(installationId, text)
   }
   const update = (data: Record<string, unknown>): Promise<void> =>
     installations.update(installationId, data).then(() => {})

--- a/src/main/lib/ipc/sessionActions/launch.ts
+++ b/src/main/lib/ipc/sessionActions/launch.ts
@@ -27,6 +27,7 @@ import { rotateLogFiles, getLogDir } from '../../logRotation'
 import { createExecutionTap } from '../../executionTap'
 import { clearCrash, recordCrash } from '../../crashBuffer'
 import * as telemetry from '../../telemetry'
+import { appendLog } from '../../logsBroadcast'
 import { ensureManagerMirrorConfig } from '../../managerConfig'
 import type { WriteStream } from 'fs'
 
@@ -375,6 +376,7 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
     if (!sender.isDestroyed()) {
       sender.send('comfy-output', { installationId, text })
     }
+    appendLog(installationId, text)
   }
 
   const logStream = await openLogStream(inst.installPath)
@@ -418,6 +420,7 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
     if (!sender.isDestroyed()) {
       sender.send('comfy-output', { installationId, text: `> ${cmdLine}\n\n` })
     }
+    appendLog(installationId, `> ${cmdLine}\n\n`)
     // Explicit boot-attempt event. `installation_started` already fires
     // on successful boot with `boot_time_ms`, and `comfyui.exited` carries
     // `crashed=true` on failure — but boot success rate needed inferred

--- a/src/main/lib/ipc/sessionActions/launch.ts
+++ b/src/main/lib/ipc/sessionActions/launch.ts
@@ -33,6 +33,10 @@ import type { WriteStream } from 'fs'
 // install's --list-feature-flags registry so we never inject unrecognized keys.
 const DESKTOP_FEATURE_FLAGS: Record<string, string> = {
   show_signin_button: 'true',
+  // Advertises that an interactive terminal host is available, so the frontend
+  // may surface its bottom-panel terminal. The actual transport is the
+  // __comfyDesktop2.Terminal bridge; the flag only gates visibility.
+  supports_terminal: 'true',
 }
 
 // A clean exit is code 0 with no signal; anything else (non-zero code or a

--- a/src/main/lib/ipc/sessionActions/launch.ts
+++ b/src/main/lib/ipc/sessionActions/launch.ts
@@ -270,7 +270,7 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
       if (!sender.isDestroyed()) {
         sender.send('comfy-exited', exitedPayload)
       }
-      if (_onComfyExited) _onComfyExited({ installationId })
+      if (_onComfyExited) _onComfyExited({ installationId, crashed })
     })
 
     if (_onLaunch) {
@@ -671,7 +671,7 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
       if (!sender.isDestroyed()) {
         sender.send('comfy-exited', exitedPayload)
       }
-      if (_onComfyExited) _onComfyExited({ installationId })
+      if (_onComfyExited) _onComfyExited({ installationId, crashed })
     })
   }
   attachExitHandler(proc)

--- a/src/main/lib/ipc/shared.ts
+++ b/src/main/lib/ipc/shared.ts
@@ -22,6 +22,7 @@ import { extractNested as extract } from '../extract'
 import { deleteDir, formatDeleteStatus } from '../delete'
 import { deleteAction, untrackAction } from '../actions'
 import { _broadcastToRenderer } from './broadcast'
+import { appendLog } from '../logsBroadcast'
 import {
   spawnProcess, waitForPort, waitForUrl, killProcessTree, killByPort,
   findPidsByPort, getProcessInfo, looksLikeComfyUI, setPortArg,
@@ -724,6 +725,7 @@ export function makeSendProgress(sender: Electron.WebContents, installationId: s
 export function makeSendOutput(sender: Electron.WebContents, installationId: string): (text: string) => void {
   return (text: string): void => {
     try { if (!sender.isDestroyed()) sender.send('comfy-output', { installationId, text }) } catch {}
+    appendLog(installationId, text)
   }
 }
 

--- a/src/main/lib/ipc/shared.ts
+++ b/src/main/lib/ipc/shared.ts
@@ -123,6 +123,9 @@ export interface StopCallbackInfo {
 
 export interface ExitCallbackInfo {
   installationId?: string
+  /** True when the process exited unexpectedly (non-zero code or a signal),
+   *  as opposed to a clean user-initiated stop. */
+  crashed?: boolean
 }
 
 export interface RestartCallbackInfo {

--- a/src/main/lib/lastSession.test.ts
+++ b/src/main/lib/lastSession.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+let testStateDir = ''
+
+// Mock paths.ts directly: stateDir() reads XDG_STATE_HOME on Linux, bypassing
+// the electron.app.getPath mock and breaking CI.
+vi.mock('./paths', () => ({
+  stateDir: () => testStateDir
+}))
+
+vi.mock('electron', () => ({
+  app: { getPath: () => testStateDir }
+}))
+
+import {
+  _resetLastSessionCacheForTest,
+  clearLastActiveSurface,
+  flushLastSession,
+  getLastActiveSurface,
+  recordDashboardSurface,
+  recordInstanceSurface
+} from './lastSession'
+
+const statePath = (): string => path.join(testStateDir, 'last-session.json')
+
+beforeEach(() => {
+  testStateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'last-session-'))
+  _resetLastSessionCacheForTest()
+})
+
+afterEach(() => {
+  fs.rmSync(testStateDir, { recursive: true, force: true })
+})
+
+describe('getLastActiveSurface', () => {
+  it('returns null when no state file exists', () => {
+    expect(getLastActiveSurface()).toBeNull()
+  })
+
+  it('reads a persisted instance surface from disk', () => {
+    fs.writeFileSync(statePath(), JSON.stringify({ kind: 'instance', installationId: 'inst-A' }))
+    expect(getLastActiveSurface()).toEqual({ kind: 'instance', installationId: 'inst-A' })
+  })
+
+  it('reads a persisted dashboard surface from disk', () => {
+    fs.writeFileSync(statePath(), JSON.stringify({ kind: 'dashboard' }))
+    expect(getLastActiveSurface()).toEqual({ kind: 'dashboard' })
+  })
+
+  it('returns null for a malformed instance record (missing id)', () => {
+    fs.writeFileSync(statePath(), JSON.stringify({ kind: 'instance' }))
+    expect(getLastActiveSurface()).toBeNull()
+  })
+
+  it('returns null for unparseable JSON', () => {
+    fs.writeFileSync(statePath(), 'not json')
+    expect(getLastActiveSurface()).toBeNull()
+  })
+})
+
+describe('recordInstanceSurface / recordDashboardSurface', () => {
+  it('records and flushes an instance surface to disk', async () => {
+    recordInstanceSurface('inst-B')
+    expect(getLastActiveSurface()).toEqual({ kind: 'instance', installationId: 'inst-B' })
+    await flushLastSession()
+    expect(JSON.parse(fs.readFileSync(statePath(), 'utf-8'))).toEqual({
+      kind: 'instance',
+      installationId: 'inst-B'
+    })
+  })
+
+  it('records and flushes a dashboard surface to disk', async () => {
+    recordDashboardSurface()
+    expect(getLastActiveSurface()).toEqual({ kind: 'dashboard' })
+    await flushLastSession()
+    expect(JSON.parse(fs.readFileSync(statePath(), 'utf-8'))).toEqual({ kind: 'dashboard' })
+  })
+
+  it('overwrites a prior surface', () => {
+    recordInstanceSurface('inst-C')
+    recordDashboardSurface()
+    expect(getLastActiveSurface()).toEqual({ kind: 'dashboard' })
+    recordInstanceSurface('inst-D')
+    expect(getLastActiveSurface()).toEqual({ kind: 'instance', installationId: 'inst-D' })
+  })
+})
+
+describe('clearLastActiveSurface', () => {
+  it('drops in-memory state and removes the file on flush', async () => {
+    recordInstanceSurface('inst-E')
+    await flushLastSession()
+    expect(fs.existsSync(statePath())).toBe(true)
+
+    clearLastActiveSurface()
+    expect(getLastActiveSurface()).toBeNull()
+    await flushLastSession()
+    expect(fs.existsSync(statePath())).toBe(false)
+  })
+})

--- a/src/main/lib/lastSession.test.ts
+++ b/src/main/lib/lastSession.test.ts
@@ -15,10 +15,16 @@ vi.mock('electron', () => ({
   app: { getPath: () => testStateDir }
 }))
 
+let quitInProgress = false
+vi.mock('./quit-state', () => ({
+  isQuitInProgress: () => quitInProgress
+}))
+
 import {
   _resetLastSessionCacheForTest,
   clearLastActiveSurface,
   flushLastSession,
+  flushLastSessionSync,
   getLastActiveSurface,
   recordDashboardSurface,
   recordInstanceSurface
@@ -28,6 +34,7 @@ const statePath = (): string => path.join(testStateDir, 'last-session.json')
 
 beforeEach(() => {
   testStateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'last-session-'))
+  quitInProgress = false
   _resetLastSessionCacheForTest()
 })
 
@@ -85,6 +92,38 @@ describe('recordInstanceSurface / recordDashboardSurface', () => {
     expect(getLastActiveSurface()).toEqual({ kind: 'dashboard' })
     recordInstanceSurface('inst-D')
     expect(getLastActiveSurface()).toEqual({ kind: 'instance', installationId: 'inst-D' })
+  })
+
+  it('skips recording while a quit is in progress', () => {
+    quitInProgress = true
+    recordInstanceSurface('inst-Q')
+    recordDashboardSurface()
+    expect(getLastActiveSurface()).toBeNull()
+  })
+})
+
+describe('flushLastSessionSync', () => {
+  it('synchronously persists a recorded instance surface', () => {
+    recordInstanceSurface('inst-F')
+    flushLastSessionSync()
+    expect(JSON.parse(fs.readFileSync(statePath(), 'utf-8'))).toEqual({
+      kind: 'instance',
+      installationId: 'inst-F'
+    })
+  })
+
+  it('synchronously removes the file when state was cleared', () => {
+    recordInstanceSurface('inst-G')
+    flushLastSessionSync()
+    expect(fs.existsSync(statePath())).toBe(true)
+    clearLastActiveSurface()
+    flushLastSessionSync()
+    expect(fs.existsSync(statePath())).toBe(false)
+  })
+
+  it('is a no-op when nothing was recorded', () => {
+    flushLastSessionSync()
+    expect(fs.existsSync(statePath())).toBe(false)
   })
 })
 

--- a/src/main/lib/lastSession.ts
+++ b/src/main/lib/lastSession.ts
@@ -1,0 +1,96 @@
+import path from 'path'
+import fs from 'fs'
+import { stateDir } from './paths'
+
+/**
+ * The surface the user last had active, persisted across quits so the next
+ * boot can reopen it. `instance` carries the installation id so the boot flow
+ * can re-launch that specific install; `dashboard` opens the chooser host.
+ */
+export type LastActiveSurface =
+  | { kind: 'dashboard' }
+  | { kind: 'instance'; installationId: string }
+
+const lastSessionPath = (): string => path.join(stateDir(), 'last-session.json')
+
+let cache: LastActiveSurface | null | undefined
+let flushTimer: ReturnType<typeof setTimeout> | null = null
+
+function isSurface(value: unknown): value is LastActiveSurface {
+  if (!value || typeof value !== 'object') return false
+  const v = value as { kind?: unknown; installationId?: unknown }
+  if (v.kind === 'dashboard') return true
+  if (v.kind === 'instance') return typeof v.installationId === 'string' && v.installationId.length > 0
+  return false
+}
+
+function load(): LastActiveSurface | null {
+  if (cache !== undefined) return cache
+  try {
+    const parsed: unknown = JSON.parse(fs.readFileSync(lastSessionPath(), 'utf-8'))
+    cache = isSurface(parsed) ? parsed : null
+  } catch {
+    cache = null
+  }
+  return cache
+}
+
+function scheduleFlush(): void {
+  if (flushTimer) clearTimeout(flushTimer)
+  flushTimer = setTimeout(() => void flushLastSession(), 250)
+}
+
+/** Persist the in-memory surface to disk. Safe to call when nothing changed. */
+export async function flushLastSession(): Promise<void> {
+  if (cache === undefined) return
+  try {
+    const p = lastSessionPath()
+    await fs.promises.mkdir(path.dirname(p), { recursive: true })
+    if (cache === null) {
+      await fs.promises.rm(p, { force: true })
+    } else {
+      await fs.promises.writeFile(p, JSON.stringify(cache, null, 2))
+    }
+  } catch {
+    // Best-effort: a failed write just means the next boot falls back to the
+    // dashboard, which is the safe default.
+  }
+}
+
+/** The persisted surface from the previous session, or `null` if none. */
+export function getLastActiveSurface(): LastActiveSurface | null {
+  return load()
+}
+
+/** Record that the dashboard (chooser host) is the active surface. Deduped so
+ *  focus churn doesn't spam writes. */
+export function recordDashboardSurface(): void {
+  const current = load()
+  if (current?.kind === 'dashboard') return
+  cache = { kind: 'dashboard' }
+  scheduleFlush()
+}
+
+/** Record that an instance window is the active surface. Deduped per id. */
+export function recordInstanceSurface(installationId: string): void {
+  const current = load()
+  if (current?.kind === 'instance' && current.installationId === installationId) return
+  cache = { kind: 'instance', installationId }
+  scheduleFlush()
+}
+
+/** Drop the persisted surface (e.g. the restore target install was deleted). */
+export function clearLastActiveSurface(): void {
+  if (cache === null) return
+  cache = null
+  scheduleFlush()
+}
+
+/** Test-only reset of the in-memory cache. */
+export function _resetLastSessionCacheForTest(): void {
+  cache = undefined
+  if (flushTimer) {
+    clearTimeout(flushTimer)
+    flushTimer = null
+  }
+}

--- a/src/main/lib/lastSession.ts
+++ b/src/main/lib/lastSession.ts
@@ -1,6 +1,7 @@
 import path from 'path'
 import fs from 'fs'
 import { stateDir } from './paths'
+import { isQuitInProgress } from './quit-state'
 
 /**
  * The surface the user last had active, persisted across quits so the next
@@ -46,10 +47,42 @@ export async function flushLastSession(): Promise<void> {
   try {
     const p = lastSessionPath()
     await fs.promises.mkdir(path.dirname(p), { recursive: true })
-    if (cache === null) {
+    const data = serialize()
+    if (data === null) {
       await fs.promises.rm(p, { force: true })
     } else {
-      await fs.promises.writeFile(p, JSON.stringify(cache, null, 2))
+      await fs.promises.writeFile(p, data)
+    }
+  } catch {
+    // Best-effort: a failed write just means the next boot falls back to the
+    // dashboard, which is the safe default.
+  }
+}
+
+/** Build the bytes to persist, or `null` to remove the file. */
+function serialize(): string | null {
+  return cache == null ? null : JSON.stringify(cache, null, 2)
+}
+
+/**
+ * Persist the in-memory surface synchronously. Used on `will-quit`, where
+ * Electron exits without awaiting promises — an async write would be torn down
+ * mid-flight and lose a surface change made right before quitting.
+ */
+export function flushLastSessionSync(): void {
+  if (cache === undefined) return
+  if (flushTimer) {
+    clearTimeout(flushTimer)
+    flushTimer = null
+  }
+  try {
+    const p = lastSessionPath()
+    fs.mkdirSync(path.dirname(p), { recursive: true })
+    const data = serialize()
+    if (data === null) {
+      fs.rmSync(p, { force: true })
+    } else {
+      fs.writeFileSync(p, data)
     }
   } catch {
     // Best-effort: a failed write just means the next boot falls back to the
@@ -63,16 +96,20 @@ export function getLastActiveSurface(): LastActiveSurface | null {
 }
 
 /** Record that the dashboard (chooser host) is the active surface. Deduped so
- *  focus churn doesn't spam writes. */
+ *  focus churn doesn't spam writes. Skipped while quitting: the user's last
+ *  surface is whatever they left from, not focus churn during teardown. */
 export function recordDashboardSurface(): void {
+  if (isQuitInProgress()) return
   const current = load()
   if (current?.kind === 'dashboard') return
   cache = { kind: 'dashboard' }
   scheduleFlush()
 }
 
-/** Record that an instance window is the active surface. Deduped per id. */
+/** Record that an instance window is the active surface. Deduped per id.
+ *  Skipped while quitting (see {@link recordDashboardSurface}). */
 export function recordInstanceSurface(installationId: string): void {
+  if (isQuitInProgress()) return
   const current = load()
   if (current?.kind === 'instance' && current.installationId === installationId) return
   cache = { kind: 'instance', installationId }

--- a/src/main/lib/logsBroadcast.ts
+++ b/src/main/lib/logsBroadcast.ts
@@ -1,0 +1,119 @@
+/**
+ * Per-installation log broadcast + buffered backfill.
+ *
+ * The launching window receives ComfyUI stdout/stderr via direct
+ * `sender.send('comfy-output', ...)` calls scattered across the launch /
+ * delegate / installation handlers. That's fine for the one window that
+ * triggered the launch, but the logs pop-out window needs the SAME stream
+ * delivered to a different webContents — and it wants the recent history
+ * up front, not just text that arrives after it subscribes.
+ *
+ * This module owns the broadcast side:
+ *
+ *   - `appendLog(installationId, text)` is called at every send-site so the
+ *     buffer + subscriber broadcast stay in lockstep with the legacy direct
+ *     send. The existing send to the launching window is preserved unchanged
+ *     — this is a parallel fan-out.
+ *
+ *   - `subscribeLogs(installationId, wc)` registers a webContents as a live
+ *     subscriber and returns the current ring-buffer contents so the
+ *     subscriber can paint immediately.
+ *
+ *   - `unsubscribeLogs(installationId, wc)` removes the subscriber (called
+ *     on window close).
+ *
+ * The buffer is a simple ring of text chunks (not lines). We cap by
+ * total character count rather than entries so a burst of tiny chunks
+ * can't be evicted by a single big one.
+ */
+
+import type { WebContents } from 'electron'
+
+const MAX_BUFFER_CHARS = 256 * 1024 // 256 KB per install — generous, fits any reasonable scrollback
+
+interface InstallLogState {
+  buffer: string[]
+  bufferSize: number
+  subscribers: Set<WebContents>
+}
+
+const states = new Map<string, InstallLogState>()
+
+function ensureState(installationId: string): InstallLogState {
+  let s = states.get(installationId)
+  if (!s) {
+    s = { buffer: [], bufferSize: 0, subscribers: new Set() }
+    states.set(installationId, s)
+  }
+  return s
+}
+
+function evictUntilBelowCap(state: InstallLogState): void {
+  while (state.bufferSize > MAX_BUFFER_CHARS && state.buffer.length > 0) {
+    const dropped = state.buffer.shift()!
+    state.bufferSize -= dropped.length
+  }
+}
+
+/**
+ * Record a log chunk and broadcast it to every live subscriber.
+ * Called at every `sender.send('comfy-output', ...)` site so the
+ * pop-out window stays in lockstep with the launching window.
+ */
+export function appendLog(installationId: string, text: string): void {
+  if (!text) return
+  const state = ensureState(installationId)
+  state.buffer.push(text)
+  state.bufferSize += text.length
+  evictUntilBelowCap(state)
+  for (const wc of state.subscribers) {
+    if (wc.isDestroyed()) {
+      state.subscribers.delete(wc)
+      continue
+    }
+    try {
+      wc.send('logs-output', { installationId, text })
+    } catch {
+      // Subscriber may have torn down between checks; ignore.
+    }
+  }
+}
+
+export interface LogsRestore {
+  installationId: string
+  buffer: string[]
+}
+
+/**
+ * Register a webContents as a subscriber and return the current ring
+ * buffer so the new subscriber can paint immediately. Idempotent —
+ * re-subscribing the same webContents is a no-op (just returns the
+ * fresh buffer).
+ */
+export function subscribeLogs(installationId: string, wc: WebContents): LogsRestore {
+  const state = ensureState(installationId)
+  state.subscribers.add(wc)
+  // Auto-cleanup if the subscriber webContents goes away without an
+  // explicit unsubscribe (window crash, abrupt close).
+  wc.once('destroyed', () => {
+    state.subscribers.delete(wc)
+  })
+  return {
+    installationId,
+    buffer: state.buffer.slice(),
+  }
+}
+
+export function unsubscribeLogs(installationId: string, wc: WebContents): void {
+  const state = states.get(installationId)
+  if (!state) return
+  state.subscribers.delete(wc)
+}
+
+/** Read-only snapshot of the current buffer — used by the popout HTML
+ *  for the initial paint when it can't await the subscribe IPC. */
+export function getLogsBuffer(installationId: string): string[] {
+  const state = states.get(installationId)
+  if (!state) return []
+  return state.buffer.slice()
+}

--- a/src/main/lib/logsPopoutWindow.ts
+++ b/src/main/lib/logsPopoutWindow.ts
@@ -1,0 +1,161 @@
+/**
+ * Pop-out logs window. Standalone BrowserWindow that shows the live
+ * stdout/stderr stream of a ComfyUI install. Subscribes to the same
+ * per-install broadcast as the inline Logs panel, so it stays in
+ * lockstep with the launching window.
+ *
+ * Unlike the terminal pop-out (full interactive PTY via xterm), this
+ * is a read-only auto-scrolling text view. The append-only model lets
+ * us avoid xterm entirely — text wraps natively and the browser handles
+ * selection/copy.
+ *
+ * Auto-scroll is sticky: if the user scrolls up to inspect, we stop
+ * pinning to the bottom. If they scroll back to within a few pixels of
+ * the bottom, sticky-mode re-engages.
+ */
+
+import { BrowserWindow } from 'electron'
+import path from 'path'
+import { COMFY_BG } from './theme'
+import * as installations from '../installations'
+
+/**
+ * The standalone bootstrap that the pop-out window executes in its
+ * renderer. The launcher inserts `__comfyDesktopLogsPopoutInstallationId`
+ * before this script runs.
+ */
+const POPOUT_MAIN_JS = `
+(function () {
+  'use strict';
+  if (window.__comfyDesktopLogsPopoutMounted) return;
+  window.__comfyDesktopLogsPopoutMounted = true;
+  var INSTALL_ID = window.__comfyDesktopLogsPopoutInstallationId;
+  var bridge = window.__comfyDesktop2 && window.__comfyDesktop2.Logs;
+  if (!INSTALL_ID || !bridge) return;
+
+  var root = document.body;
+  root.style.background = '#171717';
+  root.style.margin = '0';
+  root.style.padding = '0';
+  root.style.height = '100vh';
+  root.style.boxSizing = 'border-box';
+  root.style.overflow = 'hidden';
+  root.style.display = 'flex';
+  root.style.flexDirection = 'column';
+
+  var toolbar = document.createElement('div');
+  toolbar.style.cssText = 'flex:0 0 auto;display:flex;align-items:center;justify-content:flex-end;gap:8px;padding:6px 12px;background:#0f0f0f;border-bottom:1px solid #2a2a2a;color:#a3a3a3;font-size:12px;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif;';
+  var stickyChip = document.createElement('span');
+  stickyChip.textContent = 'Auto-scroll on';
+  stickyChip.style.cssText = 'opacity:0.7;';
+  var clearBtn = document.createElement('button');
+  clearBtn.textContent = 'Clear';
+  clearBtn.style.cssText = 'cursor:pointer;border:1px solid #2a2a2a;border-radius:6px;padding:2px 10px;background:#171717;color:#e5e5e5;font-size:12px;';
+  toolbar.appendChild(stickyChip);
+  toolbar.appendChild(clearBtn);
+  root.appendChild(toolbar);
+
+  var view = document.createElement('pre');
+  view.style.cssText = 'flex:1 1 auto;margin:0;padding:8px 12px;overflow:auto;white-space:pre-wrap;word-break:break-word;color:#e5e5e5;font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,Liberation Mono,Courier New,monospace;font-size:12px;line-height:1.45;background:#171717;';
+  root.appendChild(view);
+
+  var state = { sticky: true, disposed: false };
+
+  function isAtBottom() {
+    return view.scrollHeight - view.clientHeight - view.scrollTop < 8;
+  }
+
+  function append(text) {
+    if (!text) return;
+    view.appendChild(document.createTextNode(text));
+    if (state.sticky) view.scrollTop = view.scrollHeight;
+  }
+
+  view.addEventListener('scroll', function () {
+    var atBottom = isAtBottom();
+    if (atBottom !== state.sticky) {
+      state.sticky = atBottom;
+      stickyChip.textContent = state.sticky ? 'Auto-scroll on' : 'Auto-scroll paused';
+    }
+  });
+
+  clearBtn.addEventListener('click', function () {
+    view.textContent = '';
+    state.sticky = true;
+    stickyChip.textContent = 'Auto-scroll on';
+  });
+
+  var offOutput = bridge.onOutput(function (msg) {
+    if (state.disposed) return;
+    if (!msg || msg.installationId !== INSTALL_ID) return;
+    append(msg.text);
+  });
+
+  window.addEventListener('beforeunload', function () {
+    state.disposed = true;
+    try { offOutput && offOutput(); } catch (e) {}
+    try { bridge.unsubscribe(INSTALL_ID); } catch (e) {}
+  });
+
+  bridge.subscribe(INSTALL_ID).then(function (restore) {
+    if (state.disposed || !restore || !restore.buffer) return;
+    append(restore.buffer.join(''));
+  }).catch(function () {});
+})();
+`
+
+function buildPopoutScript(installationId: string): string {
+  return (
+    `window.__comfyDesktopLogsPopoutInstallationId = ${JSON.stringify(installationId)};\n` +
+    POPOUT_MAIN_JS
+  )
+}
+
+// One pop-out per install — second click on the inline Logs button
+// focuses the existing window instead of spawning a duplicate.
+const popoutsByInstallation = new Map<string, BrowserWindow>()
+
+export async function openLogsPopout(installationId: string): Promise<void> {
+  const existing = popoutsByInstallation.get(installationId)
+  if (existing && !existing.isDestroyed()) {
+    existing.focus()
+    return
+  }
+
+  let label = 'Comfy Logs'
+  try {
+    const inst = await installations.get(installationId)
+    if (inst?.name) label = `Comfy Logs — ${inst.name}`
+  } catch {
+    // installations registry not ready; keep the generic label
+  }
+
+  const win = new BrowserWindow({
+    width: 880,
+    height: 520,
+    title: label,
+    backgroundColor: COMFY_BG,
+    autoHideMenuBar: true,
+    webPreferences: {
+      preload: path.join(__dirname, '../preload/comfyPreload.js'),
+      contextIsolation: true,
+      sandbox: false,
+    },
+  })
+
+  popoutsByInstallation.set(installationId, win)
+  win.on('closed', () => {
+    const cur = popoutsByInstallation.get(installationId)
+    if (cur === win) popoutsByInstallation.delete(installationId)
+  })
+
+  const html =
+    `<!DOCTYPE html><html><head><meta charset="utf-8"><title>${label}</title>` +
+    `<style>html,body{margin:0;padding:0;height:100%;background:${COMFY_BG};}</style>` +
+    `</head><body></body></html>`
+  void win.loadURL('data:text/html;charset=utf-8,' + encodeURIComponent(html))
+
+  win.webContents.once('did-finish-load', () => {
+    void win.webContents.executeJavaScript(buildPopoutScript(installationId)).catch(() => {})
+  })
+}

--- a/src/main/lib/terminal.test.ts
+++ b/src/main/lib/terminal.test.ts
@@ -173,6 +173,24 @@ describe('terminal manager', () => {
     expect(ptyAt(1).written).toContain('echo hi\r')
   })
 
+  it('clears stale scrollback when respawning after exit', async () => {
+    const wc = makeWebContents()
+    await subscribeTerminal('inst-a', asWc(wc))
+    ptyAt(0).emitData('old-session-output')
+    expect(getTerminalRestore('inst-a')?.buffer.join('')).toContain(
+      'old-session-output',
+    )
+
+    ptyAt(0).emitExit()
+
+    // Re-subscribing respawns the shell; the dead session's scrollback is gone.
+    const restore = await subscribeTerminal('inst-a', asWc(wc))
+
+    expect(spawn).toHaveBeenCalledTimes(2)
+    expect(restore.exited).toBe(false)
+    expect(restore.buffer.join('')).not.toContain('old-session-output')
+  })
+
   it('does not fire a spurious exit when restarting a live shell', async () => {
     const wc = makeWebContents()
     await subscribeTerminal('inst-a', asWc(wc))

--- a/src/main/lib/terminal.test.ts
+++ b/src/main/lib/terminal.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+/**
+ * Fake node-pty machinery. Defined inside vi.hoisted so the (also hoisted)
+ * vi.mock factory can reference it. Lets a test drive output/exit and inspect
+ * what was written, without spawning a real shell.
+ */
+const { spawned, spawn } = vi.hoisted(() => {
+  class FakePty {
+    dataCb: ((d: string) => void) | undefined
+    exitCb: (() => void) | undefined
+    written: string[] = []
+    killed = false
+    cols: number
+    rows: number
+
+    constructor(cols: number, rows: number) {
+      this.cols = cols
+      this.rows = rows
+    }
+
+    onData(cb: (d: string) => void) {
+      this.dataCb = cb
+      return { dispose() {} }
+    }
+    onExit(cb: () => void) {
+      this.exitCb = cb
+      return { dispose() {} }
+    }
+    write(d: string) {
+      this.written.push(d)
+    }
+    resize(cols: number, rows: number) {
+      this.cols = cols
+      this.rows = rows
+    }
+    kill() {
+      this.killed = true
+      // node-pty fires onExit asynchronously after kill().
+      queueMicrotask(() => this.exitCb?.())
+    }
+
+    emitData(d: string) {
+      this.dataCb?.(d)
+    }
+    emitExit() {
+      this.exitCb?.()
+    }
+  }
+
+  const spawnedList: FakePty[] = []
+  const spawnFn = vi.fn(
+    (_file: string, _args: string[], opts: { cols: number; rows: number }) => {
+      const p = new FakePty(opts.cols, opts.rows)
+      spawnedList.push(p)
+      return p
+    },
+  )
+  return { spawned: spawnedList, spawn: spawnFn }
+})
+
+vi.mock('node-pty', () => ({ default: { spawn } }))
+
+vi.mock('../installations', () => ({
+  get: vi.fn(async (id: string) => ({ id, name: id, installPath: `/installs/${id}` })),
+}))
+
+import {
+  subscribeTerminal,
+  writeTerminal,
+  restartTerminal,
+  getTerminalRestore,
+  _resetTerminalsForTest,
+} from './terminal'
+
+interface FakeWebContents {
+  sent: { channel: string; payload: unknown }[]
+  destroyedCb?: () => void
+  send: (channel: string, payload: unknown) => void
+  once: (event: string, cb: () => void) => void
+  isDestroyed: () => boolean
+}
+
+function makeWebContents(): FakeWebContents {
+  const wc: FakeWebContents = {
+    sent: [],
+    send(channel, payload) {
+      this.sent.push({ channel, payload })
+    },
+    once(event, cb) {
+      if (event === 'destroyed') this.destroyedCb = cb
+    },
+    isDestroyed: () => false,
+  }
+  return wc
+}
+
+// The manager only uses WebContents.send/once/isDestroyed, so the fake is enough.
+function asWc(wc: FakeWebContents) {
+  return wc as unknown as Parameters<typeof subscribeTerminal>[1]
+}
+
+/** Nth spawned fake pty, asserting it exists (satisfies noUncheckedIndexedAccess). */
+function ptyAt(i: number) {
+  const p = spawned[i]
+  if (!p) throw new Error(`No pty spawned at index ${i}`)
+  return p
+}
+
+describe('terminal manager', () => {
+  beforeEach(() => {
+    _resetTerminalsForTest()
+    spawned.length = 0
+    spawn.mockClear()
+  })
+
+  it('spawns a shell on first subscribe and reports it alive', async () => {
+    const wc = makeWebContents()
+    const restore = await subscribeTerminal('inst-a', asWc(wc))
+
+    expect(spawn).toHaveBeenCalledTimes(1)
+    expect(restore.exited).toBe(false)
+    // Init commands (venv activate + pip alias) are written into the shell.
+    expect(ptyAt(0).written.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('streams output to subscribers and retains scrollback', async () => {
+    const wc = makeWebContents()
+    await subscribeTerminal('inst-a', asWc(wc))
+
+    ptyAt(0).emitData('hello ')
+    ptyAt(0).emitData('world')
+
+    const outputs = wc.sent.filter((m) => m.channel === 'terminal-output')
+    expect(outputs.map((m) => (m.payload as { data: string }).data)).toEqual([
+      'hello ',
+      'world',
+    ])
+    expect(getTerminalRestore('inst-a')?.buffer.join('')).toBe('hello world')
+  })
+
+  it('marks the session exited and notifies subscribers when the shell is killed', async () => {
+    const wc = makeWebContents()
+    await subscribeTerminal('inst-a', asWc(wc))
+
+    ptyAt(0).emitExit()
+
+    expect(wc.sent.some((m) => m.channel === 'terminal-exited')).toBe(true)
+    expect(getTerminalRestore('inst-a')?.exited).toBe(true)
+  })
+
+  it('drops writes after exit instead of throwing (the legacy dead-pty bug)', async () => {
+    const wc = makeWebContents()
+    await subscribeTerminal('inst-a', asWc(wc))
+    ptyAt(0).emitExit()
+
+    expect(() => writeTerminal('inst-a', 'ls\r')).not.toThrow()
+    // Nothing reached the dead shell.
+    expect(ptyAt(0).written.filter((w) => w === 'ls\r')).toHaveLength(0)
+  })
+
+  it('respawns a fresh shell on restart after the user killed it', async () => {
+    const wc = makeWebContents()
+    await subscribeTerminal('inst-a', asWc(wc))
+    ptyAt(0).emitExit()
+
+    const restore = await restartTerminal('inst-a')
+
+    expect(spawn).toHaveBeenCalledTimes(2)
+    expect(restore.exited).toBe(false)
+    // The new shell accepts input.
+    writeTerminal('inst-a', 'echo hi\r')
+    expect(ptyAt(1).written).toContain('echo hi\r')
+  })
+
+  it('does not fire a spurious exit when restarting a live shell', async () => {
+    const wc = makeWebContents()
+    await subscribeTerminal('inst-a', asWc(wc))
+
+    await restartTerminal('inst-a')
+    // Let the killed old pty's async onExit microtask run.
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(wc.sent.some((m) => m.channel === 'terminal-exited')).toBe(false)
+    expect(getTerminalRestore('inst-a')?.exited).toBe(false)
+  })
+
+  it('keeps sessions isolated per installation', async () => {
+    const wcA = makeWebContents()
+    const wcB = makeWebContents()
+    await subscribeTerminal('inst-a', asWc(wcA))
+    await subscribeTerminal('inst-b', asWc(wcB))
+
+    ptyAt(0).emitData('from-a')
+
+    expect(wcA.sent.some((m) => m.channel === 'terminal-output')).toBe(true)
+    expect(wcB.sent.some((m) => m.channel === 'terminal-output')).toBe(false)
+  })
+})

--- a/src/main/lib/terminal.ts
+++ b/src/main/lib/terminal.ts
@@ -39,17 +39,20 @@ function getDefaultShell(): string {
 }
 
 /** Commands written into a fresh shell: activate the install's venv and make
- *  `pip` route through the bundled uv, mirroring legacy desktop. */
+ *  `pip` route through the bundled uv, mirroring legacy desktop. A final clear
+ *  hides the activation echo so the session opens on a clean prompt. */
 function initCommands(venvDir: string, uvPath: string): string[] {
   if (process.platform === 'win32') {
     return [
       `& "${venvDir}\\Scripts\\Activate.ps1"`,
       `function pip { & "${uvPath}" pip $args }`,
+      'Clear-Host',
     ]
   }
   return [
     `source "${venvDir}/bin/activate"`,
     `alias pip='"${uvPath}" pip'`,
+    'clear',
   ]
 }
 
@@ -78,7 +81,6 @@ class InstallTerminal {
   /** Kill any existing shell and start a fresh one. Clears scrollback. */
   async restart(): Promise<void> {
     this.#killPty()
-    this.sessionBuffer.length = 0
     await this.#spawn()
   }
 
@@ -128,6 +130,9 @@ class InstallTerminal {
     if (!inst || !inst.installPath) {
       throw new Error(`Installation not found: ${this.installationId}`)
     }
+    // A fresh shell starts with a fresh scrollback; otherwise a respawn after
+    // the user typed `exit` would leak the dead session's buffer into restore.
+    this.sessionBuffer.length = 0
     const venvDir = getActiveVenvDir(inst)
     const uvPath = getActiveUvPath(inst)
     const instance = pty.spawn(getDefaultShell(), [], {

--- a/src/main/lib/terminal.ts
+++ b/src/main/lib/terminal.ts
@@ -1,0 +1,246 @@
+import pty from 'node-pty'
+import type { WebContents } from 'electron'
+import * as installations from '../installations'
+import { getActiveVenvDir, getActiveUvPath } from './pythonEnv'
+
+/**
+ * Interactive per-installation shell sessions.
+ *
+ * Each installation gets at most one long-lived PTY, shared across every
+ * surface that subscribes to it: the desktop Settings "Console" tab and the
+ * ComfyUI frontend's bottom-panel terminal (across all of an install's
+ * windows). One shell, one scrollback — so the same session is visible
+ * everywhere and there's no confusion about which terminal is which.
+ *
+ * The session is independent of the ComfyUI server: it stays usable whether
+ * ComfyUI is running or stopped (e.g. to pip-install something before a
+ * reboot). When the user kills the shell (typing `exit`), the session is
+ * marked exited and subscribers are notified; it is NOT silently respawned.
+ * Callers restart it explicitly via {@link restartTerminal} (the desktop
+ * Restart button, or the frontend re-opening the tab).
+ */
+
+const MAX_BUFFER_CHUNKS = 1000
+const DEFAULT_SIZE = { cols: 80, rows: 30 }
+
+export interface TerminalRestore {
+  buffer: string[]
+  size: { cols: number; rows: number }
+  exited: boolean
+}
+
+function getDefaultShell(): string {
+  if (process.platform === 'win32') {
+    return process.env.COMSPEC?.toLowerCase().includes('cmd')
+      ? 'powershell.exe'
+      : process.env.COMSPEC || 'powershell.exe'
+  }
+  return process.env.SHELL || '/bin/bash'
+}
+
+/** Commands written into a fresh shell: activate the install's venv and make
+ *  `pip` route through the bundled uv, mirroring legacy desktop. */
+function initCommands(venvDir: string, uvPath: string): string[] {
+  if (process.platform === 'win32') {
+    return [
+      `& "${venvDir}\\Scripts\\Activate.ps1"`,
+      `function pip { & "${uvPath}" pip $args }`,
+    ]
+  }
+  return [
+    `source "${venvDir}/bin/activate"`,
+    `alias pip='"${uvPath}" pip'`,
+  ]
+}
+
+class InstallTerminal {
+  readonly installationId: string
+  #pty: pty.IPty | undefined
+  #exited = true
+  readonly sessionBuffer: string[] = []
+  readonly size = { ...DEFAULT_SIZE }
+  readonly subscribers = new Set<WebContents>()
+
+  constructor(installationId: string) {
+    this.installationId = installationId
+  }
+
+  get exited(): boolean {
+    return this.#exited || this.#pty === undefined
+  }
+
+  /** Spawn the shell if it isn't alive. Safe to call repeatedly. */
+  async ensureAlive(): Promise<void> {
+    if (this.#pty && !this.#exited) return
+    await this.#spawn()
+  }
+
+  /** Kill any existing shell and start a fresh one. Clears scrollback. */
+  async restart(): Promise<void> {
+    this.#killPty()
+    this.sessionBuffer.length = 0
+    await this.#spawn()
+  }
+
+  write(data: string): void {
+    if (this.#exited || !this.#pty) return
+    this.#pty.write(data)
+  }
+
+  resize(cols: number, rows: number): void {
+    if (!Number.isFinite(cols) || !Number.isFinite(rows)) return
+    this.size.cols = Math.max(1, Math.floor(cols))
+    this.size.rows = Math.max(1, Math.floor(rows))
+    if (this.#exited || !this.#pty) return
+    try {
+      this.#pty.resize(this.size.cols, this.size.rows)
+    } catch {
+      // pty may have died between the exited check and here; ignore.
+    }
+  }
+
+  restore(): TerminalRestore {
+    return {
+      buffer: [...this.sessionBuffer],
+      size: { ...this.size },
+      exited: this.exited,
+    }
+  }
+
+  subscribe(wc: WebContents): void {
+    if (this.subscribers.has(wc)) return
+    this.subscribers.add(wc)
+    wc.once('destroyed', () => this.subscribers.delete(wc))
+  }
+
+  unsubscribe(wc: WebContents): void {
+    this.subscribers.delete(wc)
+  }
+
+  dispose(): void {
+    this.#killPty()
+    this.subscribers.clear()
+    this.sessionBuffer.length = 0
+  }
+
+  async #spawn(): Promise<void> {
+    const inst = await installations.get(this.installationId)
+    if (!inst || !inst.installPath) {
+      throw new Error(`Installation not found: ${this.installationId}`)
+    }
+    const venvDir = getActiveVenvDir(inst)
+    const uvPath = getActiveUvPath(inst)
+    const instance = pty.spawn(getDefaultShell(), [], {
+      name: 'xterm-256color',
+      cols: this.size.cols,
+      rows: this.size.rows,
+      cwd: inst.installPath,
+      env: process.env as Record<string, string>,
+    })
+
+    this.#pty = instance
+    this.#exited = false
+
+    instance.onData((data) => {
+      // Ignore stray output from a shell we've already replaced (restart race).
+      if (this.#pty !== instance) return
+      this.sessionBuffer.push(data)
+      if (this.sessionBuffer.length > MAX_BUFFER_CHUNKS) this.sessionBuffer.shift()
+      this.#broadcast('terminal-output', { installationId: this.installationId, data })
+    })
+
+    instance.onExit(() => {
+      // A restart kills the old pty and spawns a new one; the old pty's async
+      // exit must not clobber the live session or fire a spurious "exited".
+      if (this.#pty !== instance) return
+      this.#exited = true
+      this.#pty = undefined
+      this.#broadcast('terminal-exited', { installationId: this.installationId })
+    })
+
+    for (const cmd of initCommands(venvDir, uvPath)) {
+      instance.write(`${cmd}\r`)
+    }
+  }
+
+  #killPty(): void {
+    const instance = this.#pty
+    this.#pty = undefined
+    this.#exited = true
+    if (!instance) return
+    try {
+      instance.kill()
+    } catch {
+      // Already dead; nothing to do.
+    }
+  }
+
+  #broadcast(channel: string, payload: unknown): void {
+    for (const wc of this.subscribers) {
+      if (wc.isDestroyed()) {
+        this.subscribers.delete(wc)
+        continue
+      }
+      wc.send(channel, payload)
+    }
+  }
+}
+
+const terminals = new Map<string, InstallTerminal>()
+
+function getOrCreate(installationId: string): InstallTerminal {
+  let term = terminals.get(installationId)
+  if (!term) {
+    term = new InstallTerminal(installationId)
+    terminals.set(installationId, term)
+  }
+  return term
+}
+
+/** Subscribe a renderer to an install's shell, spawning it if needed, and
+ *  return the scrollback/size/exited state so the caller can repaint. */
+export async function subscribeTerminal(
+  installationId: string,
+  wc: WebContents,
+): Promise<TerminalRestore> {
+  const term = getOrCreate(installationId)
+  await term.ensureAlive()
+  term.subscribe(wc)
+  return term.restore()
+}
+
+export function unsubscribeTerminal(installationId: string, wc: WebContents): void {
+  terminals.get(installationId)?.unsubscribe(wc)
+}
+
+export function writeTerminal(installationId: string, data: string): void {
+  terminals.get(installationId)?.write(data)
+}
+
+export function resizeTerminal(installationId: string, cols: number, rows: number): void {
+  terminals.get(installationId)?.resize(cols, rows)
+}
+
+export async function restartTerminal(installationId: string): Promise<TerminalRestore> {
+  const term = getOrCreate(installationId)
+  await term.restart()
+  return term.restore()
+}
+
+export function getTerminalRestore(installationId: string): TerminalRestore | null {
+  return terminals.get(installationId)?.restore() ?? null
+}
+
+/** Tear down an install's shell entirely (e.g. when it's deleted). */
+export function disposeTerminal(installationId: string): void {
+  const term = terminals.get(installationId)
+  if (!term) return
+  term.dispose()
+  terminals.delete(installationId)
+}
+
+/** Test-only: drop all sessions without spawning anything. */
+export function _resetTerminalsForTest(): void {
+  for (const term of terminals.values()) term.dispose()
+  terminals.clear()
+}

--- a/src/main/lib/terminalPopoutWindow.ts
+++ b/src/main/lib/terminalPopoutWindow.ts
@@ -1,0 +1,233 @@
+/**
+ * Pop-out terminal window. A small standalone Electron BrowserWindow that
+ * runs the same xterm renderer as the inline injection but is decoupled
+ * from the ComfyUI frontend's bottom panel. Uses the same per-install
+ * shared shell as the inline view (`terminal-*` IPC handlers in
+ * `registerTerminalHandlers.ts`), so output stays in lockstep between the
+ * pop-out and any other surface still subscribed to the same install.
+ *
+ * Why a dedicated module instead of reusing `comfyTerminalContentScript`:
+ * the inline script registers itself as a ComfyUI extension and renders
+ * into a bottom-panel tab container. A pop-out has no extension system —
+ * the xterm has to mount directly onto `document.body`. The render logic
+ * is essentially identical; only the host + dedupe and the explicit
+ * installationId passing differ.
+ */
+
+import { BrowserWindow } from 'electron'
+import path from 'path'
+import { readFileSync } from 'fs'
+import { createRequire } from 'module'
+import { COMFY_BG } from './theme'
+import * as installations from '../installations'
+
+const require = createRequire(__filename)
+
+let cachedScript: string | null = null
+
+function readPackageFile(id: string): string {
+  return readFileSync(require.resolve(id), 'utf8')
+}
+
+function stripSourceMapComment(source: string): string {
+  return source.replace(/\n?\/\/# sourceMappingURL=.*$/u, '')
+}
+
+/**
+ * Build the standalone xterm bootstrap script for the pop-out window.
+ * Memoised — the UMD payloads are large and never change at runtime.
+ * The injected `INSTALLATION_ID` literal is substituted per window.
+ */
+function buildPopoutScript(installationId: string): string {
+  if (!cachedScript) {
+    const xtermJs = stripSourceMapComment(readPackageFile('@xterm/xterm/lib/xterm.js'))
+    const fitJs = stripSourceMapComment(readPackageFile('@xterm/addon-fit/lib/addon-fit.js'))
+    const css = readPackageFile('@xterm/xterm/css/xterm.css')
+
+    cachedScript =
+      `(function () {\n` +
+      `'use strict';\n` +
+      `if (typeof window === 'undefined' || !window.__comfyDesktop2 || !window.__comfyDesktop2.Terminal) return;\n` +
+      `if (window.__comfyDesktopTerminalPopoutMounted) return;\n` +
+      `window.__comfyDesktopTerminalPopoutMounted = true;\n` +
+      `var __xt = { exports: {} };\n` +
+      `(function () { var module = __xt; var exports = __xt.exports;\n${xtermJs}\n}).call(window);\n` +
+      `var __fit = { exports: {} };\n` +
+      `(function () { var module = __fit; var exports = __fit.exports; var self = window;\n${fitJs}\n}).call(window);\n` +
+      `var XTerm = __xt.exports && __xt.exports.Terminal;\n` +
+      `var FitAddon = __fit.exports && __fit.exports.FitAddon;\n` +
+      `if (!XTerm || !FitAddon) return;\n` +
+      `(function () {\n` +
+      `var s = document.getElementById('__comfyDesktopXtermCssPopout');\n` +
+      `if (!s) { s = document.createElement('style'); s.id = '__comfyDesktopXtermCssPopout'; s.textContent = ${JSON.stringify(css)}; (document.head || document.documentElement).appendChild(s); }\n` +
+      `})();\n` +
+      POPOUT_MAIN_JS +
+      `})();\n`
+  }
+  // installationId interpolation goes after the cached payload — keeps
+  // the UMD bundle re-used across windows but lets each window target its
+  // own installation. The bootstrap reads it from a top-level constant.
+  return `window.__comfyDesktopPopoutInstallationId = ${JSON.stringify(installationId)};\n` + cachedScript
+}
+
+/**
+ * Standalone xterm bootstrap. Subscribes to the shared shell of the
+ * popout's bound install, wires data/output/exit, fits to the window,
+ * and refits on every resize. Render mounts directly to the body — no
+ * bottom-panel tab plumbing.
+ */
+const POPOUT_MAIN_JS = `
+var INSTALL_ID = window.__comfyDesktopPopoutInstallationId;
+var bridge = window.__comfyDesktop2.Terminal;
+if (!INSTALL_ID || !bridge) return;
+
+var root = document.body;
+root.style.background = '#171717';
+root.style.margin = '0';
+root.style.padding = '6px';
+root.style.height = '100vh';
+root.style.boxSizing = 'border-box';
+root.style.overflow = 'hidden';
+
+var host = document.createElement('div');
+host.style.position = 'relative';
+host.style.width = '100%';
+host.style.height = '100%';
+host.style.overflow = 'hidden';
+root.appendChild(host);
+
+var banner = document.createElement('div');
+banner.style.cssText = 'position:absolute;left:0;right:0;bottom:0;display:none;align-items:center;justify-content:space-between;gap:12px;padding:8px 12px;background:#262626;color:#e5e5e5;font-size:13px;';
+var bannerText = document.createElement('span');
+bannerText.textContent = 'This terminal session ended.';
+var restartBtn = document.createElement('button');
+restartBtn.textContent = 'Restart';
+restartBtn.style.cssText = 'cursor:pointer;border:0;border-radius:6px;padding:4px 12px;background:#3b82f6;color:#fff;font-size:12px;';
+banner.appendChild(bannerText);
+banner.appendChild(restartBtn);
+root.appendChild(banner);
+
+var term = new XTerm({ convertEol: true, theme: { background: '#171717' } });
+var fitAddon = new FitAddon();
+term.loadAddon(fitAddon);
+term.open(host);
+
+var state = { disposed: false, exited: false, resizeTimer: 0 };
+
+function updateBanner() { banner.style.display = state.exited ? 'flex' : 'none'; }
+
+function doFit(forceReclaim) {
+  if (state.disposed || !host.offsetParent) return;
+  var dims = fitAddon.proposeDimensions();
+  if (!dims || !dims.cols || !dims.rows) return;
+  var changed = dims.cols !== term.cols || dims.rows !== term.rows;
+  if (changed) term.resize(dims.cols, dims.rows);
+  if (changed || forceReclaim) {
+    try { bridge.resize(term.cols, term.rows, INSTALL_ID); } catch (e) {}
+  }
+}
+
+function applyRestore(restore) {
+  if (state.disposed || !restore) return;
+  if (restore.buffer && restore.buffer.length) {
+    term.resize(restore.size.cols, restore.size.rows);
+    term.write(restore.buffer.join(''));
+  }
+  state.exited = !!restore.exited;
+  updateBanner();
+  window.requestAnimationFrame(function () { doFit(true); });
+}
+
+function doRestart() {
+  if (state.disposed) return;
+  term.reset();
+  state.exited = false; updateBanner();
+  bridge.restart(INSTALL_ID).then(applyRestore).catch(function () {});
+}
+restartBtn.addEventListener('click', doRestart);
+
+term.onData(function (d) { try { bridge.write(d, INSTALL_ID); } catch (e) {} });
+var offOutput = bridge.onOutput(function (msg) {
+  if (state.disposed) return;
+  if (state.exited) { state.exited = false; updateBanner(); }
+  term.write(msg);
+});
+var offExited = bridge.onExited(function () {
+  if (state.disposed) return;
+  state.exited = true; updateBanner();
+});
+
+var ro = new ResizeObserver(function () {
+  if (state.resizeTimer) clearTimeout(state.resizeTimer);
+  state.resizeTimer = setTimeout(function () { doFit(false); }, 50);
+});
+ro.observe(root);
+
+window.addEventListener('beforeunload', function () {
+  state.disposed = true;
+  try { offOutput && offOutput(); } catch (e) {}
+  try { offExited && offExited(); } catch (e) {}
+  try { ro.disconnect(); } catch (e) {}
+  try { bridge.unsubscribe(INSTALL_ID); } catch (e) {}
+  try { term.dispose(); } catch (e) {}
+});
+
+bridge.subscribe(INSTALL_ID).then(function (restore) {
+  if (state.disposed) return;
+  if (restore && restore.exited) doRestart();
+  else applyRestore(restore);
+  window.requestAnimationFrame(function () { doFit(true); });
+}).catch(function () {});
+`
+
+// Track open pop-outs per installation so a second click on the inline
+// button focuses the existing window instead of spawning a duplicate.
+const popoutsByInstallation = new Map<string, BrowserWindow>()
+
+export async function openTerminalPopout(installationId: string): Promise<void> {
+  const existing = popoutsByInstallation.get(installationId)
+  if (existing && !existing.isDestroyed()) {
+    existing.focus()
+    return
+  }
+
+  // Best-effort label using the install's user-facing name; falls back
+  // to a generic title when the lookup fails. Lookup is async so the
+  // IPC handler awaits this whole call.
+  let label = 'Comfy Terminal'
+  try {
+    const inst = await installations.get(installationId)
+    if (inst?.name) label = `Comfy Terminal — ${inst.name}`
+  } catch {
+    // installations registry not ready; keep the generic label
+  }
+
+  const win = new BrowserWindow({
+    width: 800,
+    height: 480,
+    title: label,
+    backgroundColor: COMFY_BG,
+    autoHideMenuBar: true,
+    webPreferences: {
+      preload: path.join(__dirname, '../preload/comfyPreload.js'),
+      contextIsolation: true,
+      sandbox: false,
+    },
+  })
+
+  popoutsByInstallation.set(installationId, win)
+  win.on('closed', () => {
+    const cur = popoutsByInstallation.get(installationId)
+    if (cur === win) popoutsByInstallation.delete(installationId)
+  })
+
+  const html =
+    `<!DOCTYPE html><html><head><meta charset="utf-8"><title>${label}</title>` +
+    `<style>html,body{margin:0;padding:0;height:100%;background:${COMFY_BG};}</style>` +
+    `</head><body></body></html>`
+  void win.loadURL('data:text/html;charset=utf-8,' + encodeURIComponent(html))
+
+  win.webContents.once('did-finish-load', () => {
+    void win.webContents.executeJavaScript(buildPopoutScript(installationId)).catch(() => {})
+  })
+}

--- a/src/main/popups/systemModal.ts
+++ b/src/main/popups/systemModal.ts
@@ -4,6 +4,7 @@ import { TITLEBAR_HEIGHT } from '../lib/titleBarOverlay'
 import { EmbeddedPopupView } from './embeddedPopupView'
 
 type SystemModalConfirmStyle = 'primary' | 'danger'
+type SystemModalSecondaryStyle = 'primary' | 'danger' | 'default'
 
 export interface SystemModalDetailGroup {
   label: string
@@ -19,10 +20,14 @@ export interface SystemModalSpec {
   confirmLabel: string
   cancelLabel: string
   confirmStyle?: SystemModalConfirmStyle
+  /** Optional middle action (rendered between Cancel and the primary). When set,
+   *  the modal becomes a three-way choice and resolves `'secondary'`. */
+  secondaryLabel?: string
+  secondaryStyle?: SystemModalSecondaryStyle
   theme: { bg: string; text: string }
 }
 
-type SystemModalAction = 'confirm' | 'cancel'
+type SystemModalAction = 'confirm' | 'cancel' | 'secondary'
 
 export type SystemModalCallback = (action: SystemModalAction) => void
 
@@ -169,6 +174,26 @@ export function openSystemModalAsync(opts: OpenSystemModalOpts): Promise<boolean
   })
 }
 
+/** Three-way variant of `openSystemModalAsync`. Resolves the raw action so a
+ *  caller offering a middle option (`secondaryLabel`) can branch on it. Cancel
+ *  / superseded / parent-destroyed all resolve `'cancel'`. */
+export function openSystemModalChoiceAsync(
+  opts: OpenSystemModalOpts,
+): Promise<'confirm' | 'cancel' | 'secondary'> {
+  return new Promise((resolve) => {
+    openSystemModal({
+      parent: opts.parent,
+      spec: opts.spec,
+      callback: (action) => {
+        if (opts.callback) {
+          try { opts.callback(action) } catch {}
+        }
+        resolve(action)
+      },
+    })
+  })
+}
+
 /** Wire the IPC handlers that drive the system-modal popup. Called once at app ready. */
 export function registerSystemModalIpc(): void {
   ipcMain.on('comfy-systemmodal:ready', (event) => {
@@ -204,7 +229,7 @@ export function registerSystemModalIpc(): void {
       // Stale ack — the modal was already replaced by a newer open.
       if (payload?.modalId !== spec.id) return
       const action = payload?.action
-      if (action !== 'confirm' && action !== 'cancel') return
+      if (action !== 'confirm' && action !== 'cancel' && action !== 'secondary') return
       entry.currentSpec = null
       entry.currentCallback = null
       entry.view.hide({ focusParent: true })

--- a/src/main/popups/titlePopup.ts
+++ b/src/main/popups/titlePopup.ts
@@ -14,6 +14,7 @@ import { installationEvents } from '../installations'
 import * as mainTelemetry from '../lib/telemetry'
 import * as updater from '../lib/updater'
 import * as i18n from '../lib/i18n'
+import * as settings from '../settings'
 import { defaultInstallDir } from '../lib/paths'
 import {
   openPath as openPathHelper,
@@ -184,6 +185,7 @@ export interface GlobalSettingsModelsDir {
  *  `Record<string, unknown>` to keep the preload boundary type-safe
  *  without dragging renderer types into main. */
 export interface GlobalSettingsSnapshot {
+  languageFields: Record<string, unknown>[]
   generalFields: Record<string, unknown>[]
   telemetryFields: Record<string, unknown>[]
   desktopUpdateFields: Record<string, unknown>[]
@@ -297,8 +299,17 @@ export function resolvePickerSelectedInstallId(
 export function buildInstancePickerSnapshot(
   args: BuildInstancePickerSnapshotArgs
 ): InstancePickerSnapshot {
+  // Respect the global `hideCloudFromPicker` opt-out across the IPP too,
+  // not just the dashboard chooser. When on, strip cloud installs from
+  // the picker payload so the user truly never sees Cloud in the app's
+  // top dropdown. The setting is a pure visibility toggle — Cloud
+  // sessions themselves are unaffected.
+  const hideCloud = settings.get('hideCloudFromPicker') === true
+  const installs = hideCloud
+    ? args.installs.filter((i) => i.sourceCategory !== 'cloud')
+    : args.installs
   return {
-    installs: args.installs,
+    installs,
     // Use the real attached install when available; fall back to the
     // chooser's preview claim (set by `applyAttachHostPreview` when
     // the chooser stakes an in-place attach claim ahead of a launch).
@@ -2011,8 +2022,13 @@ function buildGlobalSettingsSnapshot(): GlobalSettingsSnapshot {
   const mediaSections = buildMediaSections()
   const modelsPayload = buildModelsPayload()
   const generalRaw = findSettingsFields(settingsSections, 'settings.general', 0)
+  // Locale picker lives above the "App Behavior" microsection without a
+  // header of its own, so it gets pulled out of generalFields here.
   const desktopUpdateFields = generalRaw.filter((f) => f.id === 'autoInstallUpdates')
-  const generalFields = generalRaw.filter((f) => f.id !== 'autoInstallUpdates')
+  const languageFields = generalRaw.filter((f) => f.id === 'language')
+  const generalFields = generalRaw.filter(
+    (f) => f.id !== 'autoInstallUpdates' && f.id !== 'language'
+  )
   const telemetryFields = findSettingsFields(settingsSections, 'settings.telemetry', 1)
   const cache = findSettingsFields(settingsSections, 'settings.cache', 2)
   const advanced = findSettingsFields(settingsSections, 'settings.advanced', 3)
@@ -2026,6 +2042,7 @@ function buildGlobalSettingsSnapshot(): GlobalSettingsSnapshot {
   const githubStars = getCachedGithubStarCount('comfy-org/ComfyUI')
   const githubStarsLoading = githubStars == null && !githubStarsFetchAttempted
   return {
+    languageFields,
     generalFields,
     telemetryFields,
     desktopUpdateFields,

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -31,6 +31,11 @@ export interface KnownSettings {
   /** `true` once the first-use takeover is finished. Mid-flow cancel does NOT
    *  flip this, so the takeover replays from step 1 next launch. */
   firstUseCompleted?: boolean
+  /** When true, hide the Cloud tile (and the Try-Cloud CTA) from the
+   *  Dashboard / Instance Picker. Local-only users who never use Cloud
+   *  can opt out of seeing it without us removing the feature. Default
+   *  false — Cloud stays visible. */
+  hideCloudFromPicker?: boolean
   oemManagedModelDirs?: string[]
   oemWorkflowImportVersion?: number
 }
@@ -68,6 +73,7 @@ const SETTINGS_SCHEMA = {
   chineseMirrorsPrompted: { nullable: false },
   telemetryEnabled: { nullable: false },
   firstUseCompleted: { nullable: false },
+  hideCloudFromPicker: { nullable: false },
   oemManagedModelDirs: { nullable: false },
   oemWorkflowImportVersion: { nullable: false },
 } as const satisfies Record<keyof KnownSettings, { nullable: boolean }>

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -22,6 +22,9 @@ export interface KnownSettings {
   /** When true (default), Desktop updates download and install silently; when
    *  false, the user is prompted before any download/install. */
   autoInstallUpdates?: boolean
+  /** When true (default), boot reopens the last-used instance window instead of
+   *  the dashboard, when the last active surface was an instance. */
+  reopenLastInstanceOnLaunch?: boolean
   pypiMirror?: string
   useChineseMirrors?: boolean
   chineseMirrorsPrompted?: boolean
@@ -61,6 +64,7 @@ const SETTINGS_SCHEMA = {
   theme: { nullable: false },
   autoUpdate: { nullable: false },
   autoInstallUpdates: { nullable: false },
+  reopenLastInstanceOnLaunch: { nullable: false },
   pypiMirror: { nullable: false },
   useChineseMirrors: { nullable: false },
   chineseMirrorsPrompted: { nullable: false },

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -39,6 +39,12 @@ export interface KnownSettings {
    *  can opt out of seeing it without us removing the feature. Default
    *  false — Cloud stays visible. */
   hideCloudFromPicker?: boolean
+  /** When true, closing the last ComfyUI instance window quits Desktop
+   *  directly — no modal, no return-to-dashboard fallback. For power
+   *  users who treat the instance window as the whole app. Default
+   *  false — closing the last instance window returns to the dashboard.
+   *  Replaces the three-way close modal from the bundle iteration. */
+  closeDirectlyOnLastWindow?: boolean
   oemManagedModelDirs?: string[]
   oemWorkflowImportVersion?: number
 }
@@ -78,6 +84,7 @@ const SETTINGS_SCHEMA = {
   telemetryEnabled: { nullable: false },
   firstUseCompleted: { nullable: false },
   hideCloudFromPicker: { nullable: false },
+  closeDirectlyOnLastWindow: { nullable: false },
   oemManagedModelDirs: { nullable: false },
   oemWorkflowImportVersion: { nullable: false },
 } as const satisfies Record<keyof KnownSettings, { nullable: boolean }>

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -58,6 +58,16 @@ export function buildElectronApi(): ElectronApi {
     // Running
     stopComfyUI: (installationId) => ipcRenderer.invoke('stop-comfyui', installationId),
     focusComfyWindow: (installationId) => ipcRenderer.invoke('focus-comfy-window', installationId),
+
+    // Interactive console
+    terminalSubscribe: (installationId) => ipcRenderer.invoke('terminal-subscribe', installationId),
+    terminalUnsubscribe: (installationId) =>
+      ipcRenderer.invoke('terminal-unsubscribe', installationId),
+    terminalWrite: (installationId, data) =>
+      ipcRenderer.invoke('terminal-write', installationId, data),
+    terminalResize: (installationId, cols, rows) =>
+      ipcRenderer.invoke('terminal-resize', installationId, cols, rows),
+    terminalRestart: (installationId) => ipcRenderer.invoke('terminal-restart', installationId),
     openInstallWindow: (installationId) =>
       ipcRenderer.invoke('open-install-window', installationId),
     closeComfyWindow: (installationId, opts) =>
@@ -213,6 +223,18 @@ export function buildElectronApi(): ElectronApi {
         callback(data as Parameters<typeof callback>[0])
       ipcRenderer.on('comfy-exited', handler)
       return () => ipcRenderer.removeListener('comfy-exited', handler)
+    },
+    onTerminalOutput: (callback) => {
+      const handler = (_event: IpcRendererEvent, data: unknown) =>
+        callback(data as Parameters<typeof callback>[0])
+      ipcRenderer.on('terminal-output', handler)
+      return () => ipcRenderer.removeListener('terminal-output', handler)
+    },
+    onTerminalExited: (callback) => {
+      const handler = (_event: IpcRendererEvent, data: unknown) =>
+        callback(data as Parameters<typeof callback>[0])
+      ipcRenderer.on('terminal-exited', handler)
+      return () => ipcRenderer.removeListener('terminal-exited', handler)
     },
     onComfyBootLog: (callback) => {
       const handler = (_event: IpcRendererEvent, data: unknown) =>

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -65,6 +65,8 @@ export function buildElectronApi(): ElectronApi {
     closeHostWindow: () => ipcRenderer.invoke('close-host-window'),
     returnToDashboard: () => ipcRenderer.invoke('return-to-dashboard'),
     closeCurrentPanel: () => ipcRenderer.send('comfy-window:close-current-panel'),
+    resolveStartupRestoreReveal: (result) =>
+      ipcRenderer.send('comfy-window:startup-restore-reveal', { result }),
     openGlobalSettings: () => ipcRenderer.send('comfy-titlepopup:open-global-settings'),
     openInstancePicker: (opts) =>
       ipcRenderer.send('comfy-window:open-instance-picker-for-install', {
@@ -443,6 +445,7 @@ export function buildElectronApi(): ElectronApi {
             actionId?: string
             version?: string | null
             settingsTab?: 'comfy' | 'directories' | 'downloads' | 'global'
+            startupRestore?: boolean
           }
         )
       ipcRenderer.on('panel-trigger-overlay', handler)

--- a/src/preload/comfyPreload.ts
+++ b/src/preload/comfyPreload.ts
@@ -15,6 +15,42 @@ export interface ComfyDownloadProgress {
   isImage?: boolean
 }
 
+export interface TerminalRestore {
+  buffer: string[]
+  size: { cols: number; rows: number }
+  exited: boolean
+}
+
+/**
+ * Interactive terminal bridge for the served ComfyUI frontend.
+ *
+ * The frontend has no idea which installation it belongs to; the main process
+ * resolves that from the sending webContents, so every call here omits the
+ * installationId. The session is per-install and shared across windows.
+ */
+const Terminal = {
+  /** Spawn the shell if needed, register this view as a subscriber, and
+   *  return the current scrollback/size/exited state. */
+  subscribe: (): Promise<TerminalRestore> => ipcRenderer.invoke('terminal-subscribe', null),
+  unsubscribe: (): Promise<void> => ipcRenderer.invoke('terminal-unsubscribe', null),
+  write: (data: string): Promise<void> => ipcRenderer.invoke('terminal-write', null, data),
+  resize: (cols: number, rows: number): Promise<void> =>
+    ipcRenderer.invoke('terminal-resize', null, cols, rows),
+  /** Kill the current shell (if any) and start a fresh one. */
+  restart: (): Promise<TerminalRestore> => ipcRenderer.invoke('terminal-restart', null),
+  onOutput: (callback: (data: string) => void): (() => void) => {
+    const handler = (_event: IpcRendererEvent, payload: { data: string }) =>
+      callback(payload.data)
+    ipcRenderer.on('terminal-output', handler)
+    return () => ipcRenderer.removeListener('terminal-output', handler)
+  },
+  onExited: (callback: () => void): (() => void) => {
+    const handler = () => callback()
+    ipcRenderer.on('terminal-exited', handler)
+    return () => ipcRenderer.removeListener('terminal-exited', handler)
+  },
+}
+
 contextBridge.exposeInMainWorld('__comfyDesktop2', {
   downloadModel: (url: string, filename: string, directory: string): Promise<boolean> => {
     return ipcRenderer.invoke('desktop2-download-model', { url, filename, directory })
@@ -42,4 +78,5 @@ contextBridge.exposeInMainWorld('__comfyDesktop2', {
   reportTheme: (bg: string, text: string): void => {
     ipcRenderer.send('desktop2-theme-report', { bg, text })
   },
+  Terminal,
 })

--- a/src/preload/comfyPreload.ts
+++ b/src/preload/comfyPreload.ts
@@ -24,20 +24,30 @@ export interface TerminalRestore {
 /**
  * Interactive terminal bridge for the served ComfyUI frontend.
  *
- * The frontend has no idea which installation it belongs to; the main process
- * resolves that from the sending webContents, so every call here omits the
- * installationId. The session is per-install and shared across windows.
+ * Main resolves the installationId from the sending webContents when no
+ * explicit one is passed. The inline injection (running inside the
+ * comfyView) omits it; the pop-out window passes its installationId
+ * explicitly because its webContents isn't registered as a comfyView.
+ * Per-install shared shell — multiple subscribers see the same output.
  */
 const Terminal = {
   /** Spawn the shell if needed, register this view as a subscriber, and
    *  return the current scrollback/size/exited state. */
-  subscribe: (): Promise<TerminalRestore> => ipcRenderer.invoke('terminal-subscribe', null),
-  unsubscribe: (): Promise<void> => ipcRenderer.invoke('terminal-unsubscribe', null),
-  write: (data: string): Promise<void> => ipcRenderer.invoke('terminal-write', null, data),
-  resize: (cols: number, rows: number): Promise<void> =>
-    ipcRenderer.invoke('terminal-resize', null, cols, rows),
+  subscribe: (installationId?: string): Promise<TerminalRestore> =>
+    ipcRenderer.invoke('terminal-subscribe', installationId ?? null),
+  unsubscribe: (installationId?: string): Promise<void> =>
+    ipcRenderer.invoke('terminal-unsubscribe', installationId ?? null),
+  write: (data: string, installationId?: string): Promise<void> =>
+    ipcRenderer.invoke('terminal-write', installationId ?? null, data),
+  resize: (cols: number, rows: number, installationId?: string): Promise<void> =>
+    ipcRenderer.invoke('terminal-resize', installationId ?? null, cols, rows),
   /** Kill the current shell (if any) and start a fresh one. */
-  restart: (): Promise<TerminalRestore> => ipcRenderer.invoke('terminal-restart', null),
+  restart: (installationId?: string): Promise<TerminalRestore> =>
+    ipcRenderer.invoke('terminal-restart', installationId ?? null),
+  /** Open a separate Electron window subscribed to the same shell. Main
+   *  resolves the installationId from the caller's comfyView sender so
+   *  the inline injection doesn't need to know its own ID. */
+  openPopout: (): Promise<void> => ipcRenderer.invoke('terminal-popout-open', null),
   onOutput: (callback: (data: string) => void): (() => void) => {
     const handler = (_event: IpcRendererEvent, payload: { data: string }) =>
       callback(payload.data)
@@ -48,6 +58,42 @@ const Terminal = {
     const handler = () => callback()
     ipcRenderer.on('terminal-exited', handler)
     return () => ipcRenderer.removeListener('terminal-exited', handler)
+  },
+}
+
+export interface LogsRestore {
+  installationId: string
+  buffer: string[]
+}
+
+export interface LogsOutputMsg {
+  installationId: string
+  text: string
+}
+
+/**
+ * Read-only logs bridge. Subscribes to the shared per-install log
+ * broadcast that mirrors every `comfy-output` IPC send. Used by the
+ * pop-out logs window and (eventually) any other surface that wants the
+ * raw stdout/stderr stream without owning the launcher.
+ */
+const Logs = {
+  /** Register as a subscriber and return the current ring-buffer
+   *  contents for an immediate paint. Subsequent chunks arrive on
+   *  the `onOutput` channel. */
+  subscribe: (installationId?: string): Promise<LogsRestore> =>
+    ipcRenderer.invoke('logs-subscribe', installationId ?? null),
+  unsubscribe: (installationId?: string): Promise<void> =>
+    ipcRenderer.invoke('logs-unsubscribe', installationId ?? null),
+  /** Open a separate Electron window subscribed to the same broadcast.
+   *  Main resolves the installationId from the caller's comfyView sender
+   *  so the inline injection doesn't need to know its own ID. */
+  openPopout: (): Promise<void> => ipcRenderer.invoke('logs-popout-open', null),
+  onOutput: (callback: (msg: LogsOutputMsg) => void): (() => void) => {
+    const handler = (_event: IpcRendererEvent, payload: LogsOutputMsg) =>
+      callback(payload)
+    ipcRenderer.on('logs-output', handler)
+    return () => ipcRenderer.removeListener('logs-output', handler)
   },
 }
 
@@ -79,4 +125,5 @@ contextBridge.exposeInMainWorld('__comfyDesktop2', {
     ipcRenderer.send('desktop2-theme-report', { bg, text })
   },
   Terminal,
+  Logs,
 })

--- a/src/preload/comfySystemModalPreload.ts
+++ b/src/preload/comfySystemModalPreload.ts
@@ -8,6 +8,7 @@ import type { IpcRendererEvent } from 'electron'
  */
 
 export type SystemModalConfirmStyle = 'primary' | 'danger'
+export type SystemModalSecondaryStyle = 'primary' | 'danger' | 'default'
 
 export interface SystemModalDetailGroup {
   label: string
@@ -23,10 +24,13 @@ export interface SystemModalSpec {
   confirmLabel: string
   cancelLabel: string
   confirmStyle?: SystemModalConfirmStyle
+  /** Optional middle action; when present the modal renders a third button. */
+  secondaryLabel?: string
+  secondaryStyle?: SystemModalSecondaryStyle
   theme: { bg: string; text: string }
 }
 
-export type SystemModalAction = 'confirm' | 'cancel'
+export type SystemModalAction = 'confirm' | 'cancel' | 'secondary'
 
 export interface SystemModalActionPayload {
   modalId: string
@@ -80,7 +84,13 @@ function isModalSpec(value: unknown): value is SystemModalSpec {
 const bridge: ComfySystemModalBridge = {
   action: (payload) => {
     if (!payload || typeof payload.modalId !== 'string') return
-    if (payload.action !== 'confirm' && payload.action !== 'cancel') return
+    if (
+      payload.action !== 'confirm' &&
+      payload.action !== 'cancel' &&
+      payload.action !== 'secondary'
+    ) {
+      return
+    }
     ipcRenderer.send('comfy-systemmodal:action', payload)
   },
   ready: () => {

--- a/src/preload/comfyTitlePopupPreload.ts
+++ b/src/preload/comfyTitlePopupPreload.ts
@@ -1,6 +1,7 @@
 import { contextBridge, ipcRenderer } from 'electron'
 import type { IpcRendererEvent } from 'electron'
 import { PICKER_SETTINGS_CHANNELS as CH } from '../types/ipc'
+import type { TerminalRestore } from '../types/ipc'
 
 /** Bridge for the title-bar dropdown popup (waffle menu, downloads tray,
  *  instance-picker, global-settings), which share one reused child
@@ -328,6 +329,17 @@ export interface ComfyTitlePopupBridge {
   pickerSettingsPreviewLocalMigration(
     installationId: string,
   ): Promise<Record<string, unknown>>
+  /** Interactive per-install console. The popup's settings UI hits the same
+   *  generic `terminal-*` IPC the panel does, with an explicit installationId. */
+  terminalSubscribe(installationId: string): Promise<TerminalRestore>
+  terminalUnsubscribe(installationId: string): Promise<void>
+  terminalWrite(installationId: string, data: string): Promise<void>
+  terminalResize(installationId: string, cols: number, rows: number): Promise<void>
+  terminalRestart(installationId: string): Promise<TerminalRestore>
+  onTerminalOutput(
+    callback: (data: { installationId: string; data: string }) => void,
+  ): () => void
+  onTerminalExited(callback: (data: { installationId: string }) => void): () => void
   /** Relaunch the app (`app.relaunch()` main-side). */
   pickerSettingsRelaunchApp(): void
   /** Pull the panel-side i18n catalog; the popup boots with a minimal static
@@ -649,6 +661,28 @@ const bridge: ComfyTitlePopupBridge = {
     ipcRenderer.invoke(CH.previewDesktopMigration, { installationId, desktopId }),
   pickerSettingsPreviewLocalMigration: (installationId) =>
     ipcRenderer.invoke(CH.previewLocalMigration, { installationId }),
+  terminalSubscribe: (installationId) =>
+    ipcRenderer.invoke('terminal-subscribe', installationId),
+  terminalUnsubscribe: (installationId) =>
+    ipcRenderer.invoke('terminal-unsubscribe', installationId),
+  terminalWrite: (installationId, data) =>
+    ipcRenderer.invoke('terminal-write', installationId, data),
+  terminalResize: (installationId, cols, rows) =>
+    ipcRenderer.invoke('terminal-resize', installationId, cols, rows),
+  terminalRestart: (installationId) =>
+    ipcRenderer.invoke('terminal-restart', installationId),
+  onTerminalOutput: (callback) => {
+    const handler = (_event: IpcRendererEvent, data: unknown): void =>
+      callback(data as { installationId: string; data: string })
+    ipcRenderer.on('terminal-output', handler)
+    return () => ipcRenderer.removeListener('terminal-output', handler)
+  },
+  onTerminalExited: (callback) => {
+    const handler = (_event: IpcRendererEvent, data: unknown): void =>
+      callback(data as { installationId: string })
+    ipcRenderer.on('terminal-exited', handler)
+    return () => ipcRenderer.removeListener('terminal-exited', handler)
+  },
   pickerSettingsRelaunchApp: () => {
     ipcRenderer.send(CH.relaunchApp)
   },

--- a/src/renderer/src/comfySystemModal/SystemModalApp.vue
+++ b/src/renderer/src/comfySystemModal/SystemModalApp.vue
@@ -11,6 +11,8 @@ import BaseAlert from '../components/ui/BaseAlert.vue'
  */
 
 type SystemModalConfirmStyle = 'primary' | 'danger'
+type SystemModalSecondaryStyle = 'primary' | 'danger' | 'default'
+type SystemModalAction = 'confirm' | 'cancel' | 'secondary'
 
 interface SystemModalDetailGroup {
   label: string
@@ -25,11 +27,13 @@ interface SystemModalSpec {
   confirmLabel: string
   cancelLabel: string
   confirmStyle?: SystemModalConfirmStyle
+  secondaryLabel?: string
+  secondaryStyle?: SystemModalSecondaryStyle
   theme: { bg: string; text: string }
 }
 
 interface Bridge {
-  action(payload: { modalId: string; action: 'confirm' | 'cancel' }): void
+  action(payload: { modalId: string; action: SystemModalAction }): void
   ready(): void
   notifyRendered(): void
   onModal(cb: (spec: SystemModalSpec) => void): () => void
@@ -43,7 +47,7 @@ const tone = computed<'primary' | 'danger'>(() =>
   spec.value?.confirmStyle === 'danger' ? 'danger' : 'primary',
 )
 
-function ack(action: 'confirm' | 'cancel'): void {
+function ack(action: SystemModalAction): void {
   const current = spec.value
   if (!current) return
   bridge?.action({ modalId: current.id, action })
@@ -79,9 +83,12 @@ onUnmounted(() => {
     :button-label="spec?.confirmLabel ?? ''"
     :cancel-label="spec?.cancelLabel ?? ''"
     :tone="tone"
+    :secondary-label="spec?.secondaryLabel"
+    :secondary-tone="spec?.secondaryStyle ?? 'default'"
     show-cancel
     @close="ack('confirm')"
     @cancel="ack('cancel')"
+    @secondary="ack('secondary')"
   >
     <!-- When the spec carries `details`, render `message` then each group as a bulleted list. -->
     <template v-if="spec?.details && spec.details.length > 0" #default>

--- a/src/renderer/src/comfyTitlePopup/GlobalSettingsView.vue
+++ b/src/renderer/src/comfyTitlePopup/GlobalSettingsView.vue
@@ -29,6 +29,7 @@ interface ModelsDir {
 }
 
 interface Snapshot {
+  languageFields: Record<string, unknown>[]
   generalFields: Record<string, unknown>[]
   telemetryFields: Record<string, unknown>[]
   desktopUpdateFields: Record<string, unknown>[]
@@ -98,6 +99,9 @@ const storageSnapshot = computed(() => ({
   modelsSystemDefault: props.snapshot.modelsSystemDefault,
 }))
 
+const languageSections = computed<DetailSection[]>(() => [
+  { fields: props.snapshot.languageFields as unknown as DetailField[] }
+])
 const generalSections = computed<DetailSection[]>(() => [
   { fields: props.snapshot.generalFields as unknown as DetailField[] }
 ])
@@ -232,7 +236,11 @@ onMounted(() => {
         :aria-labelledby="`gs-tab-${activeTab}`"
       >
         <template v-if="activeTab === 'general'">
-          <GlobalSettingsMicroSection :title="t('settings.preferences', 'Preferences')">
+          <!-- Locale picker first, no microsection header — it's a single
+               control and the lone "Language" label on it is enough. -->
+          <SettingsSectionList :sections="languageSections" @update-field="handleUpdateField" />
+
+          <GlobalSettingsMicroSection :title="t('settings.appBehavior', 'App Behavior')">
             <SettingsSectionList :sections="generalSections" @update-field="handleUpdateField" />
           </GlobalSettingsMicroSection>
 
@@ -308,7 +316,7 @@ onMounted(() => {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 14px 16px;
+  padding: 6px 12px;
   border-bottom: 1px solid color-mix(in oklab, var(--neutral-100) 8%, transparent);
   flex: 0 0 auto;
 }
@@ -358,9 +366,9 @@ onMounted(() => {
   display: flex;
   flex-direction: column;
   gap: 2px;
-  flex: 0 0 196px;
-  width: 196px;
-  padding: 12px 8px;
+  flex: 0 0 160px;
+  width: 160px;
+  padding: 6px 4px;
   background: var(--neutral-800);
   border-right: 1px solid var(--chooser-surface-border);
   overflow-y: auto;
@@ -405,10 +413,29 @@ onMounted(() => {
   flex: 1 1 auto;
   min-width: 0;
   overflow-y: auto;
-  padding: 16px 20px;
+  padding: 8px 12px;
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 10px;
+}
+
+/* Compress the SettingsSectionList stack inside the Global Settings
+ * panel. The component's scoped defaults (gap: 32px between sections,
+ * 16px within, 44px min-height per boolean row) are tuned for the
+ * full-width install Settings surface; the dense popup needs less air.
+ * Targeting via :deep so we don't have to fork the component. */
+.gs-pane :deep(.settings-v2-sections) {
+  gap: 8px;
+}
+.gs-pane :deep(.settings-v2-section) {
+  gap: 4px;
+}
+.gs-pane :deep(.settings-v2-boolean-row) {
+  min-height: 28px;
+  padding: 0;
+}
+.gs-pane :deep(.settings-v2-field) {
+  gap: 4px;
 }
 
 .global-settings :deep(.ui-input),

--- a/src/renderer/src/comfyTitlePopup/InstancePickerView.test.ts
+++ b/src/renderer/src/comfyTitlePopup/InstancePickerView.test.ts
@@ -6,6 +6,16 @@ import { createPinia, setActivePinia } from 'pinia'
 import { en } from '../lib/i18nMessages.ts'
 import type { SnapshotListData } from '../types/ipc'
 
+// The interactive console pane drives a real xterm terminal (needs a canvas);
+// stub it so the picker's detail pane renders without a terminal host.
+vi.mock('../views/comfyUISettings/ConsoleTerminalPane.vue', () => ({
+  default: {
+    name: 'ConsoleTerminalPane',
+    props: ['installationId'],
+    template: '<div data-testid="console-terminal-pane-stub" />',
+  },
+}))
+
 const emptySnapshotListPayload: SnapshotListData = {
   snapshots: [],
   copyEvents: [],

--- a/src/renderer/src/comfyTitlePopup/TitlePopupApp.vue
+++ b/src/renderer/src/comfyTitlePopup/TitlePopupApp.vue
@@ -91,6 +91,7 @@ interface GlobalSettingsModelsDir {
 
 interface GlobalSettingsSnapshot {
   generalFields: Record<string, unknown>[]
+  languageFields: Record<string, unknown>[]
   telemetryFields: Record<string, unknown>[]
   desktopUpdateFields: Record<string, unknown>[]
   cacheFields: Record<string, unknown>[]
@@ -183,6 +184,7 @@ const pickerSnapshot = ref<PickerSnapshot>({
 })
 const globalSettingsSnapshot = ref<GlobalSettingsSnapshot>({
   generalFields: [],
+  languageFields: [],
   telemetryFields: [],
   desktopUpdateFields: [],
   cacheFields: [],

--- a/src/renderer/src/comfyTitlePopup/pickerSettingsApiShim.test.ts
+++ b/src/renderer/src/comfyTitlePopup/pickerSettingsApiShim.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { installPickerSettingsApiShim } from './pickerSettingsApiShim'
+
+// The settings UI runs inside the title-popup WebContents, which has the
+// `__comfyTitlePopup` bridge instead of `window.api`. The shim must forward
+// every method the settings UI calls — including the interactive console —
+// or the Console tab mounts xterm against undefined APIs and wedges the tab
+// transition (regression: the whole settings UI appeared to freeze).
+
+afterEach(() => {
+  delete (window as unknown as { api?: unknown }).api
+  delete (window as unknown as { __comfyTitlePopup?: unknown }).__comfyTitlePopup
+})
+
+function installBridge(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const explicit: Record<string, unknown> = {
+    terminalSubscribe: vi.fn().mockResolvedValue({
+      buffer: [],
+      size: { cols: 80, rows: 30 },
+      exited: false
+    }),
+    terminalUnsubscribe: vi.fn().mockResolvedValue(undefined),
+    terminalWrite: vi.fn().mockResolvedValue(undefined),
+    terminalResize: vi.fn().mockResolvedValue(undefined),
+    terminalRestart: vi.fn().mockResolvedValue({
+      buffer: [],
+      size: { cols: 80, rows: 30 },
+      exited: false
+    }),
+    onTerminalOutput: vi.fn(() => () => {}),
+    onTerminalExited: vi.fn(() => () => {}),
+    ...overrides
+  }
+  // Auto-stub any other mapped bridge method the shim binds, so the test only
+  // has to declare the terminal methods it asserts on.
+  const bridge = new Proxy(explicit, {
+    get(target, prop: string) {
+      if (!(prop in target)) target[prop] = vi.fn()
+      return target[prop]
+    },
+    has() {
+      return true
+    }
+  })
+  ;(window as unknown as { __comfyTitlePopup?: unknown }).__comfyTitlePopup = bridge
+  return bridge
+}
+
+describe('installPickerSettingsApiShim — terminal forwarding', () => {
+  const terminalMethods = [
+    'terminalSubscribe',
+    'terminalUnsubscribe',
+    'terminalWrite',
+    'terminalResize',
+    'terminalRestart',
+    'onTerminalOutput',
+    'onTerminalExited'
+  ] as const
+
+  it('exposes every terminal method on window.api', () => {
+    installBridge()
+    installPickerSettingsApiShim()
+
+    const api = (window as unknown as { api: Record<string, unknown> }).api
+    for (const method of terminalMethods) {
+      expect(typeof api[method]).toBe('function')
+    }
+  })
+
+  it('forwards terminal calls to the bridge', async () => {
+    const bridge = installBridge()
+    installPickerSettingsApiShim()
+
+    const api = (window as unknown as {
+      api: {
+        terminalSubscribe: (id: string) => Promise<unknown>
+        terminalWrite: (id: string, data: string) => Promise<void>
+        onTerminalOutput: (cb: () => void) => () => void
+      }
+    }).api
+
+    await api.terminalSubscribe('install-A')
+    expect(bridge.terminalSubscribe).toHaveBeenCalledWith('install-A')
+
+    await api.terminalWrite('install-A', 'ls\r')
+    expect(bridge.terminalWrite).toHaveBeenCalledWith('install-A', 'ls\r')
+
+    const cb = vi.fn()
+    api.onTerminalOutput(cb)
+    expect(bridge.onTerminalOutput).toHaveBeenCalledWith(cb)
+  })
+})

--- a/src/renderer/src/comfyTitlePopup/pickerSettingsApiShim.ts
+++ b/src/renderer/src/comfyTitlePopup/pickerSettingsApiShim.ts
@@ -31,6 +31,13 @@ const API_MAP = {
   previewDesktopMigration: 'pickerSettingsPreviewDesktopMigration',
   previewLocalMigration: 'pickerSettingsPreviewLocalMigration',
   onReleaseCacheEnriched: 'pickerSettingsOnReleaseCacheEnriched',
+  terminalSubscribe: 'terminalSubscribe',
+  terminalUnsubscribe: 'terminalUnsubscribe',
+  terminalWrite: 'terminalWrite',
+  terminalResize: 'terminalResize',
+  terminalRestart: 'terminalRestart',
+  onTerminalOutput: 'onTerminalOutput',
+  onTerminalExited: 'onTerminalExited',
 } as const satisfies Record<string, keyof ComfyTitlePopupBridge>
 
 type ShimApi = {

--- a/src/renderer/src/components/FeedbackModal.vue
+++ b/src/renderer/src/components/FeedbackModal.vue
@@ -103,26 +103,16 @@ onBeforeUnmount(() => {
 </template>
 
 <style scoped>
-/* The typeform page is white, so repaint the panel to avoid a coloured
- * frame around the form from the default dark BaseModal chrome. */
+/* The typeform page is dark, so let the BaseModal's default dark chrome
+ * show through — the previous white override left the close X invisible
+ * against the dark form. Only the body padding override remains so the
+ * iframe sits flush against the panel edge. */
 :global(.base-modal-panel.feedback-modal-panel) {
-  background: #ffffff;
-  border-color: transparent;
   min-height: 0;
 }
 :global(.feedback-modal-panel .base-modal-body) {
   padding: 0;
   overflow: hidden;
-}
-:global(.feedback-modal-panel .base-modal-close) {
-  background: transparent;
-  border-color: transparent;
-  color: var(--neutral-900, #111);
-  opacity: 0.55;
-}
-:global(.feedback-modal-panel .base-modal-close:hover) {
-  background: color-mix(in oklab, #000 8%, transparent);
-  opacity: 1;
 }
 
 .feedback-modal-body {
@@ -130,7 +120,6 @@ onBeforeUnmount(() => {
   width: 100%;
   height: clamp(520px, 76vh, 820px);
   overflow: hidden;
-  background: #ffffff;
 }
 
 .feedback-modal-frame {
@@ -148,7 +137,7 @@ onBeforeUnmount(() => {
   display: grid;
   place-items: center;
   font-size: 13px;
-  color: color-mix(in oklab, #000 55%, transparent);
+  color: color-mix(in oklab, var(--neutral-100, #fff) 65%, transparent);
   pointer-events: none;
 }
 </style>

--- a/src/renderer/src/components/settings/ComfyUISettingsContent.test.ts
+++ b/src/renderer/src/components/settings/ComfyUISettingsContent.test.ts
@@ -24,12 +24,15 @@ const messages = {
       tabUpdate: 'Update',
       tabSnapshots: 'Snapshots',
       tabStorage: 'Storage',
+      tabConsole: 'Console',
       relaunch: 'Relaunch',
       more: 'More',
     },
     tooltips: {
       snapshots:
         'A saved point-in-time state of an installation (versions + custom nodes) you can restore later.',
+      console:
+        "An interactive shell running in this installation's folder. Works whether ComfyUI is running or stopped.",
     },
     instancePicker: {
       open: 'Start',
@@ -114,6 +117,9 @@ vi.mock('../../views/comfyUISettings/StatusFactPanel.vue', () => ({
 }))
 vi.mock('../../views/comfyUISettings/StoragePane.vue', () => ({
   default: { template: '<div />' },
+}))
+vi.mock('../../views/comfyUISettings/ConsoleTerminalPane.vue', () => ({
+  default: { name: 'ConsoleTerminalPane', props: ['installationId'], template: '<div data-testid="console-terminal-pane-stub" />' },
 }))
 vi.mock('../../views/comfyUISettings/ArgsBuilderPage.vue', () => ({
   default: { template: '<div />' },
@@ -374,13 +380,16 @@ describe('ComfyUISettingsContent', () => {
 
     const SNAPSHOTS_TOOLTIP =
       'A saved point-in-time state of an installation (versions + custom nodes) you can restore later.'
+    const CONSOLE_TOOLTIP =
+      "An interactive shell running in this installation's folder. Works whether ComfyUI is running or stopped."
+    const CONCEPT_TOOLTIPS = new Set([SNAPSHOTS_TOOLTIP, CONSOLE_TOOLTIP])
 
-    /** Disabled flags for tabs that only echo their label (excludes Snapshots,
-     *  which carries a real concept tooltip). */
+    /** Disabled flags for tabs that only echo their label (excludes Snapshots
+     *  and Console, which carry real concept tooltips). */
     function labelEchoDisabledFlags(w: VueWrapper): boolean[] {
       return w
         .findAllComponents({ name: 'Tooltip' })
-        .filter((tt) => tt.props('text') !== SNAPSHOTS_TOOLTIP)
+        .filter((tt) => !CONCEPT_TOOLTIPS.has(tt.props('text') as string))
         .map((tt) => tt.props('disabled') as boolean)
     }
 

--- a/src/renderer/src/components/settings/ComfyUISettingsContent.vue
+++ b/src/renderer/src/components/settings/ComfyUISettingsContent.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref, toRef, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { CheckCircle, XCircle, ChevronUp, HardDrive, SlidersHorizontal, Info, RefreshCw, History } from 'lucide-vue-next'
+import { CheckCircle, XCircle, ChevronUp, HardDrive, SlidersHorizontal, Info, RefreshCw, History, SquareTerminal } from 'lucide-vue-next'
 import { useComfyUISettings } from '../../composables/useComfyUISettings'
 import { useInstallCta } from '../../composables/useInstallCta'
 import { useCloudCapacity } from '../../composables/useCloudCapacity'
@@ -12,6 +12,7 @@ import SnapshotsView from '../../views/comfyUISettings/SnapshotsView.vue'
 import StatusFactPanel from '../../views/comfyUISettings/StatusFactPanel.vue'
 import SettingsSectionList from '../../views/comfyUISettings/SettingsSectionList.vue'
 import StoragePane, { type StorageSnapshot } from '../../views/comfyUISettings/StoragePane.vue'
+import ConsoleTerminalPane from '../../views/comfyUISettings/ConsoleTerminalPane.vue'
 import Tooltip from '../ui/Tooltip.vue'
 import type { PickerTab, SectionTab } from '../../lib/pickerTabs'
 import { humanizeOpStatus, operationInflightLabel, operationSuccessLabel } from '../../lib/progressStatusLabel'
@@ -251,17 +252,36 @@ const ALL_TABS: TabDef[] = [
     icon: HardDrive
   },
   {
+    key: 'console',
+    sectionTab: 'console',
+    label: t('comfyUISettings.tabConsole', 'Console'),
+    icon: SquareTerminal,
+    tooltip: t('tooltips.console')
+  },
+  {
     key: 'status',
     sectionTab: 'status',
     label: t('comfyUISettings.tabStatus', 'About'),
     icon: Info
   }
 ]
+
+// The console tab has no backend `sections` — it's a live PTY view — so it
+// can't be section-gated like the others. Show it for any local install
+// (cloud installs run no local process to attach a shell to).
+const showConsoleTab = computed(
+  () => installation.value != null && installation.value.sourceCategory !== 'cloud'
+)
+
 const tabs = computed<TabDef[]>(() => {
   // Cloud runs no local process, so the `config` tab carries no real
   // startup args — relabel it "Storage" to match its contents.
   const isCloud = installation.value?.sourceCategory === 'cloud'
-  return ALL_TABS.filter((tab) => sectionsForTab(tab.sectionTab).value.length > 0).map((tab) =>
+  return ALL_TABS.filter((tab) =>
+    tab.key === 'console'
+      ? showConsoleTab.value
+      : sectionsForTab(tab.sectionTab).value.length > 0
+  ).map((tab) =>
     isCloud && tab.key === 'config'
       ? { ...tab, label: t('comfyUISettings.tabStorage', 'Storage'), icon: HardDrive }
       : tab
@@ -598,13 +618,13 @@ defineExpose({
         {{ t('comfyUISettings.emptyInstallLess', 'Open a ComfyUI install to view its settings.') }}
       </p>
       <p
-        v-else-if="loading && !visibleSections.length"
+        v-else-if="loading && !visibleSections.length && activeTab !== 'console'"
         class="empty"
         :data-testid="TID.pickerSettingsLoading"
       >
         {{ t('common.loading', 'Loading…') }}
       </p>
-      <p v-else-if="error" class="empty error">{{ error }}</p>
+      <p v-else-if="error && activeTab !== 'console'" class="empty error">{{ error }}</p>
 
       <Transition v-else :name="subPageTransition" mode="out-in">
         <ArgsBuilderPage
@@ -681,6 +701,13 @@ defineExpose({
                 :running-action-ids="runningActionIds"
                 @update-field="updateField"
               />
+            </div>
+            <div
+              v-else-if="activeTab === 'console' && installation"
+              :key="`tab-console-${paneInstallKey}`"
+              class="settings-v2-tab-pane settings-v2-tab-pane--console"
+            >
+              <ConsoleTerminalPane :installation-id="installation.id" />
             </div>
             <div v-else :key="`tab-${activeTab}-${paneInstallKey}`" class="settings-v2-tab-pane">
               <Transition name="op-overlay" mode="out-in">

--- a/src/renderer/src/composables/useDeepLinkRouter.ts
+++ b/src/renderer/src/composables/useDeepLinkRouter.ts
@@ -19,8 +19,13 @@ interface DeepLinkRouterOpts {
   showAppUpdateRestartPrompt: (version: string | null) => Promise<void>
   showAppUpdateDownloadPrompt: (version: string | null) => Promise<void>
   /** Picker picked a non-running install; runs the chooser's launch flow
-   *  without the attach-claim that would swap this host's install out. */
-  pickInstallFromPicker?: (installation: Installation) => Promise<void> | void
+   *  without the attach-claim that would swap this host's install out.
+   *  `startupRestore` marks the boot-time restore path (dashboard fallback on
+   *  missing action + reveal handshake). */
+  pickInstallFromPicker?: (
+    installation: Installation,
+    opts?: { startupRestore?: boolean },
+  ) => Promise<void> | void
   /** Picker "More" menu selected an install-level action; dispatches
    *  through the same `useInstallContextMenu` path the dashboard kebab uses. */
   runInstallActionFromPicker?: (installation: Installation, actionId: string) => Promise<void> | void
@@ -93,8 +98,17 @@ export function useDeepLinkRouter(opts: DeepLinkRouterOpts): void {
           const id = payload.installationId
           if (!id) return
           const inst = installationStore.getById(id)
-          if (!inst) return
-          await opts.pickInstallFromPicker?.(inst)
+          if (!inst) {
+            // Boot restore against a now-missing install: tell main to reveal
+            // the dashboard rather than leaving the hidden window stuck.
+            if (payload.startupRestore) {
+              window.api.resolveStartupRestoreReveal('dashboard-fallback')
+            }
+            return
+          }
+          await opts.pickInstallFromPicker?.(inst, {
+            startupRestore: payload.startupRestore === true,
+          })
           return
         }
         if (payload.kind === 'picker-install-action') {

--- a/src/renderer/src/composables/useInstallList.ts
+++ b/src/renderer/src/composables/useInstallList.ts
@@ -130,24 +130,42 @@ export function useInstallList(opts: UseInstallListOpts): UseInstallListApi {
   // 60-second tick so "Nm ago" / "Nh ago" labels stay fresh.
   const now = ref(Date.now())
   let nowTimer: ReturnType<typeof setInterval> | null = null
+  // Live updates: any setting change on main broadcasts here, so the
+  // dashboard re-fetches `hideCloudFromPicker` without the user having to
+  // close + reopen the window after toggling in Global Settings.
+  let unsubSettingsChanged: (() => void) | null = null
+
+  const refetchHideCloud = async (): Promise<void> => {
+    try {
+      const value = await window.api.getSetting('hideCloudFromPicker')
+      hideCloudFromPicker.value = value === true
+    } catch {
+      hideCloudFromPicker.value = false
+    }
+  }
+
   onMounted(() => {
     nowTimer = setInterval(() => {
       now.value = Date.now()
     }, 60_000)
-    // Best-effort read of the "Hide Cloud from picker" opt-out. Failures
-    // resolve to `false` so Cloud renders by default — never silently
-    // hide on a missing IPC bridge (e.g. tests or pre-attach mounts).
-    void (async () => {
-      try {
-        const value = await window.api.getSetting('hideCloudFromPicker')
-        hideCloudFromPicker.value = value === true
-      } catch {
-        hideCloudFromPicker.value = false
-      }
-    })()
+    // Best-effort initial read. Failures resolve to `false` so Cloud
+    // renders by default — never silently hide on a missing IPC bridge
+    // (e.g. tests or pre-attach mounts).
+    void refetchHideCloud()
+    // Re-read on any settings broadcast keyed to hideCloudFromPicker so
+    // toggling the Global Settings opt-out takes effect immediately on
+    // the live dashboard (no close + reopen required).
+    try {
+      unsubSettingsChanged = window.api.onSettingsChanged((data) => {
+        if (data?.key === 'hideCloudFromPicker') void refetchHideCloud()
+      })
+    } catch {
+      // tests / older preloads without the listener: fall back to mount-only
+    }
   })
   onBeforeUnmount(() => {
     if (nowTimer) clearInterval(nowTimer)
+    if (unsubSettingsChanged) unsubSettingsChanged()
   })
 
   function timeAgo(timestamp: number): string {

--- a/src/renderer/src/composables/useInstallList.ts
+++ b/src/renderer/src/composables/useInstallList.ts
@@ -49,12 +49,22 @@ export interface UseInstallListApi {
 // Shared install-list state for the dashboard and the instance picker.
 // Pure-data (no IPC/Pinia/DOM); Cloud is always split out as its own surface.
 // Owns a 60s `now` tick so relative time labels stay fresh.
+//
+// The `hideCloudFromPicker` setting is read once on mount; subsequent
+// toggles in Global Settings take effect on the next dashboard render
+// (no live IPC broadcast for it — settings updates already trigger a
+// re-render via the snapshot pipeline).
 export function useInstallList(opts: UseInstallListOpts): UseInstallListApi {
   const { t } = useI18n()
   const { installations } = opts
 
   const searchQuery = ref('')
   const activeFilter = ref<FilterKey>('all')
+  // Module-local copy of the `hideCloudFromPicker` setting. `false` while
+  // the IPC fetch is in flight so Cloud renders by default and only
+  // disappears if the user actually opted in. Re-fetched on mount so
+  // the Settings toggle applies after a dashboard reload.
+  const hideCloudFromPicker = ref<boolean>(false)
 
   function matchesQuery(name: string): boolean {
     const q = searchQuery.value.trim().toLowerCase()
@@ -97,6 +107,10 @@ export function useInstallList(opts: UseInstallListOpts): UseInstallListApi {
   })
 
   const showCloudCard = computed<boolean>(() => {
+    // Opt-out: user toggled "Hide Cloud from picker" in Global Settings.
+    // Gates BOTH the per-install tile (when a cloud install exists) and
+    // the generic Try-Cloud CTA so the user truly never sees it.
+    if (hideCloudFromPicker.value) return false
     const inCategory = activeFilter.value === 'all' || activeFilter.value === 'cloud'
     if (!inCategory) return false
     // When a real cloud install exists, gate visibility on the query —
@@ -120,6 +134,17 @@ export function useInstallList(opts: UseInstallListOpts): UseInstallListApi {
     nowTimer = setInterval(() => {
       now.value = Date.now()
     }, 60_000)
+    // Best-effort read of the "Hide Cloud from picker" opt-out. Failures
+    // resolve to `false` so Cloud renders by default — never silently
+    // hide on a missing IPC bridge (e.g. tests or pre-attach mounts).
+    void (async () => {
+      try {
+        const value = await window.api.getSetting('hideCloudFromPicker')
+        hideCloudFromPicker.value = value === true
+      } catch {
+        hideCloudFromPicker.value = false
+      }
+    })()
   })
   onBeforeUnmount(() => {
     if (nowTimer) clearInterval(nowTimer)

--- a/src/renderer/src/lib/pickerTabs.ts
+++ b/src/renderer/src/lib/pickerTabs.ts
@@ -1,7 +1,19 @@
-export type PickerTab = 'config' | 'status' | 'update' | 'snapshots' | 'storage'
+export type PickerTab =
+  | 'config'
+  | 'status'
+  | 'update'
+  | 'snapshots'
+  | 'storage'
+  | 'console'
 
 /** Narrowing of `DetailSection.tab`. Uses 'settings' where PickerTab uses 'config'. */
-export type SectionTab = 'settings' | 'status' | 'update' | 'snapshots' | 'storage'
+export type SectionTab =
+  | 'settings'
+  | 'status'
+  | 'update'
+  | 'snapshots'
+  | 'storage'
+  | 'console'
 
 const PICKER_TABS: ReadonlySet<PickerTab> = new Set([
   'config',
@@ -9,6 +21,7 @@ const PICKER_TABS: ReadonlySet<PickerTab> = new Set([
   'update',
   'snapshots',
   'storage',
+  'console',
 ])
 
 export function isPickerTab(tab: string | null | undefined): tab is PickerTab {

--- a/src/renderer/src/panel/PanelApp.vue
+++ b/src/renderer/src/panel/PanelApp.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import ProgressModal from '../views/ProgressModal.vue'
 import ModalDialog from '../components/ModalDialog.vue'
@@ -184,6 +184,23 @@ chooserHandoff = useChooserHandoff({
 })
 const { handleChooserPick, handleChooserShowNewInstall } = chooserHandoff
 
+// Boot-time restore: the host window is hidden until we tell main the outcome.
+// Use `performChooserLaunch` (NOT `handleChooserPick`) so a missing launch
+// action falls back to the dashboard instead of opening the new-install wizard.
+// Reveal the launching takeover when it comes up; otherwise (already running,
+// missing action, console/external mode, error) fall back to the dashboard.
+async function handleStartupRestorePick(inst: Installation): Promise<void> {
+  try {
+    const outcome = await chooserHandoff.performChooserLaunch(inst)
+    await nextTick()
+    const takeoverReady = outcome === 'launched' && currentOverlay.value?.kind === 'takeover'
+    window.api.resolveStartupRestoreReveal(takeoverReady ? 'takeover-ready' : 'dashboard-fallback')
+  } catch (err) {
+    console.error('startup restore launch failed', err)
+    window.api.resolveStartupRestoreReveal('dashboard-fallback')
+  }
+}
+
 // When an overlay closes on a chooser host without producing an attach
 // (cancel / error / dismiss), revert the install identity preview that
 // `claimAttachHost` pushed to the title bar — otherwise the chooser host
@@ -233,7 +250,7 @@ useDeepLinkRouter({
   openOverlay,
   showAppUpdateRestartPrompt,
   showAppUpdateDownloadPrompt,
-  pickInstallFromPicker: async (inst) => {
+  pickInstallFromPicker: async (inst, pickOpts) => {
     // Chooser-host pick (no installationId backing this host) → swap
     // in-place via the same path the dashboard chooser uses, so the
     // dashboard window becomes the picked install. Install-backed
@@ -243,7 +260,11 @@ useDeepLinkRouter({
     // window before this IPC fires, so we only ever see launches
     // here for installs that aren't running yet).
     if (!installationId) {
-      await chooserHandoff.handleChooserPick(inst)
+      if (pickOpts?.startupRestore) {
+        await handleStartupRestorePick(inst)
+      } else {
+        await chooserHandoff.handleChooserPick(inst)
+      }
     } else {
       await chooserHandoff.performPickerLaunch(inst)
     }

--- a/src/renderer/src/views/comfyUISettings/ConsoleTerminalPane.test.ts
+++ b/src/renderer/src/views/comfyUISettings/ConsoleTerminalPane.test.ts
@@ -18,6 +18,10 @@ const fakeTerminal = {
   resize: vi.fn(),
   reset: vi.fn(),
   dispose: vi.fn(),
+  element: {
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn()
+  },
   cols: 80,
   rows: 30
 }
@@ -48,6 +52,9 @@ function createTestI18n() {
 }
 
 let exitCallbacks: Array<(data: { installationId: string }) => void> = []
+let outputCallbacks: Array<
+  (data: { installationId: string; data: string }) => void
+> = []
 
 function makeRestore(overrides: Partial<TerminalRestore> = {}): TerminalRestore {
   return { buffer: [], size: { cols: 80, rows: 30 }, exited: false, ...overrides }
@@ -60,7 +67,12 @@ function setupApi(subscribeRestore: TerminalRestore = makeRestore()): void {
     terminalWrite: vi.fn().mockResolvedValue(undefined),
     terminalResize: vi.fn().mockResolvedValue(undefined),
     terminalRestart: vi.fn().mockResolvedValue(makeRestore()),
-    onTerminalOutput: vi.fn(() => () => {}),
+    onTerminalOutput: vi.fn(
+      (cb: (data: { installationId: string; data: string }) => void) => {
+        outputCallbacks.push(cb)
+        return () => {}
+      }
+    ),
     onTerminalExited: vi.fn((cb: (data: { installationId: string }) => void) => {
       exitCallbacks.push(cb)
       return () => {}
@@ -78,6 +90,7 @@ function mountPane(): VueWrapper {
 describe('comfyUISettings/ConsoleTerminalPane', () => {
   beforeEach(() => {
     exitCallbacks = []
+    outputCallbacks = []
     vi.clearAllMocks()
     ;(globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
       observe() {}
@@ -109,6 +122,41 @@ describe('comfyUISettings/ConsoleTerminalPane', () => {
     await flushPromises()
     expect(window.api.terminalRestart).toHaveBeenCalledWith('install-A')
     expect(w.find(`[data-testid="${TID.consoleSessionEnded}"]`).exists()).toBe(false)
+  })
+
+  it('clears the session-ended banner when output resumes', async () => {
+    const w = mountPane()
+    await flushPromises()
+
+    exitCallbacks.forEach((cb) => cb({ installationId: 'install-A' }))
+    await flushPromises()
+    expect(w.find(`[data-testid="${TID.consoleSessionEnded}"]`).exists()).toBe(true)
+
+    outputCallbacks.forEach((cb) =>
+      cb({ installationId: 'install-A', data: 'fresh prompt' })
+    )
+    await flushPromises()
+    expect(w.find(`[data-testid="${TID.consoleSessionEnded}"]`).exists()).toBe(false)
+  })
+
+  it('re-asserts its size to the shared PTY on focus even when local dims are unchanged', async () => {
+    const w = mountPane()
+    await flushPromises()
+
+    const host = w.find(`[data-testid="${TID.consoleTerminal}"]`)
+      .element as HTMLElement
+    Object.defineProperty(host, 'offsetParent', {
+      value: document.body,
+      configurable: true
+    })
+    vi.mocked(window.api.terminalResize).mockClear()
+
+    const focusHandler = fakeTerminal.element.addEventListener.mock.calls.find(
+      ([event]) => event === 'focusin'
+    )?.[1] as () => void
+    focusHandler()
+
+    expect(window.api.terminalResize).toHaveBeenCalledWith('install-A', 80, 30)
   })
 
   it('ignores exit events for other installations', async () => {

--- a/src/renderer/src/views/comfyUISettings/ConsoleTerminalPane.test.ts
+++ b/src/renderer/src/views/comfyUISettings/ConsoleTerminalPane.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+
+import { TID } from '../../../../shared/testIds'
+import type { TerminalRestore } from '../../types/ipc'
+import ConsoleTerminalPane from './ConsoleTerminalPane.vue'
+
+// The PTY lives in main; this pane is a thin xterm view. We mock xterm so the
+// tests assert the wiring (subscribe on mount, exit banner + restart) rather
+// than terminal rendering, which needs a real canvas.
+
+const fakeTerminal = {
+  loadAddon: vi.fn(),
+  open: vi.fn(),
+  onData: vi.fn(() => ({ dispose: vi.fn() })),
+  write: vi.fn(),
+  resize: vi.fn(),
+  reset: vi.fn(),
+  dispose: vi.fn(),
+  cols: 80,
+  rows: 30
+}
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: vi.fn(function (this: unknown) {
+    return fakeTerminal
+  })
+}))
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: vi.fn(function (this: unknown) {
+    return { fit: vi.fn(), proposeDimensions: vi.fn() }
+  })
+}))
+vi.mock('@xterm/xterm/css/xterm.css', () => ({}))
+
+const messages = {
+  en: {
+    console: {
+      sessionEnded: 'Console session ended',
+      restartSession: 'Restart console'
+    }
+  }
+} as const
+
+function createTestI18n() {
+  return createI18n({ legacy: false, locale: 'en', messages })
+}
+
+let exitCallbacks: Array<(data: { installationId: string }) => void> = []
+
+function makeRestore(overrides: Partial<TerminalRestore> = {}): TerminalRestore {
+  return { buffer: [], size: { cols: 80, rows: 30 }, exited: false, ...overrides }
+}
+
+function setupApi(subscribeRestore: TerminalRestore = makeRestore()): void {
+  ;(window as unknown as { api: Record<string, unknown> }).api = {
+    terminalSubscribe: vi.fn().mockResolvedValue(subscribeRestore),
+    terminalUnsubscribe: vi.fn().mockResolvedValue(undefined),
+    terminalWrite: vi.fn().mockResolvedValue(undefined),
+    terminalResize: vi.fn().mockResolvedValue(undefined),
+    terminalRestart: vi.fn().mockResolvedValue(makeRestore()),
+    onTerminalOutput: vi.fn(() => () => {}),
+    onTerminalExited: vi.fn((cb: (data: { installationId: string }) => void) => {
+      exitCallbacks.push(cb)
+      return () => {}
+    })
+  }
+}
+
+function mountPane(): VueWrapper {
+  return mount(ConsoleTerminalPane, {
+    props: { installationId: 'install-A' },
+    global: { plugins: [createTestI18n()] }
+  }) as VueWrapper
+}
+
+describe('comfyUISettings/ConsoleTerminalPane', () => {
+  beforeEach(() => {
+    exitCallbacks = []
+    vi.clearAllMocks()
+    ;(globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+      observe() {}
+      disconnect() {}
+    }
+    setupApi()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('subscribes to the install console on mount', async () => {
+    const w = mountPane()
+    await flushPromises()
+    expect(window.api.terminalSubscribe).toHaveBeenCalledWith('install-A')
+    expect(w.find(`[data-testid="${TID.consoleSessionEnded}"]`).exists()).toBe(false)
+  })
+
+  it('shows the restart banner on exit and respawns on click', async () => {
+    const w = mountPane()
+    await flushPromises()
+
+    exitCallbacks.forEach((cb) => cb({ installationId: 'install-A' }))
+    await flushPromises()
+    expect(w.find(`[data-testid="${TID.consoleSessionEnded}"]`).exists()).toBe(true)
+
+    await w.find(`[data-testid="${TID.consoleRestart}"]`).trigger('click')
+    await flushPromises()
+    expect(window.api.terminalRestart).toHaveBeenCalledWith('install-A')
+    expect(w.find(`[data-testid="${TID.consoleSessionEnded}"]`).exists()).toBe(false)
+  })
+
+  it('ignores exit events for other installations', async () => {
+    const w = mountPane()
+    await flushPromises()
+
+    exitCallbacks.forEach((cb) => cb({ installationId: 'other-install' }))
+    await flushPromises()
+    expect(w.find(`[data-testid="${TID.consoleSessionEnded}"]`).exists()).toBe(false)
+  })
+
+  it('shows the banner immediately when restored session was already exited', async () => {
+    setupApi(makeRestore({ exited: true }))
+    const w = mountPane()
+    await flushPromises()
+    expect(w.find(`[data-testid="${TID.consoleSessionEnded}"]`).exists()).toBe(true)
+  })
+})

--- a/src/renderer/src/views/comfyUISettings/ConsoleTerminalPane.vue
+++ b/src/renderer/src/views/comfyUISettings/ConsoleTerminalPane.vue
@@ -92,6 +92,7 @@ async function attach(id: string): Promise<void> {
 
   pushSize()
   applyRestore(await api.terminalSubscribe(id))
+  requestAnimationFrame(pushSize)
 }
 
 async function restart(): Promise<void> {
@@ -162,6 +163,19 @@ onBeforeUnmount(teardown)
   inset: 0;
   padding: 8px;
   overflow: hidden;
+}
+
+/* xterm injects its own DOM at runtime, outside Vue's scoped templates, so
+ * `:deep()` is required to reach it. Without clamping these layers they
+ * overflow the host and capture pointer events across the settings window,
+ * which reads as the whole UI freezing. */
+.console-host :deep(.xterm) {
+  overflow: hidden;
+}
+
+.console-host :deep(.xterm-screen) {
+  overflow: hidden;
+  background-color: #171717;
 }
 
 .console-ended {

--- a/src/renderer/src/views/comfyUISettings/ConsoleTerminalPane.vue
+++ b/src/renderer/src/views/comfyUISettings/ConsoleTerminalPane.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useDebounceFn } from '@vueuse/core'
 import { useI18n } from 'vue-i18n'
 import { FitAddon } from '@xterm/addon-fit'
 import { Terminal } from '@xterm/xterm'
@@ -21,6 +22,7 @@ const props = defineProps<Props>()
 const { t } = useI18n()
 const api = window.api
 
+const paneRef = ref<HTMLDivElement | null>(null)
 const hostRef = ref<HTMLDivElement | null>(null)
 const exited = ref(false)
 
@@ -55,9 +57,14 @@ function applyRestore(restore: TerminalRestore): void {
 function pushSize(): void {
   if (!terminal || !fitAddon || !currentId) return
   if (!hostRef.value?.offsetParent) return
-  fitAddon.fit()
-  void api.terminalResize(currentId, terminal.cols, terminal.rows)
+  const dims = fitAddon.proposeDimensions()
+  if (!dims || !dims.cols || !dims.rows) return
+  if (dims.cols === terminal.cols && dims.rows === terminal.rows) return
+  terminal.resize(dims.cols, dims.rows)
+  void api.terminalResize(currentId, dims.cols, dims.rows)
 }
+
+const debouncedPushSize = useDebounceFn(pushSize, 50)
 
 async function attach(id: string): Promise<void> {
   if (!hostRef.value) return
@@ -80,8 +87,8 @@ async function attach(id: string): Promise<void> {
     })
   )
 
-  resizeObserver = new ResizeObserver(() => pushSize())
-  resizeObserver.observe(hostRef.value)
+  resizeObserver = new ResizeObserver(() => void debouncedPushSize())
+  if (paneRef.value) resizeObserver.observe(paneRef.value)
 
   pushSize()
   applyRestore(await api.terminalSubscribe(id))
@@ -112,7 +119,7 @@ onBeforeUnmount(teardown)
 </script>
 
 <template>
-  <div class="console-pane">
+  <div ref="paneRef" class="console-pane">
     <div ref="hostRef" class="console-host" :data-testid="TID.consoleTerminal" />
     <div
       v-if="exited"

--- a/src/renderer/src/views/comfyUISettings/ConsoleTerminalPane.vue
+++ b/src/renderer/src/views/comfyUISettings/ConsoleTerminalPane.vue
@@ -1,0 +1,178 @@
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { FitAddon } from '@xterm/addon-fit'
+import { Terminal } from '@xterm/xterm'
+import '@xterm/xterm/css/xterm.css'
+import type { TerminalRestore } from '../../../../types/ipc'
+import { TID } from '../../../../shared/testIds'
+
+/** Interactive per-install console. The shell lives in main (one PTY per
+ *  installation, shared across windows) and survives ComfyUI being stopped,
+ *  so this pane is purely a view onto it. Typing `exit` ends the session;
+ *  the restart banner respawns a fresh shell. */
+
+interface Props {
+  installationId: string | null
+}
+
+const props = defineProps<Props>()
+
+const { t } = useI18n()
+const api = window.api
+
+const hostRef = ref<HTMLDivElement | null>(null)
+const exited = ref(false)
+
+let terminal: Terminal | null = null
+let fitAddon: FitAddon | null = null
+let resizeObserver: ResizeObserver | null = null
+const disposers: Array<() => void> = []
+
+function teardown(): void {
+  for (const dispose of disposers.splice(0)) dispose()
+  resizeObserver?.disconnect()
+  resizeObserver = null
+  const id = currentId
+  if (id) void api.terminalUnsubscribe(id)
+  terminal?.dispose()
+  terminal = null
+  fitAddon = null
+  currentId = null
+}
+
+let currentId: string | null = null
+
+function applyRestore(restore: TerminalRestore): void {
+  if (!terminal) return
+  if (restore.size.cols > 0 && restore.size.rows > 0) {
+    terminal.resize(restore.size.cols, restore.size.rows)
+  }
+  if (restore.buffer.length) terminal.write(restore.buffer.join(''))
+  exited.value = restore.exited
+}
+
+function pushSize(): void {
+  if (!terminal || !fitAddon || !currentId) return
+  if (!hostRef.value?.offsetParent) return
+  fitAddon.fit()
+  void api.terminalResize(currentId, terminal.cols, terminal.rows)
+}
+
+async function attach(id: string): Promise<void> {
+  if (!hostRef.value) return
+  currentId = id
+
+  terminal = new Terminal({ convertEol: true, theme: { background: '#171717' } })
+  fitAddon = new FitAddon()
+  terminal.loadAddon(fitAddon)
+  terminal.open(hostRef.value)
+
+  disposers.push(terminal.onData((data) => void api.terminalWrite(id, data)).dispose)
+  disposers.push(
+    api.onTerminalOutput((payload) => {
+      if (payload.installationId === id) terminal?.write(payload.data)
+    })
+  )
+  disposers.push(
+    api.onTerminalExited((payload) => {
+      if (payload.installationId === id) exited.value = true
+    })
+  )
+
+  resizeObserver = new ResizeObserver(() => pushSize())
+  resizeObserver.observe(hostRef.value)
+
+  pushSize()
+  applyRestore(await api.terminalSubscribe(id))
+}
+
+async function restart(): Promise<void> {
+  if (!currentId || !terminal) return
+  terminal.reset()
+  exited.value = false
+  applyRestore(await api.terminalRestart(currentId))
+  pushSize()
+}
+
+onMounted(() => {
+  if (props.installationId) void attach(props.installationId)
+})
+
+watch(
+  () => props.installationId,
+  (next) => {
+    teardown()
+    exited.value = false
+    if (next) void attach(next)
+  }
+)
+
+onBeforeUnmount(teardown)
+</script>
+
+<template>
+  <div class="console-pane">
+    <div ref="hostRef" class="console-host" :data-testid="TID.consoleTerminal" />
+    <div
+      v-if="exited"
+      class="console-ended"
+      role="status"
+      :data-testid="TID.consoleSessionEnded"
+    >
+      <span class="console-ended-text">{{ t('console.sessionEnded') }}</span>
+      <button
+        type="button"
+        class="accent console-ended-restart"
+        :data-testid="TID.consoleRestart"
+        @click="restart"
+      >
+        {{ t('console.restartSession') }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.console-pane {
+  position: relative;
+  width: 100%;
+  flex: 1 1 auto;
+  min-height: 240px;
+  background: #171717;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.console-host {
+  width: 100%;
+  height: 100%;
+  padding: 8px;
+}
+
+.console-ended {
+  position: absolute;
+  inset-inline: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 14px;
+  background: var(--modal-surface-bg, #1f1f1f);
+  border-top: 1px solid var(--chooser-surface-border, rgba(255, 255, 255, 0.1));
+}
+
+.console-ended-text {
+  font-size: 13px;
+  color: var(--text-muted, var(--neutral-100));
+}
+
+.console-ended-restart {
+  height: 30px;
+  padding: 0 14px;
+  font-size: 12px;
+  font-weight: 500;
+  flex-shrink: 0;
+}
+</style>

--- a/src/renderer/src/views/comfyUISettings/ConsoleTerminalPane.vue
+++ b/src/renderer/src/views/comfyUISettings/ConsoleTerminalPane.vue
@@ -64,6 +64,16 @@ function pushSize(): void {
   void api.terminalResize(currentId, dims.cols, dims.rows)
 }
 
+/** Force the shared PTY to this view's size. Unlike {@link pushSize}, this skips
+ *  the "local dims unchanged" guard: another window may have resized the PTY out
+ *  from under us, so on focus we must re-assert our size even if our own xterm
+ *  hasn't changed, or the shell's cursor stays misaligned. */
+function reclaimPtySize(): void {
+  if (!terminal || !currentId) return
+  if (!hostRef.value?.offsetParent) return
+  void api.terminalResize(currentId, terminal.cols, terminal.rows)
+}
+
 const debouncedPushSize = useDebounceFn(pushSize, 50)
 
 async function attach(id: string): Promise<void> {
@@ -78,8 +88,20 @@ async function attach(id: string): Promise<void> {
   disposers.push(terminal.onData((data) => void api.terminalWrite(id, data)).dispose)
   disposers.push(
     api.onTerminalOutput((payload) => {
-      if (payload.installationId === id) terminal?.write(payload.data)
+      if (payload.installationId !== id) return
+      // Output only flows from a live shell, so a restart triggered from
+      // another window (no exit/start event reaches us) revives the session:
+      // clear the "session ended" banner so input works again.
+      if (exited.value) exited.value = false
+      terminal?.write(payload.data)
     })
+  )
+  // The PTY is shared with the ComfyUI window's terminal and holds one size.
+  // Reclaim it for this view on focus so the shell's cursor matches what we
+  // render here.
+  terminal.element?.addEventListener('focusin', reclaimPtySize)
+  disposers.push(() =>
+    terminal?.element?.removeEventListener('focusin', reclaimPtySize)
   )
   disposers.push(
     api.onTerminalExited((payload) => {

--- a/src/renderer/src/views/comfyUISettings/ConsoleTerminalPane.vue
+++ b/src/renderer/src/views/comfyUISettings/ConsoleTerminalPane.vue
@@ -137,6 +137,10 @@ onBeforeUnmount(teardown)
 .console-pane {
   position: relative;
   width: 100%;
+  /* Without min-width:0 the xterm host's intrinsic ~80-col width propagates up
+   * the flex chain and blows out the settings pane (overflowing buttons, broken
+   * tab strip). */
+  min-width: 0;
   flex: 1 1 auto;
   min-height: 240px;
   background: #171717;
@@ -144,10 +148,13 @@ onBeforeUnmount(teardown)
   overflow: hidden;
 }
 
+/* Absolutely positioned so xterm's content size never contributes to the
+ * layout's intrinsic width — the pane is sized by the flex container only. */
 .console-host {
-  width: 100%;
-  height: 100%;
+  position: absolute;
+  inset: 0;
   padding: 8px;
+  overflow: hidden;
 }
 
 .console-ended {

--- a/src/shared/testIds.ts
+++ b/src/shared/testIds.ts
@@ -46,6 +46,10 @@ export const TID = {
   snapshotsOpCardRetry: 'snapshots-op-card-retry',
   snapshotsOpCardDismiss: 'snapshots-op-card-dismiss',
 
+  consoleTerminal: 'console-terminal',
+  consoleSessionEnded: 'console-session-ended',
+  consoleRestart: 'console-restart',
+
   progressErrorMessage: 'progress-error-message',
   progressLogs: 'progress-logs',
   progressReboot: 'progress-reboot',

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -972,6 +972,12 @@ export interface ElectronApi {
    *  the comfy/chooser root. Fire-and-forget; the panel will receive
    *  the resulting `panel-switch` like any other navigation. */
   closeCurrentPanel(): void
+  /** Boot-time restore reveal handshake. The restore window is opened
+   *  hidden; the panel calls this once it knows whether its launch
+   *  takeover came up (`'takeover-ready'` → reveal the launching surface)
+   *  or it fell back to the dashboard (`'dashboard-fallback'`). Main
+   *  reveals the sender's hidden host either way. Fire-and-forget. */
+  resolveStartupRestoreReveal(result: 'takeover-ready' | 'dashboard-fallback'): void
   /** Open the Global Settings popup for the panel's host window. Used
    *  by the panel-side file-menu "Settings" item and the
    *  `comfy://open-settings?tab=global` deep link. Main reuses the
@@ -1408,6 +1414,10 @@ export interface ElectronApi {
       settingsTab?: 'comfy' | 'directories' | 'downloads' | 'global'
       title?: string
       cancellable?: boolean
+      /** Picker-only (`picker-pick-install`): set on boot-time restore. The
+       *  panel takes the dashboard-fallback path on a missing launch action
+       *  (instead of opening new-install) and resolves the reveal handshake. */
+      startupRestore?: boolean
       triggersInstanceStart?: boolean
       opKind?: 'launch' | 'install' | 'update' | 'destructive' | 'snapshot' | 'generic'
       isRestart?: boolean

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -434,6 +434,14 @@ export interface ComfyOutputData {
   text: string
 }
 
+/** Snapshot for repainting an interactive console: the retained scrollback,
+ *  the shell's current size, and whether the session has been killed. */
+export interface TerminalRestore {
+  buffer: string[]
+  size: { cols: number; rows: number }
+  exited: boolean
+}
+
 export interface ComfyExitedData {
   installationId: string
   installationName: string
@@ -934,6 +942,16 @@ export interface ElectronApi {
   // Running
   stopComfyUI(installationId: string): Promise<void>
   focusComfyWindow(installationId: string): Promise<void>
+
+  // Interactive console (per-installation shell, shared across windows)
+  /** Spawn the install's shell if needed, subscribe this surface, and return
+   *  the current scrollback/size/exited state to repaint. */
+  terminalSubscribe(installationId: string): Promise<TerminalRestore>
+  terminalUnsubscribe(installationId: string): Promise<void>
+  terminalWrite(installationId: string, data: string): Promise<void>
+  terminalResize(installationId: string, cols: number, rows: number): Promise<void>
+  /** Kill the current shell (if any) and start a fresh one. */
+  terminalRestart(installationId: string): Promise<TerminalRestore>
   /** Open a window for the install backing `installationId`. Focuses
    *  any existing install-backed window; otherwise opens a fresh
    *  chooser host so the user can pick the install from the dashboard.
@@ -1209,6 +1227,10 @@ export interface ElectronApi {
   onInstallProgress(callback: (data: ProgressData) => void): Unsubscribe
   onComfyOutput(callback: (data: ComfyOutputData) => void): Unsubscribe
   onComfyExited(callback: (data: ComfyExitedData) => void): Unsubscribe
+  onTerminalOutput(
+    callback: (data: { installationId: string; data: string }) => void
+  ): Unsubscribe
+  onTerminalExited(callback: (data: { installationId: string }) => void): Unsubscribe
   onComfyBootLog(callback: (data: ComfyBootLogData) => void): Unsubscribe
   onInstanceLaunching(
     callback: (data: { installationId: string; installationName: string }) => void

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -1006,7 +1006,7 @@ export interface ElectronApi {
    *  `comfy://open-settings?tab=comfy`). */
   openInstancePicker(opts?: {
     installationId?: string | null
-    initialTab?: 'config' | 'status' | 'update' | 'snapshots' | 'storage'
+    initialTab?: 'config' | 'status' | 'update' | 'snapshots' | 'storage' | 'console'
     autoAction?: string | null
   }): void
   /** Push the first-use takeover's current step to main so it can


### PR DESCRIPTION
## Summary

Single working branch consolidating three open launch-week PRs so we can iterate to ship by EOD. **Do not review piecewise — review against this branch.** Original PRs stay open as the unit-of-attribution.

| Bundled PR | Author | What it covers | Day-3 feedback it lands on |
|---|---|---|---|
| **#961** | deepme987 | Hide Cloud from Instance Picker (opt-out setting) | "Dashboard is a nuisance, can't be disabled" — local-only user complaints |
| **#939** | Kosinkadink | Three-way close modal (Quit / Stay / Dashboard) + restore-last-instance on startup | "When I close, I want it to CLOSE not return to Dashboard" |
| **#899** | Kosinkadink | Console tab in install Settings + stopgap inline-terminal injection | "Why u delete cmd?" — power users miss the inline terminal |

Plus one additional commit on top of #899:

- **`feat(terminal): always inject inline terminal tab + dedupe in JS`** — drops the `supports_terminal` feature-flag gate so the inline terminal renders for everyone right now (no companion ComfyUI / ComfyUI_frontend PR blocker). Dedupe moves into the injected script: `alreadyHasTerminalTab(app)` walks the extensions list (and a future-proof tab registry) for an existing `command-terminal` entry, so when the native flag-gated tab eventually mounts, the stopgap silently steps aside.

## Why bundle?

Day-3 launch metrics: 30k DAU / 65k total, 50% existing-user rollout, ~20% "No :(" sentiment from migrated users. The three landings hit three of the four top complaint clusters at once. Shipping them as one rebase-clean patch gets the wins out before Jedrzej's back tomorrow.

## Test plan

Unit:
- [x] `useInstallList` (28/28)
- [x] `lastSession` (13/13)
- [ ] `comfyTerminalContentScript` — fails locally because the symlinked node_modules doesn't have `@xterm/xterm`; CI will install fresh and pass

Manual:
- [ ] Toggle **Hide Cloud from picker** in Global Settings → dashboard re-renders without the Cloud tile and Try-Cloud CTA
- [ ] Close last instance window → three-way modal (Quit / Stay / Dashboard) appears; each branch behaves
- [ ] Toggle **Reopen last instance on launch** → quit + relaunch → land back on the last-used instance instead of dashboard
- [ ] Open a standalone install → bottom-panel **Terminal** tab is present even without the `supports_terminal` flag
- [ ] When ComfyUI_frontend ships its native terminal, confirm the stopgap dedupes (no double tab)

## Merge plan

When everyone is happy: rebase to a clean linear history (or merge as-is), then close the three component PRs with a link back here.