### PR TITLE
fix(settings): improve Startup Arguments UX (#1001, #1002, #1003)

### DIFF
--- a/src/renderer/src/components/settings/ComfyUISettingsContent.vue
+++ b/src/renderer/src/components/settings/ComfyUISettingsContent.vue
@@ -703,6 +703,7 @@ defineExpose({
           key="subpage-args"
           :installation-id="installation.id"
           :initial-value="argsValue"
+          :pending-restart="argsField != null && pendingRestartFieldIds.has(argsField.id)"
           @back="closeSubPage"
           @update="handleArgsUpdate"
         />

--- a/src/renderer/src/components/settings/ComfyUISettingsContent.vue
+++ b/src/renderer/src/components/settings/ComfyUISettingsContent.vue
@@ -649,7 +649,6 @@ defineExpose({
       :class="{ 'is-subpage-active': subPage !== null }"
       role="tablist"
       :aria-label="t('comfyUISettings.title', 'Settings')"
-      :aria-hidden="subPage !== null"
     >
       <Tooltip
         v-for="(tab, i) in tabs"
@@ -960,9 +959,10 @@ defineExpose({
   }
 }
 
+/* Dim the strip while a sub-page is open to signal the nested context,
+   but keep tabs clickable so a tab switch can exit the sub-page. */
 .settings-v2-tabs.is-subpage-active {
-  opacity: 0.35;
-  pointer-events: none;
+  opacity: 0.6;
 }
 
 .settings-v2-tab {

--- a/src/renderer/src/components/ui/BaseInput.vue
+++ b/src/renderer/src/components/ui/BaseInput.vue
@@ -8,6 +8,9 @@ interface Props {
   mono?: boolean
   readonly?: boolean
   invalid?: boolean
+  /** Forwarded to the native input; pass false to suppress the red squiggly
+   *  spell-check underline on non-prose fields (e.g. CLI args). */
+  spellcheck?: boolean
   type?: string
   // Only meaningful when `type === 'number'`.
   min?: number
@@ -21,6 +24,7 @@ const props = withDefaults(defineProps<Props>(), {
   mono: false,
   readonly: false,
   invalid: false,
+  spellcheck: undefined,
   type: 'text',
   min: undefined,
   max: undefined,
@@ -64,6 +68,7 @@ function onChange(event: Event): void {
       :placeholder="placeholder"
       :aria-label="ariaLabel"
       :aria-invalid="invalid || undefined"
+      :spellcheck="spellcheck"
       :readonly="readonly"
       :min="min"
       :max="max"

--- a/src/renderer/src/lib/argsParser.test.ts
+++ b/src/renderer/src/lib/argsParser.test.ts
@@ -69,4 +69,38 @@ describe('validateArgs', () => {
     expect(validateArgs('--preview-method', SCHEMA).hasIssues).toBe(false)
     expect(validateArgs('--preview-method latent2rgb', SCHEMA).hasIssues).toBe(false)
   })
+
+  describe('suppressTrailingPartial', () => {
+    it('does not flag a partial trailing flag while focused (no trailing space)', () => {
+      const v = validateArgs('--po', SCHEMA, { suppressTrailingPartial: true })
+      expect(v.unsupportedFlags).toEqual([])
+      expect(v.hasIssues).toBe(false)
+      expect(v.tokens[0]).toMatchObject({ text: '--po', status: 'partial' })
+    })
+
+    it('still flags the partial once a trailing space commits the token', () => {
+      const v = validateArgs('--po ', SCHEMA, { suppressTrailingPartial: true })
+      expect(v.unsupportedFlags).toEqual(['po'])
+      expect(v.hasIssues).toBe(true)
+    })
+
+    it('flags the partial when not focused (option off)', () => {
+      const v = validateArgs('--po', SCHEMA)
+      expect(v.unsupportedFlags).toEqual(['po'])
+      expect(v.hasIssues).toBe(true)
+    })
+
+    it('only suppresses the trailing token, not earlier unknown flags', () => {
+      const v = validateArgs('--bogus --po', SCHEMA, { suppressTrailingPartial: true })
+      expect(v.unsupportedFlags).toEqual(['bogus'])
+      expect(v.hasIssues).toBe(true)
+    })
+
+    it('does not suppress a trailing positional value', () => {
+      // `81` is a value for --port, already ok — suppression must not touch it.
+      const v = validateArgs('--port 81', SCHEMA, { suppressTrailingPartial: true })
+      expect(v.tokens.map((t) => t.status)).toEqual(['ok', 'ok'])
+      expect(v.hasIssues).toBe(false)
+    })
+  })
 })

--- a/src/renderer/src/lib/argsParser.test.ts
+++ b/src/renderer/src/lib/argsParser.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { validateArgs } from './argsParser'
+import type { ComfyArgDef } from '../types/ipc'
+
+const SCHEMA: ComfyArgDef[] = [
+  { name: 'cpu', flag: '--cpu', help: 'Run on CPU.', type: 'boolean', category: 'GPU' },
+  { name: 'port', flag: '--port', help: 'Port.', type: 'value', metavar: 'PORT', category: 'Net' },
+  {
+    name: 'preview-method',
+    flag: '--preview-method',
+    help: 'Preview.',
+    type: 'optional-value',
+    metavar: 'METHOD',
+    category: 'Net',
+  },
+]
+
+describe('validateArgs', () => {
+  it('reports no issues for an empty string', () => {
+    const v = validateArgs('', SCHEMA)
+    expect(v.tokens).toEqual([])
+    expect(v.hasIssues).toBe(false)
+  })
+
+  it('marks every token ok for a valid arg string', () => {
+    const v = validateArgs('--cpu --port 8188', SCHEMA)
+    expect(v.tokens.map((t) => t.status)).toEqual(['ok', 'ok', 'ok'])
+    expect(v.hasIssues).toBe(false)
+  })
+
+  it('flags an unrecognized flag and swallows its value token', () => {
+    const v = validateArgs('--nope value --cpu', SCHEMA)
+    expect(v.unsupportedFlags).toEqual(['nope'])
+    // The flag and its value are both marked unsupported (value not orphaned).
+    expect(v.tokens[0]).toMatchObject({ text: '--nope', status: 'unsupported' })
+    expect(v.tokens[1]).toMatchObject({ text: 'value', status: 'unsupported' })
+    expect(v.tokens[2]).toMatchObject({ text: '--cpu', status: 'ok' })
+    expect(v.orphanedTokens).toEqual([])
+    expect(v.hasIssues).toBe(true)
+  })
+
+  it('flags a value flag with no value when it is not the last token', () => {
+    const v = validateArgs('--port --cpu', SCHEMA)
+    expect(v.missingValueFlags).toEqual(['--port'])
+    expect(v.hasIssues).toBe(true)
+  })
+
+  it('treats a trailing value flag as awaiting (info), not an error', () => {
+    const v = validateArgs('--cpu --port', SCHEMA)
+    expect(v.missingValueFlags).toEqual([])
+    expect(v.awaiting?.text).toBe('--port')
+    expect(v.hasIssues).toBe(false)
+  })
+
+  it('flags a bare positional token as orphaned', () => {
+    const v = validateArgs('foo --cpu', SCHEMA)
+    expect(v.orphanedTokens).toEqual(['foo'])
+    expect(v.hasIssues).toBe(true)
+  })
+
+  it('accepts --flag=value syntax and flags empty =value for value flags', () => {
+    expect(validateArgs('--port=8188', SCHEMA).hasIssues).toBe(false)
+    const empty = validateArgs('--port=', SCHEMA)
+    expect(empty.missingValueFlags).toEqual(['--port='])
+    expect(empty.hasIssues).toBe(true)
+  })
+
+  it('treats optional-value flags as ok with or without a value', () => {
+    expect(validateArgs('--preview-method', SCHEMA).hasIssues).toBe(false)
+    expect(validateArgs('--preview-method latent2rgb', SCHEMA).hasIssues).toBe(false)
+  })
+})

--- a/src/renderer/src/lib/argsParser.ts
+++ b/src/renderer/src/lib/argsParser.ts
@@ -88,8 +88,15 @@ export function parseArgs(raw: string, schema: ComfyArgDef[]): ParsedArgs {
   return { known, extra }
 }
 
-/** Per-token validation status for the raw-args field. */
-export type ArgTokenStatus = 'ok' | 'unsupported' | 'missing-value' | 'awaiting-value' | 'orphaned'
+/** Per-token validation status for the raw-args field. `partial` is the trailing
+ *  flag the user is still typing — neither valid nor an error yet. */
+export type ArgTokenStatus =
+  | 'ok'
+  | 'unsupported'
+  | 'missing-value'
+  | 'awaiting-value'
+  | 'orphaned'
+  | 'partial'
 
 export interface ArgToken {
   text: string
@@ -112,13 +119,25 @@ export interface ArgValidation {
   hasIssues: boolean
 }
 
+export interface ValidateArgsOptions {
+  /** When set (input focused), don't flag the trailing flag the user is still
+   *  typing — e.g. `--po` on the way to `--port` shouldn't turn red. The token
+   *  is reported as `partial` instead, and only once a space/another token
+   *  follows (or focus leaves) does normal validation apply. */
+  suppressTrailingPartial?: boolean
+}
+
 /**
  * Classify a raw launch-args string against the schema for inline validation.
  * Pure (no DOM) so it can be unit-tested. A trailing value-flag with no value
  * yet is reported as `awaiting-value` (info) rather than an error, so it doesn't
  * flash red while the user is still typing.
  */
-export function validateArgs(raw: string, schema: ComfyArgDef[]): ArgValidation {
+export function validateArgs(
+  raw: string,
+  schema: ComfyArgDef[],
+  opts: ValidateArgsOptions = {}
+): ArgValidation {
   const tokens = tokenize(raw)
   const schemaMap = new Map(schema.map((a) => [a.name, a]))
   const result: ArgToken[] = []
@@ -197,6 +216,18 @@ export function validateArgs(raw: string, schema: ComfyArgDef[]): ArgValidation 
         tooltip: 'Unexpected positional argument — use --flag syntax'
       })
       i++
+    }
+  }
+
+  // While the input is focused and the value has no trailing space, the last
+  // token is still being typed: downgrade an as-yet-unrecognized trailing flag
+  // from `unsupported` to `partial` so it doesn't flash red mid-word.
+  if (opts.suppressTrailingPartial && result.length > 0 && raw.trimEnd() === raw) {
+    const last = result[result.length - 1]!
+    const lastToken = tokens[tokens.length - 1]
+    if (last.text === lastToken && last.text.startsWith('-') && last.status === 'unsupported') {
+      last.status = 'partial'
+      delete last.tooltip
     }
   }
 

--- a/src/renderer/src/lib/argsParser.ts
+++ b/src/renderer/src/lib/argsParser.ts
@@ -88,6 +88,136 @@ export function parseArgs(raw: string, schema: ComfyArgDef[]): ParsedArgs {
   return { known, extra }
 }
 
+/** Per-token validation status for the raw-args field. */
+export type ArgTokenStatus = 'ok' | 'unsupported' | 'missing-value' | 'awaiting-value' | 'orphaned'
+
+export interface ArgToken {
+  text: string
+  status: ArgTokenStatus
+  tooltip?: string
+}
+
+export interface ArgValidation {
+  /** Every token in order, tagged with its status (drives the colored display). */
+  tokens: ArgToken[]
+  /** Unrecognized `--flag` names (without the leading dashes). */
+  unsupportedFlags: string[]
+  /** `--flag` tokens that require a value but have none (not the trailing one). */
+  missingValueFlags: string[]
+  /** Bare positional tokens not consumed by any flag. */
+  orphanedTokens: string[]
+  /** Trailing value-flag still waiting for its value — an info hint, not an error. */
+  awaiting: ArgToken | null
+  /** True when there is at least one real (non-awaiting) problem. */
+  hasIssues: boolean
+}
+
+/**
+ * Classify a raw launch-args string against the schema for inline validation.
+ * Pure (no DOM) so it can be unit-tested. A trailing value-flag with no value
+ * yet is reported as `awaiting-value` (info) rather than an error, so it doesn't
+ * flash red while the user is still typing.
+ */
+export function validateArgs(raw: string, schema: ComfyArgDef[]): ArgValidation {
+  const tokens = tokenize(raw)
+  const schemaMap = new Map(schema.map((a) => [a.name, a]))
+  const result: ArgToken[] = []
+
+  let i = 0
+  while (i < tokens.length) {
+    const token = tokens[i]!
+    const isLast = i === tokens.length - 1
+    if (token.startsWith('--')) {
+      const rest = token.slice(2)
+      const eqIdx = rest.indexOf('=')
+      const name = eqIdx >= 0 ? rest.slice(0, eqIdx) : rest
+      const eqValue = eqIdx >= 0 ? rest.slice(eqIdx + 1) : undefined
+      const def = schemaMap.get(name)
+      if (name === '') {
+        // A bare `--`; harmless, leave unflagged.
+        result.push({ text: token, status: 'ok' })
+        i++
+      } else if (!def) {
+        result.push({
+          text: token,
+          status: 'unsupported',
+          tooltip: 'Unrecognized argument — will not be passed when launching'
+        })
+        i++
+        // Swallow a trailing value so it isn't double-flagged as orphaned.
+        if (i < tokens.length && !tokens[i]!.startsWith('--')) {
+          result.push({ text: tokens[i]!, status: 'unsupported' })
+          i++
+        }
+      } else if (eqValue !== undefined) {
+        if (eqValue === '' && def.type === 'value') {
+          result.push({
+            text: token,
+            status: 'missing-value',
+            tooltip: `Requires a value: ${def.metavar || 'VALUE'}`
+          })
+        } else {
+          result.push({ text: token, status: 'ok' })
+        }
+        i++
+      } else if (def.type === 'value') {
+        const next = tokens[i + 1]
+        if (next !== undefined && !next.startsWith('--')) {
+          result.push({ text: token, status: 'ok' })
+          result.push({ text: next, status: 'ok' })
+          i += 2
+        } else if (isLast) {
+          result.push({
+            text: token,
+            status: 'awaiting-value',
+            tooltip: `Next: provide ${def.metavar || 'VALUE'}`
+          })
+          i++
+        } else {
+          result.push({
+            text: token,
+            status: 'missing-value',
+            tooltip: `Requires a value: ${def.metavar || 'VALUE'}`
+          })
+          i++
+        }
+      } else {
+        // Boolean or optional-value flag.
+        result.push({ text: token, status: 'ok' })
+        i++
+        if (def.type === 'optional-value' && i < tokens.length && !tokens[i]!.startsWith('--')) {
+          result.push({ text: tokens[i]!, status: 'ok' })
+          i++
+        }
+      }
+    } else {
+      result.push({
+        text: token,
+        status: 'orphaned',
+        tooltip: 'Unexpected positional argument — use --flag syntax'
+      })
+      i++
+    }
+  }
+
+  const unsupportedFlags = result
+    .filter((t) => t.status === 'unsupported' && t.text.startsWith('--'))
+    .map((t) => t.text.slice(2).split('=')[0]!)
+  const missingValueFlags = result.filter((t) => t.status === 'missing-value').map((t) => t.text)
+  const orphanedTokens = result.filter((t) => t.status === 'orphaned').map((t) => t.text)
+  const awaiting = result.find((t) => t.status === 'awaiting-value') ?? null
+
+  return {
+    tokens: result,
+    unsupportedFlags,
+    missingValueFlags,
+    orphanedTokens,
+    awaiting,
+    hasIssues:
+      unsupportedFlags.length > 0 || missingValueFlags.length > 0 || orphanedTokens.length > 0
+  }
+}
+
 /** Render parsed args back to a shell string, quoting values with whitespace so they round-trip. */
 export function serialize(known: Map<string, string>, extra: string[]): string {
   const parts: string[] = []

--- a/src/renderer/src/views/comfyUISettings/ArgsBuilderField.test.ts
+++ b/src/renderer/src/views/comfyUISettings/ArgsBuilderField.test.ts
@@ -143,4 +143,17 @@ describe('ArgsBuilderField — inline autocomplete', () => {
     expect((window as unknown as { api: { getComfyArgs: ReturnType<typeof vi.fn> } }).api.getComfyArgs).not.toHaveBeenCalled()
     expect(wrapper.find('.args-raw-input-ac').exists()).toBe(false)
   })
+
+  it('disables native spellcheck so flags do not get red squiggles', async () => {
+    const wrapper = await mountField()
+    expect(wrapper.find('input').attributes('spellcheck')).toBe('false')
+  })
+
+  it('surfaces the correctness check in the compact field, not just the helper page', async () => {
+    const wrapper = await mountField({ field: { ...FIELD, value: '--bogus' } })
+    const err = wrapper.find('.args-raw-validation-error')
+    expect(err.exists()).toBe(true)
+    expect(err.text()).toContain('--bogus')
+    expect(wrapper.find('input[aria-invalid="true"]').exists()).toBe(true)
+  })
 })

--- a/src/renderer/src/views/comfyUISettings/ArgsBuilderPage.test.ts
+++ b/src/renderer/src/views/comfyUISettings/ArgsBuilderPage.test.ts
@@ -61,9 +61,9 @@ function stubElectronApi(): void {
 
 const wrappers: VueWrapper[] = []
 
-async function mountPage(initialValue = ''): Promise<VueWrapper> {
+async function mountPage(initialValue = '', pendingRestart = false): Promise<VueWrapper> {
   const wrapper = mount(ArgsBuilderPage, {
-    props: { installationId: 'inst-1', initialValue },
+    props: { installationId: 'inst-1', initialValue, pendingRestart },
     global: {
       plugins: [i18n],
       // BaseSelect teleports its popover to <body>; render it in-tree
@@ -211,6 +211,20 @@ describe('ArgsBuilderPage — exclusive group dropdown', () => {
     expect(options.exists()).toBe(true)
     expect(options.text()).not.toContain('·')
     expect(options.text()).toContain('--cpu --gpu-only')
+  })
+})
+
+describe('ArgsBuilderPage — restart-to-apply tag', () => {
+  it('hides the restart tag by default', async () => {
+    const wrapper = await mountPage('--cpu')
+    expect(wrapper.find('.args-page-restart-tag').exists()).toBe(false)
+  })
+
+  it('shows the restart tag when args are pending a restart', async () => {
+    const wrapper = await mountPage('--cpu', true)
+    const tag = wrapper.find('.args-page-restart-tag')
+    expect(tag.exists()).toBe(true)
+    expect(tag.text()).toContain('Restart to apply')
   })
 })
 

--- a/src/renderer/src/views/comfyUISettings/ArgsBuilderPage.test.ts
+++ b/src/renderer/src/views/comfyUISettings/ArgsBuilderPage.test.ts
@@ -244,4 +244,21 @@ describe('ArgsBuilderPage — raw-args validation', () => {
     expect(err.exists()).toBe(true)
     expect(err.text()).toContain('foo')
   })
+
+  it('holds off flagging the trailing flag while the raw input is focused', async () => {
+    const wrapper = await mountPage('--po')
+    // Unfocused: the partial is flagged as unsupported.
+    expect(wrapper.find('.args-page-validation-error').exists()).toBe(true)
+
+    // Focused: the trailing flag being typed is no longer flagged.
+    await wrapper.find('.args-raw-input').trigger('focusin')
+    await flushPromises()
+    expect(wrapper.find('.args-page-validation-error').exists()).toBe(false)
+    expect(wrapper.find('input[aria-invalid="true"]').exists()).toBe(false)
+
+    // Blur: validation applies again.
+    await wrapper.find('.args-raw-input').trigger('focusout')
+    await flushPromises()
+    expect(wrapper.find('.args-page-validation-error').exists()).toBe(true)
+  })
 })

--- a/src/renderer/src/views/comfyUISettings/ArgsBuilderPage.test.ts
+++ b/src/renderer/src/views/comfyUISettings/ArgsBuilderPage.test.ts
@@ -204,19 +204,27 @@ describe('ArgsBuilderPage — exclusive group dropdown', () => {
     const trigger = wrapper.find('[role="combobox"]')
     expect(trigger.attributes('aria-label')).toContain('Choose one')
   })
+
+  it('previews cluster members space-separated, without bullet separators', async () => {
+    const wrapper = await mountPage()
+    const options = wrapper.find('.args-page-cluster-options')
+    expect(options.exists()).toBe(true)
+    expect(options.text()).not.toContain('·')
+    expect(options.text()).toContain('--cpu --gpu-only')
+  })
 })
 
 describe('ArgsBuilderPage — raw-args validation', () => {
   it('shows no validation warnings for a valid arg string', async () => {
     const wrapper = await mountPage('--cpu --port 8188')
-    expect(wrapper.find('.args-page-validation-error').exists()).toBe(false)
-    expect(wrapper.find('.args-page-validation-warn').exists()).toBe(false)
-    expect(wrapper.find('.args-page-tokens').exists()).toBe(false)
+    expect(wrapper.find('.args-raw-validation-error').exists()).toBe(false)
+    expect(wrapper.find('.args-raw-validation-warn').exists()).toBe(false)
+    expect(wrapper.find('.args-raw-tokens').exists()).toBe(false)
   })
 
   it('flags an unsupported flag and marks the raw input invalid', async () => {
     const wrapper = await mountPage('--bogus')
-    const err = wrapper.find('.args-page-validation-error')
+    const err = wrapper.find('.args-raw-validation-error')
     expect(err.exists()).toBe(true)
     expect(err.text()).toContain('--bogus')
     // BaseInput surfaces the invalid state via aria-invalid.
@@ -225,22 +233,22 @@ describe('ArgsBuilderPage — raw-args validation', () => {
 
   it('flags a missing value when a value flag is followed by another flag', async () => {
     const wrapper = await mountPage('--port --cpu')
-    const warn = wrapper.find('.args-page-validation-warn')
+    const warn = wrapper.find('.args-raw-validation-warn')
     expect(warn.exists()).toBe(true)
     expect(warn.text()).toContain('--port')
   })
 
   it('treats a trailing value flag as an info hint, not an error', async () => {
     const wrapper = await mountPage('--cpu --port')
-    expect(wrapper.find('.args-page-validation-error').exists()).toBe(false)
-    expect(wrapper.find('.args-page-validation-warn').exists()).toBe(false)
-    expect(wrapper.find('.args-page-validation-info').text()).toContain('--port')
+    expect(wrapper.find('.args-raw-validation-error').exists()).toBe(false)
+    expect(wrapper.find('.args-raw-validation-warn').exists()).toBe(false)
+    expect(wrapper.find('.args-raw-validation-info').text()).toContain('--port')
     expect(wrapper.find('input[aria-invalid="true"]').exists()).toBe(false)
   })
 
   it('flags an unexpected positional token', async () => {
     const wrapper = await mountPage('foo --cpu')
-    const err = wrapper.find('.args-page-validation-error')
+    const err = wrapper.find('.args-raw-validation-error')
     expect(err.exists()).toBe(true)
     expect(err.text()).toContain('foo')
   })
@@ -248,17 +256,17 @@ describe('ArgsBuilderPage — raw-args validation', () => {
   it('holds off flagging the trailing flag while the raw input is focused', async () => {
     const wrapper = await mountPage('--po')
     // Unfocused: the partial is flagged as unsupported.
-    expect(wrapper.find('.args-page-validation-error').exists()).toBe(true)
+    expect(wrapper.find('.args-raw-validation-error').exists()).toBe(true)
 
     // Focused: the trailing flag being typed is no longer flagged.
     await wrapper.find('.args-raw-input').trigger('focusin')
     await flushPromises()
-    expect(wrapper.find('.args-page-validation-error').exists()).toBe(false)
+    expect(wrapper.find('.args-raw-validation-error').exists()).toBe(false)
     expect(wrapper.find('input[aria-invalid="true"]').exists()).toBe(false)
 
     // Blur: validation applies again.
     await wrapper.find('.args-raw-input').trigger('focusout')
     await flushPromises()
-    expect(wrapper.find('.args-page-validation-error').exists()).toBe(true)
+    expect(wrapper.find('.args-raw-validation-error').exists()).toBe(true)
   })
 })

--- a/src/renderer/src/views/comfyUISettings/ArgsBuilderPage.test.ts
+++ b/src/renderer/src/views/comfyUISettings/ArgsBuilderPage.test.ts
@@ -4,9 +4,10 @@ import { createI18n } from 'vue-i18n'
 import ArgsBuilderPage from './ArgsBuilderPage.vue'
 import type { ComfyArgDef } from '../../types/ipc'
 
-// Pins the deselectable "Choose one" contract: the exclusive group
-// renders as a BaseSelect with a synthetic "None" option so it can clear,
-// covering pick → clear → re-pick with siblings cleaned up each time.
+// Pins the "Choose one" contract: the exclusive group renders as an inline
+// radio list (every member visible at a glance) with a leading "None" radio
+// that clears the group, covering pick → clear → re-pick with siblings
+// cleaned up each time.
 const i18n = createI18n({
   legacy: false,
   locale: 'en',
@@ -51,8 +52,6 @@ const SCHEMA: ComfyArgDef[] = [
 ]
 
 function stubElectronApi(): void {
-  // Attach to the real window so jsdom listeners survive teardown
-  // (swapping the whole window object breaks BaseSelect's resize/scroll cleanup).
   ;(window as unknown as { api: unknown }).api = {
     getComfyArgs: vi.fn().mockResolvedValue({ args: SCHEMA }),
   }
@@ -63,12 +62,7 @@ const wrappers: VueWrapper[] = []
 async function mountPage(initialValue = ''): Promise<VueWrapper> {
   const wrapper = mount(ArgsBuilderPage, {
     props: { installationId: 'inst-1', initialValue },
-    global: {
-      plugins: [i18n],
-      // BaseSelect teleports its popover to <body>; render it in-tree
-      // so we can query options through the wrapper.
-      stubs: { Teleport: { template: '<div><slot /></div>' } },
-    },
+    global: { plugins: [i18n] },
     attachTo: document.body,
   })
   wrappers.push(wrapper)
@@ -81,22 +75,21 @@ function lastUpdate(wrapper: VueWrapper): string {
   return (events.at(-1)?.[0] as string | undefined) ?? ''
 }
 
-async function openSelect(wrapper: VueWrapper): Promise<void> {
-  // BaseSelect has two root nodes (trigger button + Teleport), so the
-  // page's data-testid doesn't fall through. The test only mounts one
-  // BaseSelect per page so role=combobox is unambiguous.
-  const trigger = wrapper.get('[role="combobox"]')
-  await trigger.trigger('click')
+function radioRows(wrapper: VueWrapper) {
+  return wrapper.findAll('.args-page-radio-row')
+}
+
+async function pickRadio(wrapper: VueWrapper, labelText: string): Promise<void> {
+  const target = radioRows(wrapper).find((r) => r.text().includes(labelText))
+  if (!target) throw new Error(`Radio not found: ${labelText}`)
+  await target.get('input[type="radio"]').setValue(true)
   await flushPromises()
 }
 
-async function pickOption(wrapper: VueWrapper, labelText: string): Promise<void> {
-  await openSelect(wrapper)
-  const opts = wrapper.findAll('[role="option"]')
-  const target = opts.find((o) => o.text().includes(labelText))
-  if (!target) throw new Error(`Option not found: ${labelText}`)
-  await target.trigger('click')
-  await flushPromises()
+function isChecked(wrapper: VueWrapper, labelText: string): boolean {
+  const row = radioRows(wrapper).find((r) => r.text().includes(labelText))
+  if (!row) throw new Error(`Radio not found: ${labelText}`)
+  return (row.get('input[type="radio"]').element as HTMLInputElement).checked
 }
 
 beforeEach(() => {
@@ -109,63 +102,66 @@ afterEach(() => {
   vi.restoreAllMocks()
 })
 
-describe('ArgsBuilderPage — exclusive group select', () => {
-  it('renders a BaseSelect for the cluster with a leading "None" option + every member', async () => {
+describe('ArgsBuilderPage — exclusive group radio list', () => {
+  it('renders a radiogroup with a leading "None" option + every member', async () => {
     const wrapper = await mountPage()
-    expect(wrapper.find('[role="combobox"]').exists()).toBe(true)
+    expect(wrapper.find('[role="radiogroup"]').exists()).toBe(true)
 
-    await openSelect(wrapper)
-    const optionTexts = wrapper.findAll('[role="option"]').map((o) => o.text())
-    expect(optionTexts[0]).toContain('None (default)')
-    expect(optionTexts.some((t) => t.includes('--cpu'))).toBe(true)
-    expect(optionTexts.some((t) => t.includes('--gpu-only'))).toBe(true)
-    expect(optionTexts.some((t) => t.includes('--lowvram'))).toBe(true)
+    const texts = radioRows(wrapper).map((r) => r.text())
+    expect(texts[0]).toContain('None (default)')
+    expect(texts.some((t) => t.includes('--cpu'))).toBe(true)
+    expect(texts.some((t) => t.includes('--gpu-only'))).toBe(true)
+    expect(texts.some((t) => t.includes('--lowvram'))).toBe(true)
   })
 
-  it('shows each member\'s help text as the option description', async () => {
+  it("shows each member's help text inline", async () => {
     const wrapper = await mountPage()
-    await openSelect(wrapper)
-    const cpuOption = wrapper.findAll('[role="option"]').find((o) => o.text().includes('--cpu'))
-    expect(cpuOption?.text()).toContain('Run on CPU only.')
+    const cpuRow = radioRows(wrapper).find((r) => r.text().includes('--cpu'))
+    expect(cpuRow?.text()).toContain('Run on CPU only.')
   })
 
-  it('reflects the active member in the closed trigger when value is pre-set', async () => {
+  it('checks the active member when a value is pre-set', async () => {
     const wrapper = await mountPage('--lowvram')
-    const trigger = wrapper.get('[role="combobox"]')
-    expect(trigger.text()).toContain('--lowvram')
+    expect(isChecked(wrapper, '--lowvram')).toBe(true)
+    expect(isChecked(wrapper, 'None (default)')).toBe(false)
+  })
+
+  it('checks "None" by default when nothing in the group is set', async () => {
+    const wrapper = await mountPage()
+    expect(isChecked(wrapper, 'None (default)')).toBe(true)
   })
 
   it('emits the picked flag and replaces siblings on selection', async () => {
     const wrapper = await mountPage('--lowvram')
-    await pickOption(wrapper, '--cpu')
+    await pickRadio(wrapper, '--cpu')
     // No `--lowvram` survives — the parent commits a single-flag string.
     expect(lastUpdate(wrapper)).toBe('--cpu')
   })
 
-  it('clears the whole group when "None" is picked — the affordance the radio version lost', async () => {
+  it('clears the whole group when "None" is picked', async () => {
     const wrapper = await mountPage('--lowvram')
-    await pickOption(wrapper, 'None (default)')
+    await pickRadio(wrapper, 'None (default)')
     expect(lastUpdate(wrapper)).toBe('')
   })
 
   it('round-trips: pick → clear → pick — siblings get cleaned up each time', async () => {
     const wrapper = await mountPage('')
-    await pickOption(wrapper, '--lowvram')
+    await pickRadio(wrapper, '--lowvram')
     expect(lastUpdate(wrapper)).toBe('--lowvram')
 
-    await pickOption(wrapper, '--cpu')
+    await pickRadio(wrapper, '--cpu')
     expect(lastUpdate(wrapper)).toBe('--cpu')
 
-    await pickOption(wrapper, 'None (default)')
+    await pickRadio(wrapper, 'None (default)')
     expect(lastUpdate(wrapper)).toBe('')
 
-    await pickOption(wrapper, '--gpu-only')
+    await pickRadio(wrapper, '--gpu-only')
     expect(lastUpdate(wrapper)).toBe('--gpu-only')
   })
 
-  it('keeps unrelated flags intact when toggling the exclusive group', async () => {
+  it('keeps unrelated flags intact when clearing the exclusive group', async () => {
     const wrapper = await mountPage('--port 8188 --lowvram')
-    await pickOption(wrapper, 'None (default)')
+    await pickRadio(wrapper, 'None (default)')
     // Only the cluster member is removed; `--port 8188` survives.
     const result = lastUpdate(wrapper)
     expect(result).toContain('--port')
@@ -175,7 +171,6 @@ describe('ArgsBuilderPage — exclusive group select', () => {
 
   it('exposes the cluster purpose to assistive tech via aria-label', async () => {
     const wrapper = await mountPage()
-    const trigger = wrapper.get('[role="combobox"]')
-    expect(trigger.attributes('aria-label')).toBe('Choose one')
+    expect(wrapper.find('[role="radiogroup"]').attributes('aria-label')).toBe('Choose one')
   })
 })

--- a/src/renderer/src/views/comfyUISettings/ArgsBuilderPage.test.ts
+++ b/src/renderer/src/views/comfyUISettings/ArgsBuilderPage.test.ts
@@ -4,10 +4,10 @@ import { createI18n } from 'vue-i18n'
 import ArgsBuilderPage from './ArgsBuilderPage.vue'
 import type { ComfyArgDef } from '../../types/ipc'
 
-// Pins the "Choose one" contract: the exclusive group renders as an inline
-// radio list (every member visible at a glance) with a leading "None" radio
-// that clears the group, covering pick → clear → re-pick with siblings
-// cleaned up each time.
+// Pins the deselectable "Choose one" contract: the exclusive group renders as
+// a compact BaseSelect with a synthetic "None" option so it can clear, the
+// label previews every member, and an active group is promoted to the top
+// "Active" section as the same dropdown.
 const i18n = createI18n({
   legacy: false,
   locale: 'en',
@@ -52,6 +52,8 @@ const SCHEMA: ComfyArgDef[] = [
 ]
 
 function stubElectronApi(): void {
+  // Attach to the real window so jsdom listeners survive teardown
+  // (swapping the whole window object breaks BaseSelect's resize/scroll cleanup).
   ;(window as unknown as { api: unknown }).api = {
     getComfyArgs: vi.fn().mockResolvedValue({ args: SCHEMA }),
   }
@@ -62,7 +64,12 @@ const wrappers: VueWrapper[] = []
 async function mountPage(initialValue = ''): Promise<VueWrapper> {
   const wrapper = mount(ArgsBuilderPage, {
     props: { installationId: 'inst-1', initialValue },
-    global: { plugins: [i18n] },
+    global: {
+      plugins: [i18n],
+      // BaseSelect teleports its popover to <body>; render it in-tree
+      // so we can query options through the wrapper.
+      stubs: { Teleport: { template: '<div><slot /></div>' } },
+    },
     attachTo: document.body,
   })
   wrappers.push(wrapper)
@@ -75,21 +82,29 @@ function lastUpdate(wrapper: VueWrapper): string {
   return (events.at(-1)?.[0] as string | undefined) ?? ''
 }
 
-function radioRows(wrapper: VueWrapper) {
-  return wrapper.findAll('.args-page-radio-row')
-}
-
-async function pickRadio(wrapper: VueWrapper, labelText: string): Promise<void> {
-  const target = radioRows(wrapper).find((r) => r.text().includes(labelText))
-  if (!target) throw new Error(`Radio not found: ${labelText}`)
-  await target.get('input[type="radio"]').setValue(true)
+// An active group renders the same dropdown twice (Active section + category),
+// so target the first combobox; both share the group's state.
+async function openSelect(wrapper: VueWrapper, index = 0): Promise<void> {
+  const triggers = wrapper.findAll('[role="combobox"]')
+  const trigger = triggers[index]
+  if (!trigger) throw new Error(`No combobox at index ${index}`)
+  await trigger.trigger('click')
   await flushPromises()
 }
 
-function isChecked(wrapper: VueWrapper, labelText: string): boolean {
-  const row = radioRows(wrapper).find((r) => r.text().includes(labelText))
-  if (!row) throw new Error(`Radio not found: ${labelText}`)
-  return (row.get('input[type="radio"]').element as HTMLInputElement).checked
+async function pickOption(wrapper: VueWrapper, labelText: string, index = 0): Promise<void> {
+  await openSelect(wrapper, index)
+  const opts = wrapper.findAll('[role="option"]')
+  const target = opts.find((o) => o.text().includes(labelText))
+  if (!target) throw new Error(`Option not found: ${labelText}`)
+  await target.trigger('click')
+  await flushPromises()
+}
+
+function activeSection(wrapper: VueWrapper) {
+  return wrapper
+    .findAll('.args-page-category')
+    .find((s) => s.find('.args-page-category-title').text() === 'Active')
 }
 
 beforeEach(() => {
@@ -102,66 +117,81 @@ afterEach(() => {
   vi.restoreAllMocks()
 })
 
-describe('ArgsBuilderPage — exclusive group radio list', () => {
-  it('renders a radiogroup with a leading "None" option + every member', async () => {
+describe('ArgsBuilderPage — exclusive group dropdown', () => {
+  it('renders a BaseSelect for the cluster with a leading "None" option + every member', async () => {
     const wrapper = await mountPage()
-    expect(wrapper.find('[role="radiogroup"]').exists()).toBe(true)
+    expect(wrapper.find('[role="combobox"]').exists()).toBe(true)
 
-    const texts = radioRows(wrapper).map((r) => r.text())
-    expect(texts[0]).toContain('None (default)')
-    expect(texts.some((t) => t.includes('--cpu'))).toBe(true)
-    expect(texts.some((t) => t.includes('--gpu-only'))).toBe(true)
-    expect(texts.some((t) => t.includes('--lowvram'))).toBe(true)
+    await openSelect(wrapper)
+    const optionTexts = wrapper.findAll('[role="option"]').map((o) => o.text())
+    expect(optionTexts[0]).toContain('None (default)')
+    expect(optionTexts.some((t) => t.includes('--cpu'))).toBe(true)
+    expect(optionTexts.some((t) => t.includes('--gpu-only'))).toBe(true)
+    expect(optionTexts.some((t) => t.includes('--lowvram'))).toBe(true)
   })
 
-  it("shows each member's help text inline", async () => {
+  it('lists every member flag in the cluster label so the choices show before opening', async () => {
     const wrapper = await mountPage()
-    const cpuRow = radioRows(wrapper).find((r) => r.text().includes('--cpu'))
-    expect(cpuRow?.text()).toContain('Run on CPU only.')
+    const label = wrapper.find('.args-page-cluster-label')
+    expect(label.exists()).toBe(true)
+    expect(label.text()).toContain('--cpu')
+    expect(label.text()).toContain('--gpu-only')
+    expect(label.text()).toContain('--lowvram')
   })
 
-  it('checks the active member when a value is pre-set', async () => {
+  it("shows each member's help text as the option description", async () => {
+    const wrapper = await mountPage()
+    await openSelect(wrapper)
+    const cpuOption = wrapper.findAll('[role="option"]').find((o) => o.text().includes('--cpu'))
+    expect(cpuOption?.text()).toContain('Run on CPU only.')
+  })
+
+  it('reflects the active member in the closed trigger when value is pre-set', async () => {
     const wrapper = await mountPage('--lowvram')
-    expect(isChecked(wrapper, '--lowvram')).toBe(true)
-    expect(isChecked(wrapper, 'None (default)')).toBe(false)
+    const trigger = wrapper.findAll('[role="combobox"]')[0]
+    expect(trigger?.text()).toContain('--lowvram')
   })
 
-  it('checks "None" by default when nothing in the group is set', async () => {
-    const wrapper = await mountPage()
-    expect(isChecked(wrapper, 'None (default)')).toBe(true)
+  it('promotes an active exclusive group to the Active section as the same dropdown', async () => {
+    const wrapper = await mountPage('--lowvram')
+    const section = activeSection(wrapper)
+    expect(section, 'expected an Active section').toBeTruthy()
+    const trigger = section!.find('[role="combobox"]')
+    expect(trigger.exists()).toBe(true)
+    expect(trigger.text()).toContain('--lowvram')
   })
 
   it('emits the picked flag and replaces siblings on selection', async () => {
     const wrapper = await mountPage('--lowvram')
-    await pickRadio(wrapper, '--cpu')
+    await pickOption(wrapper, '--cpu')
     // No `--lowvram` survives — the parent commits a single-flag string.
     expect(lastUpdate(wrapper)).toBe('--cpu')
   })
 
-  it('clears the whole group when "None" is picked', async () => {
+  it('clears the whole group when "None" is picked — the affordance the radio version lost', async () => {
     const wrapper = await mountPage('--lowvram')
-    await pickRadio(wrapper, 'None (default)')
+    await pickOption(wrapper, 'None (default)')
     expect(lastUpdate(wrapper)).toBe('')
   })
 
   it('round-trips: pick → clear → pick — siblings get cleaned up each time', async () => {
     const wrapper = await mountPage('')
-    await pickRadio(wrapper, '--lowvram')
+    await pickOption(wrapper, '--lowvram')
     expect(lastUpdate(wrapper)).toBe('--lowvram')
 
-    await pickRadio(wrapper, '--cpu')
+    await pickOption(wrapper, '--cpu')
     expect(lastUpdate(wrapper)).toBe('--cpu')
 
-    await pickRadio(wrapper, 'None (default)')
+    await pickOption(wrapper, 'None (default)')
     expect(lastUpdate(wrapper)).toBe('')
 
-    await pickRadio(wrapper, '--gpu-only')
+    await pickOption(wrapper, '--gpu-only')
     expect(lastUpdate(wrapper)).toBe('--gpu-only')
   })
 
-  it('keeps unrelated flags intact when clearing the exclusive group', async () => {
+  it('keeps unrelated flags intact when toggling the exclusive group', async () => {
     const wrapper = await mountPage('--port 8188 --lowvram')
-    await pickRadio(wrapper, 'None (default)')
+    await pickOption(wrapper, 'None (default)')
     // Only the cluster member is removed; `--port 8188` survives.
     const result = lastUpdate(wrapper)
     expect(result).toContain('--port')
@@ -171,6 +201,47 @@ describe('ArgsBuilderPage — exclusive group radio list', () => {
 
   it('exposes the cluster purpose to assistive tech via aria-label', async () => {
     const wrapper = await mountPage()
-    expect(wrapper.find('[role="radiogroup"]').attributes('aria-label')).toBe('Choose one')
+    const trigger = wrapper.find('[role="combobox"]')
+    expect(trigger.attributes('aria-label')).toContain('Choose one')
+  })
+})
+
+describe('ArgsBuilderPage — raw-args validation', () => {
+  it('shows no validation warnings for a valid arg string', async () => {
+    const wrapper = await mountPage('--cpu --port 8188')
+    expect(wrapper.find('.args-page-validation-error').exists()).toBe(false)
+    expect(wrapper.find('.args-page-validation-warn').exists()).toBe(false)
+    expect(wrapper.find('.args-page-tokens').exists()).toBe(false)
+  })
+
+  it('flags an unsupported flag and marks the raw input invalid', async () => {
+    const wrapper = await mountPage('--bogus')
+    const err = wrapper.find('.args-page-validation-error')
+    expect(err.exists()).toBe(true)
+    expect(err.text()).toContain('--bogus')
+    // BaseInput surfaces the invalid state via aria-invalid.
+    expect(wrapper.find('input[aria-invalid="true"]').exists()).toBe(true)
+  })
+
+  it('flags a missing value when a value flag is followed by another flag', async () => {
+    const wrapper = await mountPage('--port --cpu')
+    const warn = wrapper.find('.args-page-validation-warn')
+    expect(warn.exists()).toBe(true)
+    expect(warn.text()).toContain('--port')
+  })
+
+  it('treats a trailing value flag as an info hint, not an error', async () => {
+    const wrapper = await mountPage('--cpu --port')
+    expect(wrapper.find('.args-page-validation-error').exists()).toBe(false)
+    expect(wrapper.find('.args-page-validation-warn').exists()).toBe(false)
+    expect(wrapper.find('.args-page-validation-info').text()).toContain('--port')
+    expect(wrapper.find('input[aria-invalid="true"]').exists()).toBe(false)
+  })
+
+  it('flags an unexpected positional token', async () => {
+    const wrapper = await mountPage('foo --cpu')
+    const err = wrapper.find('.args-page-validation-error')
+    expect(err.exists()).toBe(true)
+    expect(err.text()).toContain('foo')
   })
 })

--- a/src/renderer/src/views/comfyUISettings/ArgsBuilderPage.vue
+++ b/src/renderer/src/views/comfyUISettings/ArgsBuilderPage.vue
@@ -104,26 +104,8 @@ function commit(known: Map<string, string>): void {
   emit('update', next)
 }
 
-function toggleBoolean(def: ComfyArgDef): void {
-  const next = new Map(parsed.value.known)
-  if (next.has(def.name)) {
-    next.delete(def.name)
-  } else {
-    // Enforce exclusive group: remove siblings
-    if (def.exclusiveGroup) {
-      for (const a of schema.value) {
-        if (a.exclusiveGroup === def.exclusiveGroup && a.name !== def.name) {
-          next.delete(a.name)
-        }
-      }
-    }
-    next.set(def.name, '')
-  }
-  commit(next)
-  emitArgsChanged(def.name, def.type)
-}
-
-function toggleValue(def: ComfyArgDef): void {
+// Toggle a flag on/off; turning one on clears its exclusive-group siblings.
+function toggleFlag(def: ComfyArgDef): void {
   const next = new Map(parsed.value.known)
   if (next.has(def.name)) {
     next.delete(def.name)
@@ -439,9 +421,7 @@ function onRawChange(value: string): void {
                 :data-state="isActive(item.arg.name) ? 'checked' : 'unchecked'"
                 :aria-checked="isActive(item.arg.name)"
                 :aria-label="`--${item.arg.name}`"
-                @click="
-                  item.arg.type === 'boolean' ? toggleBoolean(item.arg) : toggleValue(item.arg)
-                "
+                @click="toggleFlag(item.arg)"
               >
                 <span class="args-page-switch-thumb" aria-hidden="true"></span>
               </button>

--- a/src/renderer/src/views/comfyUISettings/ArgsBuilderPage.vue
+++ b/src/renderer/src/views/comfyUISettings/ArgsBuilderPage.vue
@@ -20,9 +20,14 @@ import { scoreName } from '../../utils/fuzzyMatch'
 interface Props {
   installationId: string
   initialValue: string
+  /** True when args were edited while the instance is running, so they won't
+   *  apply until a restart; mirrors the tag other settings fields show. */
+  pendingRestart?: boolean
 }
 
-const props = defineProps<Props>()
+const props = withDefaults(defineProps<Props>(), {
+  pendingRestart: false
+})
 
 const emit = defineEmits<{
   back: []
@@ -328,7 +333,12 @@ function onRawChange(value: string): void {
         <ArrowLeft :size="16" />
         <span>{{ t('common.back', 'Back') }}</span>
       </button>
-      <h2 class="args-page-title">{{ t('comfyUISettings.argsTitle', 'Startup Arguments') }}</h2>
+      <div class="args-page-title-row">
+        <h2 class="args-page-title">{{ t('comfyUISettings.argsTitle', 'Startup Arguments') }}</h2>
+        <span v-if="pendingRestart" class="args-page-restart-tag" role="status">
+          {{ t('comfyUISettings.restartRequired', 'Restart to apply') }}
+        </span>
+      </div>
     </header>
 
     <div class="args-page-raw">
@@ -513,6 +523,13 @@ function onRawChange(value: string): void {
   outline-offset: 2px;
 }
 
+.args-page-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
 .args-page-title {
   margin: 0;
   font-size: 18px;
@@ -520,6 +537,22 @@ function onRawChange(value: string): void {
   color: var(--text);
   letter-spacing: -0.01em;
   line-height: 1.2;
+}
+
+/* Mirrors SettingsSectionList's restart tag so the args page reads as the same family. */
+.args-page-restart-tag {
+  flex: 0 0 auto;
+  padding: 1px 6px;
+  border-radius: 9999px;
+  font-size: 10px;
+  font-weight: 500;
+  line-height: 14px;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--warning);
+  background: color-mix(in srgb, var(--warning) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--warning) 36%, transparent);
+  white-space: nowrap;
 }
 
 .args-page-raw {

--- a/src/renderer/src/views/comfyUISettings/ArgsBuilderPage.vue
+++ b/src/renderer/src/views/comfyUISettings/ArgsBuilderPage.vue
@@ -332,11 +332,19 @@ function onRawChange(value: string): void {
   emit('update', value)
 }
 
+// True while the raw input is focused; used to hold off flagging the trailing
+// flag the user is still typing.
+const rawFocused = ref(false)
+
 // Inline validation of the raw string: colored tokens + per-issue warnings so
 // unsupported flags, missing values, and stray positionals are visible instead
 // of silently surviving. Empty until the schema loads.
 const validation = computed(() =>
-  schema.value.length ? validateArgs(localValue.value, schema.value) : null
+  schema.value.length
+    ? validateArgs(localValue.value, schema.value, {
+        suppressTrailingPartial: rawFocused.value
+      })
+    : null
 )
 const hasValidationIssues = computed(() => validation.value?.hasIssues ?? false)
 const showTokenDisplay = computed(
@@ -371,6 +379,7 @@ const showTokenDisplay = computed(
         :aria-label="t('comfyUISettings.argsRawLabel', 'Raw arguments')"
         @update:model-value="onRawInput"
         @change="onRawChange"
+        @focus-change="rawFocused = $event"
       />
       <p class="args-page-raw-hint">
         {{ t('comfyUISettings.argsRawHint', 'Edit directly, or toggle individual flags below.') }}
@@ -388,7 +397,8 @@ const showTokenDisplay = computed(
           :class="{
             'token-bad': tok.status === 'unsupported' || tok.status === 'orphaned',
             'token-missing': tok.status === 'missing-value',
-            'token-awaiting': tok.status === 'awaiting-value'
+            'token-awaiting': tok.status === 'awaiting-value',
+            'token-partial': tok.status === 'partial'
           }"
           :title="tok.tooltip || ''"
           >{{ tok.text }}</span
@@ -694,6 +704,12 @@ const showTokenDisplay = computed(
   color: var(--accent-primary);
   text-decoration: underline dotted;
   text-underline-offset: 3px;
+}
+
+/* Trailing flag still being typed: dimmed, no error decoration. */
+.args-page-tokens .token-partial {
+  color: var(--text-muted);
+  opacity: 0.6;
 }
 
 .args-page-validation {

--- a/src/renderer/src/views/comfyUISettings/ArgsBuilderPage.vue
+++ b/src/renderer/src/views/comfyUISettings/ArgsBuilderPage.vue
@@ -7,7 +7,7 @@ import BaseInput from '../../components/ui/BaseInput.vue'
 import BaseSelect, { type BaseSelectOption } from '../../components/ui/BaseSelect.vue'
 import ArgsRawInput from './ArgsRawInput.vue'
 import type { ComfyArgDef } from '../../types/ipc'
-import { parseArgs, serialize, validateArgs } from '../../lib/argsParser'
+import { parseArgs, serialize } from '../../lib/argsParser'
 import { emitTelemetryAction } from '../../lib/telemetry'
 import { scoreName } from '../../utils/fuzzyMatch'
 
@@ -194,7 +194,7 @@ function clusterOptions(args: ComfyArgDef[]): BaseSelectOption[] {
 // One-line preview of the members so the collapsed dropdown says what you're
 // choosing between, not just a generic "Choose one".
 function clusterSummary(args: ComfyArgDef[]): string {
-  return args.map((a) => `--${a.name}`).join(' · ')
+  return args.map((a) => `--${a.name}`).join(' ')
 }
 
 function onExclusivePick(group: string, value: string): void {
@@ -332,24 +332,6 @@ function onRawChange(value: string): void {
   emit('update', value)
 }
 
-// True while the raw input is focused; used to hold off flagging the trailing
-// flag the user is still typing.
-const rawFocused = ref(false)
-
-// Inline validation of the raw string: colored tokens + per-issue warnings so
-// unsupported flags, missing values, and stray positionals are visible instead
-// of silently surviving. Empty until the schema loads.
-const validation = computed(() =>
-  schema.value.length
-    ? validateArgs(localValue.value, schema.value, {
-        suppressTrailingPartial: rawFocused.value
-      })
-    : null
-)
-const hasValidationIssues = computed(() => validation.value?.hasIssues ?? false)
-const showTokenDisplay = computed(
-  () => hasValidationIssues.value || validation.value?.awaiting != null
-)
 </script>
 
 <template>
@@ -374,98 +356,14 @@ const showTokenDisplay = computed(
       <ArgsRawInput
         :model-value="localValue"
         :schema="schema"
-        :invalid="hasValidationIssues"
         :placeholder="t('comfyUISettings.argsPlaceholder', 'No arguments set')"
         :aria-label="t('comfyUISettings.argsRawLabel', 'Raw arguments')"
         @update:model-value="onRawInput"
         @change="onRawChange"
-        @focus-change="rawFocused = $event"
       />
       <p class="args-page-raw-hint">
         {{ t('comfyUISettings.argsRawHint', 'Edit directly, or toggle individual flags below.') }}
       </p>
-
-      <!-- Colored echo of the raw string so problem tokens are easy to spot. -->
-      <div
-        v-if="validation && showTokenDisplay && validation.tokens.length"
-        class="args-page-tokens"
-        aria-hidden="true"
-      >
-        <span
-          v-for="(tok, i) in validation.tokens"
-          :key="i"
-          :class="{
-            'token-bad': tok.status === 'unsupported' || tok.status === 'orphaned',
-            'token-missing': tok.status === 'missing-value',
-            'token-awaiting': tok.status === 'awaiting-value',
-            'token-partial': tok.status === 'partial'
-          }"
-          :title="tok.tooltip || ''"
-          >{{ tok.text }}</span
-        >
-      </div>
-
-      <template v-if="validation">
-        <p
-          v-if="validation.awaiting"
-          class="args-page-validation args-page-validation-info"
-          role="status"
-        >
-          <AlertCircle :size="12" aria-hidden="true" />
-          <span>
-            {{ validation.awaiting.text }}
-            {{ t('comfyUISettings.argsAwaitingValue', 'expects a value') }}
-          </span>
-        </p>
-        <p
-          v-if="validation.unsupportedFlags.length > 0"
-          class="args-page-validation args-page-validation-error"
-          role="status"
-        >
-          <AlertCircle :size="12" aria-hidden="true" />
-          <span>
-            {{ t('comfyUISettings.argsUnsupported', 'Unsupported:') }}
-            <code
-              v-for="flag in validation.unsupportedFlags"
-              :key="flag"
-              class="args-page-bad-flag"
-              >--{{ flag }}</code
-            >
-          </span>
-        </p>
-        <p
-          v-if="validation.missingValueFlags.length > 0"
-          class="args-page-validation args-page-validation-warn"
-          role="status"
-        >
-          <AlertCircle :size="12" aria-hidden="true" />
-          <span>
-            {{ t('comfyUISettings.argsMissingValue', 'Missing value for:') }}
-            <code
-              v-for="flag in validation.missingValueFlags"
-              :key="flag"
-              class="args-page-bad-flag"
-              >{{ flag }}</code
-            >
-          </span>
-        </p>
-        <p
-          v-if="validation.orphanedTokens.length > 0"
-          class="args-page-validation args-page-validation-error"
-          role="status"
-        >
-          <AlertCircle :size="12" aria-hidden="true" />
-          <span>
-            {{ t('comfyUISettings.argsUnexpected', 'Unexpected:') }}
-            <code
-              v-for="tok in validation.orphanedTokens"
-              :key="tok"
-              class="args-page-bad-flag"
-              >{{ tok }}</code
-            >
-          </span>
-        </p>
-      </template>
     </div>
 
     <BaseInput
@@ -666,94 +564,6 @@ const showTokenDisplay = computed(
   font-size: 11px;
   line-height: 1.4;
   color: color-mix(in srgb, var(--text-muted) 80%, transparent);
-}
-
-/* Colored echo of the raw string: each problem token underlined in its color. */
-.args-page-tokens {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px 6px;
-  margin: 6px 0 0;
-  padding: 6px 10px;
-  font-family:
-    ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    monospace;
-  font-size: 12px;
-  line-height: 1.5;
-  color: var(--text-muted);
-  background: var(--neutral-800);
-  border: 1px solid var(--chooser-surface-border);
-  border-radius: 6px;
-}
-
-.args-page-tokens .token-bad {
-  color: var(--danger);
-  text-decoration: underline wavy;
-  text-underline-offset: 3px;
-}
-
-.args-page-tokens .token-missing {
-  color: var(--warning);
-  text-decoration: underline wavy;
-  text-underline-offset: 3px;
-}
-
-.args-page-tokens .token-awaiting {
-  color: var(--accent-primary);
-  text-decoration: underline dotted;
-  text-underline-offset: 3px;
-}
-
-/* Trailing flag still being typed: dimmed, no error decoration. */
-.args-page-tokens .token-partial {
-  color: var(--text-muted);
-  opacity: 0.6;
-}
-
-.args-page-validation {
-  display: flex;
-  align-items: flex-start;
-  flex-wrap: wrap;
-  gap: 6px;
-  margin: 6px 0 0;
-  padding: 6px 10px;
-  font-size: 11px;
-  line-height: 1.5;
-  border-radius: 6px;
-}
-
-.args-page-validation :deep(svg) {
-  flex-shrink: 0;
-  margin-top: 2px;
-}
-
-.args-page-validation-error {
-  color: var(--danger);
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-}
-
-.args-page-validation-warn {
-  color: var(--warning);
-  background: color-mix(in srgb, var(--warning) 14%, transparent);
-}
-
-.args-page-validation-info {
-  color: var(--accent-primary);
-  background: color-mix(in srgb, var(--accent-primary) 12%, transparent);
-}
-
-.args-page-bad-flag {
-  font-family:
-    ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    monospace;
-  font-size: 11px;
-  padding: 0 4px;
-  border-radius: 3px;
-  background: color-mix(in srgb, currentcolor 14%, transparent);
 }
 
 .args-page-search :deep(.ui-input-leading) {

--- a/src/renderer/src/views/comfyUISettings/ArgsBuilderPage.vue
+++ b/src/renderer/src/views/comfyUISettings/ArgsBuilderPage.vue
@@ -4,9 +4,10 @@ import { useDebounceFn } from '@vueuse/core'
 import { useI18n } from 'vue-i18n'
 import { AlertCircle, ArrowLeft, Loader2, Search, SearchX, X } from 'lucide-vue-next'
 import BaseInput from '../../components/ui/BaseInput.vue'
+import BaseSelect, { type BaseSelectOption } from '../../components/ui/BaseSelect.vue'
 import ArgsRawInput from './ArgsRawInput.vue'
 import type { ComfyArgDef } from '../../types/ipc'
-import { parseArgs, serialize, tokenize } from '../../lib/argsParser'
+import { parseArgs, serialize, validateArgs } from '../../lib/argsParser'
 import { emitTelemetryAction } from '../../lib/telemetry'
 import { scoreName } from '../../utils/fuzzyMatch'
 
@@ -160,7 +161,8 @@ function selectExclusive(group: string, name: string): void {
   if (chosen) emitArgsChanged(chosen.name, chosen.type)
 }
 
-// Clears every member of an exclusive group (backs the "None" radio).
+// Backs the select's synthetic "None" option, which clears the group (a plain
+// radio set can't deselect).
 function clearExclusive(group: string): void {
   const next = new Map(parsed.value.known)
   for (const a of schema.value) {
@@ -176,22 +178,23 @@ function activeInGroup(group: string): string {
   return ''
 }
 
-// Radio rows for an exclusive cluster: a synthetic "" (None) entry followed by
-// each member, so the template renders them with a single loop.
-interface ClusterOption {
-  value: string
-  flag: string
-  help: string
-}
-function clusterOptions(args: ComfyArgDef[]): ClusterOption[] {
+// Dropdown options for an exclusive cluster: a synthetic "None" entry that
+// clears the group, followed by each member flag.
+function clusterOptions(args: ComfyArgDef[]): BaseSelectOption[] {
   return [
     {
       value: '',
-      flag: t('comfyUISettings.argsExclusiveNone', 'None (default)'),
-      help: t('comfyUISettings.argsExclusiveNoneHint', 'No flag from this group is set.')
+      label: t('comfyUISettings.argsExclusiveNone', 'None (default)'),
+      description: t('comfyUISettings.argsExclusiveNoneHint', 'No flag from this group is set.')
     },
-    ...args.map((a) => ({ value: a.name, flag: `--${a.name}`, help: a.help }))
+    ...args.map((a) => ({ value: a.name, label: `--${a.name}`, description: a.help }))
   ]
+}
+
+// One-line preview of the members so the collapsed dropdown says what you're
+// choosing between, not just a generic "Choose one".
+function clusterSummary(args: ComfyArgDef[]): string {
+  return args.map((a) => `--${a.name}`).join(' · ')
 }
 
 function onExclusivePick(group: string, value: string): void {
@@ -295,12 +298,20 @@ const structuredGroups = computed(() => {
 
   // Pin currently-set flags to the top as their own section so they're
   // editable without hunting through categories. Skipped while searching
-  // (the filtered list already narrows things down). Exclusive-group
-  // members surface as individual rows here for direct toggle-off.
+  // (the filtered list already narrows things down). Reuses the same items
+  // as the categories below, so an active exclusive group shows as its
+  // dropdown here too.
   if (q) return result
-  const activeItems: GroupItem[] = schema.value
-    .filter((a) => parsed.value.known.has(a.name))
-    .map((a) => ({ kind: 'arg', arg: a }))
+  const activeItems: GroupItem[] = []
+  for (const items of result.values()) {
+    for (const item of items) {
+      if (item.kind === 'exclusive') {
+        if (item.group && activeInGroup(item.group) !== '') activeItems.push(item)
+      } else if (item.arg && parsed.value.known.has(item.arg.name)) {
+        activeItems.push(item)
+      }
+    }
+  }
   if (activeItems.length === 0) return result
   const ordered = new Map<string, GroupItem[]>()
   ordered.set(t('comfyUISettings.argsActiveTitle', 'Active'), activeItems)
@@ -321,29 +332,16 @@ function onRawChange(value: string): void {
   emit('update', value)
 }
 
-// Unknown-flag warning so users know if a typo silently survives.
-const unknownFlags = computed(() => {
-  if (!schema.value.length) return []
-  const known = new Set(schema.value.map((a) => a.name))
-  const tokens = tokenize(localValue.value)
-  const out: string[] = []
-  for (const tok of tokens) {
-    if (!tok.startsWith('--')) continue
-    const rest = tok.slice(2)
-    const eqIdx = rest.indexOf('=')
-    const name = eqIdx >= 0 ? rest.slice(0, eqIdx) : rest
-    if (name && !known.has(name)) out.push(name)
-  }
-  return out
-})
-
-// Built here (not via vue-i18n) because no catalog entry exists; a locale can override by registering the key with a `{flags}` placeholder.
-const unknownFlagsMessage = computed(() => {
-  const flags = unknownFlags.value.join(', ')
-  return t('comfyUISettings.argsUnknown', { flags }) === 'comfyUISettings.argsUnknown'
-    ? `Unknown flag(s): ${flags}`
-    : t('comfyUISettings.argsUnknown', { flags })
-})
+// Inline validation of the raw string: colored tokens + per-issue warnings so
+// unsupported flags, missing values, and stray positionals are visible instead
+// of silently surviving. Empty until the schema loads.
+const validation = computed(() =>
+  schema.value.length ? validateArgs(localValue.value, schema.value) : null
+)
+const hasValidationIssues = computed(() => validation.value?.hasIssues ?? false)
+const showTokenDisplay = computed(
+  () => hasValidationIssues.value || validation.value?.awaiting != null
+)
 </script>
 
 <template>
@@ -368,6 +366,7 @@ const unknownFlagsMessage = computed(() => {
       <ArgsRawInput
         :model-value="localValue"
         :schema="schema"
+        :invalid="hasValidationIssues"
         :placeholder="t('comfyUISettings.argsPlaceholder', 'No arguments set')"
         :aria-label="t('comfyUISettings.argsRawLabel', 'Raw arguments')"
         @update:model-value="onRawInput"
@@ -376,10 +375,87 @@ const unknownFlagsMessage = computed(() => {
       <p class="args-page-raw-hint">
         {{ t('comfyUISettings.argsRawHint', 'Edit directly, or toggle individual flags below.') }}
       </p>
-      <p v-if="unknownFlags.length > 0" class="args-page-unknown" role="status">
-        <AlertCircle :size="12" aria-hidden="true" />
-        <span>{{ unknownFlagsMessage }}</span>
-      </p>
+
+      <!-- Colored echo of the raw string so problem tokens are easy to spot. -->
+      <div
+        v-if="validation && showTokenDisplay && validation.tokens.length"
+        class="args-page-tokens"
+        aria-hidden="true"
+      >
+        <span
+          v-for="(tok, i) in validation.tokens"
+          :key="i"
+          :class="{
+            'token-bad': tok.status === 'unsupported' || tok.status === 'orphaned',
+            'token-missing': tok.status === 'missing-value',
+            'token-awaiting': tok.status === 'awaiting-value'
+          }"
+          :title="tok.tooltip || ''"
+          >{{ tok.text }}</span
+        >
+      </div>
+
+      <template v-if="validation">
+        <p
+          v-if="validation.awaiting"
+          class="args-page-validation args-page-validation-info"
+          role="status"
+        >
+          <AlertCircle :size="12" aria-hidden="true" />
+          <span>
+            {{ validation.awaiting.text }}
+            {{ t('comfyUISettings.argsAwaitingValue', 'expects a value') }}
+          </span>
+        </p>
+        <p
+          v-if="validation.unsupportedFlags.length > 0"
+          class="args-page-validation args-page-validation-error"
+          role="status"
+        >
+          <AlertCircle :size="12" aria-hidden="true" />
+          <span>
+            {{ t('comfyUISettings.argsUnsupported', 'Unsupported:') }}
+            <code
+              v-for="flag in validation.unsupportedFlags"
+              :key="flag"
+              class="args-page-bad-flag"
+              >--{{ flag }}</code
+            >
+          </span>
+        </p>
+        <p
+          v-if="validation.missingValueFlags.length > 0"
+          class="args-page-validation args-page-validation-warn"
+          role="status"
+        >
+          <AlertCircle :size="12" aria-hidden="true" />
+          <span>
+            {{ t('comfyUISettings.argsMissingValue', 'Missing value for:') }}
+            <code
+              v-for="flag in validation.missingValueFlags"
+              :key="flag"
+              class="args-page-bad-flag"
+              >{{ flag }}</code
+            >
+          </span>
+        </p>
+        <p
+          v-if="validation.orphanedTokens.length > 0"
+          class="args-page-validation args-page-validation-error"
+          role="status"
+        >
+          <AlertCircle :size="12" aria-hidden="true" />
+          <span>
+            {{ t('comfyUISettings.argsUnexpected', 'Unexpected:') }}
+            <code
+              v-for="tok in validation.orphanedTokens"
+              :key="tok"
+              class="args-page-bad-flag"
+              >{{ tok }}</code
+            >
+          </span>
+        </p>
+      </template>
     </div>
 
     <BaseInput
@@ -428,35 +504,20 @@ const unknownFlagsMessage = computed(() => {
         <header class="args-page-category-title">{{ category }}</header>
 
         <div v-for="(item, idx) in items" :key="idx" class="args-page-item">
-          <!-- Exclusive cluster as an inline radio list so every option is visible at a glance; the "None" radio clears the group. -->
+          <!-- Exclusive cluster as a compact dropdown; the label lists the members so you can see the choices before opening, and a synthetic "None" option clears the group. -->
           <template v-if="item.kind === 'exclusive' && item.args && item.group">
-            <div
-              class="args-page-cluster"
-              role="radiogroup"
-              :aria-label="t('comfyUISettings.argsExclusiveLabel', 'Choose one')"
-            >
+            <div class="args-page-cluster">
               <span class="args-page-cluster-label">
-                {{ t('comfyUISettings.argsExclusiveLabel', 'Choose one') }}
+                {{ t('comfyUISettings.argsExclusiveLabel', 'Choose one') }}:
+                <span class="args-page-cluster-options">{{ clusterSummary(item.args) }}</span>
               </span>
-              <label
-                v-for="opt in clusterOptions(item.args)"
-                :key="opt.value"
-                class="args-page-radio-row"
-                :class="{ 'is-active': activeInGroup(item.group) === opt.value }"
-              >
-                <input
-                  type="radio"
-                  class="args-page-radio-input"
-                  :name="`exclusive-${item.group}`"
-                  :checked="activeInGroup(item.group) === opt.value"
-                  @change="onExclusivePick(item.group!, opt.value)"
-                >
-                <span class="args-page-radio-indicator" aria-hidden="true"></span>
-                <div class="args-page-radio-body">
-                  <span class="args-page-flag">{{ opt.flag }}</span>
-                  <p class="args-page-help">{{ opt.help }}</p>
-                </div>
-              </label>
+              <BaseSelect
+                :model-value="activeInGroup(item.group)"
+                :options="clusterOptions(item.args)"
+                :aria-label="`${t('comfyUISettings.argsExclusiveLabel', 'Choose one')}: ${clusterSummary(item.args)}`"
+                :placeholder="t('comfyUISettings.argsExclusiveNone', 'None (default)')"
+                @update:model-value="(v) => onExclusivePick(item.group!, v)"
+              />
             </div>
           </template>
 
@@ -597,21 +658,86 @@ const unknownFlagsMessage = computed(() => {
   color: color-mix(in srgb, var(--text-muted) 80%, transparent);
 }
 
-.args-page-unknown {
-  display: inline-flex;
-  align-items: center;
+/* Colored echo of the raw string: each problem token underlined in its color. */
+.args-page-tokens {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 6px;
+  margin: 6px 0 0;
+  padding: 6px 10px;
+  font-family:
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-muted);
+  background: var(--neutral-800);
+  border: 1px solid var(--chooser-surface-border);
+  border-radius: 6px;
+}
+
+.args-page-tokens .token-bad {
+  color: var(--danger);
+  text-decoration: underline wavy;
+  text-underline-offset: 3px;
+}
+
+.args-page-tokens .token-missing {
+  color: var(--warning);
+  text-decoration: underline wavy;
+  text-underline-offset: 3px;
+}
+
+.args-page-tokens .token-awaiting {
+  color: var(--accent-primary);
+  text-decoration: underline dotted;
+  text-underline-offset: 3px;
+}
+
+.args-page-validation {
+  display: flex;
+  align-items: flex-start;
+  flex-wrap: wrap;
   gap: 6px;
   margin: 6px 0 0;
   padding: 6px 10px;
   font-size: 11px;
-  line-height: 1.4;
-  color: var(--warning);
-  background: color-mix(in srgb, var(--warning) 14%, transparent);
+  line-height: 1.5;
   border-radius: 6px;
 }
 
-.args-page-unknown :deep(svg) {
+.args-page-validation :deep(svg) {
   flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.args-page-validation-error {
+  color: var(--danger);
+  background: color-mix(in srgb, var(--danger) 12%, transparent);
+}
+
+.args-page-validation-warn {
+  color: var(--warning);
+  background: color-mix(in srgb, var(--warning) 14%, transparent);
+}
+
+.args-page-validation-info {
+  color: var(--accent-primary);
+  background: color-mix(in srgb, var(--accent-primary) 12%, transparent);
+}
+
+.args-page-bad-flag {
+  font-family:
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  font-size: 11px;
+  padding: 0 4px;
+  border-radius: 3px;
+  background: color-mix(in srgb, currentcolor 14%, transparent);
 }
 
 .args-page-search :deep(.ui-input-leading) {
@@ -806,11 +932,11 @@ const unknownFlagsMessage = computed(() => {
   }
 }
 
-/* "Choose one" radio cluster: label above an inline list of every option. */
+/* "Choose one" cluster: label (with member preview) above a compact dropdown. */
 .args-page-cluster {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 4px;
   min-width: 0;
 }
 
@@ -820,74 +946,19 @@ const unknownFlagsMessage = computed(() => {
   color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  margin: 2px 0 4px;
+  margin: 2px 0 2px;
   padding: 0 2px;
 }
 
-.args-page-radio-row {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 10px 12px;
-  align-items: start;
-  padding: 8px 10px;
-  margin: 0 -10px;
-  border-radius: 8px;
-  cursor: pointer;
-  transition: background-color 120ms ease;
-}
-
-.args-page-radio-row:hover {
-  background: color-mix(in srgb, var(--text) 4%, transparent);
-}
-
-.args-page-radio-row.is-active {
-  background: color-mix(in srgb, var(--accent-primary) 8%, transparent);
-}
-
-.args-page-radio-input {
-  position: absolute;
-  opacity: 0;
-  width: 0;
-  height: 0;
-  pointer-events: none;
-}
-
-.args-page-radio-indicator {
-  flex-shrink: 0;
-  position: relative;
-  width: 16px;
-  height: 16px;
-  margin-top: 3px;
-  border-radius: 50%;
-  border: 1.5px solid color-mix(in srgb, var(--text-muted) 60%, transparent);
-  background: transparent;
-  transition:
-    border-color 150ms ease,
-    background-color 150ms ease;
-}
-
-.args-page-radio-row.is-active .args-page-radio-indicator {
-  border-color: var(--accent-primary);
-  background: var(--accent-primary);
-}
-
-.args-page-radio-row.is-active .args-page-radio-indicator::after {
-  content: '';
-  position: absolute;
-  inset: 3px;
-  border-radius: 50%;
-  background: #ffffff;
-}
-
-.args-page-radio-input:focus-visible + .args-page-radio-indicator {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
-
-.args-page-radio-body {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  min-width: 0;
+/* Member preview: monospaced and slightly dimmer so it reads as the option list. */
+.args-page-cluster-options {
+  font-family:
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  text-transform: none;
+  letter-spacing: 0;
+  color: color-mix(in srgb, var(--text-muted) 85%, transparent);
 }
 </style>

--- a/src/renderer/src/views/comfyUISettings/ArgsBuilderPage.vue
+++ b/src/renderer/src/views/comfyUISettings/ArgsBuilderPage.vue
@@ -160,7 +160,7 @@ function selectExclusive(group: string, name: string): void {
   if (chosen) emitArgsChanged(chosen.name, chosen.type)
 }
 
-// Backs the select's synthetic "None" option (radios can't deselect).
+// Clears every member of an exclusive group (backs the "None" radio).
 function clearExclusive(group: string): void {
   const next = new Map(parsed.value.known)
   for (const a of schema.value) {
@@ -174,6 +174,29 @@ function activeInGroup(group: string): string {
     if (a.exclusiveGroup === group && parsed.value.known.has(a.name)) return a.name
   }
   return ''
+}
+
+// Radio rows for an exclusive cluster: a synthetic "" (None) entry followed by
+// each member, so the template renders them with a single loop.
+interface ClusterOption {
+  value: string
+  flag: string
+  help: string
+}
+function clusterOptions(args: ComfyArgDef[]): ClusterOption[] {
+  return [
+    {
+      value: '',
+      flag: t('comfyUISettings.argsExclusiveNone', 'None (default)'),
+      help: t('comfyUISettings.argsExclusiveNoneHint', 'No flag from this group is set.')
+    },
+    ...args.map((a) => ({ value: a.name, flag: `--${a.name}`, help: a.help }))
+  ]
+}
+
+function onExclusivePick(group: string, value: string): void {
+  if (value === '') clearExclusive(group)
+  else selectExclusive(group, value)
 }
 
 // Score a query token against help prose. Strict (word-boundary or substring only); loose subsequence would make "cuda" hit unrelated help.
@@ -416,44 +439,21 @@ const unknownFlagsMessage = computed(() => {
                 {{ t('comfyUISettings.argsExclusiveLabel', 'Choose one') }}
               </span>
               <label
+                v-for="opt in clusterOptions(item.args)"
+                :key="opt.value"
                 class="args-page-radio-row"
-                :class="{ 'is-active': activeInGroup(item.group) === '' }"
+                :class="{ 'is-active': activeInGroup(item.group) === opt.value }"
               >
                 <input
                   type="radio"
                   class="args-page-radio-input"
                   :name="`exclusive-${item.group}`"
-                  :checked="activeInGroup(item.group) === ''"
-                  @change="clearExclusive(item.group!)"
+                  :checked="activeInGroup(item.group) === opt.value"
+                  @change="onExclusivePick(item.group!, opt.value)"
                 >
                 <span class="args-page-radio-indicator" aria-hidden="true"></span>
                 <div class="args-page-radio-body">
-                  <span class="args-page-flag">{{
-                    t('comfyUISettings.argsExclusiveNone', 'None (default)')
-                  }}</span>
-                  <p class="args-page-help">
-                    {{
-                      t('comfyUISettings.argsExclusiveNoneHint', 'No flag from this group is set.')
-                    }}
-                  </p>
-                </div>
-              </label>
-              <label
-                v-for="opt in item.args"
-                :key="opt.name"
-                class="args-page-radio-row"
-                :class="{ 'is-active': activeInGroup(item.group) === opt.name }"
-              >
-                <input
-                  type="radio"
-                  class="args-page-radio-input"
-                  :name="`exclusive-${item.group}`"
-                  :checked="activeInGroup(item.group) === opt.name"
-                  @change="selectExclusive(item.group!, opt.name)"
-                >
-                <span class="args-page-radio-indicator" aria-hidden="true"></span>
-                <div class="args-page-radio-body">
-                  <span class="args-page-flag">--{{ opt.name }}</span>
+                  <span class="args-page-flag">{{ opt.flag }}</span>
                   <p class="args-page-help">{{ opt.help }}</p>
                 </div>
               </label>

--- a/src/renderer/src/views/comfyUISettings/ArgsBuilderPage.vue
+++ b/src/renderer/src/views/comfyUISettings/ArgsBuilderPage.vue
@@ -4,7 +4,6 @@ import { useDebounceFn } from '@vueuse/core'
 import { useI18n } from 'vue-i18n'
 import { AlertCircle, ArrowLeft, Loader2, Search, SearchX, X } from 'lucide-vue-next'
 import BaseInput from '../../components/ui/BaseInput.vue'
-import BaseSelect, { type BaseSelectOption } from '../../components/ui/BaseSelect.vue'
 import ArgsRawInput from './ArgsRawInput.vue'
 import type { ComfyArgDef } from '../../types/ipc'
 import { parseArgs, serialize, tokenize } from '../../lib/argsParser'
@@ -177,22 +176,6 @@ function activeInGroup(group: string): string {
   return ''
 }
 
-function optionsForGroup(args: ComfyArgDef[]): BaseSelectOption[] {
-  return [
-    {
-      value: '',
-      label: t('comfyUISettings.argsExclusiveNone', 'None (default)'),
-      description: t('comfyUISettings.argsExclusiveNoneHint', 'No flag from this group is set.')
-    },
-    ...args.map((a) => ({ value: a.name, label: `--${a.name}`, description: a.help }))
-  ]
-}
-
-function onExclusiveChange(group: string, value: string): void {
-  if (value === '') clearExclusive(group)
-  else selectExclusive(group, value)
-}
-
 // Score a query token against help prose. Strict (word-boundary or substring only); loose subsequence would make "cuda" hit unrelated help.
 function scoreHelp(needle: string, help: string): number {
   if (!needle) return 1
@@ -286,7 +269,20 @@ const structuredGroups = computed(() => {
       items.map((i) => i.item)
     )
   }
-  return result
+
+  // Pin currently-set flags to the top as their own section so they're
+  // editable without hunting through categories. Skipped while searching
+  // (the filtered list already narrows things down). Exclusive-group
+  // members surface as individual rows here for direct toggle-off.
+  if (q) return result
+  const activeItems: GroupItem[] = schema.value
+    .filter((a) => parsed.value.known.has(a.name))
+    .map((a) => ({ kind: 'arg', arg: a }))
+  if (activeItems.length === 0) return result
+  const ordered = new Map<string, GroupItem[]>()
+  ordered.set(t('comfyUISettings.argsActiveTitle', 'Active'), activeItems)
+  for (const [category, items] of result) ordered.set(category, items)
+  return ordered
 })
 
 const hasResults = computed(() =>
@@ -409,22 +405,58 @@ const unknownFlagsMessage = computed(() => {
         <header class="args-page-category-title">{{ category }}</header>
 
         <div v-for="(item, idx) in items" :key="idx" class="args-page-item">
-          <!-- Exclusive cluster as a select; a synthetic "None" option makes the group clearable (radios couldn't deselect). -->
+          <!-- Exclusive cluster as an inline radio list so every option is visible at a glance; the "None" radio clears the group. -->
           <template v-if="item.kind === 'exclusive' && item.args && item.group">
-            <div class="args-page-row args-page-row-cluster-label">
+            <div
+              class="args-page-cluster"
+              role="radiogroup"
+              :aria-label="t('comfyUISettings.argsExclusiveLabel', 'Choose one')"
+            >
               <span class="args-page-cluster-label">
                 {{ t('comfyUISettings.argsExclusiveLabel', 'Choose one') }}
               </span>
-            </div>
-            <!-- BaseSelect has two root nodes, so wrap in a div to carry the layout class. -->
-            <div class="args-page-exclusive-select">
-              <BaseSelect
-                :model-value="activeInGroup(item.group)"
-                :options="optionsForGroup(item.args)"
-                :aria-label="t('comfyUISettings.argsExclusiveLabel', 'Choose one')"
-                :placeholder="t('comfyUISettings.argsExclusiveNone', 'None (default)')"
-                @update:model-value="(v) => onExclusiveChange(item.group!, v)"
-              />
+              <label
+                class="args-page-radio-row"
+                :class="{ 'is-active': activeInGroup(item.group) === '' }"
+              >
+                <input
+                  type="radio"
+                  class="args-page-radio-input"
+                  :name="`exclusive-${item.group}`"
+                  :checked="activeInGroup(item.group) === ''"
+                  @change="clearExclusive(item.group!)"
+                >
+                <span class="args-page-radio-indicator" aria-hidden="true"></span>
+                <div class="args-page-radio-body">
+                  <span class="args-page-flag">{{
+                    t('comfyUISettings.argsExclusiveNone', 'None (default)')
+                  }}</span>
+                  <p class="args-page-help">
+                    {{
+                      t('comfyUISettings.argsExclusiveNoneHint', 'No flag from this group is set.')
+                    }}
+                  </p>
+                </div>
+              </label>
+              <label
+                v-for="opt in item.args"
+                :key="opt.name"
+                class="args-page-radio-row"
+                :class="{ 'is-active': activeInGroup(item.group) === opt.name }"
+              >
+                <input
+                  type="radio"
+                  class="args-page-radio-input"
+                  :name="`exclusive-${item.group}`"
+                  :checked="activeInGroup(item.group) === opt.name"
+                  @change="selectExclusive(item.group!, opt.name)"
+                >
+                <span class="args-page-radio-indicator" aria-hidden="true"></span>
+                <div class="args-page-radio-body">
+                  <span class="args-page-flag">--{{ opt.name }}</span>
+                  <p class="args-page-help">{{ opt.help }}</p>
+                </div>
+              </label>
             </div>
           </template>
 
@@ -774,10 +806,12 @@ const unknownFlagsMessage = computed(() => {
   }
 }
 
-/* "Choose one" cluster label above the BaseSelect picker. */
-.args-page-row-cluster-label {
-  padding: 0 2px;
-  margin: 2px 0 4px;
+/* "Choose one" radio cluster: label above an inline list of every option. */
+.args-page-cluster {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
 }
 
 .args-page-cluster-label {
@@ -786,13 +820,10 @@ const unknownFlagsMessage = computed(() => {
   color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.06em;
+  margin: 2px 0 4px;
+  padding: 0 2px;
 }
 
-.args-page-exclusive-select {
-  min-width: 0;
-}
-
-/* TODO(brand-cleanup): radio cluster styles below are unreferenced (exclusive group is a BaseSelect now); drop after validation. */
 .args-page-radio-row {
   display: grid;
   grid-template-columns: auto 1fr;

--- a/src/renderer/src/views/comfyUISettings/ArgsRawInput.vue
+++ b/src/renderer/src/views/comfyUISettings/ArgsRawInput.vue
@@ -28,6 +28,7 @@ const props = withDefaults(
 const emit = defineEmits<{
   'update:modelValue': [value: string]
   change: [value: string]
+  'focus-change': [focused: boolean]
 }>()
 
 const { t } = useI18n()
@@ -64,9 +65,11 @@ function handleChange(value: string): void {
 
 function onFocus(): void {
   focused.value = true
+  emit('focus-change', true)
 }
 function onBlur(): void {
   focused.value = false
+  emit('focus-change', false)
 }
 function onKeydown(e: KeyboardEvent): void {
   if (autocomplete.handleKeydown(e.key) === 'consumed') e.preventDefault()

--- a/src/renderer/src/views/comfyUISettings/ArgsRawInput.vue
+++ b/src/renderer/src/views/comfyUISettings/ArgsRawInput.vue
@@ -1,13 +1,17 @@
 <script setup lang="ts">
-import { ref, toRef, watch } from 'vue'
+import { computed, ref, toRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { AlertCircle } from 'lucide-vue-next'
 import BaseInput from '../../components/ui/BaseInput.vue'
 import { useArgsAutocomplete } from '../../composables/useArgsAutocomplete'
+import { validateArgs } from '../../lib/argsParser'
 import type { ComfyArgDef } from '../../types/ipc'
 
 /**
- * Raw startup-arguments text input with inline flag autocomplete.
- * Shared by the compact settings field and the full args sub-page.
+ * Raw startup-arguments text input with inline flag autocomplete and inline
+ * validation (colored token echo + per-issue messages + red invalid border).
+ * Shared by the compact settings field and the full args sub-page, so the
+ * correctness check shows wherever the raw field appears.
  */
 
 const props = withDefaults(
@@ -16,19 +20,16 @@ const props = withDefaults(
     schema: ComfyArgDef[]
     placeholder?: string
     ariaLabel?: string
-    invalid?: boolean
   }>(),
   {
     placeholder: '',
     ariaLabel: undefined,
-    invalid: false,
   },
 )
 
 const emit = defineEmits<{
   'update:modelValue': [value: string]
   change: [value: string]
-  'focus-change': [focused: boolean]
 }>()
 
 const { t } = useI18n()
@@ -54,6 +55,17 @@ const autocomplete = useArgsAutocomplete({
   },
 })
 
+// Inline validation: colored tokens + per-issue messages so unsupported flags,
+// missing values, and stray positionals are visible instead of silently
+// surviving. The trailing flag being typed is held off while focused.
+const validation = computed(() =>
+  props.schema.length
+    ? validateArgs(localValue.value, props.schema, { suppressTrailingPartial: focused.value })
+    : null,
+)
+const hasIssues = computed(() => validation.value?.hasIssues ?? false)
+const showTokenDisplay = computed(() => hasIssues.value || validation.value?.awaiting != null)
+
 function handleInput(value: string): void {
   localValue.value = value
   emit('update:modelValue', value)
@@ -65,11 +77,9 @@ function handleChange(value: string): void {
 
 function onFocus(): void {
   focused.value = true
-  emit('focus-change', true)
 }
 function onBlur(): void {
   focused.value = false
-  emit('focus-change', false)
 }
 function onKeydown(e: KeyboardEvent): void {
   if (autocomplete.handleKeydown(e.key) === 'consumed') e.preventDefault()
@@ -85,10 +95,11 @@ function onKeydown(e: KeyboardEvent): void {
   >
     <BaseInput
       mono
+      :spellcheck="false"
       :model-value="localValue"
       :placeholder="placeholder || t('comfyUISettings.argsPlaceholder', 'No arguments set')"
       :aria-label="ariaLabel"
-      :invalid="invalid"
+      :invalid="hasIssues"
       @update:model-value="handleInput"
       @change="handleChange"
     >
@@ -122,6 +133,75 @@ function onKeydown(e: KeyboardEvent): void {
         {{ t('comfyUISettings.argsAutocompleteHint', '↑↓ navigate · Tab/Enter select · Esc dismiss') }}
       </li>
     </ul>
+
+    <!-- Colored echo of the raw string so problem tokens are easy to spot. -->
+    <div
+      v-if="validation && showTokenDisplay && validation.tokens.length"
+      class="args-raw-tokens"
+      aria-hidden="true"
+    >
+      <span
+        v-for="(tok, i) in validation.tokens"
+        :key="i"
+        :class="{
+          'token-bad': tok.status === 'unsupported' || tok.status === 'orphaned',
+          'token-missing': tok.status === 'missing-value',
+          'token-awaiting': tok.status === 'awaiting-value',
+          'token-partial': tok.status === 'partial',
+        }"
+        :title="tok.tooltip || ''"
+        >{{ tok.text }}</span
+      >
+    </div>
+
+    <template v-if="validation">
+      <p v-if="validation.awaiting" class="args-raw-validation args-raw-validation-info" role="status">
+        <AlertCircle :size="12" aria-hidden="true" />
+        <span>
+          {{ validation.awaiting.text }}
+          {{ t('comfyUISettings.argsAwaitingValue', 'expects a value') }}
+        </span>
+      </p>
+      <p
+        v-if="validation.unsupportedFlags.length > 0"
+        class="args-raw-validation args-raw-validation-error"
+        role="status"
+      >
+        <AlertCircle :size="12" aria-hidden="true" />
+        <span>
+          {{ t('comfyUISettings.argsUnsupported', 'Unsupported:') }}
+          <code v-for="flag in validation.unsupportedFlags" :key="flag" class="args-raw-bad-flag"
+            >--{{ flag }}</code
+          >
+        </span>
+      </p>
+      <p
+        v-if="validation.missingValueFlags.length > 0"
+        class="args-raw-validation args-raw-validation-warn"
+        role="status"
+      >
+        <AlertCircle :size="12" aria-hidden="true" />
+        <span>
+          {{ t('comfyUISettings.argsMissingValue', 'Missing value for:') }}
+          <code v-for="flag in validation.missingValueFlags" :key="flag" class="args-raw-bad-flag">{{
+            flag
+          }}</code>
+        </span>
+      </p>
+      <p
+        v-if="validation.orphanedTokens.length > 0"
+        class="args-raw-validation args-raw-validation-error"
+        role="status"
+      >
+        <AlertCircle :size="12" aria-hidden="true" />
+        <span>
+          {{ t('comfyUISettings.argsUnexpected', 'Unexpected:') }}
+          <code v-for="tok in validation.orphanedTokens" :key="tok" class="args-raw-bad-flag">{{
+            tok
+          }}</code>
+        </span>
+      </p>
+    </template>
   </div>
 </template>
 
@@ -195,5 +275,85 @@ function onKeydown(e: KeyboardEvent): void {
   margin-top: 2px;
   text-align: right;
   cursor: default;
+}
+
+/* Colored echo of the raw string: each problem token underlined in its color. */
+.args-raw-tokens {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 6px;
+  margin: 6px 0 0;
+  padding: 6px 10px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-muted);
+  background: var(--neutral-800);
+  border: 1px solid var(--chooser-surface-border);
+  border-radius: 6px;
+}
+
+.args-raw-tokens .token-bad {
+  color: var(--danger);
+  text-decoration: underline wavy;
+  text-underline-offset: 3px;
+}
+
+.args-raw-tokens .token-missing {
+  color: var(--warning);
+  text-decoration: underline wavy;
+  text-underline-offset: 3px;
+}
+
+.args-raw-tokens .token-awaiting {
+  color: var(--accent-primary);
+  text-decoration: underline dotted;
+  text-underline-offset: 3px;
+}
+
+/* Trailing flag still being typed: dimmed, no error decoration. */
+.args-raw-tokens .token-partial {
+  color: var(--text-muted);
+  opacity: 0.6;
+}
+
+.args-raw-validation {
+  display: flex;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 6px 0 0;
+  padding: 6px 10px;
+  font-size: 11px;
+  line-height: 1.5;
+  border-radius: 6px;
+}
+
+.args-raw-validation :deep(svg) {
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.args-raw-validation-error {
+  color: var(--danger);
+  background: color-mix(in srgb, var(--danger) 12%, transparent);
+}
+
+.args-raw-validation-warn {
+  color: var(--warning);
+  background: color-mix(in srgb, var(--warning) 14%, transparent);
+}
+
+.args-raw-validation-info {
+  color: var(--accent-primary);
+  background: color-mix(in srgb, var(--accent-primary) 12%, transparent);
+}
+
+.args-raw-bad-flag {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  padding: 0 4px;
+  border-radius: 3px;
+  background: color-mix(in srgb, currentcolor 14%, transparent);
 }
 </style>

--- a/src/renderer/src/views/comfyUISettings/ArgsRawInput.vue
+++ b/src/renderer/src/views/comfyUISettings/ArgsRawInput.vue
@@ -16,10 +16,12 @@ const props = withDefaults(
     schema: ComfyArgDef[]
     placeholder?: string
     ariaLabel?: string
+    invalid?: boolean
   }>(),
   {
     placeholder: '',
     ariaLabel: undefined,
+    invalid: false,
   },
 )
 
@@ -83,6 +85,7 @@ function onKeydown(e: KeyboardEvent): void {
       :model-value="localValue"
       :placeholder="placeholder || t('comfyUISettings.argsPlaceholder', 'No arguments set')"
       :aria-label="ariaLabel"
+      :invalid="invalid"
       @update:model-value="handleInput"
       @change="handleChange"
     >


### PR DESCRIPTION
## Summary

Improves the v2 Settings drawer **Startup Arguments** editor.

### #1001 — exclusive groups: clearer `Choose one` (dropdown kept)
Exclusive flag groups (e.g. GPU/VRAM mode) use the compact `BaseSelect` dropdown to save space, but the `Choose one` label now **previews every member flag** (`Choose one: --cpu · --gpu-only · --lowvram`), so the choices are visible before opening. `None (default)` clears the group.

### #1002 — pin active args to the top
Currently-set flags are pinned to an **Active** section at the top of the list (when not searching). An active exclusive group is **promoted into Active as the same dropdown**, not split into individual toggles.

### #1003 — keep tabs clickable while the args sub-page is open
The settings tabs stay clickable while the args sub-page is open (removed `pointer-events: none` + `aria-hidden`); clicking any tab exits the sub-page. The strip keeps a subtle dim for context.

### Regression fix — recover raw-arguments validation
Before the big UX changes, the Raw arguments field highlighted bad tokens red and said what was wrong; this was lost in the v2 redesign (only a flat "unknown flag" message remained). Recovered via a shared, unit-tested `validateArgs()` classifier in `argsParser.ts` that powers:
- a **colored token echo** of the raw string (unsupported/orphaned in red, missing-value in amber, awaiting-value dotted),
- distinct **"Unsupported / Missing value for / Unexpected"** messages,
- a **red invalid border** on the raw input (`BaseInput :invalid`) when there's a real problem.

A trailing value-flag (e.g. `--port` while mid-typing) is shown as an info hint, not an error, so it doesn't flash red as you type.

Closes #1001
Closes #1002
Closes #1003

## Testing
- `pnpm run typecheck` ✅
- `pnpm run lint` ✅
- `pnpm run test` ✅ (2005 passed; new `argsParser.test.ts` for the classifier + dropdown/validation cases in `ArgsBuilderPage.test.ts`)
- `pnpm run build` ✅