### PR TITLE
fix(update): surface update button when picking a stable tag on an up-to-date install

### DIFF
--- a/src/renderer/src/views/comfyUISettings/ChannelPicker.test.ts
+++ b/src/renderer/src/views/comfyUISettings/ChannelPicker.test.ts
@@ -1,0 +1,109 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+import type { ActionDef, DetailField } from '../../types/ipc'
+import { TID } from '../../../../shared/testIds'
+import BaseSelect from '../../components/ui/BaseSelect.vue'
+import ChannelPicker from './ChannelPicker.vue'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: {} },
+  missingWarn: false,
+  fallbackWarn: false
+})
+
+const STABLE_TAGS = ['v0.24.1', 'v0.23.0', 'v0.22.1']
+
+/** Stable channel field for an install sitting on the latest stable tag, so the
+ *  server attaches no `update-comfyui` action (the up-to-date case). */
+function upToDateStableField(): DetailField {
+  return {
+    id: 'updateChannel',
+    label: 'Update channel',
+    value: 'stable',
+    editable: true,
+    editType: 'channel-cards',
+    options: [
+      {
+        value: 'stable',
+        label: 'Stable',
+        data: {
+          installedVersion: 'v0.24.1',
+          latestVersion: 'v0.24.1',
+          updateAvailable: false,
+          actions: undefined
+        }
+      },
+      {
+        value: 'latest',
+        label: 'Latest',
+        data: { installedVersion: 'v0.24.1', latestVersion: 'abc1234', updateAvailable: false }
+      }
+    ]
+  } as unknown as DetailField
+}
+
+async function mountPicker(field: DetailField) {
+  const wrapper = mount(ChannelPicker, {
+    props: { field },
+    global: { plugins: [i18n] }
+  })
+  await flushPromises()
+  return wrapper
+}
+
+/** The second BaseSelect in the template is the stable version dropdown. */
+function versionSelect(wrapper: ReturnType<typeof mount>) {
+  const selects = wrapper.findAllComponents(BaseSelect)
+  return selects[selects.length - 1]!
+}
+
+beforeEach(() => {
+  window.api = {
+    getStableTags: vi.fn().mockResolvedValue([...STABLE_TAGS])
+  } as unknown as typeof window.api
+})
+
+describe('ChannelPicker version selector', () => {
+  it('shows no update button when the picked tag matches the installed tag', async () => {
+    const wrapper = await mountPicker(upToDateStableField())
+    // Defaults to the installed tag — nothing to update to.
+    expect(wrapper.find(`[data-testid="${TID.updateActionButton('update-comfyui')}"]`).exists()).toBe(
+      false
+    )
+  })
+
+  it('surfaces an update action after picking a different (older) stable tag', async () => {
+    const wrapper = await mountPicker(upToDateStableField())
+
+    await versionSelect(wrapper).vm.$emit('update:modelValue', 'v0.22.1')
+    await flushPromises()
+
+    const btn = wrapper.find(`[data-testid="${TID.updateActionButton('update-comfyui')}"]`)
+    expect(btn.exists()).toBe(true)
+
+    await btn.trigger('click')
+    const emitted = wrapper.emitted('action')!
+    expect(emitted).toHaveLength(1)
+    const action = emitted[0]![0] as ActionDef
+    expect(action.id).toBe('update-comfyui')
+    expect(action.data).toMatchObject({ channel: 'stable', targetTag: 'v0.22.1' })
+  })
+
+  it('does not synthesize an update for an install whose current tag is unknown', async () => {
+    const field = upToDateStableField()
+    // An install ahead of its base stable tag renders as "v0.24.1 +5", which
+    // isn't a clean tag — we can't pin it, so no synthesized downgrade button.
+    ;(field.options![0]!.data as Record<string, unknown>).installedVersion = 'v0.24.1 +5'
+    const wrapper = await mountPicker(field)
+
+    await versionSelect(wrapper).vm.$emit('update:modelValue', 'v0.22.1')
+    await flushPromises()
+
+    expect(wrapper.find(`[data-testid="${TID.updateActionButton('update-comfyui')}"]`).exists()).toBe(
+      false
+    )
+  })
+})

--- a/src/renderer/src/views/comfyUISettings/ChannelPicker.vue
+++ b/src/renderer/src/views/comfyUISettings/ChannelPicker.vue
@@ -232,9 +232,17 @@ const checkUpdateAction = computed<ActionDef | undefined>(() =>
   allActions.value.find((a) => a.id === 'check-update')
 )
 
-const promotedPrimaryActions = computed<ActionDef[]>(() =>
-  selectedActions.value.filter((a) => a.id === 'update-comfyui' || a.id === 'copy-update')
-)
+const promotedPrimaryActions = computed<ActionDef[]>(() => {
+  const fromServer = selectedActions.value.filter(
+    (a) => a.id === 'update-comfyui' || a.id === 'copy-update'
+  )
+  // Up-to-date installs ship no `update-comfyui` action, so picking a different
+  // stable tag below would otherwise have no button to act on. Surface a
+  // synthesized one in that case.
+  if (fromServer.some((a) => a.id === 'update-comfyui')) return fromServer
+  const synth = synthesizedUpdateAction.value
+  return synth ? [synth, ...fromServer] : fromServer
+})
 
 const otherSecondaryActions = computed<ActionDef[]>(() =>
   selectedActions.value.filter(
@@ -254,12 +262,14 @@ const showCheckInHeader = computed(
     otherSecondaryActions.value.length === 0
 )
 
-// Only surface the manual check when no update is already visible.
+// Only surface the manual check when no update is already visible — including
+// the synthesized "update to picked tag" action on an up-to-date install.
 const showCheckUpdateInFooter = computed(
   () =>
     checkUpdateAction.value != null &&
     !showCheckInHeader.value &&
-    preview.value?.updateAvailable !== true
+    preview.value?.updateAvailable !== true &&
+    synthesizedUpdateAction.value == null
 )
 
 const showFooterActions = computed(
@@ -382,6 +392,30 @@ const versionOptions = computed<BaseSelectOption[]>(() => {
     value: tag,
     label: tag === latest ? t('newInstall.latestStable') + ` — ${tag}` : tag,
   }))
+})
+
+// When the install is already up to date the server sends no `update-comfyui`
+// action, so picking a *different* stable tag from the dropdown would have no
+// button. Synthesize one here (e.g. downgrade to an older release). The backend
+// resolves the exact ref via `targetTag`, added by `attachTargetTagIfNeeded` on
+// click; only the known-installed-tag case is handled so we never surface an
+// update for an install whose current tag we can't pin.
+const synthesizedUpdateAction = computed<ActionDef | null>(() => {
+  if (!isStableDraft.value) return null
+  const tag = pickedStableTag.value
+  if (!tag || !STABLE_TAG_RE.test(tag)) return null
+  if (selectedActions.value.some((a) => a.id === 'update-comfyui')) return null
+  const current = detectCurrentInstalledTag()
+  if (!current || current === tag) return null
+  return {
+    id: 'update-comfyui',
+    label: t('standalone.updateNow'),
+    style: 'primary',
+    enabled: true,
+    showProgress: true,
+    progressTitle: t('standalone.updatingTitle', { version: tag }),
+    data: { channel: 'stable' },
+  }
 })
 
 /** Patch the `update-comfyui` action with the picked stable tag (no-op for


### PR DESCRIPTION
## Problem

In the per-instance **Update** tab, the stable channel shows a `ComfyUI Version` dropdown regardless of whether an update is available. But the actionable buttons (`Update Now` / `Copy & Update`) only come from server-built `data.actions`, which are only attached when `card.data.updateAvailable && hasGit`.

So when an install is **already up to date on the latest stable tag**, the user can pick an *older* stable tag from the dropdown but **no button appears** — there's no way to act on the selection (e.g. to downgrade).

## Fix

Synthesize an `update-comfyui` action in `ChannelPicker.vue` when:
- the drafted channel is `stable`,
- a valid `vX.Y.Z` tag is picked that differs from the installed tag, and
- no server-provided `update-comfyui` action already exists (the up-to-date case).

The backend (`handleUpdateComfyUI` -> `runComfyUIUpdate` with `--tag vX.Y.Z`) already fully supports upgrade/downgrade to a specific tag via `targetTag`, which `attachTargetTagIfNeeded` adds on click. Only the known-installed-tag case is handled, so we never offer an update we can't pin (e.g. installs ahead of their base tag rendered as `v0.24.1 +5`).

The manual `Check for update` button is hidden once the synthesized update action is shown, to avoid clutter.

## Tests

Adds `ChannelPicker.test.ts` covering: no button when picked == installed, button appears + emits `targetTag` when a different tag is picked, and no synthesis when the installed tag isn't a clean `vX.Y.Z`.

All typecheck / lint / 2109 tests / build pass.