### PR TITLE
feat(updater): default to startup install + installer UI on Windows

### DIFF
--- a/src/main/lib/updater.test.ts
+++ b/src/main/lib/updater.test.ts
@@ -312,9 +312,8 @@ describe('startup update install + session-end guard (issue #1065)', () => {
   beforeEach(() => {
     vi.resetModules()
     settingsStore = {}
-    // These tests exercise the gated "Option C" startup-install path, so enable
-    // the local flag. Individual default-mode tests delete it.
-    settingsStore['installUpdatesOnStartup'] = true
+    // Startup install (Option C) and the NSIS installer UI default ON on Windows.
+    // Tests that exercise the opt-out path set these to false explicitly.
     listeners = {}
     sessionEnding = false
     readyVersion = null
@@ -369,19 +368,21 @@ describe('startup update install + session-end guard (issue #1065)', () => {
   const findEmitCalls = (event: string): unknown[][] =>
     emitMock.mock.calls.filter((c) => c[0] === event)
 
-  it('register() leaves install-on-quit enabled by default (Option B)', async () => {
-    delete settingsStore['installUpdatesOnStartup']
+  it('register() disables install-on-quit by default on Windows (Option C)', async () => {
     const updater = await import('./updater')
     updater.register()
-    // Default mode keeps electron-updater's install-on-quit; it's only suppressed
-    // when the OS session ends (see suppressInstallOnQuit).
-    expect(electronUpdaterMock.autoInstallOnAppQuit).toBe(true)
+    // Startup install is the default on Windows, so install-on-quit is disabled
+    // entirely and the staged update applies at the next launch.
+    expect(electronUpdaterMock.autoInstallOnAppQuit).toBe(false)
   })
 
-  it('register() disables install-on-quit when the startup-install flag is on (Option C)', async () => {
+  it('register() keeps install-on-quit when startup install is opted out (Option B)', async () => {
+    settingsStore['installUpdatesOnStartup'] = false
     const updater = await import('./updater')
     updater.register()
-    expect(electronUpdaterMock.autoInstallOnAppQuit).toBe(false)
+    // Opted out: electron-updater's install-on-quit stays armed; it's only
+    // suppressed when the OS session ends (see suppressInstallOnQuit).
+    expect(electronUpdaterMock.autoInstallOnAppQuit).toBe(true)
   })
 
   it('startup install is inert on non-Windows even when the flag is on', async () => {
@@ -401,7 +402,7 @@ describe('startup update install + session-end guard (issue #1065)', () => {
   })
 
   it('suppressInstallOnQuit() disables install-on-quit (Option B session-end guard)', async () => {
-    delete settingsStore['installUpdatesOnStartup']
+    settingsStore['installUpdatesOnStartup'] = false
     const updater = await import('./updater')
     updater.register()
     expect(electronUpdaterMock.autoInstallOnAppQuit).toBe(true)
@@ -409,8 +410,8 @@ describe('startup update install + session-end guard (issue #1065)', () => {
     expect(electronUpdaterMock.autoInstallOnAppQuit).toBe(false)
   })
 
-  it('startup install is inert when the flag is off, even with a staged update', async () => {
-    delete settingsStore['installUpdatesOnStartup']
+  it('startup install is inert when opted out, even with a staged update', async () => {
+    settingsStore['installUpdatesOnStartup'] = false
     settingsStore['pendingDownloadedUpdateVersion'] = '1.0.1'
     readyVersion = '1.0.1'
     const updater = await import('./updater')
@@ -428,20 +429,19 @@ describe('startup update install + session-end guard (issue #1065)', () => {
     expect(fakeUpdater.restartAndInstall).not.toHaveBeenCalled()
   })
 
-  it('installUpdate() installs silently by default (showInstallerUI off)', async () => {
-    delete settingsStore['showInstallerUI']
-    const updater = await import('./updater')
-    updater.register()
-    updater.installUpdate()
-    expect(fakeUpdater.restartAndInstall).toHaveBeenCalledWith({ isSilent: true })
-  })
-
-  it('installUpdate() shows the NSIS installer UI when showInstallerUI is on', async () => {
-    settingsStore['showInstallerUI'] = true
+  it('installUpdate() shows the NSIS installer UI by default on Windows', async () => {
     const updater = await import('./updater')
     updater.register()
     updater.installUpdate()
     expect(fakeUpdater.restartAndInstall).toHaveBeenCalledWith({ isSilent: false })
+  })
+
+  it('installUpdate() installs silently when showInstallerUI is opted out', async () => {
+    settingsStore['showInstallerUI'] = false
+    const updater = await import('./updater')
+    updater.register()
+    updater.installUpdate()
+    expect(fakeUpdater.restartAndInstall).toHaveBeenCalledWith({ isSilent: true })
   })
 
   it('installUpdate() ignores showInstallerUI off Windows (isSilent stays true)', async () => {

--- a/src/main/lib/updater.test.ts
+++ b/src/main/lib/updater.test.ts
@@ -289,7 +289,7 @@ describe('app-update telemetry dedup (volume regression)', () => {
 })
 
 /**
- * Issue #1065 — install staged Desktop updates at startup (Option C) instead of
+ * Issue #1065 — install staged Desktop updates at startup instead of
  * silently on quit, and never spawn the installer while the OS session is
  * ending. Installing on quit is what a Windows shutdown interrupts mid-write,
  * corrupting the install and forcing endless reinstalls.
@@ -312,7 +312,7 @@ describe('startup update install + session-end guard (issue #1065)', () => {
   beforeEach(() => {
     vi.resetModules()
     settingsStore = {}
-    // Startup install (Option C) and the NSIS installer UI default ON on Windows.
+    // Startup install and the NSIS installer UI default on (enabled) on Windows.
     // Tests that exercise the opt-out path set these to false explicitly.
     listeners = {}
     sessionEnding = false
@@ -368,7 +368,7 @@ describe('startup update install + session-end guard (issue #1065)', () => {
   const findEmitCalls = (event: string): unknown[][] =>
     emitMock.mock.calls.filter((c) => c[0] === event)
 
-  it('register() disables install-on-quit by default on Windows (Option C)', async () => {
+  it('register() disables install-on-quit by default on Windows when startup install is enabled', async () => {
     const updater = await import('./updater')
     updater.register()
     // Startup install is the default on Windows, so install-on-quit is disabled
@@ -376,7 +376,7 @@ describe('startup update install + session-end guard (issue #1065)', () => {
     expect(electronUpdaterMock.autoInstallOnAppQuit).toBe(false)
   })
 
-  it('register() keeps install-on-quit when startup install is opted out (Option B)', async () => {
+  it('register() keeps install-on-quit when startup install is explicitly opted out', async () => {
     settingsStore['installUpdatesOnStartup'] = false
     const updater = await import('./updater')
     updater.register()
@@ -387,7 +387,7 @@ describe('startup update install + session-end guard (issue #1065)', () => {
 
   it('startup install is inert on non-Windows even when the flag is on', async () => {
     // macOS (Squirrel.Mac / ShipIt) and Linux don't have the NSIS shutdown
-    // corruption, so Option C must stay off there regardless of the setting.
+    // corruption, so startup install must stay off there regardless of the setting.
     Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true })
     settingsStore['installUpdatesOnStartup'] = true
     settingsStore['pendingDownloadedUpdateVersion'] = '1.0.1'
@@ -401,7 +401,7 @@ describe('startup update install + session-end guard (issue #1065)', () => {
     expect(fakeUpdater.restartAndInstall).not.toHaveBeenCalled()
   })
 
-  it('suppressInstallOnQuit() disables install-on-quit (Option B session-end guard)', async () => {
+  it('suppressInstallOnQuit() disables install-on-quit for the session-end guard', async () => {
     settingsStore['installUpdatesOnStartup'] = false
     const updater = await import('./updater')
     updater.register()

--- a/src/main/lib/updater.ts
+++ b/src/main/lib/updater.ts
@@ -137,19 +137,16 @@ function isSystemPackageInstall(): boolean {
  * so applying updates at startup there would only add risk to a working update
  * channel. On those platforms this always returns false.
  *
- * Default OFF even on Windows. With it off, the app keeps the normal
- * install-on-quit behavior; the `session-end` guard (`suppressInstallOnQuit`)
- * only suppresses that install while the OS is shutting down. With it on,
- * install-on-quit is disabled entirely and the staged update applies on the next
- * boot.
- *
- * Not a remote flag yet — flip it via the hidden `installUpdatesOnStartup`
- * setting (edited by hand in settings.json), so the startup-install path can be
- * canaried before any wider rollout.
+ * Default ON on Windows. The staged update applies at startup and
+ * electron-updater's install-on-quit is disabled entirely. Set the
+ * `installUpdatesOnStartup` setting to `false` to opt back out to the old
+ * install-on-quit behavior (where the `session-end` guard,
+ * `suppressInstallOnQuit`, only suppresses the install while the OS is shutting
+ * down).
  */
 function isStartupInstallEnabled(): boolean {
   if (process.platform !== 'win32') return false
-  return settings.get('installUpdatesOnStartup') === true
+  return settings.get('installUpdatesOnStartup') !== false
 }
 
 /**
@@ -164,12 +161,12 @@ function isStartupInstallEnabled(): boolean {
  * continuous visual feedback during the actual file copy — which our Electron
  * "Updating…" splash can't, since the copy runs after the app has quit.
  *
- * Default OFF. Not remote yet — flip the hidden `showInstallerUI` setting by
- * hand in settings.json to canary it.
+ * Default ON on Windows. Set the `showInstallerUI` setting to `false` to opt
+ * back out to a fully silent install.
  */
 function isInstallerUIEnabled(): boolean {
   if (process.platform !== 'win32') return false
-  return settings.get('showInstallerUI') === true
+  return settings.get('showInstallerUI') !== false
 }
 
 /**
@@ -530,8 +527,8 @@ export function installUpdate(): void {
       app.releaseSingleInstanceLock()
     }
     // `isSilent: false` shows the NSIS progress window during the install (see
-    // `isInstallerUIEnabled` — Windows-only, gated, default off). Off everywhere
-    // else, so the macOS/Linux paths and the default Windows path stay silent.
+    // `isInstallerUIEnabled` — Windows-only, default on). Forced silent on
+    // macOS/Linux, where `isSilent` has no effect anyway.
     updater.restartAndInstall({ isSilent: !isInstallerUIEnabled() })
   } catch (err) {
     clearQuitReason()

--- a/src/main/lib/updater.ts
+++ b/src/main/lib/updater.ts
@@ -126,6 +126,16 @@ function isSystemPackageInstall(): boolean {
 }
 
 /**
+ * Windows-only feature gate that defaults on: enabled unless the setting is
+ * explicitly `false`. The startup-install and installer-UI gates share this so
+ * their platform check and opt-out semantics can't drift apart.
+ */
+function isWindowsOptOutGate(key: 'installUpdatesOnStartup' | 'showInstallerUI'): boolean {
+  if (process.platform !== 'win32') return false
+  return settings.get(key) !== false
+}
+
+/**
  * Local, static feature gate for applying a staged update at the next launch
  * (the "startup install" path) instead of letting electron-updater install it
  * on quit.
@@ -145,8 +155,7 @@ function isSystemPackageInstall(): boolean {
  * down).
  */
 function isStartupInstallEnabled(): boolean {
-  if (process.platform !== 'win32') return false
-  return settings.get('installUpdatesOnStartup') !== false
+  return isWindowsOptOutGate('installUpdatesOnStartup')
 }
 
 /**
@@ -165,8 +174,7 @@ function isStartupInstallEnabled(): boolean {
  * back out to a fully silent install.
  */
 function isInstallerUIEnabled(): boolean {
-  if (process.platform !== 'win32') return false
-  return settings.get('showInstallerUI') !== false
+  return isWindowsOptOutGate('showInstallerUI')
 }
 
 /**

--- a/src/main/lib/updater.ts
+++ b/src/main/lib/updater.ts
@@ -261,8 +261,8 @@ function bindUpdaterEvents(): void {
       emitTelemetry('comfy.desktop.app_update.download_complete', { version })
     }
     // Persist that an installer is staged on disk. electron-updater caches the
-    // download across restarts; this marker lets the startup-install path (when
-    // enabled) apply it on the next boot. Harmless in the default on-quit mode —
+    // download across restarts; this marker lets the startup-install path apply
+    // it on the next boot. Harmless when installing on quit instead —
     // it's just a record that a download finished and is cleared once the staged
     // version is the one running.
     try {
@@ -583,8 +583,9 @@ type StartupInstallDecision =
  * Decide whether to install a staged Desktop update on this launch. Cheap and
  * synchronous (reads only persisted markers + environment).
  *
- * Returns a skip for: the startup-install gate being off (the default — installs
- * still happen on quit), E2E runs, system-package-managed installs (apt/dnf own
+ * Returns a skip for: the startup-install gate being off (non-Windows, or the
+ * `installUpdatesOnStartup` opt-out — installs still happen on quit), E2E runs,
+ * system-package-managed installs (apt/dnf own
  * the update), an OS session that's already ending, no staged download (or one
  * that's already the running version), and the loop-breaker case (we already
  * auto-attempted this exact version and are still on the old one).
@@ -727,16 +728,17 @@ export async function applyPendingUpdateOnStartup(splashShownAt?: number): Promi
 export function register(): void {
   bindUpdaterEvents()
 
-  // Default ("Option B"): keep electron-updater's install-on-quit. A normal
-  // quit still installs a staged update; the `session-end` guard
-  // (`suppressInstallOnQuit`) flips `autoInstallOnAppQuit` off only when the OS
-  // is shutting down, so a Windows shutdown/restart/logoff can't kill the
-  // installer mid-write (the "reinstall on every shutdown" corruption loop).
-  //
-  // Gated ("Option C"): when the startup-install path is enabled, disable
+  // Startup install (the Windows default): disable electron-updater's
   // install-on-quit entirely up front — the staged update applies on the next
-  // launch (`applyPendingUpdateOnStartup`) instead. `electronAutoUpdater` is the
-  // same singleton the ToDesktop runtime drives, so this affects the real updater.
+  // launch (`applyPendingUpdateOnStartup`) instead of on quit, which is what a
+  // Windows shutdown can kill mid-write (the "reinstall on every shutdown"
+  // corruption loop). `electronAutoUpdater` is the same singleton the ToDesktop
+  // runtime drives, so this affects the real updater.
+  //
+  // Opted out (non-Windows, or `installUpdatesOnStartup` set to false): keep
+  // install-on-quit armed. A normal quit still installs a staged update; the
+  // `session-end` guard (`suppressInstallOnQuit`) flips `autoInstallOnAppQuit`
+  // off only when the OS is shutting down.
   if (isStartupInstallEnabled()) {
     suppressInstallOnQuit()
   }

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -61,23 +61,20 @@ export interface KnownSettings {
    *  the same version on the next boot — the user can still install it manually
    *  via the update pill. Cleared once that version is actually running. */
   lastStartupUpdateAttemptVersion?: string
-  /** Hidden, local-only gate (default false / off) for applying a staged Desktop
-   *  update on the next launch instead of letting electron-updater install it on
-   *  quit. Windows-only — ignored on macOS/Linux, whose updaters don't have the
-   *  shutdown install-corruption this addresses. Off: install-on-quit stays armed
-   *  and is only suppressed while the OS is shutting down. On: install-on-quit is
-   *  disabled and the update applies at startup. Not remote yet — flipped by hand
-   *  in settings.json to canary the startup-install path. */
+  /** Windows-only gate (default on) for applying a staged Desktop update on the
+   *  next launch instead of letting electron-updater install it on quit. Ignored
+   *  on macOS/Linux, whose updaters don't have the shutdown install-corruption
+   *  this addresses. On (default): install-on-quit is disabled and the update
+   *  applies at startup. Set to `false` to opt back out — install-on-quit stays
+   *  armed and is only suppressed while the OS is shutting down. */
   installUpdatesOnStartup?: boolean
-  /** Hidden, local-only gate (default false / off) for showing the NSIS
-   *  installer's own progress window while an update installs, instead of
-   *  installing fully silently. Windows-only — `isSilent` is an NSIS concept and
-   *  is ignored on macOS/Linux. On update the assisted installer skips the
-   *  welcome/license/directory pages and our `customFinishPage` auto-launches +
-   *  skips the finish page, so the user only sees a progress window (no clicks).
-   *  Gives continuous visual feedback during the real file copy, which our
-   *  Electron "Updating…" splash can't cover (the copy happens after we quit).
-   *  Not remote yet — flipped by hand in settings.json to canary it. */
+  /** Windows-only gate (default on) for showing the NSIS installer's own
+   *  progress window while an update installs, instead of installing fully
+   *  silently. Ignored on macOS/Linux — `isSilent` is an NSIS concept. On update
+   *  the assisted installer skips the welcome/license/directory pages and our
+   *  `customFinishPage` auto-launches + skips the finish page, so the user only
+   *  sees a progress window (no clicks). Set to `false` for a fully silent
+   *  install. */
   showInstallerUI?: boolean
 }
 


### PR DESCRIPTION
## Summary

Commits to the **install-on-startup** update flow with the **NSIS installer UI shown** as the default behavior on Windows (issue #1065).

Both `installUpdatesOnStartup` and `showInstallerUI` were previously hidden, opt-in flags (default **off**) used to canary the new path. They are now **default-on on Windows**, mirroring the existing `autoInstallUpdates` opt-out pattern (`!== false`):

- **`installUpdatesOnStartup`** — staged updates now apply at the next launch and electron-updater's crash-prone install-on-quit is disabled entirely. This is the core fix for the Windows shutdown-corruption loop in #1065.
- **`showInstallerUI`** — the NSIS progress window is shown during the install (`isSilent: false`), giving continuous visual feedback during the file copy that the Electron "Updating…" splash can't cover (the copy runs after the app quits).

Set either setting to `false` in `settings.json` to opt back out. No-op on macOS/Linux, whose updaters don't have the NSIS shutdown-corruption failure mode.

## Why now

The startup-install path and installer UI were validated via the hidden flags across prior PRs (#1066, #1079, #1088, #1093). Both per-user and all-users update flows were manually confirmed working. This PR makes that path the committed default for Windows users.

## Changes

- `src/main/lib/updater.ts` — `isStartupInstallEnabled()` and `isInstallerUIEnabled()` flipped to default-on (`!== false`), docs updated.
- `src/main/settings.ts` — setting doc comments updated to reflect default-on / opt-out.
- `src/main/lib/updater.test.ts` — tests updated for the new defaults; added explicit opt-out coverage.

## Validation

- `pnpm exec vitest run src/main/lib/updater.test.ts` ✅ (33 passed)
- `pnpm run typecheck` ✅
- `pnpm run lint` ✅
- `pnpm run build` ✅

Final real-world confirmation still requires a ToDesktop Windows build to exercise the live update path.
