### PR TITLE
fix(terminal): runtime chmod node-pty spawn-helper (real fix for prod black-terminal)

### DIFF
--- a/scripts/afterPack.mjs
+++ b/scripts/afterPack.mjs
@@ -79,6 +79,28 @@ async function ensureVcRedist(context) {
 }
 
 /**
+ * Compute the platform-correct path to `app.asar.unpacked/` inside the
+ * built bundle. The previous version of this hook hardcoded
+ * `${appOutDir}/resources/...`, which is only correct on Linux/Windows —
+ * on macOS the resources sit under `${productFilename}.app/Contents/
+ * Resources/...`. As a result, every chmod this hook tried to apply on
+ * macOS was pointed at a path that didn't exist, the calls silently
+ * no-op'd against a missing tree, and the unpacked binaries shipped with
+ * the npm tarball's `0644` mode. `extract.ts` masks the 7za side via a
+ * runtime chmod, and `terminal.ts` does the same for spawn-helper, but
+ * fixing the pack-time hook means future native helpers don't each need
+ * their own runtime workaround.
+ *
+ * `context.packager.getResourcesDir(appOutDir)` is the electron-builder
+ * API that already encodes the per-platform layout — use it instead of
+ * re-deriving the path.
+ */
+function unpackedNodeModulesDir(context) {
+  const resourcesDir = context.packager.getResourcesDir(context.appOutDir)
+  return path.join(resourcesDir, 'app.asar.unpacked', 'node_modules')
+}
+
+/**
  * electron-builder afterPack hook.
  * Ensures bundled native helpers have the execute permission in the packaged
  * output. Without this, the unpacked binaries inherit `0644` from the npm
@@ -102,12 +124,11 @@ export default async function afterPack(context) {
     return
   }
 
-  const unpackedRoot = path.join(
-    context.appOutDir,
-    'resources',
-    'app.asar.unpacked',
-    'node_modules',
-  )
+  const unpackedRoot = unpackedNodeModulesDir(context)
+  if (!fs.existsSync(unpackedRoot)) {
+    console.log(`afterPack: unpacked node_modules not found at ${unpackedRoot}; skipping chmods`)
+    return
+  }
 
   // 7zip-bin / 7za (used during install for the standalone-python tarball).
   const sevenZipRoot = path.join(unpackedRoot, '7zip-bin')

--- a/src/main/lib/terminal.ts
+++ b/src/main/lib/terminal.ts
@@ -1,7 +1,53 @@
 import pty from 'node-pty'
+import fs from 'fs'
+import path from 'path'
+import { createRequire } from 'module'
 import type { WebContents } from 'electron'
 import * as installations from '../installations'
 import { getActiveVenvDir, getActiveUvPath } from './pythonEnv'
+
+const requireFromHere = createRequire(__filename)
+
+/**
+ * On Unix, node-pty's `pty.fork()` exec's a small `spawn-helper` binary
+ * shipped under `node-pty/prebuilds/<plat>-<arch>/`. The npm tarball
+ * ships that helper with mode `0644`, and neither electron-builder's
+ * `afterPack` hook nor ToDesktop's wrapper actually applies the chmod we
+ * set there in production builds (the same issue `extract.ts` works
+ * around for `7za` at runtime). Without `+x`, `pty.fork()` returns
+ * `EACCES` inside the native layer and the JS surface just shows a dead
+ * PTY — the user sees a black canvas with no prompt. Set the bit at
+ * module load so every spawn that follows is safe; best-effort, since on
+ * Windows there's nothing to do and a missing helper would already fail
+ * loudly. */
+function ensureSpawnHelperExecutable(): void {
+  if (process.platform === 'win32') return
+  try {
+    const pkgDir = path.dirname(requireFromHere.resolve('node-pty/package.json'))
+    const platformDir = `${process.platform}-${process.arch}`
+    const prebuiltHelper = path
+      .join(pkgDir, 'prebuilds', platformDir, 'spawn-helper')
+      .replace('app.asar', 'app.asar.unpacked')
+    if (fs.existsSync(prebuiltHelper)) {
+      fs.chmodSync(prebuiltHelper, 0o755)
+    }
+    // Dev / locally-rebuilt copy lives under `build/Release/`. node-pty's
+    // loader prefers that path when present, so chmod it too — otherwise
+    // a rebuilt local install hits the same EACCES.
+    const builtHelper = path
+      .join(pkgDir, 'build', 'Release', 'spawn-helper')
+      .replace('app.asar', 'app.asar.unpacked')
+    if (fs.existsSync(builtHelper)) {
+      fs.chmodSync(builtHelper, 0o755)
+    }
+  } catch {
+    // Resolution failure means we're in a context where node-pty isn't
+    // installed (tests, CI without deps). The spawn itself would have
+    // failed already; leave the no-op.
+  }
+}
+
+ensureSpawnHelperExecutable()
 
 /**
  * Interactive per-installation shell sessions.


### PR DESCRIPTION
## What
Move the `spawn-helper` chmod from the build-time `afterPack` hook (#966) to a runtime `ensureSpawnHelperExecutable()` call at `terminal.ts` module load.

## Why
#966 was the wrong layer. After it merged we shipped 1.0.11 and the Terminal tab was still black; checking `/Applications/Comfy Desktop.app/.../prebuilds/darwin-arm64/spawn-helper` shows mode `0644`, identical to pre-fix. Confirmed the ToDesktop build pipeline doesn't actually apply our `afterPack.mjs` chmod — `7zip-bin/mac/arm64/7za` is *also* `0644` in the shipped dmg, and it only works at runtime because `src/main/lib/extract.ts:32` chmods it on every call.

This PR mirrors the `extract.ts` pattern for `spawn-helper`:

- Resolve `node-pty`'s package dir via `createRequire(__filename).resolve('node-pty/package.json')`
- Walk to `prebuilds/<plat>-<arch>/spawn-helper`
- Swap `app.asar` → `app.asar.unpacked`
- chmod 0755 — best-effort, wrapped in try/catch

Also chmod `build/Release/spawn-helper` for dev installs where `@electron/rebuild` has produced a local copy (node-pty's loader prefers `build/Release/` over `prebuilds/`).

#966 stays useful as belt-and-braces for any future pure-electron-builder dmg path; this commit is the actual fix for the shipped ToDesktop build.

## Test
- [ ] Tag + build 1.0.12 from this branch
- [ ] Verify spawn-helper in the new dmg is `-rwxr-xr-x` after launching (runtime chmod kicked in at module load)
- [ ] Open bottom-panel Terminal tab → real prompt
- [ ] Open Settings → Console pane → real prompt