### PR TITLE
fix(instance-picker): correct tab gating, restyle Console, fix tab narrow-width overflow

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -375,7 +375,8 @@
     "processExited": "Process exited",
     "processCrashed": "Process crashed (exit code {code})",
     "sessionEnded": "This console session ended. Restart it to keep using the shell.",
-    "restartSession": "Restart console"
+    "restartSession": "Restart console",
+    "shellLabel": "Shell"
   },
 
   "settingsModal": {

--- a/src/renderer/src/components/settings/ComfyUISettingsContent.vue
+++ b/src/renderer/src/components/settings/ComfyUISettingsContent.vue
@@ -329,9 +329,9 @@ const rootRef = useTemplateRef<HTMLElement>('root')
 const tabsRef = useTemplateRef<HTMLElement>('tabs')
 
 // Tooltips that echo the visible label add nothing, so only keep them
-// alive for tabs whose label is hidden. Mirror the `< 520px` collapse
+// alive for tabs whose label is hidden. Mirror the `< 640px` collapse
 // breakpoint (see `@container settings-tabs` below) via a ResizeObserver.
-const TAB_COLLAPSE_PX = 520
+const TAB_COLLAPSE_PX = 640
 const tabsCollapsed = ref(false)
 let tabsObserver: ResizeObserver | undefined
 
@@ -940,11 +940,16 @@ defineExpose({
   border-bottom: 1px solid var(--chooser-surface-border);
   container-type: inline-size;
   container-name: settings-tabs;
+  /* Clip the strip to the pane: it must never push the pane wider, even with
+     6 tabs. min-width:0 lets the flex row shrink below its content. */
+  min-width: 0;
+  flex-wrap: nowrap;
+  overflow: hidden;
 }
 
 /* Narrow right-pane: inactive tabs collapse to icon-only; the active
-   tab keeps its label. */
-@container settings-tabs (max-width: 520px) {
+   tab keeps its label. Keep this max-width in sync with `TAB_COLLAPSE_PX`. */
+@container settings-tabs (max-width: 640px) {
   .settings-v2-tab:not(.is-active) {
     padding: 6px 8px;
     gap: 0;
@@ -973,10 +978,21 @@ defineExpose({
   opacity: 0.72;
   font-size: 13px;
   font-weight: 400;
+  /* Allow buttons to shrink so the strip clips cleanly instead of overflowing. */
+  min-width: 0;
   transition:
     color 120ms ease,
     background-color 120ms ease,
     opacity 120ms ease;
+}
+
+/* Final safety net: clip a label with ellipsis rather than ever cut a glyph
+   mid-stroke at the narrowest real widths (icon wrap never shrinks). */
+.settings-v2-tab > span:not(.settings-v2-tab-icon-wrap) {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
 }
 
 .settings-v2-tab:hover {

--- a/src/renderer/src/components/settings/ComfyUISettingsContent.vue
+++ b/src/renderer/src/components/settings/ComfyUISettingsContent.vue
@@ -15,6 +15,7 @@ import StoragePane, { type StorageSnapshot } from '../../views/comfyUISettings/S
 import ConsoleTerminalPane from '../../views/comfyUISettings/ConsoleTerminalPane.vue'
 import Tooltip from '../ui/Tooltip.vue'
 import type { PickerTab, SectionTab } from '../../lib/pickerTabs'
+import { isTabAllowedForCategory } from '../../lib/pickerTabs'
 import { humanizeOpStatus, operationInflightLabel, operationSuccessLabel } from '../../lib/progressStatusLabel'
 import type { ActionDef, DetailField, Installation, ShowProgressOpts } from '../../types/ipc'
 import { TID } from '../../../../shared/testIds'
@@ -276,10 +277,13 @@ const ALL_TABS: TabDef[] = [
 ]
 
 // The console tab has no backend `sections` — it's a live PTY view — so it
-// can't be section-gated like the others. Show it for any local install
-// (cloud installs run no local process to attach a shell to).
+// can't be section-gated like the others. Visibility by instance type is
+// centralized in `isTabAllowedForCategory` (cloud + remote run no local
+// process to attach a shell to).
 const showConsoleTab = computed(
-  () => installation.value != null && installation.value.sourceCategory !== 'cloud'
+  () =>
+    installation.value != null &&
+    isTabAllowedForCategory('console', installation.value.sourceCategory)
 )
 
 const tabs = computed<TabDef[]>(() => {

--- a/src/renderer/src/lib/pickerTabs.test.ts
+++ b/src/renderer/src/lib/pickerTabs.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { isPickerTab, isTabAllowedForCategory, resolvePickerTab } from './pickerTabs'
+
+describe('pickerTabs', () => {
+  describe('isPickerTab', () => {
+    it('accepts known tabs and rejects everything else', () => {
+      expect(isPickerTab('console')).toBe(true)
+      expect(isPickerTab('config')).toBe(true)
+      expect(isPickerTab('nope')).toBe(false)
+      expect(isPickerTab(null)).toBe(false)
+      expect(isPickerTab(undefined)).toBe(false)
+    })
+  })
+
+  describe('resolvePickerTab', () => {
+    it('coerces unknown ids to the fallback', () => {
+      expect(resolvePickerTab('status', 'update')).toBe('status')
+      expect(resolvePickerTab('garbage', 'update')).toBe('update')
+      expect(resolvePickerTab(null, 'update')).toBe('update')
+    })
+  })
+
+  describe('isTabAllowedForCategory', () => {
+    it('hides Console for cloud and remote (no local PTY to attach a shell to)', () => {
+      expect(isTabAllowedForCategory('console', 'cloud')).toBe(false)
+      expect(isTabAllowedForCategory('console', 'remote')).toBe(false)
+    })
+
+    it('allows Console for local instances', () => {
+      expect(isTabAllowedForCategory('console', 'local')).toBe(true)
+    })
+
+    it('allows non-console tabs for every category', () => {
+      for (const cat of ['local', 'cloud', 'remote']) {
+        expect(isTabAllowedForCategory('update', cat)).toBe(true)
+        expect(isTabAllowedForCategory('status', cat)).toBe(true)
+      }
+    })
+
+    it('allows everything for an unknown / undefined category (section-gating still applies)', () => {
+      expect(isTabAllowedForCategory('console', undefined)).toBe(true)
+      expect(isTabAllowedForCategory('console', 'mystery')).toBe(true)
+    })
+  })
+})

--- a/src/renderer/src/lib/pickerTabs.ts
+++ b/src/renderer/src/lib/pickerTabs.ts
@@ -28,6 +28,34 @@ export function isPickerTab(tab: string | null | undefined): tab is PickerTab {
   return tab != null && PICKER_TABS.has(tab as PickerTab)
 }
 
+/** Instance source categories (mirrors `category` in `src/main/sources/*.ts`). */
+export type InstanceCategory = 'local' | 'cloud' | 'remote'
+
+/**
+ * Tabs each instance category cannot surface, regardless of backend sections.
+ * The Console tab is a live PTY view, so it only makes sense where a local
+ * process runs — cloud and remote attach to no shell. This is the single table
+ * to scan to see what each instance type shows.
+ *
+ * Note: cloud also relabels the `config` tab to "Storage" — that's a label
+ * swap, not a visibility gate, so it stays local to the component.
+ */
+const HIDDEN_TABS_BY_CATEGORY: Record<InstanceCategory, ReadonlySet<PickerTab>> = {
+  local: new Set(),
+  cloud: new Set(['console']),
+  remote: new Set(['console']),
+}
+
+/** Whether `tab` is permitted for an instance of `category`. Unknown categories
+ *  allow everything — backend section-gating still applies downstream. */
+export function isTabAllowedForCategory(
+  tab: PickerTab,
+  category: string | undefined,
+): boolean {
+  const hidden = HIDDEN_TABS_BY_CATEGORY[category as InstanceCategory]
+  return hidden ? !hidden.has(tab) : true
+}
+
 /** Coerce an untrusted tab id to a known picker tab, or `fallback`. */
 export function resolvePickerTab(
   tab: string | null | undefined,

--- a/src/renderer/src/views/comfyUISettings/ConsoleTerminalPane.test.ts
+++ b/src/renderer/src/views/comfyUISettings/ConsoleTerminalPane.test.ts
@@ -42,7 +42,8 @@ const messages = {
   en: {
     console: {
       sessionEnded: 'Console session ended',
-      restartSession: 'Restart console'
+      restartSession: 'Restart console',
+      shellLabel: 'Shell'
     }
   }
 } as const

--- a/src/renderer/src/views/comfyUISettings/ConsoleTerminalPane.vue
+++ b/src/renderer/src/views/comfyUISettings/ConsoleTerminalPane.vue
@@ -76,11 +76,48 @@ function reclaimPtySize(): void {
 
 const debouncedPushSize = useDebounceFn(pushSize, 50)
 
+/** Read a CSS custom property off :root, trimmed, with a fallback. Lets the
+ *  xterm theme track the app's light/dark terminal tokens at attach time. */
+function cssVar(name: string, fallback: string): string {
+  const v = getComputedStyle(document.documentElement).getPropertyValue(name).trim()
+  return v || fallback
+}
+
 async function attach(id: string): Promise<void> {
   if (!hostRef.value) return
   currentId = id
 
-  terminal = new Terminal({ convertEol: true, theme: { background: '#171717' } })
+  const bg = cssVar('--neutral-800', '#211927')
+  const fg = cssVar('--neutral-100', '#c2bfb9')
+  terminal = new Terminal({
+    convertEol: true,
+    fontFamily: "'Cascadia Mono', 'Consolas', 'SF Mono', ui-monospace, monospace",
+    fontSize: 13,
+    lineHeight: 1.45,
+    theme: {
+      background: bg,
+      foreground: fg,
+      cursor: cssVar('--neutral-200', '#a6a2a1'),
+      cursorAccent: bg,
+      selectionBackground: cssVar('--terminal-selection', 'rgba(11, 140, 233, 0.28)'),
+      black: cssVar('--neutral-950', '#100c13'),
+      red: cssVar('--danger', '#e05858'),
+      green: cssVar('--success', '#00cd72'),
+      yellow: cssVar('--warning', '#fd9903'),
+      blue: cssVar('--info', '#58a6ff'),
+      magenta: cssVar('--accent-plum', '#afa3db'),
+      cyan: cssVar('--info', '#58a6ff'),
+      white: fg,
+      brightBlack: cssVar('--neutral-400', '#6f6970'),
+      brightRed: cssVar('--danger-hover', '#ef6b6b'),
+      brightGreen: cssVar('--success', '#00cd72'),
+      brightYellow: cssVar('--warning', '#fd9903'),
+      brightBlue: cssVar('--accent-hover', '#93c5fd'),
+      brightMagenta: cssVar('--accent-plum', '#afa3db'),
+      brightCyan: cssVar('--accent-hover', '#93c5fd'),
+      brightWhite: cssVar('--text', '#ffffff'),
+    },
+  })
   fitAddon = new FitAddon()
   terminal.loadAddon(fitAddon)
   terminal.open(hostRef.value)
@@ -143,29 +180,38 @@ onBeforeUnmount(teardown)
 
 <template>
   <div ref="paneRef" class="console-pane">
-    <div ref="hostRef" class="console-host" :data-testid="TID.consoleTerminal" />
-    <div
-      v-if="exited"
-      class="console-ended"
-      role="status"
-      :data-testid="TID.consoleSessionEnded"
-    >
-      <span class="console-ended-text">{{ t('console.sessionEnded') }}</span>
-      <button
-        type="button"
-        class="accent console-ended-restart"
-        :data-testid="TID.consoleRestart"
-        @click="restart"
+    <header class="console-header" aria-hidden="true">
+      <span class="console-header-dots">
+        <span /><span /><span />
+      </span>
+      <span class="console-header-title">{{ t('console.shellLabel') }}</span>
+    </header>
+    <div class="console-viewport">
+      <div ref="hostRef" class="console-host" :data-testid="TID.consoleTerminal" />
+      <div
+        v-if="exited"
+        class="console-ended"
+        role="status"
+        :data-testid="TID.consoleSessionEnded"
       >
-        {{ t('console.restartSession') }}
-      </button>
+        <span class="console-ended-text">{{ t('console.sessionEnded') }}</span>
+        <button
+          type="button"
+          class="accent console-ended-restart"
+          :data-testid="TID.consoleRestart"
+          @click="restart"
+        >
+          {{ t('console.restartSession') }}
+        </button>
+      </div>
     </div>
   </div>
 </template>
 
 <style scoped>
 .console-pane {
-  position: relative;
+  display: flex;
+  flex-direction: column;
   width: 100%;
   /* Without min-width:0 the xterm host's intrinsic ~80-col width propagates up
    * the flex chain and blows out the settings pane (overflowing buttons, broken
@@ -173,9 +219,54 @@ onBeforeUnmount(teardown)
   min-width: 0;
   flex: 1 1 auto;
   min-height: 240px;
-  background: #171717;
-  border-radius: 8px;
+  background: var(--chooser-surface-bg);
+  border: 1px solid var(--chooser-surface-border);
+  border-radius: 10px;
   overflow: hidden;
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--neutral-950) 35%, transparent),
+    0 8px 24px color-mix(in srgb, var(--neutral-950) 28%, transparent);
+}
+
+.console-header {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  height: 34px;
+  padding: 0 14px;
+  background: color-mix(in srgb, var(--neutral-800) 72%, transparent);
+  border-bottom: 1px solid var(--chooser-surface-border);
+}
+
+.console-header-dots {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.console-header-dots span {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--neutral-400) 42%, transparent);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, white 8%, transparent);
+}
+
+.console-header-title {
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--text-muted) 88%, transparent);
+}
+
+.console-viewport {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
+  background: var(--neutral-800);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, white 3%, transparent);
 }
 
 /* Absolutely positioned so xterm's content size never contributes to the
@@ -183,7 +274,7 @@ onBeforeUnmount(teardown)
 .console-host {
   position: absolute;
   inset: 0;
-  padding: 8px;
+  padding: 12px 14px 14px;
   overflow: hidden;
 }
 
@@ -193,11 +284,20 @@ onBeforeUnmount(teardown)
  * which reads as the whole UI freezing. */
 .console-host :deep(.xterm) {
   overflow: hidden;
+  height: 100%;
+}
+
+.console-host :deep(.xterm-viewport) {
+  background-color: transparent;
 }
 
 .console-host :deep(.xterm-screen) {
   overflow: hidden;
-  background-color: #171717;
+  background-color: var(--neutral-800);
+}
+
+.console-host :deep(.xterm-rows) {
+  padding-bottom: 2px;
 }
 
 .console-ended {
@@ -209,12 +309,14 @@ onBeforeUnmount(teardown)
   justify-content: space-between;
   gap: 12px;
   padding: 10px 14px;
-  background: var(--modal-surface-bg, #1f1f1f);
-  border-top: 1px solid var(--chooser-surface-border, rgba(255, 255, 255, 0.1));
+  background: color-mix(in srgb, var(--modal-surface-bg) 90%, transparent);
+  backdrop-filter: blur(10px);
+  border-top: 1px solid var(--chooser-surface-border);
 }
 
 .console-ended-text {
-  font-size: 13px;
+  font-size: 12px;
+  line-height: 1.45;
   color: var(--text-muted, var(--neutral-100));
 }
 
@@ -223,6 +325,7 @@ onBeforeUnmount(teardown)
   padding: 0 14px;
   font-size: 12px;
   font-weight: 500;
+  border-radius: 8px;
   flex-shrink: 0;
 }
 </style>


### PR DESCRIPTION
## Summary

Three fixes to the Instance Preview Picker's right-side tab strip: the `Console` tab no longer shows for remote (or cloud) instances that have no local shell, the Console tab is restyled as a proper terminal-window surface, and the tab strip no longer overflows when the window narrows with 5–6 tabs.

## Changes

**What**
- `pickerTabs.ts` — add a central `HIDDEN_TABS_BY_CATEGORY` map and `isTabAllowedForCategory(tab, category)` helper as the single source of truth for which tabs each instance type may surface. Previously the visibility logic was scattered inline.
- `ComfyUISettingsContent.vue` (`showConsoleTab`) — gate `Console` on the helper instead of an inline `!== 'cloud'` check. Net effect: `Console` is hidden for both `cloud` and `remote` (neither runs a local process to attach a PTY to). The existing `watch(tabs, …)` already falls back cleanly if `Console` was the active tab.
- `ConsoleTerminalPane.vue` — restyle the picker Console as a terminal window: header bar with traffic-light dots + a `Shell` label, recessed viewport, and an xterm theme driven by app tokens (background, foreground, cursor, full ANSI palette) so it tracks light/dark. Set `Cascadia Mono` 13px to match the app's existing console.
- `locales/en.json` — add `console.shellLabel` ("Shell") for the new header.
- `ComfyUISettingsContent.vue` (tab strip CSS) — clip the strip to the pane (`min-width: 0`, `flex-wrap: nowrap`, `overflow: hidden`), raise the icon-collapse breakpoint `520 → 640px` so 5–6 tabs collapse to icons *before* cutoff (kept `TAB_COLLAPSE_PX` in sync with the `@container` query), and add an ellipsis label clip as a final mid-glyph safety net.

**Breaking**
- None. `local` instances keep all tabs and the existing Console behavior; the `config`→"Storage" relabel for cloud is untouched; no IPC channels, PTY behavior, or test ids changed.

## Review Focus

- The crux is centralizing tab-by-category visibility in `isTabAllowedForCategory` (`pickerTabs.ts`) — that's the one table to scan to see what each instance type shows.
- Scope is the three reported issues only: tab gating, Console styling, and responsive overflow. The Console design is finalized (terminal-window treatment).
- Deliberate non-change: the cloud `config`→"Storage" relabel stays a local label swap, not part of the visibility map.

## Testing

Unit-only by design — these are visibility/styling changes with no new user-facing flow, so the gating logic is the thing worth asserting directly; the rest is verified manually.
- `pickerTabs.test.ts` (new, 6 tests) — asserts `Console` is hidden for `cloud`/`remote`, allowed for `local`, non-console tabs allowed for every category, and unknown categories allow everything.
- `ConsoleTerminalPane.test.ts`, `ComfyUISettingsContent.test.ts`, `InstancePickerView.test.ts` — unchanged behavior, all green.
- `pnpm typecheck` + `pnpm lint` clean; 68 tests pass across the affected files.
- Manual: select Remote → no Console; Local → Console present; Cloud → no Console + `config` reads "Storage"; drag the window narrow on a 5–6-tab instance → clean icon collapse, no cutoff.

Screen Recording


https://github.com/user-attachments/assets/d9e91cbd-9847-4d96-b467-9b14e9ec7cc6

closes #980 
closes #981 
closes #982 