### PR TITLE
fix(snapshots): keep Latest on newest snapshot when a copy event sorts first

### DIFF
--- a/src/renderer/src/views/comfyUISettings/SnapshotsView.test.ts
+++ b/src/renderer/src/views/comfyUISettings/SnapshotsView.test.ts
@@ -395,11 +395,13 @@ describe('comfyUISettings/SnapshotsView', () => {
       // …but the "Latest" badge appears exactly once, on the newest snapshot.
       const badges = w.findAll('.snapshot-row-latest')
       expect(badges).toHaveLength(1)
+      const newestRow = w.find(`[data-testid="${TID.snapshotRow('snap-newest.json')}"]`)
+      expect(newestRow.find('.snapshot-row-latest').exists()).toBe(true)
 
-      const current = w.findAll('.snapshots-rail-node.is-current')
-      expect(current).toHaveLength(1)
-      expect(current[0]!.find(`[data-testid="${TID.snapshotRow('snap-newest.json')}"]`).exists())
-        .toBe(true)
+      // The newest snapshot is auto-expanded; restoring it is a no-op, so it
+      // must not offer a Restore action even though a copy event sorts above it.
+      expect(w.find(`[data-testid="${TID.snapshotRowRestore('snap-newest.json')}"]`).exists())
+        .toBe(false)
     })
 
     it('keeps the Latest badge on the newest snapshot for an outgoing copy event', async () => {
@@ -407,7 +409,8 @@ describe('comfyUISettings/SnapshotsView', () => {
 
       expect(w.text()).toContain('Copied as Copy of A')
       expect(w.findAll('.snapshot-row-latest')).toHaveLength(1)
-      expect(w.findAll('.snapshots-rail-node.is-current')).toHaveLength(1)
+      expect(w.find(`[data-testid="${TID.snapshotRowRestore('snap-newest.json')}"]`).exists())
+        .toBe(false)
     })
 
     it('header "Latest:" stat reflects the newest snapshot, not the copy event time', async () => {

--- a/src/renderer/src/views/comfyUISettings/SnapshotsView.test.ts
+++ b/src/renderer/src/views/comfyUISettings/SnapshotsView.test.ts
@@ -6,7 +6,7 @@ import { nextTick } from 'vue'
 
 import { TID } from '../../../../shared/testIds'
 import SnapshotsView from './SnapshotsView.vue'
-import type { SnapshotSummary, SnapshotListData } from '../../types/ipc'
+import type { SnapshotSummary, SnapshotListData, CopyEvent } from '../../types/ipc'
 
 // Tests the snapshots tab + inline restore op-card state machine: in-flight, success (auto-dismiss 1.8s), error (Retry/Dismiss), cancelled.
 
@@ -51,6 +51,8 @@ const messages = {
       exportAll: 'Export All',
       latestLabel: 'Latest:',
       latestBadge: 'Latest',
+      copyEventLabel: 'Copied as {destination}',
+      copyEventLabelIncoming: 'Copied from {source}',
       nodesCount: '{count} nodes',
       packagesCount: '{count} pkgs',
     },
@@ -355,5 +357,67 @@ describe('comfyUISettings/SnapshotsView', () => {
     await nextTick()
 
     expect(scrollSpy).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' })
+  })
+
+  // Regression for #1007: a "Copied from/as X" event that sorts above the
+  // newest snapshot must not steal the "Latest" designation. Latest tracks the
+  // newest *snapshot* (snapshotIndex === 0), not the merged timeline index.
+  describe('latest detection with copy events (#1007)', () => {
+    function makeCopyEvent(overrides: Partial<CopyEvent> = {}): CopyEvent {
+      return {
+        installationId: 'install-B',
+        installationName: 'Copy of A',
+        copiedAt: new Date().toISOString(), // now — newer than the ~1h-old snapshots
+        copyReason: 'copy',
+        exists: true,
+        direction: 'in',
+        ...overrides,
+      }
+    }
+
+    async function mountWithCopyEvent(event: CopyEvent): Promise<VueWrapper> {
+      ;(window as unknown as { api: Record<string, unknown> }).api = {
+        getSnapshots: vi.fn().mockResolvedValue({ ...makeListData(), copyEvents: [event] }),
+        getSnapshotDiff: vi.fn().mockResolvedValue(null),
+        runAction: vi.fn(),
+        exportSnapshot: vi.fn(),
+        exportAllSnapshots: vi.fn(),
+      }
+      return mountView()
+    }
+
+    it('keeps the Latest badge on the newest snapshot when an incoming copy event sorts first', async () => {
+      const w = await mountWithCopyEvent(makeCopyEvent({ direction: 'in' }))
+
+      // The copy event is rendered (and sorts to the top of the rail)…
+      expect(w.text()).toContain('Copied from Copy of A')
+
+      // …but the "Latest" badge appears exactly once, on the newest snapshot.
+      const badges = w.findAll('.snapshot-row-latest')
+      expect(badges).toHaveLength(1)
+
+      const current = w.findAll('.snapshots-rail-node.is-current')
+      expect(current).toHaveLength(1)
+      expect(current[0]!.find(`[data-testid="${TID.snapshotRow('snap-newest.json')}"]`).exists())
+        .toBe(true)
+    })
+
+    it('keeps the Latest badge on the newest snapshot for an outgoing copy event', async () => {
+      const w = await mountWithCopyEvent(makeCopyEvent({ direction: 'out' }))
+
+      expect(w.text()).toContain('Copied as Copy of A')
+      expect(w.findAll('.snapshot-row-latest')).toHaveLength(1)
+      expect(w.findAll('.snapshots-rail-node.is-current')).toHaveLength(1)
+    })
+
+    it('header "Latest:" stat reflects the newest snapshot, not the copy event time', async () => {
+      const w = await mountWithCopyEvent(makeCopyEvent({ direction: 'in' }))
+
+      // Snapshots are ~1h old; the copy event is "now". The stat must show the
+      // snapshot's age (1h ago), proving the copy event didn't hijack it.
+      const latest = w.find('.snapshots-view-latest')
+      expect(latest.text()).toContain('Latest:')
+      expect(latest.text()).toContain('1h ago')
+    })
   })
 })

--- a/src/renderer/src/views/comfyUISettings/SnapshotsView.vue
+++ b/src/renderer/src/views/comfyUISettings/SnapshotsView.vue
@@ -216,11 +216,9 @@ const latestRelative = computed<string | null>(() => {
 
 function autoExpandFirst(): void {
   if (expandedFilenames.value.size > 0) return
-  const firstSnapshot = timeline.value.find(
-    (item): item is Extract<TimelineItem, { kind: 'snapshot' }> => item.kind === 'snapshot'
-  )
-  if (firstSnapshot) {
-    expandedFilenames.value = new Set([firstSnapshot.snapshot.filename])
+  const newest = snapshots.value[0]
+  if (newest) {
+    expandedFilenames.value = new Set([newest.filename])
   }
 }
 

--- a/src/renderer/src/views/comfyUISettings/SnapshotsView.vue
+++ b/src/renderer/src/views/comfyUISettings/SnapshotsView.vue
@@ -205,12 +205,13 @@ const timeline = computed<TimelineItem[]>(() => {
   return out
 })
 
-/** "Latest: 8d ago" stat from the newest timeline item; null when empty. */
+/** "Latest: 8d ago" stat from the newest snapshot; null when none. Copy
+ * events are excluded so an interleaved "Copied from/as X" entry can't hijack
+ * the stat (see issue #1007). */
 const latestRelative = computed<string | null>(() => {
-  const first = timeline.value[0]
-  if (!first) return null
-  const iso = first.kind === 'snapshot' ? first.snapshot.createdAt : first.event.copiedAt
-  return _formatRelative(iso, t)
+  const newest = snapshots.value[0]
+  if (!newest) return null
+  return _formatRelative(newest.createdAt, t)
 })
 
 function autoExpandFirst(): void {
@@ -756,7 +757,7 @@ async function handleImport(): Promise<void> {
         :class="{
           'is-snapshot': item.kind === 'snapshot',
           'is-copy': item.kind === 'copy',
-          'is-current': item.kind === 'snapshot' && i === 0
+          'is-current': item.kind === 'snapshot' && item.snapshotIndex === 0
         }"
       >
         <span
@@ -774,7 +775,7 @@ async function handleImport(): Promise<void> {
             <SnapshotRow
               :snapshot="item.snapshot"
               :expanded="isExpanded(item.snapshot.filename)"
-              :is-latest="i === 0"
+              :is-latest="item.snapshotIndex === 0"
               :previous-comfyui-version="snapshots[item.snapshotIndex + 1]?.comfyuiVersion"
               :toggle-test-id="TID.snapshotRow(item.snapshot.filename)"
               @toggle="toggleExpand(item.snapshot.filename)"
@@ -785,8 +786,12 @@ async function handleImport(): Promise<void> {
                 </p>
 
                 <!-- "Release notes": changes vs the previous snapshot.
-                     Hidden for the oldest (no predecessor). -->
-                <div v-if="i < timeline.length - 1" class="snap-diff-accordion">
+                     Hidden for the oldest snapshot (no predecessor); copy
+                     events interleaved in the timeline don't count. -->
+                <div
+                  v-if="item.snapshotIndex < snapshots.length - 1"
+                  class="snap-diff-accordion"
+                >
                   <button
                     type="button"
                     class="snap-diff-trigger"

--- a/src/renderer/src/views/comfyUISettings/SnapshotsView.vue
+++ b/src/renderer/src/views/comfyUISettings/SnapshotsView.vue
@@ -754,8 +754,7 @@ async function handleImport(): Promise<void> {
         class="snapshots-rail-node"
         :class="{
           'is-snapshot': item.kind === 'snapshot',
-          'is-copy': item.kind === 'copy',
-          'is-current': item.kind === 'snapshot' && item.snapshotIndex === 0
+          'is-copy': item.kind === 'copy'
         }"
       >
         <span
@@ -834,8 +833,9 @@ async function handleImport(): Promise<void> {
                 </div>
 
                 <!-- "Restore preview": changes vs live state. Hidden for the
-                     newest (restoring it is a no-op). -->
-                <div v-if="i !== 0" class="snap-diff-accordion">
+                     newest snapshot (restoring it is a no-op); copy events
+                     interleaved in the timeline don't count. -->
+                <div v-if="item.snapshotIndex !== 0" class="snap-diff-accordion">
                   <button
                     type="button"
                     class="snap-diff-trigger"
@@ -886,7 +886,7 @@ async function handleImport(): Promise<void> {
                      row stays a clean tap target. -->
                 <div class="snapshots-view-detail-actions">
                   <button
-                    v-if="i !== 0"
+                    v-if="item.snapshotIndex !== 0"
                     type="button"
                     class="snapshots-view-detail-btn"
                     :aria-label="t('snapshots.restore', 'Restore')"


### PR DESCRIPTION
## Summary

Fixes #1007 — when a snapshot timeline contains a "Copied from/as X" entry, the **newest snapshot was not detected as the latest**.

### Root cause

The Snapshots tab builds a merged timeline of snapshots + copy events sorted newest-first, then decides "latest" purely by timeline index (`i === 0`). A copy event carries `copiedAt = copy time`, so it can sort **above** the newest snapshot and occupy index 0 — stealing:

- the green **"Latest" badge** on the snapshot row (`:is-latest="i === 0"`),
- the rail **"current" node highlight** (`'is-current': … && i === 0`),
- the **"Latest: …" header stat** (read from the newest *timeline item*).

### Fix

Key "latest/current" off the snapshot's own position (`snapshotIndex === 0`) instead of the merged timeline index, and derive the header stat from the newest *snapshot* (copy events excluded). Also corrected the "what changed in this snapshot" diff-accordion guard to use the previous *snapshot* (`snapshotIndex < snapshots.length - 1`) rather than the previous timeline item, so an interleaved copy event can't make the oldest snapshot show a phantom diff.

### Tests

Added 3 regression tests in `SnapshotsView.test.ts` covering incoming/outgoing copy events that sort above the newest snapshot: the Latest badge + `is-current` stay on the newest snapshot, and the header stat reflects the snapshot's age, not the copy time.

### Validation

`pnpm run typecheck`, `lint`, `build`, and `test` (1993 tests) all pass.