### PR TITLE
feat(telemetry): installation_id super-property + install.completed (unify the desktop funnel)

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+../../node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-../../node_modules

--- a/src/main/lib/desktopAdopt.test.ts
+++ b/src/main/lib/desktopAdopt.test.ts
@@ -128,6 +128,7 @@ vi.mock('../installations', () => {
 
 vi.mock('./telemetry', () => ({
   capture: vi.fn(),
+  captureInstallCompleted: vi.fn(),
   bucketError: vi.fn(() => 'other'),
   trackedStep: vi.fn(async (_step: string, _ctx: unknown, fn: () => Promise<unknown>) => fn())
 }))
@@ -896,6 +897,13 @@ describe('adoptDesktopInstall', () => {
           carried_keys: expect.arrayContaining(['telemetryEnabled', 'firstUseCompleted'])
         })
       )
+      // Once-per-install funnel event fired exactly once with method 'adopt'.
+      expect(telemetry.captureInstallCompleted).toHaveBeenCalledTimes(1)
+      expect(telemetry.captureInstallCompleted).toHaveBeenCalledWith({
+        installationId: record.id,
+        method: 'adopt',
+        express: false
+      })
       // Telemetry consent carried from legacy SendStatistics
       expect(settingsMock.__store['telemetryEnabled']).toBe(false)
       // First-use takeover skipped for adopted users.
@@ -1367,6 +1375,10 @@ describe('adoptDesktopInstall', () => {
       const reconcileCall = installFilteredRequirementsMock.mock.calls[0]!
       expect(reconcileCall[0]).toBe(path.join(first.installPath, 'ComfyUI', 'requirements.txt'))
       expect(reconcileCall[1]).toBe(uvPath)
+      // install.completed fires once for the first adoption only — the
+      // idempotent re-run returns the existing record before runAdoption,
+      // so it must NOT re-fire the once-per-install funnel event.
+      expect(telemetry.captureInstallCompleted).toHaveBeenCalledTimes(1)
     } finally {
       legacy.cleanup()
     }

--- a/src/main/lib/desktopAdopt.ts
+++ b/src/main/lib/desktopAdopt.ts
@@ -1345,6 +1345,17 @@ async function runAdoption(
     selected_device: selectedDevice
   })
 
+  // Fire the once-per-install funnel event for the in-place Desktop-1 adoption
+  // path. Only reached on a fresh adoption — the idempotent re-run in
+  // `adoptDesktopInstall` returns the existing record before `runAdoption`, so
+  // this never re-fires for an already-adopted install. Best-effort:
+  // `capture()` swallows its own errors and never aborts adoption.
+  telemetry.captureInstallCompleted({
+    installationId: record.id,
+    method: 'adopt',
+    express: false
+  })
+
   sendProgress('done', { percent: 100 })
   return record
 }

--- a/src/main/lib/ipc/registerInstallationHandlers.ts
+++ b/src/main/lib/ipc/registerInstallationHandlers.ts
@@ -215,7 +215,7 @@ export function registerInstallationHandlers(): void {
     return { ok: true, entry }
   })
 
-  ipcMain.handle('install-instance', async (_event, installationId: string) => {
+  ipcMain.handle('install-instance', async (_event, installationId: string, express?: boolean) => {
     const inst = await installations.get(installationId)
     if (!inst) return { ok: false, message: 'Installation not found.' }
     const source = sourceMap[inst.sourceId]
@@ -396,6 +396,20 @@ export function registerInstallationHandlers(): void {
           from_version: formatComfyVersion(priorComfyVersion, 'short'),
           to_version: newComfyVersion ? formatComfyVersion(newComfyVersion, 'short') : null,
           result: 'success'
+        })
+      } else {
+        // Fresh standalone install finished (NOT a version update — an install
+        // on a record that already had a comfyVersion is a re-install/update,
+        // handled above). Fire the once-per-install funnel event at the moment
+        // the install is ready to boot. Distinct from comfyui.boot_started,
+        // which fires on every launch. `express` labels the one-click path;
+        // the manual Configure-wizard path passes no flag → 'manual'.
+        // Best-effort: capture() swallows its own errors, so this can never
+        // abort the install.
+        mainTelemetry.captureInstallCompleted({
+          installationId,
+          method: express ? 'express' : 'manual',
+          express: !!express
         })
       }
       return { ok: true }

--- a/src/main/lib/standaloneMigration.ts
+++ b/src/main/lib/standaloneMigration.ts
@@ -395,5 +395,17 @@ export async function migrateToStandaloneFromSnapshot(
 
   await installations.update(entry.id, { status: 'installed' })
 
+  // Fire the once-per-install funnel event for the snapshot-based migrate-to-
+  // standalone path (portable/git → standalone, and Desktop-1 snapshot
+  // migrations). Fired once here at completion, the moment the new install is
+  // ready to boot. This flow does NOT go through the `install-instance` IPC
+  // handler, so there is no double-fire with the express/manual path. Best-
+  // effort: `capture()` swallows its own errors and never aborts the migration.
+  telemetry.captureInstallCompleted({
+    installationId: entry.id,
+    method: 'migrate',
+    express: false
+  })
+
   return { entry, destPath }
 }

--- a/src/main/lib/telemetry.test.ts
+++ b/src/main/lib/telemetry.test.ts
@@ -290,6 +290,67 @@ describe('telemetry default event properties', () => {
   })
 })
 
+describe('telemetry.captureInstallCompleted', () => {
+  beforeEach(() => {
+    captured.length = 0
+    process.env['POSTHOG_API_KEY'] = 'test-key'
+    process.env['POSTHOG_ENABLED'] = '1'
+    telemetry._resetForTest()
+    telemetry.initTelemetry({ appVersion: '1.0.0', appEnv: 'prod', isPackaged: true })
+    telemetry.identify('install-xyz')
+    telemetry.setConsentState('granted')
+    captured.length = 0
+  })
+
+  afterEach(() => {
+    delete process.env['POSTHOG_API_KEY']
+    delete process.env['POSTHOG_ENABLED']
+    telemetry._resetForTest()
+  })
+
+  it('fires comfy.desktop.install.completed exactly once with method + express + installation_id', () => {
+    telemetry.captureInstallCompleted({
+      installationId: 'install-xyz',
+      method: 'express',
+      express: true
+    })
+
+    expect(captured).toHaveLength(1)
+    expect(captured[0]!.event).toBe('comfy.desktop.install.completed')
+    expect(captured[0]!.properties).toMatchObject({
+      installation_id: 'install-xyz',
+      method: 'express',
+      express: true
+    })
+  })
+
+  it.each([
+    ['express', true],
+    ['manual', false],
+    ['adopt', false],
+    ['migrate', false]
+  ] as const)('carries method=%s / express=%s for each install path', (method, express) => {
+    telemetry.captureInstallCompleted({ installationId: 'i1', method, express })
+    expect(captured).toHaveLength(1)
+    expect(captured[0]!.properties).toMatchObject({ method, express })
+  })
+
+  it('does NOT fire on boot — boot_started is a distinct, separately-emitted event', () => {
+    // A boot is the per-launch event; install.completed is once-per-install.
+    // Emitting boot_started must never produce an install.completed.
+    telemetry.capture('comfy.desktop.comfyui.boot_started', { installation_id: 'install-xyz' })
+    expect(captured.map((c) => c.event)).toEqual(['comfy.desktop.comfyui.boot_started'])
+    expect(captured.some((c) => c.event === 'comfy.desktop.install.completed')).toBe(false)
+  })
+
+  it('is consent-gated: no install.completed when consent is not granted', () => {
+    telemetry.setConsentState('denied')
+    captured.length = 0
+    telemetry.captureInstallCompleted({ installationId: 'i1', method: 'manual', express: false })
+    expect(captured).toHaveLength(0)
+  })
+})
+
 describe('telemetry.trackedStep', () => {
   beforeEach(async () => {
     captured.length = 0

--- a/src/main/lib/telemetry.test.ts
+++ b/src/main/lib/telemetry.test.ts
@@ -261,6 +261,33 @@ describe('telemetry default event properties', () => {
     telemetry.capture('any.event', { app_version: 'override-value' })
     expect(captured[0]!.properties).toMatchObject({ app_version: 'override-value' })
   })
+
+  it('stamps installation_id (the bound device id) on every captured event', () => {
+    telemetry.initTelemetry({ appVersion: '1.0.0', appEnv: 'prod', isPackaged: true })
+    telemetry.identify('install-abc123')
+    telemetry.setConsentState('granted')
+    captured.length = 0
+
+    // A main-process event and a renderer-routed event both go through
+    // capture(), so both must carry installation_id from the defaults.
+    telemetry.capture('comfy.desktop.execution.completed', { foo: 'bar' })
+    telemetry.capture('comfy.desktop.template.fork', { template_id: 't1' })
+
+    expect(captured).toHaveLength(2)
+    expect(captured[0]!.properties).toMatchObject({ installation_id: 'install-abc123' })
+    expect(captured[1]!.properties).toMatchObject({ installation_id: 'install-abc123' })
+  })
+
+  it('does not pass installation_id to identify() (anon-id invariant holds)', () => {
+    identifies.length = 0
+    telemetry.initTelemetry({ appVersion: '1.0.0', appEnv: 'prod', isPackaged: true })
+    telemetry.identify('install-abc123')
+    telemetry.setConsentState('granted')
+
+    // identify() stamps installation_id as an event default but must NEVER
+    // call client.identify() with it — only login (bindUserId) identifies.
+    expect(identifies).toHaveLength(0)
+  })
 })
 
 describe('telemetry.trackedStep', () => {

--- a/src/main/lib/telemetry.ts
+++ b/src/main/lib/telemetry.ts
@@ -844,6 +844,40 @@ export function registerPersonPropertiesOnce(properties: Record<string, Telemetr
   capturePersonProperties(null, properties)
 }
 
+/**
+ * How a local install was created. `express` and `manual` are the two fresh-
+ * install wizard paths; `adopt` is an in-place Desktop-1 adoption; `migrate`
+ * is a snapshot-based standalone migration. Kept as a closed union so the
+ * funnel breakdown has a fixed set of buckets.
+ */
+export type InstallMethod = 'express' | 'manual' | 'adopt' | 'migrate'
+
+/**
+ * Emit the once-per-install `comfy.desktop.install.completed` event.
+ *
+ * Fired when a local install FINISHES (before/at first boot). Distinct from
+ * `comfy.desktop.comfyui.boot_started`, which fires on EVERY launch and so
+ * can't isolate the first install→boot transition. Centralised here (rather
+ * than inlined at each completion site: express/manual, adopt, migrate) so
+ * the event's property shape can't drift between the three call sites.
+ *
+ * `installation_id` is already an event-level default once `identify()` ran
+ * at boot; it's passed explicitly here too so the event is self-describing
+ * even in queries that don't rely on the default (and so the value is the
+ * specific install that completed, not just the device).
+ */
+export function captureInstallCompleted(opts: {
+  installationId: string
+  method: InstallMethod
+  express: boolean
+}): void {
+  capture('comfy.desktop.install.completed', {
+    installation_id: opts.installationId,
+    method: opts.method,
+    express: opts.express
+  })
+}
+
 export function captureException(error: unknown, properties: TelemetryContext = {}): void {
   if (!canEmit() || !distinctId) return
   // Exceptions are reliability data; suppress them outside `'granted'`.

--- a/src/main/lib/telemetry.ts
+++ b/src/main/lib/telemetry.ts
@@ -208,13 +208,16 @@ function canEmit(): boolean {
 }
 
 /**
- * Default properties merged into every `capture()` payload. Set once at
- * `initTelemetry()` time from `InitOptions`. Holds `app_version`,
+ * Default properties merged into every `capture()` payload. Seeded at
+ * `initTelemetry()` time from `InitOptions` with `app_version`,
  * `app_channel`, `app_env`, `platform`, `arch`, and `is_packaged` so
  * per-event filters / breakdowns work without a join against the person
  * profile (PostHog person properties are joined at query time and are
  * point-in-time as of write — releasing a new app version while the user
  * still has events from the old one would mis-attribute without this).
+ * `installation_id` is added by `identify()` once the device id is known
+ * at boot, so renderer events (routed in over IPC) and main events share a
+ * single join key instead of splitting across person_id / installation_id.
  *
  * Per-call properties take precedence on key collision.
  */
@@ -629,6 +632,14 @@ export function deferMigrationAlias(opts: {
 export function identify(id: string, properties: Record<string, TelemetryValue> = {}): void {
   distinctId = id
   installationDeviceId = id
+  // Stamp the anonymous device id as an event-level default so EVERY event
+  // (main-process captures AND renderer events routed in over IPC: template.*,
+  // first_use.*, fork) carries `installation_id`. This lets renderer and main
+  // events join natively on a single key instead of splitting across
+  // person_id / installation_id, which breaks the install→boot→run funnel.
+  // This is purely an event property — it does NOT identify the id (the
+  // anon-id invariant above is preserved; only `bindUserId` calls identify).
+  defaultEventProperties = { ...defaultEventProperties, installation_id: id }
   if (Object.keys(properties).length > 0) {
     pendingPersonSet = { ...(pendingPersonSet || {}), ...properties }
   }

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -55,7 +55,8 @@ export function buildElectronApi(): ElectronApi {
     reorderInstallations: (orderedIds) => ipcRenderer.invoke('reorder-installations', orderedIds),
     probeInstallation: (dirPath) => ipcRenderer.invoke('probe-installation', dirPath),
     trackInstallation: (data) => ipcRenderer.invoke('track-installation', data),
-    installInstance: (installationId) => ipcRenderer.invoke('install-instance', installationId),
+    installInstance: (installationId, express) =>
+      ipcRenderer.invoke('install-instance', installationId, express),
     skipTemplateDownload: (installationId) =>
       ipcRenderer.invoke('skip-template-download', installationId),
     updateInstallation: (installationId, data) =>

--- a/src/renderer/src/panel/useFirstUseChain.ts
+++ b/src/renderer/src/panel/useFirstUseChain.ts
@@ -396,7 +396,7 @@ export function useFirstUseChain(opts: FirstUseChainOpts): FirstUseChainApi {
       await opts.handleShowProgress({
         installationId: result.entry.id,
         title: `Installing — ${name}`,
-        apiCall: () => window.api.installInstance(result.entry!.id),
+        apiCall: () => window.api.installInstance(result.entry!.id, true),
         autoLaunchOnFinish: true,
         opKind: 'install'
       })

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -970,7 +970,10 @@ export interface ElectronApi {
   reorderInstallations(orderedIds: string[]): Promise<void>
   probeInstallation(dirPath: string): Promise<ProbeResult[]>
   trackInstallation(data: Record<string, unknown>): Promise<TrackResult>
-  installInstance(installationId: string): Promise<void>
+  /** `express` flags the one-click express-install path (vs the manual
+   *  Configure wizard). Used only to label the `install.completed`
+   *  telemetry event's `method`; defaults to false. */
+  installInstance(installationId: string, express?: boolean): Promise<void>
   /** Skip waiting on the starter-template model download — hands the still-
    *  running task off to the title-bar downloads tray (no restart). */
   skipTemplateDownload(installationId: string): Promise<void>


### PR DESCRIPTION
## Description

Makes the desktop journey funnel actually measurable end-to-end. Today desktop telemetry is split across two non-joinable identity spaces — renderer events (`first_launch`, `first_use.fork_chosen`, `view.opened`) key on `person_id`, main-process events (`boot_started`, `execution.*`) carry `installation_id` and a fragmented `person_id` (~281k person_ids for ~154k installs). A person-grouped funnel can't connect the two halves, so every renderer↔main transition shows an artificial cliff and the install→boot transition is invisible.

### 1. `installation_id` as a super-property (commit `84028bc5`)
`identify()` stamps the bound device id into `defaultEventProperties` at boot, and `capture()` merges those defaults onto every payload. Renderer events route over IPC (`telemetry:capture` → main `capture()`), so they inherit it too. Net: **every** desktop event now carries `installation_id`, so the funnel can be aggregated on a single per-install key across renderer + main.

Critically this is an **event property only** — `identify()` is NOT called with it, so the anon-id invariant holds (only `bindUserId` identifies on login). Person-on-events means it's point-in-time-at-write, which is what funnel stitching needs.

### 2. `comfy.desktop.install.completed` — wired (commit `68dd0818`)
`captureInstallCompleted` existed but was never called, so the event never fired. Now wired into the three local-install completion sites, each firing **once** when the install is ready to boot:
- fresh **express/manual** — `install-instance` handler (`method: express ? 'express' : 'manual'`)
- Desktop-1 **adopt** — `runAdoption` (`method:'adopt'`)
- snapshot **migrate** — `migrateToStandaloneFromSnapshot` (`method:'migrate'`)

Payload `{installation_id, method, express}`. Distinct from `boot_started` (which fires every launch), so it isolates the install→boot transition the funnel was missing. Excludes the cloud fork (no local install) and the version-update path (handled by `comfyui.update.applied`). Best-effort — `capture()` swallows its own errors, so it can never abort an install.

## Why this matters
Combined with `canvas_rendered` (already merged in #1132, main-process/`installation_id`), the full journey — `first_launch → fork → install.completed → boot → canvas → run → success` — now lives in one identity space and can be built as a single accurate funnel keyed on `installation_id`. The current funnel's boot→canvas and canvas→run "cliffs" are mostly artifacts of the split this fixes.

## How has this been tested?
- `tsc` node/web/e2e/integration — all green.
- `vitest run src/main/lib` — 866 passing. New coverage: `install.completed` fires once with correct `method`/`express`, does NOT fire on `boot_started`, is consent-gated, and adopt's idempotent re-run does not re-fire. Renderer-routed events carry `installation_id` (existing assertion in `telemetry.test.ts`).
- eslint clean on all changed files.

## Not in scope (tracked separately)
- `template.loaded` (per-template canvas attribution) — needs renderer/embedded-frontend instrumentation; `canvas_rendered.template_id` is structurally null from main.
- `download_token` (web download-click → desktop first-launch join) — separate web+desktop follow-up.
- The "Copy & update to a new release" path (`copy.ts` release-update) is intentionally NOT bucketed as an install — it's an update of an existing install, not a new-install funnel entry.

## Companion
Builds on #1132 (canvas_rendered / install.phase / boot_phase). Dashboard side (aggregate the desktop funnel by `installation_id`, swap `view.opened` → `canvas_rendered`) is separate.