### PR TITLE
ci: add team-gated Cursor review (thin caller for github-workflows)

### DIFF
--- a/.github/workflows/ci-cursor-review.yml
+++ b/.github/workflows/ci-cursor-review.yml
@@ -1,0 +1,42 @@
+name: CI - Cursor Review
+
+# Thin caller for the shared reusable cursor-review workflow in
+# Comfy-Org/github-workflows. The review logic (panel matrix, judge
+# consolidation, prompts, extract/post/notify scripts) lives there as the
+# single source of truth, so this repo only carries the repo-specific diff
+# excludes.
+
+on:
+  pull_request:
+    types: [labeled, unlabeled]
+
+concurrency:
+  group: cursor-review-pr-${{ github.event.pull_request.number }}-${{ github.event.label.name }}
+  cancel-in-progress: true
+
+jobs:
+  cursor-review:
+    permissions:
+      contents: read
+      pull-requests: write
+    # SHA-pinned per zizmor `unpinned-uses: hash-pin`. Bump this SHA to pick up
+    # upstream changes; keep `workflows_ref` matching so prompts/scripts load
+    # from the same commit as the workflow definition.
+    uses: Comfy-Org/github-workflows/.github/workflows/cursor-review.yml@047ca48febe3a6647608ed2e0c4331b491cb9d6a # github-workflows#9
+    with:
+      workflows_ref: 047ca48febe3a6647608ed2e0c4331b491cb9d6a
+      diff_excludes: >-
+        :!**/pnpm-lock.yaml
+        :!**/package-lock.json
+        :!**/yarn.lock
+        :!**/node_modules/**
+        :!**/.claude/**
+        :!**/dist/**
+        :!**/vendor/**
+        :!**/*.generated.*
+        :!**/*.min.js
+        :!**/*.min.css
+        :!**/*-snapshots/**
+    secrets:
+      CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
## Summary

Adds label-triggered multi-model Cursor review as a thin caller for the reusable workflow in \`Comfy-Org/github-workflows\` — single source of truth for the panel, judge, prompts, and scripts. This repo carries only the ~50-line caller + repo-specific diff excludes.

## Prerequisites

- [ ] Add \`CURSOR_API_KEY\` secret to this repo (or ensure the org secret covers it)
- [ ] \`SLACK_BOT_TOKEN\` optional — enables start/complete Slack DMs to the PR author

## Usage

Apply the \`cursor-review\` label to any PR to trigger the panel.