### PR TITLE
feat(updater): startup update splash countdown + skip NSIS install-mode page on update

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1023,8 +1023,10 @@
     "instanceRunningReplace": "Close & Launch",
     "modelFolderRelaunchTitle": "Restarting ComfyUI",
     "modelFolderRelaunchDesc": "New model folders were detected from custom nodes. Restarting so ComfyUI can use them right away.",
-    "updateInstallTitle": "Installing update",
-    "updateInstallDesc": "Applying the latest ComfyUI Desktop update. The app will restart automatically.",
+    "updateInstallTitle": "Updating ComfyUI Desktop",
+    "updateInstallDesc": "A new version was downloaded and is about to install. The app will close briefly and reopen automatically.",
+    "updateInstallCountdown": "Restarting in {seconds}s…",
+    "updateInstallStartingNow": "Restarting now…",
     "launchSplashTitle": "Starting ComfyUI",
     "launchSplashDesc": "Launching your ComfyUI instance…",
     "activity": {

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -1023,8 +1023,10 @@
     "instanceRunningReplace": "关闭并启动",
     "modelFolderRelaunchTitle": "正在重启 ComfyUI",
     "modelFolderRelaunchDesc": "检测到来自自定义节点的新模型文件夹。正在重启，以便 ComfyUI 立即使用它们。",
-    "updateInstallTitle": "正在安装更新",
-    "updateInstallDesc": "正在应用最新的 ComfyUI Desktop 更新。应用将自动重启。",
+    "updateInstallTitle": "正在更新 ComfyUI Desktop",
+    "updateInstallDesc": "已下载新版本，即将开始安装。应用将短暂关闭并自动重新打开。",
+    "updateInstallCountdown": "{seconds} 秒后重启…",
+    "updateInstallStartingNow": "正在重启…",
     "launchSplashTitle": "正在启动 ComfyUI",
     "launchSplashDesc": "正在启动你的 ComfyUI 实例…",
     "activity": {

--- a/scripts/installer.nsh
+++ b/scripts/installer.nsh
@@ -99,6 +99,10 @@
 ;
 ; This keeps us on a single ToDesktop Windows build while still allowing
 ; OEM / IT provisioning flows to request machine installs explicitly.
+;
+; customInstallMode runs inside the install-mode page's PRE callback. Setting
+; $isForceMachineInstall / $isForceCurrentInstall makes that PRE re-apply the
+; mode and Abort (skip) the page.
 !macro customInstallMode
   ${GetParameters} $R0
 
@@ -111,6 +115,22 @@
     ${GetOptions} $R0 "/CURRENTUSER" $R1
     ${IfNot} ${Errors}
       StrCpy $isForceCurrentInstall 1
+    ${Else}
+      ; A non-silent update (electron-updater passes --updated but no install-
+      ; mode flag) would otherwise stop on the install-mode page — the one
+      ; pre-progress page electron-builder does NOT auto-skip on update — making
+      ; the user confirm before the progress bar. Re-use the mode initMultiUser
+      ; already detected in .onInit (so we never switch an install's scope) to
+      ; force-skip the page. Ambiguous (both/neither detected): let it show.
+      ${If} ${isUpdated}
+        ${If} $hasPerMachineInstallation == "1"
+        ${AndIf} $hasPerUserInstallation == "0"
+          StrCpy $isForceMachineInstall 1
+        ${ElseIf} $hasPerUserInstallation == "1"
+        ${AndIf} $hasPerMachineInstallation == "0"
+          StrCpy $isForceCurrentInstall 1
+        ${EndIf}
+      ${EndIf}
     ${EndIf}
   ${EndIf}
 !macroend

--- a/src/main/lib/relaunchPage.ts
+++ b/src/main/lib/relaunchPage.ts
@@ -23,12 +23,32 @@ function escapeHtml(s: string): string {
 export async function showSplashPage(
   webContents: WebContents,
   theme: SplashTheme = SPLASH_DARK,
-  copy?: { title: string; desc: string },
+  copy?: { title: string; desc: string; countdownSeconds?: number },
 ): Promise<void> {
   const title = escapeHtml(copy?.title ?? i18n.t('launch.modelFolderRelaunchTitle'))
   const desc = escapeHtml(copy?.desc ?? i18n.t('launch.modelFolderRelaunchDesc'))
   const { bg, fg } = theme
   const mutedFg = theme.isDark ? '#888' : '#666'
+  // Optional countdown (used by the update splash so the user can read what's
+  // about to happen before the app quits to install). The template is fetched
+  // with the `{seconds}` placeholder UNresolved so the inline script can tick it
+  // down in the renderer; the "starting now" line shows when it reaches zero.
+  const countdown = copy?.countdownSeconds
+  const countdownBlock =
+    countdown && countdown > 0
+      ? `<p class="countdown" id="cd"></p>
+<script>
+(function(){
+  var n=${Math.floor(countdown)};
+  var tmpl=${JSON.stringify(escapeHtml(i18n.t('launch.updateInstallCountdown')))};
+  var done=${JSON.stringify(escapeHtml(i18n.t('launch.updateInstallStartingNow')))};
+  var el=document.getElementById('cd');
+  function render(){el.innerHTML=tmpl.replace('{seconds}','<b>'+n+'</b>');}
+  render();
+  var id=setInterval(function(){n--;if(n<1){clearInterval(id);el.innerHTML=done;return;}render();},1000);
+})();
+</script>`
+      : ''
   const html = `<!DOCTYPE html>
 <html><head><meta charset="utf-8"><style>
 *{margin:0;padding:0;box-sizing:border-box}
@@ -43,6 +63,8 @@ h2{margin-top:32px;font-size:18px;font-weight:600}
 p{margin-top:10px;font-size:14px;color:${mutedFg};line-height:1.5;text-align:center;max-width:400px}
 .dots::after{content:'';display:inline-block;width:1.5em;text-align:left;animation:dots 1.5s steps(4,end) infinite}
 @keyframes dots{0%{content:''}25%{content:'.'}50%{content:'..'}75%{content:'...'}}
+.countdown{margin-top:20px;font-size:15px;color:${mutedFg}}
+.countdown b{color:${fg};font-weight:700;font-variant-numeric:tabular-nums}
 </style></head><body>
 <svg viewBox="0 0 879 284" fill="none" xmlns="http://www.w3.org/2000/svg">
 <defs><mask id="m"><path d="${COMFY_LOGO_PATH}" fill="white"/></mask></defs>
@@ -51,6 +73,7 @@ p{margin-top:10px;font-size:14px;color:${mutedFg};line-height:1.5;text-align:cen
 </svg>
 <h2>${title}<span class="dots"></span></h2>
 <p>${desc}</p>
+${countdownBlock}
 </body></html>`
   // Caller attaches a will-navigate blocker beforehand, so we just stop + load the data URL.
   webContents.stop()

--- a/src/main/lib/updateSplash.ts
+++ b/src/main/lib/updateSplash.ts
@@ -3,12 +3,19 @@ import { SPLASH_PURPLE } from './theme'
 import { showSplashPage } from './relaunchPage'
 import * as i18n from './i18n'
 
+/** Countdown shown on the update splash before the app quits to install, so the
+ *  user has a few seconds to read what's about to happen. Keep in sync with the
+ *  updater's `STARTUP_INSTALL_MIN_SPLASH_MS` (the splash is held that long), so
+ *  the countdown finishes right as the install begins. */
+export const UPDATE_INSTALL_COUNTDOWN_SECONDS = 5
+
 /**
- * Brief "Updating…" window shown while a previously-downloaded Desktop update is
- * applied at startup (see `applyPendingUpdateOnStartup`). It exists only so the
- * user isn't staring at an empty screen during the (bounded) install check; the
- * app quits shortly after and the installer relaunches it. If the install
- * doesn't proceed, the caller destroys this window and opens the normal UI.
+ * "Updating…" window shown while a previously-downloaded Desktop update is
+ * applied at startup (see `applyPendingUpdateOnStartup`). It tells the user an
+ * update is about to install and runs a short countdown (so they aren't
+ * surprised by the restart) while the bounded install check runs; the app quits
+ * shortly after and the installer relaunches it. If the install doesn't proceed,
+ * the caller destroys this window and opens the normal UI.
  *
  * Self-contained (renders the shared brand splash into its own webContents), so
  * it has no dependency on the host-window / panel renderer wiring that isn't up
@@ -17,7 +24,7 @@ import * as i18n from './i18n'
 export function showUpdateInstallSplash(): BrowserWindow {
   const win = new BrowserWindow({
     width: 480,
-    height: 360,
+    height: 400,
     frame: false,
     resizable: false,
     center: true,
@@ -39,7 +46,8 @@ export function showUpdateInstallSplash(): BrowserWindow {
 
   void showSplashPage(win.webContents, SPLASH_PURPLE, {
     title: i18n.t('launch.updateInstallTitle'),
-    desc: i18n.t('launch.updateInstallDesc')
+    desc: i18n.t('launch.updateInstallDesc'),
+    countdownSeconds: UPDATE_INSTALL_COUNTDOWN_SECONDS
   })
 
   return win

--- a/src/main/lib/updater.test.ts
+++ b/src/main/lib/updater.test.ts
@@ -492,15 +492,15 @@ describe('startup update install + session-end guard (issue #1065)', () => {
       const updater = await import('./updater')
       updater.register()
 
-      // Splash just went up, so the full minimum (2000ms) must elapse first.
+      // Splash just went up, so the full minimum (5000ms) must elapse first.
       const pending = updater.applyPendingUpdateOnStartup(Date.now())
 
       // Let the (instant) ready check settle, but stay short of the floor.
-      await vi.advanceTimersByTimeAsync(1500)
+      await vi.advanceTimersByTimeAsync(4000)
       expect(fakeUpdater.restartAndInstall).not.toHaveBeenCalled()
 
       // Cross the floor — the install now fires.
-      await vi.advanceTimersByTimeAsync(600)
+      await vi.advanceTimersByTimeAsync(1200)
       expect(await pending).toBe(true)
       expect(fakeUpdater.restartAndInstall).toHaveBeenCalledTimes(1)
     } finally {

--- a/src/main/lib/updater.ts
+++ b/src/main/lib/updater.ts
@@ -565,8 +565,11 @@ const STARTUP_UPDATE_CHECK_TIMEOUT_MS = 5000
  *  for a fraction of a second before the app quits — feeling like a glitch
  *  rather than an intentional update. This floor (measured from when the splash
  *  was shown, so the check's own elapsed time counts toward it) keeps the splash
- *  readable. Only applies when a splash is actually up (startup-install path). */
-const STARTUP_INSTALL_MIN_SPLASH_MS = 2000
+ *  up long enough for the user to read it and watch the countdown finish. Keep
+ *  in sync with `UPDATE_INSTALL_COUNTDOWN_SECONDS` (updateSplash.ts), the
+ *  countdown the splash shows over this window. Only applies when a splash is
+ *  actually up (startup-install path). */
+const STARTUP_INSTALL_MIN_SPLASH_MS = 5000
 
 /** Why a startup install was or wasn't attempted. The skip reasons that carry
  *  canary signal (`loop_breaker`, `session_ending`, `not_ready`) are reported via


### PR DESCRIPTION
## What

Two related startup-update improvements, bundled so they can be tested together in one build.

### 1. 5-second countdown on the startup update splash

When a previously-downloaded Desktop update is applied on startup (Windows-only Option C, gated behind the `installUpdatesOnStartup` config flag), the purple "Updating ComfyUI Desktop" splash now:

- Explains a new version was downloaded and is about to install.
- Shows a localized **"Restarting in {n}s…"** line that ticks down from 5.
- Switches to **"Restarting now…"** when it reaches zero, right as the install fires.

Previously the splash could flash for a fraction of a second before the app quit, feeling like a glitch. This gives the user a few seconds to read what's happening before the restart.

### 2. Skip the NSIS install-mode page on non-silent update (cherry-picked from #1087)

A non-silent update (electron-updater passes `--updated` but no install-mode flag) would otherwise stop on the install-mode page — the one pre-progress page electron-builder does **not** auto-skip on update — forcing the user to confirm before the progress bar appears. `customInstallMode` now re-uses the mode `initMultiUser` already detected to force-skip that page on update (ambiguous cases still show it).

## Changes

- `relaunchPage.ts` — `showSplashPage` accepts an optional `countdownSeconds`; renders a countdown line with an inline ticker.
- `updateSplash.ts` — new `UPDATE_INSTALL_COUNTDOWN_SECONDS = 5`; passes it to the splash; splash height bumped to fit the extra line.
- `updater.ts` — `STARTUP_INSTALL_MIN_SPLASH_MS` raised `2000 → 5000` so the splash stays up for the full countdown (kept in sync with the countdown constant).
- `locales/en.json`, `locales/zh.json` — updated title/desc + new `updateInstallCountdown` / `updateInstallStartingNow` strings.
- `updater.test.ts` — updated the min-splash-hold timing test for 5000ms.
- `scripts/installer.nsh` — skip the install-mode page on non-silent update.

## Scope / safety

- Windows-only, startup-install path only.
- Countdown still gated behind the existing `installUpdatesOnStartup` flag — no behavior change unless that's enabled.
- Worst case if the inline ticker didn't run: the splash simply shows title + desc without the number (graceful) — the update still proceeds normally.

## Validation

`pnpm run typecheck`, `pnpm run lint`, `pnpm run build`, `pnpm run test` (2189 tests) all green.