### PR TITLE
feat(telemetry): record git system-git fallback events (#1036)

### DIFF
--- a/src/main/lib/git.test.ts
+++ b/src/main/lib/git.test.ts
@@ -9,6 +9,7 @@ vi.mock('child_process', async (importOriginal) => {
 import { execFile, spawn } from 'child_process'
 import { EventEmitter } from 'events'
 import { countCommitsAhead, findNearestTag, findLatestVersionTag, lsRemoteLatestTag, lsRemoteRef, isAncestorOf, findMergeBase, revParseRef, fetchTags, configurePygit2, isGitAvailable, isPygit2Configured, getPygit2Status, resetPygit2State, probePygit2, resetGitAvailableCache, countUniqueCommits, gitClone, gitCheckoutCommit, gitFetchAndCheckout, isPygit2AuthFailure, isForcePygit2, isSystemGitAvailable } from './git'
+import * as telemetry from './telemetry'
 
 const mockedExecFile = vi.mocked(execFile)
 const mockedSpawn = vi.mocked(spawn)
@@ -687,6 +688,30 @@ describe('system git fallback on pygit2 auth failure', () => {
       expect(mockedSpawn.mock.calls[0]![0]).toBe('/usr/bin/python3')
       expect(mockedSpawn.mock.calls[1]![0]).toBe('git')
       expect(mockedSpawn.mock.calls[1]![1]).toEqual(['clone', 'https://github.com/test/repo', '/dest'])
+    })
+
+    it('emits a system_fallback telemetry event when it falls back', async () => {
+      const emitSpy = vi.spyOn(telemetry, 'emit').mockImplementation(() => {})
+      mockExecFile((_cmd, _args, _opts, cb) => { cb(null, 'git version 2.43.0\n', '') })
+      mockSpawnSequence([
+        { exitCode: 1, stderr: 'authentication required but no callback set\n' }, // pygit2
+        { exitCode: 0, stderr: 'Cloning...\n' }, // system git
+      ])
+      await gitClone('https://github.com/test/repo', '/dest', () => {})
+      expect(emitSpy).toHaveBeenCalledWith(
+        'comfy.desktop.git.system_fallback',
+        expect.objectContaining({ op: 'clone' })
+      )
+    })
+
+    it('does NOT emit a system_fallback event when pygit2 succeeds', async () => {
+      const emitSpy = vi.spyOn(telemetry, 'emit').mockImplementation(() => {})
+      mockSpawnSequence([{ exitCode: 0, stderr: 'Cloning...\n' }])
+      await gitClone('https://github.com/test/repo', '/dest', () => {})
+      expect(emitSpy).not.toHaveBeenCalledWith(
+        'comfy.desktop.git.system_fallback',
+        expect.anything()
+      )
     })
 
     it('does NOT fall back when COMFY_FORCE_PYGIT2=1, even on an auth error', async () => {

--- a/src/main/lib/git.ts
+++ b/src/main/lib/git.ts
@@ -1114,6 +1114,7 @@ export function isPygit2AuthFailure(result: ProcessResult): boolean {
  * system git is available, in which case the original pygit2 result is returned.
  */
 async function withSystemGitFallback(
+  op: string,
   pygit2Op: () => Promise<ProcessResult>,
   systemGitOp: () => Promise<ProcessResult>,
   sendOutput: (text: string) => void
@@ -1121,6 +1122,12 @@ async function withSystemGitFallback(
   const result = await pygit2Op()
   if (!isPygit2AuthFailure(result) || isForcePygit2()) return result
   if (!(await isSystemGitAvailable())) return result
+  // Measures how often the auth-failure fallback actually fires (e.g. corporate
+  // git configs that rewrite GitHub HTTPS to SSH, which bundled pygit2 can't use).
+  telemetry.emit('comfy.desktop.git.system_fallback', {
+    op,
+    error_bucket: telemetry.bucketError(result.stderr)
+  })
   sendOutput(
     '\npygit2 could not authenticate (your git config likely rewrites GitHub ' +
       'HTTPS to SSH, which the bundled pygit2 cannot use); retrying with system git…\n'
@@ -1144,6 +1151,7 @@ export function gitClone(
   if (isPygit2Configured()) {
     const runPygit2Spawn = makeRunPygit2(sendOutput, signal)
     return withSystemGitFallback(
+      'clone',
       () => runPygit2Spawn(['clone', url, dest]),
       systemGitClone,
       sendOutput
@@ -1192,6 +1200,7 @@ export function gitCheckoutCommit(
   if (isPygit2Configured()) {
     const runPygit2Spawn = makeRunPygit2(sendOutput, signal)
     return withSystemGitFallback(
+      'checkout',
       () => runPygit2Spawn(['checkout', repoPath, commit]),
       systemGitCheckout,
       sendOutput
@@ -1270,6 +1279,7 @@ export function gitFetchAndCheckout(
   if (isPygit2Configured()) {
     const runPygit2Spawn = makeRunPygit2(sendOutput, signal)
     return withSystemGitFallback(
+      'fetch-and-checkout',
       () => runPygit2Spawn(['fetch-and-checkout', repoPath, commit]),
       systemGitFetchAndCheckout,
       sendOutput


### PR DESCRIPTION
## What

Adds a `comfy.desktop.git.system_fallback` telemetry event, fired in `withSystemGitFallback` whenever an auth-class pygit2 failure triggers the system-git retry path (clone / checkout / fetch-and-checkout).

Follow-up to #1038, which introduced the system-git fallback for #1036 but emitted no telemetry when the fallback actually fired.

## Why

#1038 made bundled pygit2 fall back to system git when it can't authenticate â€” the typical corporate/custom-`.gitconfig` case (e.g. a global `insteadOf` that rewrites GitHub HTTPS â†’ SSH, which the bundled pygit2 can't use). But once shipped we had **no signal on how often that fallback fires**, i.e. how large the affected population actually is.

Today `git.ts` only emits pygit2 *health* events (`pygit2.probe_failed`, `pygit2.repair_attempted`, `pygit2.circuit_broken`) â€” nothing about which backend actually serviced an op, and nothing when the new fallback kicks in. This closes that gap.

## Details

- Threads an `op` label (`clone` / `checkout` / `fetch-and-checkout`) through `withSystemGitFallback`.
- Emits once, right before the system-git retry, with:
  - `op`: which operation fell back
  - `error_bucket`: bucketed pygit2 stderr (via `telemetry.bucketError`, no PII)
- No behavior change to the fallback itself.

## Telemetry routing

PostHog-only (not added to `DATADOG_MIRRORED_EVENT_NAMES`). The fallback succeeding is the system working as designed, not a reliability failure that needs an ops monitor â€” this is a product-analytics "how big is this population" question. Easy to promote to Datadog later if a spike-alert turns out to be useful.

## Tests

- New: asserts the event fires (with `op: 'clone'`) when pygit2 hits an auth error and system git is available.
- New: asserts the event does **not** fire when pygit2 succeeds.
- `pnpm run typecheck`, `lint`, `build`, `test` (2106 passed) all green.