### PR TITLE
feat(first-use): default Express Install to off

### DIFF
--- a/src/renderer/src/views/FirstUseTakeover.test.ts
+++ b/src/renderer/src/views/FirstUseTakeover.test.ts
@@ -139,10 +139,10 @@ describe('FirstUseTakeover start step', () => {
     expect(express().attributes('aria-hidden')).toBe('false')
   })
 
-  it('emits `chain-local` with `express: true` when Local is picked with Express on (no legacy desktop)', async () => {
+  it('emits `chain-local` with `express: false` when Local is picked and Express is left at its default-off state (no legacy desktop)', async () => {
     const wrapper = mountTakeover()
     // Accept T&C (Continue is gated on it), pick Local, leave Express
-    // checked (default), press Continue.
+    // at its default unchecked state, press Continue.
     await wrapper
       .find('[data-testid="first-use-consent-tos"] input[type="checkbox"]')
       .setValue(true)
@@ -151,10 +151,10 @@ describe('FirstUseTakeover start step', () => {
 
     const emitted = wrapper.emitted('chain-local')
     expect(emitted).toBeTruthy()
-    expect(emitted![0]).toEqual([{ express: true }])
+    expect(emitted![0]).toEqual([{ express: false }])
   })
 
-  it('emits `chain-local` with `express: false` when Express is unticked', async () => {
+  it('emits `chain-local` with `express: true` when Express is explicitly ticked', async () => {
     const wrapper = mountTakeover()
     await wrapper
       .find('[data-testid="first-use-consent-tos"] input[type="checkbox"]')
@@ -162,12 +162,12 @@ describe('FirstUseTakeover start step', () => {
     await wrapper.find('[data-testid="first-use-pick-local"]').trigger('click')
     await wrapper
       .find('[data-testid="first-use-express-install"] input[type="checkbox"]')
-      .setValue(false)
+      .setValue(true)
     await wrapper.find('[data-testid="first-use-continue"]').trigger('click')
 
     const emitted = wrapper.emitted('chain-local')
     expect(emitted).toBeTruthy()
-    expect(emitted![0]).toEqual([{ express: false }])
+    expect(emitted![0]).toEqual([{ express: true }])
   })
 
   it('hasLegacyDesktop + Express OFF + migrate OFF routes to the localBranch sub-step', async () => {
@@ -179,12 +179,9 @@ describe('FirstUseTakeover start step', () => {
       .find('[data-testid="first-use-consent-tos"] input[type="checkbox"]')
       .setValue(true)
     await wrapper.find('[data-testid="first-use-pick-local"]').trigger('click')
-    await wrapper
-      .find('[data-testid="first-use-express-install"] input[type="checkbox"]')
-      .setValue(false)
-    // Migrate is pre-ticked when legacy is detected; the localBranch
-    // fork is only reachable when the user explicitly opts out of
-    // BOTH express and migrate-existing.
+    // Express defaults to OFF; migrate is pre-ticked when legacy is
+    // detected. The localBranch fork is only reachable when the user
+    // explicitly opts out of migrate-existing too.
     await wrapper
       .find('[data-testid="first-use-migrate-existing"] input[type="checkbox"]')
       .setValue(false)
@@ -221,10 +218,13 @@ describe('FirstUseTakeover start step', () => {
       .find('[data-testid="first-use-consent-tos"] input[type="checkbox"]')
       .setValue(true)
     await wrapper.find('[data-testid="first-use-pick-local"]').trigger('click')
-    // Migrate AND Express are both pre-ticked on the legacy-desktop
-    // path — just press Continue. The host uses the `express: true`
-    // payload to skip the migrate confirm surface and run preview +
-    // auto-pick + run straight through.
+    // Migrate is pre-ticked on the legacy-desktop path; Express defaults
+    // to OFF and must be ticked explicitly. The host uses the
+    // `express: true` payload to skip the migrate confirm surface and
+    // run preview + auto-pick + run straight through.
+    await wrapper
+      .find('[data-testid="first-use-express-install"] input[type="checkbox"]')
+      .setValue(true)
     await wrapper.find('[data-testid="first-use-continue"]').trigger('click')
 
     const emitted = wrapper.emitted('chain-migrate')
@@ -265,11 +265,15 @@ describe('FirstUseTakeover start step', () => {
       .find('[data-testid="first-use-consent-tos"] input[type="checkbox"]')
       .setValue(true)
     await wrapper.find('[data-testid="first-use-pick-local"]').trigger('click')
-    // Untick the migrate checkbox: returning user explicitly opts out
-    // and wants a clean Standalone install instead.
+    // Untick migrate (returning user opts out, wants a clean Standalone)
+    // and tick Express (now default-off, opt-in to the skip-Configure
+    // path).
     await wrapper
       .find('[data-testid="first-use-migrate-existing"] input[type="checkbox"]')
       .setValue(false)
+    await wrapper
+      .find('[data-testid="first-use-express-install"] input[type="checkbox"]')
+      .setValue(true)
     await wrapper.find('[data-testid="first-use-continue"]').trigger('click')
 
     expect(wrapper.emitted('chain-migrate')).toBeFalsy()

--- a/src/renderer/src/views/FirstUseTakeover.vue
+++ b/src/renderer/src/views/FirstUseTakeover.vue
@@ -233,10 +233,12 @@ const cloudDescriptionKey = computed(() => {
   if (cloudCapacity.isDegraded()) return 'cloud.capacityDegradedHint'
   return 'firstUse.cloudDesc'
 })
-/** Express-install opt-out modifier on the start screen. Pre-ticked.
- *  Functional wiring (skipping optional setup steps) lands separately;
- *  for now the value is captured for telemetry only. */
-const expressInstall = ref(true)
+/** Express-install opt-in modifier on the start screen. Defaults OFF
+ *  so users land on Configure (install path, GPU, options) before any
+ *  files are written — too many people zoomed past the default-on
+ *  modifier and ended up with an unwanted C:\ install. Ticking it
+ *  restores the express skip-Configure path. */
+const expressInstall = ref(false)
 /** Peer modifier alongside Express Install, only rendered when an
  *  auto-tracked legacy install was detected on the machine. When
  *  checked, Continue routes straight to chain-migrate so the existing
@@ -590,7 +592,7 @@ async function open(opts: OpenOpts = {}): Promise<void> {
   if (forkExperimentVariant.value) {
     applyForkExperimentDefault(forkExperimentVariant.value)
   }
-  expressInstall.value = true
+  expressInstall.value = false
   migrateExisting.value = true
   // `onContinue` keeps `isContinuing` true past `routePostStart()`
   // because the chain handlers normally unmount this takeover within


### PR DESCRIPTION
Flip the Express Install modifier on the first-use start screen from default-on (opt-out) to default-off (opt-in).

## Why
Too many users have been complaining that we install ComfyUI on the C: drive. The opt-out path *exists* on the Configure step — they're just zooming past Continue while Express is still ticked, which skips Configure entirely. Making Express opt-in forces them through the install-path / GPU step before any files are written.

## Changes
- `FirstUseTakeover.vue`: `expressInstall = ref(false)` (was `true`); also flipped in the `open()` reset path so a takeover replay still defaults off.
- Updated four tests in `FirstUseTakeover.test.ts` that relied on the default-on assumption:
  - "chain-local with express: true (no legacy)" → renamed to assert `express: false` is the default emission, and added an inverse test that ticks the box.
  - "chain-migrate with express: true" → ticks Express explicitly.
  - "chain-local fresh express install" → ticks Express explicitly.
  - "Express OFF + migrate OFF routes to localBranch" → drops the now-redundant `setValue(false)` on Express.

All 24 tests in the file pass.