### PR TITLE
Feat/titlebar theme match and version pill

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -37,6 +37,7 @@
     "filterCloud": "Cloud",
     "filterRemote": "Remote",
     "updatePill": "Update",
+    "updatePillVersion": "Update {version}",
     "migratePill": "Migrate",
     "openInstall": "Open",
     "manageInstall": "Manage",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -37,6 +37,7 @@
     "filterCloud": "云端",
     "filterRemote": "远程",
     "updatePill": "更新",
+    "updatePillVersion": "更新到 {version}",
     "migratePill": "迁移",
     "openInstall": "打开",
     "manageInstall": "管理",

--- a/src/main/host/attach.ts
+++ b/src/main/host/attach.ts
@@ -5,7 +5,7 @@ import { getModelDownloadContentScript } from '../lib/comfyContentScript'
 import { getComfyTerminalContentScript } from '../lib/comfyTerminalContentScript'
 import { closeInstallPopouts } from '../lib/popoutWindows'
 import { _operationAborts, sourceMap } from '../lib/ipc/shared'
-import { TITLEBAR_BG } from '../lib/theme'
+import { readableSymbolColor } from '../lib/theme'
 import * as mainTelemetry from '../lib/telemetry'
 import { refreshCloudUserTier } from '../lib/userTier'
 import { noteCloudEntered } from '../lib/cloudEntry'
@@ -213,17 +213,16 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
   }
   installationEvents.on('updated', onInstallationUpdated)
 
-  // Sync the title bar and overlay colors with the ComfyUI frontend's theme.
-  // Currently locked to the dark title-bar palette regardless of the
-  // reported bg/text — the app's title-bar surfaces (Vue pills,
-  // dropdown popups, tooltips, OS overlay) are dark-only today, and
-  // pushing a light bg into the OS overlay paints the min/max/close
-  // symbols light over the still-dark Vue header. The arguments are
-  // kept so the observer + ipc-message wiring stays intact for a
-  // future re-introduction of theme tracking.
-  const applyComfyTheme = (_bg: string, _text: string): void => {
+  /**
+   * Paint the Vue header and the OS window-controls overlay from ComfyUI's
+   * reported `bg` in one call, so the strip behind the min/max/close controls
+   * stays seamless with the bar (the #647 divergence). `symbolColor` is
+   * luminance-derived to keep the glyphs legible on any theme. Instance-only —
+   * the install-less chooser keeps `--titlebar-bg`.
+   */
+  const applyComfyTheme = (bg: string): void => {
     if (comfyWindow.isDestroyed()) return
-    const theme = { bg: TITLEBAR_BG, text: '#dddddd' }
+    const theme = { bg, text: readableSymbolColor(bg) }
     entry.lastTheme = theme
     if (!titleBarView.webContents.isDestroyed()) {
       titleBarView.webContents.send('comfy-titlebar:theme-changed', theme)
@@ -240,8 +239,8 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
     ...args: unknown[]
   ): void => {
     if (channel === 'desktop2-theme-report') {
-      const { bg, text } = (args[0] || {}) as { bg?: string; text?: string }
-      if (bg) applyComfyTheme(bg, text || '#ddd')
+      const { bg } = (args[0] || {}) as { bg?: string; text?: string }
+      if (bg) applyComfyTheme(bg)
     }
   }
   comfyContents.on('ipc-message', onIpcMessage)

--- a/src/main/lib/theme.ts
+++ b/src/main/lib/theme.ts
@@ -1,5 +1,7 @@
 // Shared main-process color constants. Brand colors match the frontend design system.
 
+import { perceivedLuminance, LUMINANCE_LIGHT_THRESHOLD } from '../../shared/colorLuminance'
+
 /** ComfyUI "Electric Yellow" — `--color-brand-yellow` / `--color-electric-400` in the frontend. */
 export const BRAND_YELLOW = '#F0FF41'
 
@@ -15,6 +17,30 @@ export const COMFY_BG = '#171717'
 /** Title bar background. Must stay in sync with `--titlebar-bg` in `src/renderer/src/assets/main.css`
  *  so the OS window-controls overlay matches the Vue `.title-bar` on every window. */
 export const TITLEBAR_BG = '#211927'
+
+/** Window-control symbol color (`#dddddd` on dark backgrounds, `#333333` on light) chosen by the
+ *  perceived luminance of `bg` so the min/max/close glyphs stay legible against any reported
+ *  ComfyUI theme. Accepts `#rgb` / `#rrggbb` / `rgb()` / `rgba()`; falls back to the dark-safe
+ *  light glyph on any parse failure. */
+export function readableSymbolColor(bg: string): string {
+  const rgb = parseColor(bg)
+  if (!rgb) return '#dddddd'
+  const [r, g, b] = rgb
+  return perceivedLuminance(r, g, b) >= LUMINANCE_LIGHT_THRESHOLD ? '#333333' : '#dddddd'
+}
+
+function parseColor(input: string): [number, number, number] | null {
+  const s = input.trim().toLowerCase()
+  const hex = s.match(/^#([0-9a-f]{3}|[0-9a-f]{6})$/)
+  if (hex?.[1]) {
+    const h = hex[1]
+    const full = h.length === 3 ? h.replace(/./g, (c) => c + c) : h
+    return [parseInt(full.slice(0, 2), 16), parseInt(full.slice(2, 4), 16), parseInt(full.slice(4, 6), 16)]
+  }
+  const rgb = s.match(/^rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)/)
+  if (rgb) return [Number(rgb[1]), Number(rgb[2]), Number(rgb[3])]
+  return null
+}
 
 export interface SplashTheme {
   bg: string

--- a/src/renderer/src/comfyTitleBar/TitleBarApp.vue
+++ b/src/renderer/src/comfyTitleBar/TitleBarApp.vue
@@ -214,6 +214,7 @@ const isInstallLess = ref((bridge?.getInstallationId() ?? '') === '')
 const {
   installLabel,
   sourceCategory,
+  themeBg,
   themeText,
   isFullscreen,
   firstUseMode,
@@ -645,6 +646,8 @@ onUnmounted(() => {
     :data-collapse-mode="collapseMode"
     :style="{
       color: themeText ?? undefined,
+      '--titlebar-bg-active': themeBg ?? undefined,
+      '--titlebar-icon': themeText ?? undefined,
       '--title-trailing-width': `${trailingWidthPx}px`
     }"
   >
@@ -906,7 +909,10 @@ onUnmounted(() => {
      reserves 140px on the right for native min/max/close. */
   padding: 0 12px;
   box-sizing: border-box;
-  background: var(--titlebar-bg);
+  /* `--titlebar-bg-active` is set inline from the reported ComfyUI bg while
+     inside an instance; install-less / pre-report hosts fall back to the
+     static brand `--titlebar-bg`. */
+  background: var(--titlebar-bg-active, var(--titlebar-bg));
   color: var(--text-muted);
   border-bottom: 1px solid var(--border);
   font: 12px/1 var(--font-sans, 'Inter', system-ui, sans-serif);
@@ -1083,6 +1089,27 @@ onUnmounted(() => {
    * this lift automatically — one source of truth for the open tint. */
   border-color: var(--neutral-50);
   color: var(--neutral-50);
+}
+/* Light comfy theme: the resting surface (`rgba(255,255,255,.04)`) and text
+ * (`--neutral-100`, light grey) vanish on a white bar. Swap to a faint dark
+ * film + dark text so the pill — and its `currentColor` brand mark / caret —
+ * stay legible. Mirrors the `.is-light` treatment on the update chip. */
+.title-bar.is-light .title-install-pill {
+  background: rgba(0, 0, 0, 0.04);
+  color: var(--neutral-700);
+}
+.title-bar.is-light.is-hover-active .title-install-pill.is-interactive:hover:not(.is-open),
+.title-bar.is-light .title-install-pill.is-interactive:focus-visible:not(.is-open) {
+  background: rgba(0, 0, 0, 0.07);
+  border-color: color-mix(in srgb, var(--neutral-700) 35%, transparent);
+  color: var(--neutral-700);
+}
+/* Open state: the dark-theme yellow lift (`--neutral-50`) is near-invisible on
+ * a white bar, so commit border + text (and the `currentColor` mark / caret)
+ * to full-strength dark instead. */
+.title-bar.is-light .title-install-pill.is-interactive.is-open {
+  border-color: color-mix(in srgb, var(--neutral-700) 55%, transparent);
+  color: var(--neutral-700);
 }
 
 /* Inline instance-update CTA, sitting just after the install name inside
@@ -1325,8 +1352,11 @@ onUnmounted(() => {
 .title-bar.is-hover-active .title-downloads-tray:hover:not(:disabled) {
   color: var(--comfy-yellow);
 }
-.title-bar.is-light .title-downloads-tray {
-  color: var(--comfy-yellow);
+/* Light comfy theme: yellow hover/open lift is near-invisible on a white bar,
+ * so deepen the muted resting icon to full-strength dark text instead — the
+ * same active cue, kept in the light theme's color family. */
+.title-bar.is-light.is-hover-active .title-downloads-tray:hover:not(:disabled) {
+  color: var(--neutral-700);
 }
 
 .title-downloads-badge {
@@ -1347,7 +1377,7 @@ onUnmounted(() => {
   border-radius: 999px;
   /* Subtle ring against the title-bar background so the badge reads
    * as a separate token from the icon underneath at any zoom. */
-  box-shadow: 0 0 0 2px var(--titlebar-bg, var(--neutral-900));
+  box-shadow: 0 0 0 2px var(--titlebar-bg-active, var(--titlebar-bg, var(--neutral-900)));
   background: var(--accent, #60a5fa);
   color: #fff;
   font-size: 9px;
@@ -1372,6 +1402,10 @@ onUnmounted(() => {
 .title-downloads-tray.is-open,
 .title-bar.is-hover-active .title-downloads-tray.is-open:hover {
   color: var(--neutral-50);
+}
+.title-bar.is-light .title-downloads-tray.is-open,
+.title-bar.is-light.is-hover-active .title-downloads-tray.is-open:hover {
+  color: var(--neutral-700);
 }
 
 .title-downloads-tray.is-flashing .title-downloads-badge {
@@ -1422,7 +1456,7 @@ onUnmounted(() => {
   height: 8px;
   border-radius: 999px;
   background: var(--danger);
-  box-shadow: 0 0 0 2px var(--titlebar-bg, var(--neutral-900));
+  box-shadow: 0 0 0 2px var(--titlebar-bg-active, var(--titlebar-bg, var(--neutral-900)));
   pointer-events: none;
 }
 

--- a/src/renderer/src/comfyTitleBar/useTitleBarIdentity.ts
+++ b/src/renderer/src/comfyTitleBar/useTitleBarIdentity.ts
@@ -7,6 +7,7 @@ import {
   isLoadingLockdownMode,
   type FirstUseMode,
 } from '../../../shared/firstUseMode'
+import { perceivedLuminance, LUMINANCE_LIGHT_THRESHOLD } from '../../../shared/colorLuminance'
 
 interface InstallTypeMeta {
   icon: ReturnType<typeof installTypeMetaFor>['icon']
@@ -88,23 +89,23 @@ export function useTitleBarIdentity(opts: UseTitleBarIdentityOpts): TitleBarIden
 
   const showBrandMark = computed(() => opts.isInstallLess.value && !isPreviewMode.value)
 
-  /** Locked to `false`: the title-bar surface is the dark token in both themes, so
-   *  light hover variants would produce light chrome on a dark bar. */
-  const isLight = computed(() => false)
-  // Original luminance test, kept inline for the restoration.
-  // const isLight = computed(() => {
-  //   const bg = themeBg.value
-  //   if (!bg) return false
-  //   const ctx = document.createElement('canvas').getContext('2d')
-  //   if (!ctx) return false
-  //   ctx.fillStyle = bg
-  //   const hex = ctx.fillStyle as string
-  //   if (!hex.startsWith('#') || hex.length < 7) return false
-  //   const r = parseInt(hex.slice(1, 3), 16)
-  //   const g = parseInt(hex.slice(3, 5), 16)
-  //   const b = parseInt(hex.slice(5, 7), 16)
-  //   return (r * 299 + g * 587 + b * 114) / 1000 >= 128
-  // })
+  /** True when the reported ComfyUI bg is light, so the title bar's `.is-light` chrome
+   *  variants (lighter hover/pills/chips) kick in to stay legible on the matching surface.
+   *  Normalises any CSS color to hex via the canvas, then runs the standard perceived-luminance
+   *  test; defaults to dark on a non-hex / missing color. */
+  const isLight = computed(() => {
+    const bg = themeBg.value
+    if (!bg) return false
+    const ctx = document.createElement('canvas').getContext('2d')
+    if (!ctx) return false
+    ctx.fillStyle = bg
+    const hex = ctx.fillStyle as string
+    if (!hex.startsWith('#') || hex.length < 7) return false
+    const r = parseInt(hex.slice(1, 3), 16)
+    const g = parseInt(hex.slice(3, 5), 16)
+    const b = parseInt(hex.slice(5, 7), 16)
+    return perceivedLuminance(r, g, b) >= LUMINANCE_LIGHT_THRESHOLD
+  })
 
   let unsubTitle: (() => void) | undefined
   let unsubSourceCategory: (() => void) | undefined

--- a/src/renderer/src/comfyTitleBar/useTitleBarIdentity.ts
+++ b/src/renderer/src/comfyTitleBar/useTitleBarIdentity.ts
@@ -7,7 +7,7 @@ import {
   isLoadingLockdownMode,
   type FirstUseMode,
 } from '../../../shared/firstUseMode'
-import { perceivedLuminance, LUMINANCE_LIGHT_THRESHOLD } from '../../../shared/colorLuminance'
+import { isColorLight } from '../lib/colorScheme'
 
 interface InstallTypeMeta {
   icon: ReturnType<typeof installTypeMetaFor>['icon']
@@ -90,22 +90,8 @@ export function useTitleBarIdentity(opts: UseTitleBarIdentityOpts): TitleBarIden
   const showBrandMark = computed(() => opts.isInstallLess.value && !isPreviewMode.value)
 
   /** True when the reported ComfyUI bg is light, so the title bar's `.is-light` chrome
-   *  variants (lighter hover/pills/chips) kick in to stay legible on the matching surface.
-   *  Normalises any CSS color to hex via the canvas, then runs the standard perceived-luminance
-   *  test; defaults to dark on a non-hex / missing color. */
-  const isLight = computed(() => {
-    const bg = themeBg.value
-    if (!bg) return false
-    const ctx = document.createElement('canvas').getContext('2d')
-    if (!ctx) return false
-    ctx.fillStyle = bg
-    const hex = ctx.fillStyle as string
-    if (!hex.startsWith('#') || hex.length < 7) return false
-    const r = parseInt(hex.slice(1, 3), 16)
-    const g = parseInt(hex.slice(3, 5), 16)
-    const b = parseInt(hex.slice(5, 7), 16)
-    return perceivedLuminance(r, g, b) >= LUMINANCE_LIGHT_THRESHOLD
-  })
+   *  variants (lighter hover/pills/chips) kick in to stay legible on the matching surface. */
+  const isLight = computed(() => isColorLight(themeBg.value))
 
   let unsubTitle: (() => void) | undefined
   let unsubSourceCategory: (() => void) | undefined

--- a/src/renderer/src/comfyTitlePopup/TitlePopupApp.vue
+++ b/src/renderer/src/comfyTitlePopup/TitlePopupApp.vue
@@ -11,6 +11,7 @@ import { dismissPickerModals } from './dismissPickerModals'
 import { popupLocaleSource } from './pickerSettingsApiShim'
 import { useAppLocale } from '../lib/useAppLocale'
 import type { DetailSection, SnapshotListData } from '../types/ipc'
+import { perceivedLuminance, LUMINANCE_LIGHT_THRESHOLD } from '../../../shared/colorLuminance'
 
 // Title-bar dropdown popup shell. Hosts every title-bar dropdown in one
 // reused transparent WebContentsView attached to the host window. Each open
@@ -230,7 +231,7 @@ const isLight = computed(() => {
   const r = parseInt(hex.slice(1, 3), 16)
   const g = parseInt(hex.slice(3, 5), 16)
   const b = parseInt(hex.slice(5, 7), 16)
-  return (r * 299 + g * 587 + b * 114) / 1000 >= 128
+  return perceivedLuminance(r, g, b) >= LUMINANCE_LIGHT_THRESHOLD
 })
 
 function handleActivate(id: string): void {

--- a/src/renderer/src/comfyTitlePopup/TitlePopupApp.vue
+++ b/src/renderer/src/comfyTitlePopup/TitlePopupApp.vue
@@ -11,7 +11,7 @@ import { dismissPickerModals } from './dismissPickerModals'
 import { popupLocaleSource } from './pickerSettingsApiShim'
 import { useAppLocale } from '../lib/useAppLocale'
 import type { DetailSection, SnapshotListData } from '../types/ipc'
-import { perceivedLuminance, LUMINANCE_LIGHT_THRESHOLD } from '../../../shared/colorLuminance'
+import { isColorLight } from '../lib/colorScheme'
 
 // Title-bar dropdown popup shell. Hosts every title-bar dropdown in one
 // reused transparent WebContentsView attached to the host window. Each open
@@ -222,17 +222,7 @@ const globalSettingsSnapshot = ref<GlobalSettingsSnapshot>({
 const downloadsState = ref<DownloadsState>({ active: [], recent: [] })
 
 /** Body-luminance test driving is-light styling; matches TitleBarApp.vue. */
-const isLight = computed(() => {
-  const ctx = document.createElement('canvas').getContext('2d')
-  if (!ctx) return false
-  ctx.fillStyle = themeBg.value
-  const hex = ctx.fillStyle as string
-  if (!hex.startsWith('#') || hex.length < 7) return false
-  const r = parseInt(hex.slice(1, 3), 16)
-  const g = parseInt(hex.slice(3, 5), 16)
-  const b = parseInt(hex.slice(5, 7), 16)
-  return perceivedLuminance(r, g, b) >= LUMINANCE_LIGHT_THRESHOLD
-})
+const isLight = computed(() => isColorLight(themeBg.value))
 
 function handleActivate(id: string): void {
   bridge?.activate(id)

--- a/src/renderer/src/lib/colorScheme.ts
+++ b/src/renderer/src/lib/colorScheme.ts
@@ -1,0 +1,22 @@
+import { perceivedLuminance, LUMINANCE_LIGHT_THRESHOLD } from '../../../shared/colorLuminance'
+
+/**
+ * Whether a CSS color reads as "light" (so chrome should switch to its dark/`.is-light`
+ * variant). Normalises any CSS color to `#rrggbb` via a throwaway canvas — the only reliable
+ * way to resolve named/`rgb()`/`hsl()` inputs in the renderer — then runs the shared
+ * perceived-luminance test. Returns `false` for empty / unresolvable colors so the default
+ * stays dark. Renderer-only (depends on `document`); main uses `readableSymbolColor` in
+ * `src/main/lib/theme.ts`, which shares the same luminance math.
+ */
+export function isColorLight(color: string | null | undefined): boolean {
+  if (!color) return false
+  const ctx = document.createElement('canvas').getContext('2d')
+  if (!ctx) return false
+  ctx.fillStyle = color
+  const hex = ctx.fillStyle as string
+  if (!hex.startsWith('#') || hex.length < 7) return false
+  const r = parseInt(hex.slice(1, 3), 16)
+  const g = parseInt(hex.slice(3, 5), 16)
+  const b = parseInt(hex.slice(5, 7), 16)
+  return perceivedLuminance(r, g, b) >= LUMINANCE_LIGHT_THRESHOLD
+}

--- a/src/renderer/src/views/chooser/ChooserInstallTile.vue
+++ b/src/renderer/src/views/chooser/ChooserInstallTile.vue
@@ -83,6 +83,13 @@ function handleClick(): void {
   if (isStopping.value) return
   emit('pick', inst.value)
 }
+
+/** Fire an action pill's emit, no-op while REQUIRES_STOPPED actions are gated.
+ *  Shared by the update + migrate pills' click / enter / space handlers. */
+function triggerInstallAction(action: 'update' | 'migrate'): void {
+  if (props.isStoppedActionGated) return
+  emit('trigger-action', action, inst.value)
+}
 </script>
 
 <template>
@@ -172,9 +179,9 @@ function handleClick(): void {
         tabindex="0"
         :aria-disabled="isStoppedActionGated || undefined"
         :title="inst.statusTag?.label"
-        @click.stop="isStoppedActionGated || emit('trigger-action', 'update', inst)"
-        @keydown.enter.stop="isStoppedActionGated || emit('trigger-action', 'update', inst)"
-        @keydown.space.prevent.stop="isStoppedActionGated || emit('trigger-action', 'update', inst)"
+        @click.stop="triggerInstallAction('update')"
+        @keydown.enter.stop="triggerInstallAction('update')"
+        @keydown.space.prevent.stop="triggerInstallAction('update')"
       >
         <ArrowDownToLine :size="11" />
         {{ updatePillLabel }}
@@ -187,9 +194,9 @@ function handleClick(): void {
         tabindex="0"
         :aria-disabled="isStoppedActionGated || undefined"
         :title="t('dashboard.migrateBannerTitle')"
-        @click.stop="isStoppedActionGated || emit('trigger-action', 'migrate', inst)"
-        @keydown.enter.stop="isStoppedActionGated || emit('trigger-action', 'migrate', inst)"
-        @keydown.space.prevent.stop="isStoppedActionGated || emit('trigger-action', 'migrate', inst)"
+        @click.stop="triggerInstallAction('migrate')"
+        @keydown.enter.stop="triggerInstallAction('migrate')"
+        @keydown.space.prevent.stop="triggerInstallAction('migrate')"
       >
         <ArrowRightLeft :size="11" />
         {{ t('chooser.migratePill') }}

--- a/src/renderer/src/views/chooser/ChooserInstallTile.vue
+++ b/src/renderer/src/views/chooser/ChooserInstallTile.vue
@@ -54,6 +54,15 @@ const statusPill = computed<{ label: string; dotClass: string } | null>(() => {
 })
 
 const hasUpdate = computed(() => inst.value.statusTag?.style === 'update')
+/** "Update v0.25.0" when the backend tags the target version, else the bare
+ *  "Update" — the action stays self-describing without hiding the current
+ *  version pill beside it. */
+const updatePillLabel = computed(() => {
+  const version = inst.value.statusTag?.version
+  return version
+    ? t('chooser.updatePillVersion', { version })
+    : t('chooser.updatePill')
+})
 // The backend tags every migratable install (Legacy Desktop, portable, git)
 // with a `migrate` status tag — mirror `hasUpdate` rather than special-casing
 // a single source.
@@ -142,9 +151,22 @@ function handleClick(): void {
       >
         {{ sourcePillLabel }}
       </span>
+      <!-- Current version: always shown as quiet metadata, independent of any
+           available action so an update never hides it. Secondary shrink
+           target after the source pill. -->
+      <span
+        v-if="inst.version"
+        class="chooser-tile-pill chooser-tile-pill-version"
+        :title="inst.version"
+      >
+        {{ inst.version }}
+      </span>
+      <!-- Action pill (update / migrate): right-aligned and width-holding so
+           it reads as the affordance, separate from the metadata cluster. The
+           update label carries the target version when known. -->
       <span
         v-if="hasUpdate"
-        class="chooser-tile-pill chooser-tile-pill-update"
+        class="chooser-tile-pill chooser-tile-pill-update chooser-tile-pill-action"
         :class="{ 'chooser-tile-pill-disabled': isStoppedActionGated }"
         role="button"
         tabindex="0"
@@ -155,11 +177,11 @@ function handleClick(): void {
         @keydown.space.prevent.stop="isStoppedActionGated || emit('trigger-action', 'update', inst)"
       >
         <ArrowDownToLine :size="11" />
-        {{ t('chooser.updatePill') }}
+        {{ updatePillLabel }}
       </span>
       <span
         v-else-if="hasMigratePrompt"
-        class="chooser-tile-pill chooser-tile-pill-migrate"
+        class="chooser-tile-pill chooser-tile-pill-migrate chooser-tile-pill-action"
         :class="{ 'chooser-tile-pill-disabled': isStoppedActionGated }"
         role="button"
         tabindex="0"
@@ -171,13 +193,6 @@ function handleClick(): void {
       >
         <ArrowRightLeft :size="11" />
         {{ t('chooser.migratePill') }}
-      </span>
-      <span
-        v-else-if="inst.version"
-        class="chooser-tile-pill chooser-tile-pill-version"
-        :title="inst.version"
-      >
-        {{ inst.version }}
       </span>
       <!-- Launched pill disabled per redesign; kept for later restore.
       <span

--- a/src/renderer/src/views/chooser/chooser-tiles.css
+++ b/src/renderer/src/views/chooser/chooser-tiles.css
@@ -115,8 +115,19 @@
 }
 .chooser-tile-pill-version {
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  /* Action/version pills hold their content width so the source pill
-   * is the one that truncates when the row is tight. */
+  /* Secondary shrink target: with source + version + a (possibly
+   * versioned) action pill in one no-wrap row, the source pill
+   * ellipsizes first, then the version. The action pill holds its
+   * width (see `.chooser-tile-pill-action`). */
+  flex-shrink: 1;
+  min-width: 0;
+}
+
+/* Action pill (update / migrate) — right-aligned so it sits apart from the
+ * source + version metadata cluster (App-Store-style action), and holds its
+ * width so the interactive label never truncates. */
+.chooser-tile-pill-action {
+  margin-left: auto;
   flex-shrink: 0;
 }
 

--- a/src/shared/colorLuminance.ts
+++ b/src/shared/colorLuminance.ts
@@ -1,0 +1,13 @@
+/**
+ * Perceived luminance of an 8-bit RGB color via the ITU-R BT.601 weights
+ * (`(r*299 + g*587 + b*114) / 1000`), range 0–255. Shared by main + renderer so
+ * the dark/light title-bar threshold can't drift between the two. Callers keep
+ * their own color parsing (regex in main, canvas-normalise in the renderer) and
+ * compare against {@link LUMINANCE_LIGHT_THRESHOLD}.
+ */
+export function perceivedLuminance(r: number, g: number, b: number): number {
+  return (r * 299 + g * 587 + b * 114) / 1000
+}
+
+/** Luminance at/above which a background reads as "light" (so it wants dark chrome). */
+export const LUMINANCE_LIGHT_THRESHOLD = 128

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -29,7 +29,7 @@ export interface Installation {
   sourceLabel: string
   sourceCategory: string
   version?: string
-  statusTag?: { style: string; label: string }
+  statusTag?: { style: string; label: string; version?: string }
   seen?: boolean
   listPreview?: string
   launchMode?: string


### PR DESCRIPTION
## Summary

Match the desktop title bar to ComfyUI's in-page theme while inside an instance (dark/light, Win/Linux/macOS), and stop the dashboard tile from hiding an install's version when an update is available. Two independent fixes, one commit each.

## Changes

**What**

- `applyComfyTheme` (`src/main/host/attach.ts`) — drive the Vue header and the OS window-controls overlay from ComfyUI's reported `--comfy-menu-bg` in one call, so the strip behind min/max/close stays seamless with the bar (the divergence fixed in #647). `symbolColor` is luminance-derived (`readableSymbolColor`) so the glyphs stay legible on any theme. Instance-only — the install-less chooser keeps `--titlebar-bg`.
- `readableSymbolColor` (`src/main/lib/theme.ts`) — new helper: parses `#rgb`/`#rrggbb`/`rgb()`, returns `#333` on light bgs / `#ddd` on dark by perceived luminance; dark-safe fallback on parse failure.
- `isLight` (`src/renderer/src/comfyTitleBar/useTitleBarIdentity.ts`) — un-stubbed from `false` to the real luminance test, activating the existing `.is-light` chrome.
- `TitleBarApp.vue` — bind `--titlebar-bg-active` / `--titlebar-icon` inline from the reported theme; extend `.is-light` to the resting/hover/open states it never covered (install pill, downloads tray, icon buttons) so nothing washes out or lifts to invisible yellow on a light bar.
- `ChooserInstallTile.vue` + `chooser-tiles.css` — render the version pill independently of the action pill (was a `v-if`/`v-else-if` chain), right-align the update/migrate action (`.chooser-tile-pill-action`), and carry the target version in the label (`Update v0.25.0`) via `chooser.updatePillVersion`, sourced from `statusTag.version`.
- `src/types/ipc.ts`, `locales/en.json`, `locales/zh.json` — add `statusTag.version` to the renderer `Installation` type and the new `updatePillVersion` key.

**Breaking**

None. The theme path only runs for attached instances (`applyComfyTheme` is bound inside `attachInstall`); the chooser/dashboard still reverts via `applyChooserHostTheme`. The `desktop2-theme-report` IPC channel, overlay-at-creation defaults, and the migrate/update action emits are unchanged.

## Review Focus

- The crux is that both title-bar surfaces are painted from the same `theme.bg` in one call — that's what keeps the min/max/close strip seamless (re #647). Confirm no path updates the Vue header theme for an instance without the matching overlay repaint.
- `.is-light` was already authored but gated behind a hardcoded `isLight = false`; this enables it and fills the resting/hover/open gaps. Worth a glance on a custom (non-standard) ComfyUI theme.
- Scope is title-bar theming + the dashboard version/update pill only. macOS has no app-controlled overlay (traffic lights are system-drawn), so it themes the header only — intentional, not a gap.

## Testing

Unit/typecheck-only by design: the title-bar binding and pill split are presentational, and the existing `TitleBarApp` suite already exercises the theme-changed and pill-render paths. No new user-visible IPC behavior to E2E.

- `src/renderer/src/comfyTitleBar/TitleBarApp.test.ts` — 59 tests pass (theme binding + pill render unaffected).
- `pnpm typecheck` (node/web/e2e/integration), `pnpm lint` — clean.
- Manual: launch an instance, flip ComfyUI dark⇄light → header + Win/Linux min/max/close follow live; return to dashboard → reverts to purple. Force an instance with an available update → version pill and `Update v…` pill both visible.

Screen Recording


https://github.com/user-attachments/assets/dae8c7e0-e2af-4b55-ab14-7c1076fb72d2



closes #1060 