### PR TITLE
feat(telemetry): boot_completed + boot_id for a per-attempt boot-success rate

### DIFF
--- a/src/main/lib/ipc/sessionActions/launch.ts
+++ b/src/main/lib/ipc/sessionActions/launch.ts
@@ -21,6 +21,7 @@ import {
   _broadcastToRenderer,
 } from '../shared'
 import type { ChildProcess, InstallationRecord, LaunchCmd } from '../shared'
+import { randomUUID } from 'node:crypto'
 import { displayLaunchUrl } from '../../cloudUrl'
 import type { ModelPathsOptions } from '../../models'
 import type { ActionContext, ActionResult } from './types'
@@ -705,6 +706,9 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
   const REBOOT_RETRY_MAX = 5
   let portRetries = 0
   let rebootRetries = 0
+  // One id per logical boot, reused across port/reboot retries (tryLaunch
+  // recurses), so boot_started→boot_completed joins per-attempt, not per-machine.
+  const bootId = randomUUID()
 
   const tryLaunch = async (): Promise<{ ok: true; proc: ChildProcess; getStderr: () => string } | { ok: false; message: string; cancelled?: boolean }> => {
     const cmdLine = [launchCmd.cmd!, ...launchCmd.args!].map((a, ci, ca) => {
@@ -724,6 +728,7 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
     // retries (port_retry / reboot_retry counters) directly.
     telemetry.capture('comfy.desktop.comfyui.boot_started', {
       installation_id: installationId,
+      boot_id: bootId,
       variant: (inst.variant as string | undefined) ?? null,
       port_retry_count: portRetries,
       reboot_retry_count: rebootRetries
@@ -811,6 +816,7 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
     const failedPhase = flushBootPhasesOnFailure(installationId)
     telemetry.emit('comfy.desktop.comfyui.boot_failed', {
       installation_id: installationId,
+      boot_id: bootId,
       variant: (inst.variant as string | undefined) ?? null,
       failed_phase: failedPhase,
       error_bucket: telemetry.bucketError(launchResult.message),
@@ -828,12 +834,24 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
   _pendingPorts.delete(launchCmd.port!)
   _operationAborts.delete(installationId)
   const mode = (inst.launchMode as string | undefined) || 'window'
+  const bootTimeMs = Date.now() - launchStartedAt
   _addSession(
     installationId,
     { proc, port: launchCmd.port!, mode, installationName: inst.name },
-    Date.now() - launchStartedAt,
+    bootTimeMs,
     { portRetries, rebootRetries },
   )
+  // Paired success terminal for boot_started: server up + session registered.
+  // Same boot_id as this launch's boot_started(s), so the boot-success rate is
+  // count(boot_completed.boot_id) / count(distinct boot_started.boot_id).
+  telemetry.capture('comfy.desktop.comfyui.boot_completed', {
+    installation_id: installationId,
+    boot_id: bootId,
+    variant: (inst.variant as string | undefined) ?? null,
+    boot_time_ms: bootTimeMs,
+    port_retry_count: portRetries,
+    reboot_retry_count: rebootRetries
+  })
   writePortLock(launchCmd.port!, { pid: proc.pid!, installationName: inst.name })
 
   if (!sender.isDestroyed()) {

--- a/src/main/lib/telemetry.test.ts
+++ b/src/main/lib/telemetry.test.ts
@@ -335,6 +335,24 @@ describe('telemetry.captureInstallCompleted', () => {
     expect(captured[0]!.properties).toMatchObject({ method, express })
   })
 
+  it('boot_completed is a distinct success event carrying the boot_id join key', () => {
+    // boot_started -> boot_completed is the per-attempt boot-success funnel.
+    // Both must carry the same boot_id (the per-launch correlation id) and
+    // installation_id (the cross-event join key from defaults) so the rate is
+    // count(boot_completed.boot_id) / count(distinct boot_started.boot_id).
+    telemetry.capture('comfy.desktop.comfyui.boot_completed', {
+      installation_id: 'install-xyz',
+      boot_id: 'boot-1',
+      boot_time_ms: 1234
+    })
+    expect(captured.map((c) => c.event)).toEqual(['comfy.desktop.comfyui.boot_completed'])
+    expect(captured[0]!.properties).toMatchObject({
+      installation_id: 'install-xyz',
+      boot_id: 'boot-1',
+      boot_time_ms: 1234
+    })
+  })
+
   it('does NOT fire on boot — boot_started is a distinct, separately-emitted event', () => {
     // A boot is the per-launch event; install.completed is once-per-install.
     // Emitting boot_started must never produce an install.completed.

--- a/src/shared/datadogMirroredEvents.test.ts
+++ b/src/shared/datadogMirroredEvents.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+
+import { isDatadogMirroredEvent } from './datadogMirroredEvents'
+
+describe('isDatadogMirroredEvent', () => {
+  // The boot lifecycle splits success vs failure: boot_failed is a failure
+  // signal ops alerts on, boot_started/boot_completed are funnel events
+  // (PostHog only). Mirroring a success event would page on-call on healthy
+  // boots and double its RUM volume for no monitor benefit.
+  it('mirrors boot_failed but not boot_started / boot_completed', () => {
+    expect(isDatadogMirroredEvent('comfy.desktop.comfyui.boot_failed')).toBe(true)
+    expect(isDatadogMirroredEvent('comfy.desktop.comfyui.boot_started')).toBe(false)
+    expect(isDatadogMirroredEvent('comfy.desktop.comfyui.boot_completed')).toBe(false)
+  })
+
+  it('returns false for unknown event names', () => {
+    expect(isDatadogMirroredEvent('comfy.desktop.not.a.real.event')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Quick Read

`boot_started` had no positive "the server came up" counterpart, so ComfyUI server-boot success could only be *inferred* per-machine — and `boot_started` fires ~5.8×/machine (port/reboot retries, relaunches), so a per-launch success rate wasn't computable at all. This adds a per-launch `boot_id` and a new `comfy.desktop.comfyui.boot_completed` event so boot success is a clean **per-attempt** funnel:

```
count(boot_completed.boot_id) / count(distinct boot_started.boot_id)
```

## The problem

There is no `boot_completed` / `boot_succeeded` event in the taxonomy. The only success milestone is `canvas_rendered` (downstream "canvas painted", and brand-new), and the only broadly-populated negative is `exited(crashed=true)`, which fires on just ~7% of started machines. With no shared correlation id on the boot events (only `installation_id`, per-machine), success could only be approximated per-machine, never per boot attempt.

## The change (`launch.ts`, `handleLaunch`)

- **`boot_id`** — a UUID generated once per logical boot, reused across port/reboot retries (since `tryLaunch` recurses). Stamped on `boot_started`, `boot_failed`, and `boot_completed`, so all events for one launch share an id.
- **`comfy.desktop.comfyui.boot_completed`** — emitted in main right after `_addSession()` (server confirmed up via `waitForPort`, session registered). Carries `installation_id`, `boot_id`, `boot_time_ms`, `port_retry_count`, `reboot_retry_count`.
- `boot_completed` is a success/funnel event → **PostHog only**, deliberately not on the Datadog mirror list (a healthy boot must never page on-call). `boot_failed` stays mirrored.

No renderer changes; all three events emit from main.

## Why per-attempt, not per-machine

`boot_started` fires on every spawn + every retry. Keying the funnel on `distinct boot_id` collapses retries into one logical launch, so the denominator is *launches the user initiated* and the numerator is *launches where the server came up*. That's the reliability number; the old per-machine approximation couldn't separate "this machine eventually booted" from "what fraction of attempts succeed."

## Rollout

Same shape as #1147: lands `installation_id` + `boot_id` on these events going forward; the metric becomes meaningful as the release rolls out (older builds emit neither `boot_completed` nor `boot_id`). 100% `installation_id` coverage is inherited from the `defaultEventProperties` stamp shipped in #1147.

## Testing

- `src/shared/datadogMirroredEvents.test.ts` (new) — guards that `boot_failed` is mirrored (pages on-call) while `boot_started` / `boot_completed` are not.
- `src/main/lib/telemetry.test.ts` — `boot_completed` is a distinct success event carrying the `boot_id` join key + `installation_id`.
- `pnpm test` (affected suites) green; eslint clean on changed files; `boot_id` correlation verified by construction (single closure var across the three emit sites).

## Follow-up (intentionally out of scope)

Extending `boot_id` to `canvas_rendered` (`attach.ts`) and `comfyui.exited` (renderer-emitted) would make the full **boot → canvas** and **boot → crash** funnels per-attempt too, but both fire renderer-side and need `boot_id` threaded through the session object / exit IPC. Kept separate to keep this a tight, hot-path-safe change.

## Related

Builds on #1147 (`installation_id` super-property + `install.completed`) — part of the desktop identity-stitch / funnel work (MAR-367). Feeds the "Desktop Funnel — Trustworthy (installation_id-keyed)" PostHog dashboard.
