### PR TITLE
feat: signal enable_telemetry to ComfyUI on opted-in standalone installs

### DIFF
--- a/src/main/lib/ipc/sessionActions/launch.test.ts
+++ b/src/main/lib/ipc/sessionActions/launch.test.ts
@@ -16,7 +16,35 @@ vi.mock('electron', () => ({
   nativeTheme: { on: vi.fn(), shouldUseDarkColors: false },
 }))
 
-import { isCrashedExit } from './launch'
+import { desktopFeatureFlags, isCrashedExit } from './launch'
+import type { InstallationRecord } from '../shared'
+
+const installOf = (sourceId: string) => ({ sourceId }) as InstallationRecord
+
+describe('desktopFeatureFlags', () => {
+  it('always injects the unconditional desktop flags', () => {
+    const flags = desktopFeatureFlags(installOf('standalone'), false)
+    expect(flags.show_signin_button).toBe('true')
+    expect(flags.supports_terminal).toBe('true')
+  })
+
+  it('injects enable_telemetry only for standalone installs that opted in', () => {
+    expect(desktopFeatureFlags(installOf('standalone'), true).enable_telemetry).toBe('true')
+  })
+
+  it('omits enable_telemetry when telemetry is disabled (default off)', () => {
+    expect(desktopFeatureFlags(installOf('standalone'), false)).not.toHaveProperty(
+      'enable_telemetry'
+    )
+  })
+
+  it('omits enable_telemetry for non-standalone installs even when opted in', () => {
+    expect(desktopFeatureFlags(installOf('portable'), true)).not.toHaveProperty(
+      'enable_telemetry'
+    )
+    expect(desktopFeatureFlags(installOf('git'), true)).not.toHaveProperty('enable_telemetry')
+  })
+})
 
 describe('isCrashedExit', () => {
   it('treats a clean exit (code 0, no signal) as not crashed', () => {

--- a/src/main/lib/ipc/sessionActions/launch.ts
+++ b/src/main/lib/ipc/sessionActions/launch.ts
@@ -20,7 +20,7 @@ import {
   getComfyFeatureFlagRegistry,
   _broadcastToRenderer,
 } from '../shared'
-import type { ChildProcess, LaunchCmd } from '../shared'
+import type { ChildProcess, InstallationRecord, LaunchCmd } from '../shared'
 import { displayLaunchUrl } from '../../cloudUrl'
 import type { ModelPathsOptions } from '../../models'
 import type { ActionContext, ActionResult } from './types'
@@ -45,14 +45,25 @@ import { appendLog } from '../../logsBroadcast'
 import { ensureManagerMirrorConfig } from '../../managerConfig'
 import type { WriteStream } from 'fs'
 
-// Feature flags injected on every spawned ComfyUI, gated by the running
-// install's --list-feature-flags registry so we never inject unrecognized keys.
-const DESKTOP_FEATURE_FLAGS: Record<string, string> = {
-  show_signin_button: 'true',
-  // Advertises that an interactive terminal host is available, so the frontend
-  // may surface its bottom-panel terminal. The actual transport is the
-  // __comfyDesktop2.Terminal bridge; the flag only gates visibility.
-  supports_terminal: 'true',
+// Feature flags injected on a spawned ComfyUI, gated by the running install's
+// --list-feature-flags registry so we never inject unrecognized keys.
+export function desktopFeatureFlags(
+  inst: InstallationRecord,
+  telemetryEnabled: boolean
+): Record<string, string> {
+  const flags: Record<string, string> = {
+    show_signin_button: 'true',
+    // Advertises that an interactive terminal host is available, so the frontend
+    // may surface its bottom-panel terminal. The actual transport is the
+    // __comfyDesktop2.Terminal bridge; the flag only gates visibility.
+    supports_terminal: 'true',
+  }
+  // Telemetry is opt-in (default off) and only signaled for managed standalone
+  // installs — never for portable or user-managed git clones.
+  if (inst.sourceId === 'standalone' && telemetryEnabled) {
+    flags.enable_telemetry = 'true'
+  }
+  return flags
 }
 
 // A clean exit is code 0 with no signal; anything else (non-zero code or a
@@ -240,7 +251,10 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
         const desktopFlagArgs: string[] = []
         if (schema.knownFlags.has('feature-flag') && schema.knownFlags.has('list-feature-flags')) {
           const registry = await getComfyFeatureFlagRegistry(launchCmd.cmd, mainPyAbs, launchCmd.cwd, installationId, version)
-          for (const [key, value] of Object.entries(DESKTOP_FEATURE_FLAGS)) {
+          const flagEntries = Object.entries(
+            desktopFeatureFlags(inst, settings.get('telemetryEnabled') === true)
+          )
+          for (const [key, value] of flagEntries) {
             if (key in registry) {
               desktopFlagArgs.push('--feature-flag', `${key}=${value}`)
             }


### PR DESCRIPTION
Passes `--feature-flag enable_telemetry=true` to the spawned ComfyUI **only when** the install is `standalone` **and** the user opted into telemetry (`telemetryEnabled === true`). Nothing is passed otherwise (default off), and portable / git-manual installs never receive it. Injection stays gated by the running ComfyUI's `--list-feature-flags` registry, so older versions that don't know the flag won't get it.

`desktopFeatureFlags` is now a pure `(inst, telemetryEnabled)` helper with colocated unit tests covering each gating case.

Requires the matching ComfyUI registry entry (Comfy-Org/ComfyUI).

- Fixes #1142