### PR TITLE
perf(install): pre-warm full stable tag list at startup

### DIFF
--- a/src/main/lib/ipc/index.ts
+++ b/src/main/lib/ipc/index.ts
@@ -184,12 +184,11 @@ export function register(callbacks: RegisterCallbacks = {}): void {
 
     await configureGitBackend()
 
-    // Pre-warm the stable tags so the New Install wizard is responsive on first
-    // open (no local clone needed): the latest tag drives the concrete version
-    // shown for the stable channel, and the full list backs the version picker.
-    // Both go through the same `ls-remote-tags` call, which is the slow part on
-    // cold/proxied setups, so fetching them here moves that cost off the wizard's
-    // blocking field cascade.
+    // Pre-warm both stable-tag caches so the New Install wizard is responsive on
+    // first open (no local clone needed): the latest tag drives the concrete
+    // version shown for the stable channel, and the full list backs the version
+    // picker. They use independent caches, so warm both here to move the slow
+    // ls-remote (cold/proxied setups) off the wizard's blocking field cascade.
     try {
       await Promise.all([getLatestStableTag(), getStableTags()])
     } catch {}

--- a/src/main/lib/ipc/index.ts
+++ b/src/main/lib/ipc/index.ts
@@ -10,6 +10,7 @@ import {
   createCache,
   fetchJSON,
   getLatestStableTag,
+  getStableTags,
   setCallbacks,
   _broadcastToRenderer,
   migrateDefaults,
@@ -183,10 +184,14 @@ export function register(callbacks: RegisterCallbacks = {}): void {
 
     await configureGitBackend()
 
-    // Pre-warm the latest stable tag so the New Install wizard shows the
-    // concrete version on first open (no local clone needed).
+    // Pre-warm the stable tags so the New Install wizard is responsive on first
+    // open (no local clone needed): the latest tag drives the concrete version
+    // shown for the stable channel, and the full list backs the version picker.
+    // Both go through the same `ls-remote-tags` call, which is the slow part on
+    // cold/proxied setups, so fetching them here moves that cost off the wizard's
+    // blocking field cascade.
     try {
-      await getLatestStableTag()
+      await Promise.all([getLatestStableTag(), getStableTags()])
     } catch {}
   })()
 

--- a/src/main/lib/ipc/shared.ts
+++ b/src/main/lib/ipc/shared.ts
@@ -42,7 +42,7 @@ import * as i18n from '../i18n'
 import { syncCustomModelFolders, discoverExtraModelFolders, instanceModelPathsYaml, isSamePath } from '../models'
 import { copyDirWithProgress } from '../copy'
 import { fetchJSON } from '../fetch'
-import { fetchLatestRelease, getLatestStableTag } from '../comfyui-releases'
+import { fetchLatestRelease, getLatestStableTag, getStableTags } from '../comfyui-releases'
 import { captureSnapshotIfChanged, getSnapshotCount, getSnapshotListData, getSnapshotDetailData, getSnapshotDiffVsPrevious, diffAgainstCurrent, loadSnapshot, listSnapshots, deleteSnapshot, diffSnapshots, buildExportEnvelope, validateExportEnvelope, importSnapshots, saveSnapshot, statesMatch, restoreCustomNodes, restorePipPackages, restoreComfyUIVersion, buildPostRestoreState, frozenSnapshotInstallOverrides, formatSnapshotVersion, resolveSnapshotVersion } from '../snapshots'
 import type { SnapshotExportEnvelope, Snapshot } from '../snapshots'
 import { getVariantLabel, buildPinnedVariant } from '../../sources/standalone'
@@ -75,7 +75,7 @@ export {
   getDiskSpace, getDirectorySize, validateInstallPath,
   syncOemSeed, formatTime, getActiveDownloads,
   syncCustomModelFolders, discoverExtraModelFolders, instanceModelPathsYaml, isSamePath,
-  copyDirWithProgress, fetchJSON, fetchLatestRelease, getLatestStableTag,
+  copyDirWithProgress, fetchJSON, fetchLatestRelease, getLatestStableTag, getStableTags,
   captureSnapshotIfChanged, getSnapshotCount, getSnapshotListData, getSnapshotDetailData,
   getSnapshotDiffVsPrevious, diffAgainstCurrent, loadSnapshot, listSnapshots, diffSnapshots,
   buildExportEnvelope, validateExportEnvelope, importSnapshots, saveSnapshot, statesMatch, deleteSnapshot,


### PR DESCRIPTION
## Problem

The New Install wizard loads its fields as a **sequential, blocking cascade** — elease -> comfyVersion -> ariant — and the **Continue** button (plus the downstream dropdowns) stays disabled until the *entire* chain resolves (saveDisabled only flips false after the last field).

On the **stable** channel, the comfyVersion field calls getStableTags(), an `ls-remote-tags` round-trip. On the bundled **pygit2** backend (the default), that spawns a cold Python process and pulls the **full, unfiltered ref advertisement** (~5000 refs / ~320 KB for ComfyUI, the bulk being `refs/pull/*`) rather than the ~9 KB a protocol-v2 `git ls-remote --tags` would fetch. On cold machines (native-lib AV scan on first spawn) or proxied/corporate networks, that can stall the wizard for several seconds before anything becomes interactable.

Most users never change the version — they take the recommended latest stable — so paying that cost synchronously on the wizard's critical path is wasted for the common case.

## Change

Startup already pre-warms `getLatestStableTag()` in the background. This fetches the **full stable tag list** there too, so it lands in the existing 10-minute in-memory cache before the wizard is ever opened.

- Common "take the default" path: pays **nothing** on the wizard's blocking cascade — the list is already cached.
- Rare user who opens the version picker: gets a warm cache instead of a cold `ls-remote`.

Both calls are kept intentionally (per review preference) so `getLatestStableTag` remains independently guaranteed; they share the same cache key and in-flight dedup, so this is at most one extra background `ls-remote-tags` at startup.

## Notes / scope

- No UI changes; the blocking cascade itself is unchanged (out of scope here). This only moves the fetch cost off the critical path via pre-warm.
- Failure is graceful and unchanged: `getStableTags()` returns `[]` on error, the wizard still unlocks Continue, and the install proceeds to latest stable.

## Verification

`pnpm run typecheck` / `lint` / `build` / `test` (2106 tests) all pass.