### PR TITLE
feat(telemetry): close acquisition and billing funnel gaps

### DIFF
--- a/src/main/host/attach.ts
+++ b/src/main/host/attach.ts
@@ -8,6 +8,7 @@ import { _operationAborts, sourceMap } from '../lib/ipc/shared'
 import { TITLEBAR_BG } from '../lib/theme'
 import * as mainTelemetry from '../lib/telemetry'
 import { refreshCloudUserTier } from '../lib/userTier'
+import { noteCloudEntered } from '../lib/cloudEntry'
 import { forwardDatadogError } from '../lib/processErrorHandlers'
 import { recordInstanceSurface } from '../lib/lastSession'
 import { installationEvents, type InstallationRecord } from '../installations'
@@ -409,6 +410,9 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
       // kill-switch to let paying users through `disabled`. Fire-and-
       // forget — failures leave the tier cache as-is.
       void refreshCloudUserTier(comfyContents)
+      // Mark cloud entry for the acquisition funnel. Deduped per session
+      // and carries `first_time` for the first-ever cloud entry.
+      noteCloudEntered()
     }
   }
   comfyContents.on('dom-ready', onDomReady)

--- a/src/main/host/createHostWindow.ts
+++ b/src/main/host/createHostWindow.ts
@@ -27,6 +27,7 @@ import {
   resolveTheme,
 } from '../lib/ipc/shared'
 import * as mainTelemetry from '../lib/telemetry'
+import { getUserTier } from '../lib/userTier'
 import { forwardDatadogError } from '../lib/processErrorHandlers'
 import { recordDashboardSurface, recordInstanceSurface } from '../lib/lastSession'
 import * as settings from '../settings'
@@ -296,6 +297,7 @@ function wireCheckoutPopup(
   childWindow: BrowserWindow,
   parent: BrowserWindow,
   hostContents: Electron.WebContents,
+  openedAt: number,
 ): void {
   const close = (): void => {
     if (!childWindow.isDestroyed()) childWindow.close()
@@ -317,6 +319,15 @@ function wireCheckoutPopup(
   const closeOnReturn = (_e: Electron.Event, targetUrl: string): void => {
     if (returning || childWindow.isDestroyed() || !isCheckoutReturnUrl(targetUrl)) return
     returning = true
+    // Fires when the checkout flow ENDS, including cancel — the return URL is
+    // the same first-party comfy.org page whether the user paid or backed out.
+    // `duration_ms` is measured from popup open. Purchase truth is server-side
+    // (billing:topup_completed / billing:subscription_created); do not read a
+    // conversion off this event.
+    mainTelemetry.capture('comfy.desktop.billing.checkout_returned', {
+      duration_ms: Date.now() - openedAt,
+      user_tier: getUserTier(),
+    })
     if (hostContents.isDestroyed()) {
       close()
       return
@@ -1135,16 +1146,21 @@ export function buildComfyView(
 
   // Set by the window-open handler immediately before the matching
   // `did-create-window` fires (synchronous pairing), then reset there so
-  // it can never leak to a later non-checkout popup.
+  // it can never leak to a later non-checkout popup. `nextCheckoutOpenedAt`
+  // carries the popup-open timestamp through to `wireCheckoutPopup` so the
+  // return event can report how long the checkout flow took.
   let nextPopupIsCheckout = false
+  let nextCheckoutOpenedAt = 0
 
   comfyContents.on('did-create-window', (childWindow) => {
     const isCheckout = nextPopupIsCheckout
+    const openedAt = nextCheckoutOpenedAt
     nextPopupIsCheckout = false
+    nextCheckoutOpenedAt = 0
     childWindow.setIcon(APP_ICON)
     if (process.platform !== 'darwin') childWindow.removeMenu()
     injectMacPasskeyWarning(childWindow)
-    if (isCheckout) wireCheckoutPopup(childWindow, comfyWindow, comfyContents)
+    if (isCheckout) wireCheckoutPopup(childWindow, comfyWindow, comfyContents, openedAt)
   })
   comfyContents.setWindowOpenHandler(({ url: childUrl }) => {
     // Intercept Firebase auth popups (`<authDomain>/__/auth/handler?...`)
@@ -1176,6 +1192,11 @@ export function buildComfyView(
       // dragged/closed reliably, so it keeps its frame. preload:
       // undefined strips our title-bar bridge.
       nextPopupIsCheckout = true
+      nextCheckoutOpenedAt = Date.now()
+      mainTelemetry.capture('comfy.desktop.billing.checkout_opened', {
+        source: 'cloud_webview',
+        user_tier: getUserTier(),
+      })
       const bounds = checkoutPopupBounds(comfyWindow)
       return {
         action: 'allow',

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -77,6 +77,7 @@ import { lookupInstallUpdateOverride, recordIpcInvocation } from './lib/e2eOverr
 import * as mainTelemetry from './lib/telemetry'
 import {
   clearPendingAlias,
+  consumeFirstLaunch,
   getDeviceId,
   getIdClass,
   initDeviceId,
@@ -1410,6 +1411,23 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
 
     const locale = (settings.get('language') as string | undefined) || app.getLocale().split('-')[0]
     i18n.init(locale)
+
+    // Desktop-side anchor of the website → download → first-launch acquisition
+    // funnel. Fires exactly once per installation, ever (guard file alongside
+    // device-id.txt). app_version / app_channel / platform / arch ride in as
+    // default event properties; id_class + locale are added here.
+    //
+    // `captureFirstLaunch` (not plain `capture`) because this fires on a fresh
+    // install, when consent is still `'undecided'` — a plain capture would be
+    // dropped on the consent gate while the once-ever guard stays burned,
+    // losing the event forever. The deferred path ships it on the first
+    // `undecided → granted` transition and never on a decline.
+    if (consumeFirstLaunch()) {
+      mainTelemetry.captureFirstLaunch({
+        id_class: getIdClass(),
+        locale
+      })
+    }
     registerTitleTooltipIpc({
       findParentByTitleBarSender: (wc) => findEntryByTitleBarSender(wc)?.entry.window ?? null
     })

--- a/src/main/lib/cloudEntry.ts
+++ b/src/main/lib/cloudEntry.ts
@@ -1,0 +1,67 @@
+/**
+ * Cloud-entry telemetry tap.
+ *
+ * Fires `comfy.desktop.cloud.entered` the first time a cloud install's page
+ * reaches dom-ready in a given app session. Gives the acquisition funnel a
+ * clean `first_use.fork_chosen → cloud.entered` join point without depending
+ * on the renderer's cohort-context register pass.
+ *
+ * Two guards:
+ *   - Session dedup (module-level flag): the cloud page's `dom-ready` fires
+ *     on every reload / re-attach, so the event would otherwise repeat many
+ *     times per session.
+ *   - First-ever marker (`cloud-entered-completed` guard file in `configDir`,
+ *     mirroring the identity-migration guard): drives the `first_time`
+ *     property. `true` only on the launch where the marker did not yet exist;
+ *     also written as the `has_launched_cloud` person property so cohort
+ *     filters agree with the event.
+ */
+import path from 'path'
+import fs from 'fs'
+import * as telemetry from './telemetry'
+import { configDir } from './paths'
+
+let enteredThisSession = false
+
+function cloudEnteredGuardPath(): string {
+  return path.join(configDir(), 'cloud-entered-completed')
+}
+
+function hasEnteredCloudBefore(): boolean {
+  try {
+    return fs.existsSync(cloudEnteredGuardPath())
+  } catch {
+    return false
+  }
+}
+
+function markCloudEntered(): void {
+  try {
+    fs.mkdirSync(path.dirname(cloudEnteredGuardPath()), { recursive: true })
+    fs.writeFileSync(cloudEnteredGuardPath(), new Date().toISOString())
+  } catch {
+    // best-effort persist; a failed write just means `first_time` may read
+    // true again on a later launch, which over-counts rather than loses data.
+  }
+}
+
+/**
+ * Emit `comfy.desktop.cloud.entered` once per app session. `first_time` is
+ * true only on the first-ever cloud entry across the installation's lifetime.
+ * Subsequent calls within the same session no-op.
+ */
+export function noteCloudEntered(): void {
+  if (enteredThisSession) return
+  enteredThisSession = true
+  const firstTime = !hasEnteredCloudBefore()
+  if (firstTime) {
+    markCloudEntered()
+    telemetry.registerPersonProperties({ has_launched_cloud: true })
+  }
+  telemetry.emit('comfy.desktop.cloud.entered', { first_time: firstTime })
+}
+
+/** @internal — exposed for tests. */
+export function _resetForTest(): void {
+  enteredThisSession = false
+}

--- a/src/main/lib/deviceId.ts
+++ b/src/main/lib/deviceId.ts
@@ -63,6 +63,34 @@ function migrationGuardPath(): string {
   return path.join(configDir(), 'identity-migration-completed')
 }
 
+function firstLaunchGuardPath(): string {
+  return path.join(configDir(), 'first-launch-completed')
+}
+
+/**
+ * One-shot first-launch marker. Returns `true` exactly once per installation
+ * (the first boot where the guard file does not yet exist) and writes the
+ * guard so every later boot returns `false`. Best-effort: a failed write
+ * leaves the marker absent, so a later boot would re-fire — over-counting
+ * rather than losing the first-launch anchor of the acquisition funnel.
+ */
+export function consumeFirstLaunch(): boolean {
+  let isFirst: boolean
+  try {
+    isFirst = !fs.existsSync(firstLaunchGuardPath())
+  } catch {
+    isFirst = false
+  }
+  if (!isFirst) return false
+  try {
+    fs.mkdirSync(path.dirname(firstLaunchGuardPath()), { recursive: true })
+    fs.writeFileSync(firstLaunchGuardPath(), new Date().toISOString())
+  } catch {
+    // best-effort persist
+  }
+  return true
+}
+
 /**
  * Persisted legacy-id awaiting a successful alias to the new
  * `installation_id`. Written when we first detect a legacy random UUID

--- a/src/main/lib/executionTap.ts
+++ b/src/main/lib/executionTap.ts
@@ -115,6 +115,10 @@ export function createExecutionTap(opts: {
           ...baseContext,
           first_run_at: firstRunAt
         })
+        // Per-PERSON activation marker. The event above is per-installation
+        // and over-counts users with multiple installs; `$set_once` keeps
+        // the earliest first-completion timestamp on the person profile.
+        telemetry.registerPersonPropertiesOnce({ first_generation_at: firstRunAt })
       } catch {
         // ignore – telemetry side effect, not user-visible
       }

--- a/src/main/lib/telemetry.test.ts
+++ b/src/main/lib/telemetry.test.ts
@@ -57,7 +57,7 @@ const aliases: AliasCall[] = []
 
 interface IdentifyCall {
   distinctId: string
-  properties?: { $set?: Record<string, unknown> }
+  properties?: { $set?: Record<string, unknown>; $set_once?: Record<string, unknown> }
 }
 const identifies: IdentifyCall[] = []
 
@@ -541,6 +541,122 @@ describe('telemetry.registerPersonProperties pre-consent merge', () => {
       locale: 'en',
       theme: 'dark'
     })
+  })
+})
+
+describe('telemetry.registerPersonPropertiesOnce ($set_once)', () => {
+  beforeEach(() => {
+    captured.length = 0
+    identifies.length = 0
+    process.env['POSTHOG_API_KEY'] = 'test-key'
+    process.env['POSTHOG_ENABLED'] = '1'
+    telemetry._resetForTest()
+    telemetry.initTelemetry({ appVersion: '0.0.0', appEnv: 'test', isPackaged: true })
+  })
+
+  afterEach(() => {
+    delete process.env['POSTHOG_API_KEY']
+    delete process.env['POSTHOG_ENABLED']
+    telemetry.setConsentState('granted')
+  })
+
+  it('ships the property under $set_once (not $set) when consent is already granted', () => {
+    telemetry.setConsentState('granted')
+    telemetry.identify('id')
+    identifies.length = 0
+
+    telemetry.registerPersonPropertiesOnce({ first_generation_at: '2026-06-12T00:00:00.000Z' })
+
+    expect(identifies).toHaveLength(1)
+    expect(identifies[0]?.properties?.$set_once).toMatchObject({
+      first_generation_at: '2026-06-12T00:00:00.000Z'
+    })
+    expect(identifies[0]?.properties?.$set).toBeUndefined()
+  })
+
+  it('defers the $set_once write until consent flips to granted', () => {
+    telemetry.setConsentState('undecided')
+    telemetry.identify('id')
+    identifies.length = 0
+
+    telemetry.registerPersonPropertiesOnce({ first_generation_at: 'first' })
+    // Nothing ships pre-consent.
+    expect(identifies).toHaveLength(0)
+
+    telemetry.setConsentState('granted')
+
+    const once = identifies.find((i) => i.properties?.$set_once)
+    expect(once?.properties?.$set_once).toMatchObject({ first_generation_at: 'first' })
+  })
+
+  it('carries $set and $set_once in the same identify when both are queued pre-consent', () => {
+    telemetry.setConsentState('undecided')
+    telemetry.identify('id')
+    identifies.length = 0
+
+    telemetry.registerPersonProperties({ gpu_tier: 'mid' })
+    telemetry.registerPersonPropertiesOnce({ first_generation_at: 'first' })
+
+    telemetry.setConsentState('granted')
+
+    const call = identifies.find((i) => i.properties?.$set_once)
+    expect(call?.properties?.$set).toMatchObject({ gpu_tier: 'mid' })
+    expect(call?.properties?.$set_once).toMatchObject({ first_generation_at: 'first' })
+  })
+})
+
+describe('telemetry.captureFirstLaunch (deferred once-ever event)', () => {
+  beforeEach(() => {
+    captured.length = 0
+    process.env['POSTHOG_API_KEY'] = 'test-key'
+    process.env['POSTHOG_ENABLED'] = '1'
+    telemetry._resetForTest()
+    telemetry.initTelemetry({ appVersion: '0.0.0', appEnv: 'test', isPackaged: true })
+  })
+
+  afterEach(() => {
+    delete process.env['POSTHOG_API_KEY']
+    delete process.env['POSTHOG_ENABLED']
+    telemetry.setConsentState('granted')
+  })
+
+  it('queues on a fresh install (undecided) and ships on the grant transition', () => {
+    // This is the real first-boot path: consent undecided, guard already
+    // consumed. A plain capture would be dropped here and never re-fire.
+    telemetry.setConsentState('undecided')
+    telemetry.identify('install-id')
+    captured.length = 0
+
+    telemetry.captureFirstLaunch({ id_class: 'machine_derived', locale: 'en' })
+    expect(captured).toHaveLength(0)
+
+    telemetry.setConsentState('granted')
+
+    const ev = captured.find((c) => c.event === 'comfy.desktop.app.first_launch')
+    expect(ev?.distinctId).toBe('install-id')
+    expect(ev?.properties).toMatchObject({ id_class: 'machine_derived', locale: 'en' })
+  })
+
+  it('never ships when the user declines (denied), no later flush', () => {
+    telemetry.setConsentState('undecided')
+    telemetry.identify('install-id')
+    captured.length = 0
+
+    telemetry.captureFirstLaunch({ id_class: 'machine_derived', locale: 'en' })
+    telemetry.setConsentState('denied')
+
+    expect(captured.find((c) => c.event === 'comfy.desktop.app.first_launch')).toBeUndefined()
+  })
+
+  it('captures immediately when consent is already granted', () => {
+    telemetry.setConsentState('granted')
+    telemetry.identify('install-id')
+    captured.length = 0
+
+    telemetry.captureFirstLaunch({ id_class: 'random_uuid', locale: 'fr' })
+
+    const ev = captured.find((c) => c.event === 'comfy.desktop.app.first_launch')
+    expect(ev?.properties).toMatchObject({ id_class: 'random_uuid', locale: 'fr' })
   })
 })
 

--- a/src/main/lib/telemetry.ts
+++ b/src/main/lib/telemetry.ts
@@ -162,7 +162,9 @@ export function _resetForTest(): void {
   installationDeviceId = null
   consentState = 'undecided'
   pendingSessionStart = null
+  pendingFirstLaunch = null
   pendingIdentifyProperties = null
+  pendingIdentifyPropertiesOnce = null
   pendingMigrationAlias = null
   defaultEventProperties = {}
   initialized = false
@@ -509,7 +511,25 @@ export function initTelemetry(opts: InitOptions): void {
 }
 
 let pendingSessionStart: Record<string, TelemetryValue> | null = null
+/**
+ * Deferred once-ever first-launch event payload. The guard file in
+ * `deviceId.ts` is consumed at boot (so it can never re-fire on a later
+ * launch), but on a fresh install consent is still `'undecided'` at that
+ * moment — the event would be dropped by `isAllowedToFire` and the guard
+ * would be burned for nothing. Holding the payload here lets it ship on the
+ * `undecided → granted` transition via `tryFlushDeferred()`, exactly like
+ * `pendingSessionStart`. A `'denied'` choice never flushes it, which is the
+ * intended consent outcome.
+ */
+let pendingFirstLaunch: TelemetryContext | null = null
 let pendingIdentifyProperties: Record<string, TelemetryValue> | null = null
+/**
+ * Deferred `$set_once` person properties — write-once activation markers
+ * (e.g. `first_generation_at`) that PostHog ignores on every call after the
+ * first. Kept separate from `pendingIdentifyProperties` (`$set`) so the two
+ * merge semantics don't collide in the same identify payload.
+ */
+let pendingIdentifyPropertiesOnce: Record<string, TelemetryValue> | null = null
 
 /**
  * Deferred legacy-id alias. Set by `deferMigrationAlias()` at boot if
@@ -541,13 +561,17 @@ let installationDeviceId: string | null = null
 function tryFlushDeferred(): void {
   if (!canEmit() || !distinctId) return
   if (consentState !== 'granted') return
-  if (pendingIdentifyProperties) {
+  if (pendingIdentifyProperties || pendingIdentifyPropertiesOnce) {
+    const properties: Record<string, Record<string, TelemetryValue>> = {}
+    if (pendingIdentifyProperties) properties.$set = pendingIdentifyProperties
+    if (pendingIdentifyPropertiesOnce) properties.$set_once = pendingIdentifyPropertiesOnce
     try {
-      client!.identify({ distinctId, properties: { $set: pendingIdentifyProperties } })
+      client!.identify({ distinctId, properties })
     } catch {
       // ignore
     }
     pendingIdentifyProperties = null
+    pendingIdentifyPropertiesOnce = null
   }
   if (pendingMigrationAlias) {
     // Snapshot + clear before await so a re-entrant flush doesn't double-fire.
@@ -577,6 +601,10 @@ function tryFlushDeferred(): void {
   if (pendingSessionStart) {
     capture('comfy.desktop.session.started', pendingSessionStart)
     pendingSessionStart = null
+  }
+  if (pendingFirstLaunch) {
+    capture('comfy.desktop.app.first_launch', pendingFirstLaunch)
+    pendingFirstLaunch = null
   }
 }
 
@@ -733,6 +761,32 @@ export function capture(event: string, properties: TelemetryContext = {}): void 
 }
 
 /**
+ * Capture the once-ever `comfy.desktop.app.first_launch` event with the same
+ * deferral semantics as the boot session-start event.
+ *
+ * The caller's on-disk guard (in `deviceId.ts`) is consumed at boot, so this
+ * fires for at most one launch in the installation's lifetime. But that launch
+ * is, by definition, a fresh install whose consent is still `'undecided'` —
+ * routing it through plain `capture()` would drop it on the consent gate while
+ * the guard stays burned, so the event would never reach PostHog. Instead we
+ * queue the payload and let `tryFlushDeferred()` ship it on the
+ * `undecided → granted` transition (and never on a `'denied'` choice). If
+ * consent is already `'granted'` (returning user who reinstalled after opting
+ * in, or the rare migrator), it captures immediately.
+ */
+export function captureFirstLaunch(properties: TelemetryContext = {}): void {
+  if (!canEmit() || !distinctId) {
+    pendingFirstLaunch = { ...(pendingFirstLaunch || {}), ...properties }
+    return
+  }
+  if (consentState !== 'granted') {
+    pendingFirstLaunch = { ...(pendingFirstLaunch || {}), ...properties }
+    return
+  }
+  capture('comfy.desktop.app.first_launch', properties)
+}
+
+/**
  * Update PostHog person properties for the current distinct id (`$set`).
  *
  * Used by the renderer's cohort-context register pass and any other
@@ -751,6 +805,32 @@ export function registerPersonProperties(properties: Record<string, TelemetryVal
   }
   try {
     client!.identify({ distinctId, properties: { $set: properties } })
+  } catch {
+    // ignore – telemetry must never break the app
+  }
+}
+
+/**
+ * Update PostHog person properties using `$set_once` semantics: the value is
+ * written only if the property is currently absent on the person, and ignored
+ * on every subsequent call. For durable activation markers (first-ever
+ * timestamps) that must reflect the first occurrence across a person's
+ * lifetime, even when the per-installation event that fires them can recur on
+ * a reinstall or a second machine.
+ *
+ * Honors the same three-state consent gate as `registerPersonProperties`:
+ * queued in `pendingIdentifyPropertiesOnce` until consent grants, at which
+ * point `tryFlushDeferred()` ships it. Repeated queued calls merge per key;
+ * `$set_once` makes the server-side write idempotent regardless.
+ */
+export function registerPersonPropertiesOnce(properties: Record<string, TelemetryValue>): void {
+  if (!canEmit()) return
+  if (consentState !== 'granted' || !distinctId) {
+    pendingIdentifyPropertiesOnce = { ...(pendingIdentifyPropertiesOnce || {}), ...properties }
+    return
+  }
+  try {
+    client!.identify({ distinctId, properties: { $set_once: properties } })
   } catch {
     // ignore – telemetry must never break the app
   }

--- a/src/main/lib/userTier.test.ts
+++ b/src/main/lib/userTier.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import os from 'os'
+import path from 'path'
+
+vi.mock('electron', () => ({
+  app: { getPath: () => path.join(os.tmpdir(), 'launcher-test-usertier') }
+}))
+
+const telemetry = await import('./telemetry')
+const { refreshCloudUserTier, getUserTier, _resetForTest } = await import('./userTier')
+
+/** Stub WebContents whose executeJavaScript resolves to a fixed tier result. */
+function stubContents(result: unknown): { wc: Electron.WebContents } {
+  return {
+    wc: {
+      executeJavaScript: () => Promise.resolve(result)
+    } as unknown as Electron.WebContents
+  }
+}
+
+describe('userTier tier_changed telemetry', () => {
+  let captured: Array<{ event: string; ctx: Record<string, unknown> }>
+
+  beforeEach(() => {
+    _resetForTest()
+    captured = []
+    vi.spyOn(telemetry, 'capture').mockImplementation((event, ctx) => {
+      captured.push({ event, ctx: (ctx ?? {}) as Record<string, unknown> })
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  const tierChanges = (): Array<{ event: string; ctx: Record<string, unknown> }> =>
+    captured.filter((c) => c.event === 'comfy.desktop.billing.tier_changed')
+
+  it('does not emit on the first resolution out of unknown (hydration, not a change)', async () => {
+    expect(getUserTier()).toBe('unknown')
+    await refreshCloudUserTier(stubContents({ tier: 'FREE' }).wc)
+    expect(getUserTier()).toBe('free')
+    expect(tierChanges()).toHaveLength(0)
+  })
+
+  it('emits from_tier/to_tier on a real free → paid transition', async () => {
+    await refreshCloudUserTier(stubContents({ tier: 'FREE' }).wc)
+    await refreshCloudUserTier(stubContents({ tier: 'PRO' }).wc)
+    expect(getUserTier()).toBe('paid')
+    expect(tierChanges()).toHaveLength(1)
+    expect(tierChanges()[0]!.ctx).toMatchObject({ from_tier: 'free', to_tier: 'paid' })
+  })
+
+  it('emits on a paid → free downgrade too', async () => {
+    await refreshCloudUserTier(stubContents({ tier: 'CREATOR' }).wc)
+    await refreshCloudUserTier(stubContents({ tier: 'FREE' }).wc)
+    expect(tierChanges()).toHaveLength(1)
+    expect(tierChanges()[0]!.ctx).toMatchObject({ from_tier: 'paid', to_tier: 'free' })
+  })
+
+  it('does not emit when the tier is unchanged', async () => {
+    await refreshCloudUserTier(stubContents({ tier: 'PRO' }).wc)
+    await refreshCloudUserTier(stubContents({ tier: 'STANDARD' }).wc)
+    expect(getUserTier()).toBe('paid')
+    expect(tierChanges()).toHaveLength(0)
+  })
+
+  it('leaves the cache (and emits nothing) when no signed-in user is present', async () => {
+    await refreshCloudUserTier(stubContents({ tier: 'PRO' }).wc)
+    captured = []
+    await refreshCloudUserTier(stubContents(null).wc)
+    expect(getUserTier()).toBe('paid')
+    expect(tierChanges()).toHaveLength(0)
+  })
+})

--- a/src/main/lib/userTier.ts
+++ b/src/main/lib/userTier.ts
@@ -10,6 +10,7 @@
 import { app, type WebContents } from 'electron'
 import * as fs from 'fs/promises'
 import * as path from 'path'
+import * as telemetry from './telemetry'
 
 export type CloudUserTier = 'free' | 'paid' | 'unknown'
 
@@ -80,7 +81,18 @@ async function setTier(rawTierName: string | null | undefined): Promise<void> {
       ? 'paid'
       : 'free'
   if (next === cached) return
+  const previous = cached
   cached = next
+  // Emit only on a real transition between two known tiers. The first
+  // resolution out of `unknown` is hydration, not a change, so it is not a
+  // conversion signal. A `free → paid` flip shortly after
+  // `billing.checkout_returned` is the desktop-visible conversion.
+  if (previous === 'free' || previous === 'paid') {
+    telemetry.capture('comfy.desktop.billing.tier_changed', {
+      from_tier: previous,
+      to_tier: next,
+    })
+  }
   try {
     await fs.writeFile(
       getPersistPath(),

--- a/src/renderer/src/views/FirstUseTakeover.vue
+++ b/src/renderer/src/views/FirstUseTakeover.vue
@@ -457,7 +457,7 @@ async function routePostStart(): Promise<void> {
     // does on chain-local: with both ticked, the host runs the
     // migration straight through (preview + auto-pick + run) without
     // surfacing the confirm step.
-    emitTelemetryAction('desktop2.first_use.local_branch_chosen', { choice: 'migrate' })
+    emitTelemetryAction('comfy.desktop.first_use.local_branch_chosen', { choice: 'migrate' })
     emitCompleted('local-migrate')
     emit('chain-migrate', { express: expressInstall.value })
   } else if (hasLegacyDesktop.value && !expressInstall.value) {


### PR DESCRIPTION
## What

Six telemetry-only additions plus one event-name fix, closing the desktop-side gaps found in the end-to-end activation funnel audit (acquisition → activation → monetization). No behavior changes.

### New events

| Event | Fires | Funnel question it answers |
|---|---|---|
| `comfy.desktop.app.first_launch` | Once per installation, ever (guard file alongside `device-id.txt`) | Desktop-side anchor of the website → download → first-launch acquisition funnel. Consent-deferred: queued while consent is `undecided`, shipped on the `undecided → granted` transition, never on decline — so the once-ever guard is not burned while gated. |
| `comfy.desktop.billing.checkout_opened` | Purchase Credits popup opens from the cloud webview | Top-up intent from desktop, previously invisible |
| `comfy.desktop.billing.checkout_returned` | Checkout popup hits the return URL | Checkout flow ended (fires on cancel too — purchase truth stays server-side in `billing:topup_completed` / `billing:subscription_created`); carries `duration_ms` |
| `comfy.desktop.billing.tier_changed` | Cached subscription tier transitions between known values | `free → paid` shortly after `checkout_returned` is the desktop-visible conversion signal. Hydration out of `unknown` is not a transition. |
| `comfy.desktop.cloud.entered` | First cloud dom-ready per app session, with `first_time` | Clean `fork_chosen → cloud.entered` join point; `first_time` also sets the `has_launched_cloud` person property |

### Person property

- `first_generation_at` via `$set_once` on first completed generation. `execution.first_completed` is per-installation and over-counts multi-install users; this gives activation analysis a per-person marker. Adds a `registerPersonPropertiesOnce()` helper with the same three-state consent deferral as `$set`.

### Fix

- `FirstUseTakeover.vue` migrate-checkbox path emitted `desktop2.first_use.local_branch_chosen` while the other paths use the `comfy.desktop.` prefix, splitting migrate-vs-fresh ratios across two event names. Dashboards reading historical data should union both names; new data lands on one.

## Validation

- `pnpm typecheck` (node + web) clean, `pnpm lint` clean
- Full test suite: 148 files, 2184 tests passing; new coverage for the deferred first-launch consent semantics, `$set_once` queueing, and tier-transition emission