### PR TITLE
Launch ComfyUI with Desktop2 frontend assets

### DIFF
--- a/src/main/lib/desktopFrontendRoot.test.ts
+++ b/src/main/lib/desktopFrontendRoot.test.ts
@@ -12,9 +12,9 @@ import os from 'os'
 import path from 'path'
 
 import {
+  hasFrontEndRootArg,
   isLocalComfyPythonLaunch,
-  resolveDesktop2FrontendRoot,
-  setDesktop2FrontendRootArg
+  resolveDesktop2FrontendRoot
 } from './desktopFrontendRoot'
 
 const mockedExecFile = vi.mocked(execFile)
@@ -53,14 +53,14 @@ describe('isLocalComfyPythonLaunch', () => {
   })
 })
 
-describe('setDesktop2FrontendRootArg', () => {
-  it('sets exactly one front-end-root arg', () => {
-    expect(
-      setDesktop2FrontendRootArg(
-        ['-s', 'main.py', '--front-end-root', '/old', '--front-end-root=/older', '--port', '8188'],
-        '/desktop2'
-      )
-    ).toEqual(['-s', 'main.py', '--port', '8188', '--front-end-root', '/desktop2'])
+describe('hasFrontEndRootArg', () => {
+  it('detects a user-supplied front-end-root', () => {
+    expect(hasFrontEndRootArg(['-s', 'main.py', '--front-end-root', '/custom'])).toBe(true)
+    expect(hasFrontEndRootArg(['-s', 'main.py', '--front-end-root=/custom'])).toBe(true)
+  })
+
+  it('returns false when no front-end-root is present', () => {
+    expect(hasFrontEndRootArg(['-s', 'main.py', '--port', '8188'])).toBe(false)
   })
 })
 
@@ -104,15 +104,11 @@ describe('resolveDesktop2FrontendRoot', () => {
     await expect(resolveDesktop2FrontendRoot('/python', '/install')).resolves.toBe(frontendRoot)
   })
 
-  it('rejects when packaged frontend assets are missing', async () => {
-    const desktop2Root = path.join(tempDir, 'static-desktop2')
-    const staticRoot = path.join(tempDir, 'static')
+  it('returns null when packaged frontend assets are missing', async () => {
     mockExecFile((_cmd, _args, _opts, callback) => {
       callback(null, `${tempDir}\n`, '')
     })
 
-    await expect(resolveDesktop2FrontendRoot('/python', '/install')).rejects.toThrow(
-      `Desktop2 frontend assets not found: ${desktop2Root} or ${staticRoot}`
-    )
+    await expect(resolveDesktop2FrontendRoot('/python', '/install')).resolves.toBeNull()
   })
 })

--- a/src/main/lib/desktopFrontendRoot.test.ts
+++ b/src/main/lib/desktopFrontendRoot.test.ts
@@ -76,31 +76,43 @@ describe('resolveDesktop2FrontendRoot', () => {
     vi.restoreAllMocks()
   })
 
-  it('resolves the Desktop2 frontend root from the selected Python env', async () => {
-    const frontendRoot = path.join(tempDir, 'static-desktop2')
-    fs.mkdirSync(frontendRoot)
+  it('prefers the Desktop2 frontend root when it exists', async () => {
+    const desktop2Root = path.join(tempDir, 'static-desktop2')
+    fs.mkdirSync(path.join(tempDir, 'static'))
+    fs.mkdirSync(desktop2Root)
     mockExecFile((_cmd, _args, _opts, callback) => {
-      callback(null, `${frontendRoot}\n`, '')
+      callback(null, `${tempDir}\n`, '')
     })
 
-    await expect(resolveDesktop2FrontendRoot('/python', '/install')).resolves.toBe(frontendRoot)
+    await expect(resolveDesktop2FrontendRoot('/python', '/install')).resolves.toBe(desktop2Root)
 
     expect(mockedExecFile).toHaveBeenCalledWith(
       '/python',
-      ['-s', '-c', expect.stringContaining('comfyui_frontend_package')],
+      ['-s', '-c', expect.stringContaining('resources.files("comfyui_frontend_package")')],
       expect.objectContaining({ cwd: '/install', windowsHide: true }),
       expect.any(Function)
     )
   })
 
-  it('rejects when the Desktop2 assets are missing', async () => {
-    const frontendRoot = path.join(tempDir, 'static-desktop2')
+  it('uses the packaged static frontend when the Desktop2 root is absent', async () => {
+    const frontendRoot = path.join(tempDir, 'static')
+    fs.mkdirSync(frontendRoot)
     mockExecFile((_cmd, _args, _opts, callback) => {
-      callback(null, `${frontendRoot}\n`, '')
+      callback(null, `${tempDir}\n`, '')
+    })
+
+    await expect(resolveDesktop2FrontendRoot('/python', '/install')).resolves.toBe(frontendRoot)
+  })
+
+  it('rejects when packaged frontend assets are missing', async () => {
+    const desktop2Root = path.join(tempDir, 'static-desktop2')
+    const staticRoot = path.join(tempDir, 'static')
+    mockExecFile((_cmd, _args, _opts, callback) => {
+      callback(null, `${tempDir}\n`, '')
     })
 
     await expect(resolveDesktop2FrontendRoot('/python', '/install')).rejects.toThrow(
-      `Desktop2 frontend assets not found: ${frontendRoot}`
+      `Desktop2 frontend assets not found: ${desktop2Root} or ${staticRoot}`
     )
   })
 })

--- a/src/main/lib/desktopFrontendRoot.test.ts
+++ b/src/main/lib/desktopFrontendRoot.test.ts
@@ -76,37 +76,27 @@ describe('resolveDesktop2FrontendRoot', () => {
     vi.restoreAllMocks()
   })
 
-  it('prefers the Desktop2 frontend root when it exists', async () => {
-    const desktop2Root = path.join(tempDir, 'static-desktop2')
-    fs.mkdirSync(path.join(tempDir, 'static'))
-    fs.mkdirSync(desktop2Root)
+  it('resolves the Desktop2 frontend root from the selected Python env', async () => {
+    const frontendRoot = path.join(tempDir, 'static-desktop2')
+    fs.mkdirSync(frontendRoot)
     mockExecFile((_cmd, _args, _opts, callback) => {
-      callback(null, `${tempDir}\n`, '')
+      callback(null, `${frontendRoot}\n`, '')
     })
 
-    await expect(resolveDesktop2FrontendRoot('/python', '/install')).resolves.toBe(desktop2Root)
+    await expect(resolveDesktop2FrontendRoot('/python', '/install')).resolves.toBe(frontendRoot)
 
     expect(mockedExecFile).toHaveBeenCalledWith(
       '/python',
-      ['-s', '-c', expect.stringContaining('resources.files("comfyui_frontend_package")')],
+      ['-s', '-c', expect.stringContaining('comfyui_frontend_package')],
       expect.objectContaining({ cwd: '/install', windowsHide: true }),
       expect.any(Function)
     )
   })
 
-  it('uses the packaged static frontend when the Desktop2 root is absent', async () => {
-    const frontendRoot = path.join(tempDir, 'static')
-    fs.mkdirSync(frontendRoot)
+  it('returns null when the Desktop2 assets are missing', async () => {
+    const frontendRoot = path.join(tempDir, 'static-desktop2')
     mockExecFile((_cmd, _args, _opts, callback) => {
-      callback(null, `${tempDir}\n`, '')
-    })
-
-    await expect(resolveDesktop2FrontendRoot('/python', '/install')).resolves.toBe(frontendRoot)
-  })
-
-  it('returns null when packaged frontend assets are missing', async () => {
-    mockExecFile((_cmd, _args, _opts, callback) => {
-      callback(null, `${tempDir}\n`, '')
+      callback(null, `${frontendRoot}\n`, '')
     })
 
     await expect(resolveDesktop2FrontendRoot('/python', '/install')).resolves.toBeNull()

--- a/src/main/lib/desktopFrontendRoot.test.ts
+++ b/src/main/lib/desktopFrontendRoot.test.ts
@@ -1,0 +1,106 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return { ...actual, execFile: vi.fn() }
+})
+
+import { execFile } from 'child_process'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+import {
+  isLocalComfyPythonLaunch,
+  resolveDesktop2FrontendRoot,
+  setDesktop2FrontendRootArg
+} from './desktopFrontendRoot'
+
+const mockedExecFile = vi.mocked(execFile)
+
+function mockExecFile(
+  cb: (
+    cmd: string,
+    args: string[],
+    opts: Record<string, unknown>,
+    callback: (err: Error | null, stdout: string, stderr: string) => void
+  ) => void
+): void {
+  mockedExecFile.mockImplementation(cb as never)
+}
+
+describe('isLocalComfyPythonLaunch', () => {
+  it('matches local ComfyUI python launches', () => {
+    expect(
+      isLocalComfyPythonLaunch({
+        cmd: '/python',
+        args: ['-s', 'main.py'],
+        cwd: '/ComfyUI'
+      })
+    ).toBe(true)
+  })
+
+  it('rejects external app launches', () => {
+    expect(
+      isLocalComfyPythonLaunch({
+        cmd: '/Applications/ComfyUI.app',
+        args: [],
+        cwd: '/Applications',
+        skipSharedPaths: true
+      })
+    ).toBe(false)
+  })
+})
+
+describe('setDesktop2FrontendRootArg', () => {
+  it('sets exactly one front-end-root arg', () => {
+    expect(
+      setDesktop2FrontendRootArg(
+        ['-s', 'main.py', '--front-end-root', '/old', '--front-end-root=/older', '--port', '8188'],
+        '/desktop2'
+      )
+    ).toEqual(['-s', 'main.py', '--port', '8188', '--front-end-root', '/desktop2'])
+  })
+})
+
+describe('resolveDesktop2FrontendRoot', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'desktop2-fe-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+    vi.restoreAllMocks()
+  })
+
+  it('resolves the Desktop2 frontend root from the selected Python env', async () => {
+    const frontendRoot = path.join(tempDir, 'static-desktop2')
+    fs.mkdirSync(frontendRoot)
+    mockExecFile((_cmd, _args, _opts, callback) => {
+      callback(null, `${frontendRoot}\n`, '')
+    })
+
+    await expect(resolveDesktop2FrontendRoot('/python', '/install')).resolves.toBe(frontendRoot)
+
+    expect(mockedExecFile).toHaveBeenCalledWith(
+      '/python',
+      ['-s', '-c', expect.stringContaining('comfyui_frontend_package')],
+      expect.objectContaining({ cwd: '/install', windowsHide: true }),
+      expect.any(Function)
+    )
+  })
+
+  it('rejects when the Desktop2 assets are missing', async () => {
+    const frontendRoot = path.join(tempDir, 'static-desktop2')
+    mockExecFile((_cmd, _args, _opts, callback) => {
+      callback(null, `${frontendRoot}\n`, '')
+    })
+
+    await expect(resolveDesktop2FrontendRoot('/python', '/install')).rejects.toThrow(
+      `Desktop2 frontend assets not found: ${frontendRoot}`
+    )
+  })
+})

--- a/src/main/lib/desktopFrontendRoot.ts
+++ b/src/main/lib/desktopFrontendRoot.ts
@@ -1,15 +1,12 @@
 import { execFile } from 'child_process'
 import fs from 'fs'
-import path from 'path'
 
 import type { LaunchCommand } from '../types/sources'
 
-const DESKTOP2_FRONTEND_ROOT_DIRS = ['static-desktop2', 'static'] as const
-
-const RESOLVE_DESKTOP2_FRONTEND_PACKAGE_ROOT_SCRIPT = `
+const RESOLVE_DESKTOP2_FRONTEND_ROOT_SCRIPT = `
 from importlib import resources
 
-print(resources.files("comfyui_frontend_package"))
+print(resources.files("comfyui_frontend_package").joinpath("static-desktop2"))
 `.trim()
 
 export function isLocalComfyPythonLaunch(
@@ -23,23 +20,22 @@ export function isLocalComfyPythonLaunch(
 }
 
 /**
- * Resolve the frontend root from the selected Python env, preferring the
- * Desktop2 assets and falling back to the packaged `static` frontend. Returns
- * `null` when neither exists so callers can launch without pinning
+ * Resolve the Desktop2 frontend root from the selected Python env. Returns
+ * `null` when the install's `comfyui_frontend_package` doesn't ship the
+ * `static-desktop2` assets, so callers can launch without pinning
  * `--front-end-root` rather than treating it as fatal.
  */
 export async function resolveDesktop2FrontendRoot(
   pythonPath: string,
   cwd: string
 ): Promise<string | null> {
-  const packageRoot = (
-    await runPython(pythonPath, ['-s', '-c', RESOLVE_DESKTOP2_FRONTEND_PACKAGE_ROOT_SCRIPT], cwd)
+  const frontendRoot = (
+    await runPython(pythonPath, ['-s', '-c', RESOLVE_DESKTOP2_FRONTEND_ROOT_SCRIPT], cwd)
   ).trim()
-  if (!packageRoot) {
+  if (!frontendRoot || !fs.existsSync(frontendRoot)) {
     return null
   }
-  const frontendRoots = DESKTOP2_FRONTEND_ROOT_DIRS.map((dir) => path.join(packageRoot, dir))
-  return frontendRoots.find((root) => fs.existsSync(root)) ?? null
+  return frontendRoot
 }
 
 /** Whether the user already supplied a `--front-end-root` we should respect. */

--- a/src/main/lib/desktopFrontendRoot.ts
+++ b/src/main/lib/desktopFrontendRoot.ts
@@ -22,32 +22,29 @@ export function isLocalComfyPythonLaunch(
   return sIdx !== -1 && sIdx + 1 < launchCmd.args.length
 }
 
+/**
+ * Resolve the frontend root from the selected Python env, preferring the
+ * Desktop2 assets and falling back to the packaged `static` frontend. Returns
+ * `null` when neither exists so callers can launch without pinning
+ * `--front-end-root` rather than treating it as fatal.
+ */
 export async function resolveDesktop2FrontendRoot(
   pythonPath: string,
   cwd: string
-): Promise<string> {
+): Promise<string | null> {
   const packageRoot = (
     await runPython(pythonPath, ['-s', '-c', RESOLVE_DESKTOP2_FRONTEND_PACKAGE_ROOT_SCRIPT], cwd)
   ).trim()
-  const frontendRoots = DESKTOP2_FRONTEND_ROOT_DIRS.map((dir) => path.join(packageRoot, dir))
-  const frontendRoot = frontendRoots.find((root) => fs.existsSync(root))
-  if (!frontendRoot) {
-    throw new Error(`Desktop2 frontend assets not found: ${frontendRoots.join(' or ')}`)
+  if (!packageRoot) {
+    return null
   }
-  return frontendRoot
+  const frontendRoots = DESKTOP2_FRONTEND_ROOT_DIRS.map((dir) => path.join(packageRoot, dir))
+  return frontendRoots.find((root) => fs.existsSync(root)) ?? null
 }
 
-export function setDesktop2FrontendRootArg(args: string[], frontendRoot: string): string[] {
-  const nextArgs: string[] = []
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i]!
-    if (arg === '--front-end-root') {
-      i++
-    } else if (!arg.startsWith('--front-end-root=')) {
-      nextArgs.push(arg)
-    }
-  }
-  return [...nextArgs, '--front-end-root', frontendRoot]
+/** Whether the user already supplied a `--front-end-root` we should respect. */
+export function hasFrontEndRootArg(args: string[]): boolean {
+  return args.some((arg) => arg === '--front-end-root' || arg.startsWith('--front-end-root='))
 }
 
 function runPython(pythonPath: string, args: string[], cwd: string): Promise<string> {

--- a/src/main/lib/desktopFrontendRoot.ts
+++ b/src/main/lib/desktopFrontendRoot.ts
@@ -1,12 +1,15 @@
 import { execFile } from 'child_process'
 import fs from 'fs'
+import path from 'path'
 
 import type { LaunchCommand } from '../types/sources'
 
-const RESOLVE_DESKTOP2_FRONTEND_ROOT_SCRIPT = `
+const DESKTOP2_FRONTEND_ROOT_DIRS = ['static-desktop2', 'static'] as const
+
+const RESOLVE_DESKTOP2_FRONTEND_PACKAGE_ROOT_SCRIPT = `
 from importlib import resources
 
-print(resources.files("comfyui_frontend_package").joinpath("static-desktop2"))
+print(resources.files("comfyui_frontend_package"))
 `.trim()
 
 export function isLocalComfyPythonLaunch(
@@ -23,11 +26,13 @@ export async function resolveDesktop2FrontendRoot(
   pythonPath: string,
   cwd: string
 ): Promise<string> {
-  const frontendRoot = (
-    await runPython(pythonPath, ['-s', '-c', RESOLVE_DESKTOP2_FRONTEND_ROOT_SCRIPT], cwd)
+  const packageRoot = (
+    await runPython(pythonPath, ['-s', '-c', RESOLVE_DESKTOP2_FRONTEND_PACKAGE_ROOT_SCRIPT], cwd)
   ).trim()
-  if (!fs.existsSync(frontendRoot)) {
-    throw new Error(`Desktop2 frontend assets not found: ${frontendRoot}`)
+  const frontendRoots = DESKTOP2_FRONTEND_ROOT_DIRS.map((dir) => path.join(packageRoot, dir))
+  const frontendRoot = frontendRoots.find((root) => fs.existsSync(root))
+  if (!frontendRoot) {
+    throw new Error(`Desktop2 frontend assets not found: ${frontendRoots.join(' or ')}`)
   }
   return frontendRoot
 }

--- a/src/main/lib/desktopFrontendRoot.ts
+++ b/src/main/lib/desktopFrontendRoot.ts
@@ -1,0 +1,64 @@
+import { execFile } from 'child_process'
+import fs from 'fs'
+
+import type { LaunchCommand } from '../types/sources'
+
+const RESOLVE_DESKTOP2_FRONTEND_ROOT_SCRIPT = `
+from importlib import resources
+
+print(resources.files("comfyui_frontend_package").joinpath("static-desktop2"))
+`.trim()
+
+export function isLocalComfyPythonLaunch(
+  launchCmd: LaunchCommand
+): launchCmd is LaunchCommand & { cmd: string; args: string[]; cwd: string } {
+  if (launchCmd.skipSharedPaths || !launchCmd.cmd || !launchCmd.args || !launchCmd.cwd) {
+    return false
+  }
+  const sIdx = launchCmd.args.indexOf('-s')
+  return sIdx !== -1 && sIdx + 1 < launchCmd.args.length
+}
+
+export async function resolveDesktop2FrontendRoot(
+  pythonPath: string,
+  cwd: string
+): Promise<string> {
+  const frontendRoot = (
+    await runPython(pythonPath, ['-s', '-c', RESOLVE_DESKTOP2_FRONTEND_ROOT_SCRIPT], cwd)
+  ).trim()
+  if (!fs.existsSync(frontendRoot)) {
+    throw new Error(`Desktop2 frontend assets not found: ${frontendRoot}`)
+  }
+  return frontendRoot
+}
+
+export function setDesktop2FrontendRootArg(args: string[], frontendRoot: string): string[] {
+  const nextArgs: string[] = []
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]!
+    if (arg === '--front-end-root') {
+      i++
+    } else if (!arg.startsWith('--front-end-root=')) {
+      nextArgs.push(arg)
+    }
+  }
+  return [...nextArgs, '--front-end-root', frontendRoot]
+}
+
+function runPython(pythonPath: string, args: string[], cwd: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      pythonPath,
+      args,
+      { cwd, windowsHide: true, timeout: 15_000 },
+      (err, stdout, stderr) => {
+        if (err) {
+          const detail = stderr ? `\nstderr: ${stderr.trim()}` : ''
+          reject(new Error(`Failed to resolve Desktop2 frontend root: ${err.message}${detail}`))
+          return
+        }
+        resolve(stdout)
+      }
+    )
+  })
+}

--- a/src/main/lib/ipc/sessionActions/launch.ts
+++ b/src/main/lib/ipc/sessionActions/launch.ts
@@ -37,9 +37,9 @@ import { appendLog } from '../../logsBroadcast'
 import { ensureManagerMirrorConfig } from '../../managerConfig'
 import type { WriteStream } from 'fs'
 import {
+  hasFrontEndRootArg,
   isLocalComfyPythonLaunch,
   resolveDesktop2FrontendRoot,
-  setDesktop2FrontendRootArg,
 } from '../../desktopFrontendRoot'
 
 // Feature flags injected on every spawned ComfyUI, gated by the running
@@ -240,12 +240,17 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
     }
   }
 
-  if (isLocalComfyPythonLaunch(launchCmd)) {
+  // Pin the Desktop-managed frontend assets for local launches, unless the user
+  // supplied their own --front-end-root (respected) or the install doesn't ship
+  // the assets / resolution fails (launch without them rather than blocking).
+  if (isLocalComfyPythonLaunch(launchCmd) && !hasFrontEndRootArg(launchCmd.args)) {
     try {
       const frontendRoot = await resolveDesktop2FrontendRoot(launchCmd.cmd, launchCmd.cwd)
-      launchCmd.args = setDesktop2FrontendRootArg(launchCmd.args, frontendRoot)
+      if (frontendRoot) {
+        launchCmd.args = [...launchCmd.args, '--front-end-root', frontendRoot]
+      }
     } catch (err) {
-      return { ok: false, message: (err as Error).message }
+      console.warn('Failed to resolve Desktop2 frontend root:', err)
     }
   }
 

--- a/src/main/lib/ipc/sessionActions/launch.ts
+++ b/src/main/lib/ipc/sessionActions/launch.ts
@@ -36,6 +36,11 @@ import * as telemetry from '../../telemetry'
 import { appendLog } from '../../logsBroadcast'
 import { ensureManagerMirrorConfig } from '../../managerConfig'
 import type { WriteStream } from 'fs'
+import {
+  isLocalComfyPythonLaunch,
+  resolveDesktop2FrontendRoot,
+  setDesktop2FrontendRootArg,
+} from '../../desktopFrontendRoot'
 
 // Feature flags injected on every spawned ComfyUI, gated by the running
 // install's --list-feature-flags registry so we never inject unrecognized keys.
@@ -232,6 +237,15 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
       } catch {
         // Schema not available — pass args as-is.
       }
+    }
+  }
+
+  if (isLocalComfyPythonLaunch(launchCmd)) {
+    try {
+      const frontendRoot = await resolveDesktop2FrontendRoot(launchCmd.cmd, launchCmd.cwd)
+      launchCmd.args = setDesktop2FrontendRootArg(launchCmd.args, frontendRoot)
+    } catch (err) {
+      return { ok: false, message: (err as Error).message }
     }
   }
 


### PR DESCRIPTION
## Summary
- resolve `comfyui_frontend_package/static-desktop2` from the selected ComfyUI Python environment
- inject Desktop-managed `--front-end-root` for local ComfyUI launches
- replace any user-supplied `--front-end-root` so Desktop owns this launch plumbing

## Tests
- `pnpm exec vitest run src/main/lib/desktopFrontendRoot.test.ts`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test`

Note: repo-wide `pnpm run format` currently fails on an existing malformed `src/renderer/src/components/DetailSection.vue`; this PR was formatted only on touched files.