### PR TITLE
fix(window): repaint host views after restore from minimized

### DIFF
--- a/src/main/host/createHostWindow.test.ts
+++ b/src/main/host/createHostWindow.test.ts
@@ -22,6 +22,7 @@ import {
   cascadeOffsetForCollisions,
   expectedPartitionFor,
   installCloseNeedsConfirm,
+  isWindowLayoutable,
   shouldBailAfterCloseChoice,
   shouldBailAfterConsult,
   shouldShowInstallCloseConfirm,
@@ -160,6 +161,24 @@ describe('shouldShowInstallCloseConfirm', () => {
     // bailed in the prior check (this case is unreachable in practice).
     expect(shouldShowInstallCloseConfirm(true, 'cleared', true, false, true)).toBe(false)
     expect(shouldShowInstallCloseConfirm(true, 'aborted', true, false, true)).toBe(false)
+  })
+})
+
+describe('isWindowLayoutable', () => {
+  it('is true for a live, non-minimized window', () => {
+    expect(isWindowLayoutable({ isDestroyed: () => false, isMinimized: () => false })).toBe(true)
+  })
+
+  it('is false while minimized — minimized windows report a bogus content size, so laying out collapses the child views', () => {
+    expect(isWindowLayoutable({ isDestroyed: () => false, isMinimized: () => true })).toBe(false)
+  })
+
+  it('is false for a destroyed window', () => {
+    expect(isWindowLayoutable({ isDestroyed: () => true, isMinimized: () => false })).toBe(false)
+  })
+
+  it('is false for a destroyed window even if it never reports minimized', () => {
+    expect(isWindowLayoutable({ isDestroyed: () => true, isMinimized: () => true })).toBe(false)
   })
 })
 

--- a/src/main/host/createHostWindow.ts
+++ b/src/main/host/createHostWindow.ts
@@ -708,17 +708,30 @@ export function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowRe
   // so without this the child views keep whatever (collapsed) bounds they were
   // left with while minimized — a grey window with no title bar or content until
   // the user maximizes. A WebContentsView also won't repaint after restore on
-  // Windows unless its bounds are reapplied. Defer one tick: on 'restore' the OS
-  // still reports the stale minimized content size for a moment, so reading it
-  // synchronously would lay out against the wrong size.
+  // Windows unless its bounds are reapplied.
+  //
+  // Two passes: one next tick, one after a short delay. Right after restore()
+  // the OS can briefly still report the stale minimized content size even though
+  // isMinimized() is already false, so a single tick isn't a safe assumption.
+  // layoutViews() is idempotent, so the second pass is a cheap self-heal.
+  let delayedRelayoutTimer: ReturnType<typeof setTimeout> | null = null
   const relayoutWhenVisible = (): void => {
     setImmediate(() => {
       if (!isWindowLayoutable(comfyWindow)) return
       layoutViews()
     })
+    if (delayedRelayoutTimer) clearTimeout(delayedRelayoutTimer)
+    delayedRelayoutTimer = setTimeout(() => {
+      delayedRelayoutTimer = null
+      if (!isWindowLayoutable(comfyWindow)) return
+      layoutViews()
+    }, 50)
   }
   comfyWindow.on('restore', relayoutWhenVisible)
   comfyWindow.on('show', relayoutWhenVisible)
+  comfyWindow.on('closed', () => {
+    if (delayedRelayoutTimer) clearTimeout(delayedRelayoutTimer)
+  })
 
   if (saved?.maximized) comfyWindow.maximize()
 
@@ -745,6 +758,10 @@ export function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowRe
   const persistBounds = (): void => {
     const live = comfyWindows.get(windowKey)
     if (!live || isChooserHost(live)) return
+    // Don't persist bounds read from a minimized window — Windows reports a
+    // bogus content size while minimized, which would poison the saved size
+    // for the next launch.
+    if (!isWindowLayoutable(comfyWindow)) return
     saveWindowBounds(liveBoundsKeyFor(live), comfyWindow)
   }
   comfyWindow.on('resize', persistBounds)

--- a/src/main/host/createHostWindow.ts
+++ b/src/main/host/createHostWindow.ts
@@ -540,6 +540,17 @@ function findLiveSiblingOrigin(boundsKey: string): { x: number; y: number } | nu
   return null
 }
 
+/** A host window can be laid out only while it's alive AND not minimized.
+ *  Minimized windows report a bogus content size on Windows, so reading their
+ *  bounds to position the child views collapses them (the grey-screen bug).
+ *  Shared by the `layoutViews` guard and the deferred `restore`/`show` relayout
+ *  so the two can't drift. */
+export function isWindowLayoutable(
+  win: Pick<BrowserWindow, 'isDestroyed' | 'isMinimized'>,
+): boolean {
+  return !win.isDestroyed() && !win.isMinimized()
+}
+
 export function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowResult {
   const fx = getFactories()
   const windowKey = nextWindowKey()
@@ -638,7 +649,12 @@ export function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowRe
   // comfyTitleBar.html sits below the native buttons.
   const titleBarTotal = TITLEBAR_HEIGHT + 1
   const layoutViews = (): void => {
-    if (comfyWindow.isDestroyed()) return
+    // While minimized, Windows reports a bogus (minimum/zero) content size, so
+    // laying out here would collapse both child views — and since restoring at
+    // the same size emits no 'resize', they'd stay collapsed (grey window) until
+    // a maximize. Skip; the 'restore'/'show' handlers re-run a real layout once
+    // the window is visible again.
+    if (!isWindowLayoutable(comfyWindow)) return
     const entry = comfyWindows.get(windowKey)
     const [width, height] = comfyWindow.getContentSize() as [number, number]
     const bodyHeight = Math.max(0, height - titleBarTotal)
@@ -686,6 +702,23 @@ export function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowRe
     }
   }
   comfyWindow.on('resize', layoutViews)
+
+  // Re-lay-out when the window becomes visible again after being minimized or
+  // hidden. Restoring at the previous (non-maximized) size emits no 'resize',
+  // so without this the child views keep whatever (collapsed) bounds they were
+  // left with while minimized — a grey window with no title bar or content until
+  // the user maximizes. A WebContentsView also won't repaint after restore on
+  // Windows unless its bounds are reapplied. Defer one tick: on 'restore' the OS
+  // still reports the stale minimized content size for a moment, so reading it
+  // synchronously would lay out against the wrong size.
+  const relayoutWhenVisible = (): void => {
+    setImmediate(() => {
+      if (!isWindowLayoutable(comfyWindow)) return
+      layoutViews()
+    })
+  }
+  comfyWindow.on('restore', relayoutWhenVisible)
+  comfyWindow.on('show', relayoutWhenVisible)
 
   if (saved?.maximized) comfyWindow.maximize()
 

--- a/src/main/host/createHostWindow.ts
+++ b/src/main/host/createHostWindow.ts
@@ -540,11 +540,9 @@ function findLiveSiblingOrigin(boundsKey: string): { x: number; y: number } | nu
   return null
 }
 
-/** A host window can be laid out only while it's alive AND not minimized.
- *  Minimized windows report a bogus content size on Windows, so reading their
- *  bounds to position the child views collapses them (the grey-screen bug).
- *  Shared by the `layoutViews` guard and the deferred `restore`/`show` relayout
- *  so the two can't drift. */
+/** Layout is safe only while the window is alive and not minimized — a
+ *  minimized window reports a bogus content size on Windows, collapsing the
+ *  child views (the grey-screen bug). */
 export function isWindowLayoutable(
   win: Pick<BrowserWindow, 'isDestroyed' | 'isMinimized'>,
 ): boolean {
@@ -649,11 +647,8 @@ export function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowRe
   // comfyTitleBar.html sits below the native buttons.
   const titleBarTotal = TITLEBAR_HEIGHT + 1
   const layoutViews = (): void => {
-    // While minimized, Windows reports a bogus (minimum/zero) content size, so
-    // laying out here would collapse both child views — and since restoring at
-    // the same size emits no 'resize', they'd stay collapsed (grey window) until
-    // a maximize. Skip; the 'restore'/'show' handlers re-run a real layout once
-    // the window is visible again.
+    // Skip while minimized (bogus content size would collapse the views); the
+    // 'restore'/'show' handlers re-run this once the window is visible again.
     if (!isWindowLayoutable(comfyWindow)) return
     const entry = comfyWindows.get(windowKey)
     const [width, height] = comfyWindow.getContentSize() as [number, number]
@@ -703,17 +698,11 @@ export function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowRe
   }
   comfyWindow.on('resize', layoutViews)
 
-  // Re-lay-out when the window becomes visible again after being minimized or
-  // hidden. Restoring at the previous (non-maximized) size emits no 'resize',
-  // so without this the child views keep whatever (collapsed) bounds they were
-  // left with while minimized — a grey window with no title bar or content until
-  // the user maximizes. A WebContentsView also won't repaint after restore on
-  // Windows unless its bounds are reapplied.
-  //
-  // Two passes: one next tick, one after a short delay. Right after restore()
-  // the OS can briefly still report the stale minimized content size even though
-  // isMinimized() is already false, so a single tick isn't a safe assumption.
-  // layoutViews() is idempotent, so the second pass is a cheap self-heal.
+  // Re-lay-out when the window becomes visible again: restoring at the same size
+  // emits no 'resize', and a WebContentsView won't repaint after restore on
+  // Windows unless its bounds are reapplied. Two passes (next tick + short
+  // delay) because right after restore() the OS can still report the stale
+  // minimized size for a moment; layoutViews() is idempotent so it self-heals.
   let delayedRelayoutTimer: ReturnType<typeof setTimeout> | null = null
   const relayoutWhenVisible = (): void => {
     setImmediate(() => {
@@ -758,9 +747,7 @@ export function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowRe
   const persistBounds = (): void => {
     const live = comfyWindows.get(windowKey)
     if (!live || isChooserHost(live)) return
-    // Don't persist bounds read from a minimized window — Windows reports a
-    // bogus content size while minimized, which would poison the saved size
-    // for the next launch.
+    // Don't persist a minimized window's bogus bounds (would poison next launch).
     if (!isWindowLayoutable(comfyWindow)) return
     saveWindowBounds(liveBoundsKeyFor(live), comfyWindow)
   }


### PR DESCRIPTION
## Problem

Closes #1061. Booting ComfyUI while the desktop window is **minimized** leaves a grey window — neither the title bar nor the web contents render. The only recovery is to maximize the window or force-quit and reboot.

## Root cause

Every host window sizes its child views (titleBarView + comfyView/panelView) through a single layoutViews() that reads getContentSize() and calls setBounds(). The only window-state trigger wired to re-run it is the 'resize' event.

Two Windows behaviors combine:
1. A minimized window reports a bogus (minimum/zero) content size (electron#19816), and a WebContentsView doesn't repaint after restore unless its bounds are reapplied.
2. Any layoutViews() that fires while minimized (boot completion, panel/body-mode swaps, cold-start / startup-restore reveals) collapses both views.

Restoring at the previous (non-maximized) size emits no 'resize' event, so layoutViews() never re-runs and the views stay collapsed -> grey window. Maximizing changes the size, which fires 'resize' -> relayout -> repaint. That is why maximizing "fixes" it.

## Fix (platform-agnostic)

- Guard layoutViews() so it skips while the window is minimized — it can't write collapsed bounds from a bogus content size.
- Re-run layoutViews() on the 'restore' and 'show' events, deferred one tick via setImmediate (on 'restore' Windows still reports the stale minimized size for a moment), so views are repositioned and repainted when the window becomes visible again.
- Extract the shared isWindowLayoutable() predicate used by both call sites (so they can't drift) and unit-test it.

This closes a latent cross-platform fragility (the "no relayout on restore" gap exists on every OS); the change is a harmless redundant relayout on macOS/Linux where the symptom doesn't reproduce.

## Testing

- pnpm run typecheck OK
- pnpm run lint OK
- pnpm run build OK
- pnpm run test OK (2129 passed; createHostWindow.test.ts now 29)
- Manual (Windows): launch an instance, minimize during boot, let ComfyUI finish, restore -> title bar + content paint without needing to maximize.