### PR TITLE
feat(telemetry): privacy-preserving country cohort from OS region

### DIFF
--- a/src/main/lib/telemetry.test.ts
+++ b/src/main/lib/telemetry.test.ts
@@ -3,11 +3,16 @@ import os from 'os'
 import path from 'path'
 import { EventEmitter } from 'events'
 
+// Mutable so individual tests can drive `app.getLocaleCountryCode()`'s
+// return value (including empty / junk) to exercise the `country` default.
+let mockCountryCode = 'US'
+
 vi.mock('electron', () => ({
   app: {
     getPath: () => path.join(os.tmpdir(), 'launcher-test'),
     isPackaged: true,
-    on: () => {}
+    on: () => {},
+    getLocaleCountryCode: () => mockCountryCode
   },
   BrowserWindow: { getAllWindows: () => [] }
 }))
@@ -205,12 +210,14 @@ describe('telemetry.bucketError', () => {
 describe('telemetry default event properties', () => {
   beforeEach(() => {
     captured.length = 0
+    mockCountryCode = 'US'
     process.env['POSTHOG_API_KEY'] = 'test-key'
     process.env['POSTHOG_ENABLED'] = '1'
     telemetry._resetForTest()
   })
 
   afterEach(() => {
+    mockCountryCode = 'US'
     delete process.env['POSTHOG_API_KEY']
     delete process.env['POSTHOG_ENABLED']
     telemetry._resetForTest()
@@ -261,6 +268,39 @@ describe('telemetry default event properties', () => {
 
     telemetry.capture('any.event', { app_version: 'override-value' })
     expect(captured[0]!.properties).toMatchObject({ app_version: 'override-value' })
+  })
+
+  it('injects an uppercased OS-region country (not IP-geo) on every capture', () => {
+    mockCountryCode = 'de'
+    telemetry.initTelemetry({ appVersion: '1.0.0', appEnv: 'prod', isPackaged: true })
+    telemetry.identify('id')
+    telemetry.setConsentState('granted')
+    captured.length = 0
+
+    telemetry.capture('any.event')
+    expect(captured[0]!.properties).toMatchObject({ country: 'DE' })
+  })
+
+  it('omits country (does not send empty string) when the OS returns no region', () => {
+    mockCountryCode = ''
+    telemetry.initTelemetry({ appVersion: '1.0.0', appEnv: 'prod', isPackaged: true })
+    telemetry.identify('id')
+    telemetry.setConsentState('granted')
+    captured.length = 0
+
+    telemetry.capture('any.event')
+    expect(captured[0]!.properties).not.toHaveProperty('country')
+  })
+
+  it('omits country when the OS returns a non-ISO-3166 value', () => {
+    mockCountryCode = 'USA'
+    telemetry.initTelemetry({ appVersion: '1.0.0', appEnv: 'prod', isPackaged: true })
+    telemetry.identify('id')
+    telemetry.setConsentState('granted')
+    captured.length = 0
+
+    telemetry.capture('any.event')
+    expect(captured[0]!.properties).not.toHaveProperty('country')
   })
 })
 

--- a/src/main/lib/telemetry.ts
+++ b/src/main/lib/telemetry.ts
@@ -434,6 +434,42 @@ export interface InitOptions {
 }
 
 /**
+ * Privacy-preserving country signal.
+ *
+ * Derived from the OS region (`app.getLocaleCountryCode()`), NOT from IP.
+ * The OS returns the user's configured region as an ISO 3166-1 alpha-2 code
+ * (e.g. `"US"`, `"CN"`, `"DE"`) with no network call, no geoip, and no new
+ * dependency. This is deliberately the opposite of IP-based geo: we keep
+ * `disableGeoip: true` at PostHog init and force `$ip: ''` on every event
+ * (see `capture`), so PostHog never sees the user IP or derives city-level
+ * geo. The country cohort rides only on the OS region instead.
+ *
+ * Validation: enforce a 2-letter uppercase shape at the call site (per the
+ * telemetry-discipline note at the top of this file). Anything that isn't a
+ * clean ISO-3166 alpha-2 code (empty string, unexpected length, non-letters)
+ * resolves to `undefined` so the property is OMITTED rather than sent as
+ * `''` or a junk value.
+ *
+ * Caveat for analysis: OS region reflects the user's chosen locale, not their
+ * physical location. VPN users, travelers, and people who set a non-local
+ * region will be attributed to their configured region, not where they sit.
+ * That is an acceptable tradeoff for a coarse cohort and is exactly why this
+ * is a low-cardinality categorical, not a precise-location field.
+ */
+function deriveCountry(): string | undefined {
+  let raw: string
+  try {
+    raw = app.getLocaleCountryCode()
+  } catch {
+    return undefined
+  }
+  if (typeof raw !== 'string') return undefined
+  const code = raw.trim().toUpperCase()
+  if (!/^[A-Z]{2}$/.test(code)) return undefined
+  return code
+}
+
+/**
  * Initialize PostHog Node. Safe to call before consent decision is known —
  * events are queued by setConsent(false) and dropped at capture time.
  *
@@ -456,6 +492,16 @@ export function initTelemetry(opts: InitOptions): void {
     is_packaged: opts.isPackaged,
     platform: process.platform,
     arch: process.arch
+  }
+
+  // `country` = OS region (ISO 3166-1 alpha-2), NOT IP-geo. See
+  // `deriveCountry`. Omitted entirely when the OS returns no usable region
+  // so we never ship an empty string. Rides as a default event property
+  // alongside `platform` / `app_channel`; deliberately NOT routed through
+  // `identify()` / person properties.
+  const country = deriveCountry()
+  if (country !== undefined) {
+    defaultEventProperties.country = country
   }
 
   // Suppress event capture on unpackaged (developer / `pnpm dev`) runs.


### PR DESCRIPTION
## Summary

Adds a `country` cohort to ComfyUI Desktop telemetry so we can finally see country distribution in PostHog, **without reversing the intentional geoip-off privacy posture.**

`country` is derived from the **OS region** (`app.getLocaleCountryCode()`, ISO 3166-1 alpha-2 like `US` / `CN` / `DE`) and set as a default event property alongside `platform` / `app_channel`, so it rides on every desktop event. No IP, no geoip, no network call, no new dependency.

## The decision this answers (for @Deep Mehta and nav): "is geoip-off intentional?"

**Yes, geoip-off is an intentional privacy decision.** `src/main/lib/telemetry.ts:489-497` documents it: `posthog-node` runs in the desktop main process on the user's machine, so the request IP is the *real user IP*. PostHog would then derive and store city-level geo plus the raw IP, both rejected as high-cardinality PII we don't need. The init sets `disableGeoip: true` and `capture()` forces `$ip: ''` on every event. The existing comment even points the way: "If we ever need country-level cohorts for paying users, derive it from Stripe checkout country instead." This ties to shipped privacy-policy work.

**This PR delivers country distribution without touching any of that.** `disableGeoip: true` and `$ip: ''` are unchanged. The country signal comes from the OS region setting, not from the network. Zero new PII, no IP sent.

It is wired as a plain super/default event property and is deliberately **not** routed through `client.identify()` / person properties (a parallel PR is fixing identity stitching and forbids identifying the anonymous id). A default event property is conflict-free with that work.

## Alternative for explicit sign-off

If product needs **IP-accurate country (and city)** rather than OS region, the change would be:

- `disableGeoip: false` at PostHog init, **and**
- stop forcing `$ip: ''` in `capture()`

That sends the **real user IP** to PostHog for ingest-time geo resolution. It is a **reversal of the privacy posture** and needs nav's explicit approval, and may conflict with the privacy policy. Flagging it here rather than silently choosing it.

### OS-region caveats reviewers should know
- Reflects the user's configured locale, **not** physical location: VPN users, travelers, and people with a non-local region are attributed to their configured region.
- Acceptable for a coarse cohort; it is exactly why this stays a low-cardinality categorical, not a precise-location field.

## Behavior
- 2-letter uppercase ISO-3166 validation at the call site.
- Empty / malformed OS value -> property **omitted** (never sends `''`).

## Tests
- `country` default present and uppercased (`de` -> `DE`).
- `country` absent when OS returns empty.
- `country` absent when OS returns a non-ISO value (`USA`).
- Full suite: 67 passed. Typecheck (node/web/e2e/integration) + lint green.