### PR TITLE
ci(release): use cloud-code-bot app token for version bump PRs

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -41,11 +41,21 @@ jobs:
     name: Bump package.json Version
 
     steps:
+      - name: Mint bot app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.CLOUD_CODE_BOT_PRIVATE_KEY }}
+
       - name: Checkout target branch
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ inputs.target_branch }}
+          # Use the bot token so the branch push is the bot's and triggers
+          # downstream workflows (the default GITHUB_TOKEN does not).
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -255,7 +265,7 @@ jobs:
       - name: Find existing version bump pull request
         id: find_pr
         env:
-          GH_TOKEN: ${{ secrets.BEN_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TARGET_BRANCH: ${{ inputs.target_branch }}
           PR_BRANCH: ${{ steps.prepare.outputs.pr_branch }}
         run: |
@@ -280,7 +290,7 @@ jobs:
       - name: Create or update version bump pull request
         id: upsert_pr
         env:
-          GH_TOKEN: ${{ secrets.BEN_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TARGET_BRANCH: ${{ inputs.target_branch }}
           PR_BRANCH: ${{ steps.prepare.outputs.pr_branch }}
           BODY_FILE: ${{ steps.body.outputs.body_file }}


### PR DESCRIPTION
## What
Replaces the personal PAT (`secrets.BEN_PAT`) in `version-bump.yml` with a GitHub App token minted from **cloud-code-bot** (`vars.APP_ID` = 2016716 + `secrets.CLOUD_CODE_BOT_PRIVATE_KEY`), matching how the `cloud` repo creates its release PRs.

## Why
The Version Bump workflow needed a non-default token because GitHub's `GITHUB_TOKEN` can't trigger downstream workflows. It was using one person's PAT, so releases were tied to that account. Now it uses an org-owned bot, so **anyone can run a release** and the bumped PR is opened by `cloud-code-bot`.

## Changes
- Add a `create-github-app-token@v2` step (`id: app-token`).
- `actions/checkout` uses `token: ${{ steps.app-token.outputs.token }}` so the branch push is the bot's and still triggers workflows.
- Both `gh` PR steps (find + create/update) use the minted token instead of `BEN_PAT`.

## Prereqs (already done on this repo, verified)
- `APP_ID` variable = `2016716` ✅
- `CLOUD_CODE_BOT_PRIVATE_KEY` secret set ✅
- cloud-code-bot installed on the repo (installation 87539551), `contents: write` + `pull-requests: write` ✅ (token mint + repo access verified via a throwaway run)

`BEN_PAT` can be removed from repo secrets after this merges.