### PR TITLE
refactor(titlebar): tighten reset-zoom gate + drop redundant e2e case

### DIFF
--- a/e2e/dropdowns.test.ts
+++ b/e2e/dropdowns.test.ts
@@ -3,8 +3,8 @@
  * targeted assertions on top of the existing dropdown smoke tests in
  * `chooser.test.ts`:
  *
- * 1. The Reset Zoom item only appears when the comfyView is at a
- *    non-default zoom level (gated branch in `buildTitlePopupMenuItems`).
+ * 1. The Reset Zoom item is absent on the chooser dashboard, even if the
+ *    internal dummy comfyView carries a non-default zoom level.
  * 2. The popup webContents doesn't accumulate listeners across opens
  *    (regression net for `EmbeddedPopupView` lifecycle drift).
  * 3. Showing the title-bar tooltip and then opening the menu hides
@@ -56,16 +56,13 @@ test('Reset Zoom menu item is absent at zoom level 0 @windows @macos @linux', as
   expect(labels.some((l) => /reset zoom/i.test(l))).toBe(false)
 })
 
-test('Reset Zoom menu item appears with the current percent label when zoom is non-zero @windows @macos @linux', async () => {
+test('Reset Zoom menu item is absent on the dashboard even when the dummy comfyView zoom is non-zero @windows @macos @linux', async () => {
   await setComfyViewZoomLevel(ctx.app, 1)
   await openTitleMenu(ctx.titleBar)
   await popup.waitForSelector('[role="menuitem"]', { timeout: 5_000 })
 
   const labels = await popup.allText('[role="menuitem"]')
-  const resetZoom = labels.find((l) => /reset zoom/i.test(l))
-  expect(resetZoom, `expected "Reset Zoom" item among [${labels.join(', ')}]`).toBeTruthy()
-  // Label includes the percent (1.2^1 = 120%, rounded).
-  expect(resetZoom).toMatch(/\(\s*120\s*%\s*\)/)
+  expect(labels.some((l) => /reset zoom/i.test(l))).toBe(false)
 
   // Reset for downstream tests in the serial run.
   await setComfyViewZoomLevel(ctx.app, 0)
@@ -137,12 +134,9 @@ test('opening the title menu hides the title-bar tooltip @windows @macos @linux'
 // Helpers (kept inline; promote to support/ if a third file needs them).
 // ---------------------------------------------------------------------------
 
-/** Set the chooser host's comfyView zoom level. The dummy comfyView
- *  on install-less hosts never loads a URL — and Electron's
- *  `setZoomLevel` is a no-op until a webContents has loaded SOMETHING
- *  — so we load `about:blank` first if the URL is empty. We identify
- *  the comfyView as the BrowserWindow's WebContentsView child whose
- *  URL doesn't match any known popup / panel / title-bar marker. */
+/** Force the chooser host's dummy comfyView zoom level. Users cannot zoom the
+ *  dashboard through app UI; this preserves regression coverage for stale
+ *  internal zoom state without treating it as supported dashboard behavior. */
 async function setComfyViewZoomLevel(app: ElectronApplication, level: number): Promise<void> {
   await app.evaluate(async ({ BrowserWindow, WebContentsView }, lvl) => {
     const KNOWN_HTML_MARKERS = [

--- a/e2e/dropdowns.test.ts
+++ b/e2e/dropdowns.test.ts
@@ -43,17 +43,11 @@ test.beforeEach(async () => {
   await new Promise((r) => setTimeout(r, TITLE_REOPEN_SUPPRESSION_MS))
 })
 
-// ---------------------------------------------------------------------------
-// `Reset Zoom` menu-item gating.
-//
-// The dashboard / chooser host has no install bound to it, so the menu
-// builder's `installationId !== null` gate hides Reset Zoom regardless of
-// the dummy comfyView's zoom level. Asserting against a non-zero zoom is
-// the stronger case — it would catch a future regression where the gate
-// flipped to `zoomLevel > 0` (which would resurface the dashboard zoom
-// path the PR explicitly removed). The zoom=0 case is implied.
-// ---------------------------------------------------------------------------
-
+// Dashboard host has no install bound, so the menu builder's
+// `installationId !== null` gate hides Reset Zoom regardless of the dummy
+// comfyView's zoom level. Asserting against a non-zero zoom is the stronger
+// case — would catch the gate flipping to `zoomLevel > 0` and resurfacing
+// dashboard zoom; the zoom=0 case is implied.
 test('Reset Zoom menu item is absent on the dashboard even when the dummy comfyView zoom is non-zero @windows @macos @linux', async () => {
   await expectNoResetZoomAtLevel(ctx.app, 1)
 })

--- a/e2e/dropdowns.test.ts
+++ b/e2e/dropdowns.test.ts
@@ -48,24 +48,11 @@ test.beforeEach(async () => {
 // ---------------------------------------------------------------------------
 
 test('Reset Zoom menu item is absent at zoom level 0 @windows @macos @linux', async () => {
-  await setComfyViewZoomLevel(ctx.app, 0)
-  await openTitleMenu(ctx.titleBar)
-  await popup.waitForSelector('[role="menuitem"]', { timeout: 5_000 })
-
-  const labels = await popup.allText('[role="menuitem"]')
-  expect(labels.some((l) => /reset zoom/i.test(l))).toBe(false)
+  await expectNoResetZoomAtLevel(ctx.app, 0)
 })
 
 test('Reset Zoom menu item is absent on the dashboard even when the dummy comfyView zoom is non-zero @windows @macos @linux', async () => {
-  await setComfyViewZoomLevel(ctx.app, 1)
-  await openTitleMenu(ctx.titleBar)
-  await popup.waitForSelector('[role="menuitem"]', { timeout: 5_000 })
-
-  const labels = await popup.allText('[role="menuitem"]')
-  expect(labels.some((l) => /reset zoom/i.test(l))).toBe(false)
-
-  // Reset for downstream tests in the serial run.
-  await setComfyViewZoomLevel(ctx.app, 0)
+  await expectNoResetZoomAtLevel(ctx.app, 1)
 })
 
 // ---------------------------------------------------------------------------
@@ -158,6 +145,19 @@ async function setComfyViewZoomLevel(app: ElectronApplication, level: number): P
       }
     }
   }, level)
+}
+
+async function expectNoResetZoomAtLevel(app: ElectronApplication, level: number): Promise<void> {
+  await setComfyViewZoomLevel(app, level)
+  try {
+    await openTitleMenu(ctx.titleBar)
+    await popup.waitForSelector('[role="menuitem"]', { timeout: 5_000 })
+
+    const labels = await popup.allText('[role="menuitem"]')
+    expect(labels.some((l) => /reset zoom/i.test(l))).toBe(false)
+  } finally {
+    await setComfyViewZoomLevel(app, 0)
+  }
 }
 
 async function waitForPopupHidden(app: ElectronApplication): Promise<void> {

--- a/e2e/dropdowns.test.ts
+++ b/e2e/dropdowns.test.ts
@@ -45,11 +45,14 @@ test.beforeEach(async () => {
 
 // ---------------------------------------------------------------------------
 // `Reset Zoom` menu-item gating.
+//
+// The dashboard / chooser host has no install bound to it, so the menu
+// builder's `installationId !== null` gate hides Reset Zoom regardless of
+// the dummy comfyView's zoom level. Asserting against a non-zero zoom is
+// the stronger case — it would catch a future regression where the gate
+// flipped to `zoomLevel > 0` (which would resurface the dashboard zoom
+// path the PR explicitly removed). The zoom=0 case is implied.
 // ---------------------------------------------------------------------------
-
-test('Reset Zoom menu item is absent at zoom level 0 @windows @macos @linux', async () => {
-  await expectNoResetZoomAtLevel(ctx.app, 0)
-})
 
 test('Reset Zoom menu item is absent on the dashboard even when the dummy comfyView zoom is non-zero @windows @macos @linux', async () => {
   await expectNoResetZoomAtLevel(ctx.app, 1)

--- a/src/main/host/attach.ts
+++ b/src/main/host/attach.ts
@@ -22,6 +22,13 @@ import type { ComfyWindowEntry } from './registry'
 
 const APP_VERSION = getAppVersion()
 
+/** Entry point that triggered a zoom reset, tagged as `source` on the
+ *  `comfy.desktop.zoom.reset` telemetry event. `titlebar` (the zoom pill)
+ *  and `menu` (the title menu's "Reset Zoom") flow through the per-install
+ *  `comfyZoomResets` closure; `shortcut` (Ctrl/Cmd + 0) emits directly from
+ *  the key handler. */
+export type ZoomResetSource = 'titlebar' | 'menu' | 'shortcut'
+
 /** Lifecycle-state maps owned by `index.ts` that `attachInstall` and the
  *  related relaunch flow both touch. Late-bound via
  *  `setAttachFactories(...)` so a future move of these maps doesn't
@@ -36,10 +43,12 @@ export interface AttachFactories {
    *  the same reload path as F5/Ctrl+R without lifting the closure. */
   comfyReloads: Map<string, () => void>
   /** Per-install comfyView zoom reset (→ 100%). Registered on attach,
-   *  cleared on detach. Lets the title-bar zoom pill reset the live
-   *  comfyContents and emit the matching `comfy.desktop.zoom.reset` telemetry
-   *  without lifting the closure. */
-  comfyZoomResets: Map<string, () => void>
+   *  cleared on detach. Lets both the title-bar zoom pill and the title
+   *  menu's "Reset Zoom" entry reset the live comfyContents, push the
+   *  `comfy-titlebar:zoom-changed` update so the pill clears, and emit the
+   *  matching `comfy.desktop.zoom.reset` telemetry (`source` tags which
+   *  entry point) without lifting the closure. */
+  comfyZoomResets: Map<string, (source: ZoomResetSource) => void>
   /** Per-install relaunch state. Keys present in this map gate every
    *  attach-side reload path so a relaunch-in-progress install can't
    *  be auto-retried out from under the splash. */
@@ -468,13 +477,7 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
         // Only emit when this was a real reset (skip no-op presses at 1x)
         // so the event count tracks actual recovery actions, not key-spam.
         if (previousLevel !== 0) {
-          mainTelemetry.emit('comfy.desktop.zoom.reset', {
-            source: 'shortcut',
-            parent_entry_id: entry.windowKey,
-            installation_id: entry.installationId,
-            previous_zoom_level: previousLevel,
-            previous_zoom_percent: Math.round(Math.pow(1.2, previousLevel) * 100)
-          })
+          emitZoomReset('shortcut', previousLevel)
         }
         return
       }
@@ -492,6 +495,18 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
   const onZoomChanged = (): void => pushZoom()
   comfyContents.on('zoom-changed', onZoomChanged)
 
+  // One emit site for `comfy.desktop.zoom.reset` so every entry point (zoom
+  // pill, title menu, Ctrl/Cmd + 0) shares the payload shape and a typed `source`.
+  const emitZoomReset = (source: ZoomResetSource, previousLevel: number): void => {
+    mainTelemetry.emit('comfy.desktop.zoom.reset', {
+      source,
+      parent_entry_id: entry.windowKey,
+      installation_id: entry.installationId,
+      previous_zoom_level: previousLevel,
+      previous_zoom_percent: Math.round(Math.pow(1.2, previousLevel) * 100)
+    })
+  }
+
   // Failure retry — backoff on did-fail-load that isn't aborted /
   // mid-relaunch. Per-install timer cancel registered into the
   // shared map so onModelFolderRelaunch can interrupt a pending
@@ -505,19 +520,13 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
   }
   fx.comfyFailRetryTimerCancels.set(installationId, cancelFailRetry)
   fx.comfyReloads.set(installationId, reloadComfy)
-  fx.comfyZoomResets.set(installationId, () => {
+  fx.comfyZoomResets.set(installationId, (source) => {
     if (comfyContents.isDestroyed()) return
     const previousLevel = comfyContents.getZoomLevel()
     if (previousLevel === 0) return
     comfyContents.setZoomLevel(0)
     pushZoom()
-    mainTelemetry.emit('comfy.desktop.zoom.reset', {
-      source: 'titlebar',
-      parent_entry_id: entry.windowKey,
-      installation_id: entry.installationId,
-      previous_zoom_level: previousLevel,
-      previous_zoom_percent: Math.round(Math.pow(1.2, previousLevel) * 100)
-    })
+    emitZoomReset(source, previousLevel)
   })
   const onDidFailLoad = (
     _e: Electron.Event,

--- a/src/main/host/attach.ts
+++ b/src/main/host/attach.ts
@@ -11,6 +11,7 @@ import { refreshCloudUserTier } from '../lib/userTier'
 import { noteCloudEntered } from '../lib/cloudEntry'
 import { forwardDatadogError } from '../lib/processErrorHandlers'
 import { recordInstanceSurface } from '../lib/lastSession'
+import { convertLevelToZoomPercent } from '../lib/zoom'
 import { installationEvents, type InstallationRecord } from '../installations'
 import {
   dropInstallationIndex,
@@ -503,7 +504,7 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
       parent_entry_id: entry.windowKey,
       installation_id: entry.installationId,
       previous_zoom_level: previousLevel,
-      previous_zoom_percent: Math.round(Math.pow(1.2, previousLevel) * 100)
+      previous_zoom_percent: convertLevelToZoomPercent(previousLevel)
     })
   }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -113,7 +113,7 @@ import {
   rebuildComfyViewIfNeeded,
   setHostWindowFactories
 } from './host/createHostWindow'
-import { attachInstall, setAttachFactories } from './host/attach'
+import { attachInstall, setAttachFactories, type ZoomResetSource } from './host/attach'
 import { IN_PLACE_RELAUNCH, REQUIRES_STOPPED } from '../types/ipc'
 import { dispatchSessionAction, handleLaunch } from './lib/ipc/sessionActions'
 import { applyAttachHostPreview, clearAttachHostPreview } from './host/attachHostPreview'
@@ -344,8 +344,9 @@ const comfyFailRetryTimerCancels = new Map<string, () => void>()
  *  `attachInstall`; reached by the title-bar refresh button's IPC handler. */
 const comfyReloads = new Map<string, () => void>()
 /** comfyView zoom reset (→ 100%) per installation. Registered by
- *  `attachInstall`; reached by the title-bar zoom pill's IPC handler. */
-const comfyZoomResets = new Map<string, () => void>()
+ *  `attachInstall`; reached by the title-bar zoom pill's IPC handler and
+ *  the title menu's "Reset Zoom" entry (`source` distinguishes them). */
+const comfyZoomResets = new Map<string, (source: ZoomResetSource) => void>()
 /** Counter for generating unique relaunch tokens. */
 let relaunchTokenCounter = 0
 /** Per-install token guarding the async splash-then-reveal in the `onLaunch`
@@ -857,7 +858,7 @@ ipcMain.on('comfy-window:reset-zoom', (event) => {
   if (entry.window.isDestroyed()) return
   const id = entry.installationId
   if (id === null) return
-  comfyZoomResets.get(id)?.()
+  comfyZoomResets.get(id)?.('titlebar')
   focusActiveBody(entry)
 })
 
@@ -1568,6 +1569,7 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
       confirmAndCloseHostWindow,
       setActivePanel,
       triggerOpenFeedback,
+      resetComfyZoom: (installationId) => comfyZoomResets.get(installationId)?.('menu'),
       sendToPanelDeferred,
       ensurePanelViewForEntry: (entry) =>
         entry.panelView ?? ensurePanelView(entry.windowKey, entry, computeBodyMode(entry)),

--- a/src/main/lib/zoom.ts
+++ b/src/main/lib/zoom.ts
@@ -1,0 +1,3 @@
+export function convertLevelToZoomPercent(level: number): number {
+  return Math.round(Math.pow(1.2, level) * 100)
+}

--- a/src/main/popups/titlePopup.test.ts
+++ b/src/main/popups/titlePopup.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 // shared.ts (via registry.ts) loads electron at import, so mock it first.
 vi.mock('electron', () => ({
@@ -16,7 +16,12 @@ vi.mock('electron', () => ({
   nativeTheme: { on: vi.fn(), shouldUseDarkColors: false },
 }))
 
+// The menu-click handler emits PostHog Node telemetry on every activation;
+// stub it so the dispatch tests stay pure and don't bootstrap the SDK.
+vi.mock('../lib/telemetry', () => ({ emit: vi.fn() }))
+
 import {
+  activateTitlePopupMenuItem,
   buildInstancePickerSnapshot,
   resolvePickerSelectedInstallId,
   buildTitlePopupMenuItems,
@@ -25,8 +30,13 @@ import {
   isFlowMenuItemId,
   type FlowMenuItemId,
   type InstancePickerInstall,
+  type TitlePopupHostBindings,
 } from './titlePopup'
-import { nextWindowKey, type ComfyWindowEntry } from '../host/registry'
+import { comfyWindows, nextWindowKey, type ComfyWindowEntry } from '../host/registry'
+
+afterEach(() => {
+  comfyWindows.clear()
+})
 
 interface FakeComfyWebContents {
   destroyed: boolean
@@ -175,15 +185,9 @@ describe('buildTitlePopupMenuItems', () => {
     expect(ids).not.toContain('return-to-dashboard')
   })
 
-  it('exposes Reset Zoom on chooser host when comfy zoom is non-zero, with the percent in the label', () => {
-    const noZoom = buildTitlePopupMenuItems(makeEntry({ installationId: null, zoomLevel: 0 }))
-    expect(noZoom.find((i) => i.id === 'reset-zoom')).toBeUndefined()
-
-    // 1.2^2 ≈ 1.44 → 144 %
-    const zoomed = buildTitlePopupMenuItems(makeEntry({ installationId: null, zoomLevel: 2 }))
-    const resetZoom = zoomed.find((i) => i.id === 'reset-zoom')
-    expect(resetZoom).toBeDefined()
-    expect(resetZoom?.label).toBe('Reset Zoom (144%)')
+  it('omits Reset Zoom on chooser hosts even if the dummy comfy view has a zoom level', () => {
+    const items = buildTitlePopupMenuItems(makeEntry({ installationId: null, zoomLevel: 2 }))
+    expect(items.find((i) => i.id === 'reset-zoom')).toBeUndefined()
   })
 
   it('exposes Reset Zoom on install host when comfy zoom is non-zero', () => {
@@ -195,9 +199,9 @@ describe('buildTitlePopupMenuItems', () => {
     expect(resetZoom?.label).toBe('Reset Zoom (144%)')
   })
 
-  it('omits Reset Zoom from the chooser host menu when the comfy webContents has been destroyed', () => {
+  it('omits Reset Zoom from the install host menu when the comfy webContents has been destroyed', () => {
     const items = buildTitlePopupMenuItems(
-      makeEntry({ installationId: null, comfyDestroyed: true, zoomLevel: 2 }),
+      makeEntry({ installationId: 'inst-1', comfyDestroyed: true, zoomLevel: 2 }),
     )
     expect(items.find((i) => i.id === 'reset-zoom')).toBeUndefined()
   })
@@ -228,6 +232,40 @@ describe('buildTitlePopupMenuItems', () => {
       )
       expect(locked.map((i) => i.id ?? null)).toEqual(normal.map((i) => i.id ?? null))
     }
+  })
+})
+
+describe('activateTitlePopupMenuItem', () => {
+  // Minimal popup entry: the reset-zoom branch reads `kind` + `parentEntryId`
+  // (the latter resolves the host from `comfyWindows`), and the shared
+  // `hideTitlePopup` tail reads `view`. An inert closed view makes the
+  // dismiss a no-op so the test stays focused on the dispatch.
+  function makePopupEntry(parentEntryId: number) {
+    return {
+      kind: 'menu',
+      parentEntryId,
+      view: { isOpen: false, pendingShowTimer: null, hide: vi.fn() },
+    } as unknown as Parameters<typeof activateTitlePopupMenuItem>[0]
+  }
+
+  it('routes Reset Zoom through resetComfyZoom with the host installation id', () => {
+    const host = makeEntry({ installationId: 'inst-1', zoomLevel: 3 })
+    comfyWindows.set(host.windowKey, host)
+    const bindings = { resetComfyZoom: vi.fn() } as unknown as TitlePopupHostBindings
+
+    activateTitlePopupMenuItem(makePopupEntry(host.windowKey), 'reset-zoom', bindings)
+
+    expect(bindings.resetComfyZoom).toHaveBeenCalledExactlyOnceWith('inst-1')
+  })
+
+  it('defensively ignores Reset Zoom on an install-less host', () => {
+    const host = makeEntry({ installationId: null })
+    comfyWindows.set(host.windowKey, host)
+    const bindings = { resetComfyZoom: vi.fn() } as unknown as TitlePopupHostBindings
+
+    activateTitlePopupMenuItem(makePopupEntry(host.windowKey), 'reset-zoom', bindings)
+
+    expect(bindings.resetComfyZoom).not.toHaveBeenCalled()
   })
 })
 
@@ -461,4 +499,3 @@ describe('buildInstancePickerSnapshot', () => {
     expect(snap.pickerSelectionEpoch).toBe(7)
   })
 })
-

--- a/src/main/popups/titlePopup.ts
+++ b/src/main/popups/titlePopup.ts
@@ -18,6 +18,7 @@ import * as updater from '../lib/updater'
 import * as i18n from '../lib/i18n'
 import * as settings from '../settings'
 import { defaultInstallDir } from '../lib/paths'
+import { convertLevelToZoomPercent } from '../lib/zoom'
 import {
   openPath as openPathHelper,
   getAppVersion,
@@ -760,7 +761,7 @@ export function buildTitlePopupMenuItems(entry: ComfyWindowEntry): TitlePopupMen
   if (entry.installationId !== null && !entry.comfyView.webContents.isDestroyed()) {
     const level = entry.comfyView.webContents.getZoomLevel()
     if (level !== 0) {
-      const percent = Math.round(Math.pow(1.2, level) * 100)
+      const percent = convertLevelToZoomPercent(level)
       items.push({ id: 'reset-zoom', label: `Reset Zoom (${percent}%)` })
     }
   }

--- a/src/main/popups/titlePopup.ts
+++ b/src/main/popups/titlePopup.ts
@@ -1911,8 +1911,11 @@ export function activateTitlePopupMenuItem(
     // `buildTitlePopupMenuItems`). Route through the shared reset so the
     // title-bar pill gets the `comfy-titlebar:zoom-changed` push and clears:
     // that event only fires for mouse-wheel zoom, never the programmatic
-    // `setZoomLevel` reset, so the pill won't update on its own.
-    if (parentEntry?.installationId) {
+    // `setZoomLevel` reset, so the pill won't update on its own. Explicit
+    // null check matches the builder's gate at line 761 so a future
+    // `installationId: ''` from a serialization quirk can't show the menu
+    // and silently swallow the click here.
+    if (parentEntry != null && parentEntry.installationId !== null) {
       bindings.resetComfyZoom(parentEntry.installationId)
     }
   } else if (isFlowMenuItemId(id)) {

--- a/src/main/popups/titlePopup.ts
+++ b/src/main/popups/titlePopup.ts
@@ -1907,14 +1907,10 @@ export function activateTitlePopupMenuItem(
     // two entry points in the telemetry payload.
     bindings.triggerOpenFeedback(entry.parentEntryId, 'menu')
   } else if (id === 'reset-zoom') {
-    // The menu entry exists only when zoom is non-zero (see
-    // `buildTitlePopupMenuItems`). Route through the shared reset so the
-    // title-bar pill gets the `comfy-titlebar:zoom-changed` push and clears:
-    // that event only fires for mouse-wheel zoom, never the programmatic
-    // `setZoomLevel` reset, so the pill won't update on its own. Explicit
-    // null check matches the builder's gate at line 761 so a future
-    // `installationId: ''` from a serialization quirk can't show the menu
-    // and silently swallow the click here.
+    // Route through the shared reset so the title-bar pill picks up the
+    // `comfy-titlebar:zoom-changed` push (that event fires only for
+    // mouse-wheel zoom, never the programmatic `setZoomLevel`). `!== null`
+    // (not truthy) keeps this gate aligned with the builder at line 761.
     if (parentEntry != null && parentEntry.installationId !== null) {
       bindings.resetComfyZoom(parentEntry.installationId)
     }

--- a/src/main/popups/titlePopup.ts
+++ b/src/main/popups/titlePopup.ts
@@ -716,7 +716,7 @@ export function buildTitlePopupMenuItems(entry: ComfyWindowEntry): TitlePopupMen
   //   ── separator ──
   //   Desktop Settings
   //   Send Beta Feedback
-  //   (Reset Zoom — when zoom level != 0)
+  //   (Reset Zoom — on install-backed hosts when zoom level != 0)
   //   ── separator ──
   //   Close Window
   //   Quit Desktop
@@ -755,13 +755,9 @@ export function buildTitlePopupMenuItems(entry: ComfyWindowEntry): TitlePopupMen
     },
     { id: 'feedback', label: 'Send Beta Feedback', labelKey: 'fileMenu.sendFeedback' }
   ]
-  // Reset Zoom — discoverable recovery path for users who zoom the
-  // comfyView too far to read. Contextual: only surfaces when the
-  // current view actually carries a non-zero zoom. Available on
-  // every host (the dashboard's dummy comfyView can be zoomed via
-  // Ctrl/Cmd+scroll, and the instance host's live comfyView even
-  // more so).
-  if (!entry.comfyView.webContents.isDestroyed()) {
+  // Reset Zoom — discoverable recovery path for users who zoom the live
+  // ComfyUI view too far to read. Dashboard hosts do not expose zoom controls.
+  if (entry.installationId !== null && !entry.comfyView.webContents.isDestroyed()) {
     const level = entry.comfyView.webContents.getZoomLevel()
     if (level !== 0) {
       const percent = Math.round(Math.pow(1.2, level) * 100)
@@ -1501,6 +1497,11 @@ export interface TitlePopupHostBindings {
   setActivePanel: (windowKey: number, panel: ComfyPanelKey) => void
   /** Forward a Send Feedback request to the host's panel renderer. */
   triggerOpenFeedback: (entryId: number, source: 'titlebar' | 'menu') => void
+  /** Reset the host install's comfyView zoom to 100%. Routes through the
+   *  same per-install closure (`comfyZoomResets`) the title-bar zoom pill
+   *  uses, so the menu path also pushes `comfy-titlebar:zoom-changed` and
+   *  the pill clears — emitting `comfy.desktop.zoom.reset` with source 'menu'. */
+  resetComfyZoom: (installationId: string) => void
   /** Send an IPC to the host's panel webContents, deferring until
    *  `did-finish-load` if the bundle is still loading. */
   sendToPanelDeferred: (panelView: WebContentsView, channel: string, payload: unknown) => void
@@ -1819,7 +1820,7 @@ export function decideFlowMenuItemTarget(
     : { kind: 'open-chooser-host', panel: id }
 }
 
-function activateTitlePopupMenuItem(
+export function activateTitlePopupMenuItem(
   entry: TitlePopupEntry,
   id: string,
   bindings: TitlePopupHostBindings
@@ -1905,27 +1906,13 @@ function activateTitlePopupMenuItem(
     // two entry points in the telemetry payload.
     bindings.triggerOpenFeedback(entry.parentEntryId, 'menu')
   } else if (id === 'reset-zoom') {
-    // Pair to the Ctrl/Cmd + 0 shortcut wired in `onLaunch`. The menu
-    // entry is only built when zoom is non-zero (see `buildTitlePopupMenuItems`),
-    // so this always corresponds to a visible state change.
-    if (parentEntry && !parentEntry.comfyView.webContents.isDestroyed()) {
-      const previousLevel = parentEntry.comfyView.webContents.getZoomLevel()
-      parentEntry.comfyView.webContents.setZoomLevel(0)
-      // Mirrors the Ctrl/Cmd + 0 shortcut emit in `attachInstall`.
-      // Same event name + payload shape so dashboards can group on the
-      // event and pivot on `source` to compare discoverability paths.
-      // No previousLevel === 0 guard here: the menu item is only built
-      // when zoom is non-zero (see `buildTitlePopupMenuItems`), so any click
-      // is a real reset. The complementary `comfy.desktop.title_menu.item_clicked`
-      // emit at the top of this function still fires for menu-engagement
-      // rollups; this one is the action-specific signal.
-      mainTelemetry.emit('comfy.desktop.zoom.reset', {
-        source: 'menu',
-        parent_entry_id: entry.parentEntryId,
-        installation_id: parentEntry.installationId,
-        previous_zoom_level: previousLevel,
-        previous_zoom_percent: Math.round(Math.pow(1.2, previousLevel) * 100)
-      })
+    // The menu entry exists only when zoom is non-zero (see
+    // `buildTitlePopupMenuItems`). Route through the shared reset so the
+    // title-bar pill gets the `comfy-titlebar:zoom-changed` push and clears:
+    // that event only fires for mouse-wheel zoom, never the programmatic
+    // `setZoomLevel` reset, so the pill won't update on its own.
+    if (parentEntry?.installationId) {
+      bindings.resetComfyZoom(parentEntry.installationId)
     }
   } else if (isFlowMenuItemId(id)) {
     if (parentEntry) {


### PR DESCRIPTION
**Supersedes #1129 (closed unmerged). This PR is standalone and complete — nothing to wait on.**

#1129 was closed in favor of this PR, which carries @Nynxz's title-menu zoom-reset fix (commits + authorship preserved) plus two small follow-ups I flagged while reviewing it. The diff here is the full change — the original fix *and* the follow-ups — not a 2-line delta.

## What's included

**From #1129 (@Nynxz) — the core fix:**
- Route title-menu **Reset Zoom** through the same per-install reset closure used by the titlebar zoom pill, so programmatic `setZoomLevel(0)` no longer leaves the titlebar zoom pill stale.
- Share zoom-reset telemetry payload generation across the titlebar, menu, and keyboard-shortcut reset paths, with a typed `source`.
- Keep **Reset Zoom** out of the dashboard/chooser menu (dashboard zoom isn't a supported user path).
- Extract a shared zoom-level→percent helper used by both telemetry and menu labeling.
- Unit coverage for install-backed Reset Zoom menu visibility + menu reset dispatch.

**Follow-ups (this PR, on top of #1129):**
1. **`src/main/popups/titlePopup.ts`** — align the click-handler's `installationId` gate with the menu builder's gate. The builder uses `!== null` (allowing empty string through); the click handler used truthy (rejecting empty string). Identical today given the `string | null` type, but if an `installationId: ''` ever became producible the menu item would show and the click would silently swallow. Switched to `!== null` so both sites move together.
2. **`e2e/dropdowns.test.ts`** — dropped the redundant zoom-level-0 e2e case. Both cases short-circuited on the dashboard's `installationId !== null` gate before the zoom-level check was reached, so the `level=1` case is doing all the regression work — the `level=0` case is implied. Kept the `level=1` case (the stronger one: catches a future regression where the gate flipped to `zoomLevel > 0` and resurfaced the dashboard zoom path the PR explicitly removed) and clarified its intent in the file-level comment.

## Skipped
The third review note (no integration test for `comfyZoomResets` → `pushZoom` → `'comfy-titlebar:zoom-changed'`) — extracting a testable helper from the closure in `attach.ts` and setting up new attach-process test scaffolding felt too invasive for a quick follow-up. Worth filing as a separate ticket if we want to lock down that the menu / shortcut / titlebar reset paths all share the same emit semantics in tests.

## Tests
- `pnpm vitest run src/main/popups/titlePopup.test.ts` — 46/46 pass
- `pnpm typecheck` — clean across node/web/e2e/integration
- `pnpm exec playwright test e2e/dropdowns.test.ts --project=linux` (from #1129; green)
- `pnpm run lint` / `pnpm run build` (from #1129; green)
