### PR TITLE
fix(snapshot+aimdo): unblock snapshot-import + cure ModelMMAP/aimdo drift

### DIFF
--- a/src/main/lib/ipc/registerSnapshotHandlers.ts
+++ b/src/main/lib/ipc/registerSnapshotHandlers.ts
@@ -489,7 +489,12 @@ export function registerSnapshotHandlers(): void {
       const baseGpu = strippedVariant.replace(/-.*$/, '')
 
       const source = sourceMap['standalone']!
-      const releaseOptions = await source.getFieldOptions!('release', {}, {})
+      // `includeLatestStable: true` opens the standalone source's release list
+      // (see `standalone/index.ts:328`). Without it the source returns an
+      // empty array and create-from-snapshot bails with "No releases available."
+      // even when there *are* releases. Mirrors the InstallWizard / QuickInstall
+      // call shape on the renderer side.
+      const releaseOptions = await source.getFieldOptions!('release', {}, { includeLatestStable: true })
       if (releaseOptions.length === 0) return { ok: false, message: 'No releases available.' }
 
       let selectedRelease: FieldOption

--- a/src/main/lib/pip.ts
+++ b/src/main/lib/pip.ts
@@ -48,7 +48,10 @@ export interface PipMirrorConfig {
   useChineseMirrors?: boolean
 }
 
-/** Install a requirements file via `uv pip install -r`, filtering out PyTorch packages first. */
+/** Install a requirements file via `uv pip install -r`, filtering out PyTorch packages first.
+ *  Pass `upgrade: true` to add `--upgrade` so already-installed packages whose pinned versions
+ *  drifted (e.g. the bundled venv's `comfy-aimdo` lagging ComfyUI's `requirements.txt`) get
+ *  reconciled instead of skipped by uv's satisfaction check. */
 export async function installFilteredRequirements(
   reqPath: string,
   uvPath: string,
@@ -57,7 +60,8 @@ export async function installFilteredRequirements(
   tempName: string,
   sendOutput: (text: string) => void,
   signal?: AbortSignal,
-  mirrors?: PipMirrorConfig
+  mirrors?: PipMirrorConfig,
+  upgrade = false,
 ): Promise<number> {
   const content = await fs.promises.readFile(reqPath, 'utf-8')
   const filtered = content.split('\n').filter((l) => !PYTORCH_RE.test(l.trim())).join('\n')
@@ -66,7 +70,8 @@ export async function installFilteredRequirements(
 
   try {
     const indexArgs = getPipIndexArgs(mirrors?.pypiMirror, mirrors?.useChineseMirrors)
-    return await runUvPip(uvPath, ['pip', 'install', '-r', filteredPath, '--python', pythonPath, ...indexArgs], installPath, sendOutput, signal)
+    const upgradeArg = upgrade ? ['--upgrade'] : []
+    return await runUvPip(uvPath, ['pip', 'install', ...upgradeArg, '-r', filteredPath, '--python', pythonPath, ...indexArgs], installPath, sendOutput, signal)
   } finally {
     try { await fs.promises.unlink(filteredPath) } catch {}
   }

--- a/src/main/lib/standaloneMigration.ts
+++ b/src/main/lib/standaloneMigration.ts
@@ -100,7 +100,11 @@ async function resolveStandaloneInstallData(
     release = target.release
     variant = target.variant
   } else {
-    const releaseOptions = await standaloneSource.getFieldOptions!('release', {}, {})
+    // `includeLatestStable: true` opens the standalone source's release list
+    // (see `standalone/index.ts:328`). Without it the source returns an
+    // empty array and the legacy-desktop migration silently bails with
+    // "No releases available." instead of progressing.
+    const releaseOptions = await standaloneSource.getFieldOptions!('release', {}, { includeLatestStable: true })
     if (releaseOptions.length === 0) {
       cleanupOnError()
       throw new Error('No releases available.')

--- a/src/main/sources/standalone/install.ts
+++ b/src/main/sources/standalone/install.ts
@@ -172,6 +172,14 @@ export async function postInstall(installation: InstallationRecord, { sendProgre
           update,
           sendProgress: sendProgress as (step: string, data: Record<string, unknown>) => void,
           signal,
+          // The standalone bundle ships a pre-extracted venv whose pinned
+          // versions can lag ComfyUI's own `requirements.txt` (most visibly
+          // `comfy-aimdo`, which crashes on import when the venv's copy is
+          // older than what ComfyUI's source expects). Force a `pip install
+          // --upgrade -r requirements.txt` after the post-install git update,
+          // even when the file is byte-identical pre/post, so the venv always
+          // ends up in sync with ComfyUI's pins before the user runs anything.
+          forceDepsSync: true,
         })
         installation = result.installation
         if (result.ok) {

--- a/src/main/sources/standalone/updateOrchestrator.ts
+++ b/src/main/sources/standalone/updateOrchestrator.ts
@@ -34,6 +34,15 @@ export interface UpdateOrchestrationOptions {
   dryRunConflictCheck?: boolean
   saveRollback?: boolean
   preUpdateSnapshot?: boolean
+  /** Force `uv pip install --upgrade -r requirements.txt` to run after the git
+   *  update, even when the requirements.txt content is byte-identical pre/post.
+   *  Used by the post-install auto-update in `install.ts` to reconcile the
+   *  pre-extracted standalone bundle's venv (which can ship deps lagging
+   *  ComfyUI's own pinned versions — most visibly `comfy-aimdo`, which crashes
+   *  loading with `'ModelMMAP' object has no attribute 'get_file_handle'` or
+   *  `ModuleNotFoundError: No module named 'comfy_aimdo.vram_buffer'` when the
+   *  bundled aimdo lags the source's import surface). */
+  forceDepsSync?: boolean
 }
 
 export interface UpdateOrchestrationResult {
@@ -228,7 +237,16 @@ export async function runComfyUIUpdate(opts: UpdateOrchestrationOptions): Promis
   let postReqs = ''
   try { postReqs = await fs.promises.readFile(reqPath, 'utf-8') } catch {}
 
-  if (preReqs !== postReqs && postReqs.length > 0) {
+  // Re-sync deps when reqs changed (the historical trigger), OR when git HEAD
+  // moved (source can import new APIs without bumping requirements.txt — saw
+  // this with `comfy_aimdo.vram_buffer` showing up in `model_management.py`
+  // between aimdo bumps), OR when the caller demands it (first-run auto-update
+  // reconciling the bundled venv against the bundled requirements.txt).
+  const headMoved = !!(markers.PRE_UPDATE_HEAD && markers.POST_UPDATE_HEAD && markers.PRE_UPDATE_HEAD !== markers.POST_UPDATE_HEAD)
+  const reqsChanged = preReqs !== postReqs
+  const shouldSyncDeps = (reqsChanged || headMoved || !!opts.forceDepsSync) && postReqs.length > 0
+
+  if (shouldSyncDeps) {
     const uvPath = getActiveUvPath(installation)
     const activeEnvPython = getActivePythonPath(installation)
 
@@ -244,7 +262,7 @@ export async function runComfyUIUpdate(opts: UpdateOrchestrationOptions): Promis
           if (signal?.aborted) return { ok: false, message: 'Cancelled', installation }
 
           const dryRunResult = await spawnCommand(
-            uvPath, ['pip', 'install', '--dry-run', '-r', filteredReqPath, '--python', activeEnvPython, ...indexArgs],
+            uvPath, ['pip', 'install', '--dry-run', '--upgrade', '-r', filteredReqPath, '--python', activeEnvPython, ...indexArgs],
             installPath, undefined, undefined, signal
           )
 
@@ -259,7 +277,7 @@ export async function runComfyUIUpdate(opts: UpdateOrchestrationOptions): Promis
           sendProgress('deps', { percent: -1, status: t('standalone.updateDepsInstalling') })
 
           const pipResult = await spawnCommand(
-            uvPath, ['pip', 'install', '-r', filteredReqPath, '--python', activeEnvPython, ...indexArgs],
+            uvPath, ['pip', 'install', '--upgrade', '-r', filteredReqPath, '--python', activeEnvPython, ...indexArgs],
             installPath, sendOutput, sendOutput, signal
           )
 
@@ -274,7 +292,7 @@ export async function runComfyUIUpdate(opts: UpdateOrchestrationOptions): Promis
         const logFn = sendOutput ?? console.log
         const installResult = await installFilteredRequirements(
           reqPath, uvPath, activeEnvPython, installPath,
-          '.post-install-reqs.txt', logFn, signal, settings.getMirrorConfig()
+          '.post-install-reqs.txt', logFn, signal, settings.getMirrorConfig(), true
         )
         if (installResult !== 0) {
           console.warn(`Post-install requirements install exited with code ${installResult}`)

--- a/src/renderer/src/composables/useMigrateAction.ts
+++ b/src/renderer/src/composables/useMigrateAction.ts
@@ -212,7 +212,11 @@ export function useMigrateAction(opts?: { surface?: 'modal' | 'takeover' }) {
     let migrateRelease: FieldOption | null = null
     let autoPickedVariant: FieldOption | null = null
     try {
-      const releaseOptions = await window.api.getFieldOptions('standalone', 'release', {})
+      // `includeLatestStable: true` opens the standalone release list — same
+      // gate the install wizard passes (`standalone/index.ts:328`). Without it
+      // releaseOptions is empty, `migrateRelease` ends up null, and the
+      // migrate flow silently gives up without picking a variant.
+      const releaseOptions = await window.api.getFieldOptions('standalone', 'release', {}, { includeLatestStable: true })
       migrateRelease = releaseOptions[0] || null
       if (migrateRelease) {
         const variantOptions = await window.api.getFieldOptions('standalone', 'variant', { release: toRaw(migrateRelease) })

--- a/src/renderer/src/views/LoadSnapshotModal.vue
+++ b/src/renderer/src/views/LoadSnapshotModal.vue
@@ -129,7 +129,12 @@ async function loadReleaseOptions(): Promise<void> {
     if (gen !== optionsGeneration) return
     detectedGpu.value = gpu
 
-    const options = await window.api.getFieldOptions('standalone', 'release', {})
+    // `includeLatestStable: true` is the gate that opens the standalone source's
+    // release list (see `standalone/index.ts:328`). Without it the source returns
+    // an empty array and the Create Installation button stays disabled with no
+    // visible reason. Mirrors the InstallWizardModal / QuickInstallModal calls
+    // — the snapshot-import path was the only place that forgot to pass it.
+    const options = await window.api.getFieldOptions('standalone', 'release', {}, { includeLatestStable: true })
     if (gen !== optionsGeneration) return
     releaseOptions.value = options
 


### PR DESCRIPTION
Combines #974 + #975 into a single bundle — both surface during the same workflow (user wants to restore from a snapshot, hits two consecutive bugs).

## Problem 1 — Create Installation disabled in Load Snapshot dialog
Four call sites of `standaloneSource.getFieldOptions('release', ...)` were missing `{ includeLatestStable: true }` in the context arg. The standalone source's release branch gates the entire option list on that flag (`standalone/index.ts:328`); without it the source returns `[]` silently. Downstream:
- `LoadSnapshotModal` — release fetch empty → no variant fetch → `selectedVariant` stays `null` → Create Installation button is disabled with no visible reason ("Load Snapshot shows all the stuff but Create is grey" — verbatim field report)
- `useMigrateAction` — migrate flow silently picks neither release nor variant
- `registerSnapshotHandlers.handleCreateFromSnapshot` — throws "No releases available." even when releases exist
- `standaloneMigration` — same

Mirrors the InstallWizardModal / QuickInstallModal call shape (which already pass the flag and work).

## Problem 2 — ModelMMAP / aimdo drift after a successful create
The standalone install bundle ships a pre-extracted venv with `comfy-aimdo` pinned at the bundle's freeze time (e.g. `0.3.0`). ComfyUI's own `requirements.txt` evolves in lockstep with new aimdo APIs (`get_file_handle`, `vram_buffer` module, etc.). When the post-install auto-update runs, the requirements.txt diff was the only gate triggering `pip install -r requirements.txt`. If the file was byte-identical pre/post (common — the upstream pin doesn't move on every commit), the install skipped, and the bundled aimdo stayed lagged forever → mid-workflow crash on the first VAE/checkpoint load with `'ModelMMAP' object has no attribute 'get_file_handle'`.

Fixes:
- `installFilteredRequirements` takes an `upgrade` flag → adds `--upgrade` to the uv pip command
- `runComfyUIUpdate` takes a `forceDepsSync` flag and triggers the pip sync when reqs changed OR HEAD moved OR caller forces it; all pip-install paths pass `--upgrade`
- Post-install auto-update sets `forceDepsSync: true` so the bundled venv is always reconciled against the bundled requirements.txt

PyTorch protection (`PYTORCH_RE` filter) preserved — `--upgrade` only applies to the filtered set, so `torch` / `torchvision` / `torchaudio` / `torchsde` are never touched.

## Verified locally
Patched the installed `Comfy Desktop.app` with both fixes on a side-copy, imported a real broken-user snapshot (`comfy-aimdo: 0.3.0`, ComfyUI v0.24.1), Create Installation enabled cleanly, the install proceeded, and the post-restore snapshot shows `comfy-aimdo: 0.4.8` (the version ComfyUI v0.24.1's requirements.txt pins) instead of the stale 0.3.0.

## Test
- [ ] Open dashboard → Load Snapshot → drop a `.json` snapshot file → release dropdown auto-populates with "Stable" + "Latest" → variant cards render → Create Installation enables
- [ ] Click Create → install proceeds without "No releases available." error
- [ ] After post-install auto-update completes, the venv's `comfy-aimdo` matches ComfyUI's `requirements.txt` pin (verify via Snapshot → Export → grep `comfy-aimdo`)
- [ ] First workflow with VAELoader / CheckpointLoaderSimple runs without `ModelMMAP` errors
- [ ] Legacy-desktop migration: trigger from a legacy install → confirm it picks a release/variant instead of bailing
- [ ] Confirm no-op updates (already up to date, no reqs/HEAD change, no force flag) still skip pip — no UX regression on no-op updates

## Closes
#974, #975