### PR TITLE
fix(updater): gate auto-install on the autoInstallUpdates toggle

### DIFF
--- a/src/main/lib/updater.test.ts
+++ b/src/main/lib/updater.test.ts
@@ -380,9 +380,50 @@ describe('startup update install + session-end guard (issue #1065)', () => {
     settingsStore['installUpdatesOnStartup'] = false
     const updater = await import('./updater')
     updater.register()
-    // Opted out: electron-updater's install-on-quit stays armed; it's only
-    // suppressed when the OS session ends (see suppressInstallOnQuit).
+    // Opted out with auto-install on (the default): install-on-quit stays armed;
+    // it's only suppressed when the OS session ends (see suppressInstallOnQuit).
     expect(electronUpdaterMock.autoInstallOnAppQuit).toBe(true)
+  })
+
+  it('register() disables install-on-quit when auto-install is off (opted out of startup install)', async () => {
+    settingsStore['installUpdatesOnStartup'] = false
+    settingsStore['autoInstallUpdates'] = false
+    const updater = await import('./updater')
+    updater.register()
+    // Auto-install OFF: a staged update must not apply on quit; the user installs
+    // explicitly from the 'ready' pill.
+    expect(electronUpdaterMock.autoInstallOnAppQuit).toBe(false)
+  })
+
+  it('toggling auto-install off after register() disarms install-on-quit', async () => {
+    settingsStore['installUpdatesOnStartup'] = false
+    const updater = await import('./updater')
+    updater.register()
+    expect(electronUpdaterMock.autoInstallOnAppQuit).toBe(true)
+    // User flips the toggle off; the settings handler calls notifyAutoUpdateChanged().
+    // The quit handler re-reads the flag, so this disarms an update downloaded
+    // while the toggle was on (the stale-download case).
+    settingsStore['autoInstallUpdates'] = false
+    updater.notifyAutoUpdateChanged()
+    expect(electronUpdaterMock.autoInstallOnAppQuit).toBe(false)
+    // Back on re-arms it.
+    settingsStore['autoInstallUpdates'] = true
+    updater.notifyAutoUpdateChanged()
+    expect(electronUpdaterMock.autoInstallOnAppQuit).toBe(true)
+  })
+
+  it('startup install is skipped when auto-install is off (staged update waits)', async () => {
+    // Windows default: startup-install is on, but auto-install off must leave the
+    // staged update for an explicit install rather than applying it at launch.
+    settingsStore['installUpdatesOnStartup'] = true
+    settingsStore['autoInstallUpdates'] = false
+    settingsStore['pendingDownloadedUpdateVersion'] = '1.0.1'
+    readyVersion = '1.0.1'
+    const updater = await import('./updater')
+    updater.register()
+    expect(updater.hasPendingStartupUpdate()).toBe(false)
+    expect(await updater.applyPendingUpdateOnStartup()).toBe(false)
+    expect(fakeUpdater.restartAndInstall).not.toHaveBeenCalled()
   })
 
   it('startup install is inert on non-Windows even when the flag is on', async () => {

--- a/src/main/lib/updater.ts
+++ b/src/main/lib/updater.ts
@@ -108,9 +108,15 @@ function isAutoInstallEnabled(): boolean {
  * the autoUpdate preference so a pending `'ready'` state immediately
  * starts reading as auto-on / auto-off (drives the title-bar pill copy
  * and the click-modal flow without having to wait for the next
- * update-check broadcast). No-op when there's no cached state.
+ * update-check broadcast). Also re-syncs install-on-quit to the new
+ * preference so an off toggle never auto-installs an already-staged update on
+ * the next quit; that sync runs even with no cached state, while the
+ * re-broadcast is a no-op without one.
  */
 export function notifyAutoUpdateChanged(): void {
+  // The quit handler re-reads autoInstallOnAppQuit at quit time, so flipping it
+  // here disarms install-on-quit for an update downloaded while the toggle was on.
+  syncInstallOnQuitToPreference()
   if (_appUpdateState.kind === null) return
   const refreshed = isAutoInstallEnabled()
   if (_appUpdateState.autoUpdate === refreshed) return
@@ -189,6 +195,22 @@ function isInstallerUIEnabled(): boolean {
 export function suppressInstallOnQuit(): void {
   try {
     electronAutoUpdater.autoInstallOnAppQuit = false
+  } catch {}
+}
+
+/**
+ * Map electron-updater's install-on-quit to the user's auto-install preference
+ * (`autoInstallUpdates`). ON keeps the default — a staged update applies on the
+ * next quit. OFF disables it, so a downloaded update waits for an explicit
+ * install from the 'ready' pill instead of applying on restart. No-op while the
+ * Windows startup-install path owns the flag (it keeps install-on-quit off and
+ * applies the update at the next launch, gated on the same preference in
+ * `evaluateStartupInstall`).
+ */
+function syncInstallOnQuitToPreference(): void {
+  if (isStartupInstallEnabled()) return
+  try {
+    electronAutoUpdater.autoInstallOnAppQuit = isAutoInstallEnabled()
   } catch {}
 }
 
@@ -584,7 +606,14 @@ type StartupInstallDecision =
   | { attempt: true; version: string }
   | {
       attempt: false
-      reason: 'disabled' | 'e2e' | 'system_managed' | 'session_ending' | 'no_pending' | 'loop_breaker'
+      reason:
+        | 'disabled'
+        | 'auto_install_off'
+        | 'e2e'
+        | 'system_managed'
+        | 'session_ending'
+        | 'no_pending'
+        | 'loop_breaker'
     }
 
 /**
@@ -600,6 +629,9 @@ type StartupInstallDecision =
  */
 function evaluateStartupInstall(): StartupInstallDecision {
   if (!isStartupInstallEnabled()) return { attempt: false, reason: 'disabled' }
+  // Auto-install OFF: leave the staged update in place for an explicit install
+  // from the 'ready' pill rather than applying it automatically at launch.
+  if (!isAutoInstallEnabled()) return { attempt: false, reason: 'auto_install_off' }
   if (process.env['E2E'] === '1') return { attempt: false, reason: 'e2e' }
   if (isSystemPackageInstall()) return { attempt: false, reason: 'system_managed' }
   if (isSessionEnding()) return { attempt: false, reason: 'session_ending' }
@@ -743,12 +775,16 @@ export function register(): void {
   // corruption loop). `electronAutoUpdater` is the same singleton the ToDesktop
   // runtime drives, so this affects the real updater.
   //
-  // Opted out (non-Windows, or `installUpdatesOnStartup` set to false): keep
-  // install-on-quit armed. A normal quit still installs a staged update; the
-  // `session-end` guard (`suppressInstallOnQuit`) flips `autoInstallOnAppQuit`
-  // off only when the OS is shutting down.
+  // Opted out (non-Windows, or `installUpdatesOnStartup` set to false): gate
+  // install-on-quit on the auto-install preference. With auto-install ON a
+  // normal quit still installs a staged update (the `session-end` guard,
+  // `suppressInstallOnQuit`, flips `autoInstallOnAppQuit` off only during OS
+  // shutdown); with it OFF the staged update waits for an explicit install from
+  // the 'ready' pill.
   if (isStartupInstallEnabled()) {
     suppressInstallOnQuit()
+  } else {
+    syncInstallOnQuitToPreference()
   }
 
   ipcMain.handle('check-for-update', async () => {


### PR DESCRIPTION
## Problem

Turning off **Automatically install Desktop updates** (`autoInstallUpdates`) did not stop updates. The toggle only swapped the update pill's presentation (silent `ready` vs an `available` prompt); it never gated the updater, so a discovered update still installed on the next restart. The two paths:

- **Windows (startup-install is the default):** `evaluateStartupInstall()` applied a staged update at the next launch without consulting the toggle.
- **macOS / Linux:** electron-updater's `autoInstallOnAppQuit` stayed at its default (`true`), so a staged update installed on quit.

Cleanest repro: with the toggle **on**, let an update download in the background; turn the toggle **off**; restart. The staged update still installed.

## Fix

Gate both auto-install paths on `isAutoInstallEnabled()`:

- `evaluateStartupInstall()` now returns a new `auto_install_off` skip when the toggle is off, so a staged update is left in place instead of being applied at launch (also suppresses the "Updating…" splash).
- `register()`'s opted-out path and `notifyAutoUpdateChanged()` set `autoInstallOnAppQuit` from the preference via a new `syncInstallOnQuitToPreference()` helper. The quit handler re-reads the flag at quit time, so toggling off also disarms an update that was downloaded while the toggle was on.

The always-on check loop and background download are unchanged: an update still stages so the `ready` pill offers a one-click install. It just no longer installs automatically when the toggle is off.

## Test plan

`src/main/lib/updater.test.ts` (added):
- `register()` disables install-on-quit when auto-install is off (opted-out path)
- toggling auto-install off after `register()` disarms install-on-quit, and back on re-arms it (stale-download case)
- startup install is skipped when auto-install is off, even with a pending staged update

All 36 updater tests pass; full `typecheck` (node/web/e2e/integration) and `lint` clean.