### PR TITLE
fix(progress): stop truncating the in-progress stepper detail line

### DIFF
--- a/src/renderer/src/components/BrandProgressView.vue
+++ b/src/renderer/src/components/BrandProgressView.vue
@@ -78,7 +78,7 @@ function rowOpacity(index: number): number {
   --bpv-row-h: 46px;
   position: relative;
   width: 100%;
-  max-width: 26rem;
+  max-width: 38rem;
   margin-inline: auto;
   overflow: hidden;
   -webkit-mask-image: linear-gradient(
@@ -146,7 +146,9 @@ function rowOpacity(index: number): number {
   align-items: center;
   gap: 1px;
   min-width: 0;
-  max-width: min(22rem, 72vw);
+  /* Wide enough for the full download detail line (bytes · speed · ETA) so it
+     isn't ellipsized; clamped to the viewport on narrow windows. */
+  max-width: min(34rem, 88vw);
   text-align: center;
 }
 .bpv__label {


### PR DESCRIPTION
## Problem

In the new in-progress stepper display, the **detail line** for the active step (bytes / speed / ETA, e.g. `423 MB / 1,234 MB  ·  15.2 MB/s  ·  53s remaining`) is rendered single-line with `text-overflow: ellipsis`. Its container `.bpv__text` was capped at `min(22rem, 72vw)` (and `.bpv` at `26rem`), which is too narrow for a full download/clone status — so the `remaining` tail got clipped and you couldn't read the whole line.

The flat (non-stepper) fallback already wraps freely; only the stepper truncated.

## Fix

Widen the stepper (`38rem`) and its text column (`min(34rem, 88vw)`) so the full detail line fits within the modal card (up to 880px), while staying clamped to the viewport on narrow windows. CSS-only change in `BrandProgressView.vue`.

## Verification

typecheck (web), lint, build, and ProgressModal tests (23) all pass.