### PR TITLE
fix(telemetry): address CodeRabbit review from #1132

### DIFF
--- a/src/main/lib/canvasEntry.ts
+++ b/src/main/lib/canvasEntry.ts
@@ -31,7 +31,9 @@ export function noteCanvasRendered(
     _renderedThisLaunch.add(installationId)
   }
   const startedAt = getSessionStartedAt(installationId)
-  const serverReadyToCanvasMs = startedAt !== null ? Date.now() - startedAt : null
+  // Clamp: Date.now() can move backward (clock skew), which would emit a
+  // negative, funnel-polluting duration.
+  const serverReadyToCanvasMs = startedAt !== null ? Math.max(0, Date.now() - startedAt) : null
   telemetry.emit('comfy.desktop.comfyui.canvas_rendered', {
     installation_id: installationId,
     server_ready_to_canvas_ms: serverReadyToCanvasMs,

--- a/src/main/lib/installer.ts
+++ b/src/main/lib/installer.ts
@@ -48,14 +48,26 @@ async function withInstallPhase<T>(
   phase: InstallPhaseName,
   fn: () => Promise<T>
 ): Promise<T> {
-  onPhase?.(phase, 'start')
+  // The phase tap is a pure side-channel; a throwing `onPhase` must never abort
+  // or mask the install, so every invocation is isolated.
+  const safeOnPhase = (
+    status: InstallPhaseStatus,
+    info?: { durationMs?: number; error?: unknown }
+  ): void => {
+    try {
+      onPhase?.(phase, status, info)
+    } catch {
+      // swallow: telemetry failures don't affect install control flow
+    }
+  }
+  safeOnPhase('start')
   const t0 = Date.now()
   try {
     const result = await fn()
-    onPhase?.(phase, 'end', { durationMs: Date.now() - t0 })
+    safeOnPhase('end', { durationMs: Date.now() - t0 })
     return result
   } catch (err) {
-    onPhase?.(phase, 'error', { durationMs: Date.now() - t0, error: err })
+    safeOnPhase('error', { durationMs: Date.now() - t0, error: err })
     throw err
   }
 }

--- a/src/main/sources/standalone/install.ts
+++ b/src/main/sources/standalone/install.ts
@@ -45,19 +45,25 @@ function emitInstallPhase(
   status: InstallPhaseStatus,
   info: { durationMs?: number; error?: unknown } = {}
 ): void {
-  const props: Record<string, string | number | null> = {
-    installation_id: installation.id,
-    variant: (installation.variant as string | undefined) ?? null,
-    phase,
-    status
+  // Side-channel only: classification/emission must never derail an install
+  // phase (this is also the installer's onPhase tap).
+  try {
+    const props: Record<string, string | number | null> = {
+      installation_id: installation.id,
+      variant: (installation.variant as string | undefined) ?? null,
+      phase,
+      status
+    }
+    if (typeof info.durationMs === 'number') props.duration_ms = info.durationMs
+    if (status === 'error') {
+      props.error_bucket = mainTelemetry.bucketError(
+        info.error instanceof Error ? info.error.message : String(info.error ?? '')
+      )
+    }
+    mainTelemetry.emit('comfy.desktop.install.phase', props)
+  } catch (err) {
+    console.warn('Install phase telemetry emission failed:', err)
   }
-  if (typeof info.durationMs === 'number') props.duration_ms = info.durationMs
-  if (status === 'error') {
-    props.error_bucket = mainTelemetry.bucketError(
-      info.error instanceof Error ? info.error.message : String(info.error ?? '')
-    )
-  }
-  mainTelemetry.emit('comfy.desktop.install.phase', props)
 }
 
 /** Wrap a post-install phase with start/end/error boundaries. Re-throws so the

--- a/src/renderer/src/composables/useCloudCapacity.test.ts
+++ b/src/renderer/src/composables/useCloudCapacity.test.ts
@@ -41,7 +41,7 @@ async function loadComposable(opts: {
   status: CloudCapacityStatus
   tier: CloudUserTier
 }): Promise<{
-  composable: Awaited<ReturnType<typeof importComposable>>
+  composable: ReturnType<Awaited<ReturnType<typeof importComposable>>>
   scope: ReturnType<typeof effectScope>
   api: MockApi
 }> {


### PR DESCRIPTION
## Description

Follow-ups to the install → boot → canvas instrumentation merged in #1132. CodeRabbit posted four actionable comments after that PR was squash-merged, so they land here. All are side-channel hardening — **no change to the funnel events themselves**.

1. **`canvasEntry.ts` — clamp `server_ready_to_canvas_ms` to `>= 0`.** `Date.now()` can move backward (clock skew), which would emit a negative, funnel-polluting duration. `Math.max(0, …)`.
2. **`installer.withInstallPhase` — isolate the `onPhase` tap.** The phase tap is documented side-channel-only, but a throwing `onPhase` could abort or mask an install. Each invocation is now wrapped in try/catch (`safeOnPhase`).
3. **`install.emitInstallPhase` — guard classification/emission.** Telemetry bucketing/emit is wrapped so a failure can't derail a post-install phase (this function is also the installer's `onPhase` tap, so this guards both paths).
4. **`useCloudCapacity.test.ts` — fix the `loadComposable` return type.** `Awaited<ReturnType<typeof importComposable>>` resolved to the composable *function*; the value assigned is its *call result*. Now `ReturnType<Awaited<ReturnType<typeof importComposable>>>`, matching the inner `composable` declaration.

## How has this been tested?

- `typecheck:node` + `typecheck:web` — clean.
- `vitest run` on `canvasEntry.test.ts`, `bootPhaseBuffer.test.ts`, `useCloudCapacity.test.ts` — 33 passing.

## Related

Follow-up to #1132 (merged). Resolves the four CodeRabbit threads on that PR.