### PR TITLE
revert(standalone): drop --upgrade from post-update pip install (rolls back the upgrade slice of #976)

### DIFF
--- a/src/main/lib/pip.ts
+++ b/src/main/lib/pip.ts
@@ -48,10 +48,7 @@ export interface PipMirrorConfig {
   useChineseMirrors?: boolean
 }
 
-/** Install a requirements file via `uv pip install -r`, filtering out PyTorch packages first.
- *  Pass `upgrade: true` to add `--upgrade` so already-installed packages whose pinned versions
- *  drifted (e.g. the bundled venv's `comfy-aimdo` lagging ComfyUI's `requirements.txt`) get
- *  reconciled instead of skipped by uv's satisfaction check. */
+/** Install a requirements file via `uv pip install -r`, filtering out PyTorch packages first. */
 export async function installFilteredRequirements(
   reqPath: string,
   uvPath: string,
@@ -61,7 +58,6 @@ export async function installFilteredRequirements(
   sendOutput: (text: string) => void,
   signal?: AbortSignal,
   mirrors?: PipMirrorConfig,
-  upgrade = false,
 ): Promise<number> {
   const content = await fs.promises.readFile(reqPath, 'utf-8')
   const filtered = content.split('\n').filter((l) => !PYTORCH_RE.test(l.trim())).join('\n')
@@ -70,8 +66,7 @@ export async function installFilteredRequirements(
 
   try {
     const indexArgs = getPipIndexArgs(mirrors?.pypiMirror, mirrors?.useChineseMirrors)
-    const upgradeArg = upgrade ? ['--upgrade'] : []
-    return await runUvPip(uvPath, ['pip', 'install', ...upgradeArg, '-r', filteredPath, '--python', pythonPath, ...indexArgs], installPath, sendOutput, signal)
+    return await runUvPip(uvPath, ['pip', 'install', '-r', filteredPath, '--python', pythonPath, ...indexArgs], installPath, sendOutput, signal)
   } finally {
     try { await fs.promises.unlink(filteredPath) } catch {}
   }

--- a/src/main/sources/standalone/updateOrchestrator.ts
+++ b/src/main/sources/standalone/updateOrchestrator.ts
@@ -34,14 +34,10 @@ export interface UpdateOrchestrationOptions {
   dryRunConflictCheck?: boolean
   saveRollback?: boolean
   preUpdateSnapshot?: boolean
-  /** Force `uv pip install --upgrade -r requirements.txt` to run after the git
-   *  update, even when the requirements.txt content is byte-identical pre/post.
-   *  Used by the post-install auto-update in `install.ts` to reconcile the
-   *  pre-extracted standalone bundle's venv (which can ship deps lagging
-   *  ComfyUI's own pinned versions — most visibly `comfy-aimdo`, which crashes
-   *  loading with `'ModelMMAP' object has no attribute 'get_file_handle'` or
-   *  `ModuleNotFoundError: No module named 'comfy_aimdo.vram_buffer'` when the
-   *  bundled aimdo lags the source's import surface). */
+  /** Force `uv pip install -r requirements.txt` to run after the git update,
+   *  even when the requirements.txt content is byte-identical pre/post. Used
+   *  by the post-install auto-update in `install.ts` to reconcile the
+   *  pre-extracted standalone bundle's venv against ComfyUI's pinned deps. */
   forceDepsSync?: boolean
 }
 
@@ -262,7 +258,7 @@ export async function runComfyUIUpdate(opts: UpdateOrchestrationOptions): Promis
           if (signal?.aborted) return { ok: false, message: 'Cancelled', installation }
 
           const dryRunResult = await spawnCommand(
-            uvPath, ['pip', 'install', '--dry-run', '--upgrade', '-r', filteredReqPath, '--python', activeEnvPython, ...indexArgs],
+            uvPath, ['pip', 'install', '--dry-run', '-r', filteredReqPath, '--python', activeEnvPython, ...indexArgs],
             installPath, undefined, undefined, signal
           )
 
@@ -277,7 +273,7 @@ export async function runComfyUIUpdate(opts: UpdateOrchestrationOptions): Promis
           sendProgress('deps', { percent: -1, status: t('standalone.updateDepsInstalling') })
 
           const pipResult = await spawnCommand(
-            uvPath, ['pip', 'install', '--upgrade', '-r', filteredReqPath, '--python', activeEnvPython, ...indexArgs],
+            uvPath, ['pip', 'install', '-r', filteredReqPath, '--python', activeEnvPython, ...indexArgs],
             installPath, sendOutput, sendOutput, signal
           )
 
@@ -292,7 +288,7 @@ export async function runComfyUIUpdate(opts: UpdateOrchestrationOptions): Promis
         const logFn = sendOutput ?? console.log
         const installResult = await installFilteredRequirements(
           reqPath, uvPath, activeEnvPython, installPath,
-          '.post-install-reqs.txt', logFn, signal, settings.getMirrorConfig(), true
+          '.post-install-reqs.txt', logFn, signal, settings.getMirrorConfig()
         )
         if (installResult !== 0) {
           console.warn(`Post-install requirements install exited with code ${installResult}`)


### PR DESCRIPTION
## What
Surgical revert of only the \`--upgrade\` slice of #976. Removes:

- \`--upgrade\` from both \`uv pip install\` calls in \`updateOrchestrator.ts\` (dry-run + real)
- \`true\` 9th arg passed to \`installFilteredRequirements\` in the post-install fallback branch
- \`upgrade\` parameter from \`installFilteredRequirements\` and its conditional \`--upgrade\` argv injection
- \`--upgrade\` references from the surrounding JSDoc

## Why
Field reports indicate the flag caused more drift than it cured. \`--upgrade\` on a \`uv pip install -r requirements.txt\` opts into the unrestricted upgrade strategy for every package in the (post-PyTorch-filter) requirements file — which can bump indirect deps past versions an install was working with, wedging installs that used to launch fine. The \`comfy-aimdo\` case it was meant to cure (#976 body) still has the underlying gap, but the cost of attempting it via \`--upgrade\` is higher than the benefit.

## Kept intact
- The snapshot-import \`includeLatestStable: true\` fix (4 call sites from #976) — unrelated to this regression, still landed correctly
- \`forceDepsSync\` + the HEAD-movement gate — they decide WHEN pip-install runs (still useful for catching first-launch deps drift), not WHAT flags it uses

So the post-install pip-install still fires on first launch when it should, just without \`--upgrade\` semantics.

## Follow-ups
- The original ModelMMAP / aimdo drift on existing installs still needs a different cure. Possible avenues, none in this PR:
  - More targeted: detect ComfyUI's WARNING about \`comfy-aimdo\` version on launch and run \`uv pip install comfy-aimdo\` against the pinned version explicitly (no \`--upgrade\` flag)
  - Surface a "Sync dependencies" action in the install settings as a manual escape hatch
  - File a follow-up Linear ticket so the affected-install path doesn't fall off the radar

## Test
- [x] 70 standalone + pip tests pass (no behaviour change those tests would catch — they don't assert pip argv)
- [ ] Manual: existing install with drifted deps still launches normally after a no-op update (no spurious re-installs)
- [ ] Manual: a fresh install's post-install auto-update still runs pip install when reqs change (forceDepsSync still wired)