### PR TITLE
[codex] Add survey identity bridge

### DIFF
--- a/packages/comfyui-desktop-bridge-types/comfyDesktopBridge.d.ts
+++ b/packages/comfyui-desktop-bridge-types/comfyDesktopBridge.d.ts
@@ -48,6 +48,14 @@ export interface ComfyDesktop2LogsBridge {
 export interface ComfyDesktop2TelemetryBridge {
     capture(event: string, properties?: ComfyDesktop2TelemetryProperties): void;
 }
+export interface ComfyDesktop2SurveyIdentity {
+    anon_id: string;
+    distinct_id?: string;
+    comfy_id?: string;
+}
+export interface ComfyDesktop2SurveysBridge {
+    getIdentity(): Promise<ComfyDesktop2SurveyIdentity | null>;
+}
 export interface ComfyDesktop2Bridge {
     isRemote(): boolean;
     downloadModel?: (url: string, filename: string, directory: string) => Promise<boolean>;
@@ -60,6 +68,7 @@ export interface ComfyDesktop2Bridge {
     Terminal?: ComfyDesktop2TerminalBridge;
     Logs?: ComfyDesktop2LogsBridge;
     Telemetry?: ComfyDesktop2TelemetryBridge;
+    Surveys?: ComfyDesktop2SurveysBridge;
 }
 export type ComfyDesktop2BridgeImplementation = {
     [K in keyof ComfyDesktop2Bridge]-?: NonNullable<ComfyDesktop2Bridge[K]>;

--- a/packages/comfyui-desktop-bridge-types/package.json
+++ b/packages/comfyui-desktop-bridge-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comfyorg/comfyui-desktop-bridge-types",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "TypeScript definitions for the Comfy Desktop hosted frontend bridge",
   "type": "module",
   "main": "./index.js",

--- a/src/main/lib/ipc/registerTelemetryHandlers.test.ts
+++ b/src/main/lib/ipc/registerTelemetryHandlers.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   capture: vi.fn(),
   captureException: vi.fn(),
   getFlag: vi.fn(),
+  getSurveyIdentity: vi.fn(),
   handle: vi.fn(),
   on: vi.fn(),
   recordExposure: vi.fn(),
@@ -22,6 +23,7 @@ vi.mock('../telemetry', () => ({
   bindUserId: mocks.bindUserId,
   capture: mocks.capture,
   captureException: mocks.captureException,
+  getSurveyIdentity: mocks.getSurveyIdentity,
   registerPersonProperties: mocks.registerPersonProperties
 }))
 
@@ -33,11 +35,18 @@ vi.mock('../experiments', () => ({
 import { registerTelemetryHandlers } from './registerTelemetryHandlers'
 
 type IpcListener = (_event: unknown, payload: unknown) => void
+type IpcHandler = (_event: unknown, ...args: unknown[]) => unknown
 
 function listener(channel: string): IpcListener {
   const call = mocks.on.mock.calls.find(([name]) => name === channel)
   expect(call).toBeDefined()
   return call![1] as IpcListener
+}
+
+function handler(channel: string): IpcHandler {
+  const call = mocks.handle.mock.calls.find(([name]) => name === channel)
+  expect(call).toBeDefined()
+  return call![1] as IpcHandler
 }
 
 describe('registerTelemetryHandlers', () => {
@@ -82,5 +91,19 @@ describe('registerTelemetryHandlers', () => {
     expect(sent.long).toBe('x'.repeat(2048))
     expect(sent.key_125).toBe(125)
     expect(sent.key_126).toBeUndefined()
+  })
+
+  it('exposes the consent-gated survey identity over IPC', () => {
+    mocks.getSurveyIdentity.mockReturnValue({
+      anon_id: 'install-1',
+      distinct_id: 'user-1',
+      comfy_id: 'user-1'
+    })
+
+    expect(handler('surveys:get-identity')(null)).toEqual({
+      anon_id: 'install-1',
+      distinct_id: 'user-1',
+      comfy_id: 'user-1'
+    })
   })
 })

--- a/src/main/lib/ipc/registerTelemetryHandlers.ts
+++ b/src/main/lib/ipc/registerTelemetryHandlers.ts
@@ -123,6 +123,8 @@ export function registerTelemetryHandlers(): void {
     mainTelemetry.unbindUserId()
   })
 
+  ipcMain.handle('surveys:get-identity', () => mainTelemetry.getSurveyIdentity())
+
   // Flag lookup for renderer A/B branches; awaits the boot fetch so a query
   // landing before it settles still gets the real variant. null → control.
   ipcMain.handle('telemetry:getExperimentFlag', async (_event, key: unknown) => {

--- a/src/main/lib/telemetry.test.ts
+++ b/src/main/lib/telemetry.test.ts
@@ -290,6 +290,61 @@ describe('telemetry default event properties', () => {
   })
 })
 
+describe('telemetry.getSurveyIdentity', () => {
+  beforeEach(() => {
+    captured.length = 0
+    aliases.length = 0
+    identifies.length = 0
+    process.env['POSTHOG_API_KEY'] = 'test-key'
+    process.env['POSTHOG_ENABLED'] = '1'
+    telemetry._resetForTest()
+    telemetry.initTelemetry({ appVersion: '1.0.0', appEnv: 'prod', isPackaged: true })
+  })
+
+  afterEach(() => {
+    delete process.env['POSTHOG_API_KEY']
+    delete process.env['POSTHOG_ENABLED']
+    telemetry._resetForTest()
+  })
+
+  it('returns null until consent is granted', () => {
+    telemetry.identify('install-abc123')
+
+    expect(telemetry.getSurveyIdentity()).toBeNull()
+  })
+
+  it('returns the Desktop-owned anonymous identity after consent', () => {
+    telemetry.identify('install-abc123')
+    telemetry.setConsentState('granted')
+
+    expect(telemetry.getSurveyIdentity()).toEqual({
+      anon_id: 'install-abc123',
+      distinct_id: 'install-abc123'
+    })
+  })
+
+  it('returns the active user id after the renderer binds login identity', () => {
+    telemetry.identify('install-abc123')
+    telemetry.setConsentState('granted')
+
+    telemetry.bindUserId('user-42')
+
+    expect(telemetry.getSurveyIdentity()).toEqual({
+      anon_id: 'install-abc123',
+      distinct_id: 'user-42',
+      comfy_id: 'user-42'
+    })
+  })
+
+  it('returns null again if consent is revoked', () => {
+    telemetry.identify('install-abc123')
+    telemetry.setConsentState('granted')
+    telemetry.setConsentState('denied')
+
+    expect(telemetry.getSurveyIdentity()).toBeNull()
+  })
+})
+
 describe('telemetry.captureInstallCompleted', () => {
   beforeEach(() => {
     captured.length = 0

--- a/src/main/lib/telemetry.ts
+++ b/src/main/lib/telemetry.ts
@@ -117,6 +117,12 @@ import { scrubAll } from '../../shared/piiScrub'
 export type TelemetryValue = boolean | number | string | null | undefined
 export type TelemetryContext = Record<string, TelemetryValue | TelemetryValue[]>
 
+export interface SurveyIdentity {
+  anon_id: string
+  distinct_id?: string
+  comfy_id?: string
+}
+
 /**
  * Long-lived renderer WebContents that receive main-emitted telemetry events
  * for fan-out to renderer-side Datadog RUM. Registered exactly once per host
@@ -706,6 +712,20 @@ export function unbindUserId(): void {
   distinctId = installationDeviceId
   if (canEmit() && consentState === 'granted') {
     capturePersonProperties({ is_authenticated: false }, null)
+  }
+}
+
+export function getSurveyIdentity(): SurveyIdentity | null {
+  if (consentState !== 'granted') return null
+  if (!installationDeviceId) return null
+
+  const activeDistinctId = distinctId ?? installationDeviceId
+  return {
+    anon_id: installationDeviceId,
+    distinct_id: activeDistinctId,
+    ...(activeDistinctId !== installationDeviceId
+      ? { comfy_id: activeDistinctId }
+      : {})
   }
 }
 

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -429,6 +429,7 @@ export function buildElectronApi(): ElectronApi {
       }
     },
     telemetryGetExperimentFlag: (key) => ipcRenderer.invoke('telemetry:getExperimentFlag', key),
+    getSurveyIdentity: () => ipcRenderer.invoke('surveys:get-identity'),
     telemetryRecordExposure: (payload) => {
       try {
         ipcRenderer.send('telemetry:recordExposure', payload)

--- a/src/preload/comfyPreload.ts
+++ b/src/preload/comfyPreload.ts
@@ -10,6 +10,7 @@ import type {
   LogsRestore,
   TerminalRestore
 } from '@comfyorg/comfyui-desktop-bridge-types'
+import type { ComfyDesktop2SurveysBridge } from '../types/comfyDesktopBridge'
 
 /**
  * Interactive terminal bridge for the served ComfyUI frontend.
@@ -86,6 +87,14 @@ const Telemetry: ComfyDesktop2TelemetryBridge = {
   }
 }
 
+const Surveys: ComfyDesktop2SurveysBridge = {
+  getIdentity: () => ipcRenderer.invoke('surveys:get-identity')
+}
+
+type ComfyDesktop2RuntimeBridge = ComfyDesktop2Bridge & {
+  Surveys: ComfyDesktop2SurveysBridge
+}
+
 const bridge = {
   isRemote: (): boolean => ipcRenderer.sendSync('desktop2-is-remote') as boolean,
   downloadModel: (url: string, filename: string, directory: string): Promise<boolean> => {
@@ -118,7 +127,8 @@ const bridge = {
   },
   Terminal,
   Logs,
-  Telemetry
-} satisfies ComfyDesktop2Bridge
+  Telemetry,
+  Surveys
+} satisfies ComfyDesktop2RuntimeBridge
 
 contextBridge.exposeInMainWorld('__comfyDesktop2', bridge)

--- a/src/renderer/src/composables/useSendFeedback.ts
+++ b/src/renderer/src/composables/useSendFeedback.ts
@@ -5,7 +5,7 @@ import { buildSupportUrl } from '../lib/supportUrl'
 interface UseSendFeedbackApi {
   /** True while the in-app feedback modal is mounted. */
   feedbackOpen: Ref<boolean>
-  /** Typeform URL with `ver` + `platform` query params resolved at open time. */
+  /** Typeform URL with build, platform, and consent-gated identity tags resolved at open time. */
   feedbackUrl: Ref<string>
   /** Imperative dismiss for the modal's `@close` handler. */
   closeFeedback: () => void
@@ -30,10 +30,20 @@ export function useSendFeedback(): UseSendFeedbackApi {
   const feedbackUrl = ref('')
   let unsubOpenFeedback: (() => void) | null = null
 
+  async function resolveSurveyIdentity() {
+    try {
+      return await window.api.getSurveyIdentity()
+    } catch {
+      return null
+    }
+  }
+
   function handleOpenFeedback(source: 'titlebar' | 'menu'): void {
     emitTelemetryAction('comfy.desktop.feedback.opened', { source })
-    feedbackUrl.value = buildSupportUrl(appVersion.value || undefined)
-    feedbackOpen.value = true
+    void resolveSurveyIdentity().then((identity) => {
+      feedbackUrl.value = buildSupportUrl(appVersion.value || undefined, identity)
+      feedbackOpen.value = true
+    })
   }
 
   function closeFeedback(): void {

--- a/src/renderer/src/lib/supportUrl.ts
+++ b/src/renderer/src/lib/supportUrl.ts
@@ -1,3 +1,5 @@
+import type { SurveyIdentity } from '../types/ipc'
+
 const FEEDBACK_URL = 'https://form.typeform.com/to/VhOXmuaL'
 
 function detectPlatform(): string {
@@ -8,9 +10,20 @@ function detectPlatform(): string {
   return 'unknown'
 }
 
-export function buildSupportUrl(version?: string): string {
+function buildHiddenFields(version: string | undefined, identity: SurveyIdentity | null): string {
+  const fields = new URLSearchParams()
+  if (version) fields.set('ver', version)
+  fields.set('platform', detectPlatform())
+  if (identity?.anon_id) fields.set('anon_id', identity.anon_id)
+  if (identity?.distinct_id) fields.set('distinct_id', identity.distinct_id)
+  if (identity?.comfy_id) fields.set('comfy_id', identity.comfy_id)
+  return fields.toString()
+}
+
+export function buildSupportUrl(version?: string, identity: SurveyIdentity | null = null): string {
   const url = new URL(FEEDBACK_URL)
   if (version) url.searchParams.set('ver', version)
   url.searchParams.set('platform', detectPlatform())
+  url.hash = buildHiddenFields(version, identity)
   return url.toString()
 }

--- a/src/renderer/src/panel/PanelApp.test.ts
+++ b/src/renderer/src/panel/PanelApp.test.ts
@@ -183,6 +183,7 @@ interface MockApiState {
   getInstallations: ReturnType<typeof vi.fn>
   openExternal: ReturnType<typeof vi.fn>
   getAppVersion: ReturnType<typeof vi.fn>
+  getSurveyIdentity: ReturnType<typeof vi.fn>
   /** Per-key getSetting values. Tests that need first-use takeover to
    *  auto-mount can flip `firstUseCompleted` to false here. Default is
    *  `true` so existing tests don't trip the takeover. */
@@ -209,6 +210,11 @@ function installMockApi(initial?: {
     getInstallations: vi.fn(async () => state.installations),
     openExternal: vi.fn(async () => {}),
     getAppVersion: vi.fn(async () => '0.5.0'),
+    getSurveyIdentity: vi.fn(async () => ({
+      anon_id: 'install-1',
+      distinct_id: 'user-1',
+      comfy_id: 'user-1'
+    })),
     settings: { firstUseCompleted: true, ...initial?.settings },
     installUpdate: vi.fn(async () => {}),
     downloadUpdate: vi.fn(async () => {})
@@ -247,6 +253,7 @@ function installMockApi(initial?: {
     }),
     openExternal: state.openExternal,
     getAppVersion: state.getAppVersion,
+    getSurveyIdentity: state.getSurveyIdentity,
     onSettingsChanged: vi.fn(() => () => {}),
     // Main consults the panel renderer before tearing down the host
     // window. PanelApp subscribes on mount; tests can fire the consult
@@ -688,10 +695,16 @@ describe('PanelApp', () => {
     // through `openFeedback`.
     const frame = document.body.querySelector<HTMLIFrameElement>('iframe.feedback-modal-frame')
     expect(frame).not.toBeNull()
-    const url = frame?.getAttribute('src') ?? ''
-    expect(url).toContain('form.typeform.com/to/VhOXmuaL')
-    expect(url).toContain('ver=0.5.0')
-    expect(url).toMatch(/[?&]platform=/)
+    const url = new URL(frame?.getAttribute('src') ?? '')
+    expect(url.href).toContain('form.typeform.com/to/VhOXmuaL')
+    expect(url.searchParams.get('ver')).toBe('0.5.0')
+    expect(url.searchParams.get('platform')).toBeTruthy()
+    const hiddenFields = new URLSearchParams(url.hash.slice(1))
+    expect(hiddenFields.get('ver')).toBe('0.5.0')
+    expect(hiddenFields.get('platform')).toBeTruthy()
+    expect(hiddenFields.get('anon_id')).toBe('install-1')
+    expect(hiddenFields.get('distinct_id')).toBe('user-1')
+    expect(hiddenFields.get('comfy_id')).toBe('user-1')
   })
 
   // The first-use takeover has no in-app ✕ close button (first-use

--- a/src/renderer/src/types/ipc.ts
+++ b/src/renderer/src/types/ipc.ts
@@ -60,6 +60,7 @@ export type {
   ErrorDetailData,
   AppUpdateState,
   AppUpdateDownloadProgress,
+  SurveyIdentity,
   CloudCapacityStatus,
   CloudUserTier,
   ElectronApi,

--- a/src/types/comfyDesktopBridge.ts
+++ b/src/types/comfyDesktopBridge.ts
@@ -56,6 +56,16 @@ export interface ComfyDesktop2TelemetryBridge {
   capture(event: string, properties?: ComfyDesktop2TelemetryProperties): void
 }
 
+export interface ComfyDesktop2SurveyIdentity {
+  anon_id: string
+  distinct_id?: string
+  comfy_id?: string
+}
+
+export interface ComfyDesktop2SurveysBridge {
+  getIdentity(): Promise<ComfyDesktop2SurveyIdentity | null>
+}
+
 export interface ComfyDesktop2Bridge {
   isRemote(): boolean
   downloadModel?: (url: string, filename: string, directory: string) => Promise<boolean>
@@ -68,6 +78,7 @@ export interface ComfyDesktop2Bridge {
   Terminal?: ComfyDesktop2TerminalBridge
   Logs?: ComfyDesktop2LogsBridge
   Telemetry?: ComfyDesktop2TelemetryBridge
+  Surveys?: ComfyDesktop2SurveysBridge
 }
 
 export type ComfyDesktop2BridgeImplementation = {

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -906,6 +906,12 @@ export interface AppUpdateDownloadProgress {
   bytesPerSecond: number | null
 }
 
+export interface SurveyIdentity {
+  anon_id: string
+  distinct_id?: string
+  comfy_id?: string
+}
+
 // --- IPC API interface ---
 export interface ElectronApi {
   /** Host OS — set synchronously by the preload from `process.platform`.
@@ -1428,6 +1434,11 @@ export interface ElectronApi {
    * refresh; see `src/main/lib/experiments.ts`.
    */
   telemetryGetExperimentFlag(key: string): Promise<string | boolean | null>
+  /**
+   * Returns the Desktop-owned survey identity tags when analytics consent is
+   * granted. Null means the renderer should keep the form anonymous.
+   */
+  getSurveyIdentity(): Promise<SurveyIdentity | null>
   /**
    * Record an A/B experiment exposure. Per-session dedup is enforced
    * main-side, so it's safe to call this on every render of an


### PR DESCRIPTION
## Summary

Adds a Desktop-owned survey identity bridge for Typeform flows.

- exposes `window.__comfyDesktop2.Surveys.getIdentity()` for hosted frontend bundles
- exposes `window.api.getSurveyIdentity()` for Desktop renderer surfaces
- returns `null` unless telemetry consent is granted
- returns Desktop's existing anonymous installation id plus the active PostHog distinct/user id when available
- adds the identity fields to Desktop2's existing Typeform feedback URL fragment while preserving the old `ver` and `platform` query params
- updates the bridge-types package declarations for the new `Surveys` surface

## Related frontend PR

ComfyUI_frontend #13021 consumes `window.__comfyDesktop2.Surveys.getIdentity()` from the hosted frontend Typeform path. Older frontend/Desktop combinations continue to fall back to anonymous survey ids.

## Why

Typeform submissions go directly to Typeform, so they cannot inherit identity through the existing PostHog telemetry capture relay. Desktop needs to provide the consent-gated identity tags before the form opens.

## Validation

- `pnpm typecheck`
- `pnpm exec eslint src/types/comfyDesktopBridge.ts src/preload/comfyPreload.ts src/preload/api.ts src/main/lib/telemetry.ts src/main/lib/telemetry.test.ts src/main/lib/ipc/registerTelemetryHandlers.ts src/main/lib/ipc/registerTelemetryHandlers.test.ts src/types/ipc.ts src/renderer/src/types/ipc.ts src/renderer/src/lib/supportUrl.ts src/renderer/src/composables/useSendFeedback.ts src/renderer/src/panel/PanelApp.test.ts`
- `pnpm exec vitest run src/main/lib/telemetry.test.ts src/main/lib/ipc/registerTelemetryHandlers.test.ts src/renderer/src/panel/PanelApp.test.ts`

Note: the focused Desktop test run exits 0 but Happy DOM logs an external iframe fetch abort for the Typeform URL after the tests pass.