### PR TITLE
fix(terminal): Windows venv activation, native tab order, Console->Terminal label

### DIFF
--- a/src/main/host/attach.ts
+++ b/src/main/host/attach.ts
@@ -3,6 +3,7 @@ import { getAppVersion } from '../lib/ipc'
 import { attachSessionDownloadHandler } from '../lib/comfyDownloadManager'
 import { getModelDownloadContentScript } from '../lib/comfyContentScript'
 import { getComfyTerminalContentScript } from '../lib/comfyTerminalContentScript'
+import { closeInstallPopouts } from '../lib/popoutWindows'
 import { _operationAborts, sourceMap } from '../lib/ipc/shared'
 import { TITLEBAR_BG } from '../lib/theme'
 import * as mainTelemetry from '../lib/telemetry'
@@ -610,6 +611,11 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
         comfyContents.off('will-navigate', relaunch.navBlocker)
       }
       ipc.stopRunning(id)
+      // Close this install's pop-out terminal/logs windows. They're standalone
+      // BrowserWindows outside the host registry, so without this they outlive
+      // the install and — being open windows — suppress `window-all-closed`,
+      // keeping the whole app alive after the user closed its host window.
+      closeInstallPopouts(id)
       fx.comfyFailRetryTimerCancels.delete(id)
       fx.comfyReloads.delete(id)
       fx.comfyZoomResets.delete(id)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,6 +10,8 @@ import todesktop from '@todesktop/runtime'
 import * as ipc from './lib/ipc'
 import { getAppVersion } from './lib/ipc'
 import type { ExitCallbackInfo } from './lib/ipc'
+import { closeAllPopouts } from './lib/popoutWindows'
+import { disposeAllTerminals } from './lib/terminal'
 import * as updater from './lib/updater'
 import * as settings from './settings'
 import { installAppMenu } from './menu'
@@ -2046,6 +2048,10 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
         if (!entry.window.isDestroyed()) entry.window.destroy()
       }
       comfyWindows.clear()
+      // Pop-out terminal/logs windows live outside `comfyWindows`; close them
+      // here too and kill their shared shells so no window or PTY child lingers.
+      closeAllPopouts()
+      disposeAllTerminals()
       if (tray) {
         tray.destroy()
         tray = null

--- a/src/main/lib/comfyTerminalContentScript.test.ts
+++ b/src/main/lib/comfyTerminalContentScript.test.ts
@@ -38,6 +38,11 @@ describe('getComfyTerminalContentScript', () => {
     expect(script).toContain(`title: 'Terminal'`)
   })
 
+  it('waits for the native Logs tab so Terminal registers second', () => {
+    expect(script).toContain('logs-terminal')
+    expect(script).toContain('extensionManager')
+  })
+
   it('uses the shared desktop terminal transport', () => {
     for (const member of ['subscribe', 'write', 'resize', 'restart', 'onOutput', 'onExited']) {
       expect(script).toContain(member)

--- a/src/main/lib/comfyTerminalContentScript.ts
+++ b/src/main/lib/comfyTerminalContentScript.ts
@@ -191,6 +191,24 @@ function alreadyHasTerminalTab(app) {
   return false;
 }
 
+// The native Logs tab is registered asynchronously into the bottom-panel
+// store. We register our Terminal tab AFTER it so Logs stays first + default
+// and Terminal lands second, matching the native frontend ordering (the store
+// makes the first-registered tab the default active one).
+function hasLogsTab(app) {
+  try {
+    var bp = app && app.extensionManager && app.extensionManager.bottomPanel;
+    var terminalPanel = bp && bp.panels && bp.panels.terminal;
+    var tabs = terminalPanel && terminalPanel.tabs;
+    if (tabs) {
+      for (var i = 0; i < tabs.length; i++) {
+        if (tabs[i] && tabs[i].id === 'logs-terminal') return true;
+      }
+    }
+  } catch (e) {}
+  return false;
+}
+
 function waitForRegister(timeoutMs) {
   var startedAt = Date.now();
   (function tick() {
@@ -201,6 +219,13 @@ function waitForRegister(timeoutMs) {
       // Native frontend tab already mounted — leave it alone.
       if (alreadyHasTerminalTab(app)) {
         STATE.registered = true;
+        return;
+      }
+      // Hold until the native Logs tab exists so ours registers second. Fall
+      // back to registering anyway once the timeout elapses, so a frontend
+      // without a Logs tab never strands the user without a terminal.
+      if (!hasLogsTab(app) && Date.now() - startedAt <= timeoutMs) {
+        setTimeout(tick, 100);
         return;
       }
       try {

--- a/src/main/lib/logsPopoutWindow.ts
+++ b/src/main/lib/logsPopoutWindow.ts
@@ -159,3 +159,22 @@ export async function openLogsPopout(installationId: string): Promise<void> {
     void win.webContents.executeJavaScript(buildPopoutScript(installationId)).catch(() => {})
   })
 }
+
+/**
+ * Close the logs pop-out for a single install, if one is open. Mirrors
+ * {@link closeTerminalPopout}: invoked on detach / host-window close so a
+ * lingering pop-out can't keep the app alive, and before update/restore.
+ */
+export function closeLogsPopout(installationId: string): void {
+  const win = popoutsByInstallation.get(installationId)
+  popoutsByInstallation.delete(installationId)
+  if (win && !win.isDestroyed()) win.destroy()
+}
+
+/** Close every open logs pop-out (e.g. on app quit). */
+export function closeAllLogsPopouts(): void {
+  for (const win of popoutsByInstallation.values()) {
+    if (!win.isDestroyed()) win.destroy()
+  }
+  popoutsByInstallation.clear()
+}

--- a/src/main/lib/popoutWindows.test.ts
+++ b/src/main/lib/popoutWindows.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('./terminal', () => ({ disposeTerminal: vi.fn() }))
+vi.mock('./logsPopoutWindow', () => ({
+  closeLogsPopout: vi.fn(),
+  closeAllLogsPopouts: vi.fn(),
+}))
+vi.mock('./terminalPopoutWindow', () => ({
+  closeTerminalPopout: vi.fn(),
+  closeAllTerminalPopouts: vi.fn(),
+}))
+
+import { closeInstallPopouts, closeAllPopouts, releaseInstallTerminalForFsOp } from './popoutWindows'
+import { disposeTerminal } from './terminal'
+import { closeLogsPopout, closeAllLogsPopouts } from './logsPopoutWindow'
+import { closeTerminalPopout, closeAllTerminalPopouts } from './terminalPopoutWindow'
+
+describe('popoutWindows', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('closeInstallPopouts closes both surfaces for the install', () => {
+    closeInstallPopouts('inst-a')
+    expect(closeTerminalPopout).toHaveBeenCalledWith('inst-a')
+    expect(closeLogsPopout).toHaveBeenCalledWith('inst-a')
+    expect(disposeTerminal).not.toHaveBeenCalled()
+  })
+
+  it('closeAllPopouts closes every pop-out window', () => {
+    closeAllPopouts()
+    expect(closeAllTerminalPopouts).toHaveBeenCalledTimes(1)
+    expect(closeAllLogsPopouts).toHaveBeenCalledTimes(1)
+  })
+
+  it('releaseInstallTerminalForFsOp closes pop-outs then kills the shell', () => {
+    releaseInstallTerminalForFsOp('inst-a')
+    expect(closeTerminalPopout).toHaveBeenCalledWith('inst-a')
+    expect(closeLogsPopout).toHaveBeenCalledWith('inst-a')
+    expect(disposeTerminal).toHaveBeenCalledWith('inst-a')
+  })
+})

--- a/src/main/lib/popoutWindows.ts
+++ b/src/main/lib/popoutWindows.ts
@@ -1,0 +1,36 @@
+/**
+ * Aggregate helpers over the terminal + logs pop-out windows so callers
+ * (install detach, app quit, update/restore) close both surfaces with one
+ * call instead of importing each module separately and risking one being
+ * forgotten.
+ */
+
+import { disposeTerminal } from './terminal'
+import { closeAllLogsPopouts, closeLogsPopout } from './logsPopoutWindow'
+import { closeAllTerminalPopouts, closeTerminalPopout } from './terminalPopoutWindow'
+
+/** Close both the terminal and logs pop-outs bound to a single install. */
+export function closeInstallPopouts(installationId: string): void {
+  closeTerminalPopout(installationId)
+  closeLogsPopout(installationId)
+}
+
+/** Close every open pop-out window across all installs (e.g. on app quit). */
+export function closeAllPopouts(): void {
+  closeAllTerminalPopouts()
+  closeAllLogsPopouts()
+}
+
+/**
+ * Release everything bound to an install's shared shell before a destructive
+ * filesystem operation (update / snapshot restore). On Windows a live shell
+ * holds a handle on the install dir (its cwd) and any running `python` keeps
+ * venv DLLs locked, so `uv pip` upgrades and `site-packages` removals fail
+ * with EBUSY/EPERM. Closing the pop-outs and killing the shell drops those
+ * locks; the next time a surface subscribes, the shell respawns lazily with
+ * the post-operation environment.
+ */
+export function releaseInstallTerminalForFsOp(installationId: string): void {
+  closeInstallPopouts(installationId)
+  disposeTerminal(installationId)
+}

--- a/src/main/lib/terminal.test.ts
+++ b/src/main/lib/terminal.test.ts
@@ -218,6 +218,16 @@ describe('terminal manager', () => {
     expect(wcB.sent.some((m) => m.channel === 'terminal-output')).toBe(false)
   })
 
+  it('spawns only one shell when subscribed concurrently', async () => {
+    // Two surfaces racing to subscribe must share one PTY, not orphan extras.
+    await Promise.all([
+      subscribeTerminal('inst-a', asWc(makeWebContents())),
+      subscribeTerminal('inst-a', asWc(makeWebContents())),
+    ])
+
+    expect(spawn).toHaveBeenCalledTimes(1)
+  })
+
   it('disposeTerminal kills the install shell so an FS op runs unlocked', async () => {
     await subscribeTerminal('inst-a', asWc(makeWebContents()))
     expect(ptyAt(0).killed).toBe(false)

--- a/src/main/lib/terminal.test.ts
+++ b/src/main/lib/terminal.test.ts
@@ -70,6 +70,8 @@ import {
   writeTerminal,
   restartTerminal,
   getTerminalRestore,
+  disposeTerminal,
+  disposeAllTerminals,
   _resetTerminalsForTest,
 } from './terminal'
 
@@ -214,5 +216,29 @@ describe('terminal manager', () => {
 
     expect(wcA.sent.some((m) => m.channel === 'terminal-output')).toBe(true)
     expect(wcB.sent.some((m) => m.channel === 'terminal-output')).toBe(false)
+  })
+
+  it('disposeTerminal kills the install shell so an FS op runs unlocked', async () => {
+    await subscribeTerminal('inst-a', asWc(makeWebContents()))
+    expect(ptyAt(0).killed).toBe(false)
+
+    disposeTerminal('inst-a')
+
+    expect(ptyAt(0).killed).toBe(true)
+    // A fresh subscribe respawns a new shell rather than reusing the dead one.
+    await subscribeTerminal('inst-a', asWc(makeWebContents()))
+    expect(spawn).toHaveBeenCalledTimes(2)
+  })
+
+  it('disposeAllTerminals kills every install shell (app quit)', async () => {
+    await subscribeTerminal('inst-a', asWc(makeWebContents()))
+    await subscribeTerminal('inst-b', asWc(makeWebContents()))
+
+    disposeAllTerminals()
+
+    expect(ptyAt(0).killed).toBe(true)
+    expect(ptyAt(1).killed).toBe(true)
+    expect(getTerminalRestore('inst-a')).toBeNull()
+    expect(getTerminalRestore('inst-b')).toBeNull()
   })
 })

--- a/src/main/lib/terminal.ts
+++ b/src/main/lib/terminal.ts
@@ -89,8 +89,19 @@ function getDefaultShell(): string {
  *  hides the activation echo so the session opens on a clean prompt. */
 function initCommands(venvDir: string, uvPath: string): string[] {
   if (process.platform === 'win32') {
+    // We can't `& Activate.ps1`: PowerShell's ExecutionPolicy blocks running
+    // script *files*, and on locked-down machines even `Set-ExecutionPolicy`
+    // is unavailable, so relaxing it isn't an option. Inline commands typed
+    // into the shell are never gated by ExecutionPolicy, so replicate what
+    // Activate.ps1 does directly: set VIRTUAL_ENV, prepend the venv's Scripts
+    // dir to PATH, drop any PYTHONHOME, and add the `(.venv)` prompt prefix.
+    const promptName = path.basename(venvDir)
     return [
-      `& "${venvDir}\\Scripts\\Activate.ps1"`,
+      `$env:VIRTUAL_ENV = "${venvDir}"`,
+      `$env:VIRTUAL_ENV_PROMPT = "${promptName}"`,
+      `$env:PATH = "${venvDir}\\Scripts;$env:PATH"`,
+      'if (Test-Path Env:PYTHONHOME) { Remove-Item Env:PYTHONHOME }',
+      'function global:prompt { Write-Host -NoNewline -ForegroundColor Green "($env:VIRTUAL_ENV_PROMPT) "; "PS $($executionContext.SessionState.Path.CurrentLocation)$(\'>\' * ($nestedPromptLevel + 1)) " }',
       `function pip { & "${uvPath}" pip $args }`,
       'Clear-Host',
     ]

--- a/src/main/lib/terminal.ts
+++ b/src/main/lib/terminal.ts
@@ -1,10 +1,27 @@
-import pty from 'node-pty'
+import type * as NodePty from 'node-pty'
 import fs from 'fs'
 import path from 'path'
 import { createRequire } from 'module'
 import type { WebContents } from 'electron'
 import * as installations from '../installations'
 import { getActiveVenvDir, getActiveUvPath } from './pythonEnv'
+
+/**
+ * Lazily load node-pty. Its index eagerly loads a native binding at import
+ * time, which fails outside a built Electron runtime (e.g. vitest under plain
+ * node). Loading on first spawn keeps this module importable from the eagerly
+ * evaluated `sources`/IPC graph without dragging the native module into every
+ * test that transitively imports it; surfaces that actually spawn a shell run
+ * inside Electron where the binding loads fine.
+ */
+let ptyModulePromise: Promise<typeof NodePty> | undefined
+async function loadPty(): Promise<typeof NodePty> {
+  ptyModulePromise ??= import('node-pty')
+  const mod = await ptyModulePromise
+  // node-pty is CJS: under esModuleInterop the API lives on the synthesized
+  // `default`; fall back to the namespace for native-ESM / mocked shapes.
+  return (mod as { default?: typeof NodePty }).default ?? mod
+}
 
 const requireFromHere = createRequire(__filename)
 
@@ -115,7 +132,7 @@ function initCommands(venvDir: string, uvPath: string): string[] {
 
 class InstallTerminal {
   readonly installationId: string
-  #pty: pty.IPty | undefined
+  #pty: NodePty.IPty | undefined
   #exited = true
   readonly sessionBuffer: string[] = []
   readonly size = { ...DEFAULT_SIZE }
@@ -192,6 +209,7 @@ class InstallTerminal {
     this.sessionBuffer.length = 0
     const venvDir = getActiveVenvDir(inst)
     const uvPath = getActiveUvPath(inst)
+    const pty = await loadPty()
     const instance = pty.spawn(getDefaultShell(), [], {
       name: 'xterm-256color',
       cols: this.size.cols,
@@ -299,6 +317,11 @@ export function disposeTerminal(installationId: string): void {
   if (!term) return
   term.dispose()
   terminals.delete(installationId)
+}
+
+/** Tear down every install's shell (e.g. on app quit) so no PTY child lingers. */
+export function disposeAllTerminals(): void {
+  for (const id of [...terminals.keys()]) disposeTerminal(id)
 }
 
 /** Test-only: drop all sessions without spawning anything. */

--- a/src/main/lib/terminal.ts
+++ b/src/main/lib/terminal.ts
@@ -133,6 +133,7 @@ function initCommands(venvDir: string, uvPath: string): string[] {
 class InstallTerminal {
   readonly installationId: string
   #pty: NodePty.IPty | undefined
+  #spawnInFlight: Promise<void> | undefined
   #exited = true
   readonly sessionBuffer: string[] = []
   readonly size = { ...DEFAULT_SIZE }
@@ -149,7 +150,14 @@ class InstallTerminal {
   /** Spawn the shell if it isn't alive. Safe to call repeatedly. */
   async ensureAlive(): Promise<void> {
     if (this.#pty && !this.#exited) return
-    await this.#spawn()
+    // Dedupe concurrent spawns: several surfaces can call subscribeTerminal at
+    // once, and #spawn awaits before assigning #pty — without this each caller
+    // would spawn its own shell and orphan all but the last (a leaked PTY that
+    // keeps holding the install dir / venv locked).
+    this.#spawnInFlight ??= this.#spawn().finally(() => {
+      this.#spawnInFlight = undefined
+    })
+    await this.#spawnInFlight
   }
 
   /** Kill any existing shell and start a fresh one. Clears scrollback. */

--- a/src/main/lib/terminalPopoutWindow.ts
+++ b/src/main/lib/terminalPopoutWindow.ts
@@ -231,3 +231,25 @@ export async function openTerminalPopout(installationId: string): Promise<void> 
     void win.webContents.executeJavaScript(buildPopoutScript(installationId)).catch(() => {})
   })
 }
+
+/**
+ * Close the terminal pop-out for a single install, if one is open. Used when
+ * the install is detached / its host window closes (so an orphaned pop-out
+ * can't keep the app alive) and before update/restore (so the shared shell
+ * can be torn down without a surface still bound to it). The window's
+ * `closed` handler drops the map entry; we delete eagerly too so a
+ * concurrent re-open spawns a fresh window.
+ */
+export function closeTerminalPopout(installationId: string): void {
+  const win = popoutsByInstallation.get(installationId)
+  popoutsByInstallation.delete(installationId)
+  if (win && !win.isDestroyed()) win.destroy()
+}
+
+/** Close every open terminal pop-out (e.g. on app quit). */
+export function closeAllTerminalPopouts(): void {
+  for (const win of popoutsByInstallation.values()) {
+    if (!win.isDestroyed()) win.destroy()
+  }
+  popoutsByInstallation.clear()
+}

--- a/src/main/sources/standalone/actions.ts
+++ b/src/main/sources/standalone/actions.ts
@@ -16,6 +16,7 @@ import * as snapshots from '../../lib/snapshots'
 import { getActivePythonPath, getActiveUvPath, getMasterPythonPath } from './envPaths'
 import { COMFYUI_REPO, getEffectiveChannel } from './updateSections'
 import { runComfyUIUpdate } from './updateOrchestrator'
+import { releaseInstallTerminalForFsOp } from '../../lib/popoutWindows'
 import type { InstallationRecord } from '../../installations'
 import type { ActionResult, ActionTools } from '../../types/sources'
 
@@ -36,6 +37,11 @@ export async function handleAction(
   if (actionId === 'snapshot-restore') {
     const file = actionData?.file as string | undefined
     if (!file) return { ok: false, message: t('standalone.snapshotNoFile') }
+
+    // Drop the shared shell + pop-outs first: on Windows a live shell holds a
+    // handle on the install dir and any running python locks venv DLLs, which
+    // breaks the site-packages removals/upgrades this restore performs.
+    releaseInstallTerminalForFsOp(installation.id)
 
     sendProgress('steps', { steps: [
       { phase: 'restore-comfyui', label: t('standalone.snapshotRestoreComfyUIPhase') },
@@ -295,6 +301,11 @@ async function handleUpdateComfyUI(
   if (!fs.existsSync(gitDir)) {
     return { ok: false, message: t('standalone.updateNoGit') }
   }
+
+  // Drop the shared shell + pop-outs before touching git / the venv: a live
+  // shell's cwd and any running python lock files the update would rewrite
+  // (Windows can't replace open files), so `uv pip` upgrades would fail.
+  releaseInstallTerminalForFsOp(installation.id)
 
   // Adopted installs route through `adoptedPythonPath`; only managed installs
   // need the standalone-env Python, so check existence per-case.

--- a/src/renderer/src/components/settings/ComfyUISettingsContent.test.ts
+++ b/src/renderer/src/components/settings/ComfyUISettingsContent.test.ts
@@ -24,7 +24,7 @@ const messages = {
       tabUpdate: 'Update',
       tabSnapshots: 'Snapshots',
       tabStorage: 'Storage',
-      tabConsole: 'Console',
+      tabTerminal: 'Terminal',
       relaunch: 'Relaunch',
       more: 'More',
     },
@@ -427,7 +427,7 @@ describe('ComfyUISettingsContent', () => {
      *  Every current tab carries a concept tooltip, so finding a Tooltip whose
      *  text is one of these would mean the tab fell back to the label-echo
      *  path — what these tests are guarding against. */
-    const TAB_LABELS = new Set(['Update', 'Startup Args', 'Snapshots', 'Storage', 'Console', 'About'])
+    const TAB_LABELS = new Set(['Update', 'Startup Args', 'Snapshots', 'Storage', 'Terminal', 'About'])
 
     function tabTooltips(w: VueWrapper) {
       return w

--- a/src/renderer/src/components/settings/ComfyUISettingsContent.vue
+++ b/src/renderer/src/components/settings/ComfyUISettingsContent.vue
@@ -263,7 +263,7 @@ const ALL_TABS: TabDef[] = [
   {
     key: 'console',
     sectionTab: 'console',
-    label: t('comfyUISettings.tabConsole', 'Console'),
+    label: t('comfyUISettings.tabTerminal', 'Terminal'),
     icon: SquareTerminal,
     tooltip: t('tooltips.console')
   },

--- a/src/renderer/src/views/comfyUISettings/ConsoleTerminalPane.vue
+++ b/src/renderer/src/views/comfyUISettings/ConsoleTerminalPane.vue
@@ -274,6 +274,10 @@ onBeforeUnmount(teardown)
 .console-host {
   position: absolute;
   inset: 0;
+  /* content-box so FitAddon's getComputedStyle(host).height reports the inner
+   * area (excludes padding). Under the global border-box reset it returns the
+   * padded height, over-counting ~1 row and pushing the prompt below the fold. */
+  box-sizing: content-box;
   padding: 12px 14px 14px;
   overflow: hidden;
 }
@@ -294,10 +298,6 @@ onBeforeUnmount(teardown)
 .console-host :deep(.xterm-screen) {
   overflow: hidden;
   background-color: var(--neutral-800);
-}
-
-.console-host :deep(.xterm-rows) {
-  padding-bottom: 2px;
 }
 
 .console-ended {


### PR DESCRIPTION
## Summary

Three fixes to the per-installation terminal feature, all surfaced while testing on Windows.

### 1. Windows venv activation (bug fix)
The terminal shell wrote `& "<venv>\Scripts\Activate.ps1"`, but PowerShell's default ExecutionPolicy blocks running script files - so the venv silently never activated and the shell stayed at the install path. On locked-down machines even `Set-ExecutionPolicy` cannot load, so relaxing the policy is not viable. Replaced with inline commands (set `VIRTUAL_ENV`, prepend `Scripts` to `PATH`, drop `PYTHONHOME`, add the `(.venv)` prompt) which ExecutionPolicy never gates. macOS/Linux (`source .../activate`) unchanged. Verified end-to-end via a real `node-pty` PTY: `python` resolves to the venv and the prompt shows the venv prefix.

### 2. Tab order matches native frontend
The injected stopgap registered its Terminal tab as soon as `registerExtension` existed - often winning the race against the frontend's async Logs tab, so Terminal became first + default. The store makes the first-registered tab the default, so this diverged from native (Logs first + default, Terminal second). Now the stopgap waits for the native Logs tab (`app.extensionManager.bottomPanel.panels.terminal.tabs`) before registering, with a timeout fallback so a Logs-less frontend never strands the user.

### 3. "Console" to "Terminal" label
The install Settings tab was labeled Console; the frontend bottom-panel tab is Terminal. Renamed the label for consistency (internal `console` key/sectionTab identifiers unchanged).

## Testing
- `pnpm typecheck`, `pnpm lint`, `pnpm build` pass
- `pnpm test` pass (1938 tests)
- Manual: real PTY spawn confirms venv activation + prompt on Windows.
