### PR TITLE
fix(shared-models): emit clip/unet/t2i_adapter alias entries in YAML

### DIFF
--- a/src/main/lib/models.test.ts
+++ b/src/main/lib/models.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, afterAll, vi } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'models-yaml-'))
+
+// `models.ts` reads `dataDir()` at module-load time to derive YAML_PATH. The
+// real `dataDir()` calls `electron.app.getPath('userData')`, which crashes
+// outside Electron. Mock the import so YAML_PATH lands inside our tmp root.
+vi.mock('./paths', () => ({
+  dataDir: () => tmpRoot,
+}))
+
+const { ensureModelPathsConfig } = await import('./models')
+
+/**
+ * Locks the YAML shape that `ensureModelPathsConfig` emits, with focus on the
+ * legacy alias directories (`clip/`, `unet/`, `t2i_adapter/`) that ComfyUI
+ * registers under canonical folder types via `folder_paths.map_legacy`.
+ * Without these in the YAML, shared-dir users who keep encoders in
+ * `<shared>/clip/` (the historical ComfyUI layout) see their files invisible
+ * to `DualCLIPLoader` / `UNETLoader` even though Storage shows the dir.
+ */
+describe('ensureModelPathsConfig — YAML emission', () => {
+  afterAll(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+  })
+
+  it('emits clip/, unet/, t2i_adapter/ entries for every shared dir', () => {
+    const sharedDir = fs.mkdtempSync(path.join(tmpRoot, 'shared-'))
+    const result = ensureModelPathsConfig([sharedDir])
+    expect(result).not.toBeNull()
+    const yaml = fs.readFileSync(result!.yamlPath, 'utf-8')
+
+    // Canonical entries still present.
+    expect(yaml).toMatch(/'loras': 'loras\/'/)
+    expect(yaml).toMatch(/'text_encoders': 'text_encoders\/'/)
+    expect(yaml).toMatch(/'diffusion_models': 'diffusion_models\/'/)
+    expect(yaml).toMatch(/'controlnet': 'controlnet\/'/)
+
+    // Legacy alias entries — the actual bug fix.
+    expect(yaml).toMatch(/'clip': 'clip\/'/)
+    expect(yaml).toMatch(/'unet': 'unet\/'/)
+    expect(yaml).toMatch(/'t2i_adapter': 't2i_adapter\/'/)
+  })
+
+  it('emits the alias entries for each shared dir (not just the first)', () => {
+    const d1 = fs.mkdtempSync(path.join(tmpRoot, 'd1-'))
+    const d2 = fs.mkdtempSync(path.join(tmpRoot, 'd2-'))
+    const result = ensureModelPathsConfig([d1, d2])
+    const yaml = fs.readFileSync(result!.yamlPath, 'utf-8')
+
+    const clipMatches = yaml.match(/'clip': 'clip\/'/g) || []
+    expect(clipMatches.length).toBe(2)
+    const unetMatches = yaml.match(/'unet': 'unet\/'/g) || []
+    expect(unetMatches.length).toBe(2)
+  })
+
+  it('canonical entries come before legacy aliases (search-order matters)', () => {
+    const sharedDir = fs.mkdtempSync(path.join(tmpRoot, 'order-'))
+    const result = ensureModelPathsConfig([sharedDir])
+    const yaml = fs.readFileSync(result!.yamlPath, 'utf-8')
+    const canonical = yaml.indexOf("'text_encoders': 'text_encoders/'")
+    const alias = yaml.indexOf("'clip': 'clip/'")
+    expect(canonical).toBeGreaterThan(0)
+    expect(alias).toBeGreaterThan(canonical)
+  })
+})

--- a/src/main/lib/models.ts
+++ b/src/main/lib/models.ts
@@ -115,6 +115,29 @@ function discoverExtraFoldersFromSharedDirs(modelsDirs: string[]): string[] {
   return [...seen].sort()
 }
 
+/**
+ * Legacy directory aliases that ComfyUI's own defaults register under canonical
+ * folder types (`folder_paths.py`):
+ *   - `clip/` is a second path on `text_encoders` (ComfyUI's `map_legacy` maps
+ *     a YAML `clip:` key to `text_encoders` automatically).
+ *   - `unet/` is a second path on `diffusion_models` (same legacy mapping).
+ *   - `t2i_adapter/` is a second path on `controlnet` (no legacy mapping —
+ *     emitted as its own key, ComfyUI's controlnet defaults already list it).
+ *
+ * Without these in the YAML, shared-dir users who keep encoders in
+ * `<shared>/clip/` (the historical ComfyUI layout) or diffusion models in
+ * `<shared>/unet/` see their files invisible to `DualCLIPLoader` / `UNETLoader`,
+ * even though Storage shows the shared dir is configured. ComfyUI's defaults
+ * find them when they live under `<install>/ComfyUI/models/clip|unet/` because
+ * those are baked into `folder_names_and_paths`, but the extra-paths YAML only
+ * registers what we explicitly list. Emitting the aliases for every shared dir
+ * keeps the shared layout on equal footing with the install's own defaults. */
+const LEGACY_FOLDER_ALIASES: ReadonlyArray<{ key: string; dir: string }> = [
+  { key: 'clip', dir: 'clip' },
+  { key: 'unet', dir: 'unet' },
+  { key: 't2i_adapter', dir: 't2i_adapter' },
+]
+
 function buildYaml(modelsDirs: string[], extraFolders: string[] = []): string {
   const allFolders = [...MODEL_FOLDER_TYPES, ...extraFolders]
   const lines = [
@@ -134,6 +157,14 @@ function buildYaml(modelsDirs: string[], extraFolders: string[] = []): string {
     for (const folder of allFolders) {
       const escapedFolder = folder.replace(/'/g, "''")
       lines.push(`  '${escapedFolder}': '${escapedFolder}/'`)
+    }
+    // Emit legacy aliases AFTER the canonical entries so the canonical
+    // directories (e.g. `text_encoders/`) stay first in ComfyUI's search
+    // order — `add_model_folder_path` appends to the existing list.
+    for (const { key, dir } of LEGACY_FOLDER_ALIASES) {
+      const escapedKey = key.replace(/'/g, "''")
+      const escapedDir = dir.replace(/'/g, "''")
+      lines.push(`  '${escapedKey}': '${escapedDir}/'`)
     }
     lines.push('')
   })


### PR DESCRIPTION
## What
The generated `shared_model_paths.yaml` now also emits `clip:`, `unet:`, and `t2i_adapter:` keys per shared dir, in addition to the canonical folder names. ComfyUI's `add_model_folder_path` runs every YAML key through `map_legacy` (`folder_paths.py:107-110`), routing those keys onto the right canonical folder type:

| YAML key emitted | ComfyUI registers as | Reason |
|---|---|---|
| `clip:` | `text_encoders` path | `map_legacy("clip") → "text_encoders"` |
| `unet:` | `diffusion_models` path | `map_legacy("unet") → "diffusion_models"` |
| `t2i_adapter:` | `controlnet` path (second default) | matches `folder_paths.py:36` |

## Why
Field reports of "Models not detected even after adding to shared models" — most visibly in workflows that use `DualCLIPLoader` (text encoders) or `UNETLoader` (diffusion models). Reproduced by inspecting a live install's stdout:

```
Adding extra search path checkpoints /Users/x/ComfyUI-Shared/models/checkpoints
Adding extra search path text_encoders /Users/x/ComfyUI-Shared/models/text_encoders
...
(no `clip` line, no `unet` line)
```

ComfyUI's own defaults register *two* paths on `text_encoders` (`text_encoders/` AND `clip/`) and on `diffusion_models` (`diffusion_models/` AND `unet/`) — `folder_paths.py:28-29`. But that's hardcoded to the install's default models dir (`<install>/ComfyUI/models/`). For shared dirs, only what we explicitly list in the YAML is registered, and we were only listing canonical names. Result: users with the historical layout (`<shared>/clip/` for text encoders, `<shared>/unet/` for diffusion models) saw their files invisible to `DualCLIPLoader` / `UNETLoader` even though the Storage screen showed the shared dir was configured.

The same is true for `t2i_adapter/` — ComfyUI's `controlnet` folder type lists it as a second default path; we now mirror that for shared dirs too.

## Safety
- Aliases are emitted *after* canonical entries so the canonical directories stay first in ComfyUI's search order (`add_model_folder_path` appends to the existing list — `is_default: true` on the first comfy.desktop section keeps canonical first).
- If the alias dir doesn't exist (e.g., user has `text_encoders/` but no `clip/`), ComfyUI just `os.listdir`s an empty path — harmless.
- No change to canonical entry shape, dir creation, or per-install fallback paths.

## Test
- [x] 3 new unit tests in `models.test.ts` — alias emission, multi-dir coverage, canonical-before-alias ordering
- [ ] Manual: add a shared models dir with `clip/` containing a text encoder, launch ComfyUI, confirm `DualCLIPLoader` lists the file
- [ ] Manual: add `unet/` with a diffusion model, confirm `UNETLoader` lists it
- [ ] Manual: confirm canonical `text_encoders/` and `diffusion_models/` content is still listed (no regression)