### PR TITLE
fix(telemetry): emit session.instance_started; deprecate session.installation_started (#1054)

### DIFF
--- a/src/renderer/src/lib/rendererBootstrap.ts
+++ b/src/renderer/src/lib/rendererBootstrap.ts
@@ -643,13 +643,32 @@ export function initializeRendererBootstrap(role: RendererRole = 'panel'): void 
         .then((ctx) => {
           if (!ctx) return
           const { snapshot_diffs, ...metadata } = ctx
-          trackTelemetryAction('comfy.desktop.session.installation_started', {
+          // Fires on EVERY ComfyUI instance boot (fresh install, restart, port
+          // realloc) — not on new-install completion. Despite its previous name
+          // (`session.installation_started`) it tracks per-instance boots, so
+          // dashboards built off the old name were over-counting new installs by
+          // ~2.3x (median fires/user/week, 656 max). Use `install.flow.opened`
+          // or `op.result` with `op_kind='install'` for actual install activity.
+          // The old name is also emitted below for one release cycle so existing
+          // PostHog dashboards stay alive while migration happens.
+          const instanceStartedProps = {
             ...(metadata as unknown as Record<
               string,
               string | number | boolean | null | undefined
             >),
             boot_time_ms: bootTimeMs ?? null
-          })
+          }
+          trackTelemetryAction(
+            'comfy.desktop.session.instance_started',
+            instanceStartedProps
+          )
+          // DEPRECATED 2026-06-12: misleadingly named — remove after 2026-07-01
+          // once any consumers have migrated to `session.instance_started`.
+          // Tracked in issue #1054.
+          trackTelemetryAction(
+            'comfy.desktop.session.installation_started',
+            instanceStartedProps
+          )
           if (snapshot_diffs.length > 0) {
             // snapshot_diffs is an array of objects, which Datadog/PostHog handle
             // natively; bypass the typed bridge via a fresh call.


### PR DESCRIPTION
Closes #1054.

## What
Add a new, accurately-named telemetry event \`comfy.desktop.session.instance_started\` at the existing emit site in \`rendererBootstrap.ts:646\`. Keep firing the old name \`comfy.desktop.session.installation_started\` in parallel for one release cycle (drop after **2026-07-01**) so any PostHog dashboards built off the old name stay alive while migration happens.

## Why
Verified Robin's issue end-to-end:

- The event was emitted inside \`onInstanceStarted\` — the handler for the main-side \`instance-started\` IPC, broadcast by \`_addSession()\` on **every** successful ComfyUI process boot (fresh install, restart, port realloc). Not new-install completion.
- Per PostHog, last 7 days:
  - avg **2.3 fires per user per week**
  - **43%** of firing users fire it more than once
  - **656** max fires by a single user in 7 days
- A new-install-completion event would fire once per install. The old name was over-counting net-new installs by ~2.3x and anyone reading the name would build a wrong funnel.

## Naming
\`session.instance_started\` keeps the event in the existing \`session.*\` namespace alongside:
- \`comfy.desktop.session.started\` — Desktop app session start (already taken)
- \`comfy.desktop.session.ended\` — Desktop app session end
- \`comfy.desktop.session.installs_inventory\` — per-session install census
- \`comfy.desktop.session.system_info\` — one-shot metadata

And matches the names it lives next to in code (\`instance-started\` IPC, \`onInstanceStarted\` handler).

## The right events for actual install activity
The inline comment at the emit site now points consumers at:
- \`comfy.desktop.install.flow.opened\` — user opened the install wizard
- \`comfy.desktop.op.result\` with \`op_kind='install'\` and \`result='success'\` — completed install op
- \`comfy.desktop.install.standalone.{start,end,error}\` — standalone install lifecycle

## Safety
- No schema change for either name — same props payload on both emits.
- Datadog mirror list (\`shared/datadogMirroredEvents.ts\`) wasn't covering the old name; new name also isn't on it. Both stay PostHog-only.
- Existing \`session.installation_started\` callers (none in repo) continue working until the grace period ends.

## Follow-up
Filed as a TODO with the deprecation date in the code comment. A drop-the-old-name PR should land before **2026-07-01** — quick \`git rm\` of the parallel emit, plus a heads-up in #frontend before it lands.

## Test
- [x] \`pnpm typecheck\` passes (node + web + e2e + integration)
- [x] \`pnpm lint\` passes
- [ ] After deploy: confirm \`session.instance_started\` shows up in PostHog with the same daily volume as \`session.installation_started\`
- [ ] After deploy: rebuild any dashboards using the new event name (none in repo today)