### PR TITLE
fix(downloads): pass extension-derived filters to Save dialog (#989)

### DIFF
--- a/src/main/lib/comfyDownloadManager.test.ts
+++ b/src/main/lib/comfyDownloadManager.test.ts
@@ -20,6 +20,7 @@ let hasValidExtension: (filename: string) => boolean
 let isPathContained: (filePath: string, baseDir: string) => boolean
 let sanitizeAssetFilename: (filename: string, outputDir: string) => string | null
 let parseContentDispositionFilename: (header: string | null) => string | null
+let buildSaveDialogFilters: (suggestedName: string) => Electron.FileFilter[]
 
 beforeAll(async () => {
   const mod = await import('./comfyDownloadManager')
@@ -28,6 +29,7 @@ beforeAll(async () => {
   isPathContained = mod.isPathContained
   sanitizeAssetFilename = mod.sanitizeAssetFilename
   parseContentDispositionFilename = mod.parseContentDispositionFilename
+  buildSaveDialogFilters = mod.buildSaveDialogFilters
 })
 
 describe('ALLOWED_EXTENSIONS', () => {
@@ -142,5 +144,66 @@ describe('parseContentDispositionFilename', () => {
   it('returns null for header without filename', () => {
     expect(parseContentDispositionFilename('inline')).toBeNull()
     expect(parseContentDispositionFilename('attachment')).toBeNull()
+  })
+})
+
+/**
+ * The Preview Image "Save image..." right-click goes through Electron's
+ * generic Save dialog; Windows collapses the "Save as type" dropdown to
+ * "All Files (*.*)" if `filters` is omitted, which is the symptom field-
+ * reported in #989. These tests lock the primary-extension inference and
+ * the All Files fallback so the dialog always opens on a sensible format.
+ */
+describe('buildSaveDialogFilters (#989 save-image extension filters)', () => {
+  it('picks PNG as the primary filter for a .png filename', () => {
+    const filters = buildSaveDialogFilters('ComfyUI_00001_.png')
+    expect(filters[0]).toEqual({ name: 'PNG Image', extensions: ['png'] })
+    expect(filters.at(-1)).toEqual({ name: 'All Files', extensions: ['*'] })
+  })
+
+  it('groups jpg and jpeg under the same JPEG family filter', () => {
+    expect(buildSaveDialogFilters('photo.jpg')[0]).toEqual({
+      name: 'JPEG Image',
+      extensions: ['jpg', 'jpeg'],
+    })
+    expect(buildSaveDialogFilters('photo.jpeg')[0]).toEqual({
+      name: 'JPEG Image',
+      extensions: ['jpg', 'jpeg'],
+    })
+  })
+
+  it.each([
+    ['out.webp', 'WebP Image', 'webp'],
+    ['anim.gif', 'GIF Image', 'gif'],
+    ['clip.mp4', 'MP4 Video', 'mp4'],
+    ['clip.webm', 'WebM Video', 'webm'],
+    ['clip.mov', 'QuickTime Video', 'mov'],
+    ['voice.wav', 'WAV Audio', 'wav'],
+    ['voice.mp3', 'MP3 Audio', 'mp3'],
+    ['voice.flac', 'FLAC Audio', 'flac'],
+    ['voice.ogg', 'OGG Audio', 'ogg'],
+  ] as const)('maps %s to %s', (filename, expectedName, expectedExt) => {
+    const filters = buildSaveDialogFilters(filename)
+    expect(filters[0]).toEqual({ name: expectedName, extensions: [expectedExt] })
+    expect(filters.at(-1)).toEqual({ name: 'All Files', extensions: ['*'] })
+  })
+
+  it('is case-insensitive on the input extension', () => {
+    expect(buildSaveDialogFilters('CAPS.PNG')[0]).toEqual({
+      name: 'PNG Image',
+      extensions: ['png'],
+    })
+  })
+
+  it('falls back to a literal-extension filter for unknown types', () => {
+    const filters = buildSaveDialogFilters('weird.xyz')
+    expect(filters[0]).toEqual({ name: 'XYZ File', extensions: ['xyz'] })
+    expect(filters.at(-1)).toEqual({ name: 'All Files', extensions: ['*'] })
+  })
+
+  it('returns only All Files when there is no extension at all', () => {
+    expect(buildSaveDialogFilters('justname')).toEqual([
+      { name: 'All Files', extensions: ['*'] },
+    ])
   })
 })

--- a/src/main/lib/comfyDownloadManager.ts
+++ b/src/main/lib/comfyDownloadManager.ts
@@ -10,6 +10,47 @@ export const ALLOWED_EXTENSIONS = ['.safetensors', '.sft', '.ckpt', '.pth', '.pt
 /** Asset (output) downloads whose final file is itself an image we can preview. */
 export const IMAGE_EXTENSIONS = ['.png', '.jpg', '.jpeg', '.webp', '.gif']
 
+/**
+ * Build "Save as type" filters for the generic Save dialog from the suggested
+ * filename. Electron's `showSaveDialog`/`showSaveDialogSync` does not infer
+ * filters from the default filename — on Windows the dropdown collapses to
+ * "All Files (*.*)" if you omit `filters`, which is the symptom field-reported
+ * as "Can't save image from Preview Image node" (#989). Pick a primary filter
+ * matching the file's actual extension so the dialog opens on the right
+ * format, with "All Files" as a fallback escape hatch.
+ */
+export function buildSaveDialogFilters(suggestedName: string): Electron.FileFilter[] {
+  const ext = path.extname(suggestedName).toLowerCase().replace(/^\./, '')
+  const ALL_FILES: Electron.FileFilter = { name: 'All Files', extensions: ['*'] }
+  if (!ext) return [ALL_FILES]
+
+  // Group images / video / audio by family so the user can switch between
+  // related extensions inside the same Save dialog instead of being locked
+  // to the single one we infer. Comfy outputs png/webp/jpg images, mp4/webm
+  // video, and wav/mp3/flac/ogg audio depending on the node graph.
+  const FAMILIES: Record<string, { name: string; extensions: string[] }> = {
+    png:  { name: 'PNG Image',  extensions: ['png'] },
+    jpg:  { name: 'JPEG Image', extensions: ['jpg', 'jpeg'] },
+    jpeg: { name: 'JPEG Image', extensions: ['jpg', 'jpeg'] },
+    webp: { name: 'WebP Image', extensions: ['webp'] },
+    gif:  { name: 'GIF Image',  extensions: ['gif'] },
+    bmp:  { name: 'Bitmap Image', extensions: ['bmp'] },
+    mp4:  { name: 'MP4 Video',  extensions: ['mp4'] },
+    webm: { name: 'WebM Video', extensions: ['webm'] },
+    mov:  { name: 'QuickTime Video', extensions: ['mov'] },
+    wav:  { name: 'WAV Audio',  extensions: ['wav'] },
+    mp3:  { name: 'MP3 Audio',  extensions: ['mp3'] },
+    flac: { name: 'FLAC Audio', extensions: ['flac'] },
+    ogg:  { name: 'OGG Audio',  extensions: ['ogg'] },
+  }
+
+  const primary = FAMILIES[ext]
+  if (primary) return [primary, ALL_FILES]
+  // Unknown extension — keep it as a literal filter so the dialog still shows
+  // the user what file type they're saving instead of collapsing to *.
+  return [{ name: `${ext.toUpperCase()} File`, extensions: [ext] }, ALL_FILES]
+}
+
 export interface DownloadProgress {
   url: string
   filename: string
@@ -664,6 +705,7 @@ export function attachSessionDownloadHandler(sess: Electron.Session): void {
       if (win) {
         const filePath = dialog.showSaveDialogSync(win, {
           defaultPath: path.join(startDir, suggestedName),
+          filters: buildSaveDialogFilters(suggestedName),
         })
         if (filePath) {
           savePath = filePath


### PR DESCRIPTION
Closes #989.

## What
Right-click → Save image (and any other WebContents-initiated download that goes through the generic Save dialog) now opens with a sensible "Save as type" dropdown matching the file's actual extension, with "All Files" as a fallback. Today it collapses to just "All Files (\*.\*)".

## Why
\`dialog.showSaveDialogSync\` in \`comfyDownloadManager.ts\` was called with only \`defaultPath\` — no \`filters\`. Windows interprets a missing \`filters\` array as "show All Files only", which is exactly the screenshot in #989. The file still saves, but the dialog UX is broken: no format reminder, no extension enforcement, and the dropdown looks like the dialog forgot what it's saving.

This is the path that handles right-click Save Image / Save Video / Save Audio for output nodes (PNG / JPG / WebP / MP4 / WebM / WAV / MP3 / FLAC / ...), so the cure has to cover everything Comfy actually emits.

## How
New \`buildSaveDialogFilters(suggestedName)\` helper:
- Inspect the file extension on the suggested filename
- Pick the matching family filter (e.g. \`{ name: 'PNG Image', extensions: ['png'] }\`, JPEG groups \`jpg\` + \`jpeg\` together)
- Append \`{ name: 'All Files', extensions: ['*'] }\` as a fallback escape hatch
- Case-insensitive; unknown extensions become a literal \`<EXT> File\` filter so the dropdown still reads correctly
- Returns just \`All Files\` for extensionless filenames

Wired into the single \`showSaveDialogSync\` callsite in the general-download branch of \`attachSessionDownloadHandler\`. The managed-download path (asset downloads with a known target) is unchanged — it never opens a dialog.

## Test
- [x] 14 new unit tests in \`comfyDownloadManager.test.ts\` (43 total passing)
- [ ] Manual on Windows: right-click a Preview Image output → "Save image…" → confirm "Save as type" shows "PNG Image (\*.png)" + "All Files (\*.\*)" instead of just "All Files"
- [ ] Manual on Windows: same for JPEG, WebP, GIF outputs
- [ ] Manual on Windows: right-click a video output (\`SaveVideo\` etc.) → confirm MP4 / WebM filter shows
- [ ] Manual on macOS: confirm the dialog still opens with the right default extension (macOS infers the extension from \`defaultPath\` regardless of filters — no regression expected)