### PR TITLE
fix(update): skip install-mode page on non-silent update (no start confirmation)

### DIFF
--- a/scripts/installer.nsh
+++ b/scripts/installer.nsh
@@ -99,6 +99,10 @@
 ;
 ; This keeps us on a single ToDesktop Windows build while still allowing
 ; OEM / IT provisioning flows to request machine installs explicitly.
+;
+; customInstallMode runs inside the install-mode page's PRE callback. Setting
+; $isForceMachineInstall / $isForceCurrentInstall makes that PRE re-apply the
+; mode and Abort (skip) the page.
 !macro customInstallMode
   ${GetParameters} $R0
 
@@ -111,6 +115,22 @@
     ${GetOptions} $R0 "/CURRENTUSER" $R1
     ${IfNot} ${Errors}
       StrCpy $isForceCurrentInstall 1
+    ${Else}
+      ; A non-silent update (electron-updater passes --updated but no install-
+      ; mode flag) would otherwise stop on the install-mode page — the one
+      ; pre-progress page electron-builder does NOT auto-skip on update — making
+      ; the user confirm before the progress bar. Re-use the mode initMultiUser
+      ; already detected in .onInit (so we never switch an install's scope) to
+      ; force-skip the page. Ambiguous (both/neither detected): let it show.
+      ${If} ${isUpdated}
+        ${If} $hasPerMachineInstallation == "1"
+        ${AndIf} $hasPerUserInstallation == "0"
+          StrCpy $isForceMachineInstall 1
+        ${ElseIf} $hasPerUserInstallation == "1"
+        ${AndIf} $hasPerMachineInstallation == "0"
+          StrCpy $isForceCurrentInstall 1
+        ${EndIf}
+      ${EndIf}
     ${EndIf}
   ${EndIf}
 !macroend


### PR DESCRIPTION
## Problem

Follow-up to #1079. With `showInstallerUI: true` (the gated NSIS progress UI added in #1079), a **non-silent update** stops on a confirmation page *before* the progress bar — the user has to confirm to start the install. The end (progress + relaunch) is fine; only the start is interrupted.

## Root cause

The page shown is electron-builder's **`PAGE_INSTALL_MODE`** ("install for me / all users"). It's the **only** pre-progress page electron-builder does *not* auto-skip on update — the license and directory pages both get a `skipPageIfUpdated` guard, but `PAGE_INSTALL_MODE` does not. Its PRE callback only `Abort`s (skips) for: UAC inner-instance, `$isForceMachineInstall`/`$isForceCurrentInstall`, or the `/allusers`/`/currentuser` command-line flags. electron-updater launches the updater with `--updated` but **no** install-mode flag, so none of those fire and the page shows.

## Fix

`PAGE_INSTALL_MODE`'s PRE callback invokes our `customInstallMode` hook (and re-applies the mode + `Abort`s when a force flag is set). So in [`scripts/installer.nsh`](https://github.com/Comfy-Org/Comfy-Desktop/blob/main/scripts/installer.nsh) we extend `customInstallMode`: on `${isUpdated}`, mirror the mode that `initMultiUser` already detected in `.onInit` and set the matching force flag, which skips the page:

```nsis
${If} ${isUpdated}
  ${If} $hasPerMachineInstallation == "1"
  ${AndIf} $hasPerUserInstallation == "0"
    StrCpy $isForceMachineInstall 1
  ${ElseIf} $hasPerUserInstallation == "1"
  ${AndIf} $hasPerMachineInstallation == "0"
    StrCpy $isForceCurrentInstall 1
  ${EndIf}
${EndIf}
```

Result: a non-silent update goes straight to the progress window (and our existing `customFinishPage` already auto-launches + skips the finish page on update), so the user sees a progress bar with **no clicks**.

## Safety

- **Mirrors the already-detected scope** (`$hasPerMachineInstallation` / `$hasPerUserInstallation`, set by `initMultiUser` before the page PRE runs) so an existing install's scope is never switched. Ambiguous (both/neither detected) → page still shows.
- **Fresh installs unaffected** — `${isUpdated}` is false, so the block is skipped and the normal install-mode page shows.
- **OEM `/ALLUSERS` / `/CURRENTUSER` flow unaffected** — those branches run first and take precedence; the `${isUpdated}` branch is the fallback only when no explicit flag is passed.

## Testing

- NSIS only — compiled by electron-builder during packaging (not by `pnpm build`), so it needs a packaged build to validate end-to-end. `typecheck` / `lint` / `build` / `test` still pass (no TS changes; 2189 tests).
- End-to-end validation needs 2 releases (a build with this + `showInstallerUI:true`, and a newer build to update to): trigger an update → confirm the progress window appears immediately with **no start confirmation**, and the app relaunches into the new version.
