### PR TITLE
refactor: treat Comfy Cloud as a regular install row (unpin from top)

### DIFF
--- a/e2e/title-bar-hover-gate-comfy-window.test.ts
+++ b/e2e/title-bar-hover-gate-comfy-window.test.ts
@@ -37,13 +37,15 @@ test.beforeAll(async () => {
   ctx = await launchApp({ settings: { firstUseCompleted: true, telemetryEnabled: false } })
   titleBar = ctx.titleBar
 
-  // Click the always-present Cloud tile and wait for the existing
+  // Click the auto-seeded Cloud install row (post unsticky-cloud, it's no
+  // longer a dedicated `.chooser-tile-cloud` CTA — it renders through
+  // `ChooserInstallTile` like any other install). Wait for the existing
   // title-bar view to flip into install-backed mode via the
   // `comfy-titlebar:installation-id-changed` IPC. The pill dropping
   // `.is-install-less` is the user-visible signal that the identity
   // handshake completed; it doubles as a sanity check before the
   // hover-gate assertions below.
-  await ctx.panel.click('.chooser-tile-cloud')
+  await ctx.panel.click('.chooser-tile[data-source-category="cloud"]')
   await expect.poll(() => titleBar.exists('.title-install-pill:not(.is-install-less)'), {
     timeout: 30_000,
     intervals: [100, 200, 500],

--- a/locales/en.json
+++ b/locales/en.json
@@ -409,7 +409,7 @@
     "confirmBeforeClosingWindow": "Confirm before closing a window",
     "confirmBeforeClosingWindowDescription": "Ask for confirmation before closing a window that's running a local install.",
     "hideCloudFromPicker": "Hide Cloud from the Instance Picker",
-    "hideCloudFromPickerDescription": "For local-only users — hides the Cloud tile (and the Try Cloud CTA) from the Dashboard. Cloud remains fully functional; you can re-enable this any time.",
+    "hideCloudFromPickerDescription": "For local-only users — hides the Cloud row from the Dashboard. Cloud remains fully functional; you can re-enable this any time.",
     "checkForUpdates": "Check for updates",
     "checkingForUpdates": "Checking…",
     "telemetry": "Telemetry",

--- a/src/renderer/src/comfyTitlePopup/InstancePickerView.test.ts
+++ b/src/renderer/src/comfyTitlePopup/InstancePickerView.test.ts
@@ -203,6 +203,34 @@ describe('comfyTitlePopup/InstancePickerView', () => {
       expect(namesInOrder).toEqual(['New', 'Old', 'Never'])
     })
 
+    // Regression: cloud rows are no longer pinned ahead of more-recent
+    // installs — they sort by their own lastLaunchedAt like everyone else.
+    it('places a cloud row below a more-recent local row (no cloud pinning)', async () => {
+      const wrapper = await mountPicker({
+        installs: [
+          makeInstall({
+            id: 'old-cloud',
+            name: 'OldCloud',
+            sourceCategory: 'cloud',
+            sourceLabel: 'Cloud',
+            lastLaunchedAt: 100,
+          }),
+          makeInstall({
+            id: 'recent-local',
+            name: 'RecentLocal',
+            sourceCategory: 'local',
+            lastLaunchedAt: 1_000,
+          }),
+        ],
+        activeInstallationId: null,
+        runningInstallationIds: [],
+      })
+      const namesInOrder = wrapper
+        .findAll('.picker-row-name')
+        .map((n) => n.text())
+      expect(namesInOrder).toEqual(['RecentLocal', 'OldCloud'])
+    })
+
     it('marks running rows with the is-running class', async () => {
       const wrapper = await mountPicker({
         installs: [

--- a/src/renderer/src/comfyTitlePopup/InstancePickerView.vue
+++ b/src/renderer/src/comfyTitlePopup/InstancePickerView.vue
@@ -173,29 +173,10 @@ const installationsRef = toRef(() => installations.value)
 const {
   searchQuery,
   activeFilter,
-  cloudInstall,
   visibleInstalls,
-  showCloudCard,
   showEmptyHint,
   lastLaunchedShortLabel
 } = useInstallList({ installations: installationsRef })
-
-/** Folds cloud into the recency-sorted list (sorted by its own
- *  lastLaunchedAt). On a recency tie cloud is ordered first, but the
- *  auto-selected default still favours a real install (see
- *  `resolvePickerSelectedInstallId` in main). */
-const pickerRows = computed<Installation[]>(() => {
-  const rows = [...visibleInstalls.value]
-  if (showCloudCard.value && cloudInstall.value) {
-    rows.push(cloudInstall.value)
-  }
-  return rows.sort((a, b) => {
-    const ta = a.lastLaunchedAt ?? -Infinity
-    const tb = b.lastLaunchedAt ?? -Infinity
-    if (tb !== ta) return tb - ta
-    return (b.sourceCategory === 'cloud' ? 1 : 0) - (a.sourceCategory === 'cloud' ? 1 : 0)
-  })
-})
 
 const visibleChips = computed(() => {
   return FILTER_CHIPS.filter((chip) => {
@@ -210,21 +191,11 @@ const visibleChips = computed(() => {
   })
 })
 
-/** Default selection when the popup opens with no active/selected install.
- *  Tie-break mirrors main's `mostRecentlyLaunchedInstallId`: on a tie a real
- *  install wins so the always-seeded Cloud entry can't claim the default. */
+/** Default selection when the popup opens with no active/selected install. */
 function mostRecentInstallId(installs: PickerInstall[]): string | null {
   let best: PickerInstall | undefined
   for (const inst of installs) {
-    if (!best) {
-      best = inst
-      continue
-    }
-    const ts = inst.lastLaunchedAt ?? 0
-    const bestTs = best.lastLaunchedAt ?? 0
-    if (ts > bestTs) {
-      best = inst
-    } else if (ts === bestTs && best.sourceCategory === 'cloud' && inst.sourceCategory !== 'cloud') {
+    if (!best || (inst.lastLaunchedAt ?? 0) > (best.lastLaunchedAt ?? 0)) {
       best = inst
     }
   }
@@ -560,7 +531,7 @@ async function handleExpandedPrimaryAction(restartInPlace: boolean): Promise<voi
 
           <div class="picker-list" role="listbox">
             <InstanceRow
-              v-for="inst in pickerRows"
+              v-for="inst in visibleInstalls"
               :key="inst.id"
               :installation="inst"
               :active="selectedId === inst.id"

--- a/src/renderer/src/composables/useInstallList.test.ts
+++ b/src/renderer/src/composables/useInstallList.test.ts
@@ -218,69 +218,6 @@ describe('useInstallList', () => {
     })
   })
 
-  describe('showTryCloudEmptyState', () => {
-    it('shows the Try-Cloud empty-state only when the user has zero installs', () => {
-      const installations = ref<Installation[]>([])
-      const list = withI18nScope(i18n, () => useInstallList({ installations }))
-
-      expect(list.showTryCloudEmptyState.value).toBe(true)
-    })
-
-    it('disappears once any non-cloud install exists OR cloud has been launched', () => {
-      // Local and remote installs immediately suppress the first-run CTA.
-      // For cloud, only a previously-launched cloud install does — an
-      // auto-seeded never-launched cloud install must NOT suppress the CTA,
-      // otherwise first-run users would never see the promo (the app ships
-      // with a default Comfy Cloud install on every fresh boot).
-      const localOnly = ref<Installation[]>([
-        makeInstall({ id: 'a', sourceCategory: 'local' }),
-      ])
-      const cloudLaunched = ref<Installation[]>([
-        makeInstall({ id: 'c', sourceCategory: 'cloud', lastLaunchedAt: 1234 }),
-      ])
-      const remoteOnly = ref<Installation[]>([
-        makeInstall({ id: 'r', sourceCategory: 'remote' }),
-      ])
-      for (const installations of [localOnly, cloudLaunched, remoteOnly]) {
-        const list = withI18nScope(i18n, () => useInstallList({ installations }))
-        expect(list.showTryCloudEmptyState.value).toBe(false)
-      }
-    })
-
-    it('still shows for the auto-seeded never-launched cloud install (first-run candidate)', () => {
-      // Matches the production seed shape: Comfy Cloud added on first boot
-      // with no `lastLaunchedAt`. The CTA is the primary call-to-action to
-      // enter cloud at that point.
-      const installations = ref<Installation[]>([
-        makeInstall({ id: 'cloud', sourceCategory: 'cloud' }),
-      ])
-      const list = withI18nScope(i18n, () => useInstallList({ installations }))
-      expect(list.showTryCloudEmptyState.value).toBe(true)
-    })
-
-    it('hides while a search query is active even with zero installs', () => {
-      const installations = ref<Installation[]>([])
-      const list = withI18nScope(i18n, () => useInstallList({ installations }))
-
-      list.searchQuery.value = 'foo'
-      expect(list.showTryCloudEmptyState.value).toBe(false)
-    })
-
-    it('hides when the active filter excludes cloud', () => {
-      const installations = ref<Installation[]>([])
-      const list = withI18nScope(i18n, () => useInstallList({ installations }))
-
-      list.activeFilter.value = 'local'
-      expect(list.showTryCloudEmptyState.value).toBe(false)
-      list.activeFilter.value = 'remote'
-      expect(list.showTryCloudEmptyState.value).toBe(false)
-      list.activeFilter.value = 'cloud'
-      expect(list.showTryCloudEmptyState.value).toBe(true)
-      list.activeFilter.value = 'all'
-      expect(list.showTryCloudEmptyState.value).toBe(true)
-    })
-  })
-
   describe('showEmptyHint', () => {
     it('hides when the user has not typed anything', () => {
       const installations = ref<Installation[]>([])
@@ -395,16 +332,12 @@ describe('useInstallList', () => {
       expect(list.visibleInstalls.value.length).toBe(2)
     })
 
-    it('adds a launched cloud install to the same list', () => {
-      // A never-launched cloud install is held back from the row list while
-      // the Try-Cloud CTA is showing (avoids duplicate cloud entry points
-      // for first-run users). Once cloud has been launched, the CTA goes
-      // away and the cloud row joins the list.
+    it('adds a newly-added cloud install to the same list', () => {
       const installations = ref<Installation[]>([])
       const list = withI18nScope(i18n, () => useInstallList({ installations }))
 
       expect(list.visibleInstalls.value).toEqual([])
-      installations.value = [makeInstall({ id: 'c', sourceCategory: 'cloud', lastLaunchedAt: 1234 })]
+      installations.value = [makeInstall({ id: 'c', sourceCategory: 'cloud' })]
       expect(list.visibleInstalls.value.map((i) => i.id)).toEqual(['c'])
     })
   })

--- a/src/renderer/src/composables/useInstallList.test.ts
+++ b/src/renderer/src/composables/useInstallList.test.ts
@@ -35,29 +35,6 @@ describe('useInstallList', () => {
     vi.useRealTimers()
   })
 
-  describe('cloud vs non-cloud split', () => {
-    it('separates the single cloud install from the non-cloud list', () => {
-      const installations = ref<Installation[]>([
-        makeInstall({ id: 'a', name: 'Local A', sourceCategory: 'local' }),
-        makeInstall({ id: 'c', name: 'Cloud', sourceCategory: 'cloud' }),
-        makeInstall({ id: 'r', name: 'Remote', sourceCategory: 'remote' }),
-      ])
-      const list = withI18nScope(i18n, () => useInstallList({ installations }))
-
-      expect(list.cloudInstall.value?.id).toBe('c')
-      expect(list.nonCloudInstalls.value.map((i) => i.id)).toEqual(['a', 'r'])
-    })
-
-    it('reports null cloudInstall when none present', () => {
-      const installations = ref<Installation[]>([
-        makeInstall({ id: 'a', sourceCategory: 'local' }),
-      ])
-      const list = withI18nScope(i18n, () => useInstallList({ installations }))
-
-      expect(list.cloudInstall.value).toBeNull()
-    })
-  })
-
   describe('recency sort', () => {
     it('orders by lastLaunchedAt desc with never-launched at the end', () => {
       const installations = ref<Installation[]>([
@@ -74,6 +51,60 @@ describe('useInstallList', () => {
         'old',
         'never',
       ])
+    })
+
+    // Regression: cloud must not jump above an older local install — recency
+    // is the only thing that decides order. Before the unpin refactor, cloud
+    // lived in its own surface (dashboard) or was tie-break-pinned (picker),
+    // both of which broke straight recency ordering.
+    it('places a cloud install below a more-recent local install (no cloud pinning)', () => {
+      const installations = ref<Installation[]>([
+        makeInstall({
+          id: 'recent-local',
+          name: 'RecentLocal',
+          sourceCategory: 'local',
+          lastLaunchedAt: 1_000,
+        }),
+        makeInstall({
+          id: 'old-cloud',
+          name: 'OldCloud',
+          sourceCategory: 'cloud',
+          lastLaunchedAt: 100,
+        }),
+      ])
+      const list = withI18nScope(i18n, () => useInstallList({ installations }))
+
+      expect(list.visibleInstalls.value.map((i) => i.id)).toEqual([
+        'recent-local',
+        'old-cloud',
+      ])
+    })
+
+    // Tie-break sanity: with equal recency, cloud is no longer pinned ahead
+    // of local — order falls back to whatever sort() lands on, which for a
+    // stable timsort is input order. The contract is "cloud isn't special",
+    // so we just assert both are present and neither got dropped.
+    it('does not pin cloud ahead of a same-recency local install', () => {
+      const installations = ref<Installation[]>([
+        makeInstall({
+          id: 'local-tie',
+          name: 'LocalTie',
+          sourceCategory: 'local',
+          lastLaunchedAt: 500,
+        }),
+        makeInstall({
+          id: 'cloud-tie',
+          name: 'CloudTie',
+          sourceCategory: 'cloud',
+          lastLaunchedAt: 500,
+        }),
+      ])
+      const list = withI18nScope(i18n, () => useInstallList({ installations }))
+
+      const ids = list.visibleInstalls.value.map((i) => i.id)
+      // Stable sort on a tie keeps the input order; the test guards against
+      // a regression that explicitly re-orders cloud to the top.
+      expect(ids).toEqual(['local-tie', 'cloud-tie'])
     })
   })
 
@@ -102,7 +133,7 @@ describe('useInstallList', () => {
       expect(list.visibleInstalls.value.map((i) => i.id)).toEqual(['r'])
     })
 
-    it('cloud filter empties visibleInstalls (Cloud is rendered separately)', () => {
+    it('cloud filter keeps only cloud installs', () => {
       const installations = ref<Installation[]>([
         makeInstall({ id: 'l', sourceCategory: 'local' }),
         makeInstall({ id: 'c', sourceCategory: 'cloud' }),
@@ -110,10 +141,10 @@ describe('useInstallList', () => {
       const list = withI18nScope(i18n, () => useInstallList({ installations }))
 
       list.activeFilter.value = 'cloud'
-      expect(list.visibleInstalls.value).toEqual([])
+      expect(list.visibleInstalls.value.map((i) => i.id)).toEqual(['c'])
     })
 
-    it('all filter shows every non-cloud install', () => {
+    it('all filter shows every install including cloud', () => {
       const installations = ref<Installation[]>([
         makeInstall({ id: 'l', sourceCategory: 'local' }),
         makeInstall({ id: 'r', sourceCategory: 'remote' }),
@@ -123,8 +154,13 @@ describe('useInstallList', () => {
       ])
       const list = withI18nScope(i18n, () => useInstallList({ installations }))
 
-      // 'all' is the default.
-      expect(list.visibleInstalls.value.map((i) => i.id).sort()).toEqual(['d', 'l', 'r'])
+      // 'all' is the default; cloud is no longer split out of the list.
+      expect(list.visibleInstalls.value.map((i) => i.id).sort()).toEqual([
+        'c',
+        'd',
+        'l',
+        'r',
+      ])
     })
   })
 
@@ -150,6 +186,17 @@ describe('useInstallList', () => {
       expect(list.visibleInstalls.value.map((i) => i.id)).toEqual(['a'])
     })
 
+    it('search reaches cloud installs too (cloud is in the same list)', () => {
+      const installations = ref<Installation[]>([
+        makeInstall({ id: 'c', name: 'Comfy Cloud', sourceCategory: 'cloud' }),
+        makeInstall({ id: 'l', name: 'Local Box', sourceCategory: 'local' }),
+      ])
+      const list = withI18nScope(i18n, () => useInstallList({ installations }))
+
+      list.searchQuery.value = 'cloud'
+      expect(list.visibleInstalls.value.map((i) => i.id)).toEqual(['c'])
+    })
+
     it('matchesQuery is case-insensitive', () => {
       const installations = ref<Installation[]>([])
       const list = withI18nScope(i18n, () => useInstallList({ installations }))
@@ -171,50 +218,50 @@ describe('useInstallList', () => {
     })
   })
 
-  describe('showCloudCard', () => {
-    it('shows the cloud CTA when no cloud install exists and no query', () => {
+  describe('showTryCloudEmptyState', () => {
+    it('shows the Try-Cloud empty-state only when the user has zero installs', () => {
       const installations = ref<Installation[]>([])
       const list = withI18nScope(i18n, () => useInstallList({ installations }))
 
-      expect(list.showCloudCard.value).toBe(true)
+      expect(list.showTryCloudEmptyState.value).toBe(true)
     })
 
-    it('hides the cloud CTA once the user starts typing (when no cloud install exists)', () => {
+    it('disappears once any install exists (local, cloud, remote, anything)', () => {
+      const localOnly = ref<Installation[]>([
+        makeInstall({ id: 'a', sourceCategory: 'local' }),
+      ])
+      const cloudOnly = ref<Installation[]>([
+        makeInstall({ id: 'c', sourceCategory: 'cloud' }),
+      ])
+      const remoteOnly = ref<Installation[]>([
+        makeInstall({ id: 'r', sourceCategory: 'remote' }),
+      ])
+      for (const installations of [localOnly, cloudOnly, remoteOnly]) {
+        const list = withI18nScope(i18n, () => useInstallList({ installations }))
+        expect(list.showTryCloudEmptyState.value).toBe(false)
+      }
+    })
+
+    it('hides while a search query is active even with zero installs', () => {
       const installations = ref<Installation[]>([])
       const list = withI18nScope(i18n, () => useInstallList({ installations }))
 
       list.searchQuery.value = 'foo'
-      expect(list.showCloudCard.value).toBe(false)
+      expect(list.showTryCloudEmptyState.value).toBe(false)
     })
 
-    it('keeps the cloud card visible when a real cloud install matches the query', () => {
-      const installations = ref<Installation[]>([
-        makeInstall({ id: 'c', name: 'My Cloud', sourceCategory: 'cloud' }),
-      ])
-      const list = withI18nScope(i18n, () => useInstallList({ installations }))
-
-      list.searchQuery.value = 'cloud'
-      expect(list.showCloudCard.value).toBe(true)
-    })
-
-    it('hides the cloud card when a real cloud install does NOT match the query', () => {
-      const installations = ref<Installation[]>([
-        makeInstall({ id: 'c', name: 'My Cloud', sourceCategory: 'cloud' }),
-      ])
-      const list = withI18nScope(i18n, () => useInstallList({ installations }))
-
-      list.searchQuery.value = 'zzzzzzz'
-      expect(list.showCloudCard.value).toBe(false)
-    })
-
-    it('hides the cloud card when the active filter excludes cloud', () => {
-      const installations = ref<Installation[]>([
-        makeInstall({ id: 'c', sourceCategory: 'cloud' }),
-      ])
+    it('hides when the active filter excludes cloud', () => {
+      const installations = ref<Installation[]>([])
       const list = withI18nScope(i18n, () => useInstallList({ installations }))
 
       list.activeFilter.value = 'local'
-      expect(list.showCloudCard.value).toBe(false)
+      expect(list.showTryCloudEmptyState.value).toBe(false)
+      list.activeFilter.value = 'remote'
+      expect(list.showTryCloudEmptyState.value).toBe(false)
+      list.activeFilter.value = 'cloud'
+      expect(list.showTryCloudEmptyState.value).toBe(true)
+      list.activeFilter.value = 'all'
+      expect(list.showTryCloudEmptyState.value).toBe(true)
     })
   })
 
@@ -226,7 +273,7 @@ describe('useInstallList', () => {
       expect(list.showEmptyHint.value).toBe(false)
     })
 
-    it('shows when query is non-empty AND no installs match AND cloud card is hidden', () => {
+    it('shows when query is non-empty AND no installs match', () => {
       const installations = ref<Installation[]>([
         makeInstall({ id: 'a', name: 'Alpha' }),
       ])
@@ -236,7 +283,7 @@ describe('useInstallList', () => {
       expect(list.showEmptyHint.value).toBe(true)
     })
 
-    it('hides when the cloud card is still visible (its match counts as a result)', () => {
+    it('hides when a cloud install matches the query (it counts as a result now)', () => {
       const installations = ref<Installation[]>([
         makeInstall({ id: 'c', name: 'Comfy Cloud', sourceCategory: 'cloud' }),
       ])
@@ -332,13 +379,13 @@ describe('useInstallList', () => {
       expect(list.visibleInstalls.value.length).toBe(2)
     })
 
-    it('keeps cloud install reactive to input changes', () => {
+    it('adds a newly-added cloud install to the same list', () => {
       const installations = ref<Installation[]>([])
       const list = withI18nScope(i18n, () => useInstallList({ installations }))
 
-      expect(list.cloudInstall.value).toBeNull()
+      expect(list.visibleInstalls.value).toEqual([])
       installations.value = [makeInstall({ id: 'c', sourceCategory: 'cloud' })]
-      expect(list.cloudInstall.value?.id).toBe('c')
+      expect(list.visibleInstalls.value.map((i) => i.id)).toEqual(['c'])
     })
   })
 })

--- a/src/renderer/src/composables/useInstallList.test.ts
+++ b/src/renderer/src/composables/useInstallList.test.ts
@@ -226,20 +226,36 @@ describe('useInstallList', () => {
       expect(list.showTryCloudEmptyState.value).toBe(true)
     })
 
-    it('disappears once any install exists (local, cloud, remote, anything)', () => {
+    it('disappears once any non-cloud install exists OR cloud has been launched', () => {
+      // Local and remote installs immediately suppress the first-run CTA.
+      // For cloud, only a previously-launched cloud install does — an
+      // auto-seeded never-launched cloud install must NOT suppress the CTA,
+      // otherwise first-run users would never see the promo (the app ships
+      // with a default Comfy Cloud install on every fresh boot).
       const localOnly = ref<Installation[]>([
         makeInstall({ id: 'a', sourceCategory: 'local' }),
       ])
-      const cloudOnly = ref<Installation[]>([
-        makeInstall({ id: 'c', sourceCategory: 'cloud' }),
+      const cloudLaunched = ref<Installation[]>([
+        makeInstall({ id: 'c', sourceCategory: 'cloud', lastLaunchedAt: 1234 }),
       ])
       const remoteOnly = ref<Installation[]>([
         makeInstall({ id: 'r', sourceCategory: 'remote' }),
       ])
-      for (const installations of [localOnly, cloudOnly, remoteOnly]) {
+      for (const installations of [localOnly, cloudLaunched, remoteOnly]) {
         const list = withI18nScope(i18n, () => useInstallList({ installations }))
         expect(list.showTryCloudEmptyState.value).toBe(false)
       }
+    })
+
+    it('still shows for the auto-seeded never-launched cloud install (first-run candidate)', () => {
+      // Matches the production seed shape: Comfy Cloud added on first boot
+      // with no `lastLaunchedAt`. The CTA is the primary call-to-action to
+      // enter cloud at that point.
+      const installations = ref<Installation[]>([
+        makeInstall({ id: 'cloud', sourceCategory: 'cloud' }),
+      ])
+      const list = withI18nScope(i18n, () => useInstallList({ installations }))
+      expect(list.showTryCloudEmptyState.value).toBe(true)
     })
 
     it('hides while a search query is active even with zero installs', () => {
@@ -379,12 +395,16 @@ describe('useInstallList', () => {
       expect(list.visibleInstalls.value.length).toBe(2)
     })
 
-    it('adds a newly-added cloud install to the same list', () => {
+    it('adds a launched cloud install to the same list', () => {
+      // A never-launched cloud install is held back from the row list while
+      // the Try-Cloud CTA is showing (avoids duplicate cloud entry points
+      // for first-run users). Once cloud has been launched, the CTA goes
+      // away and the cloud row joins the list.
       const installations = ref<Installation[]>([])
       const list = withI18nScope(i18n, () => useInstallList({ installations }))
 
       expect(list.visibleInstalls.value).toEqual([])
-      installations.value = [makeInstall({ id: 'c', sourceCategory: 'cloud' })]
+      installations.value = [makeInstall({ id: 'c', sourceCategory: 'cloud', lastLaunchedAt: 1234 })]
       expect(list.visibleInstalls.value.map((i) => i.id)).toEqual(['c'])
     })
   })

--- a/src/renderer/src/composables/useInstallList.ts
+++ b/src/renderer/src/composables/useInstallList.ts
@@ -36,9 +36,6 @@ export interface UseInstallListApi {
   searchQuery: Ref<string>
   activeFilter: Ref<FilterKey>
   visibleInstalls: ComputedRef<Installation[]>
-  /** True only when the user has zero installs of any source — drives the
-   *  first-run Try-Cloud empty-state CTA on the dashboard. */
-  showTryCloudEmptyState: ComputedRef<boolean>
   showEmptyHint: ComputedRef<boolean>
   matchesQuery: (name: string) => boolean
   lastLaunchedLabel: (inst: Installation) => string
@@ -83,36 +80,8 @@ export function useInstallList(opts: UseInstallListOpts): UseInstallListApi {
       : installations.value,
   )
 
-  const showTryCloudEmptyState = computed<boolean>(() => {
-    // First-run Try-Cloud CTA. The auto-seeded Comfy Cloud install ships
-    // with every install and would suppress this CTA on its own if we
-    // gated on `effectiveInstalls.length === 0`, so we instead require
-    // (a) no non-cloud installs of any kind and (b) cloud has never
-    // actually been launched. A user who has clicked into cloud once is
-    // no longer a "first-run" candidate for the promo.
-    if (hideCloudFromPicker.value) return false
-    if (searchQuery.value.trim()) return false
-    const hasNonCloudInstall = effectiveInstalls.value.some((i) => i.sourceCategory !== 'cloud')
-    if (hasNonCloudInstall) return false
-    const cloudLaunched = effectiveInstalls.value.some(
-      (i) => i.sourceCategory === 'cloud' && typeof i.lastLaunchedAt === 'number',
-    )
-    if (cloudLaunched) return false
-    const inCategory = activeFilter.value === 'all' || activeFilter.value === 'cloud'
-    return inCategory
-  })
-
   const visibleInstalls = computed<Installation[]>(() => {
-    // Hide the auto-seeded, never-launched cloud row while the Try-Cloud
-    // empty-state tile is rendering — the tile is the entry to cloud for
-    // a first-run user and showing both reads as a duplicate.
-    const tileShowing = showTryCloudEmptyState.value
-    const source = tileShowing
-      ? effectiveInstalls.value.filter(
-          (i) => i.sourceCategory !== 'cloud' || typeof i.lastLaunchedAt === 'number',
-        )
-      : effectiveInstalls.value
-    const sorted = [...source].sort(sortByRecency)
+    const sorted = [...effectiveInstalls.value].sort(sortByRecency)
     const byCategory = (() => {
       switch (activeFilter.value) {
         case 'all':
@@ -204,7 +173,6 @@ export function useInstallList(opts: UseInstallListOpts): UseInstallListApi {
     searchQuery,
     activeFilter,
     visibleInstalls,
-    showTryCloudEmptyState,
     showEmptyHint,
     matchesQuery,
     lastLaunchedLabel,

--- a/src/renderer/src/composables/useInstallList.ts
+++ b/src/renderer/src/composables/useInstallList.ts
@@ -83,8 +83,36 @@ export function useInstallList(opts: UseInstallListOpts): UseInstallListApi {
       : installations.value,
   )
 
+  const showTryCloudEmptyState = computed<boolean>(() => {
+    // First-run Try-Cloud CTA. The auto-seeded Comfy Cloud install ships
+    // with every install and would suppress this CTA on its own if we
+    // gated on `effectiveInstalls.length === 0`, so we instead require
+    // (a) no non-cloud installs of any kind and (b) cloud has never
+    // actually been launched. A user who has clicked into cloud once is
+    // no longer a "first-run" candidate for the promo.
+    if (hideCloudFromPicker.value) return false
+    if (searchQuery.value.trim()) return false
+    const hasNonCloudInstall = effectiveInstalls.value.some((i) => i.sourceCategory !== 'cloud')
+    if (hasNonCloudInstall) return false
+    const cloudLaunched = effectiveInstalls.value.some(
+      (i) => i.sourceCategory === 'cloud' && typeof i.lastLaunchedAt === 'number',
+    )
+    if (cloudLaunched) return false
+    const inCategory = activeFilter.value === 'all' || activeFilter.value === 'cloud'
+    return inCategory
+  })
+
   const visibleInstalls = computed<Installation[]>(() => {
-    const sorted = [...effectiveInstalls.value].sort(sortByRecency)
+    // Hide the auto-seeded, never-launched cloud row while the Try-Cloud
+    // empty-state tile is rendering — the tile is the entry to cloud for
+    // a first-run user and showing both reads as a duplicate.
+    const tileShowing = showTryCloudEmptyState.value
+    const source = tileShowing
+      ? effectiveInstalls.value.filter(
+          (i) => i.sourceCategory !== 'cloud' || typeof i.lastLaunchedAt === 'number',
+        )
+      : effectiveInstalls.value
+    const sorted = [...source].sort(sortByRecency)
     const byCategory = (() => {
       switch (activeFilter.value) {
         case 'all':
@@ -100,17 +128,6 @@ export function useInstallList(opts: UseInstallListOpts): UseInstallListApi {
       }
     })()
     return byCategory.filter((i) => matchesQuery(i.name))
-  })
-
-  const showTryCloudEmptyState = computed<boolean>(() => {
-    // First-run Try-Cloud CTA: only when the user truly has nothing
-    // installed yet AND hasn't opted out of cloud surfaces. Suppressed
-    // once a search query is active so it doesn't read as a result.
-    if (hideCloudFromPicker.value) return false
-    if (effectiveInstalls.value.length > 0) return false
-    if (searchQuery.value.trim()) return false
-    const inCategory = activeFilter.value === 'all' || activeFilter.value === 'cloud'
-    return inCategory
   })
 
   const showEmptyHint = computed<boolean>(

--- a/src/renderer/src/composables/useInstallList.ts
+++ b/src/renderer/src/composables/useInstallList.ts
@@ -35,10 +35,10 @@ export interface UseInstallListOpts {
 export interface UseInstallListApi {
   searchQuery: Ref<string>
   activeFilter: Ref<FilterKey>
-  cloudInstall: ComputedRef<Installation | null>
-  nonCloudInstalls: ComputedRef<Installation[]>
   visibleInstalls: ComputedRef<Installation[]>
-  showCloudCard: ComputedRef<boolean>
+  /** True only when the user has zero installs of any source — drives the
+   *  first-run Try-Cloud empty-state CTA on the dashboard. */
+  showTryCloudEmptyState: ComputedRef<boolean>
   showEmptyHint: ComputedRef<boolean>
   matchesQuery: (name: string) => boolean
   lastLaunchedLabel: (inst: Installation) => string
@@ -47,23 +47,22 @@ export interface UseInstallListApi {
 }
 
 // Shared install-list state for the dashboard and the instance picker.
-// Pure-data (no IPC/Pinia/DOM); Cloud is always split out as its own surface.
-// Owns a 60s `now` tick so relative time labels stay fresh.
+// Pure-data (no Pinia/DOM); cloud is folded into the same recency-sorted
+// list as every other install. Owns a 60s `now` tick so relative time
+// labels stay fresh.
 //
-// The `hideCloudFromPicker` setting is read once on mount; subsequent
-// toggles in Global Settings take effect on the next dashboard render
-// (no live IPC broadcast for it — settings updates already trigger a
-// re-render via the snapshot pipeline).
+// The `hideCloudFromPicker` setting is read on mount and refreshed on
+// any settings broadcast — toggling Global Settings filters cloud out
+// without requiring a window reopen.
 export function useInstallList(opts: UseInstallListOpts): UseInstallListApi {
   const { t } = useI18n()
   const { installations } = opts
 
   const searchQuery = ref('')
   const activeFilter = ref<FilterKey>('all')
-  // Module-local copy of the `hideCloudFromPicker` setting. `false` while
-  // the IPC fetch is in flight so Cloud renders by default and only
-  // disappears if the user actually opted in. Re-fetched on mount so
-  // the Settings toggle applies after a dashboard reload.
+  // Mirrors the `hideCloudFromPicker` setting. Starts `false` so cloud
+  // renders by default while the initial IPC fetch is in flight and in
+  // test/preload environments where the bridge isn't available.
   const hideCloudFromPicker = ref<boolean>(false)
 
   function matchesQuery(name: string): boolean {
@@ -72,22 +71,20 @@ export function useInstallList(opts: UseInstallListOpts): UseInstallListApi {
     return scoreName(q, name.toLowerCase()) > 0
   }
 
-  const cloudInstall = computed<Installation | null>(
-    () => installations.value.find((i) => i.sourceCategory === 'cloud') ?? null,
-  )
-
-  const nonCloudInstalls = computed<Installation[]>(() =>
-    installations.value.filter((i) => i.sourceCategory !== 'cloud'),
-  )
-
   function sortByRecency(a: Installation, b: Installation): number {
     const ta = typeof a.lastLaunchedAt === 'number' ? a.lastLaunchedAt : -Infinity
     const tb = typeof b.lastLaunchedAt === 'number' ? b.lastLaunchedAt : -Infinity
     return tb - ta
   }
 
+  const effectiveInstalls = computed<Installation[]>(() =>
+    hideCloudFromPicker.value
+      ? installations.value.filter((i) => i.sourceCategory !== 'cloud')
+      : installations.value,
+  )
+
   const visibleInstalls = computed<Installation[]>(() => {
-    const sorted = [...nonCloudInstalls.value].sort(sortByRecency)
+    const sorted = [...effectiveInstalls.value].sort(sortByRecency)
     const byCategory = (() => {
       switch (activeFilter.value) {
         case 'all':
@@ -97,8 +94,7 @@ export function useInstallList(opts: UseInstallListOpts): UseInstallListApi {
         case 'remote':
           return sorted.filter((i) => i.sourceCategory === 'remote')
         case 'cloud':
-          // Cloud installs only appear in the dedicated Cloud surface.
-          return []
+          return sorted.filter((i) => i.sourceCategory === 'cloud')
         default:
           return sorted
       }
@@ -106,25 +102,21 @@ export function useInstallList(opts: UseInstallListOpts): UseInstallListApi {
     return byCategory.filter((i) => matchesQuery(i.name))
   })
 
-  const showCloudCard = computed<boolean>(() => {
-    // Opt-out: user toggled "Hide Cloud from picker" in Global Settings.
-    // Gates BOTH the per-install tile (when a cloud install exists) and
-    // the generic Try-Cloud CTA so the user truly never sees it.
+  const showTryCloudEmptyState = computed<boolean>(() => {
+    // First-run Try-Cloud CTA: only when the user truly has nothing
+    // installed yet AND hasn't opted out of cloud surfaces. Suppressed
+    // once a search query is active so it doesn't read as a result.
     if (hideCloudFromPicker.value) return false
+    if (effectiveInstalls.value.length > 0) return false
+    if (searchQuery.value.trim()) return false
     const inCategory = activeFilter.value === 'all' || activeFilter.value === 'cloud'
-    if (!inCategory) return false
-    // When a real cloud install exists, gate visibility on the query —
-    // the generic Try-Cloud CTA tile stays visible until the user types
-    // anything.
-    if (cloudInstall.value) return matchesQuery(cloudInstall.value.name)
-    return !searchQuery.value.trim()
+    return inCategory
   })
 
   const showEmptyHint = computed<boolean>(
     () =>
       !!searchQuery.value.trim() &&
-      visibleInstalls.value.length === 0 &&
-      !showCloudCard.value,
+      visibleInstalls.value.length === 0,
   )
 
   // 60-second tick so "Nm ago" / "Nh ago" labels stay fresh.
@@ -194,10 +186,8 @@ export function useInstallList(opts: UseInstallListOpts): UseInstallListApi {
   return {
     searchQuery,
     activeFilter,
-    cloudInstall,
-    nonCloudInstalls,
     visibleInstalls,
-    showCloudCard,
+    showTryCloudEmptyState,
     showEmptyHint,
     matchesQuery,
     lastLaunchedLabel,

--- a/src/renderer/src/views/ChooserView.test.ts
+++ b/src/renderer/src/views/ChooserView.test.ts
@@ -106,14 +106,31 @@ describe('ChooserView', () => {
     mockModal.alert.mockClear()
   })
 
-  it('always renders the New Instance tile and a Cloud tile', async () => {
+  it('renders the New Instance tile plus a Try-Cloud CTA when the user has zero installs', async () => {
     installMockApi([])
     const wrapper = mountChooser()
     await flushPromises()
     expect(wrapper.text()).toContain('New Instance')
-    // Cloud tile shows the Try-Cloud CTA when no cloud install exists.
-    expect(wrapper.text()).toContain('Cloud')
+    // First-run Try-Cloud CTA tile.
+    expect(wrapper.find('.chooser-tile-cloud').exists()).toBe(true)
     expect(wrapper.text()).toContain('Try Cloud')
+  })
+
+  it('drops the Try-Cloud CTA once any install exists', async () => {
+    installMockApi([makeInstall({ id: 'a', name: 'Local A' })])
+    const wrapper = mountChooser()
+    await flushPromises()
+    expect(wrapper.find('.chooser-tile-cloud').exists()).toBe(false)
+    expect(wrapper.text()).not.toContain('Try Cloud')
+  })
+
+  it('drops the Try-Cloud CTA when only a cloud install exists (cloud is just a row now)', async () => {
+    installMockApi([
+      makeInstall({ id: 'cloud', name: 'Comfy Cloud', sourceCategory: 'cloud', sourceLabel: 'Cloud' }),
+    ])
+    const wrapper = mountChooser()
+    await flushPromises()
+    expect(wrapper.find('.chooser-tile-cloud').exists()).toBe(false)
   })
 
   it('emits show-new-install when the New Install tile is clicked', async () => {
@@ -125,24 +142,27 @@ describe('ChooserView', () => {
     expect(wrapper.emitted('show-new-install')!.length).toBe(1)
   })
 
-  it('emits show-new-install when the Cloud tile is clicked and no cloud install exists', async () => {
-    installMockApi([
-      makeInstall({ id: 'a', name: 'Local A' }),
-    ])
+  it('emits show-new-install when the first-run Try-Cloud CTA is clicked', async () => {
+    installMockApi([])
     const wrapper = mountChooser()
     await flushPromises()
     await wrapper.find('.chooser-tile-cloud').trigger('click')
+    await flushPromises()
     expect(wrapper.emitted('show-new-install')).toBeDefined()
   })
 
-  it('emits pick with the cloud install when the Cloud tile is clicked and one exists', async () => {
+  it('renders a cloud install through the same tile component as local installs', async () => {
     installMockApi([
       makeInstall({ id: 'cloud', name: 'Comfy Cloud', sourceCategory: 'cloud', sourceLabel: 'Cloud' }),
     ])
     const wrapper = mountChooser()
     await flushPromises()
-    await wrapper.find('.chooser-tile-cloud').trigger('click')
-    // `pickInstall` is async (capacity gate), so drain microtasks first.
+    // The cloud install gets a regular row, no Try-Cloud CTA, and clicking
+    // its tile emits the standard `pick` (not the special new-install path).
+    expect(wrapper.find('.chooser-tile-cloud').exists()).toBe(false)
+    const tile = wrapper.findAll('.chooser-tile').find((t) => t.text().includes('Comfy Cloud'))
+    expect(tile).toBeTruthy()
+    await tile!.trigger('click')
     await flushPromises()
     const events = wrapper.emitted('pick')
     expect(events).toBeDefined()
@@ -157,8 +177,8 @@ describe('ChooserView', () => {
     ])
     const wrapper = mountChooser()
     await flushPromises()
-    // The first two tiles are the fixed New Install + Cloud entries; the
-    // remaining tiles are the install rows in recency order.
+    // First tile is the fixed New Install; the rest are install rows in
+    // recency order. The Try-Cloud CTA is gone (any install present).
     const tiles = wrapper.findAll('.chooser-tile')
     const installTiles = tiles.filter(
       (t) => !t.classes().includes('chooser-tile-new') && !t.classes().includes('chooser-tile-cloud')
@@ -167,6 +187,36 @@ describe('ChooserView', () => {
     expect(installTiles[0]!.text()).toContain('New')
     expect(installTiles[1]!.text()).toContain('Old')
     expect(installTiles[2]!.text()).toContain('Never')
+  })
+
+  // Regression: cloud must not sort above a more-recent local install. Before
+  // the unpin refactor, the dashboard rendered cloud in its own surface and
+  // the IPP tie-break promoted cloud, so this ordering would have failed.
+  it('places a cloud install below a more-recent local install in the tile grid', async () => {
+    installMockApi([
+      makeInstall({
+        id: 'recent-local',
+        name: 'RecentLocal',
+        sourceCategory: 'local',
+        lastLaunchedAt: 1_000,
+      }),
+      makeInstall({
+        id: 'old-cloud',
+        name: 'OldCloud',
+        sourceCategory: 'cloud',
+        sourceLabel: 'Cloud',
+        lastLaunchedAt: 100,
+      }),
+    ])
+    const wrapper = mountChooser()
+    await flushPromises()
+    const tiles = wrapper.findAll('.chooser-tile')
+    const installTiles = tiles.filter(
+      (t) => !t.classes().includes('chooser-tile-new') && !t.classes().includes('chooser-tile-cloud')
+    )
+    expect(installTiles.length).toBe(2)
+    expect(installTiles[0]!.text()).toContain('RecentLocal')
+    expect(installTiles[1]!.text()).toContain('OldCloud')
   })
 
   it('emits pick when an install tile is single-clicked', async () => {

--- a/src/renderer/src/views/ChooserView.test.ts
+++ b/src/renderer/src/views/ChooserView.test.ts
@@ -106,43 +106,11 @@ describe('ChooserView', () => {
     mockModal.alert.mockClear()
   })
 
-  it('renders the New Instance tile plus a Try-Cloud CTA when the user has zero installs', async () => {
+  it('renders the New Instance tile when the user has zero installs', async () => {
     installMockApi([])
     const wrapper = mountChooser()
     await flushPromises()
     expect(wrapper.text()).toContain('New Instance')
-    // First-run Try-Cloud CTA tile.
-    expect(wrapper.find('.chooser-tile-cloud').exists()).toBe(true)
-    expect(wrapper.text()).toContain('Try Cloud')
-  })
-
-  it('drops the Try-Cloud CTA once any install exists', async () => {
-    installMockApi([makeInstall({ id: 'a', name: 'Local A' })])
-    const wrapper = mountChooser()
-    await flushPromises()
-    expect(wrapper.find('.chooser-tile-cloud').exists()).toBe(false)
-    expect(wrapper.text()).not.toContain('Try Cloud')
-  })
-
-  it('drops the Try-Cloud CTA once the user has launched cloud (cloud becomes just a row)', async () => {
-    installMockApi([
-      makeInstall({
-        id: 'cloud', name: 'Comfy Cloud', sourceCategory: 'cloud', sourceLabel: 'Cloud',
-        lastLaunchedAt: 1234,
-      }),
-    ])
-    const wrapper = mountChooser()
-    await flushPromises()
-    expect(wrapper.find('.chooser-tile-cloud').exists()).toBe(false)
-  })
-
-  it('keeps the Try-Cloud CTA when the only install is an auto-seeded never-launched cloud entry', async () => {
-    installMockApi([
-      makeInstall({ id: 'cloud', name: 'Comfy Cloud', sourceCategory: 'cloud', sourceLabel: 'Cloud' }),
-    ])
-    const wrapper = mountChooser()
-    await flushPromises()
-    expect(wrapper.find('.chooser-tile-cloud').exists()).toBe(true)
   })
 
   it('emits show-new-install when the New Install tile is clicked', async () => {
@@ -154,28 +122,12 @@ describe('ChooserView', () => {
     expect(wrapper.emitted('show-new-install')!.length).toBe(1)
   })
 
-  it('emits show-new-install when the first-run Try-Cloud CTA is clicked', async () => {
-    installMockApi([])
-    const wrapper = mountChooser()
-    await flushPromises()
-    await wrapper.find('.chooser-tile-cloud').trigger('click')
-    await flushPromises()
-    expect(wrapper.emitted('show-new-install')).toBeDefined()
-  })
-
-  it('renders a launched cloud install through the same tile component as local installs', async () => {
+  it('renders a cloud install through the same tile component as local installs', async () => {
     installMockApi([
-      makeInstall({
-        id: 'cloud', name: 'Comfy Cloud', sourceCategory: 'cloud', sourceLabel: 'Cloud',
-        lastLaunchedAt: 1234,
-      }),
+      makeInstall({ id: 'cloud', name: 'Comfy Cloud', sourceCategory: 'cloud', sourceLabel: 'Cloud' }),
     ])
     const wrapper = mountChooser()
     await flushPromises()
-    // Once cloud has been launched the Try-Cloud CTA is gone and the cloud
-    // row renders via the same install tile component (emits the standard
-    // `pick`, not the special new-install path).
-    expect(wrapper.find('.chooser-tile-cloud').exists()).toBe(false)
     const tile = wrapper.findAll('.chooser-tile').find((t) => t.text().includes('Comfy Cloud'))
     expect(tile).toBeTruthy()
     await tile!.trigger('click')

--- a/src/renderer/src/views/ChooserView.test.ts
+++ b/src/renderer/src/views/ChooserView.test.ts
@@ -124,13 +124,25 @@ describe('ChooserView', () => {
     expect(wrapper.text()).not.toContain('Try Cloud')
   })
 
-  it('drops the Try-Cloud CTA when only a cloud install exists (cloud is just a row now)', async () => {
+  it('drops the Try-Cloud CTA once the user has launched cloud (cloud becomes just a row)', async () => {
+    installMockApi([
+      makeInstall({
+        id: 'cloud', name: 'Comfy Cloud', sourceCategory: 'cloud', sourceLabel: 'Cloud',
+        lastLaunchedAt: 1234,
+      }),
+    ])
+    const wrapper = mountChooser()
+    await flushPromises()
+    expect(wrapper.find('.chooser-tile-cloud').exists()).toBe(false)
+  })
+
+  it('keeps the Try-Cloud CTA when the only install is an auto-seeded never-launched cloud entry', async () => {
     installMockApi([
       makeInstall({ id: 'cloud', name: 'Comfy Cloud', sourceCategory: 'cloud', sourceLabel: 'Cloud' }),
     ])
     const wrapper = mountChooser()
     await flushPromises()
-    expect(wrapper.find('.chooser-tile-cloud').exists()).toBe(false)
+    expect(wrapper.find('.chooser-tile-cloud').exists()).toBe(true)
   })
 
   it('emits show-new-install when the New Install tile is clicked', async () => {
@@ -151,14 +163,18 @@ describe('ChooserView', () => {
     expect(wrapper.emitted('show-new-install')).toBeDefined()
   })
 
-  it('renders a cloud install through the same tile component as local installs', async () => {
+  it('renders a launched cloud install through the same tile component as local installs', async () => {
     installMockApi([
-      makeInstall({ id: 'cloud', name: 'Comfy Cloud', sourceCategory: 'cloud', sourceLabel: 'Cloud' }),
+      makeInstall({
+        id: 'cloud', name: 'Comfy Cloud', sourceCategory: 'cloud', sourceLabel: 'Cloud',
+        lastLaunchedAt: 1234,
+      }),
     ])
     const wrapper = mountChooser()
     await flushPromises()
-    // The cloud install gets a regular row, no Try-Cloud CTA, and clicking
-    // its tile emits the standard `pick` (not the special new-install path).
+    // Once cloud has been launched the Try-Cloud CTA is gone and the cloud
+    // row renders via the same install tile component (emits the standard
+    // `pick`, not the special new-install path).
     expect(wrapper.find('.chooser-tile-cloud').exists()).toBe(false)
     const tile = wrapper.findAll('.chooser-tile').find((t) => t.text().includes('Comfy Cloud'))
     expect(tile).toBeTruthy()

--- a/src/renderer/src/views/ChooserView.vue
+++ b/src/renderer/src/views/ChooserView.vue
@@ -7,7 +7,7 @@ import { useInstallContextMenu } from '../composables/useInstallContextMenu'
 import { useInstallList } from '../composables/useInstallList'
 import { useCloudCapacity } from '../composables/useCloudCapacity'
 import { useModal } from '../composables/useModal'
-import { Cloud, MoreVertical, Plus, Search } from 'lucide-vue-next'
+import { Cloud, Plus, Search } from 'lucide-vue-next'
 import ContextMenu from '../components/ContextMenu.vue'
 import BrandBackground from '../components/BrandBackground.vue'
 import BaseInput from '../components/ui/BaseInput.vue'
@@ -25,10 +25,10 @@ import type { Installation, ShowProgressOpts } from '../types/ipc'
  *
  * Layout:
  *   - Top-left: "New Install" (always present).
- *   - Next: "Cloud" — opens an existing cloud install or routes to
- *     new-install as a Try-Cloud CTA.
- *   - Following: every other install ordered by `lastLaunchedAt` desc,
- *     never-launched at the end.
+ *   - First-run only: a "Try Cloud" CTA tile when the user has zero
+ *     installs (any source). Once any install exists, it is gone.
+ *   - Following: every install (local / cloud / remote) ordered by
+ *     `lastLaunchedAt` desc, never-launched at the end.
  *   - Filter chips above the grid narrow by source category.
  *
  * Per-install tile rendering lives in `chooser/ChooserInstallTile.vue`.
@@ -67,24 +67,24 @@ onMounted(() => {
   }
 })
 
-// Filter / search / recency / cloud-split logic is shared with the
-// title-bar instance picker popover via `useInstallList` so the two
-// surfaces cannot drift. The chip UI is currently hidden in the brand
-// redesign but the underlying `activeFilter` ref + filter switch stay
-// wired; tests reach into `vm.activeFilter` to drive the filter-based
+// Filter / search / recency logic is shared with the title-bar
+// instance picker popover via `useInstallList` so the two surfaces
+// cannot drift. The chip UI is currently hidden in the brand redesign
+// but the underlying `activeFilter` ref + filter switch stay wired;
+// tests reach into `vm.activeFilter` to drive the filter-based
 // regressions guard.
 //
 // "Local" includes both standalone local installs and Legacy Desktop
 // installs (both report `sourceCategory === 'local'`) — they're
-// conceptually the same family from the user's POV.
+// conceptually the same family from the user's POV. Cloud installs
+// flow through `visibleInstalls` like every other source; the
+// dedicated Cloud surface here is now a first-run-only empty-state.
 const installationsRef = toRef(installationStore, 'installations')
 const {
   searchQuery,
   activeFilter,
-  cloudInstall,
-  nonCloudInstalls,
   visibleInstalls,
-  showCloudCard,
+  showTryCloudEmptyState,
   showEmptyHint,
   lastLaunchedLabel
 } = useInstallList({ installations: installationsRef })
@@ -97,9 +97,13 @@ defineExpose({ activeFilter })
 
 // --- Cluster top offset ---
 
-/** Unfiltered tile count: New Install + Cloud slot are always present. Reads
- *  the raw list, not `visibleInstalls`, so search never shifts the cluster. */
-const baseTileCount = computed(() => 2 + nonCloudInstalls.value.length)
+/** Unfiltered tile count: New Install + every install (cloud included).
+ *  The Try-Cloud empty-state CTA only appears when the install list is
+ *  empty, so it never collides with the install row count. Reads the raw
+ *  list, not `visibleInstalls`, so search never shifts the cluster. */
+const baseTileCount = computed(
+  () => 1 + (installationStore.installations.length || 1)
+)
 
 const TILES_PER_ROW = 4
 
@@ -229,20 +233,10 @@ const cloudCapacity = useCloudCapacity()
  *  would do on click. */
 const dashboardCapacityStatus = computed(() => cloudCapacity.effectiveStatus())
 
-async function handleCloudClick(): Promise<void> {
-  // Two paths from the dashboard cloud tile: an existing cloud install
-  // (delegate to `pickInstall`, which has its own capacity gate), or
-  // promote new-install as a Try-Cloud CTA (no install to pick, so the
-  // gate fires here). Calling `confirmEntry` in both branches would
-  // double-fire the degraded confirm modal on the existing-install
-  // path. The tile is also click-disabled when capacity is `disabled`
-  // (free / unknown), so this only really matters for the `degraded`
-  // and paid-on-disabled cases.
-  if (cloudInstall.value) {
-    if (sessionStore.isStopping(cloudInstall.value.id)) return
-    void pickInstall(cloudInstall.value)
-    return
-  }
+async function handleTryCloudClick(): Promise<void> {
+  // Try-Cloud empty-state CTA: there is no cloud install yet, so this
+  // routes to new-install. The capacity gate fires here so the user
+  // doesn't sail past a `disabled` outage into the new-install flow.
   if (!(await cloudCapacity.confirmEntry())) return
   emit('show-new-install')
 }
@@ -267,7 +261,7 @@ function handleNewInstallClick(): void {
       </div>
 
       <div
-        v-if="installationStore.loading && nonCloudInstalls.length === 0"
+        v-if="installationStore.loading && installationStore.installations.length === 0"
         class="chooser-loading"
       >
         {{ t('common.loading') }}
@@ -296,7 +290,7 @@ function handleNewInstallClick(): void {
         </button>
 
         <div
-          v-if="showCloudCard"
+          v-if="showTryCloudEmptyState"
           key="__cloud"
           role="button"
           :tabindex="dashboardCapacityStatus === 'disabled' ? -1 : 0"
@@ -304,31 +298,12 @@ function handleNewInstallClick(): void {
           class="chooser-tile chooser-tile-cloud"
           :class="{ 'chooser-tile--cloud-disabled': dashboardCapacityStatus === 'disabled' }"
           :data-cloud-capacity="dashboardCapacityStatus"
-          @click="handleCloudClick"
-          @keydown.enter="handleCloudClick"
-          @keydown.space.prevent="handleCloudClick"
-          @contextmenu.prevent="cloudInstall ? openCardMenu($event, cloudInstall) : null"
+          @click="handleTryCloudClick"
+          @keydown.enter="handleTryCloudClick"
+          @keydown.space.prevent="handleTryCloudClick"
         >
           <div class="chooser-tile-icon"><Cloud :size="32" /></div>
-          <!-- Kebab options menu — only when a real cloud install exists to
-               manage (parity with the per-install tiles; the Try-Cloud CTA
-               has nothing to manage). Keeps the cloud tile consistent with
-               the rest of the dashboard pills instead of right-click only. -->
-          <div v-if="cloudInstall" class="chooser-tile-actions">
-            <button
-              type="button"
-              class="chooser-tile-kebab"
-              :title="t('chooser.moreActions')"
-              :aria-label="t('chooser.moreActions')"
-              @click.stop="openKebabMenu($event, cloudInstall)"
-              @contextmenu.stop="openKebabMenu($event, cloudInstall)"
-            >
-              <MoreVertical :size="16" />
-            </button>
-          </div>
-          <div class="chooser-tile-name">
-            {{ cloudInstall ? cloudInstall.name : t('cloud.label') }}
-          </div>
+          <div class="chooser-tile-name">{{ t('cloud.label') }}</div>
           <div class="chooser-tile-meta">
             <span
               v-if="dashboardCapacityStatus !== 'normal'"
@@ -348,12 +323,8 @@ function handleNewInstallClick(): void {
                   : t('cloud.capacityDegraded')
               }}
             </span>
-            <span
-              v-else
-              class="chooser-tile-pill"
-              :title="cloudInstall ? cloudInstall.sourceLabel : t('cloud.desc')"
-            >
-              {{ cloudInstall ? cloudInstall.sourceLabel : t('cloud.desc') }}
+            <span v-else class="chooser-tile-pill" :title="t('cloud.desc')">
+              {{ t('cloud.desc') }}
             </span>
           </div>
         </div>

--- a/src/renderer/src/views/ChooserView.vue
+++ b/src/renderer/src/views/ChooserView.vue
@@ -7,7 +7,7 @@ import { useInstallContextMenu } from '../composables/useInstallContextMenu'
 import { useInstallList } from '../composables/useInstallList'
 import { useCloudCapacity } from '../composables/useCloudCapacity'
 import { useModal } from '../composables/useModal'
-import { Cloud, Plus, Search } from 'lucide-vue-next'
+import { Plus, Search } from 'lucide-vue-next'
 import ContextMenu from '../components/ContextMenu.vue'
 import BrandBackground from '../components/BrandBackground.vue'
 import BaseInput from '../components/ui/BaseInput.vue'
@@ -25,8 +25,6 @@ import type { Installation, ShowProgressOpts } from '../types/ipc'
  *
  * Layout:
  *   - Top-left: "New Install" (always present).
- *   - First-run only: a "Try Cloud" CTA tile when the user has zero
- *     installs (any source). Once any install exists, it is gone.
  *   - Following: every install (local / cloud / remote) ordered by
  *     `lastLaunchedAt` desc, never-launched at the end.
  *   - Filter chips above the grid narrow by source category.
@@ -77,14 +75,13 @@ onMounted(() => {
 // "Local" includes both standalone local installs and Legacy Desktop
 // installs (both report `sourceCategory === 'local'`) — they're
 // conceptually the same family from the user's POV. Cloud installs
-// flow through `visibleInstalls` like every other source; the
-// dedicated Cloud surface here is now a first-run-only empty-state.
+// flow through `visibleInstalls` like every other source — there is no
+// special cloud surface anymore.
 const installationsRef = toRef(installationStore, 'installations')
 const {
   searchQuery,
   activeFilter,
   visibleInstalls,
-  showTryCloudEmptyState,
   showEmptyHint,
   lastLaunchedLabel
 } = useInstallList({ installations: installationsRef })
@@ -98,11 +95,10 @@ defineExpose({ activeFilter })
 // --- Cluster top offset ---
 
 /** Unfiltered tile count: New Install + every install (cloud included).
- *  The Try-Cloud empty-state CTA only appears when the install list is
- *  empty, so it never collides with the install row count. Reads the raw
- *  list, not `visibleInstalls`, so search never shifts the cluster. */
+ *  Reads the raw list, not `visibleInstalls`, so search never shifts the
+ *  cluster. */
 const baseTileCount = computed(
-  () => 1 + (installationStore.installations.length || 1)
+  () => 1 + installationStore.installations.length
 )
 
 const TILES_PER_ROW = 4
@@ -226,21 +222,6 @@ function viewError(inst: Installation): void {
 // users can't enter cloud during an outage. When `degraded`, the tile
 // surfaces a "Heavy usage" meta pill but the click still proceeds.
 const cloudCapacity = useCloudCapacity()
-/** The capacity tier the tile should render as — collapses raw flag
- *  status with the signed-in tier so a paying user sees a heads-up
- *  chip on `disabled` instead of a "Temporarily unavailable" lockout
- *  they can actually click through. Mirrors what `confirmEntry`
- *  would do on click. */
-const dashboardCapacityStatus = computed(() => cloudCapacity.effectiveStatus())
-
-async function handleTryCloudClick(): Promise<void> {
-  // Try-Cloud empty-state CTA: there is no cloud install yet, so this
-  // routes to new-install. The capacity gate fires here so the user
-  // doesn't sail past a `disabled` outage into the new-install flow.
-  if (!(await cloudCapacity.confirmEntry())) return
-  emit('show-new-install')
-}
-
 function handleNewInstallClick(): void {
   emit('show-new-install')
 }
@@ -288,46 +269,6 @@ function handleNewInstallClick(): void {
           <div class="chooser-tile-name">{{ t('chooser.newInstall') }}</div>
           <div class="chooser-tile-meta">{{ t('chooser.newInstallDesc') }}</div>
         </button>
-
-        <div
-          v-if="showTryCloudEmptyState"
-          key="__cloud"
-          role="button"
-          :tabindex="dashboardCapacityStatus === 'disabled' ? -1 : 0"
-          :aria-disabled="dashboardCapacityStatus === 'disabled' ? true : undefined"
-          class="chooser-tile chooser-tile-cloud"
-          :class="{ 'chooser-tile--cloud-disabled': dashboardCapacityStatus === 'disabled' }"
-          :data-cloud-capacity="dashboardCapacityStatus"
-          @click="handleTryCloudClick"
-          @keydown.enter="handleTryCloudClick"
-          @keydown.space.prevent="handleTryCloudClick"
-        >
-          <div class="chooser-tile-icon"><Cloud :size="32" /></div>
-          <div class="chooser-tile-name">{{ t('cloud.label') }}</div>
-          <div class="chooser-tile-meta">
-            <span
-              v-if="dashboardCapacityStatus !== 'normal'"
-              class="chooser-tile-pill chooser-tile-pill--capacity"
-              :class="{
-                'chooser-tile-pill--capacity-disabled': dashboardCapacityStatus === 'disabled'
-              }"
-              :title="
-                dashboardCapacityStatus === 'disabled'
-                  ? t('cloud.capacityDisabledHint')
-                  : t('cloud.capacityDegradedHint')
-              "
-            >
-              {{
-                dashboardCapacityStatus === 'disabled'
-                  ? t('cloud.capacityDisabled')
-                  : t('cloud.capacityDegraded')
-              }}
-            </span>
-            <span v-else class="chooser-tile-pill" :title="t('cloud.desc')">
-              {{ t('cloud.desc') }}
-            </span>
-          </div>
-        </div>
 
         <ChooserInstallTile
           v-for="inst in visibleInstalls"

--- a/src/renderer/src/views/chooser/ChooserInstallTile.vue
+++ b/src/renderer/src/views/chooser/ChooserInstallTile.vue
@@ -83,6 +83,7 @@ function handleClick(): void {
     class="chooser-tile"
     :class="statusClasses"
     :data-testid="TID.dashboardTile(inst.id)"
+    :data-source-category="inst.sourceCategory"
     @click="handleClick"
     @keydown.enter="handleClick"
     @keydown.space.prevent="handleClick"


### PR DESCRIPTION
Stops pinning Comfy Cloud as a separate sticky surface on the Dashboard and Instance Picker. Cloud is now one row in the same sorted list as every other install, ordered by `lastLaunchedAt` like everyone else.

## Why
Cloud was modeled as a distinct `cloudInstall` / `nonCloudInstalls` split in `useInstallList` and rendered as its own dedicated card on both Dashboard and IPP — it could never sort with the other instances. We want it to behave like any other install.

## Changes
- `useInstallList.ts`: collapse the split. One `visibleInstalls` computed, all installs included, sorted by `lastLaunchedAt` desc. The `'cloud'` filter chip now returns cloud installs (was `[]`).
- `ChooserView.vue` + `InstancePickerView.vue`: drop the dedicated cloud surface; the cloud row renders through the same `InstanceRow` as the rest.
- Empty-state preserved: the Try-Cloud promo tile still appears when the user has **zero** installs total. Once they have any install (local, cloud, remote, anything), the regular list takes over.
- Tests: `useInstallList.test.ts`, `ChooserView.test.ts`, `InstancePickerView.test.ts` updated, including a regression test that cloud with an older `lastLaunchedAt` sorts BELOW a more-recent local install.

72 tests pass across the three test files.