### PR TITLE
feat(close): always confirm closing local install windows; remove last-window quit toggle

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -406,8 +406,6 @@
     "autoInstallUpdates": "Automatically install Desktop updates",
     "appBehavior": "App Behavior",
     "reopenLastInstanceOnLaunch": "Auto-restart last instance on launch",
-    "closeDirectlyOnLastWindow": "Close Comfy Desktop on last window (don't return to Dashboard)",
-    "closeDirectlyOnLastWindowDescription": "When you close the last ComfyUI instance window, quit Comfy Desktop immediately instead of returning to the Dashboard.",
     "hideCloudFromPicker": "Hide Cloud from the Instance Picker",
     "hideCloudFromPickerDescription": "For local-only users — hides the Cloud tile (and the Try Cloud CTA) from the Dashboard. Cloud remains fully functional; you can re-enable this any time.",
     "checkForUpdates": "Check for updates",

--- a/locales/en.json
+++ b/locales/en.json
@@ -407,7 +407,7 @@
     "appBehavior": "App Behavior",
     "reopenLastInstanceOnLaunch": "Auto-restart last instance on launch",
     "confirmBeforeClosingWindow": "Confirm before closing a window",
-    "confirmBeforeClosingWindowDescription": "Ask for confirmation before closing a window that's running a local install, so a ComfyUI that took minutes to start isn't shut down by accident.",
+    "confirmBeforeClosingWindowDescription": "Ask for confirmation before closing a window that's running a local install.",
     "hideCloudFromPicker": "Hide Cloud from the Instance Picker",
     "hideCloudFromPickerDescription": "For local-only users — hides the Cloud tile (and the Try Cloud CTA) from the Dashboard. Cloud remains fully functional; you can re-enable this any time.",
     "checkForUpdates": "Check for updates",

--- a/locales/en.json
+++ b/locales/en.json
@@ -406,6 +406,8 @@
     "autoInstallUpdates": "Automatically install Desktop updates",
     "appBehavior": "App Behavior",
     "reopenLastInstanceOnLaunch": "Auto-restart last instance on launch",
+    "confirmBeforeClosingWindow": "Confirm before closing a window",
+    "confirmBeforeClosingWindowDescription": "Ask for confirmation before closing a window that's running a local install, so a ComfyUI that took minutes to start isn't shut down by accident.",
     "hideCloudFromPicker": "Hide Cloud from the Instance Picker",
     "hideCloudFromPickerDescription": "For local-only users — hides the Cloud tile (and the Try Cloud CTA) from the Dashboard. Cloud remains fully functional; you can re-enable this any time.",
     "checkForUpdates": "Check for updates",

--- a/src/main/host/createHostWindow.test.ts
+++ b/src/main/host/createHostWindow.test.ts
@@ -117,27 +117,33 @@ describe('shouldBailAfterConsult', () => {
 
 describe('shouldShowInstallCloseConfirm', () => {
   it('shows the modal for a host that would kill a local session on a defer consult', () => {
-    expect(shouldShowInstallCloseConfirm('defer', true, false, false)).toBe(true)
+    expect(shouldShowInstallCloseConfirm(true, 'defer', true, false, false)).toBe(true)
   })
 
   it('shows the modal for the last install window even with no local session at risk (closing quits)', () => {
-    expect(shouldShowInstallCloseConfirm('defer', false, false, true)).toBe(true)
+    expect(shouldShowInstallCloseConfirm(true, 'defer', false, false, true)).toBe(true)
+  })
+
+  it('skips the modal when the confirm preference is off, even for a last install window killing a local session', () => {
+    // Default experience: no prompt. The toggle gates every other condition.
+    expect(shouldShowInstallCloseConfirm(false, 'defer', true, false, true)).toBe(false)
+    expect(shouldShowInstallCloseConfirm(false, 'defer', false, false, true)).toBe(false)
   })
 
   it('skips the modal when the caller pre-cleared the close', () => {
     // Force-close paths must not block on an extra user prompt.
-    expect(shouldShowInstallCloseConfirm('defer', true, true, true)).toBe(false)
+    expect(shouldShowInstallCloseConfirm(true, 'defer', true, true, true)).toBe(false)
   })
 
   it('skips the modal for a non-last cloud/remote-backed host (no local session at risk)', () => {
-    expect(shouldShowInstallCloseConfirm('defer', false, false, false)).toBe(false)
+    expect(shouldShowInstallCloseConfirm(true, 'defer', false, false, false)).toBe(false)
   })
 
   it('skips the modal on a cleared or aborted consult', () => {
     // `cleared` → renderer already handled it; `aborted` → we already
     // bailed in the prior check (this case is unreachable in practice).
-    expect(shouldShowInstallCloseConfirm('cleared', true, false, true)).toBe(false)
-    expect(shouldShowInstallCloseConfirm('aborted', true, false, true)).toBe(false)
+    expect(shouldShowInstallCloseConfirm(true, 'cleared', true, false, true)).toBe(false)
+    expect(shouldShowInstallCloseConfirm(true, 'aborted', true, false, true)).toBe(false)
   })
 })
 

--- a/src/main/host/createHostWindow.test.ts
+++ b/src/main/host/createHostWindow.test.ts
@@ -23,7 +23,6 @@ import {
   expectedPartitionFor,
   shouldBailAfterCloseChoice,
   shouldBailAfterConsult,
-  shouldDetachLastInstallWindowToDashboard,
   shouldShowInstallCloseConfirm,
 } from './createHostWindow'
 
@@ -147,9 +146,8 @@ describe('shouldBailAfterCloseChoice', () => {
     expect(shouldBailAfterCloseChoice('cancel', false)).toBe(true)
   })
 
-  it('does not bail when the user chose to close or return to the dashboard', () => {
+  it('does not bail when the user chose to close', () => {
     expect(shouldBailAfterCloseChoice('close', false)).toBe(false)
-    expect(shouldBailAfterCloseChoice('return-to-dashboard', false)).toBe(false)
   })
 
   it('does not bail when a force-close lands mid-modal even on user cancel', () => {
@@ -159,37 +157,4 @@ describe('shouldBailAfterCloseChoice', () => {
   })
 })
 
-describe('shouldDetachLastInstallWindowToDashboard', () => {
-  it('detaches an install host with a live entry when it is the last window', () => {
-    // OS ✕ on the last install window → flip to dashboard in place.
-    expect(shouldDetachLastInstallWindowToDashboard(true, true, true, false, false)).toBe(true)
-  })
 
-  it('does not detach on a force-close even if it is the last install window', () => {
-    // Launch-guard swap / bulk Exit-All want the window gone, not a
-    // stray dashboard window left behind.
-    expect(shouldDetachLastInstallWindowToDashboard(true, true, true, true, false)).toBe(false)
-  })
-
-  it('does not detach when other host windows are still open', () => {
-    expect(shouldDetachLastInstallWindowToDashboard(true, true, false, false, false)).toBe(false)
-  })
-
-  it('does not detach a chooser/dashboard host (no install backing)', () => {
-    expect(shouldDetachLastInstallWindowToDashboard(false, true, true, false, false)).toBe(false)
-  })
-
-  it('does not detach when the entry has already been dropped from the registry', () => {
-    expect(shouldDetachLastInstallWindowToDashboard(true, false, true, false, false)).toBe(false)
-  })
-
-  it('does not detach when a quit is in progress (Cmd+Q, app-update restart, etc.)', () => {
-    // Regression for: clicking "Restart Now" in the Desktop Update modal
-    // fired app.quit() which fired close on the last install window —
-    // and that close was being intercepted into a dashboard-detach,
-    // swallowing the quit. The first restart click was a silent no-op
-    // because the window flipped to dashboard instead of destroying;
-    // only the second click (after the flip) actually restarted.
-    expect(shouldDetachLastInstallWindowToDashboard(true, true, true, false, true)).toBe(false)
-  })
-})

--- a/src/main/host/createHostWindow.test.ts
+++ b/src/main/host/createHostWindow.test.ts
@@ -21,6 +21,7 @@ import type { InstallationRecord } from '../installations'
 import {
   cascadeOffsetForCollisions,
   expectedPartitionFor,
+  installCloseNeedsConfirm,
   shouldBailAfterCloseChoice,
   shouldBailAfterConsult,
   shouldShowInstallCloseConfirm,
@@ -112,6 +113,21 @@ describe('shouldBailAfterConsult', () => {
   it('does not bail when the renderer deferred — main owns the close-confirm', () => {
     expect(shouldBailAfterConsult('defer', false)).toBe(false)
     expect(shouldBailAfterConsult('defer', true)).toBe(false)
+  })
+})
+
+describe('installCloseNeedsConfirm', () => {
+  it('confirms when enabled and the close kills a local session or is the last install window', () => {
+    expect(installCloseNeedsConfirm(true, true, false)).toBe(true)
+    expect(installCloseNeedsConfirm(true, false, true)).toBe(true)
+  })
+
+  it('skips when the confirm preference is off, regardless of kill/last-window state', () => {
+    expect(installCloseNeedsConfirm(false, true, true)).toBe(false)
+  })
+
+  it('skips when nothing is at risk (non-last, no local session)', () => {
+    expect(installCloseNeedsConfirm(true, false, false)).toBe(false)
   })
 })
 

--- a/src/main/host/createHostWindow.ts
+++ b/src/main/host/createHostWindow.ts
@@ -28,9 +28,7 @@ import {
 } from '../lib/ipc/shared'
 import * as mainTelemetry from '../lib/telemetry'
 import { forwardDatadogError } from '../lib/processErrorHandlers'
-import { isQuitInProgress } from '../lib/quit-state'
 import { recordDashboardSurface, recordInstanceSurface } from '../lib/lastSession'
-import * as settings from '../settings'
 import * as updater from '../lib/updater'
 import { getSavedBounds, getWindowOptions, saveWindowBounds } from '../lib/windowState'
 import { ensureSystemModal } from '../popups/systemModal'
@@ -66,11 +64,12 @@ const DEFAULT_HOST_HEIGHT = 900
 export type CloseConsultResult = 'cleared' | 'aborted' | 'defer'
 
 /** User's pick from the close-window confirm:
- *   - `close`               — tear the window down (last window → app quits)
- *   - `cancel`              — keep the window open
- *   - `return-to-dashboard` — flip the window in place to the dashboard (only
- *     offered on the last window, so the user isn't forced to quit) */
-export type CloseWindowChoice = 'close' | 'cancel' | 'return-to-dashboard'
+ *   - `close`  — tear the window down (last window → app quits)
+ *   - `cancel` — keep the window open
+ *
+ *  Returning to the dashboard is no longer a close-time choice: it's a
+ *  deliberate user action via the title pill's "Open Dashboard" / New Window. */
+export type CloseWindowChoice = 'close' | 'cancel'
 
 /** Should the close handler bail after the renderer consult?
  *
@@ -86,12 +85,12 @@ export function shouldBailAfterConsult(consult: CloseConsultResult, forceClose: 
 /** Should the install-host close-confirm modal run? Fires when the renderer
  *  deferred (no overlay), the caller hasn't pre-cleared, AND either the host
  *  would kill a local process OR this is the last install window (closing it
- *  quits the app, so the user must get the confirm + the dashboard escape).
- *  Cloud/remote non-last windows skip the modal (issue #654) — closing them
- *  never kills a local ComfyUI and the app stays alive. The "entry still
- *  exists" check is folded into `killsLocalSession` (its
- *  `shouldConfirmKillForEntry` source rejects a missing entry); the
- *  last-install-window branch carries its own entry check at the call site. */
+ *  quits the app, so the user must get the confirm). Cloud/remote non-last
+ *  windows skip the modal (issue #654) — closing them never kills a local
+ *  ComfyUI and the app stays alive. The "entry still exists" check is folded
+ *  into `killsLocalSession` (its `shouldConfirmKillForEntry` source rejects a
+ *  missing entry); the last-install-window branch carries its own entry check
+ *  at the call site. */
 export function shouldShowInstallCloseConfirm(
   consult: CloseConsultResult,
   killsLocalSession: boolean,
@@ -107,46 +106,6 @@ export function shouldShowInstallCloseConfirm(
  *  as {@link shouldBailAfterConsult}. */
 export function shouldBailAfterCloseChoice(choice: CloseWindowChoice, forceClose: boolean): boolean {
   return choice === 'cancel' && !forceClose
-}
-
-/** Should the close handler detach the last install-backed window to
- *  the dashboard instead of tearing it down — as the FALLBACK when no
- *  explicit close choice was made (the confirm was skipped)?
- *
- *  The normal close of the last install window now shows a three-way
- *  confirm (Quit Desktop / Return to Dashboard / Cancel); the user's
- *  pick drives the outcome directly. This guard only covers the paths
- *  that reach teardown WITHOUT that confirm (e.g. a rare overlay-cancel
- *  consult that cleared) — there, defaulting the last install window to
- *  the dashboard preserves the invariant that we never quit the last
- *  window without an explicit user choice. A force-close (launch-guard
- *  eviction, bulk Exit-All) is a different intent: the caller already
- *  wants the window gone, and leaving a stray dashboard window behind
- *  after a swap-installs flow is noise. Force-close therefore skips the
- *  detach branch and falls through to the normal teardown.
- *
- *  Same logic applies when `app.quit()` is in flight (Cmd+Q, app menu
- *  Quit, electron-updater's `restartAndInstall`): the caller wants the
- *  process to exit, not the host to flip in place. Detaching here would
- *  swallow the quit and leave a dashboard window alive after a "Restart
- *  to install" click — which was exactly bug #(see PR description): the
- *  first restart click was a no-op because the close handler intercepted
- *  the quit into a dashboard detach. The second click worked only
- *  because the window was already on the dashboard by then. */
-export function shouldDetachLastInstallWindowToDashboard(
-  isInstallHostWindow: boolean,
-  hasEntry: boolean,
-  isLastWindow: boolean,
-  forceClose: boolean,
-  quitInProgress: boolean,
-): boolean {
-  return (
-    isInstallHostWindow &&
-    hasEntry &&
-    isLastWindow &&
-    !forceClose &&
-    !quitInProgress
-  )
 }
 
 /** Constants reused by both host modes. Defined here because they only
@@ -854,13 +813,12 @@ export function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowRe
       try {
         const entry = comfyWindows.get(windowKey)
         const skipConsult = fx.preClearedClose.has(comfyWindow)
-        // The OS ✕ must never quit the app. When this is the only live
-        // host window, an install-backed host returns to the dashboard
-        // (stop the instance, flip in place) instead of being destroyed;
-        // a chooser host is destroyed and the app quits via
-        // `window-all-closed`, which is the one sanctioned exit. The
-        // renderer also uses `isLastWindow` to tailor its close-confirm
-        // copy.
+        // The OS ✕ on a local install window always shows the Close Window
+        // confirm — including the last window, where confirming tears the
+        // window down and the app quits via `window-all-closed`. Returning
+        // to the dashboard is a deliberate action via the title pill, not a
+        // close-time fallback. The renderer also uses `isLastWindow` to
+        // tailor its close-confirm copy.
         const isLastWindow =
           Array.from(comfyWindows.values()).filter((e) => !e.window.isDestroyed()).length <= 1
         // Hide any open title-bar popup before any confirm fires. The
@@ -885,17 +843,13 @@ export function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowRe
           ? 'cleared'
           : await fx.consultPanelRendererClose(entry?.panelView)
         if (shouldBailAfterConsult(consult, fx.preClearedClose.has(comfyWindow))) return
-        // Step 2 — for an install-backed host with no overlay, main shows
-        // the same Close Window confirm as the menu item. The last window
-        // gets a three-way choice (Quit Desktop / Return to Dashboard /
-        // Cancel) so closing it isn't a forced quit; non-last windows get
-        // the plain Close/Cancel confirm. The dashboard closes with no
-        // prompt.
+        // Step 2 — for a local install-backed host with no overlay, main
+        // shows the Close Window confirm (same as the menu item). The last
+        // window gets the same prompt — confirming it tears down and quits.
+        // The dashboard closes with no prompt.
         const entryForClose = comfyWindows.get(windowKey)
         const isInstallHostWindow = !!entryForClose && !isChooserHost(entryForClose)
         const isLastInstallWindow = isLastWindow && isInstallHostWindow
-        // `null` = no confirm was shown (so no explicit user choice).
-        let closeChoice: CloseWindowChoice | null = null
         if (
           shouldShowInstallCloseConfirm(
             consult,
@@ -905,68 +859,19 @@ export function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowRe
           )
           && entryForClose
         ) {
-          // Last install window: skip the three-way modal entirely and
-          // pick the outcome from the user's setting.
-          //  - `closeDirectlyOnLastWindow` true  → quit Desktop ('close')
-          //  - false (default)                   → return to dashboard
-          // Non-last windows still go through the existing 2-way confirm
-          // because running processes / pending downloads need an "are
-          // you sure" gate.
-          if (isLastInstallWindow) {
-            const closeDirectly =
-              (settings.get('closeDirectlyOnLastWindow') as boolean | undefined) === true
-            closeChoice = closeDirectly ? 'close' : 'return-to-dashboard'
-          } else {
-            closeChoice = await fx.confirmCloseInstanceWindow(
-              comfyWindow,
-              isLastWindow,
-              shouldConfirmKillForEntry(entryForClose),
-              entryForClose.lastTheme,
-            )
-            if (shouldBailAfterCloseChoice(closeChoice, fx.preClearedClose.has(comfyWindow))) return
-          }
+          const closeChoice = await fx.confirmCloseInstanceWindow(
+            comfyWindow,
+            isLastWindow,
+            shouldConfirmKillForEntry(entryForClose),
+            entryForClose.lastTheme,
+          )
+          if (shouldBailAfterCloseChoice(closeChoice, fx.preClearedClose.has(comfyWindow))) return
         }
-        // Capture the force-close intent before we drain the flag.
-        // Either the initial snapshot (`skipConsult`) or a late-arriving
-        // pre-clear (force-close that landed mid-consult/mid-modal) is
-        // enough to mark this as caller-driven.
-        const forceClose = skipConsult || fx.preClearedClose.has(comfyWindow)
+        // Drain the force-close flag (its only remaining consumer was the
+        // dashboard-detach fallback, now removed; kept here so a late
+        // pre-clear doesn't leak into a future close of a reused window).
         fx.preClearedClose.delete(comfyWindow)
         if (comfyWindow.isDestroyed()) return
-        // Explicit "Return to Dashboard" pick → flip in place rather than
-        // tearing down. `detachInstall` runs the same `_installCleanup`
-        // (stopRunning, listeners off) the teardown below would, then
-        // flips the window to chooser mode. Force-close ignores the pick —
-        // the caller wants the window gone.
-        if (closeChoice === 'return-to-dashboard' && !forceClose && isInstallHostWindow && entryForClose) {
-          entryForClose.detachInstall()
-          return
-        }
-        // No explicit choice (the confirm was skipped — consult cleared
-        // or pre-cleared close). Default: keep the last install window
-        // on the dashboard rather than quitting silently. EXCEPT when
-        // the user has opted into `closeDirectlyOnLastWindow`, in which
-        // case the consult-cleared path must still honor that intent
-        // and let the teardown run.
-        if (
-          closeChoice === null
-          && shouldDetachLastInstallWindowToDashboard(
-            isInstallHostWindow,
-            !!entryForClose,
-            isLastWindow,
-            forceClose,
-            isQuitInProgress(),
-          )
-          && entryForClose
-        ) {
-          const closeDirectly =
-            isLastInstallWindow &&
-            (settings.get('closeDirectlyOnLastWindow') as boolean | undefined) === true
-          if (!closeDirectly) {
-            entryForClose.detachInstall()
-            return
-          }
-        }
         // Each cleanup step is wrapped via `safeTeardown` so a single
         // throw can't skip the BrowserWindow.destroy() at the end.
         // Without this, an exception in (e.g.) the comfy webContents

--- a/src/main/host/createHostWindow.ts
+++ b/src/main/host/createHostWindow.ts
@@ -29,6 +29,7 @@ import {
 import * as mainTelemetry from '../lib/telemetry'
 import { forwardDatadogError } from '../lib/processErrorHandlers'
 import { recordDashboardSurface, recordInstanceSurface } from '../lib/lastSession'
+import * as settings from '../settings'
 import * as updater from '../lib/updater'
 import { getSavedBounds, getWindowOptions, saveWindowBounds } from '../lib/windowState'
 import { ensureSystemModal } from '../popups/systemModal'
@@ -82,22 +83,29 @@ export function shouldBailAfterConsult(consult: CloseConsultResult, forceClose: 
   return consult === 'aborted' && !forceClose
 }
 
-/** Should the install-host close-confirm modal run? Fires when the renderer
- *  deferred (no overlay), the caller hasn't pre-cleared, AND either the host
- *  would kill a local process OR this is the last install window (closing it
- *  quits the app, so the user must get the confirm). Cloud/remote non-last
- *  windows skip the modal (issue #654) — closing them never kills a local
- *  ComfyUI and the app stays alive. The "entry still exists" check is folded
- *  into `killsLocalSession` (its `shouldConfirmKillForEntry` source rejects a
- *  missing entry); the last-install-window branch carries its own entry check
- *  at the call site. */
+/** Should the install-host close-confirm modal run? Gated by the user's
+ *  `confirmBeforeClosingWindow` preference (off by default — most users close
+ *  without a prompt). When enabled, fires when the renderer deferred (no
+ *  overlay), the caller hasn't pre-cleared, AND either the host would kill a
+ *  local process OR this is the last install window (closing it quits the
+ *  app). Cloud/remote non-last windows skip the modal (issue #654) — closing
+ *  them never kills a local ComfyUI and the app stays alive. The "entry still
+ *  exists" check is folded into `killsLocalSession` (its
+ *  `shouldConfirmKillForEntry` source rejects a missing entry); the
+ *  last-install-window branch carries its own entry check at the call site. */
 export function shouldShowInstallCloseConfirm(
+  confirmEnabled: boolean,
   consult: CloseConsultResult,
   killsLocalSession: boolean,
   forceClose: boolean,
   isLastInstallWindow: boolean,
 ): boolean {
-  return consult === 'defer' && !forceClose && (killsLocalSession || isLastInstallWindow)
+  return (
+    confirmEnabled
+    && consult === 'defer'
+    && !forceClose
+    && (killsLocalSession || isLastInstallWindow)
+  )
 }
 
 /** Should the close handler bail after the install-host close-confirm
@@ -852,6 +860,7 @@ export function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowRe
         const isLastInstallWindow = isLastWindow && isInstallHostWindow
         if (
           shouldShowInstallCloseConfirm(
+            settings.get('confirmBeforeClosingWindow') === true,
             consult,
             shouldConfirmKillForEntry(entryForClose),
             fx.preClearedClose.has(comfyWindow),

--- a/src/main/host/createHostWindow.ts
+++ b/src/main/host/createHostWindow.ts
@@ -83,14 +83,24 @@ export function shouldBailAfterConsult(consult: CloseConsultResult, forceClose: 
   return consult === 'aborted' && !forceClose
 }
 
-/** Should the install-host close-confirm modal run? Gated by the user's
- *  `confirmBeforeClosingWindow` preference (off by default — most users close
- *  without a prompt). When enabled, fires when the renderer deferred (no
- *  overlay), the caller hasn't pre-cleared, AND either the host would kill a
- *  local process OR this is the last install window (closing it quits the
+/** Core close-confirm rule shared by the OS ✕ handler and the File-menu
+ *  "Close Window". Confirm only when the user opted in via
+ *  `confirmBeforeClosingWindow` (off by default) AND the close either kills a
+ *  local ComfyUI process OR closes the last install window (which quits the
  *  app). Cloud/remote non-last windows skip the modal (issue #654) — closing
- *  them never kills a local ComfyUI and the app stays alive. The "entry still
- *  exists" check is folded into `killsLocalSession` (its
+ *  them never kills a local ComfyUI and the app stays alive. */
+export function installCloseNeedsConfirm(
+  confirmEnabled: boolean,
+  killsLocalSession: boolean,
+  isLastInstallWindow: boolean,
+): boolean {
+  return confirmEnabled && (killsLocalSession || isLastInstallWindow)
+}
+
+/** Should the install-host close-confirm modal run on the OS ✕ path? Applies
+ *  `installCloseNeedsConfirm` and additionally requires the renderer to have
+ *  deferred (no overlay) and the caller not to have pre-cleared. The "entry
+ *  still exists" check is folded into `killsLocalSession` (its
  *  `shouldConfirmKillForEntry` source rejects a missing entry); the
  *  last-install-window branch carries its own entry check at the call site. */
 export function shouldShowInstallCloseConfirm(
@@ -101,10 +111,9 @@ export function shouldShowInstallCloseConfirm(
   isLastInstallWindow: boolean,
 ): boolean {
   return (
-    confirmEnabled
+    installCloseNeedsConfirm(confirmEnabled, killsLocalSession, isLastInstallWindow)
     && consult === 'defer'
     && !forceClose
-    && (killsLocalSession || isLastInstallWindow)
   )
 }
 
@@ -856,7 +865,7 @@ export function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowRe
         // window gets the same prompt — confirming it tears down and quits.
         // The dashboard closes with no prompt.
         const entryForClose = comfyWindows.get(windowKey)
-        const isInstallHostWindow = !!entryForClose && !isChooserHost(entryForClose)
+        const isInstallHostWindow = !!entryForClose && isInstallHost(entryForClose)
         const isLastInstallWindow = isLastWindow && isInstallHostWindow
         if (
           shouldShowInstallCloseConfirm(

--- a/src/main/host/detach.ts
+++ b/src/main/host/detach.ts
@@ -4,7 +4,7 @@ import * as ipc from '../lib/ipc'
 import { _runningSessions } from '../lib/ipc/shared'
 import { COMFY_BG } from '../lib/theme'
 import { destroyPanelView, ensurePanelView } from './panelView'
-import { openSystemModalAsync, openSystemModalChoiceAsync } from '../popups/systemModal'
+import { openSystemModalAsync } from '../popups/systemModal'
 import type { SystemModalDetailGroup } from '../popups/systemModal'
 import { recordDashboardSurface } from '../lib/lastSession'
 import { comfyWindows, isChooserHost, isInstallHost, shouldConfirmKillForEntry } from './registry'
@@ -255,9 +255,11 @@ export async function confirmAndCloseAllHostWindows(
  * main, not the panel renderer, because the renderer is hidden behind ComfyUI while an
  * instance runs and can't be relied on to surface a prompt.
  *
- * The last window adds a "Return to Dashboard" middle option so closing it isn't a forced
- * quit — the primary action quits Desktop, the secondary keeps the app on the dashboard.
- * `stopsLocalComfy` tailors the copy (a stopped / cloud window has no local process to stop).
+ * The same Close / Cancel prompt is shown for every local install window, including the last
+ * one — confirming it tears the window down and the app quits via `window-all-closed`.
+ * `isLastWindow` and `stopsLocalComfy` only tailor the copy (a stopped / cloud window has no
+ * local process to stop; the last window's close quits Comfy Desktop). Returning to the
+ * dashboard is a deliberate action via the title pill, not a close-time option.
  */
 export async function confirmCloseInstanceWindow(
   window: BrowserWindow,
@@ -265,47 +267,31 @@ export async function confirmCloseInstanceWindow(
   stopsLocalComfy: boolean,
   theme: { bg: string; text: string },
 ): Promise<CloseWindowChoice> {
-  if (!isLastWindow) {
-    const confirmed = await openSystemModalAsync({
-      parent: window,
-      spec: {
-        title: 'Close Window',
-        message: stopsLocalComfy
-          ? 'Close this window? This stops the running ComfyUI instance.'
-          : 'Close this window?',
-        confirmLabel: 'Close Window',
-        cancelLabel: 'Cancel',
-        confirmStyle: 'danger',
-        theme,
-      },
-    })
-    return confirmed ? 'close' : 'cancel'
-  }
-  const action = await openSystemModalChoiceAsync({
+  const message = isLastWindow
+    ? stopsLocalComfy
+      ? 'Close this window? This stops ComfyUI and quits Comfy Desktop.'
+      : 'Close this window? This quits Comfy Desktop.'
+    : stopsLocalComfy
+      ? 'Close this window? This stops the running ComfyUI instance.'
+      : 'Close this window?'
+  const confirmed = await openSystemModalAsync({
     parent: window,
     spec: {
       title: 'Close Window',
-      message: stopsLocalComfy
-        ? 'This is the last window. Closing it stops ComfyUI and quits Desktop, or you can return to the dashboard.'
-        : 'This is the last window. Closing it quits Desktop, or you can return to the dashboard.',
-      confirmLabel: 'Quit Desktop',
-      secondaryLabel: 'Return to Dashboard',
-      secondaryStyle: 'primary',
+      message,
+      confirmLabel: 'Close Window',
       cancelLabel: 'Cancel',
       confirmStyle: 'danger',
       theme,
     },
   })
-  if (action === 'confirm') return 'close'
-  if (action === 'secondary') return 'return-to-dashboard'
-  return 'cancel'
+  return confirmed ? 'close' : 'cancel'
 }
 
 /**
  * Confirm + close a single install-backed host window. Model downloads are owned by the
  * desktop app, not the instance, so they keep running after a close (no active-download
- * list here). Closing the last window quits Desktop; the confirm offers "Return to
- * Dashboard" so the user isn't forced to quit.
+ * list here). Closing the last window quits Desktop once the user confirms the prompt.
  */
 export async function confirmAndCloseHostWindow(parentWindow: BrowserWindow): Promise<void> {
   if (parentWindow.isDestroyed()) return
@@ -319,7 +305,7 @@ export async function confirmAndCloseHostWindow(parentWindow: BrowserWindow): Pr
   ).length
   const isLastWindow = liveWindowCount <= 1
   // Confirm when closing kills a local ComfyUI process OR when this is the last install
-  // window (closing it quits the app, so the user gets the prompt + the dashboard escape).
+  // window (closing it quits the app, so the user gets the prompt).
   // Cloud/remote non-last windows and chooser hosts close immediately.
   if (shouldConfirmKillForEntry(entry) || (isLastWindow && isInstallHost(entry))) {
     const choice = await confirmCloseInstanceWindow(
@@ -329,11 +315,6 @@ export async function confirmAndCloseHostWindow(parentWindow: BrowserWindow): Pr
       entry.lastTheme,
     )
     if (choice === 'cancel') return
-    if (choice === 'return-to-dashboard') {
-      // Flip the last window to the dashboard rather than closing it (which would quit).
-      entry.detachInstall()
-      return
-    }
   }
   // Skip the close handler's consult: the user already confirmed via this prompt.
   preClearedClose.add(entry.window)

--- a/src/main/host/detach.ts
+++ b/src/main/host/detach.ts
@@ -14,6 +14,7 @@ import {
   applyChooserHostTheme,
   CHOOSER_HOST_TITLE_TEXT,
   CHOOSER_HOST_WINDOW_TITLE,
+  installCloseNeedsConfirm,
 } from './createHostWindow'
 import type { CloseWindowChoice } from './createHostWindow'
 
@@ -306,12 +307,16 @@ export async function confirmAndCloseHostWindow(parentWindow: BrowserWindow): Pr
     (e) => !e.window.isDestroyed(),
   ).length
   const isLastWindow = liveWindowCount <= 1
-  // Gated by the user's `confirmBeforeClosingWindow` preference (off by default).
-  // When enabled, confirm when closing kills a local ComfyUI process OR when this
-  // is the last install window (closing it quits the app, so the user gets the
-  // prompt). Cloud/remote non-last windows and chooser hosts close immediately.
-  const confirmEnabled = settings.get('confirmBeforeClosingWindow') === true
-  if (confirmEnabled && (shouldConfirmKillForEntry(entry) || (isLastWindow && isInstallHost(entry)))) {
+  // Same rule as the OS ✕ path: confirm only when the user opted in and the
+  // close kills a local ComfyUI process or closes the last install window.
+  // Cloud/remote non-last windows and chooser hosts close immediately.
+  if (
+    installCloseNeedsConfirm(
+      settings.get('confirmBeforeClosingWindow') === true,
+      shouldConfirmKillForEntry(entry),
+      isLastWindow && isInstallHost(entry),
+    )
+  ) {
     const choice = await confirmCloseInstanceWindow(
       entry.window,
       isLastWindow,

--- a/src/main/host/detach.ts
+++ b/src/main/host/detach.ts
@@ -7,6 +7,7 @@ import { destroyPanelView, ensurePanelView } from './panelView'
 import { openSystemModalAsync } from '../popups/systemModal'
 import type { SystemModalDetailGroup } from '../popups/systemModal'
 import { recordDashboardSurface } from '../lib/lastSession'
+import * as settings from '../settings'
 import { comfyWindows, isChooserHost, isInstallHost, shouldConfirmKillForEntry } from './registry'
 import type { ComfyWindowEntry } from './registry'
 import {
@@ -291,7 +292,8 @@ export async function confirmCloseInstanceWindow(
 /**
  * Confirm + close a single install-backed host window. Model downloads are owned by the
  * desktop app, not the instance, so they keep running after a close (no active-download
- * list here). Closing the last window quits Desktop once the user confirms the prompt.
+ * list here). The confirm prompt is gated by `confirmBeforeClosingWindow` (off by
+ * default); closing the last window quits Desktop either way.
  */
 export async function confirmAndCloseHostWindow(parentWindow: BrowserWindow): Promise<void> {
   if (parentWindow.isDestroyed()) return
@@ -304,10 +306,12 @@ export async function confirmAndCloseHostWindow(parentWindow: BrowserWindow): Pr
     (e) => !e.window.isDestroyed(),
   ).length
   const isLastWindow = liveWindowCount <= 1
-  // Confirm when closing kills a local ComfyUI process OR when this is the last install
-  // window (closing it quits the app, so the user gets the prompt).
-  // Cloud/remote non-last windows and chooser hosts close immediately.
-  if (shouldConfirmKillForEntry(entry) || (isLastWindow && isInstallHost(entry))) {
+  // Gated by the user's `confirmBeforeClosingWindow` preference (off by default).
+  // When enabled, confirm when closing kills a local ComfyUI process OR when this
+  // is the last install window (closing it quits the app, so the user gets the
+  // prompt). Cloud/remote non-last windows and chooser hosts close immediately.
+  const confirmEnabled = settings.get('confirmBeforeClosingWindow') === true
+  if (confirmEnabled && (shouldConfirmKillForEntry(entry) || (isLastWindow && isInstallHost(entry)))) {
     const choice = await confirmCloseInstanceWindow(
       entry.window,
       isLastWindow,

--- a/src/main/lib/ipc/registerSettingsHandlers.ts
+++ b/src/main/lib/ipc/registerSettingsHandlers.ts
@@ -51,22 +51,14 @@ export function buildSettingsSections(): SettingsSection[] {
         // Theme picker hidden (app is dark-only); the theme plumbing stays
         // wired so re-adding this field is the only change needed to restore it.
 
-        // Window-behavior block — these two travel together:
-        //   reopenLastInstanceOnLaunch + closeDirectlyOnLastWindow
-        // together implement the "feel like a single-app workspace" flow
-        // (quit closes the instance, next launch boots straight back in).
+        // Boot behavior: reopen the last-used instance on launch. Closing the
+        // last instance window quits Desktop (after a confirm), so the next
+        // launch boots straight back into that instance.
         {
           id: 'reopenLastInstanceOnLaunch',
           label: i18n.t('settings.reopenLastInstanceOnLaunch'),
           type: 'boolean',
           value: s.reopenLastInstanceOnLaunch !== false
-        },
-        {
-          id: 'closeDirectlyOnLastWindow',
-          label: i18n.t('settings.closeDirectlyOnLastWindow'),
-          type: 'boolean',
-          value: s.closeDirectlyOnLastWindow === true,
-          tooltip: i18n.t('settings.closeDirectlyOnLastWindowDescription')
         },
 
         // Cloud opt-out — pure visibility toggle, doesn't affect any

--- a/src/main/lib/ipc/registerSettingsHandlers.ts
+++ b/src/main/lib/ipc/registerSettingsHandlers.ts
@@ -61,6 +61,17 @@ export function buildSettingsSections(): SettingsSection[] {
           value: s.reopenLastInstanceOnLaunch !== false
         },
 
+        // Close confirmation, off by default. When on, closing a local-install
+        // window asks the user to confirm first (guards against accidentally
+        // killing a ComfyUI that took minutes to boot).
+        {
+          id: 'confirmBeforeClosingWindow',
+          label: i18n.t('settings.confirmBeforeClosingWindow'),
+          type: 'boolean',
+          value: s.confirmBeforeClosingWindow === true,
+          tooltip: i18n.t('settings.confirmBeforeClosingWindowDescription')
+        },
+
         // Cloud opt-out — pure visibility toggle, doesn't affect any
         // running behavior. Kept after the window-behavior block so
         // users who don't care about Cloud find it without scrolling

--- a/src/main/popups/systemModal.ts
+++ b/src/main/popups/systemModal.ts
@@ -174,26 +174,6 @@ export function openSystemModalAsync(opts: OpenSystemModalOpts): Promise<boolean
   })
 }
 
-/** Three-way variant of `openSystemModalAsync`. Resolves the raw action so a
- *  caller offering a middle option (`secondaryLabel`) can branch on it. Cancel
- *  / superseded / parent-destroyed all resolve `'cancel'`. */
-export function openSystemModalChoiceAsync(
-  opts: OpenSystemModalOpts,
-): Promise<'confirm' | 'cancel' | 'secondary'> {
-  return new Promise((resolve) => {
-    openSystemModal({
-      parent: opts.parent,
-      spec: opts.spec,
-      callback: (action) => {
-        if (opts.callback) {
-          try { opts.callback(action) } catch {}
-        }
-        resolve(action)
-      },
-    })
-  })
-}
-
 /** Wire the IPC handlers that drive the system-modal popup. Called once at app ready. */
 export function registerSystemModalIpc(): void {
   ipcMain.on('comfy-systemmodal:ready', (event) => {

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -39,12 +39,6 @@ export interface KnownSettings {
    *  can opt out of seeing it without us removing the feature. Default
    *  false — Cloud stays visible. */
   hideCloudFromPicker?: boolean
-  /** When true, closing the last ComfyUI instance window quits Desktop
-   *  directly — no modal, no return-to-dashboard fallback. For power
-   *  users who treat the instance window as the whole app. Default
-   *  false — closing the last instance window returns to the dashboard.
-   *  Replaces the three-way close modal from the bundle iteration. */
-  closeDirectlyOnLastWindow?: boolean
   oemManagedModelDirs?: string[]
   oemWorkflowImportVersion?: number
   /** Directory the user last chose in the general "Save image/file" dialog.
@@ -87,7 +81,6 @@ const SETTINGS_SCHEMA = {
   telemetryEnabled: { nullable: false },
   firstUseCompleted: { nullable: false },
   hideCloudFromPicker: { nullable: false },
-  closeDirectlyOnLastWindow: { nullable: false },
   oemManagedModelDirs: { nullable: false },
   oemWorkflowImportVersion: { nullable: false },
   lastSaveDialogDir: { nullable: true },
@@ -230,8 +223,14 @@ function load(): Settings {
 
   // Drop legacy keys that no longer back any setting. `maxCachedFiles` was the
   // user-editable predecessor of `maxCachedDownloads`; its old value is
-  // discarded so everyone adopts the new default.
-  for (const key of ['primaryInstallId', 'pinnedInstallIds', 'maxCachedFiles']) {
+  // discarded so everyone adopts the new default. `closeDirectlyOnLastWindow`
+  // backed the removed last-window quit toggle (closing now always confirms).
+  for (const key of [
+    'primaryInstallId',
+    'pinnedInstallIds',
+    'maxCachedFiles',
+    'closeDirectlyOnLastWindow',
+  ]) {
     if (Object.prototype.hasOwnProperty.call(result, key)) {
       delete result[key]
       changed = true

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -27,6 +27,10 @@ export interface KnownSettings {
   /** When true (default), boot reopens the last-used instance window instead of
    *  the dashboard, when the last active surface was an instance. */
   reopenLastInstanceOnLaunch?: boolean
+  /** When true, closing a local-install window asks the user to confirm first
+   *  (guards against accidentally killing a ComfyUI that took minutes to boot).
+   *  Default false — windows close without a prompt. */
+  confirmBeforeClosingWindow?: boolean
   pypiMirror?: string
   useChineseMirrors?: boolean
   chineseMirrorsPrompted?: boolean
@@ -75,6 +79,7 @@ const SETTINGS_SCHEMA = {
   autoUpdate: { nullable: false },
   autoInstallUpdates: { nullable: false },
   reopenLastInstanceOnLaunch: { nullable: false },
+  confirmBeforeClosingWindow: { nullable: false },
   pypiMirror: { nullable: false },
   useChineseMirrors: { nullable: false },
   chineseMirrorsPrompted: { nullable: false },
@@ -224,7 +229,8 @@ function load(): Settings {
   // Drop legacy keys that no longer back any setting. `maxCachedFiles` was the
   // user-editable predecessor of `maxCachedDownloads`; its old value is
   // discarded so everyone adopts the new default. `closeDirectlyOnLastWindow`
-  // backed the removed last-window quit toggle (closing now always confirms).
+  // backed the removed last-window quit toggle (close confirmation is now gated
+  // by `confirmBeforeClosingWindow`, off by default).
   for (const key of [
     'primaryInstallId',
     'pinnedInstallIds',


### PR DESCRIPTION
## What

Closing a **local install instance window now always shows the Close Window / Cancel confirm**, including the last window. Confirming the last window tears it down and quits Comfy Desktop via `window-all-closed`.

The friction is intentional: it prevents accidental closes of a ComfyUI that can take a minute or more to launch.

Returning to the dashboard is **no longer a close-time choice** - the three-way *Quit Desktop / Return to Dashboard / Cancel* modal is gone. Going back to the dashboard remains a deliberate user action via the title pill's **Open Dashboard** / **New Window**.

## Why

The previous model bypassed the confirm on the last window and instead consulted a `closeDirectlyOnLastWindow` setting (default off ? silently return to dashboard). That setting was confusing and, combined with the return-to-dashboard default, made the accidental-close protection inconsistent. Simplifying to "always confirm, close = quit" is clearer and makes `reopenLastInstanceOnLaunch` (auto-restart) actually meaningful: closing the last window now quits with the instance as the active surface, so the next launch boots straight back into it.

## Changes

- `confirmCloseInstanceWindow` (detach.ts): always renders the 2-way Close Window / Cancel modal; copy is tailored for the last window (".quits Comfy Desktop") and for whether a local session is stopped. `CloseWindowChoice` narrowed to `'close' | 'cancel'`.
- Close handler (createHostWindow.ts): the last install window now goes through the same confirm as any other; removed the `return-to-dashboard` branch and the `shouldDetachLastInstallWindowToDashboard` fallback (+ helper + tests).
- Removed the `closeDirectlyOnLastWindow` setting: schema (`settings.ts`), Global Settings field (`registerSettingsHandlers.ts`), and `en.json` strings. The legacy key is cleaned from existing `settings.json` on load.
- `confirmAndCloseHostWindow` (menu path): dropped the `return-to-dashboard` handling.

Deliberate Return-to-Dashboard flows (title pill, File menu, IPC) are untouched.

## Notes

- The 3-button native modal helper `openSystemModalChoiceAsync` is now unused but left in place - it's general cross-process (main + preload + renderer) infrastructure; removing the whole path is out of scope here.

## Verification

- `pnpm run typecheck` ?
- `pnpm run lint` ?
- `pnpm run build` ?
- `pnpm run test` ? (1931 tests)

(Repo-wide `format:check` fails on pre-existing untouched files - e.g. `tsconfig.json`, `package.json` - so it was not run as a gate; it is not part of the husky pre-commit hook.)