### PR TITLE
fix(update): install staged updates at startup, not on quit (#1065)

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1015,6 +1015,8 @@
     "instanceRunningReplace": "Close & Launch",
     "modelFolderRelaunchTitle": "Restarting ComfyUI",
     "modelFolderRelaunchDesc": "New model folders were detected from custom nodes. Restarting so ComfyUI can use them right away.",
+    "updateInstallTitle": "Installing update",
+    "updateInstallDesc": "Applying the latest ComfyUI Desktop update. The app will restart automatically.",
     "launchSplashTitle": "Starting ComfyUI",
     "launchSplashDesc": "Launching your ComfyUI instance…",
     "activity": {

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -1015,6 +1015,8 @@
     "instanceRunningReplace": "关闭并启动",
     "modelFolderRelaunchTitle": "正在重启 ComfyUI",
     "modelFolderRelaunchDesc": "检测到来自自定义节点的新模型文件夹。正在重启，以便 ComfyUI 立即使用它们。",
+    "updateInstallTitle": "正在安装更新",
+    "updateInstallDesc": "正在应用最新的 ComfyUI Desktop 更新。应用将自动重启。",
     "launchSplashTitle": "正在启动 ComfyUI",
     "launchSplashDesc": "正在启动你的 ComfyUI 实例…",
     "activity": {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -34,8 +34,8 @@ import {
 import { registerPickerSettingsIpc } from './popups/pickerSettingsHandlers'
 import { waitForPort, COMFY_BOOT_TIMEOUT_MS } from './lib/process'
 import {
+  clearQuitReason,
   isQuitInProgress,
-  isUpdateInstallQuit,
   setQuitReason,
   setSessionEnding
 } from './lib/quit-state'
@@ -2004,17 +2004,31 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
     // while the bounded check runs; if it commits to installing, the app quits
     // here and the installer relaunches it — so we skip opening the normal UI.
     const updateSplash = updater.hasPendingStartupUpdate() ? showUpdateInstallSplash() : undefined
+    // Track whether the install actually started quitting the app. Quit intent
+    // (`quitReason`) alone isn't proof — `restartAndInstall` can return without
+    // quitting if the staged installer is gone — so key the backstop off a real
+    // `before-quit`.
+    let updateInstallQuitStarted = false
+    const onUpdateInstallQuit = (): void => {
+      updateInstallQuitStarted = true
+    }
+    app.once('before-quit', onUpdateInstallQuit)
     const installingUpdate = await updater.applyPendingUpdateOnStartup()
     if (installingUpdate) {
-      // Safety net: a successful install quits the app within a tick. If it
-      // didn't (e.g. the staged installer was gone), don't strand the user on
-      // the splash — fall back to the normal surface.
+      // Safety net: a successful install quits the app within a tick (firing
+      // before-quit). If that didn't happen the install didn't proceed — recover
+      // into the normal surface instead of stranding the user on the splash, and
+      // clear the now-stale 'update-install' quit intent so the next real quit
+      // still runs its cleanup.
       setTimeout(() => {
-        if (isUpdateInstallQuit()) return
+        if (updateInstallQuitStarted) return
+        app.removeListener('before-quit', onUpdateInstallQuit)
+        clearQuitReason()
         if (updateSplash && !updateSplash.isDestroyed()) updateSplash.destroy()
         void openStartupSurface()
       }, STARTUP_INSTALL_QUIT_BACKSTOP_MS)
     } else {
+      app.removeListener('before-quit', onUpdateInstallQuit)
       if (updateSplash && !updateSplash.isDestroyed()) updateSplash.destroy()
       // The install-less chooser host is the primary surface. Each
       // install gets its own ComfyUI window via openComfyWindow()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -33,7 +33,13 @@ import {
 } from './popups/titlePopup'
 import { registerPickerSettingsIpc } from './popups/pickerSettingsHandlers'
 import { waitForPort, COMFY_BOOT_TIMEOUT_MS } from './lib/process'
-import { isQuitInProgress, setQuitReason } from './lib/quit-state'
+import {
+  isQuitInProgress,
+  isUpdateInstallQuit,
+  setQuitReason,
+  setSessionEnding
+} from './lib/quit-state'
+import { showUpdateInstallSplash } from './lib/updateSplash'
 import type { InstallationRecord } from './installations'
 import {
   cleanupTempDownloads,
@@ -207,6 +213,11 @@ function quitApp(): void {
  *  never reaches the restore handler, so the window can't stay invisible. */
 const STARTUP_RESTORE_REVEAL_BACKSTOP_MS = 10_000
 const pendingStartupRestoreRevealTimers = new Map<number, ReturnType<typeof setTimeout>>()
+
+/** A successful startup update install quits the app within a tick. If the quit
+ *  hasn't happened by now the install didn't proceed, so we recover into the
+ *  normal surface rather than leaving the user on the "Updating…" splash. */
+const STARTUP_INSTALL_QUIT_BACKSTOP_MS = 4_000
 
 function clearStartupRestoreRevealTimer(windowKey: number): void {
   const timer = pendingStartupRestoreRevealTimers.get(windowKey)
@@ -1227,6 +1238,18 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
     })
   }
 
+  // Record OS session-end (Windows shutdown / restart / logoff, also macOS) so
+  // the update install paths can bail out — spawning the installer while the OS
+  // is tearing everything down risks it being force-killed mid-write, which is
+  // the corruption mode behind the "reinstall on every shutdown" reports.
+  // `session-end` is a BrowserWindow event, so attach it to every window as it
+  // is created.
+  app.on('browser-window-created', (_event, window) => {
+    window.on('session-end', () => {
+      setSessionEnding()
+    })
+  })
+
   app.whenReady().then(async () => {
     // Test-only hooks for the E2E suite. Registered before any host
     // opens so seeded state (downloads, install-update overrides,
@@ -1975,13 +1998,32 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
     // and the tray-aware `window-all-closed` gating will all come back
     // when the docked-app flow is reinstated. Until then, see git
     // history for the previous tray construction code.
-    // The install-less chooser host is the primary surface. Each
-    // install gets its own ComfyUI window via openComfyWindow()
-    // when launched, and the chooser host is the entry-point for
-    // picking / creating installs. When the user last left an instance
-    // window (and the reopen setting is on), restore that instance
-    // in-place on top of the freshly-opened chooser host.
-    void openStartupSurface()
+    // Apply a previously-downloaded Desktop update at startup rather than on
+    // quit (installing on quit is what a Windows shutdown interrupts and
+    // corrupts). When an update is staged we show a brief "Updating…" splash
+    // while the bounded check runs; if it commits to installing, the app quits
+    // here and the installer relaunches it — so we skip opening the normal UI.
+    const updateSplash = updater.hasPendingStartupUpdate() ? showUpdateInstallSplash() : undefined
+    const installingUpdate = await updater.applyPendingUpdateOnStartup()
+    if (installingUpdate) {
+      // Safety net: a successful install quits the app within a tick. If it
+      // didn't (e.g. the staged installer was gone), don't strand the user on
+      // the splash — fall back to the normal surface.
+      setTimeout(() => {
+        if (isUpdateInstallQuit()) return
+        if (updateSplash && !updateSplash.isDestroyed()) updateSplash.destroy()
+        void openStartupSurface()
+      }, STARTUP_INSTALL_QUIT_BACKSTOP_MS)
+    } else {
+      if (updateSplash && !updateSplash.isDestroyed()) updateSplash.destroy()
+      // The install-less chooser host is the primary surface. Each
+      // install gets its own ComfyUI window via openComfyWindow()
+      // when launched, and the chooser host is the entry-point for
+      // picking / creating installs. When the user last left an instance
+      // window (and the reopen setting is on), restore that instance
+      // in-place on top of the freshly-opened chooser host.
+      void openStartupSurface()
+    }
 
     // Single subscription rebroadcasts every install-list mutation
     // (add/remove/update/markLaunched/reorder/...) to all renderers as

--- a/src/main/lib/quit-state.ts
+++ b/src/main/lib/quit-state.ts
@@ -21,3 +21,18 @@ export function isQuitInProgress(): boolean {
 export function isUpdateInstallQuit(): boolean {
   return quitReason === 'update-install'
 }
+
+/** Set once the OS signals the session is ending (Windows shutdown / restart /
+ *  logoff, via `app.on('session-end')`). Guards the update install paths so we
+ *  never spawn an installer the OS is about to kill mid-write — the corruption
+ *  mode behind the "reinstall every shutdown" loop. Never reset: the process is
+ *  on its way out. */
+let sessionEnding = false
+
+export function setSessionEnding(): void {
+  sessionEnding = true
+}
+
+export function isSessionEnding(): boolean {
+  return sessionEnding
+}

--- a/src/main/lib/updateSplash.ts
+++ b/src/main/lib/updateSplash.ts
@@ -1,0 +1,42 @@
+import { BrowserWindow } from 'electron'
+import { COMFY_BG_DARK, SPLASH_DARK } from './theme'
+import { showSplashPage } from './relaunchPage'
+import * as i18n from './i18n'
+
+/**
+ * Brief "Updating…" window shown while a previously-downloaded Desktop update is
+ * applied at startup (see `applyPendingUpdateOnStartup`). It exists only so the
+ * user isn't staring at an empty screen during the (bounded) install check; the
+ * app quits shortly after and the installer relaunches it. If the install
+ * doesn't proceed, the caller destroys this window and opens the normal UI.
+ *
+ * Self-contained (renders the shared brand splash into its own webContents), so
+ * it has no dependency on the host-window / panel renderer wiring that isn't up
+ * yet this early in boot.
+ */
+export function showUpdateInstallSplash(): BrowserWindow {
+  const win = new BrowserWindow({
+    width: 480,
+    height: 360,
+    frame: false,
+    resizable: false,
+    center: true,
+    show: false,
+    backgroundColor: COMFY_BG_DARK,
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true
+    }
+  })
+
+  win.once('ready-to-show', () => {
+    if (!win.isDestroyed()) win.show()
+  })
+
+  void showSplashPage(win.webContents, SPLASH_DARK, {
+    title: i18n.t('launch.updateInstallTitle'),
+    desc: i18n.t('launch.updateInstallDesc')
+  })
+
+  return win
+}

--- a/src/main/lib/updater.test.ts
+++ b/src/main/lib/updater.test.ts
@@ -412,12 +412,21 @@ describe('startup update install + session-end guard (issue #1065)', () => {
   })
 
   it('applyPendingUpdateOnStartup() does not install when the check cannot confirm a ready update', async () => {
-    settingsStore['pendingDownloadedUpdateVersion'] = '1.0.1'
-    readyVersion = null // e.g. cached installer invalid / offline
-    const updater = await import('./updater')
-    updater.register()
-    expect(await updater.applyPendingUpdateOnStartup()).toBe(false)
-    expect(fakeUpdater.restartAndInstall).not.toHaveBeenCalled()
+    vi.useFakeTimers()
+    try {
+      settingsStore['pendingDownloadedUpdateVersion'] = '1.0.1'
+      readyVersion = null // e.g. cached installer invalid / offline
+      const updater = await import('./updater')
+      updater.register()
+      const pending = updater.applyPendingUpdateOnStartup()
+      // No 'ready' transition arrives, so the bounded wait falls through on its
+      // timeout rather than hanging boot forever.
+      await vi.advanceTimersByTimeAsync(5000)
+      expect(await pending).toBe(false)
+      expect(fakeUpdater.restartAndInstall).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('loop-breaker: a previously-attempted version is not auto-retried', async () => {

--- a/src/main/lib/updater.test.ts
+++ b/src/main/lib/updater.test.ts
@@ -4,6 +4,7 @@ let mockPlatform = 'linux'
 let mockAppImage: string | undefined
 let mockIsPackaged = true
 let mockExePath = '/opt/Comfy Desktop/comfyui-desktop-2'
+let mockAppVersion = '1.0.0'
 
 vi.mock('electron', () => ({
   app: {
@@ -13,7 +14,9 @@ vi.mock('electron', () => ({
     getPath: (name: string) => {
       if (name === 'exe') return mockExePath
       return ''
-    }
+    },
+    getVersion: () => mockAppVersion,
+    releaseSingleInstanceLock: vi.fn()
   },
   ipcMain: {
     handle: vi.fn()
@@ -27,13 +30,19 @@ vi.mock('@todesktop/runtime', () => ({
   default: { autoUpdater: null }
 }))
 
+vi.mock('electron-updater', () => ({
+  autoUpdater: { autoInstallOnAppQuit: true }
+}))
+
 vi.mock('../settings', () => ({
-  get: vi.fn()
+  get: vi.fn(),
+  set: vi.fn()
 }))
 
 vi.mock('./quit-state', () => ({
   clearQuitReason: vi.fn(),
-  setQuitReason: vi.fn()
+  setQuitReason: vi.fn(),
+  isSessionEnding: vi.fn(() => false)
 }))
 
 const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
@@ -276,5 +285,159 @@ describe('app-update telemetry dedup (volume regression)', () => {
     )
     expect(checkedEmits).toHaveLength(1)
     expect(checkedEmits[0]?.[1]).toMatchObject({ trigger: 'manual-check', result: 'available' })
+  })
+})
+
+/**
+ * Issue #1065 — install staged Desktop updates at startup (Option C) instead of
+ * silently on quit, and never spawn the installer while the OS session is
+ * ending. Installing on quit is what a Windows shutdown interrupts mid-write,
+ * corrupting the install and forcing endless reinstalls.
+ */
+describe('startup update install + session-end guard (issue #1065)', () => {
+  let settingsStore: Record<string, unknown>
+  let listeners: Record<string, Array<(...args: unknown[]) => void>>
+  let fakeUpdater: {
+    on: ReturnType<typeof vi.fn>
+    checkForUpdates: ReturnType<typeof vi.fn>
+    restartAndInstall: ReturnType<typeof vi.fn>
+  }
+  let electronUpdaterMock: { autoInstallOnAppQuit: boolean }
+  let sessionEnding: boolean
+  let readyVersion: string | null
+
+  const originalPlat = Object.getOwnPropertyDescriptor(process, 'platform')!
+
+  beforeEach(() => {
+    vi.resetModules()
+    settingsStore = {}
+    listeners = {}
+    sessionEnding = false
+    readyVersion = null
+    mockAppVersion = '1.0.0'
+    delete process.env.E2E
+    // Non-system, non-darwin platform so isSystemPackageInstall() is false and
+    // installUpdate() skips the darwin single-instance-lock dance.
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+
+    fakeUpdater = {
+      on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+        listeners[event] = listeners[event] || []
+        listeners[event].push(cb)
+      }) as ReturnType<typeof vi.fn>,
+      // Mimic the ToDesktop wrapper: a successful check of an already-downloaded
+      // update re-emits `update-downloaded`, which flips state to 'ready'.
+      checkForUpdates: vi.fn(async () => {
+        if (readyVersion) {
+          for (const cb of listeners['update-downloaded'] || []) cb({ version: readyVersion })
+          return { updateInfo: { version: readyVersion } }
+        }
+        return { updateInfo: null }
+      }),
+      restartAndInstall: vi.fn()
+    }
+    electronUpdaterMock = { autoInstallOnAppQuit: true }
+
+    vi.doMock('@todesktop/runtime', () => ({ default: { autoUpdater: fakeUpdater } }))
+    vi.doMock('electron-updater', () => ({ autoUpdater: electronUpdaterMock }))
+    vi.doMock('./telemetry', () => ({ emit: vi.fn(), bucketError: (s: string) => s }))
+    vi.doMock('./quit-state', () => ({
+      clearQuitReason: vi.fn(),
+      setQuitReason: vi.fn(),
+      isSessionEnding: vi.fn(() => sessionEnding)
+    }))
+    vi.doMock('../settings', () => ({
+      get: vi.fn((key: string) => settingsStore[key]),
+      set: vi.fn((key: string, value: unknown) => {
+        if (value === undefined) delete settingsStore[key]
+        else settingsStore[key] = value
+      })
+    }))
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', originalPlat)
+  })
+
+  it('register() disables electron-updater autoInstallOnAppQuit', async () => {
+    const updater = await import('./updater')
+    updater.register()
+    expect(electronUpdaterMock.autoInstallOnAppQuit).toBe(false)
+  })
+
+  it('installUpdate() is a no-op while the OS session is ending', async () => {
+    sessionEnding = true
+    const updater = await import('./updater')
+    updater.register()
+    updater.installUpdate()
+    expect(fakeUpdater.restartAndInstall).not.toHaveBeenCalled()
+  })
+
+  it('hasPendingStartupUpdate() reflects the staged-update markers', async () => {
+    const updater = await import('./updater')
+
+    expect(updater.hasPendingStartupUpdate()).toBe(false)
+
+    settingsStore['pendingDownloadedUpdateVersion'] = '1.0.1'
+    expect(updater.hasPendingStartupUpdate()).toBe(true)
+
+    // Staged version is already what we are running.
+    settingsStore['pendingDownloadedUpdateVersion'] = '1.0.0'
+    expect(updater.hasPendingStartupUpdate()).toBe(false)
+
+    // Loop-breaker: already auto-attempted this version.
+    settingsStore['pendingDownloadedUpdateVersion'] = '1.0.1'
+    settingsStore['lastStartupUpdateAttemptVersion'] = '1.0.1'
+    expect(updater.hasPendingStartupUpdate()).toBe(false)
+  })
+
+  it('applyPendingUpdateOnStartup() installs a staged update and records the attempt', async () => {
+    settingsStore['pendingDownloadedUpdateVersion'] = '1.0.1'
+    readyVersion = '1.0.1'
+    const updater = await import('./updater')
+    updater.register()
+
+    const installing = await updater.applyPendingUpdateOnStartup()
+
+    expect(installing).toBe(true)
+    expect(fakeUpdater.restartAndInstall).toHaveBeenCalledTimes(1)
+    expect(settingsStore['lastStartupUpdateAttemptVersion']).toBe('1.0.1')
+  })
+
+  it('applyPendingUpdateOnStartup() does nothing when no update is staged', async () => {
+    const updater = await import('./updater')
+    updater.register()
+    expect(await updater.applyPendingUpdateOnStartup()).toBe(false)
+    expect(fakeUpdater.restartAndInstall).not.toHaveBeenCalled()
+  })
+
+  it('applyPendingUpdateOnStartup() does not install when the check cannot confirm a ready update', async () => {
+    settingsStore['pendingDownloadedUpdateVersion'] = '1.0.1'
+    readyVersion = null // e.g. cached installer invalid / offline
+    const updater = await import('./updater')
+    updater.register()
+    expect(await updater.applyPendingUpdateOnStartup()).toBe(false)
+    expect(fakeUpdater.restartAndInstall).not.toHaveBeenCalled()
+  })
+
+  it('loop-breaker: a previously-attempted version is not auto-retried', async () => {
+    settingsStore['pendingDownloadedUpdateVersion'] = '1.0.1'
+    settingsStore['lastStartupUpdateAttemptVersion'] = '1.0.1'
+    readyVersion = '1.0.1'
+    const updater = await import('./updater')
+    updater.register()
+    expect(await updater.applyPendingUpdateOnStartup()).toBe(false)
+    expect(fakeUpdater.restartAndInstall).not.toHaveBeenCalled()
+  })
+
+  it('clears stale markers once the staged version is actually running', async () => {
+    settingsStore['pendingDownloadedUpdateVersion'] = '1.0.0'
+    settingsStore['lastStartupUpdateAttemptVersion'] = '1.0.0'
+    mockAppVersion = '1.0.0' // install succeeded; we now run it
+    const updater = await import('./updater')
+    updater.register()
+    await updater.applyPendingUpdateOnStartup()
+    expect(settingsStore['pendingDownloadedUpdateVersion']).toBeUndefined()
+    expect(settingsStore['lastStartupUpdateAttemptVersion']).toBeUndefined()
   })
 })

--- a/src/main/lib/updater.ts
+++ b/src/main/lib/updater.ts
@@ -1,7 +1,8 @@
 import { app, ipcMain } from 'electron'
 import todesktop from '@todesktop/runtime'
+import { autoUpdater as electronAutoUpdater } from 'electron-updater'
 import * as settings from '../settings'
-import { clearQuitReason, setQuitReason } from './quit-state'
+import { clearQuitReason, isSessionEnding, setQuitReason } from './quit-state'
 import { _broadcastToRenderer } from './ipc/shared'
 import { emit as emitTelemetry, bucketError } from './telemetry'
 
@@ -200,6 +201,14 @@ function bindUpdaterEvents(): void {
     if (_shouldEmitAppUpdateOnce('comfy.desktop.app_update.download_complete', version)) {
       emitTelemetry('comfy.desktop.app_update.download_complete', { version })
     }
+    // Persist that an installer is staged on disk so the next launch knows to
+    // run the (bounded) startup-install check. The download is cached by
+    // electron-updater across restarts, so we apply it on the next boot rather
+    // than on quit — installing on quit is what gets killed mid-write during a
+    // Windows shutdown and corrupts the install.
+    try {
+      settings.set('pendingDownloadedUpdateVersion', version)
+    } catch {}
     _setUpdateState({ kind: 'ready', version, autoUpdate: isAutoInstallEnabled() })
     if (_userInitiatedDownload) {
       // The user opted in to download via the auto-off available pill
@@ -428,6 +437,13 @@ export async function downloadUpdate(): Promise<void> {
  * system-modal "Restart" confirm) share a single implementation.
  */
 export function installUpdate(): void {
+  if (isSessionEnding()) {
+    // The OS is shutting down / logging off. Spawning the installer now risks
+    // it being force-killed mid-write, corrupting the install — the exact
+    // failure this whole flow exists to avoid. The staged update stays put and
+    // applies on the next launch instead.
+    return
+  }
   const updater = getAutoUpdater()
   if (!updater) {
     _broadcastToRenderer('app-update:user-action-failed', { message: UPDATER_UNAVAILABLE_MESSAGE })
@@ -472,8 +488,99 @@ export function _test_setUpdateState(next: AppUpdateState): void {
   _setUpdateState(next)
 }
 
+/** Upper bound on how long the startup-install check may delay boot. The
+ *  installer was already downloaded in a previous session, so this only
+ *  re-validates the cached file against the release feed (no re-download); the
+ *  cap keeps a slow / offline network from ever hanging the launch. */
+const STARTUP_UPDATE_CHECK_TIMEOUT_MS = 5000
+
+/**
+ * True when there is a staged Desktop update we should try to install on this
+ * launch. Cheap and synchronous (reads only persisted markers + environment),
+ * so callers can use it to decide whether to show an "Updating…" splash before
+ * the bounded `applyPendingUpdateOnStartup` check runs.
+ *
+ * Returns false for: E2E runs, system-package-managed installs (apt/dnf own the
+ * update), an OS session that's already ending, no staged download, a staged
+ * version that's already the running version, and the loop-breaker case (we
+ * already auto-attempted this exact version and are still on the old one).
+ */
+function shouldAttemptStartupInstall(): boolean {
+  if (process.env['E2E'] === '1') return false
+  if (isSystemPackageInstall()) return false
+  if (isSessionEnding()) return false
+  const pending = settings.get('pendingDownloadedUpdateVersion')
+  if (!pending) return false
+  if (pending === app.getVersion()) return false
+  const lastAttempt = settings.get('lastStartupUpdateAttemptVersion')
+  if (lastAttempt === pending) return false
+  return true
+}
+
+export function hasPendingStartupUpdate(): boolean {
+  return shouldAttemptStartupInstall()
+}
+
+/**
+ * Apply a previously-downloaded Desktop update at startup instead of on quit.
+ * Installing on quit is what gets interrupted by a Windows shutdown and leaves
+ * a corrupted install; doing it at launch decouples the install from the
+ * shutdown entirely. Returns `true` when an install was triggered (the caller
+ * should then keep the splash up and NOT open the normal UI — the app is about
+ * to quit and the installer relaunches it). Returns `false` (open the UI as
+ * usual) when there's nothing to do, the check can't confirm a ready update, or
+ * the loop-breaker is engaged.
+ */
+export async function applyPendingUpdateOnStartup(): Promise<boolean> {
+  // Clear stale markers once the attempted/staged version is actually running
+  // (the install succeeded on a previous boot).
+  const running = app.getVersion()
+  if (settings.get('lastStartupUpdateAttemptVersion') === running) {
+    settings.set('lastStartupUpdateAttemptVersion', undefined)
+  }
+  if (settings.get('pendingDownloadedUpdateVersion') === running) {
+    settings.set('pendingDownloadedUpdateVersion', undefined)
+  }
+
+  if (!shouldAttemptStartupInstall()) return false
+
+  // The installer is cached on disk from a previous session; this check
+  // re-validates it (no re-download) and populates the updater's ready state.
+  // Bounded so a slow/offline network can't hang boot — if it doesn't resolve
+  // to a ready update in time, we open the UI and try again next launch.
+  await Promise.race([
+    runCheck('startup-install').catch(() => {}),
+    new Promise((resolve) => setTimeout(resolve, STARTUP_UPDATE_CHECK_TIMEOUT_MS))
+  ])
+
+  const state = getCurrentUpdateState()
+  if (state.kind !== 'ready' || !state.version) return false
+  if (state.version === running) return false
+  // The session may have started ending while we awaited the check.
+  if (isSessionEnding()) return false
+
+  // Record the attempt BEFORE installing so a failed install (app relaunches on
+  // the old version) trips the loop-breaker next boot instead of looping.
+  settings.set('lastStartupUpdateAttemptVersion', state.version)
+  emitTelemetry('comfy.desktop.app_update.startup_install', { version: state.version })
+  installUpdate()
+  return true
+}
+
 export function register(): void {
   bindUpdaterEvents()
+
+  // Disable electron-updater's silent install-on-quit. Its default
+  // (`autoInstallOnAppQuit = true`) registers a quit handler that spawns the
+  // installer whenever the app closes — including during a Windows shutdown,
+  // where the OS kills the installer mid-write and corrupts the install
+  // (the "reinstall on every shutdown" loop). Installs now happen only via the
+  // explicit pill (`installUpdate`) or on the next launch
+  // (`applyPendingUpdateOnStartup`). `electronAutoUpdater` is the same singleton
+  // the ToDesktop runtime drives, so this affects the actual updater.
+  try {
+    electronAutoUpdater.autoInstallOnAppQuit = false
+  } catch {}
 
   ipcMain.handle('check-for-update', async () => {
     try {

--- a/src/main/lib/updater.ts
+++ b/src/main/lib/updater.ts
@@ -522,6 +522,36 @@ export function hasPendingStartupUpdate(): boolean {
 }
 
 /**
+ * Kick off a startup update check and resolve once the update reaches the
+ * `'ready'` state or the deadline passes. Don't rely on `runCheck` resolving to
+ * imply readiness — the `'ready'` transition happens in the `update-downloaded`
+ * handler, which (depending on the updater) can fire slightly after the check
+ * promise settles. Subscribing first closes that race.
+ */
+function waitForReadyState(timeoutMs: number): Promise<void> {
+  if (getCurrentUpdateState().kind === 'ready') return Promise.resolve()
+  return new Promise<void>((resolve) => {
+    let done = false
+    const finish = (): void => {
+      if (done) return
+      done = true
+      unsub()
+      clearTimeout(timer)
+      resolve()
+    }
+    const unsub = onUpdateStateChanged((s) => {
+      if (s.kind === 'ready') finish()
+    })
+    const timer = setTimeout(finish, timeoutMs)
+    runCheck('startup-install')
+      .then(() => {
+        if (getCurrentUpdateState().kind === 'ready') finish()
+      })
+      .catch(() => {})
+  })
+}
+
+/**
  * Apply a previously-downloaded Desktop update at startup instead of on quit.
  * Installing on quit is what gets interrupted by a Windows shutdown and leaves
  * a corrupted install; doing it at launch decouples the install from the
@@ -548,10 +578,7 @@ export async function applyPendingUpdateOnStartup(): Promise<boolean> {
   // re-validates it (no re-download) and populates the updater's ready state.
   // Bounded so a slow/offline network can't hang boot — if it doesn't resolve
   // to a ready update in time, we open the UI and try again next launch.
-  await Promise.race([
-    runCheck('startup-install').catch(() => {}),
-    new Promise((resolve) => setTimeout(resolve, STARTUP_UPDATE_CHECK_TIMEOUT_MS))
-  ])
+  await waitForReadyState(STARTUP_UPDATE_CHECK_TIMEOUT_MS)
 
   const state = getCurrentUpdateState()
   if (state.kind !== 'ready' || !state.version) return false

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -51,6 +51,16 @@ export interface KnownSettings {
   /** Directory the user last chose in the general "Save image/file" dialog.
    *  Used to seed the dialog's defaultPath so it matches browser behavior. */
   lastSaveDialogDir?: string
+  /** Version of a Desktop update whose installer finished downloading in a
+   *  previous session and is staged on disk. Gates the bounded startup
+   *  install check so boots without a staged update aren't delayed. Cleared
+   *  once that version is actually running. */
+  pendingDownloadedUpdateVersion?: string
+  /** Version we last auto-attempted to install at startup. Loop-breaker: if an
+   *  attempt didn't take (still running the old version), we don't auto-retry
+   *  the same version on the next boot — the user can still install it manually
+   *  via the update pill. Cleared once that version is actually running. */
+  lastStartupUpdateAttemptVersion?: string
 }
 
 export type Settings = KnownSettings & Record<string, unknown>
@@ -92,6 +102,8 @@ const SETTINGS_SCHEMA = {
   oemManagedModelDirs: { nullable: false },
   oemWorkflowImportVersion: { nullable: false },
   lastSaveDialogDir: { nullable: true },
+  pendingDownloadedUpdateVersion: { nullable: true },
+  lastStartupUpdateAttemptVersion: { nullable: true },
 } as const satisfies Record<keyof KnownSettings, { nullable: boolean }>
 
 export type KnownSettingKey = keyof typeof SETTINGS_SCHEMA


### PR DESCRIPTION
## Summary

Fixes #1065 — Desktop installs becoming corrupted on every Windows shutdown, forcing endless reinstalls.

### Root cause
The app runs its own updater UX (download in background, show a "Desktop Update Ready" pill, install on explicit restart) and disables ToDesktop's loop with `todesktop.init({ autoUpdater: false })`. But it never disabled **electron-updater's** `autoInstallOnAppQuit`, which defaults to `true`. After any background download, electron-updater registers an `app.once('quit', … install())` handler that **silently spawns the NSIS installer whenever the app quits**.

During a Windows shutdown the OS force-kills that detached installer mid-write, leaving a half-installed/corrupted app. Reinstalling restores an older build that re-downloads on next launch and re-arms the same trap → endless loop.

### Fix — install at startup, never on quit (decouples install from shutdown)
- **Disable `autoInstallOnAppQuit`** on the electron-updater singleton (the same instance the ToDesktop runtime drives). Nothing installs on quit/shutdown anymore.
- **Apply on next launch instead.** When a download completes we persist a `pendingDownloadedUpdateVersion` marker. On the next launch a bounded (≤5 s), splash-gated check re-validates the cached installer (no re-download, since electron-updater persists it across restarts) and applies it, then the installer relaunches the app.
- **Silent loop-breaker.** We record the attempted version; if an install doesn't "take" (app still on the old version), we back off silently on the next launch rather than looping. The "Desktop Update Ready" pill remains for manual retry — no nag.
- **`session-end` guard.** A `BrowserWindow` `session-end` flag makes `installUpdate()` a no-op while the OS is shutting down, so even an explicit restart-to-update can't spawn an installer mid-shutdown.
- **Boot safety-net.** If a startup install doesn't actually quit the app (e.g. the staged installer vanished), we fall back to the normal surface so the user is never stranded on the splash.

The explicit pill path (`installUpdate` / `restartAndInstall`) is otherwise unchanged, and auto-check + auto-download are untouched.

### User-visible behavior
- Updates still apply automatically — at the next launch instead of on close.
- At most one "it restarted to update" blip; the very next launch always lets the user in.
- A failed auto-install is silent (no error popups); the pill stays available for a manual retry which surfaces the existing error modal only if the user clicks it.

## Testing
- `pnpm run typecheck` ✅
- `pnpm run lint` ✅
- `pnpm run test` ✅ (2137 tests; added 8 covering the new startup-install + session-end + loop-breaker behavior)
- `pnpm run build` ✅