### PR TITLE
docs: add linux to supported platforms badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![License](https://img.shields.io/github/license/Comfy-Org/Comfy-Desktop?style=flat&color=blue)](LICENSE)
 [![Stars](https://img.shields.io/github/stars/Comfy-Org/Comfy-Desktop?style=flat&logo=github&color=f5c518)](https://github.com/Comfy-Org/Comfy-Desktop/stargazers)
 [![Discord](https://img.shields.io/badge/Discord-comfy.org-5865F2?style=flat&logo=discord&logoColor=white)](https://www.comfy.org/discord)
-![Platforms](https://img.shields.io/badge/platforms-Windows%20·%20macOS-555?style=flat)
+![Platforms](https://img.shields.io/badge/platforms-Windows%20·%20macOS%20·%20Linux-555?style=flat)
 
 [**Download**](#download) · [**Getting Started**](#getting-started) · [**Contributing**](#development) · [**Discord**](https://www.comfy.org/discord)
 


### PR DESCRIPTION
https://github.com/Comfy-Org/Comfy-Desktop/commit/b82c0276b2d9aab0b452ccdcc77c09fc3b85b91d removed Linux from the supported operating system badge. This PR adds it back to remove mixed signals and keeps it removed from the installer badge - where I assume the actual support is dropped