### PR TITLE
fix(telemetry): parse ComfyUI Desktop [LEVEL]-prefixed logs (hardware + execution events)

### DIFF
--- a/src/main/lib/executionTap.test.ts
+++ b/src/main/lib/executionTap.test.ts
@@ -55,14 +55,14 @@ describe('executionTap', () => {
     expect(err!.ctx).toMatchObject({ error_class: 'validation_failed', node_id: '42' })
   })
 
-  it('parses ComfyUI Desktop log lines carrying a [LEVEL] prefix', () => {
-    // ComfyUI Desktop's bundled build logs as `[INFO] got prompt` /
-    // `[INFO] Prompt executed in …` / `[ERROR] Failed to validate …`, not the
-    // bare strings the anchored patterns expect.
+  it('parses current ComfyUI log lines carrying a colored [LEVEL] prefix', () => {
+    // ComfyUI's ColoredFormatter emits `\x1b[32m[INFO]\x1b[0m got prompt` etc.,
+    // not the bare strings the anchored patterns expect — ANSI must be stripped
+    // before the level tag for the funnel events to fire.
     const tap = createExecutionTap({ installationId: 'inst-1' })
-    tap.ingest('[INFO] got prompt\n', 'stdout')
-    tap.ingest('[INFO] Prompt executed in 7.78 seconds\n', 'stdout')
-    tap.ingest('[ERROR] Failed to validate prompt for output 9:\n', 'stdout')
+    tap.ingest('\u001b[32m[INFO]\u001b[0m got prompt\n', 'stdout')
+    tap.ingest('\u001b[32m[INFO]\u001b[0m Prompt executed in 7.78 seconds\n', 'stdout')
+    tap.ingest('\u001b[1m\u001b[31m[ERROR]\u001b[0m Failed to validate prompt for output 9:\n', 'stdout')
 
     const started = captured.find((c) => c.event === 'comfy.desktop.execution.started')
     expect(started).toBeDefined()

--- a/src/main/lib/executionTap.test.ts
+++ b/src/main/lib/executionTap.test.ts
@@ -55,6 +55,23 @@ describe('executionTap', () => {
     expect(err!.ctx).toMatchObject({ error_class: 'validation_failed', node_id: '42' })
   })
 
+  it('parses ComfyUI Desktop log lines carrying a [LEVEL] prefix', () => {
+    // ComfyUI Desktop's bundled build logs as `[INFO] got prompt` /
+    // `[INFO] Prompt executed in …` / `[ERROR] Failed to validate …`, not the
+    // bare strings the anchored patterns expect.
+    const tap = createExecutionTap({ installationId: 'inst-1' })
+    tap.ingest('[INFO] got prompt\n', 'stdout')
+    tap.ingest('[INFO] Prompt executed in 7.78 seconds\n', 'stdout')
+    tap.ingest('[ERROR] Failed to validate prompt for output 9:\n', 'stdout')
+
+    const started = captured.find((c) => c.event === 'comfy.desktop.execution.started')
+    expect(started).toBeDefined()
+    const completed = captured.find((c) => c.event === 'comfy.desktop.execution.completed')
+    expect(completed!.ctx).toMatchObject({ duration_seconds: 7.78, completed_count: 1 })
+    const err = captured.find((c) => c.event === 'comfy.desktop.execution.error')
+    expect(err!.ctx).toMatchObject({ error_class: 'validation_failed', node_id: '9' })
+  })
+
   it('captures Python tracebacks from stderr and emits a single error', () => {
     const tap = createExecutionTap({ installationId: 'inst-1' })
     // Trailing line after the blank-line boundary so the parser sees the

--- a/src/main/lib/executionTap.ts
+++ b/src/main/lib/executionTap.ts
@@ -25,6 +25,7 @@
  */
 import * as installationsApi from '../installations'
 import * as telemetry from './telemetry'
+import { stripLogLevelPrefix } from './stderrTail'
 import { scrubAll } from '../../shared/piiScrub'
 
 /**
@@ -177,7 +178,11 @@ export function createExecutionTap(opts: {
   }
 
   function handleNewLine(line: string, source: 'stdout' | 'stderr'): void {
-    const trimmed = line.trim()
+    // `got prompt` / `Prompt executed in …` / `Failed to validate …` are
+    // logging-formatted, so on ComfyUI Desktop they arrive with a `[LEVEL] `
+    // tag the anchored patterns below don't expect. Strip it. Raw tracebacks
+    // have no tag, so TRACEBACK_START detection is unaffected.
+    const trimmed = stripLogLevelPrefix(line.trim())
 
     if (trimmed.length === 0) return
 

--- a/src/main/lib/executionTap.ts
+++ b/src/main/lib/executionTap.ts
@@ -25,7 +25,7 @@
  */
 import * as installationsApi from '../installations'
 import * as telemetry from './telemetry'
-import { stripLogLevelPrefix } from './stderrTail'
+import { stripAnsi, stripLogLevelPrefix } from './stderrTail'
 import { scrubAll } from '../../shared/piiScrub'
 
 /**
@@ -179,10 +179,11 @@ export function createExecutionTap(opts: {
 
   function handleNewLine(line: string, source: 'stdout' | 'stderr'): void {
     // `got prompt` / `Prompt executed in …` / `Failed to validate …` are
-    // logging-formatted, so on ComfyUI Desktop they arrive with a `[LEVEL] `
-    // tag the anchored patterns below don't expect. Strip it. Raw tracebacks
-    // have no tag, so TRACEBACK_START detection is unaffected.
-    const trimmed = stripLogLevelPrefix(line.trim())
+    // logging-formatted, so on current ComfyUI they arrive with a colored
+    // `\x1b[..m[LEVEL]\x1b[0m ` tag the anchored patterns below don't expect.
+    // Strip ANSI first, then the level tag. Raw Python tracebacks carry
+    // neither, so TRACEBACK_START detection is unaffected.
+    const trimmed = stripLogLevelPrefix(stripAnsi(line).trim())
 
     if (trimmed.length === 0) return
 

--- a/src/main/lib/hardwareTap.test.ts
+++ b/src/main/lib/hardwareTap.test.ts
@@ -157,16 +157,19 @@ describe('createHardwareTap', () => {
     })
   })
 
-  it('parses ComfyUI Desktop log lines carrying a [LEVEL] prefix', () => {
-    // ComfyUI Desktop's bundled build logs as `[INFO] <message>`, not the bare
-    // `%(message)s` the parsers are anchored against. The tap must strip the
-    // level tag so the accelerator + model-usage signals still fire.
+  it('parses current ComfyUI log lines carrying a colored [LEVEL] prefix', () => {
+    // ComfyUI's ColoredFormatter emits `\x1b[32m[INFO]\x1b[0m <message>`, not
+    // the bare `%(message)s` the parsers are anchored against. The tap must
+    // strip ANSI then the level tag for accelerator + model-usage to fire.
     const tap = createHardwareTap({ installationId: 'inst-1' })
-    tap.ingest('[INFO] Total VRAM 32607 MB, total RAM 97430 MB\n', 'stdout')
-    tap.ingest('[INFO] pytorch version: 2.10.0+cu130\n', 'stdout')
-    tap.ingest('[INFO] Device: cuda:0 NVIDIA GeForce RTX 5090 : cudaMallocAsync\n', 'stdout')
-    tap.ingest('[INFO] model weight dtype torch.bfloat16, manual cast: None\n', 'stdout')
-    tap.ingest('[INFO] model_type FLOW\n', 'stdout')
+    tap.ingest('\u001b[32m[INFO]\u001b[0m Total VRAM 32607 MB, total RAM 97430 MB\n', 'stdout')
+    tap.ingest('\u001b[32m[INFO]\u001b[0m pytorch version: 2.10.0+cu130\n', 'stdout')
+    tap.ingest(
+      '\u001b[32m[INFO]\u001b[0m Device: cuda:0 NVIDIA GeForce RTX 5090 : cudaMallocAsync\n',
+      'stdout'
+    )
+    tap.ingest('\u001b[32m[INFO]\u001b[0m model weight dtype torch.bfloat16, manual cast: None\n', 'stdout')
+    tap.ingest('\u001b[32m[INFO]\u001b[0m model_type FLOW\n', 'stdout')
 
     const accel = captured.filter((c) => c.event === 'comfy.desktop.comfyui.accelerator_detected')
     expect(accel).toHaveLength(1)

--- a/src/main/lib/hardwareTap.test.ts
+++ b/src/main/lib/hardwareTap.test.ts
@@ -157,6 +157,38 @@ describe('createHardwareTap', () => {
     })
   })
 
+  it('parses ComfyUI Desktop log lines carrying a [LEVEL] prefix', () => {
+    // ComfyUI Desktop's bundled build logs as `[INFO] <message>`, not the bare
+    // `%(message)s` the parsers are anchored against. The tap must strip the
+    // level tag so the accelerator + model-usage signals still fire.
+    const tap = createHardwareTap({ installationId: 'inst-1' })
+    tap.ingest('[INFO] Total VRAM 32607 MB, total RAM 97430 MB\n', 'stdout')
+    tap.ingest('[INFO] pytorch version: 2.10.0+cu130\n', 'stdout')
+    tap.ingest('[INFO] Device: cuda:0 NVIDIA GeForce RTX 5090 : cudaMallocAsync\n', 'stdout')
+    tap.ingest('[INFO] model weight dtype torch.bfloat16, manual cast: None\n', 'stdout')
+    tap.ingest('[INFO] model_type FLOW\n', 'stdout')
+
+    const accel = captured.filter((c) => c.event === 'comfy.desktop.comfyui.accelerator_detected')
+    expect(accel).toHaveLength(1)
+    expect(accel[0]!.ctx).toMatchObject({
+      device_type: 'cuda',
+      device_index: 0,
+      gpu_model: 'NVIDIA GeForce RTX 5090',
+      backend: 'cudaMallocAsync',
+      vram_mb: 32607,
+      pytorch_version: '2.10.0+cu130'
+    })
+
+    tap.flushSummary()
+    const usage = captured.filter((c) => c.event === 'comfy.desktop.comfyui.model_usage')
+    expect(usage).toHaveLength(1)
+    expect(usage[0]!.ctx).toMatchObject({
+      model_type: 'FLOW',
+      count: 1,
+      dtype: 'torch.bfloat16'
+    })
+  })
+
   it('detects a complete Device line even in an oversized chunk', () => {
     // A single large stdout chunk: complete metadata + Device lines, then a
     // huge unterminated tail. The buffer cap must only trim the tail, never

--- a/src/main/lib/hardwareTap.ts
+++ b/src/main/lib/hardwareTap.ts
@@ -39,7 +39,7 @@
  * strips a leading `[LEVEL] ` tag before matching so both formats parse.
  */
 import * as telemetry from './telemetry'
-import { stripAnsi } from './stderrTail'
+import { stripAnsi, stripLogLevelPrefix } from './stderrTail'
 
 export interface AcceleratorInfo {
   deviceType: string
@@ -176,13 +176,9 @@ export function createHardwareTap(opts: {
   }
 
   function handleLine(line: string): void {
-    // ComfyUI Desktop's bundled build logs with a `[LEVEL] ` prefix (e.g.
-    // `[INFO] Device: ...`), unlike the bare `%(message)s` format the parsers
-    // below are anchored against. Strip an optional leading level tag so a
-    // prefixed line still matches.
-    const trimmed = stripAnsi(line)
-      .trim()
-      .replace(/^\[[A-Z]+\]\s+/, '')
+    // Strip a leading `[LEVEL] ` tag (ComfyUI Desktop's bundled build) so the
+    // anchored parsers below match both the prefixed and bare log formats.
+    const trimmed = stripLogLevelPrefix(stripAnsi(line).trim())
     if (trimmed.length === 0) return
 
     if (!acceleratorEmitted) {

--- a/src/main/lib/hardwareTap.ts
+++ b/src/main/lib/hardwareTap.ts
@@ -33,6 +33,10 @@
  *
  * NOTE: there is no literal "loading SDXL model" string in ComfyUI; the
  * architecture surfaces as `model_type <NAME>` (EPS / FLUX / FLOW / ...).
+ *
+ * NOTE: ComfyUI Desktop's bundled build prefixes every log line with a level
+ * tag (`[INFO] Device: ...`), unlike the bare `%(message)s` format. `handleLine`
+ * strips a leading `[LEVEL] ` tag before matching so both formats parse.
  */
 import * as telemetry from './telemetry'
 import { stripAnsi } from './stderrTail'
@@ -172,7 +176,13 @@ export function createHardwareTap(opts: {
   }
 
   function handleLine(line: string): void {
-    const trimmed = stripAnsi(line).trim()
+    // ComfyUI Desktop's bundled build logs with a `[LEVEL] ` prefix (e.g.
+    // `[INFO] Device: ...`), unlike the bare `%(message)s` format the parsers
+    // below are anchored against. Strip an optional leading level tag so a
+    // prefixed line still matches.
+    const trimmed = stripAnsi(line)
+      .trim()
+      .replace(/^\[[A-Z]+\]\s+/, '')
     if (trimmed.length === 0) return
 
     if (!acceleratorEmitted) {

--- a/src/main/lib/stderrTail.test.ts
+++ b/src/main/lib/stderrTail.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { lastNLines, stripAnsi } from './stderrTail'
+import { lastNLines, stripAnsi, stripLogLevelPrefix } from './stderrTail'
 
 describe('stripAnsi', () => {
   it('removes color codes', () => {
@@ -12,6 +12,29 @@ describe('stripAnsi', () => {
 
   it('leaves plain text unchanged', () => {
     expect(stripAnsi('no codes here')).toBe('no codes here')
+  })
+})
+
+describe('stripLogLevelPrefix', () => {
+  it('strips a leading [LEVEL] tag (ComfyUI Desktop format)', () => {
+    expect(stripLogLevelPrefix('[INFO] Device: cuda:0')).toBe('Device: cuda:0')
+    expect(stripLogLevelPrefix('[ERROR] Failed to validate prompt for output 9:')).toBe(
+      'Failed to validate prompt for output 9:'
+    )
+  })
+
+  it('leaves bare lines unchanged (ComfyUI source format)', () => {
+    expect(stripLogLevelPrefix('got prompt')).toBe('got prompt')
+  })
+
+  it('does not touch a raw Python traceback line', () => {
+    expect(stripLogLevelPrefix('Traceback (most recent call last):')).toBe(
+      'Traceback (most recent call last):'
+    )
+  })
+
+  it('only strips a leading tag, not a bracket mid-line', () => {
+    expect(stripLogLevelPrefix('model_type [INFO]')).toBe('model_type [INFO]')
   })
 })
 

--- a/src/main/lib/stderrTail.ts
+++ b/src/main/lib/stderrTail.ts
@@ -8,3 +8,14 @@ export function stripAnsi(text: string): string {
 export function lastNLines(text: string, n: number): string {
   return text.split('\n').slice(-n).join('\n')
 }
+
+// ComfyUI Desktop's bundled build logs every line with a level tag
+// (`[INFO] Device: ...`, `[ERROR] Failed to validate ...`), unlike ComfyUI's
+// source default (`%(message)s`, no prefix). Log-line parsers anchored at `^`
+// must strip this tag first or they silently match nothing on Desktop. A
+// raw Python traceback (no logging format) has no tag, so this is a no-op there.
+const LOG_LEVEL_PREFIX_RE = /^\[[A-Z]+\]\s+/
+
+export function stripLogLevelPrefix(text: string): string {
+  return text.replace(LOG_LEVEL_PREFIX_RE, '')
+}


### PR DESCRIPTION
## Summary

Follow-up fix to #1165. Several ComfyUI-log-derived telemetry events **never fire in real installs** because their parsers assume ComfyUI's source log format.

### Root cause

ComfyUI Desktop's bundled build logs every line with a level tag, e.g.:

```
[INFO] Total VRAM 32607 MB, total RAM 97430 MB
[INFO] Device: cuda:0 NVIDIA GeForce RTX 5090 : cudaMallocAsync
[INFO] model_type FLOW
[INFO] got prompt
[INFO] Prompt executed in 7.78 seconds
[ERROR] Failed to validate prompt for output 9:
```

ComfyUI's source default is `logging.Formatter("%(message)s")` (no prefix). The taps' parsers are anchored at line start (`/^Device:/`, `/^model_type/`, `/^got prompt/`, `/^Prompt executed in/`, `/^Failed to validate/`, ...), so they never match `[INFO] …` / `[ERROR] …` and silently emit nothing.

`comfy.desktop.comfyui.boot_started` / `boot_completed` are not log-derived, and the boot-progress parsers use **unanchored** substring matches, so those kept arriving in PostHog — which is what made the gap easy to miss. Confirmed against `1.0.25-rc.*`.

### Events restored

- **hardwareTap:** `comfy.desktop.comfyui.accelerator_detected`, `comfy.desktop.comfyui.model_usage`
- **executionTap:** `comfy.desktop.execution.started`, `comfy.desktop.execution.completed`, `comfy.desktop.execution.first_completed`, `comfy.desktop.execution.session_summary`, and the validation path of `comfy.desktop.execution.error`

Traceback-based `execution.error` was unaffected — raw Python tracebacks are not logging-formatted (no tag), so `/^Traceback/` still matches.

### Fix

Extract a shared `stripLogLevelPrefix()` helper in `stderrTail.ts` and apply it at the line-handling chokepoint of both taps, so both the prefixed Desktop format and the bare `%(message)s` format parse. The exported pure parsers are unchanged.

### Verification

- New regression tests drive the real Desktop `[INFO] ` / `[ERROR] `-prefixed lines through each tap (`hardwareTap`, `executionTap`) plus unit tests for the helper.
- 47 tests pass across `stderrTail` / `hardwareTap` / `executionTap`; full `typecheck` + `lint` green via pre-commit.

> [!NOTE]
> Existing `1.0.25-rc` builds in the field stay missing these events until a build ships with this fix.
