### PR TITLE
fix(telemetry): installation_id is always the machine id (per-install id → install_id)

### DIFF
--- a/src/main/lib/telemetry.test.ts
+++ b/src/main/lib/telemetry.test.ts
@@ -278,6 +278,35 @@ describe('telemetry default event properties', () => {
     expect(captured[1]!.properties).toMatchObject({ installation_id: 'install-abc123' })
   })
 
+  it('keeps installation_id = the machine id and redirects a per-install id to install_id', () => {
+    telemetry.initTelemetry({ appVersion: '1.0.0', appEnv: 'prod', isPackaged: true })
+    telemetry.identify('machine-sha-abc')
+    telemetry.setConsentState('granted')
+    captured.length = 0
+
+    // Renderer/onboarding event: no explicit installation_id -> machine id, no install_id.
+    telemetry.capture('comfy.desktop.first_use.fork_chosen', { choice: 'local' })
+    // Main event: passes its per-install record id under installation_id -> redirected.
+    telemetry.capture('comfy.desktop.comfyui.boot_started', { installation_id: 'inst-123' })
+    // Explicit machine id (== default) is left as-is, no install_id introduced.
+    telemetry.capture('comfy.desktop.test.echo', { installation_id: 'machine-sha-abc' })
+
+    const fork = captured.find((c) => c.event === 'comfy.desktop.first_use.fork_chosen')!
+    expect(fork.properties).toMatchObject({ installation_id: 'machine-sha-abc' })
+    expect(fork.properties!.install_id).toBeUndefined()
+
+    const boot = captured.find((c) => c.event === 'comfy.desktop.comfyui.boot_started')!
+    // installation_id stays the machine id (joinable); the per-install id moves to install_id.
+    expect(boot.properties).toMatchObject({
+      installation_id: 'machine-sha-abc',
+      install_id: 'inst-123'
+    })
+
+    const echo = captured.find((c) => c.event === 'comfy.desktop.test.echo')!
+    expect(echo.properties).toMatchObject({ installation_id: 'machine-sha-abc' })
+    expect(echo.properties!.install_id).toBeUndefined()
+  })
+
   it('does not pass installation_id to identify() (anon-id invariant holds)', () => {
     identifies.length = 0
     telemetry.initTelemetry({ appVersion: '1.0.0', appEnv: 'prod', isPackaged: true })

--- a/src/main/lib/telemetry.ts
+++ b/src/main/lib/telemetry.ts
@@ -44,7 +44,13 @@
  *     merge one identified id into another, so the login alias below silently
  *     no-ops (prod: 0/13,528 stitched). Anonymous person-prop writes go
  *     through capture-`$set` instead, which updates the person without
- *     identifying the id.
+ *     identifying the id. INVARIANT: `installation_id` is ALWAYS the machine
+ *     id on every event — `capture()` enforces this and redirects any per-call
+ *     `installation_id` to `install_id` so the field never means two things.
+ *   - `install_id` = the per-install record id (`inst-<ts>`, `installations.ts`).
+ *     A machine can hold several installs; this is an operational key. It rides
+ *     telemetry only as the secondary `install_id` (never `installation_id`),
+ *     for the minority of analyses that need per-install granularity.
  *   - `download_token` (TODO): web → desktop acquisition bridge.
  *   - `user_id`: set on login via `bindUserId`. The ONLY `client.identify()`
  *     call. Aliases `installation_id` → `user_id` (now merges, since the anon
@@ -769,6 +775,20 @@ export function capture(event: string, properties: TelemetryContext = {}): void 
   if (!_checkRateLimit(event)) return
   _eventsCapturedThisProcess++
   try {
+    // `installation_id` is the MACHINE key (SHA-256 device hash, set as a
+    // default at identify()). Many call sites pass a per-INSTALL record id
+    // (`inst-<ts>`, from installations.json) under installation_id, which would
+    // override the machine default and split the field's meaning (machine on
+    // renderer events, install-record on main) so they can't join. Enforce the
+    // invariant here, in one place: installation_id is ALWAYS the machine id; a
+    // per-call value is redirected to `install_id`, preserved for the few
+    // analyses that need per-install granularity (e.g. multi-install machines).
+    let perCall = properties
+    const callInstallId = properties.installation_id
+    if (callInstallId != null && callInstallId !== defaultEventProperties.installation_id) {
+      const { installation_id: _movedToInstallId, ...rest } = properties
+      perCall = { ...rest, install_id: callInstallId }
+    }
     // Per-call properties override defaults on key collision — callers
     // that explicitly pass `app_version` (e.g. session-start payload,
     // legacy event re-emitters) win.
@@ -776,7 +796,7 @@ export function capture(event: string, properties: TelemetryContext = {}): void 
     // to derive country (`disableGeoip: false` at init). The raw IP and all
     // sub-country geo are then discarded by an ingestion transformation, so
     // only the country code/name is retained. See the init comment.
-    const merged = { ...defaultEventProperties, ...properties }
+    const merged = { ...defaultEventProperties, ...perCall }
     client!.capture({
       distinctId,
       event,


### PR DESCRIPTION
## Quick Read

`installation_id` is documented as the **machine** key (`SHA-256(machine_id+salt)`, one per machine). But ~24 main-process emit sites pass the **per-install record id** (`inst-<ts>`, from `installations.json`) *as* `installation_id`, which overrides the machine-id default. So the field means **machine** on renderer/onboarding events and **install-record** on main events — they share no value, so the **install → boot → canvas funnel can't join on it** even after v1.0.24 stamped the machine id everywhere.

This fixes it in **one place**: `capture()` now guarantees `installation_id` is always the machine id, and redirects any per-call install id to a secondary `install_id`.

## The bug (audited)

- `identify()` correctly sets `defaultEventProperties.installation_id = machine_id`.
- ~24 main emit sites then pass `installation_id: installationId` where `installationId` is the `inst-<ts>` record id (`boot_started/completed/failed`, `canvas_rendered`, `install.completed`, `install.phase`, `execution.*`, `snapshot.*`, `op.result`, …). Per-call props win the merge → the machine default is overwritten.
- Result, confirmed in prod data: renderer events carry a 64-char SHA-256; main events carry `inst-<ts>`; cross-boundary overlap is **0** (`method.selected → install.completed` = 0/239). The funnel reads ~100% false drop at the install boundary.

## The fix

In `capture()`, before merging defaults:
```ts
const callInstallId = properties.installation_id
if (callInstallId != null && callInstallId !== defaultEventProperties.installation_id) {
  const { installation_id: _movedToInstallId, ...rest } = properties
  perCall = { ...rest, install_id: callInstallId }
}
```
- `installation_id` is **always** the machine id (the documented invariant, now enforced).
- A per-call install id is preserved as `install_id` — available for the minority of per-install analyses (multi-install machines, `instance.switched`), just not overloaded onto the canonical key.
- An explicit machine id (== default) is left as-is; no `install_id` introduced.

## Why central, not 24 call sites

The bug exists *because* call sites can override `installation_id`. Fixing 24 sites is large, error-prone, and a 25th site re-breaks it. Enforcing the invariant in the single capture path makes it complete and self-protecting. Header identity-model doc updated to match.

## Scope / what to know

- **What changes:** every main event's `installation_id` flips from `inst-<ts>` to the machine hash; the install id rides along as `install_id`.
- **`boot_id`** (per-launch, #1156) and **`user_id`** (per-person, login) are untouched — different scopes, different purposes.
- **Dashboards:** funnels keyed on `installation_id` become true **per-machine** (e.g. "weekly active machines" stops counting installs, drops the multi-install over-count). Any query that genuinely wanted per-install switches to `install_id`. Most analyses want per-machine, so this is the intended direction.
- **Rollout-gated**, like the other v1.0.x telemetry: takes effect on the build carrying it; older builds keep the split.

## Testing

`telemetry.test.ts`: a per-install id under `installation_id` is redirected to `install_id` while `installation_id` stays the machine id; a renderer event (no install id) and an explicit-machine-id event are left untouched. 76 telemetry tests green; eslint + typecheck clean on the changed file.

## Related

Completes the desktop identity-stitch line (#1147 stamped the machine id as a default; #1156 added `boot_id`). This is the last blocker on a clean, single-key install → boot → canvas funnel.
