### PR TITLE
fix(launch): show host only in cloud "Connecting…" status

### DIFF
--- a/src/main/lib/cloudUrl.test.ts
+++ b/src/main/lib/cloudUrl.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { withCloudDistributionUtm } from './cloudUrl'
+import { displayLaunchUrl, withCloudDistributionUtm } from './cloudUrl'
 
 // The default deviceIdProvider reads (and may write) a file under the
 // user data dir via `getDeviceId`. Inject a no-op provider so the UTM
@@ -73,5 +73,23 @@ describe('withCloudDistributionUtm', () => {
     )
 
     expect(url.searchParams.get('desktop_device_id')).toBe('caller-explicit')
+  })
+})
+
+describe('displayLaunchUrl', () => {
+  it('strips UTM + desktop_device_id and the path down to the host', () => {
+    expect(
+      displayLaunchUrl(
+        'https://cloud.comfy.org/workflows/123?utm_source=comfy.desktop&desktop_device_id=abc'
+      )
+    ).toBe('cloud.comfy.org')
+  })
+
+  it('keeps a non-default port', () => {
+    expect(displayLaunchUrl('http://127.0.0.1:8188/?foo=bar')).toBe('127.0.0.1:8188')
+  })
+
+  it('returns the input unchanged when it is not a URL', () => {
+    expect(displayLaunchUrl('not a url')).toBe('not a url')
   })
 })

--- a/src/main/lib/cloudUrl.ts
+++ b/src/main/lib/cloudUrl.ts
@@ -60,3 +60,16 @@ export function withCloudDistributionUtm(
 
   return url.href
 }
+
+/** Human-readable form of a launch URL: just the host (e.g. "cloud.comfy.org").
+ *  Used for "Connecting to …" status text so the UTM + desktop_device_id params
+ *  appended by `withCloudDistributionUtm` — and the rest of the path/query — don't
+ *  leak into the UI. Host is parsed from the URL, never hardcoded, so it works for
+ *  any remote/cloud target. `url.host` keeps a non-default port if present. */
+export function displayLaunchUrl(rawUrl: string): string {
+  try {
+    return new URL(rawUrl).host
+  } catch {
+    return rawUrl
+  }
+}

--- a/src/main/lib/ipc/sessionActions/launch.ts
+++ b/src/main/lib/ipc/sessionActions/launch.ts
@@ -21,6 +21,7 @@ import {
   _broadcastToRenderer,
 } from '../shared'
 import type { ChildProcess, LaunchCmd } from '../shared'
+import { displayLaunchUrl } from '../../cloudUrl'
 import type { ModelPathsOptions } from '../../models'
 import type { ActionContext, ActionResult } from './types'
 import { lastNLines, stripAnsi } from '../../stderrTail'
@@ -343,20 +344,24 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
 
   // Remote connection
   if (launchCmd.remote) {
-    sendProgress('launch', { percent: -1, status: i18n.t('launch.connecting', { url: launchCmd.url || '' }) })
+    // Display the host only — the full `launchCmd.url` carries UTM + a long
+    // desktop_device_id (see `withCloudDistributionUtm`) that mustn't leak
+    // into the user-facing status. `waitForUrl` below still gets the real URL.
+    const displayUrl = displayLaunchUrl(launchCmd.url || '')
+    sendProgress('launch', { percent: -1, status: i18n.t('launch.connecting', { url: displayUrl }) })
     try {
       await waitForUrl(launchCmd.url!, {
         timeoutMs: 15000,
         signal: abort.signal,
         onPoll: ({ elapsedMs }) => {
           const secs = Math.round(elapsedMs / 1000)
-          sendProgress('launch', { percent: -1, status: i18n.t('launch.connectingTime', { url: launchCmd.url || '', secs }) })
+          sendProgress('launch', { percent: -1, status: i18n.t('launch.connectingTime', { url: displayUrl, secs }) })
         },
       })
     } catch (_err) {
       _operationAborts.delete(installationId)
       if (abort.signal.aborted) return { ok: false, cancelled: true }
-      return { ok: false, message: i18n.t('errors.cannotConnect', { url: launchCmd.url || '' }) }
+      return { ok: false, message: i18n.t('errors.cannotConnect', { url: displayUrl }) }
     }
 
     _operationAborts.delete(installationId)


### PR DESCRIPTION
## Summary

Fixes a regression where the cloud **Connecting…** loader briefly flashed the full launch URL — including the `utm_source`/`utm_medium`/64-char `desktop_device_id` query params that `withCloudDistributionUtm` appends. The status now shows only the host (e.g. `Connecting to cloud.comfy.org…`) while the real, fully-tagged URL is still what we connect to.

## Changes

**What**
- `cloudUrl.ts` — add `displayLaunchUrl(rawUrl)`: returns `new URL(rawUrl).host`, falling back to the raw string on a parse failure. Host is parsed from the URL, never hardcoded, so it works for any remote/cloud target; `url.host` keeps a non-default port (e.g. `127.0.0.1:8188`). Co-located with `withCloudDistributionUtm` so the "tag for the wire / strip for the UI" pair lives in one file.
- `launch.ts` — in the `launchCmd.remote` branch, compute `displayUrl` once and feed it to the `launch.connecting`, `launch.connectingTime`, and `errors.cannotConnect` strings. `waitForUrl`, `_addSession`, `_onLaunch`, and the returned `url` all still use the full `launchCmd.url`.

**Breaking**
- None. No IPC channels, locale keys, or telemetry change — `launch.connecting` / `launch.connectingTime` / `errors.cannotConnect` keep their `{url}` placeholder; only the value passed in changed. The URL actually connected to is untouched.

## Review Focus

- The crux: this is a display-only fix. Confirm the full tagged URL still flows to `waitForUrl(launchCmd.url!, …)` and the session record — only the user-facing status text is stripped to the host.
- The leak originates in `withCloudDistributionUtm` (UTM + `desktop_device_id`); before that tagging shipped the URL was short, so the status read fine. Scope is the connecting/error status text only.

## Testing

Unit-only by design — the change has no new behavior beyond string formatting, and the existing launch flow is otherwise untouched.
- `cloudUrl.test.ts` — three new `displayLaunchUrl` cases: strips UTM + `desktop_device_id` + path down to the host, keeps a non-default port, returns non-URL input unchanged.
- `pnpm typecheck` (node/web/e2e/integration) and `pnpm lint` clean; `vitest run src/main/lib/cloudUrl.test.ts` → 10/10 pass.
- Manual: click the Cloud card, confirm the loader reads `Connecting to cloud.comfy.org… (Ns)` with no path / `utm_*` / `desktop_device_id` visible, and that the connection still completes.

Screen Recording

https://github.com/user-attachments/assets/166c28ef-b87f-4c60-bb1d-2f292bcd96af

closes #1133 