### PR TITLE
feat(telemetry): loaded model-class usage, full GPU/AMD/Intel/DirectML accelerator detection, reconstructable snapshot inventory, and reliable main-process session events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-desktop-2",
-  "version": "1.0.25-rc.4",
+  "version": "1.0.25-rc.5",
   "description": "Comfy Desktop",
   "author": {
     "name": "Comfy Org",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-desktop-2",
-  "version": "1.0.25-rc.7",
+  "version": "1.0.25-rc.8",
   "description": "Comfy Desktop",
   "author": {
     "name": "Comfy Org",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-desktop-2",
-  "version": "1.0.25-rc.6",
+  "version": "1.0.25-rc.7",
   "description": "Comfy Desktop",
   "author": {
     "name": "Comfy Org",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-desktop-2",
-  "version": "1.0.25-rc.5",
+  "version": "1.0.25-rc.6",
   "description": "Comfy Desktop",
   "author": {
     "name": "Comfy Org",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -51,6 +51,7 @@ import { hasActiveTemplateDownloads, getTemplateDownloadState } from './sources/
 import { isTerminal as isTemplateDownloadTerminal } from './sources/standalone/templateDownloadCore'
 import { registerAssetDownloadHandlers } from './lib/ipc/registerAssetDownloadHandlers'
 import { registerDownloadHandlers } from './lib/ipc/registerDownloadHandlers'
+import { emitInstanceStartedTelemetry } from './lib/ipc/sessionStartTelemetry'
 import {
   get as getInstallation,
   installationEvents,
@@ -2039,6 +2040,9 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
       onLaunch,
       onStop,
       onComfyExited,
+      onInstanceStarted: (info) => {
+        void emitInstanceStartedTelemetry(info)
+      },
       onComfyRestarted,
       onModelFolderRelaunch,
       onLocaleChanged: updateTrayMenu,

--- a/src/main/lib/gpu.test.ts
+++ b/src/main/lib/gpu.test.ts
@@ -5,6 +5,7 @@ import {
   selectPrimaryGpu,
   parseAmdSmiDriverVersion,
   parseRocmSmiDriverVersion,
+  parseWmiDriverVersions,
   type SystemGpuEntry
 } from './gpu'
 
@@ -176,5 +177,40 @@ describe('parseRocmSmiDriverVersion', () => {
   it('returns undefined when no driver version key is present', () => {
     expect(parseRocmSmiDriverVersion(JSON.stringify({ system: {} }))).toBeUndefined()
     expect(parseRocmSmiDriverVersion('not json')).toBeUndefined()
+  })
+})
+
+describe('parseWmiDriverVersions', () => {
+  it('parses an array of controllers, keyed by lowercased name', () => {
+    const out = JSON.stringify([
+      { Name: 'NVIDIA GeForce RTX 5090', DriverVersion: '32.0.15.9174' },
+      { Name: 'AMD Radeon(TM) Graphics', DriverVersion: '31.0.22044.1' }
+    ])
+    const map = parseWmiDriverVersions(out)
+    expect(map.get('nvidia geforce rtx 5090')).toBe('32.0.15.9174')
+    expect(map.get('amd radeon(tm) graphics')).toBe('31.0.22044.1')
+  })
+
+  it('parses a single bare object (ConvertTo-Json single-item shape)', () => {
+    const out = JSON.stringify({ Name: 'Intel Arc A770', DriverVersion: '31.0.101.5333' })
+    const map = parseWmiDriverVersions(out)
+    expect(map.get('intel arc a770')).toBe('31.0.101.5333')
+  })
+
+  it('skips entries with missing or blank driver versions', () => {
+    const out = JSON.stringify([
+      { Name: 'Real GPU', DriverVersion: '1.2.3.4' },
+      { Name: 'No Version' },
+      { Name: 'Blank Version', DriverVersion: '   ' }
+    ])
+    const map = parseWmiDriverVersions(out)
+    expect(map.get('real gpu')).toBe('1.2.3.4')
+    expect(map.has('no version')).toBe(false)
+    expect(map.has('blank version')).toBe(false)
+  })
+
+  it('returns an empty map for malformed or empty output', () => {
+    expect(parseWmiDriverVersions('not json').size).toBe(0)
+    expect(parseWmiDriverVersions('').size).toBe(0)
   })
 })

--- a/src/main/lib/gpu.ts
+++ b/src/main/lib/gpu.ts
@@ -28,6 +28,23 @@ function pickGPU(hasNvidia: boolean, hasAmd: boolean, hasIntel: boolean): GpuId 
   return null
 }
 
+// Force UTF-8 stdout so adapter names with non-ASCII chars survive, and emit
+// compact JSON. Returns stdout, or null on spawn/timeout/non-zero exit.
+const PS_UTF8_PREFIX = "[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false); "
+
+function runPowershellJson(command: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    execFile(
+      "powershell.exe",
+      ["-NoProfile", "-NonInteractive", "-Command", PS_UTF8_PREFIX + command],
+      { timeout: 10000, windowsHide: true },
+      (err: Error | null, stdout: string) => {
+        resolve(err ? null : stdout)
+      },
+    )
+  })
+}
+
 /**
  * Detect GPU type, or null if no supported GPU is found.
  *   Windows: WMI vendor IDs, then nvidia-smi.
@@ -54,35 +71,28 @@ async function detectWindowsGPU(): Promise<GpuId | null> {
   return null
 }
 
-function queryWmiVendorIds(): Promise<GpuId | null> {
-  return new Promise((resolve) => {
-    execFile(
-      "powershell.exe",
-      ["-NoProfile", "-NonInteractive", "-Command",
-        '[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false); Get-CimInstance Win32_VideoController | Select-Object -ExpandProperty PNPDeviceID | ConvertTo-Json -Compress'],
-      { timeout: 10000, windowsHide: true },
-      (err: Error | null, stdout: string) => {
-        if (err) return resolve(null)
-        try {
-          const ids: unknown = JSON.parse(stdout)
-          const list: unknown[] = Array.isArray(ids) ? ids : [ids]
-          let hasNvidia = false, hasAmd = false, hasIntel = false
-          for (const id of list) {
-            if (typeof id !== "string") continue
-            const match = id.match(/ven_([0-9a-f]{4})/i)
-            if (!match || !match[1]) continue
-            const vendor = match[1].toUpperCase()
-            if (vendor === NVIDIA_VENDOR_ID) hasNvidia = true
-            else if (vendor === AMD_VENDOR_ID) hasAmd = true
-            else if (vendor === INTEL_VENDOR_ID) hasIntel = true
-          }
-          resolve(pickGPU(hasNvidia, hasAmd, hasIntel))
-        } catch {
-          resolve(null)
-        }
-      },
-    )
-  })
+async function queryWmiVendorIds(): Promise<GpuId | null> {
+  const stdout = await runPowershellJson(
+    "Get-CimInstance Win32_VideoController | Select-Object -ExpandProperty PNPDeviceID | ConvertTo-Json -Compress",
+  )
+  if (stdout === null) return null
+  try {
+    const ids: unknown = JSON.parse(stdout)
+    const list: unknown[] = Array.isArray(ids) ? ids : [ids]
+    let hasNvidia = false, hasAmd = false, hasIntel = false
+    for (const id of list) {
+      if (typeof id !== "string") continue
+      const match = id.match(/ven_([0-9a-f]{4})/i)
+      if (!match || !match[1]) continue
+      const vendor = match[1].toUpperCase()
+      if (vendor === NVIDIA_VENDOR_ID) hasNvidia = true
+      else if (vendor === AMD_VENDOR_ID) hasAmd = true
+      else if (vendor === INTEL_VENDOR_ID) hasIntel = true
+    }
+    return pickGPU(hasNvidia, hasAmd, hasIntel)
+  } catch {
+    return null
+  }
 }
 
 /**
@@ -121,18 +131,9 @@ export function parseWmiDriverVersions(stdout: string): Map<string, string> {
  */
 export function getWindowsGpuDriverVersions(): Promise<Map<string, string>> {
   if (process.platform !== "win32") return Promise.resolve(new Map())
-  return new Promise((resolve) => {
-    execFile(
-      "powershell.exe",
-      ["-NoProfile", "-NonInteractive", "-Command",
-        '[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false); Get-CimInstance Win32_VideoController | Select-Object Name,DriverVersion | ConvertTo-Json -Compress'],
-      { timeout: 10000, windowsHide: true },
-      (err: Error | null, stdout: string) => {
-        if (err) return resolve(new Map())
-        resolve(parseWmiDriverVersions(stdout))
-      },
-    )
-  })
+  return runPowershellJson(
+    "Get-CimInstance Win32_VideoController | Select-Object Name,DriverVersion | ConvertTo-Json -Compress",
+  ).then((stdout) => (stdout === null ? new Map() : parseWmiDriverVersions(stdout)))
 }
 
 function hasNvidiaSmi(): Promise<boolean> {

--- a/src/main/lib/gpu.ts
+++ b/src/main/lib/gpu.ts
@@ -85,6 +85,56 @@ function queryWmiVendorIds(): Promise<GpuId | null> {
   })
 }
 
+/**
+ * Parse `Win32_VideoController` Name/DriverVersion JSON into a name->version
+ * map (keys lowercased). `ConvertTo-Json` emits a bare object for a single
+ * controller and an array for several, so both shapes are handled.
+ */
+export function parseWmiDriverVersions(stdout: string): Map<string, string> {
+  const map = new Map<string, string>()
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(stdout)
+  } catch {
+    return map
+  }
+  const list: unknown[] = Array.isArray(parsed) ? parsed : [parsed]
+  for (const entry of list) {
+    if (!entry || typeof entry !== "object") continue
+    const rec = entry as Record<string, unknown>
+    const name = rec.Name
+    const version = rec.DriverVersion
+    if (typeof name === "string" && typeof version === "string" && version.trim()) {
+      map.set(name.toLowerCase(), version.trim())
+    }
+  }
+  return map
+}
+
+/**
+ * Map adapter name -> driver version from `Win32_VideoController`.
+ *
+ * `systeminformation` only fills `driverVersion` for NVIDIA on Windows (it
+ * enriches from nvidia-smi) and leaves AMD/Intel blank, even though WMI
+ * carries `DriverVersion` for every adapter. We read it directly so AMD/Intel
+ * driver telemetry is populated. Returns an empty map off-Windows or on error.
+ */
+export function getWindowsGpuDriverVersions(): Promise<Map<string, string>> {
+  if (process.platform !== "win32") return Promise.resolve(new Map())
+  return new Promise((resolve) => {
+    execFile(
+      "powershell.exe",
+      ["-NoProfile", "-NonInteractive", "-Command",
+        '[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false); Get-CimInstance Win32_VideoController | Select-Object Name,DriverVersion | ConvertTo-Json -Compress'],
+      { timeout: 10000, windowsHide: true },
+      (err: Error | null, stdout: string) => {
+        if (err) return resolve(new Map())
+        resolve(parseWmiDriverVersions(stdout))
+      },
+    )
+  })
+}
+
 function hasNvidiaSmi(): Promise<boolean> {
   return new Promise((resolve) => {
     execFile("nvidia-smi", { timeout: 5000, windowsHide: true }, (err: Error | null) => {

--- a/src/main/lib/hardwareTap.test.ts
+++ b/src/main/lib/hardwareTap.test.ts
@@ -141,15 +141,17 @@ describe('createHardwareTap', () => {
     vi.restoreAllMocks()
   })
 
-  it('emits accelerator_detected once on the first Device line, merging earlier lines', () => {
+  it('emits a single accelerator_detected for the whole Device run, merging earlier lines', () => {
     const tap = createHardwareTap({ installationId: 'inst-1' })
     tap.ingest('Set cuda device to: 0\n', 'stdout')
     tap.ingest('Total VRAM 24576 MB, total RAM 65461 MB\n', 'stdout')
     tap.ingest('pytorch version: 2.10.0+cu130\n', 'stdout')
     tap.ingest('xformers version: 0.0.31\n', 'stdout')
     tap.ingest('Device: cuda:0 NVIDIA GeForce RTX 4090 : native\n', 'stdout')
-    // A second Device line (other GPU) must NOT re-emit.
-    tap.ingest('Device: cuda:1 NVIDIA GeForce RTX 4090 : native\n', 'stdout')
+    // A second Device line (other GPU) is part of the SAME event, not a new one.
+    tap.ingest('Device: cuda:1 NVIDIA GeForce RTX 5090 : native\n', 'stdout')
+    // A non-Device line closes the run and triggers the single emit.
+    tap.ingest('Using xformers attention\n', 'stdout')
 
     const accel = captured.filter((c) => c.event === 'comfy.desktop.comfyui.accelerator_detected')
     expect(accel).toHaveLength(1)
@@ -159,6 +161,7 @@ describe('createHardwareTap', () => {
       device_index: 0,
       gpu_model: 'NVIDIA GeForce RTX 4090',
       backend: 'native',
+      device_count: 2,
       vram_mb: 24576,
       vram_gb: 24,
       ram_mb: 65461,
@@ -166,6 +169,14 @@ describe('createHardwareTap', () => {
       xformers_version: '0.0.31',
       cuda_device_set: 0
     })
+    // All devices reported as parallel arrays aligned by index.
+    expect(accel[0]!.ctx['device_types']).toEqual(['cuda', 'cuda'])
+    expect(accel[0]!.ctx['device_indices']).toEqual([0, 1])
+    expect(accel[0]!.ctx['gpu_models']).toEqual([
+      'NVIDIA GeForce RTX 4090',
+      'NVIDIA GeForce RTX 5090'
+    ])
+    expect(accel[0]!.ctx['device_backends']).toEqual(['native', 'native'])
   })
 
   it('parses current ComfyUI log lines carrying a colored [LEVEL] prefix', () => {
@@ -210,6 +221,7 @@ describe('createHardwareTap', () => {
     tap.ingest(
       'Total VRAM 24576 MB, total RAM 65461 MB\n' +
         'Device: cuda:0 NVIDIA GeForce RTX 4090 : native\n' +
+        'startup continues\n' +
         hugeTail,
       'stdout'
     )
@@ -223,20 +235,64 @@ describe('createHardwareTap', () => {
     const tap = createHardwareTap({ installationId: 'inst-1' })
     tap.ingest('Total VRAM 24576 MB, total RAM 65461 MB\n', 'stdout')
     tap.ingest('Device: cuda:0 NVIDIA GeForce RTX 4090 : native\n', 'stdout')
+    tap.flushSummary()
     expect(personProps).toContainEqual({
       comfyui_gpu_model: 'NVIDIA GeForce RTX 4090',
       comfyui_gpu_vram_gb: 24,
-      comfyui_device_type: 'cuda'
+      comfyui_device_type: 'cuda',
+      comfyui_gpu_count: 1
     })
   })
 
   it('does not promote a cpu device to gpu person properties', () => {
     const tap = createHardwareTap({ installationId: 'inst-1' })
     tap.ingest('Device: cpu\n', 'stdout')
+    tap.flushSummary()
     expect(personProps).toHaveLength(0)
     const accel = captured.filter((c) => c.event === 'comfy.desktop.comfyui.accelerator_detected')
     expect(accel).toHaveLength(1)
     expect(accel[0]!.ctx).toMatchObject({ device_type: 'cpu', gpu_model: null })
+  })
+
+  it('recovers the DirectML GPU name from the separate "Using directml" line', () => {
+    const tap = createHardwareTap({ installationId: 'inst-1' })
+    tap.ingest('Using directml with device: AMD Radeon RX 6800\n', 'stdout')
+    tap.ingest('Total VRAM 16384 MB, total RAM 32768 MB\n', 'stdout')
+    tap.ingest('Device: privateuseone\n', 'stdout')
+    tap.flushSummary()
+    const accel = captured.filter((c) => c.event === 'comfy.desktop.comfyui.accelerator_detected')
+    expect(accel).toHaveLength(1)
+    expect(accel[0]!.ctx).toMatchObject({
+      device_type: 'privateuseone',
+      gpu_model: 'AMD Radeon RX 6800'
+    })
+    expect(personProps).toContainEqual({
+      comfyui_gpu_model: 'AMD Radeon RX 6800',
+      comfyui_gpu_vram_gb: 16,
+      comfyui_device_type: 'privateuseone',
+      comfyui_gpu_count: 1
+    })
+  })
+
+  it('emits non-cuda accelerators (Intel xpu) without requiring a cuda device', () => {
+    const tap = createHardwareTap({ installationId: 'inst-1' })
+    tap.ingest('Total VRAM 16384 MB, total RAM 32768 MB\n', 'stdout')
+    tap.ingest('Device: xpu:0 Intel(R) Arc(TM) A770 Graphics\n', 'stdout')
+    tap.flushSummary()
+    const accel = captured.filter((c) => c.event === 'comfy.desktop.comfyui.accelerator_detected')
+    expect(accel).toHaveLength(1)
+    expect(accel[0]!.ctx).toMatchObject({
+      device_type: 'xpu',
+      device_index: 0,
+      gpu_model: 'Intel(R) Arc(TM) A770 Graphics',
+      device_count: 1
+    })
+    expect(personProps).toContainEqual({
+      comfyui_gpu_model: 'Intel(R) Arc(TM) A770 Graphics',
+      comfyui_gpu_vram_gb: 16,
+      comfyui_device_type: 'xpu',
+      comfyui_gpu_count: 1
+    })
   })
 
   it('aggregates model loads into per-class deltas flushed on session end', () => {
@@ -325,12 +381,14 @@ describe('createHardwareTap', () => {
     const tap = createHardwareTap({ installationId: 'inst-1' })
     tap.ingest('Total VRAM 24576 MB, total RAM 65461 MB\n', 'stdout')
     tap.ingest('Device: cuda:0 NVIDIA GeForce RTX 4090 : native\n', 'stdout')
+    tap.ingest('startup continues\n', 'stdout') // closes the run -> emit
     expect(
       captured.filter((c) => c.event === 'comfy.desktop.comfyui.accelerator_detected')
     ).toHaveLength(1)
 
-    // Simulate a restart: a stale Device line is ignored until beginBoot resets.
+    // A stale Device line after the run already emitted must NOT re-emit.
     tap.ingest('Device: cuda:0 NVIDIA GeForce RTX 4090 : native\n', 'stdout')
+    tap.ingest('more logs\n', 'stdout')
     expect(
       captured.filter((c) => c.event === 'comfy.desktop.comfyui.accelerator_detected')
     ).toHaveLength(1)
@@ -338,6 +396,7 @@ describe('createHardwareTap', () => {
     tap.beginBoot()
     tap.ingest('Total VRAM 16384 MB, total RAM 32768 MB\n', 'stdout')
     tap.ingest('Device: cuda:0 NVIDIA GeForce RTX 4080 : native\n', 'stdout')
+    tap.flushSummary() // closes the second boot's run
     const accel = captured.filter((c) => c.event === 'comfy.desktop.comfyui.accelerator_detected')
     expect(accel).toHaveLength(2)
     expect(accel[1]!.ctx).toMatchObject({ gpu_model: 'NVIDIA GeForce RTX 4080', vram_mb: 16384 })
@@ -367,6 +426,7 @@ describe('createHardwareTap', () => {
     const tap = createHardwareTap({ installationId: 'inst-1' })
     tap.ingest('Device: cuda:0 NVIDIA GeForce ', 'stdout')
     tap.ingest('RTX 4090 : native\n', 'stdout')
+    tap.flushSummary() // closes the run -> emit
     const accel = captured.filter((c) => c.event === 'comfy.desktop.comfyui.accelerator_detected')
     expect(accel).toHaveLength(1)
     expect(accel[0]!.ctx).toMatchObject({ gpu_model: 'NVIDIA GeForce RTX 4090' })

--- a/src/main/lib/hardwareTap.test.ts
+++ b/src/main/lib/hardwareTap.test.ts
@@ -15,8 +15,7 @@ const {
   createHardwareTap,
   parseDeviceLine,
   parseVramLine,
-  parseModelType,
-  parseWeightDtype
+  parseRequestedModelLoad
 } = await import('./hardwareTap')
 const telemetry = await import('./telemetry')
 
@@ -72,7 +71,7 @@ describe('parseDeviceLine', () => {
   })
 })
 
-describe('parseVramLine / parseModelType / parseWeightDtype', () => {
+describe('parseVramLine / parseRequestedModelLoad', () => {
   it('parses VRAM/RAM amounts', () => {
     expect(parseVramLine('Total VRAM 24576 MB, total RAM 65461 MB')).toEqual({
       vramMb: 24576,
@@ -81,28 +80,19 @@ describe('parseVramLine / parseModelType / parseWeightDtype', () => {
     expect(parseVramLine('nope')).toBeNull()
   })
 
-  it('parses model_type architecture name', () => {
-    expect(parseModelType('model_type FLUX')).toBe('FLUX')
-    expect(parseModelType('model_type EPS')).toBe('EPS')
-    expect(parseModelType('model_type V_PREDICTION')).toBe('V_PREDICTION')
-    expect(parseModelType('something else')).toBeNull()
+  it('parses the loaded model class name', () => {
+    expect(parseRequestedModelLoad('Requested to load Lumina2')).toBe('Lumina2')
+    expect(parseRequestedModelLoad('Requested to load ZImageTEModel_')).toBe('ZImageTEModel_')
+    expect(parseRequestedModelLoad('Requested to load AutoencodingEngine')).toBe(
+      'AutoencodingEngine'
+    )
+    expect(parseRequestedModelLoad('something else')).toBeNull()
   })
 
-  it('rejects non-enum model_type tokens (paths, filenames, lowercase)', () => {
-    expect(parseModelType('model_type C:\\Users\\me\\secret.safetensors')).toBeNull()
-    expect(parseModelType('model_type my-private-model.safetensors')).toBeNull()
-    expect(parseModelType('model_type flux')).toBeNull()
-    expect(parseModelType('model_type FLUX extra trailing words')).toBeNull()
-  })
-
-  it('parses weight dtype', () => {
-    expect(parseWeightDtype('model weight dtype torch.float16, manual cast: None')).toBe(
-      'torch.float16'
-    )
-    expect(parseWeightDtype('model weight dtype torch.bfloat16, manual cast: torch.float32')).toBe(
-      'torch.bfloat16'
-    )
-    expect(parseWeightDtype('no dtype here')).toBeNull()
+  it('rejects non-identifier load tokens (paths, filenames, trailing words)', () => {
+    expect(parseRequestedModelLoad('Requested to load C:\\Users\\me\\secret.safetensors')).toBeNull()
+    expect(parseRequestedModelLoad('Requested to load my-private-model.safetensors')).toBeNull()
+    expect(parseRequestedModelLoad('Requested to load Lumina2 and free memory')).toBeNull()
   })
 })
 
@@ -168,8 +158,7 @@ describe('createHardwareTap', () => {
       '\u001b[32m[INFO]\u001b[0m Device: cuda:0 NVIDIA GeForce RTX 5090 : cudaMallocAsync\n',
       'stdout'
     )
-    tap.ingest('\u001b[32m[INFO]\u001b[0m model weight dtype torch.bfloat16, manual cast: None\n', 'stdout')
-    tap.ingest('\u001b[32m[INFO]\u001b[0m model_type FLOW\n', 'stdout')
+    tap.ingest('\u001b[32m[INFO]\u001b[0m Requested to load Lumina2\n', 'stdout')
 
     const accel = captured.filter((c) => c.event === 'comfy.desktop.comfyui.accelerator_detected')
     expect(accel).toHaveLength(1)
@@ -186,9 +175,8 @@ describe('createHardwareTap', () => {
     const usage = captured.filter((c) => c.event === 'comfy.desktop.comfyui.model_usage')
     expect(usage).toHaveLength(1)
     expect(usage[0]!.ctx).toMatchObject({
-      model_type: 'FLOW',
-      count: 1,
-      dtype: 'torch.bfloat16'
+      model_class: 'Lumina2',
+      count: 1
     })
   })
 
@@ -230,41 +218,45 @@ describe('createHardwareTap', () => {
     expect(accel[0]!.ctx).toMatchObject({ device_type: 'cpu', gpu_model: null })
   })
 
-  it('aggregates model loads into per-arch deltas flushed on session end', () => {
+  it('aggregates model loads into per-class deltas flushed on session end', () => {
     const tap = createHardwareTap({ installationId: 'inst-1' })
-    tap.ingest('model weight dtype torch.float16, manual cast: None\nmodel_type FLUX\n', 'stdout')
-    tap.ingest('model_type FLUX\n', 'stdout')
-    tap.ingest('model weight dtype torch.float16, manual cast: None\nmodel_type EPS\n', 'stdout')
+    tap.ingest('Requested to load Lumina2\n', 'stdout')
+    tap.ingest('Requested to load Lumina2\n', 'stdout')
+    tap.ingest('Requested to load AutoencodingEngine\n', 'stdout')
     // Nothing emitted until flush.
     expect(captured.filter((c) => c.event === 'comfy.desktop.comfyui.model_usage')).toHaveLength(0)
 
     tap.flushSummary()
     const usage = captured.filter((c) => c.event === 'comfy.desktop.comfyui.model_usage')
     expect(usage).toHaveLength(2)
-    expect(usage.find((u) => u.ctx['model_type'] === 'FLUX')!.ctx).toMatchObject({
-      count: 2,
-      dtype: 'torch.float16'
+    expect(usage.find((u) => u.ctx['model_class'] === 'Lumina2')!.ctx).toMatchObject({
+      count: 2
     })
-    expect(usage.find((u) => u.ctx['model_type'] === 'EPS')!.ctx).toMatchObject({ count: 1 })
+    expect(usage.find((u) => u.ctx['model_class'] === 'AutoencodingEngine')!.ctx).toMatchObject({
+      count: 1
+    })
   })
 
   it('flushes deltas: a second flush only reports loads since the first', () => {
     const tap = createHardwareTap({ installationId: 'inst-1' })
-    tap.ingest('model_type FLUX\n', 'stdout')
+    tap.ingest('Requested to load Lumina2\n', 'stdout')
     tap.flushSummary()
-    tap.ingest('model_type FLUX\nmodel_type FLUX\n', 'stdout')
+    tap.ingest('Requested to load Lumina2\nRequested to load Lumina2\n', 'stdout')
     tap.flushSummary()
     const usage = captured.filter((c) => c.event === 'comfy.desktop.comfyui.model_usage')
     expect(usage.map((u) => u.ctx['count'])).toEqual([1, 2])
   })
 
-  it('writes a per-person $set_once marker the first time each arch is seen', () => {
+  it('writes a per-person $set_once marker the first time each class is seen', () => {
     const tap = createHardwareTap({ installationId: 'inst-1' })
-    tap.ingest('model_type FLUX\nmodel_type FLUX\nmodel_type EPS\n', 'stdout')
-    // One marker per distinct arch, not per load.
+    tap.ingest(
+      'Requested to load Lumina2\nRequested to load Lumina2\nRequested to load ZImageTEModel_\n',
+      'stdout'
+    )
+    // One marker per distinct class, not per load.
     expect(personPropsOnce).toHaveLength(2)
-    expect(Object.keys(personPropsOnce[0]!)[0]).toBe('used_model_flux_at')
-    expect(Object.keys(personPropsOnce[1]!)[0]).toBe('used_model_eps_at')
+    expect(Object.keys(personPropsOnce[0]!)[0]).toBe('used_model_lumina2_at')
+    expect(Object.keys(personPropsOnce[1]!)[0]).toBe('used_model_zimagetemodel__at')
   })
 
   it('re-emits accelerator_detected after beginBoot (ComfyUI restart in one launch)', () => {
@@ -291,22 +283,22 @@ describe('createHardwareTap', () => {
 
   it('preserves model-usage counts across beginBoot (aggregate per launch)', () => {
     const tap = createHardwareTap({ installationId: 'inst-1' })
-    tap.ingest('model_type FLUX\n', 'stdout')
+    tap.ingest('Requested to load Lumina2\n', 'stdout')
     tap.beginBoot()
-    tap.ingest('model_type FLUX\n', 'stdout')
+    tap.ingest('Requested to load Lumina2\n', 'stdout')
     tap.flushSummary()
     const usage = captured.filter((c) => c.event === 'comfy.desktop.comfyui.model_usage')
     expect(usage).toHaveLength(1)
-    expect(usage[0]!.ctx).toMatchObject({ model_type: 'FLUX', count: 2 })
+    expect(usage[0]!.ctx).toMatchObject({ model_class: 'Lumina2', count: 2 })
   })
 
-  it('flushes a trailing unterminated model_type line on session end', () => {
+  it('flushes a trailing unterminated load line on session end', () => {
     const tap = createHardwareTap({ installationId: 'inst-1' })
-    tap.ingest('model_type FLUX', 'stdout') // no newline
+    tap.ingest('Requested to load Lumina2', 'stdout') // no newline
     tap.flushSummary()
     const usage = captured.filter((c) => c.event === 'comfy.desktop.comfyui.model_usage')
     expect(usage).toHaveLength(1)
-    expect(usage[0]!.ctx).toMatchObject({ model_type: 'FLUX', count: 1 })
+    expect(usage[0]!.ctx).toMatchObject({ model_class: 'Lumina2', count: 1 })
   })
 
   it('handles lines split across chunk boundaries', () => {
@@ -322,26 +314,26 @@ describe('createHardwareTap', () => {
     const tap = createHardwareTap({ installationId: 'inst-1' })
     // Interleaved partial lines from two streams must not be concatenated into
     // a bogus combined line; each stream's buffer completes independently.
-    tap.ingest('model_type ', 'stdout')
+    tap.ingest('Requested to load ', 'stdout')
     tap.ingest('some unrelated stderr noise\n', 'stderr')
-    tap.ingest('FLUX\n', 'stdout')
+    tap.ingest('Lumina2\n', 'stdout')
     tap.flushSummary()
     const usage = captured.filter((c) => c.event === 'comfy.desktop.comfyui.model_usage')
     expect(usage).toHaveLength(1)
-    expect(usage[0]!.ctx).toMatchObject({ model_type: 'FLUX', count: 1 })
+    expect(usage[0]!.ctx).toMatchObject({ model_class: 'Lumina2', count: 1 })
   })
 
   it('flushes trailing unterminated lines from both stdout and stderr', () => {
     const tap = createHardwareTap({ installationId: 'inst-1' })
-    tap.ingest('model_type FLUX', 'stdout') // no newline
-    tap.ingest('model_type EPS', 'stderr') // no newline
+    tap.ingest('Requested to load Lumina2', 'stdout') // no newline
+    tap.ingest('Requested to load Flux', 'stderr') // no newline
     tap.flushSummary()
     const usage = captured.filter((c) => c.event === 'comfy.desktop.comfyui.model_usage')
     expect(usage).toContainEqual(
-      expect.objectContaining({ ctx: expect.objectContaining({ model_type: 'FLUX', count: 1 }) })
+      expect.objectContaining({ ctx: expect.objectContaining({ model_class: 'Lumina2', count: 1 }) })
     )
     expect(usage).toContainEqual(
-      expect.objectContaining({ ctx: expect.objectContaining({ model_type: 'EPS', count: 1 }) })
+      expect.objectContaining({ ctx: expect.objectContaining({ model_class: 'Flux', count: 1 }) })
     )
   })
 })

--- a/src/main/lib/hardwareTap.test.ts
+++ b/src/main/lib/hardwareTap.test.ts
@@ -15,7 +15,9 @@ const {
   createHardwareTap,
   parseDeviceLine,
   parseVramLine,
-  parseRequestedModelLoad
+  parseRequestedModelLoad,
+  parseDynamicVramPrepare,
+  parseModelLoad
 } = await import('./hardwareTap')
 const telemetry = await import('./telemetry')
 
@@ -94,25 +96,44 @@ describe('parseVramLine / parseRequestedModelLoad', () => {
     expect(parseRequestedModelLoad('Requested to load my-private-model.safetensors')).toBeNull()
     expect(parseRequestedModelLoad('Requested to load Lumina2 and free memory')).toBeNull()
   })
+
+  it('parses the dynamic-VRAM prepare class name', () => {
+    expect(
+      parseDynamicVramPrepare(
+        'Model Lumina2 prepared for dynamic VRAM loading. 11738MB Staged. 0 patches attached.'
+      )
+    ).toBe('Lumina2')
+    expect(
+      parseDynamicVramPrepare('Model ZImageTEModel_ prepared for dynamic VRAM loading. 7671MB Staged.')
+    ).toBe('ZImageTEModel_')
+    expect(parseDynamicVramPrepare('Requested to load Lumina2')).toBeNull()
+    expect(parseDynamicVramPrepare('Model prepared for something else')).toBeNull()
+  })
+
+  it('classifies a model-load line by trigger', () => {
+    expect(parseModelLoad('Requested to load Lumina2')).toEqual({
+      modelClass: 'Lumina2',
+      trigger: 'requested'
+    })
+    expect(
+      parseModelLoad('Model AutoencodingEngine prepared for dynamic VRAM loading. 159MB Staged.')
+    ).toEqual({ modelClass: 'AutoencodingEngine', trigger: 'dynamic_prepare' })
+    expect(parseModelLoad('unrelated noise')).toBeNull()
+  })
 })
 
 describe('createHardwareTap', () => {
   let captured: Array<{ event: string; ctx: Record<string, unknown> }>
   let personProps: Array<Record<string, unknown>>
-  let personPropsOnce: Array<Record<string, unknown>>
 
   beforeEach(() => {
     captured = []
     personProps = []
-    personPropsOnce = []
     vi.spyOn(telemetry, 'emit').mockImplementation((event, ctx) => {
       captured.push({ event, ctx: ctx as Record<string, unknown> })
     })
     vi.spyOn(telemetry, 'registerPersonProperties').mockImplementation((p) => {
       personProps.push(p as Record<string, unknown>)
-    })
-    vi.spyOn(telemetry, 'registerPersonPropertiesOnce').mockImplementation((p) => {
-      personPropsOnce.push(p as Record<string, unknown>)
     })
   })
 
@@ -247,16 +268,39 @@ describe('createHardwareTap', () => {
     expect(usage.map((u) => u.ctx['count'])).toEqual([1, 2])
   })
 
-  it('writes a per-person $set_once marker the first time each class is seen', () => {
+  it('tags each model_usage event with its load_trigger', () => {
     const tap = createHardwareTap({ installationId: 'inst-1' })
+    tap.ingest('Requested to load Lumina2\n', 'stdout')
+    tap.flushSummary()
+    const usage = captured.filter((c) => c.event === 'comfy.desktop.comfyui.model_usage')
+    expect(usage).toHaveLength(1)
+    expect(usage[0]!.ctx).toMatchObject({
+      model_class: 'Lumina2',
+      load_trigger: 'requested',
+      count: 1
+    })
+  })
+
+  it('counts dynamic-VRAM prepares separately from cold loads of the same class', () => {
+    const tap = createHardwareTap({ installationId: 'inst-1' })
+    tap.ingest('Requested to load Lumina2\n', 'stdout')
     tap.ingest(
-      'Requested to load Lumina2\nRequested to load Lumina2\nRequested to load ZImageTEModel_\n',
+      'Model Lumina2 prepared for dynamic VRAM loading. 11738MB Staged. 0 patches attached.\n',
       'stdout'
     )
-    // One marker per distinct class, not per load.
-    expect(personPropsOnce).toHaveLength(2)
-    expect(Object.keys(personPropsOnce[0]!)[0]).toBe('used_model_lumina2_at')
-    expect(Object.keys(personPropsOnce[1]!)[0]).toBe('used_model_zimagetemodel__at')
+    tap.ingest(
+      'Model Lumina2 prepared for dynamic VRAM loading. 11738MB Staged. 0 patches attached.\n',
+      'stdout'
+    )
+    tap.flushSummary()
+    const usage = captured.filter((c) => c.event === 'comfy.desktop.comfyui.model_usage')
+    expect(usage).toHaveLength(2)
+    expect(
+      usage.find((u) => u.ctx['load_trigger'] === 'requested')!.ctx
+    ).toMatchObject({ model_class: 'Lumina2', count: 1 })
+    expect(
+      usage.find((u) => u.ctx['load_trigger'] === 'dynamic_prepare')!.ctx
+    ).toMatchObject({ model_class: 'Lumina2', count: 2 })
   })
 
   it('re-emits accelerator_detected after beginBoot (ComfyUI restart in one launch)', () => {

--- a/src/main/lib/hardwareTap.test.ts
+++ b/src/main/lib/hardwareTap.test.ts
@@ -17,6 +17,7 @@ const {
   parseVramLine,
   parseRequestedModelLoad,
   parseDynamicVramPrepare,
+  parseModelDeepclone,
   parseModelLoad
 } = await import('./hardwareTap')
 const telemetry = await import('./telemetry')
@@ -110,6 +111,22 @@ describe('parseVramLine / parseRequestedModelLoad', () => {
     expect(parseDynamicVramPrepare('Model prepared for something else')).toBeNull()
   })
 
+  it('parses a multi-GPU deepclone line into class + target device', () => {
+    expect(parseModelDeepclone('Creating deepclone of Lumina2 for cuda:1.')).toEqual({
+      modelClass: 'Lumina2',
+      targetDevice: 'cuda:1'
+    })
+    expect(
+      parseModelDeepclone('Reusing loaded multigpu deepclone of Lumina2 for cuda:1')
+    ).toEqual({ modelClass: 'Lumina2', targetDevice: 'cuda:1' })
+    expect(parseModelDeepclone('Creating deepclone of ZImageTEModel_ for xpu:2')).toEqual({
+      modelClass: 'ZImageTEModel_',
+      targetDevice: 'xpu:2'
+    })
+    expect(parseModelDeepclone('Requested to load Lumina2')).toBeNull()
+    expect(parseModelDeepclone('Creating deepclone of some file.safetensors for cuda:1')).toBeNull()
+  })
+
   it('classifies a model-load line by trigger', () => {
     expect(parseModelLoad('Requested to load Lumina2')).toEqual({
       modelClass: 'Lumina2',
@@ -118,6 +135,11 @@ describe('parseVramLine / parseRequestedModelLoad', () => {
     expect(
       parseModelLoad('Model AutoencodingEngine prepared for dynamic VRAM loading. 159MB Staged.')
     ).toEqual({ modelClass: 'AutoencodingEngine', trigger: 'dynamic_prepare' })
+    expect(parseModelLoad('Creating deepclone of Lumina2 for cuda:1.')).toEqual({
+      modelClass: 'Lumina2',
+      trigger: 'deepclone',
+      targetDevice: 'cuda:1'
+    })
     expect(parseModelLoad('unrelated noise')).toBeNull()
   })
 })
@@ -333,8 +355,26 @@ describe('createHardwareTap', () => {
     expect(usage[0]!.ctx).toMatchObject({
       model_class: 'Lumina2',
       load_trigger: 'requested',
-      count: 1
+      count: 1,
+      target_device: null
     })
+  })
+
+  it('emits multi-GPU deepclones with their target device, counted per device', () => {
+    const tap = createHardwareTap({ installationId: 'inst-1' })
+    // Desktop's bundled build prefixes lines with a level tag.
+    tap.ingest('[INFO] Creating deepclone of Lumina2 for cuda:1.\n', 'stdout')
+    tap.ingest('[INFO] Reusing loaded multigpu deepclone of Lumina2 for cuda:1\n', 'stdout')
+    tap.ingest('[INFO] Creating deepclone of Lumina2 for cuda:2.\n', 'stdout')
+    tap.flushSummary()
+    const usage = captured.filter((c) => c.event === 'comfy.desktop.comfyui.model_usage')
+    expect(usage).toHaveLength(2)
+    expect(
+      usage.find((u) => u.ctx['target_device'] === 'cuda:1')!.ctx
+    ).toMatchObject({ model_class: 'Lumina2', load_trigger: 'deepclone', count: 2 })
+    expect(
+      usage.find((u) => u.ctx['target_device'] === 'cuda:2')!.ctx
+    ).toMatchObject({ model_class: 'Lumina2', load_trigger: 'deepclone', count: 1 })
   })
 
   it('counts dynamic-VRAM prepares separately from cold loads of the same class', () => {

--- a/src/main/lib/hardwareTap.test.ts
+++ b/src/main/lib/hardwareTap.test.ts
@@ -303,6 +303,24 @@ describe('createHardwareTap', () => {
     ).toMatchObject({ model_class: 'Lumina2', count: 2 })
   })
 
+  it('caps distinct model classes across the tap lifetime, not per flush', () => {
+    const tap = createHardwareTap({ installationId: 'inst-1' })
+    // MAX_TRACKED_ARCHITECTURES (64) distinct classes across two flush windows,
+    // then one more. The cap must persist across the clear() that flushSummary
+    // performs, so the 65th distinct class is rejected.
+    for (let i = 0; i < 32; i++) tap.ingest(`Requested to load Model${i}\n`, 'stdout')
+    tap.flushSummary()
+    for (let i = 32; i < 64; i++) tap.ingest(`Requested to load Model${i}\n`, 'stdout')
+    tap.ingest('Requested to load OverflowModel\n', 'stdout')
+    tap.flushSummary()
+
+    const classes = captured
+      .filter((c) => c.event === 'comfy.desktop.comfyui.model_usage')
+      .map((c) => c.ctx['model_class'])
+    expect(classes).toHaveLength(64)
+    expect(classes).not.toContain('OverflowModel')
+  })
+
   it('re-emits accelerator_detected after beginBoot (ComfyUI restart in one launch)', () => {
     const tap = createHardwareTap({ installationId: 'inst-1' })
     tap.ingest('Total VRAM 24576 MB, total RAM 65461 MB\n', 'stdout')
@@ -373,6 +391,7 @@ describe('createHardwareTap', () => {
     tap.ingest('Requested to load Flux', 'stderr') // no newline
     tap.flushSummary()
     const usage = captured.filter((c) => c.event === 'comfy.desktop.comfyui.model_usage')
+    expect(usage).toHaveLength(2)
     expect(usage).toContainEqual(
       expect.objectContaining({ ctx: expect.objectContaining({ model_class: 'Lumina2', count: 1 }) })
     )

--- a/src/main/lib/hardwareTap.test.ts
+++ b/src/main/lib/hardwareTap.test.ts
@@ -305,19 +305,19 @@ describe('createHardwareTap', () => {
 
   it('caps distinct model classes across the tap lifetime, not per flush', () => {
     const tap = createHardwareTap({ installationId: 'inst-1' })
-    // MAX_TRACKED_ARCHITECTURES (64) distinct classes across two flush windows,
+    // MAX_TRACKED_ARCHITECTURES (60) distinct classes across two flush windows,
     // then one more. The cap must persist across the clear() that flushSummary
-    // performs, so the 65th distinct class is rejected.
-    for (let i = 0; i < 32; i++) tap.ingest(`Requested to load Model${i}\n`, 'stdout')
+    // performs, so the 61st distinct class is rejected.
+    for (let i = 0; i < 30; i++) tap.ingest(`Requested to load Model${i}\n`, 'stdout')
     tap.flushSummary()
-    for (let i = 32; i < 64; i++) tap.ingest(`Requested to load Model${i}\n`, 'stdout')
+    for (let i = 30; i < 60; i++) tap.ingest(`Requested to load Model${i}\n`, 'stdout')
     tap.ingest('Requested to load OverflowModel\n', 'stdout')
     tap.flushSummary()
 
     const classes = captured
       .filter((c) => c.event === 'comfy.desktop.comfyui.model_usage')
       .map((c) => c.ctx['model_class'])
-    expect(classes).toHaveLength(64)
+    expect(classes).toHaveLength(60)
     expect(classes).not.toContain('OverflowModel')
   })
 

--- a/src/main/lib/hardwareTap.ts
+++ b/src/main/lib/hardwareTap.ts
@@ -11,9 +11,11 @@
  *
  * Two signals, two shapes:
  *   - `comfy.desktop.comfyui.accelerator_detected` — emitted ONCE per boot,
- *     on the first `Device:` line (the current/selected device; ComfyUI
- *     prints additional devices afterwards). Carries the compute GPU model,
- *     VRAM/RAM, and torch/xformers versions accumulated from earlier lines.
+ *     after the consecutive run of `Device:` lines ends (ComfyUI logs the
+ *     selected device first, then one line per other GPU). Top-level fields
+ *     describe the selected device (the authoritative compute GPU); `devices`
+ *     carries every detected GPU and `device_count` their number. Also carries
+ *     VRAM/RAM and torch/xformers versions accumulated from earlier lines.
  *   - `comfy.desktop.comfyui.model_usage` — model loads happen many times per
  *     session, so per-load events would blow past the telemetry rate limiter
  *     and corrupt the very counts we want. Instead we count loads per
@@ -39,6 +41,8 @@
  *   - "Total VRAM 24576 MB, total RAM 65461 MB"
  *   - "pytorch version: 2.10.0+cu130" / "xformers version: 0.0.x"
  *   - "Set cuda device to: 0"                              (main.py)
+ *   - "Using directml with device: AMD Radeon RX 6800"     (model_management.py)
+ *   - "Device: cuda:0 …" / "xpu:0 …" / "npu:0 …" / "mlu:0 …" / "cpu" / "mps"
  *   - "Requested to load Lumina2"                          (model_management.py)
  *   - "Model Lumina2 prepared for dynamic VRAM loading. …" (dynamic VRAM / aimdo)
  *
@@ -65,6 +69,10 @@ const VRAM_LINE = /^Total VRAM\s+(\d+)\s*MB,\s*total RAM\s+(\d+)\s*MB/i
 const PYTORCH_LINE = /^pytorch version:\s*(.+)$/i
 const XFORMERS_LINE = /^xformers version:\s*(.+)$/i
 const CUDA_DEVICE_LINE = /^Set cuda device to:\s*(\d+)/i
+// DirectML (AMD/Intel on Windows without ROCm) logs the GPU name here, on a
+// separate line that precedes a nameless `Device: privateuseone` line — so it's
+// the only way to recover the model for those vendors.
+const DIRECTML_LINE = /^Using directml with device:\s*(.+)$/i
 // ComfyUI logs `Requested to load <ClassName>` once per cold GPU load, where the
 // name is the loaded module's Python class (`x.model.__class__.__name__`) — the
 // real architecture (`Lumina2`, `Flux`), text encoder (`ZImageTEModel_`), or
@@ -162,6 +170,8 @@ const MODEL_USAGE_FLUSH_INTERVAL_MS = 5 * 60_000
  * larger cap would let a single full flush self-throttle and drop its tail.
  */
 const MAX_TRACKED_ARCHITECTURES = 60
+/** Cap on devices reported in one accelerator event, so a malformed log can't grow the array. */
+const MAX_DEVICES = 16
 
 export function createHardwareTap(opts: {
   installationId: string
@@ -178,14 +188,19 @@ export function createHardwareTap(opts: {
     release: opts.release ?? null
   }
 
-  // Accelerator accumulation — fields trickle in over several lines; we emit
-  // once, on the first Device line (which arrives after VRAM / versions).
+  // Accelerator accumulation — fields trickle in over several lines. ComfyUI
+  // logs the selected device first, then one `Device:` line per other GPU. We
+  // collect the consecutive run and emit ONE event (per boot) when the run ends
+  // — i.e. on the first non-`Device:` line, or at session end — so the event
+  // carries every GPU, not just the selected one.
   let acceleratorEmitted = false
   let vramMb: number | null = null
   let ramMb: number | null = null
   let pytorchVersion: string | null = null
   let xformersVersion: string | null = null
   let cudaDeviceSet: number | null = null
+  let directmlDeviceName: string | null = null
+  const devices: AcceleratorInfo[] = []
 
   // Per-(class, trigger) load counts since the last flush (deltas). The map key
   // is `<trigger>\t<class>`; `\t` can't appear in either (trigger is a literal,
@@ -235,6 +250,59 @@ export function createHardwareTap(opts: {
     flushTimer.unref?.()
   }
 
+  /**
+   * Emit the single per-boot `accelerator_detected` event for the collected run
+   * of `Device:` lines. The first device is the one ComfyUI selected (the
+   * authoritative compute GPU); `devices` carries every detected GPU. No-op
+   * until at least one device is seen, and only once per boot.
+   */
+  function emitAccelerator(): void {
+    if (acceleratorEmitted || devices.length === 0) return
+    acceleratorEmitted = true
+    const primary = devices[0]!
+    const vramGb = vramMb != null ? Math.round(vramMb / 1024) : null
+    // DirectML logs a nameless `Device: privateuseone`; recover the model from
+    // the earlier `Using directml with device:` line (never for cpu/mps).
+    const primaryName =
+      primary.deviceName ??
+      (primary.deviceType !== 'cpu' && primary.deviceType !== 'mps' ? directmlDeviceName : null)
+    // The telemetry layer only accepts scalars + scalar arrays (and only scrubs
+    // PII from those), so report all devices as parallel arrays aligned by index
+    // rather than an array of objects.
+    const gpuModels = devices.map((d, i) => (i === 0 ? primaryName : d.deviceName))
+    telemetry.emit('comfy.desktop.comfyui.accelerator_detected', {
+      ...baseContext,
+      device_type: primary.deviceType,
+      device_index: primary.deviceIndex,
+      gpu_model: primaryName,
+      backend: primary.backend,
+      device_count: devices.length,
+      device_types: devices.map((d) => d.deviceType),
+      device_indices: devices.map((d) => d.deviceIndex),
+      gpu_models: gpuModels,
+      device_backends: devices.map((d) => d.backend),
+      vram_mb: vramMb,
+      vram_gb: vramGb,
+      ram_mb: ramMb,
+      pytorch_version: pytorchVersion,
+      xformers_version: xformersVersion,
+      cuda_device_set: cudaDeviceSet
+    })
+    // The compute device ComfyUI selected is more authoritative than the
+    // OS-enumerated GPU in `system_info` (which can be a virtual display).
+    // Promote it under dedicated `comfyui_*` person props so cohort queries can
+    // coalesce(comfyui_gpu_model, gpu_model) without losing either signal. Only
+    // for real accelerators — `cpu` is not a GPU.
+    if (primaryName && primary.deviceType !== 'cpu') {
+      telemetry.registerPersonProperties({
+        comfyui_gpu_model: primaryName,
+        comfyui_gpu_vram_gb: vramGb,
+        comfyui_device_type: primary.deviceType,
+        comfyui_gpu_count: devices.length
+      })
+    }
+  }
+
   function handleLine(line: string): void {
     // Strip a leading `[LEVEL] ` tag (ComfyUI Desktop's bundled build) so the
     // anchored parsers below match both the prefixed and bare log formats.
@@ -263,37 +331,20 @@ export function createHardwareTap(opts: {
         cudaDeviceSet = Number(cudaDevice)
         return
       }
-      const device = parseDeviceLine(trimmed)
-      if (device) {
-        acceleratorEmitted = true
-        const vramGb = vramMb != null ? Math.round(vramMb / 1024) : null
-        telemetry.emit('comfy.desktop.comfyui.accelerator_detected', {
-          ...baseContext,
-          device_type: device.deviceType,
-          device_index: device.deviceIndex,
-          gpu_model: device.deviceName,
-          backend: device.backend,
-          vram_mb: vramMb,
-          vram_gb: vramGb,
-          ram_mb: ramMb,
-          pytorch_version: pytorchVersion,
-          xformers_version: xformersVersion,
-          cuda_device_set: cudaDeviceSet
-        })
-        // The compute device ComfyUI selected is more authoritative than the
-        // OS-enumerated GPU in `system_info` (which can be a virtual display).
-        // Promote it under dedicated `comfyui_*` person props so cohort
-        // queries can coalesce(comfyui_gpu_model, gpu_model) without losing
-        // either signal. Only for real accelerators — `cpu` is not a GPU.
-        if (device.deviceName && device.deviceType !== 'cpu') {
-          telemetry.registerPersonProperties({
-            comfyui_gpu_model: device.deviceName,
-            comfyui_gpu_vram_gb: vramGb,
-            comfyui_device_type: device.deviceType
-          })
-        }
+      const directml = parseTail(trimmed, DIRECTML_LINE)
+      if (directml) {
+        directmlDeviceName = directml
         return
       }
+      const device = parseDeviceLine(trimmed)
+      if (device) {
+        // Collect the consecutive run; the event is emitted when the run ends.
+        if (devices.length < MAX_DEVICES) devices.push(device)
+        return
+      }
+      // First non-`Device:` line after a run of them: the run is complete, so
+      // emit, then fall through (this line may itself be a model-load line).
+      if (devices.length > 0) emitAccelerator()
     }
 
     const load = parseModelLoad(trimmed)
@@ -349,6 +400,8 @@ export function createHardwareTap(opts: {
       pytorchVersion = null
       xformersVersion = null
       cudaDeviceSet = null
+      directmlDeviceName = null
+      devices.length = 0
       // Drop any incomplete lines from the previous (now-dead) process streams.
       pendingBySource.stdout = ''
       pendingBySource.stderr = ''
@@ -366,6 +419,9 @@ export function createHardwareTap(opts: {
           if (pending.trim()) handleLine(pending)
           pendingBySource[source] = ''
         }
+        // Emit the accelerator event if the process exited right after its
+        // `Device:` lines with no following line to close the run.
+        emitAccelerator()
         emitModelUsage()
       } catch {
         // ignore – telemetry side effect, not user-visible

--- a/src/main/lib/hardwareTap.ts
+++ b/src/main/lib/hardwareTap.ts
@@ -186,13 +186,22 @@ export function createHardwareTap(opts: {
   // is `<trigger>\t<class>`; `\t` can't appear in either (trigger is a literal,
   // class is a Python identifier), so it's a safe composite key.
   const pendingCounts = new Map<string, number>()
+  // Every (class, trigger) key ever recorded by this tap. Persists across
+  // flushes (which clear `pendingCounts`) so the cardinality cap below bounds
+  // distinct `model_class` values over the tap's whole lifetime, not just the
+  // current flush window — a malformed log can't grow the event-value space.
+  const seenKeys = new Set<string>()
 
   let flushTimer: ReturnType<typeof setInterval> | null = null
 
   function recordLoad(modelClass: string, trigger: ModelLoadTrigger): void {
     const key = `${trigger}\t${modelClass}`
-    // Cap distinct (class, trigger) pairs so a malformed log can't grow the map.
-    if (!pendingCounts.has(key) && pendingCounts.size >= MAX_TRACKED_ARCHITECTURES) return
+    // Reject brand-new (class, trigger) pairs once the cap is hit; keep counting
+    // ones already seen so existing series stay accurate.
+    if (!seenKeys.has(key)) {
+      if (seenKeys.size >= MAX_TRACKED_ARCHITECTURES) return
+      seenKeys.add(key)
+    }
     pendingCounts.set(key, (pendingCounts.get(key) ?? 0) + 1)
     ensureFlushTimer()
   }

--- a/src/main/lib/hardwareTap.ts
+++ b/src/main/lib/hardwareTap.ts
@@ -29,14 +29,20 @@
  *     (`x.model.__class__.__name__`) — the real architecture (e.g. `Lumina2`,
  *     `Flux`), text encoder (`ZImageTEModel_`), or VAE (`AutoencodingEngine`) —
  *     NOT the sampling `model_type` enum, which can't identify an architecture.
- *     `load_trigger` distinguishes the two log signals:
+ *     `load_trigger` distinguishes the log signals:
  *       - `requested` — "Requested to load X": a cold load (model not resident).
  *         Misses runs that reuse an already-loaded model.
  *       - `dynamic_prepare` — "Model X prepared for dynamic VRAM loading":
  *         emitted per prepare when dynamic VRAM (aimdo) is enabled, so it tracks
  *         models that stay staged across runs. Absent when dynamic VRAM is off.
- *     Neither line is a perfect per-run-per-model signal on its own — see the
- *     PR discussion — but together they cover cold loads and dynamic reuse.
+ *       - `deepclone` — "Creating deepclone of X for <device>" / "Reusing loaded
+ *         multigpu deepclone of X for <device>": a multi-GPU feature (MultiGPU
+ *         CFG Split, per-device ControlNets, …) cloning the model onto another
+ *         device. Carries `target_device` (e.g. `cuda:1`) so cross-GPU spread is
+ *         visible; presence + distinct `installation_id` = who uses these
+ *         features. `target_device` is null for the two load triggers.
+ *     Neither load line is a perfect per-run-per-model signal on its own — see
+ *     the PR discussion — but together they cover cold loads and dynamic reuse.
  *
  * Log strings parsed (current ComfyUI main branch):
  *   - "Device: cuda:0 NVIDIA GeForce RTX 4090 : native"   (model_management.py)
@@ -47,6 +53,8 @@
  *   - "Device: cuda:0 …" / "xpu:0 …" / "npu:0 …" / "mlu:0 …" / "cpu" / "mps"
  *   - "Requested to load Lumina2"                          (model_management.py)
  *   - "Model Lumina2 prepared for dynamic VRAM loading. …" (dynamic VRAM / aimdo)
+ *   - "Creating deepclone of Lumina2 for cuda:1."          (model_patcher.py, multi-GPU)
+ *   - "Reusing loaded multigpu deepclone of Lumina2 for cuda:1" (multigpu.py)
  *
  * NOTE: the architecture is the loaded class name on the `Requested to load`
  * line, NOT the `model_type <ENUM>` sampling tag — `model_type` is the same
@@ -90,6 +98,15 @@ const REQUESTED_LOAD_LINE = /^Requested to load\s+([A-Za-z_][A-Za-z0-9_]{0,63})\
 // constraint and length cap as above.
 const DYNAMIC_PREPARE_LINE =
   /^Model\s+([A-Za-z_][A-Za-z0-9_]{0,63})\s+prepared for dynamic VRAM loading\b/
+// Multi-GPU features (MultiGPU CFG Split, per-device ControlNets, …) deepclone a
+// model onto another device. ComfyUI logs `Creating deepclone of <ClassName>
+// for <device>.` on a fresh clone (model_patcher.py) and `Reusing loaded
+// multigpu deepclone of <ClassName> for <device>` when the clone is reused
+// (multigpu.py). Either line means the install uses a deepclone-based multi-GPU
+// feature; the captured `<device>` (e.g. `cuda:1`) shows the cross-GPU spread.
+// Same identifier-only + length-cap constraint on the class as the load lines.
+const DEEPCLONE_LINE =
+  /^(?:Creating deepclone of|Reusing loaded multigpu deepclone of)\s+([A-Za-z_][A-Za-z0-9_]{0,63})\s+for\s+([a-z][a-z0-9]*(?::\d+)?)/
 
 /**
  * Parse a ComfyUI `Device:` line into its components. Handles the cuda
@@ -135,8 +152,13 @@ function parseTail(line: string, re: RegExp): string | null {
   return m && m[1] ? m[1].trim() : null
 }
 
-/** How a model load was observed in the logs. */
-export type ModelLoadTrigger = 'requested' | 'dynamic_prepare'
+/**
+ * How a model load/clone was observed in the logs.
+ *   - `requested` / `dynamic_prepare` — a model load (see the line comments).
+ *   - `deepclone` — a multi-GPU deepclone onto another device; carries a
+ *     `targetDevice` the load triggers don't.
+ */
+export type ModelLoadTrigger = 'requested' | 'dynamic_prepare' | 'deepclone'
 
 /** Parse "Requested to load Lumina2" → "Lumina2". */
 export function parseRequestedModelLoad(line: string): string | null {
@@ -149,17 +171,38 @@ export function parseDynamicVramPrepare(line: string): string | null {
 }
 
 /**
- * Match either model-load log line, returning the loaded class and which
- * signal produced it, or null. `Requested to load` is a cold load;
- * `Model X prepared for dynamic VRAM loading` is a dynamic-VRAM (aimdo) prepare.
+ * Parse a multi-GPU deepclone line → its class + target device, or null.
+ * Matches both "Creating deepclone of X for cuda:1." and "Reusing loaded
+ * multigpu deepclone of X for cuda:1".
+ */
+export function parseModelDeepclone(
+  line: string
+): { modelClass: string; targetDevice: string } | null {
+  const m = line.match(DEEPCLONE_LINE)
+  if (!m || !m[1] || !m[2]) return null
+  return { modelClass: m[1], targetDevice: m[2] }
+}
+
+/**
+ * Match any model load/clone log line, returning the class, which signal
+ * produced it, and (for deepclones) the target device, or null. `Requested to
+ * load` is a cold load; `Model X prepared for dynamic VRAM loading` is a
+ * dynamic-VRAM (aimdo) prepare; the deepclone lines are multi-GPU clones.
  */
 export function parseModelLoad(
   line: string
-): { modelClass: string; trigger: ModelLoadTrigger } | null {
+): { modelClass: string; trigger: ModelLoadTrigger; targetDevice?: string } | null {
   const requested = parseRequestedModelLoad(line)
   if (requested) return { modelClass: requested, trigger: 'requested' }
   const prepared = parseDynamicVramPrepare(line)
   if (prepared) return { modelClass: prepared, trigger: 'dynamic_prepare' }
+  const deepclone = parseModelDeepclone(line)
+  if (deepclone)
+    return {
+      modelClass: deepclone.modelClass,
+      trigger: 'deepclone',
+      targetDevice: deepclone.targetDevice
+    }
   return null
 }
 
@@ -204,9 +247,11 @@ export function createHardwareTap(opts: {
   let directmlDeviceName: string | null = null
   const devices: AcceleratorInfo[] = []
 
-  // Per-(class, trigger) load counts since the last flush (deltas). The map key
-  // is `<trigger>\t<class>`; `\t` can't appear in either (trigger is a literal,
-  // class is a Python identifier), so it's a safe composite key.
+  // Per-(class, trigger, device) load counts since the last flush (deltas). The
+  // map key is `<trigger>\t<class>\t<device>` (device is empty for the load
+  // triggers, a device token like `cuda:1` for deepclones); `\t` can't appear in
+  // any part (trigger is a literal, class is a Python identifier, device is a
+  // `<type>:<n>` token), so it's a safe composite key.
   const pendingCounts = new Map<string, number>()
   // Every (class, trigger) key ever recorded by this tap. Persists across
   // flushes (which clear `pendingCounts`) so the cardinality cap below bounds
@@ -216,10 +261,14 @@ export function createHardwareTap(opts: {
 
   let flushTimer: ReturnType<typeof setInterval> | null = null
 
-  function recordLoad(modelClass: string, trigger: ModelLoadTrigger): void {
-    const key = `${trigger}\t${modelClass}`
-    // Reject brand-new (class, trigger) pairs once the cap is hit; keep counting
-    // ones already seen so existing series stay accurate.
+  function recordLoad(
+    modelClass: string,
+    trigger: ModelLoadTrigger,
+    targetDevice: string | null
+  ): void {
+    const key = `${trigger}\t${modelClass}\t${targetDevice ?? ''}`
+    // Reject brand-new (class, trigger, device) keys once the cap is hit; keep
+    // counting ones already seen so existing series stay accurate.
     if (!seenKeys.has(key)) {
       if (seenKeys.size >= MAX_TRACKED_ARCHITECTURES) return
       seenKeys.add(key)
@@ -232,13 +281,14 @@ export function createHardwareTap(opts: {
     if (pendingCounts.size === 0) return
     for (const [key, count] of pendingCounts) {
       if (count <= 0) continue
-      const sep = key.indexOf('\t')
-      const trigger = key.slice(0, sep)
-      const modelClass = key.slice(sep + 1)
+      const [trigger, modelClass, targetDevice] = key.split('\t')
       telemetry.emit('comfy.desktop.comfyui.model_usage', {
         ...baseContext,
         model_class: modelClass,
         load_trigger: trigger,
+        // Only deepclones carry a target device; null keeps the column stable
+        // for the load triggers.
+        target_device: targetDevice ? targetDevice : null,
         count
       })
     }
@@ -352,7 +402,7 @@ export function createHardwareTap(opts: {
 
     const load = parseModelLoad(trimmed)
     if (load) {
-      recordLoad(load.modelClass, load.trigger)
+      recordLoad(load.modelClass, load.trigger, load.targetDevice ?? null)
       return
     }
   }

--- a/src/main/lib/hardwareTap.ts
+++ b/src/main/lib/hardwareTap.ts
@@ -155,8 +155,13 @@ export function parseModelLoad(
 
 /** Flush model-usage deltas at most this often while a session keeps loading models. */
 const MODEL_USAGE_FLUSH_INTERVAL_MS = 5 * 60_000
-/** Hard cap on distinct architectures tracked, so a malformed log can't grow the map. */
-const MAX_TRACKED_ARCHITECTURES = 64
+/**
+ * Hard cap on distinct (class, trigger) keys tracked, so a malformed log can't
+ * grow the map. Kept at/under the telemetry per-event-name rate limit (60/min)
+ * because a flush emits every pending key synchronously into one window — a
+ * larger cap would let a single full flush self-throttle and drop its tail.
+ */
+const MAX_TRACKED_ARCHITECTURES = 60
 
 export function createHardwareTap(opts: {
   installationId: string

--- a/src/main/lib/hardwareTap.ts
+++ b/src/main/lib/hardwareTap.ts
@@ -16,16 +16,23 @@
  *     VRAM/RAM, and torch/xformers versions accumulated from earlier lines.
  *   - `comfy.desktop.comfyui.model_usage` — model loads happen many times per
  *     session, so per-load events would blow past the telemetry rate limiter
- *     and corrupt the very counts we want. Instead we count loads per model
- *     class in memory and flush DELTAS (periodically + on session end), at
- *     most one event per distinct class per flush. Summing `count` gives total
- *     loads; counting distinct `installation_id` gives reach. A per-person
- *     `$set_once` marker (`used_model_<class>_at`) answers "has this user ever
- *     loaded class X" with a single person-property filter. The class is the
- *     loaded module's Python class name (`x.model.__class__.__name__`) — the
- *     real architecture (e.g. `Lumina2`, `Flux`), the text encoder
- *     (`ZImageTEModel_`), and the VAE (`AutoencodingEngine`) — NOT the sampling
- *     `model_type` enum, which doesn't identify the architecture.
+ *     and corrupt the very counts we want. Instead we count loads per
+ *     (model class, trigger) in memory and flush DELTAS (periodically + on
+ *     session end), at most one event per distinct (class, trigger) per flush.
+ *     Summing `count` gives total loads; counting distinct `installation_id`
+ *     gives reach (no person-property marker needed — reach is derivable from
+ *     the events). `model_class` is the loaded module's Python class name
+ *     (`x.model.__class__.__name__`) — the real architecture (e.g. `Lumina2`,
+ *     `Flux`), text encoder (`ZImageTEModel_`), or VAE (`AutoencodingEngine`) —
+ *     NOT the sampling `model_type` enum, which can't identify an architecture.
+ *     `load_trigger` distinguishes the two log signals:
+ *       - `requested` — "Requested to load X": a cold load (model not resident).
+ *         Misses runs that reuse an already-loaded model.
+ *       - `dynamic_prepare` — "Model X prepared for dynamic VRAM loading":
+ *         emitted per prepare when dynamic VRAM (aimdo) is enabled, so it tracks
+ *         models that stay staged across runs. Absent when dynamic VRAM is off.
+ *     Neither line is a perfect per-run-per-model signal on its own — see the
+ *     PR discussion — but together they cover cold loads and dynamic reuse.
  *
  * Log strings parsed (current ComfyUI main branch):
  *   - "Device: cuda:0 NVIDIA GeForce RTX 4090 : native"   (model_management.py)
@@ -33,6 +40,7 @@
  *   - "pytorch version: 2.10.0+cu130" / "xformers version: 0.0.x"
  *   - "Set cuda device to: 0"                              (main.py)
  *   - "Requested to load Lumina2"                          (model_management.py)
+ *   - "Model Lumina2 prepared for dynamic VRAM loading. …" (dynamic VRAM / aimdo)
  *
  * NOTE: the architecture is the loaded class name on the `Requested to load`
  * line, NOT the `model_type <ENUM>` sampling tag — `model_type` is the same
@@ -57,15 +65,21 @@ const VRAM_LINE = /^Total VRAM\s+(\d+)\s*MB,\s*total RAM\s+(\d+)\s*MB/i
 const PYTORCH_LINE = /^pytorch version:\s*(.+)$/i
 const XFORMERS_LINE = /^xformers version:\s*(.+)$/i
 const CUDA_DEVICE_LINE = /^Set cuda device to:\s*(\d+)/i
-// ComfyUI logs `Requested to load <ClassName>` once per GPU load, where the
+// ComfyUI logs `Requested to load <ClassName>` once per cold GPU load, where the
 // name is the loaded module's Python class (`x.model.__class__.__name__`) — the
 // real architecture (`Lumina2`, `Flux`), text encoder (`ZImageTEModel_`), or
 // VAE (`AutoencodingEngine`). Match a whole Python identifier only: custom
 // nodes write to the same stdout, so a loose `.+` could turn an arbitrary
-// string into a high-cardinality event value AND a dynamic `used_model_<x>_at`
-// person-property key (keys are not scrubbed). The length cap bounds a
+// string into a high-cardinality event value. The length cap bounds a
 // pathological match.
 const REQUESTED_LOAD_LINE = /^Requested to load\s+([A-Za-z_][A-Za-z0-9_]{0,63})\s*$/
+// With dynamic VRAM (aimdo) enabled, ComfyUI logs `Model <ClassName> prepared
+// for dynamic VRAM loading. <N>MB Staged. …` per prepare — the same class name
+// as `Requested to load`, but emitted for models that stay staged across runs
+// (so it captures reuse that the cold-load line misses). Same identifier-only
+// constraint and length cap as above.
+const DYNAMIC_PREPARE_LINE =
+  /^Model\s+([A-Za-z_][A-Za-z0-9_]{0,63})\s+prepared for dynamic VRAM loading\b/
 
 /**
  * Parse a ComfyUI `Device:` line into its components. Handles the cuda
@@ -111,9 +125,32 @@ function parseTail(line: string, re: RegExp): string | null {
   return m && m[1] ? m[1].trim() : null
 }
 
+/** How a model load was observed in the logs. */
+export type ModelLoadTrigger = 'requested' | 'dynamic_prepare'
+
 /** Parse "Requested to load Lumina2" → "Lumina2". */
 export function parseRequestedModelLoad(line: string): string | null {
   return parseTail(line, REQUESTED_LOAD_LINE)
+}
+
+/** Parse "Model Lumina2 prepared for dynamic VRAM loading. …" → "Lumina2". */
+export function parseDynamicVramPrepare(line: string): string | null {
+  return parseTail(line, DYNAMIC_PREPARE_LINE)
+}
+
+/**
+ * Match either model-load log line, returning the loaded class and which
+ * signal produced it, or null. `Requested to load` is a cold load;
+ * `Model X prepared for dynamic VRAM loading` is a dynamic-VRAM (aimdo) prepare.
+ */
+export function parseModelLoad(
+  line: string
+): { modelClass: string; trigger: ModelLoadTrigger } | null {
+  const requested = parseRequestedModelLoad(line)
+  if (requested) return { modelClass: requested, trigger: 'requested' }
+  const prepared = parseDynamicVramPrepare(line)
+  if (prepared) return { modelClass: prepared, trigger: 'dynamic_prepare' }
+  return null
 }
 
 /** Flush model-usage deltas at most this often while a session keeps loading models. */
@@ -145,19 +182,32 @@ export function createHardwareTap(opts: {
   let xformersVersion: string | null = null
   let cudaDeviceSet: number | null = null
 
-  // Per-class load counts since the last flush (deltas).
+  // Per-(class, trigger) load counts since the last flush (deltas). The map key
+  // is `<trigger>\t<class>`; `\t` can't appear in either (trigger is a literal,
+  // class is a Python identifier), so it's a safe composite key.
   const pendingCounts = new Map<string, number>()
-  const markedArchitectures = new Set<string>()
 
   let flushTimer: ReturnType<typeof setInterval> | null = null
 
+  function recordLoad(modelClass: string, trigger: ModelLoadTrigger): void {
+    const key = `${trigger}\t${modelClass}`
+    // Cap distinct (class, trigger) pairs so a malformed log can't grow the map.
+    if (!pendingCounts.has(key) && pendingCounts.size >= MAX_TRACKED_ARCHITECTURES) return
+    pendingCounts.set(key, (pendingCounts.get(key) ?? 0) + 1)
+    ensureFlushTimer()
+  }
+
   function emitModelUsage(): void {
     if (pendingCounts.size === 0) return
-    for (const [modelClass, count] of pendingCounts) {
+    for (const [key, count] of pendingCounts) {
       if (count <= 0) continue
+      const sep = key.indexOf('\t')
+      const trigger = key.slice(0, sep)
+      const modelClass = key.slice(sep + 1)
       telemetry.emit('comfy.desktop.comfyui.model_usage', {
         ...baseContext,
         model_class: modelClass,
+        load_trigger: trigger,
         count
       })
     }
@@ -232,20 +282,9 @@ export function createHardwareTap(opts: {
       }
     }
 
-    const modelClass = parseRequestedModelLoad(trimmed)
-    if (modelClass) {
-      if (pendingCounts.has(modelClass) || pendingCounts.size < MAX_TRACKED_ARCHITECTURES) {
-        pendingCounts.set(modelClass, (pendingCounts.get(modelClass) ?? 0) + 1)
-        ensureFlushTimer()
-        // Per-person "ever loaded class X" marker. `$set_once` is idempotent
-        // server-side; the per-tap Set avoids re-emitting person.set events.
-        if (!markedArchitectures.has(modelClass)) {
-          markedArchitectures.add(modelClass)
-          telemetry.registerPersonPropertiesOnce({
-            [`used_model_${modelClass.toLowerCase()}_at`]: new Date().toISOString()
-          })
-        }
-      }
+    const load = parseModelLoad(trimmed)
+    if (load) {
+      recordLoad(load.modelClass, load.trigger)
       return
     }
   }

--- a/src/main/lib/hardwareTap.ts
+++ b/src/main/lib/hardwareTap.ts
@@ -13,9 +13,11 @@
  *   - `comfy.desktop.comfyui.accelerator_detected` — emitted ONCE per boot,
  *     after the consecutive run of `Device:` lines ends (ComfyUI logs the
  *     selected device first, then one line per other GPU). Top-level fields
- *     describe the selected device (the authoritative compute GPU); `devices`
- *     carries every detected GPU and `device_count` their number. Also carries
- *     VRAM/RAM and torch/xformers versions accumulated from earlier lines.
+ *     describe the selected device (the authoritative compute GPU); every
+ *     detected GPU is reported via `device_count` plus the index-aligned
+ *     parallel arrays `device_types` / `device_indices` / `gpu_models` /
+ *     `device_backends`. Also carries VRAM/RAM and torch/xformers versions
+ *     accumulated from earlier lines.
  *   - `comfy.desktop.comfyui.model_usage` — model loads happen many times per
  *     session, so per-load events would blow past the telemetry rate limiter
  *     and corrupt the very counts we want. Instead we count loads per
@@ -253,8 +255,9 @@ export function createHardwareTap(opts: {
   /**
    * Emit the single per-boot `accelerator_detected` event for the collected run
    * of `Device:` lines. The first device is the one ComfyUI selected (the
-   * authoritative compute GPU); `devices` carries every detected GPU. No-op
-   * until at least one device is seen, and only once per boot.
+   * authoritative compute GPU); the index-aligned parallel arrays carry every
+   * detected GPU. No-op until at least one device is seen, and only once per
+   * boot.
    */
   function emitAccelerator(): void {
     if (acceleratorEmitted || devices.length === 0) return

--- a/src/main/lib/hardwareTap.ts
+++ b/src/main/lib/hardwareTap.ts
@@ -16,23 +16,27 @@
  *     VRAM/RAM, and torch/xformers versions accumulated from earlier lines.
  *   - `comfy.desktop.comfyui.model_usage` — model loads happen many times per
  *     session, so per-load events would blow past the telemetry rate limiter
- *     and corrupt the very counts we want. Instead we count loads per
- *     architecture in memory and flush DELTAS (periodically + on session end),
- *     at most one event per distinct architecture per flush. Summing `count`
- *     gives total loads; counting distinct `installation_id` gives reach. A
- *     per-person `$set_once` marker (`used_model_<arch>_at`) answers "has this
- *     user ever used arch X" with a single person-property filter.
+ *     and corrupt the very counts we want. Instead we count loads per model
+ *     class in memory and flush DELTAS (periodically + on session end), at
+ *     most one event per distinct class per flush. Summing `count` gives total
+ *     loads; counting distinct `installation_id` gives reach. A per-person
+ *     `$set_once` marker (`used_model_<class>_at`) answers "has this user ever
+ *     loaded class X" with a single person-property filter. The class is the
+ *     loaded module's Python class name (`x.model.__class__.__name__`) — the
+ *     real architecture (e.g. `Lumina2`, `Flux`), the text encoder
+ *     (`ZImageTEModel_`), and the VAE (`AutoencodingEngine`) — NOT the sampling
+ *     `model_type` enum, which doesn't identify the architecture.
  *
  * Log strings parsed (current ComfyUI main branch):
  *   - "Device: cuda:0 NVIDIA GeForce RTX 4090 : native"   (model_management.py)
  *   - "Total VRAM 24576 MB, total RAM 65461 MB"
  *   - "pytorch version: 2.10.0+cu130" / "xformers version: 0.0.x"
  *   - "Set cuda device to: 0"                              (main.py)
- *   - "model_type FLUX"                                    (model_base.py)
- *   - "model weight dtype torch.float16, manual cast: None"
+ *   - "Requested to load Lumina2"                          (model_management.py)
  *
- * NOTE: there is no literal "loading SDXL model" string in ComfyUI; the
- * architecture surfaces as `model_type <NAME>` (EPS / FLUX / FLOW / ...).
+ * NOTE: the architecture is the loaded class name on the `Requested to load`
+ * line, NOT the `model_type <ENUM>` sampling tag — `model_type` is the same
+ * `EPS` / `FLOW` for many distinct architectures and so can't identify one.
  *
  * NOTE: ComfyUI Desktop's bundled build prefixes every log line with a level
  * tag (`[INFO] Device: ...`), unlike the bare `%(message)s` format. `handleLine`
@@ -53,14 +57,15 @@ const VRAM_LINE = /^Total VRAM\s+(\d+)\s*MB,\s*total RAM\s+(\d+)\s*MB/i
 const PYTORCH_LINE = /^pytorch version:\s*(.+)$/i
 const XFORMERS_LINE = /^xformers version:\s*(.+)$/i
 const CUDA_DEVICE_LINE = /^Set cuda device to:\s*(\d+)/i
-// ComfyUI's `model_type.name` is always an uppercase enum (EPS, FLUX, FLOW,
-// V_PREDICTION, STABLE_CASCADE, ...). Restrict to that shape and require it to
-// be the whole token: custom nodes write to the same stdout, so a loose `\S+`
-// could turn an arbitrary string (a path, a filename) into a high-cardinality
-// event value AND a dynamic `used_model_<x>_at` person-property key (keys are
-// not scrubbed). The length cap bounds a pathological match.
-const MODEL_TYPE_LINE = /^model_type\s+([A-Z][A-Z0-9_]{0,63})\s*$/
-const WEIGHT_DTYPE_LINE = /^model weight dtype\s+([^,]+),/
+// ComfyUI logs `Requested to load <ClassName>` once per GPU load, where the
+// name is the loaded module's Python class (`x.model.__class__.__name__`) — the
+// real architecture (`Lumina2`, `Flux`), text encoder (`ZImageTEModel_`), or
+// VAE (`AutoencodingEngine`). Match a whole Python identifier only: custom
+// nodes write to the same stdout, so a loose `.+` could turn an arbitrary
+// string into a high-cardinality event value AND a dynamic `used_model_<x>_at`
+// person-property key (keys are not scrubbed). The length cap bounds a
+// pathological match.
+const REQUESTED_LOAD_LINE = /^Requested to load\s+([A-Za-z_][A-Za-z0-9_]{0,63})\s*$/
 
 /**
  * Parse a ComfyUI `Device:` line into its components. Handles the cuda
@@ -106,14 +111,9 @@ function parseTail(line: string, re: RegExp): string | null {
   return m && m[1] ? m[1].trim() : null
 }
 
-/** Parse "model_type FLUX" → "FLUX". */
-export function parseModelType(line: string): string | null {
-  return parseTail(line, MODEL_TYPE_LINE)
-}
-
-/** Parse "model weight dtype torch.float16, manual cast: None" → "torch.float16". */
-export function parseWeightDtype(line: string): string | null {
-  return parseTail(line, WEIGHT_DTYPE_LINE)
+/** Parse "Requested to load Lumina2" → "Lumina2". */
+export function parseRequestedModelLoad(line: string): string | null {
+  return parseTail(line, REQUESTED_LOAD_LINE)
 }
 
 /** Flush model-usage deltas at most this often while a session keeps loading models. */
@@ -145,24 +145,20 @@ export function createHardwareTap(opts: {
   let xformersVersion: string | null = null
   let cudaDeviceSet: number | null = null
 
-  // Per-architecture load counts since the last flush (deltas). `dtype` keeps
-  // the most recent weight dtype seen for that arch as a representative.
+  // Per-class load counts since the last flush (deltas).
   const pendingCounts = new Map<string, number>()
-  const lastDtype = new Map<string, string>()
   const markedArchitectures = new Set<string>()
-  let pendingDtype: string | null = null
 
   let flushTimer: ReturnType<typeof setInterval> | null = null
 
   function emitModelUsage(): void {
     if (pendingCounts.size === 0) return
-    for (const [modelType, count] of pendingCounts) {
+    for (const [modelClass, count] of pendingCounts) {
       if (count <= 0) continue
       telemetry.emit('comfy.desktop.comfyui.model_usage', {
         ...baseContext,
-        model_type: modelType,
-        count,
-        dtype: lastDtype.get(modelType) ?? null
+        model_class: modelClass,
+        count
       })
     }
     pendingCounts.clear()
@@ -236,30 +232,20 @@ export function createHardwareTap(opts: {
       }
     }
 
-    // Weight dtype is logged just before the model_type line; hold it so the
-    // model_usage event can record a representative dtype per architecture.
-    const dtype = parseWeightDtype(trimmed)
-    if (dtype) {
-      pendingDtype = dtype
-      return
-    }
-
-    const modelType = parseModelType(trimmed)
-    if (modelType) {
-      if (pendingCounts.has(modelType) || pendingCounts.size < MAX_TRACKED_ARCHITECTURES) {
-        pendingCounts.set(modelType, (pendingCounts.get(modelType) ?? 0) + 1)
-        if (pendingDtype) lastDtype.set(modelType, pendingDtype)
+    const modelClass = parseRequestedModelLoad(trimmed)
+    if (modelClass) {
+      if (pendingCounts.has(modelClass) || pendingCounts.size < MAX_TRACKED_ARCHITECTURES) {
+        pendingCounts.set(modelClass, (pendingCounts.get(modelClass) ?? 0) + 1)
         ensureFlushTimer()
-        // Per-person "ever used arch X" marker. `$set_once` is idempotent
+        // Per-person "ever loaded class X" marker. `$set_once` is idempotent
         // server-side; the per-tap Set avoids re-emitting person.set events.
-        if (!markedArchitectures.has(modelType)) {
-          markedArchitectures.add(modelType)
+        if (!markedArchitectures.has(modelClass)) {
+          markedArchitectures.add(modelClass)
           telemetry.registerPersonPropertiesOnce({
-            [`used_model_${modelType.toLowerCase()}_at`]: new Date().toISOString()
+            [`used_model_${modelClass.toLowerCase()}_at`]: new Date().toISOString()
           })
         }
       }
-      pendingDtype = null
       return
     }
   }
@@ -276,8 +262,8 @@ export function createHardwareTap(opts: {
 
   function appendChunk(source: 'stdout' | 'stderr', chunk: string): string[] {
     // Split first so a large chunk's complete lines (e.g. `Device:` /
-    // `model_type`) are never lost; cap only the unterminated tail we carry
-    // over, which is the sole unbounded-growth risk.
+    // `Requested to load`) are never lost; cap only the unterminated tail we
+    // carry over, which is the sole unbounded-growth risk.
     const lines = (pendingBySource[source] + chunk).split(/\r?\n/)
     const tail = lines.pop() ?? ''
     pendingBySource[source] = tail.length > MAX_PENDING_CHARS ? tail.slice(-MAX_PENDING_CHARS) : tail
@@ -310,7 +296,6 @@ export function createHardwareTap(opts: {
       pytorchVersion = null
       xformersVersion = null
       cudaDeviceSet = null
-      pendingDtype = null
       // Drop any incomplete lines from the previous (now-dead) process streams.
       pendingBySource.stdout = ''
       pendingBySource.stderr = ''

--- a/src/main/lib/ipc/registerAppHandlers.ts
+++ b/src/main/lib/ipc/registerAppHandlers.ts
@@ -24,7 +24,8 @@ import {
   getAppVersion,
   openPath,
   listSnapshots,
-  diffSnapshots
+  diffSnapshots,
+  buildInstallationDdContext
 } from './shared'
 import si from 'systeminformation'
 import type { FieldOption } from './shared'
@@ -420,112 +421,9 @@ export function registerAppHandlers(): void {
     return result
   })
 
-  ipcMain.handle('get-installation-dd-context', async (_event, installationId: string) => {
-    const MAX_CONTEXT_BYTES = 200 * 1024
-    const inst = await installations.get(installationId)
-    if (!inst || !inst.installPath) return null
-
-    const entries = await listSnapshots(inst.installPath)
-    const latest = entries.length > 0 ? entries[0]!.snapshot : null
-
-    const copiedFrom = inst.copiedFrom as string | undefined
-    const copyReason = inst.copyReason as string | undefined
-
-    let diskFreeGb: number | null = null
-    let diskTotalGb: number | null = null
-    try {
-      const disk = await getDiskSpace(inst.installPath)
-      diskFreeGb = Math.round(disk.free / 1073741824)
-      diskTotalGb = Math.round(disk.total / 1073741824)
-    } catch {}
-
-    const result = {
-      installation_id: inst.id,
-      variant: (inst.variant as string) || '',
-      source_id: (inst.sourceId as string) || '',
-      update_channel: (inst.updateChannel as string) || 'stable',
-      comfyui_version: (inst.comfyuiVersion as string) || '',
-      ...(copiedFrom ? { copied_from: copiedFrom } : {}),
-      ...(copyReason ? { copy_reason: copyReason } : {}),
-      snapshot_count: entries.length,
-      disk_free_gb: diskFreeGb,
-      disk_total_gb: diskTotalGb,
-      latest_snapshot: latest
-        ? {
-            createdAt: latest.createdAt,
-            trigger: latest.trigger,
-            label: latest.label,
-            comfyui: {
-              ref: latest.comfyui.ref,
-              commit: latest.comfyui.commit,
-              releaseTag: latest.comfyui.releaseTag,
-              variant: latest.comfyui.variant
-            },
-            customNodes: latest.customNodes.map((n) => ({
-              id: n.id,
-              type: n.type,
-              dirName: n.dirName,
-              enabled: n.enabled,
-              version: n.version,
-              commit: n.commit
-            })),
-            pipPackages: latest.pipPackages,
-            pythonVersion: latest.pythonVersion,
-            updateChannel: latest.updateChannel
-          }
-        : null,
-      snapshot_diffs: [] as Array<Record<string, unknown>>
-    }
-
-    let runningSize = JSON.stringify(result).length
-    for (let i = 0; i < entries.length - 1; i++) {
-      const newer = entries[i]!.snapshot
-      const older = entries[i + 1]!.snapshot
-      const diff = diffSnapshots(older, newer)
-      const entry: Record<string, unknown> = {
-        createdAt: newer.createdAt,
-        trigger: newer.trigger,
-        label: newer.label,
-        nodesAdded: diff.nodesAdded.map((n) => ({
-          id: n.id,
-          type: n.type,
-          dirName: n.dirName,
-          enabled: n.enabled,
-          version: n.version,
-          commit: n.commit
-        })),
-        nodesRemoved: diff.nodesRemoved.map((n) => ({
-          id: n.id,
-          type: n.type,
-          dirName: n.dirName,
-          enabled: n.enabled,
-          version: n.version,
-          commit: n.commit
-        })),
-        nodesChanged: diff.nodesChanged.map((n) => ({ id: n.id, from: n.from, to: n.to })),
-        pipsAdded: diff.pipsAdded,
-        pipsRemoved: diff.pipsRemoved,
-        pipsChanged: diff.pipsChanged,
-        comfyuiChanged: diff.comfyuiChanged,
-        updateChannelChanged: diff.updateChannelChanged
-      }
-      if (diff.comfyui) {
-        entry.comfyui = {
-          from: { ref: diff.comfyui.from.ref, commit: diff.comfyui.from.commit },
-          to: { ref: diff.comfyui.to.ref, commit: diff.comfyui.to.commit }
-        }
-      }
-      if (diff.updateChannel) {
-        entry.updateChannel = diff.updateChannel
-      }
-      const entrySize = JSON.stringify(entry).length + 1
-      if (runningSize + entrySize > MAX_CONTEXT_BYTES) break
-      result.snapshot_diffs.push(entry)
-      runningSize += entrySize
-    }
-
-    return result
-  })
+  ipcMain.handle('get-installation-dd-context', (_event, installationId: string) =>
+    buildInstallationDdContext(installationId)
+  )
 
   ipcMain.handle('get-device-id', () => getDeviceId())
 }

--- a/src/main/lib/ipc/registerAppHandlers.ts
+++ b/src/main/lib/ipc/registerAppHandlers.ts
@@ -19,6 +19,7 @@ import {
   checkAmdDriver,
   selectPrimaryGpu,
   vendorMatches,
+  getWindowsGpuDriverVersions,
   sourceMap,
   getAppVersion,
   openPath,
@@ -238,6 +239,15 @@ export function registerAppHandlers(): void {
         vram_mb: ctrl.vram ?? null,
         driver_version: ctrl.driverVersion?.trim() || null
       }))
+      // systeminformation only fills `driverVersion` for NVIDIA on Windows
+      // (via nvidia-smi), leaving AMD/Intel blank even though WMI carries it.
+      // Backfill the missing versions from Win32_VideoController by name.
+      const wmiDrivers = await getWindowsGpuDriverVersions()
+      if (wmiDrivers.size > 0) {
+        allGpus = allGpus.map((g) =>
+          g.driver_version ? g : { ...g, driver_version: wmiDrivers.get(g.model.toLowerCase()) ?? null }
+        )
+      }
     }
 
     // `detectGPU()` only resolves the vendor (NVIDIA / AMD / Intel /

--- a/src/main/lib/ipc/sessionActions/launch.ts
+++ b/src/main/lib/ipc/sessionActions/launch.ts
@@ -670,12 +670,20 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
         lastStderr,
         ...crashDiagnosis,
       }
+      // Emit from main (not the panel renderer) so the event survives the
+      // Desktop 2 panel teardown around exit. `telemetry.emit` captures to
+      // PostHog and mirrors to Datadog (crash-rate monitor). `last_stderr` is
+      // redacted by `scrubProperties`.
+      telemetry.emit('comfy.desktop.comfyui.exited', {
+        installation_id: installationId,
+        crashed,
+        exit_code: code ?? null,
+        last_stderr: lastStderr ?? null,
+      })
       if (crashed) {
         recordCrash(exitedPayload)
         // Broadcast to every renderer (not just `sender`) so any already-open
-        // dashboard shows the red error tile live. `comfy-exited` stays
-        // sender-only because its panel-side handler fires per-window
-        // telemetry that must not multiply across windows.
+        // dashboard shows the red error tile live.
         _broadcastToRenderer('instance-crashed', exitedPayload)
       }
       if (!sender.isDestroyed()) {
@@ -1140,12 +1148,20 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
         lastStderr,
         ...crashDiagnosis,
       }
+      // Emit from main (not the panel renderer) so the event survives the
+      // Desktop 2 panel teardown around exit. `telemetry.emit` captures to
+      // PostHog and mirrors to Datadog (crash-rate monitor). `last_stderr` is
+      // redacted by `scrubProperties`.
+      telemetry.emit('comfy.desktop.comfyui.exited', {
+        installation_id: installationId,
+        crashed,
+        exit_code: code ?? null,
+        last_stderr: lastStderr ?? null,
+      })
       if (crashed) {
         recordCrash(exitedPayload)
         // Broadcast to every renderer (not just `sender`) so any already-open
-        // dashboard shows the red error tile live. `comfy-exited` stays
-        // sender-only because its panel-side handler fires per-window
-        // telemetry that must not multiply across windows.
+        // dashboard shows the red error tile live.
         _broadcastToRenderer('instance-crashed', exitedPayload)
       }
       if (!sender.isDestroyed()) {

--- a/src/main/lib/ipc/sessionActions/launch.ts
+++ b/src/main/lib/ipc/sessionActions/launch.ts
@@ -670,10 +670,8 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
         lastStderr,
         ...crashDiagnosis,
       }
-      // Emit from main (not the panel renderer) so the event survives the
-      // Desktop 2 panel teardown around exit. `telemetry.emit` captures to
-      // PostHog and mirrors to Datadog (crash-rate monitor). `last_stderr` is
-      // redacted by `scrubProperties`.
+      // Emit from main so it survives the Desktop 2 panel teardown on exit.
+      // `emit` = PostHog + Datadog crash-rate monitor; `last_stderr` is scrubbed.
       telemetry.emit('comfy.desktop.comfyui.exited', {
         installation_id: installationId,
         crashed,
@@ -1148,10 +1146,8 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
         lastStderr,
         ...crashDiagnosis,
       }
-      // Emit from main (not the panel renderer) so the event survives the
-      // Desktop 2 panel teardown around exit. `telemetry.emit` captures to
-      // PostHog and mirrors to Datadog (crash-rate monitor). `last_stderr` is
-      // redacted by `scrubProperties`.
+      // Emit from main so it survives the Desktop 2 panel teardown on exit.
+      // `emit` = PostHog + Datadog crash-rate monitor; `last_stderr` is scrubbed.
       telemetry.emit('comfy.desktop.comfyui.exited', {
         installation_id: installationId,
         crashed,

--- a/src/main/lib/ipc/sessionStartTelemetry.ts
+++ b/src/main/lib/ipc/sessionStartTelemetry.ts
@@ -1,23 +1,16 @@
 /**
- * Main-process emitters for the per-instance session-start telemetry:
- * `session.instance_started`, the deprecated `session.installation_started`
- * shadow, and `session.snapshot_history`.
- *
- * These used to fire from the panel renderer's `onInstanceStarted` handler, but
- * Desktop 2's unified window destroys/swaps the dashboard panel around
- * server-ready, so the renderer callback frequently never ran and the events
- * silently vanished from rc.3 onward. Emitting from main — on the same
- * `_addSession` that drives the `instance-started` broadcast — makes them fire
- * reliably regardless of renderer lifecycle, with the exact same event names
- * and property shapes so existing dashboards/SQL keep working.
+ * Main-process emitters for the per-instance session-start telemetry
+ * (`session.instance_started`, the deprecated `installation_started` shadow,
+ * `session.snapshot_history`). Emitted from main rather than the panel renderer
+ * because Desktop 2 tears the panel down around server-ready, so the old
+ * renderer callbacks frequently never ran. Same event names/shapes as before.
  */
 import * as telemetry from '../telemetry'
 import { buildInstallationDdContext } from './shared'
 import { scrubAll } from '../../../shared/piiScrub'
 
-// Mirror the IPC bridge's large-`_json` ceiling so a structured payload either
-// ships intact or is omitted with a `*_truncated` flag — never sliced mid-string
-// into invalid JSON. Kept under PostHog's 1 MB per-event hard limit.
+// Mirror the bridge's large-`_json` ceiling: ship intact or omit + flag
+// `*_truncated`, never slice mid-string. Under PostHog's 1 MB event limit.
 const MAX_TELEMETRY_JSON_LENGTH = 768 * 1024
 
 function serializeForTelemetry(value: unknown): { json: string | null; truncated: boolean } {
@@ -26,10 +19,8 @@ function serializeForTelemetry(value: unknown): { json: string | null; truncated
   return { json, truncated: false }
 }
 
-// Scrub every pip spec value (an editable/local install can embed a home-dir
-// path like `pkg @ file:///C:/Users/<name>/...`) while leaving package names
-// untouched. Runs at the emit site so the scrub is intentional and the
-// serialized-JSON safety net never has to redact a path mid-string.
+// Scrub pip spec values (editable/local installs can embed a home-dir path)
+// while leaving package names untouched.
 function scrubPipSpecs(pipPackages: Record<string, string>): Record<string, string> {
   const scrubbed: Record<string, string> = {}
   for (const [name, spec] of Object.entries(pipPackages)) {
@@ -47,10 +38,8 @@ interface SnapshotNodeFields {
   commit?: string
 }
 
-// Single source of truth for the snapshot custom-node shape sent to telemetry,
-// shared by the latest-snapshot and per-diff node arrays so they can't drift.
-// `id`/`dirName` are folder/project names (never absolute paths today) but are
-// run through `scrubAll` as defense-in-depth; `version`/`commit` are git refs.
+// Shared custom-node shape for the latest-snapshot and per-diff node arrays so
+// they can't drift. `id`/`dirName` go through `scrubAll` as defense-in-depth.
 function serializeSnapshotNode(n: SnapshotNodeFields): {
   id: string
   type: string
@@ -108,13 +97,9 @@ export async function emitInstanceStartedTelemetry(info: InstanceStartedInfo): P
 
     const { snapshot_diffs, latest_snapshot, ...metadata } = ctx
 
-    // Forward the FULL latest snapshot so an installation's exact state (every
-    // custom node + pip package, with versions) is queryable, and earlier
-    // states can be reconstructed by walking `snapshot_diffs` back from it. The
-    // only genuine PII is the user-typed `label` (kept as a boolean
-    // `has_label`); package/node names and versions are public identifiers.
-    // Editable/local pip specs can embed a home-dir path, so each spec value is
-    // run through `scrubAll` here at the emit site.
+    // Full latest snapshot (every node + pip package) so exact state is
+    // queryable and earlier states reconstruct via `snapshot_diffs`. Only PII is
+    // the user-typed `label`, kept as a `has_label` bool.
     const latestSnapshotFull = latest_snapshot
       ? {
           createdAt: latest_snapshot.createdAt,
@@ -129,19 +114,16 @@ export async function emitInstanceStartedTelemetry(info: InstanceStartedInfo): P
       : null
     const latestSnapshotJson = serializeForTelemetry(latestSnapshotFull)
 
-    // Fires on EVERY ComfyUI instance boot (fresh install, restart, port
-    // realloc) — not on new-install completion. Despite its previous name
-    // (`session.installation_started`) it tracks per-instance boots. The old
-    // name is also emitted below for one release cycle so existing PostHog
-    // dashboards stay alive while migration happens (issue #1054).
+    // Fires on EVERY ComfyUI instance boot, not on new-install completion. The
+    // legacy `installation_started` name below tracks the same thing; kept for
+    // one release cycle so existing dashboards survive migration (issue #1054).
     const instanceStartedProps = {
       ...(metadata as Record<string, string | number | boolean | null | undefined>),
       boot_time_ms: info.bootTimeMs ?? null,
       port_retries: info.portRetries,
       reboot_retries: info.rebootRetries,
-      // Top-level so they stay queryable in PostHog's UI and survive even when
-      // `latest_snapshot_json` is dropped by the size cap (heavy installs are
-      // exactly the ones most likely to truncate).
+      // Top-level so they stay queryable and survive `latest_snapshot_json`
+      // truncation (heavy installs are the most likely to truncate).
       custom_nodes_count: latest_snapshot?.customNodes.length ?? null,
       pip_packages_count: latest_snapshot
         ? Object.keys(latest_snapshot.pipPackages).length
@@ -155,13 +137,8 @@ export async function emitInstanceStartedTelemetry(info: InstanceStartedInfo): P
     telemetry.capture('comfy.desktop.session.installation_started', instanceStartedProps)
 
     if (snapshot_diffs.length > 0) {
-      // Forward the FULL per-transition diffs (which nodes/packages were
-      // added/removed/changed, with versions) so the entire snapshot history
-      // can be reconstructed by applying these deltas backward from
-      // `latest_snapshot`. Drop only the user-typed `label` (kept as
-      // `has_label`); names/versions are public identifiers, and each pip spec
-      // value is run through `scrubAll` here at the emit site. PostHog only, per
-      // the Datadog "failures-only" policy.
+      // Full per-transition diffs so the history reconstructs by walking back
+      // from `latest_snapshot`. Drop only the user-typed `label` (→ `has_label`).
       const snapshotDiffsFull = (snapshot_diffs as unknown as RawSnapshotDiff[]).map((d) => ({
         createdAt: d.createdAt,
         trigger: d.trigger,

--- a/src/main/lib/ipc/sessionStartTelemetry.ts
+++ b/src/main/lib/ipc/sessionStartTelemetry.ts
@@ -1,0 +1,199 @@
+/**
+ * Main-process emitters for the per-instance session-start telemetry:
+ * `session.instance_started`, the deprecated `session.installation_started`
+ * shadow, and `session.snapshot_history`.
+ *
+ * These used to fire from the panel renderer's `onInstanceStarted` handler, but
+ * Desktop 2's unified window destroys/swaps the dashboard panel around
+ * server-ready, so the renderer callback frequently never ran and the events
+ * silently vanished from rc.3 onward. Emitting from main — on the same
+ * `_addSession` that drives the `instance-started` broadcast — makes them fire
+ * reliably regardless of renderer lifecycle, with the exact same event names
+ * and property shapes so existing dashboards/SQL keep working.
+ */
+import * as telemetry from '../telemetry'
+import { buildInstallationDdContext } from './shared'
+import { scrubAll } from '../../../shared/piiScrub'
+
+// Mirror the IPC bridge's large-`_json` ceiling so a structured payload either
+// ships intact or is omitted with a `*_truncated` flag — never sliced mid-string
+// into invalid JSON. Kept under PostHog's 1 MB per-event hard limit.
+const MAX_TELEMETRY_JSON_LENGTH = 768 * 1024
+
+function serializeForTelemetry(value: unknown): { json: string | null; truncated: boolean } {
+  const json = JSON.stringify(value)
+  if (json.length > MAX_TELEMETRY_JSON_LENGTH) return { json: null, truncated: true }
+  return { json, truncated: false }
+}
+
+// Scrub every pip spec value (an editable/local install can embed a home-dir
+// path like `pkg @ file:///C:/Users/<name>/...`) while leaving package names
+// untouched. Runs at the emit site so the scrub is intentional and the
+// serialized-JSON safety net never has to redact a path mid-string.
+function scrubPipSpecs(pipPackages: Record<string, string>): Record<string, string> {
+  const scrubbed: Record<string, string> = {}
+  for (const [name, spec] of Object.entries(pipPackages)) {
+    scrubbed[name] = scrubAll(spec)
+  }
+  return scrubbed
+}
+
+interface SnapshotNodeFields {
+  id: string
+  type: string
+  dirName: string
+  enabled: boolean
+  version?: string
+  commit?: string
+}
+
+// Single source of truth for the snapshot custom-node shape sent to telemetry,
+// shared by the latest-snapshot and per-diff node arrays so they can't drift.
+// `id`/`dirName` are folder/project names (never absolute paths today) but are
+// run through `scrubAll` as defense-in-depth; `version`/`commit` are git refs.
+function serializeSnapshotNode(n: SnapshotNodeFields): {
+  id: string
+  type: string
+  dirName: string
+  enabled: boolean
+  version: string | null
+  commit: string | null
+} {
+  return {
+    id: scrubAll(n.id),
+    type: n.type,
+    dirName: scrubAll(n.dirName),
+    enabled: n.enabled,
+    version: n.version ?? null,
+    commit: n.commit ?? null
+  }
+}
+
+// Shape of a single `snapshot_diffs` entry from `buildInstallationDdContext`
+// (typed there as `Record<string, unknown>` since it's built dynamically).
+interface RawSnapshotDiff {
+  createdAt: string
+  trigger: string
+  label?: string | null
+  nodesAdded: SnapshotNodeFields[]
+  nodesRemoved: SnapshotNodeFields[]
+  nodesChanged: Array<{ id: string; from: string; to: string }>
+  pipsAdded: Array<{ name: string; version: string }>
+  pipsRemoved: Array<{ name: string; version: string }>
+  pipsChanged: Array<{ name: string; from: string; to: string }>
+  comfyuiChanged: boolean
+  comfyui?: unknown
+  updateChannelChanged: boolean
+  updateChannel?: unknown
+}
+
+export interface InstanceStartedInfo {
+  installationId: string
+  /** Wall-clock ms from launch start to server-ready, folded onto the event. */
+  bootTimeMs?: number
+  /** Spawn-retry counts for THIS boot (0 on the remote / skip-port paths). */
+  portRetries: number
+  rebootRetries: number
+}
+
+/**
+ * Fire-and-forget. Invoked from `_addSession` (via the `onInstanceStarted`
+ * callback) on every ComfyUI instance boot. Builds the installation snapshot
+ * context, scrubs PII at the emit site, and captures the session-start events.
+ */
+export async function emitInstanceStartedTelemetry(info: InstanceStartedInfo): Promise<void> {
+  try {
+    const ctx = await buildInstallationDdContext(info.installationId)
+    if (!ctx) return
+
+    const { snapshot_diffs, latest_snapshot, ...metadata } = ctx
+
+    // Forward the FULL latest snapshot so an installation's exact state (every
+    // custom node + pip package, with versions) is queryable, and earlier
+    // states can be reconstructed by walking `snapshot_diffs` back from it. The
+    // only genuine PII is the user-typed `label` (kept as a boolean
+    // `has_label`); package/node names and versions are public identifiers.
+    // Editable/local pip specs can embed a home-dir path, so each spec value is
+    // run through `scrubAll` here at the emit site.
+    const latestSnapshotFull = latest_snapshot
+      ? {
+          createdAt: latest_snapshot.createdAt,
+          trigger: latest_snapshot.trigger,
+          has_label: latest_snapshot.label != null,
+          comfyui: latest_snapshot.comfyui,
+          customNodes: latest_snapshot.customNodes.map(serializeSnapshotNode),
+          pipPackages: scrubPipSpecs(latest_snapshot.pipPackages),
+          python_version: latest_snapshot.pythonVersion ?? null,
+          update_channel: latest_snapshot.updateChannel ?? null
+        }
+      : null
+    const latestSnapshotJson = serializeForTelemetry(latestSnapshotFull)
+
+    // Fires on EVERY ComfyUI instance boot (fresh install, restart, port
+    // realloc) — not on new-install completion. Despite its previous name
+    // (`session.installation_started`) it tracks per-instance boots. The old
+    // name is also emitted below for one release cycle so existing PostHog
+    // dashboards stay alive while migration happens (issue #1054).
+    const instanceStartedProps = {
+      ...(metadata as Record<string, string | number | boolean | null | undefined>),
+      boot_time_ms: info.bootTimeMs ?? null,
+      port_retries: info.portRetries,
+      reboot_retries: info.rebootRetries,
+      // Top-level so they stay queryable in PostHog's UI and survive even when
+      // `latest_snapshot_json` is dropped by the size cap (heavy installs are
+      // exactly the ones most likely to truncate).
+      custom_nodes_count: latest_snapshot?.customNodes.length ?? null,
+      pip_packages_count: latest_snapshot
+        ? Object.keys(latest_snapshot.pipPackages).length
+        : null,
+      latest_snapshot_json: latestSnapshotJson.json,
+      latest_snapshot_json_truncated: latestSnapshotJson.truncated
+    }
+    telemetry.capture('comfy.desktop.session.instance_started', instanceStartedProps)
+    // DEPRECATED 2026-06-12: misleadingly named — remove after 2026-07-01 once
+    // consumers migrate to `session.instance_started`. Tracked in issue #1054.
+    telemetry.capture('comfy.desktop.session.installation_started', instanceStartedProps)
+
+    if (snapshot_diffs.length > 0) {
+      // Forward the FULL per-transition diffs (which nodes/packages were
+      // added/removed/changed, with versions) so the entire snapshot history
+      // can be reconstructed by applying these deltas backward from
+      // `latest_snapshot`. Drop only the user-typed `label` (kept as
+      // `has_label`); names/versions are public identifiers, and each pip spec
+      // value is run through `scrubAll` here at the emit site. PostHog only, per
+      // the Datadog "failures-only" policy.
+      const snapshotDiffsFull = (snapshot_diffs as unknown as RawSnapshotDiff[]).map((d) => ({
+        createdAt: d.createdAt,
+        trigger: d.trigger,
+        has_label: d.label != null,
+        nodesAdded: d.nodesAdded.map(serializeSnapshotNode),
+        nodesRemoved: d.nodesRemoved.map(serializeSnapshotNode),
+        nodesChanged: d.nodesChanged.map((n) => ({
+          id: scrubAll(n.id),
+          from: n.from,
+          to: n.to
+        })),
+        pipsAdded: d.pipsAdded.map((p) => ({ name: p.name, version: scrubAll(p.version) })),
+        pipsRemoved: d.pipsRemoved.map((p) => ({ name: p.name, version: scrubAll(p.version) })),
+        pipsChanged: d.pipsChanged.map((p) => ({
+          name: p.name,
+          from: scrubAll(p.from),
+          to: scrubAll(p.to)
+        })),
+        comfyuiChanged: d.comfyuiChanged,
+        comfyui: d.comfyui ?? null,
+        updateChannelChanged: d.updateChannelChanged,
+        updateChannel: d.updateChannel ?? null
+      }))
+      const snapshotDiffsJson = serializeForTelemetry(snapshotDiffsFull)
+      telemetry.capture('comfy.desktop.session.snapshot_history', {
+        installation_id: ctx.installation_id,
+        snapshot_count: snapshot_diffs.length,
+        snapshot_diffs_json: snapshotDiffsJson.json,
+        snapshot_diffs_json_truncated: snapshotDiffsJson.truncated
+      })
+    }
+  } catch {
+    // Telemetry must never break a launch.
+  }
+}

--- a/src/main/lib/ipc/shared.ts
+++ b/src/main/lib/ipc/shared.ts
@@ -134,9 +134,21 @@ export interface RestartCallbackInfo {
   process?: ChildProcess
 }
 
+/** Fired from `_addSession` on every ComfyUI instance boot, carrying the same
+ *  timing/retry signal folded onto the `instance-started` broadcast. Drives the
+ *  main-process `session.instance_started` / `snapshot_history` telemetry that
+ *  used to live in the (now-unreliable) panel renderer. */
+export interface InstanceStartedCallbackInfo {
+  installationId: string
+  bootTimeMs?: number
+  portRetries: number
+  rebootRetries: number
+}
+
 export type LaunchCallback = (info: LaunchCallbackInfo) => void
 export type StopCallback = (info: StopCallbackInfo) => void
 export type ExitCallback = (info: ExitCallbackInfo) => void
+export type InstanceStartedCallback = (info: InstanceStartedCallbackInfo) => void
 export type RestartCallback = (info: RestartCallbackInfo) => void
 export type ModelFolderRelaunchCallback = (info: { installationId: string }) => void | Promise<void>
 export type LocaleCallback = () => void
@@ -146,6 +158,7 @@ export interface RegisterCallbacks {
   onLaunch?: LaunchCallback
   onStop?: StopCallback
   onComfyExited?: ExitCallback
+  onInstanceStarted?: InstanceStartedCallback
   onComfyRestarted?: RestartCallback
   onModelFolderRelaunch?: ModelFolderRelaunchCallback
   onLocaleChanged?: LocaleCallback
@@ -161,6 +174,7 @@ export const sourceMap: Record<string, SourcePlugin> = Object.fromEntries(source
 export let _onLaunch: LaunchCallback | null = null
 export let _onStop: StopCallback | null = null
 export let _onComfyExited: ExitCallback | null = null
+export let _onInstanceStarted: InstanceStartedCallback | null = null
 export let _onComfyRestarted: RestartCallback | null = null
 export let _onModelFolderRelaunch: ModelFolderRelaunchCallback | null = null
 export let _onLocaleChanged: LocaleCallback | null = null
@@ -262,6 +276,7 @@ export function setCallbacks(callbacks: RegisterCallbacks): void {
   _onLaunch = callbacks.onLaunch ?? null
   _onStop = callbacks.onStop ?? null
   _onComfyExited = callbacks.onComfyExited ?? null
+  _onInstanceStarted = callbacks.onInstanceStarted ?? null
   _onComfyRestarted = callbacks.onComfyRestarted ?? null
   _onModelFolderRelaunch = callbacks.onModelFolderRelaunch ?? null
   _onLocaleChanged = callbacks.onLocaleChanged ?? null
@@ -741,6 +756,18 @@ export function _addSession(
     rebootRetries: retries?.rebootRetries ?? 0,
   })
   sessionLifecycleEvents.emit('changed')
+  // Per-instance-boot telemetry (instance_started / snapshot_history). Emitted
+  // from main — not the panel renderer — because Desktop 2's unified window
+  // tears the panel down around server-ready, so the old renderer callback
+  // frequently never fired. Fire-and-forget; never blocks the launch.
+  if (_onInstanceStarted) {
+    _onInstanceStarted({
+      installationId,
+      bootTimeMs,
+      portRetries: retries?.portRetries ?? 0,
+      rebootRetries: retries?.rebootRetries ?? 0,
+    })
+  }
   // Stamps lastLaunchedAt + per-category recency so those surfaces needn't scan every record.
   installations.markLaunched(installationId, (inst) => sourceMap[inst.sourceId]?.category)
     .then(() => _broadcastToRenderer('installations-changed', {}))
@@ -767,6 +794,122 @@ export function _getPublicSessions(): Record<string, unknown>[] {
     installationName: s.installationName,
     startedAt: s.startedAt,
   }))
+}
+
+/**
+ * Build the installation snapshot/disk context consumed by both the
+ * `get-installation-dd-context` IPC handler and the main-process
+ * `instance_started` / `snapshot_history` telemetry emitters. Returns the full
+ * latest snapshot plus reconstructable per-transition diffs (capped to
+ * `MAX_CONTEXT_BYTES` so a deep history can't blow the event size); callers do
+ * their own PII scrubbing of the snapshot fields at the emit site. Returns
+ * `null` when the install is missing or has no install path.
+ */
+export async function buildInstallationDdContext(installationId: string) {
+  const MAX_CONTEXT_BYTES = 200 * 1024
+  const inst = await installations.get(installationId)
+  if (!inst || !inst.installPath) return null
+
+  const entries = await listSnapshots(inst.installPath)
+  const latest = entries.length > 0 ? entries[0]!.snapshot : null
+
+  const copiedFrom = inst.copiedFrom as string | undefined
+  const copyReason = inst.copyReason as string | undefined
+
+  let diskFreeGb: number | null = null
+  let diskTotalGb: number | null = null
+  try {
+    const disk = await getDiskSpace(inst.installPath)
+    diskFreeGb = Math.round(disk.free / 1073741824)
+    diskTotalGb = Math.round(disk.total / 1073741824)
+  } catch {}
+
+  const result = {
+    installation_id: inst.id,
+    variant: (inst.variant as string) || '',
+    source_id: (inst.sourceId as string) || '',
+    update_channel: (inst.updateChannel as string) || 'stable',
+    comfyui_version: (inst.comfyuiVersion as string) || '',
+    ...(copiedFrom ? { copied_from: copiedFrom } : {}),
+    ...(copyReason ? { copy_reason: copyReason } : {}),
+    snapshot_count: entries.length,
+    disk_free_gb: diskFreeGb,
+    disk_total_gb: diskTotalGb,
+    latest_snapshot: latest
+      ? {
+          createdAt: latest.createdAt,
+          trigger: latest.trigger,
+          label: latest.label,
+          comfyui: {
+            ref: latest.comfyui.ref,
+            commit: latest.comfyui.commit,
+            releaseTag: latest.comfyui.releaseTag,
+            variant: latest.comfyui.variant
+          },
+          customNodes: latest.customNodes.map((n) => ({
+            id: n.id,
+            type: n.type,
+            dirName: n.dirName,
+            enabled: n.enabled,
+            version: n.version,
+            commit: n.commit
+          })),
+          pipPackages: latest.pipPackages,
+          pythonVersion: latest.pythonVersion,
+          updateChannel: latest.updateChannel
+        }
+      : null,
+    snapshot_diffs: [] as Array<Record<string, unknown>>
+  }
+
+  let runningSize = JSON.stringify(result).length
+  for (let i = 0; i < entries.length - 1; i++) {
+    const newer = entries[i]!.snapshot
+    const older = entries[i + 1]!.snapshot
+    const diff = diffSnapshots(older, newer)
+    const entry: Record<string, unknown> = {
+      createdAt: newer.createdAt,
+      trigger: newer.trigger,
+      label: newer.label,
+      nodesAdded: diff.nodesAdded.map((n) => ({
+        id: n.id,
+        type: n.type,
+        dirName: n.dirName,
+        enabled: n.enabled,
+        version: n.version,
+        commit: n.commit
+      })),
+      nodesRemoved: diff.nodesRemoved.map((n) => ({
+        id: n.id,
+        type: n.type,
+        dirName: n.dirName,
+        enabled: n.enabled,
+        version: n.version,
+        commit: n.commit
+      })),
+      nodesChanged: diff.nodesChanged.map((n) => ({ id: n.id, from: n.from, to: n.to })),
+      pipsAdded: diff.pipsAdded,
+      pipsRemoved: diff.pipsRemoved,
+      pipsChanged: diff.pipsChanged,
+      comfyuiChanged: diff.comfyuiChanged,
+      updateChannelChanged: diff.updateChannelChanged
+    }
+    if (diff.comfyui) {
+      entry.comfyui = {
+        from: { ref: diff.comfyui.from.ref, commit: diff.comfyui.from.commit },
+        to: { ref: diff.comfyui.to.ref, commit: diff.comfyui.to.commit }
+      }
+    }
+    if (diff.updateChannel) {
+      entry.updateChannel = diff.updateChannel
+    }
+    const entrySize = JSON.stringify(entry).length + 1
+    if (runningSize + entrySize > MAX_CONTEXT_BYTES) break
+    result.snapshot_diffs.push(entry)
+    runningSize += entrySize
+  }
+
+  return result
 }
 
 export async function _fetchAndResolveLatestTags(

--- a/src/main/lib/ipc/shared.ts
+++ b/src/main/lib/ipc/shared.ts
@@ -134,10 +134,8 @@ export interface RestartCallbackInfo {
   process?: ChildProcess
 }
 
-/** Fired from `_addSession` on every ComfyUI instance boot, carrying the same
- *  timing/retry signal folded onto the `instance-started` broadcast. Drives the
- *  main-process `session.instance_started` / `snapshot_history` telemetry that
- *  used to live in the (now-unreliable) panel renderer. */
+/** Fired from `_addSession` on every ComfyUI instance boot; drives the
+ *  main-process `instance_started` / `snapshot_history` telemetry. */
 export interface InstanceStartedCallbackInfo {
   installationId: string
   bootTimeMs?: number
@@ -756,10 +754,9 @@ export function _addSession(
     rebootRetries: retries?.rebootRetries ?? 0,
   })
   sessionLifecycleEvents.emit('changed')
-  // Per-instance-boot telemetry (instance_started / snapshot_history). Emitted
-  // from main — not the panel renderer — because Desktop 2's unified window
-  // tears the panel down around server-ready, so the old renderer callback
-  // frequently never fired. Fire-and-forget; never blocks the launch.
+  // Per-instance-boot telemetry (instance_started / snapshot_history), emitted
+  // from main since Desktop 2 tears the panel down before the old renderer
+  // callback could fire. Fire-and-forget; never blocks the launch.
   if (_onInstanceStarted) {
     _onInstanceStarted({
       installationId,
@@ -797,13 +794,12 @@ export function _getPublicSessions(): Record<string, unknown>[] {
 }
 
 /**
- * Build the installation snapshot/disk context consumed by both the
+ * Build the installation snapshot/disk context for the
  * `get-installation-dd-context` IPC handler and the main-process
- * `instance_started` / `snapshot_history` telemetry emitters. Returns the full
- * latest snapshot plus reconstructable per-transition diffs (capped to
- * `MAX_CONTEXT_BYTES` so a deep history can't blow the event size); callers do
- * their own PII scrubbing of the snapshot fields at the emit site. Returns
- * `null` when the install is missing or has no install path.
+ * `instance_started` / `snapshot_history` telemetry. Returns the full latest
+ * snapshot plus reconstructable per-transition diffs (capped to
+ * `MAX_CONTEXT_BYTES`); callers scrub PII at the emit site. `null` when the
+ * install is missing or has no install path.
  */
 export async function buildInstallationDdContext(installationId: string) {
   const MAX_CONTEXT_BYTES = 200 * 1024
@@ -841,12 +837,9 @@ export async function buildInstallationDdContext(installationId: string) {
           trigger: latest.trigger,
           label: latest.label,
           comfyui: {
-            // `ref`/`releaseTag` come from the install's static manifest.json
-            // (the version the standalone env shipped with) and DON'T move on
-            // in-place ComfyUI updates. `commit` is live; `baseTag`/
-            // `commitsAhead`/`formattedVersion` are the resolved real version
-            // (nearest tag + N commits ahead) and are what to read for "what
-            // ComfyUI is actually running".
+            // `ref`/`releaseTag` are static manifest values (the version the env
+            // shipped with) and don't move on in-place updates; read
+            // `formattedVersion` (resolved from `commit`) for what's running.
             ref: latest.comfyui.ref,
             commit: latest.comfyui.commit,
             releaseTag: latest.comfyui.releaseTag,
@@ -904,10 +897,8 @@ export async function buildInstallationDdContext(installationId: string) {
       updateChannelChanged: diff.updateChannelChanged
     }
     if (diff.comfyui) {
-      // `formattedVersion` (+ raw `baseTag`/`commitsAhead`) is the resolved real
-      // ComfyUI version on each side of the transition; `ref` is the static
-      // manifest value and doesn't move on in-place updates. See the
-      // latest-snapshot comfyui note above.
+      // `formattedVersion` is the resolved version per side; `ref` is the static
+      // manifest value. See the latest-snapshot comfyui note above.
       entry.comfyui = {
         from: {
           ref: diff.comfyui.from.ref,

--- a/src/main/lib/ipc/shared.ts
+++ b/src/main/lib/ipc/shared.ts
@@ -841,10 +841,19 @@ export async function buildInstallationDdContext(installationId: string) {
           trigger: latest.trigger,
           label: latest.label,
           comfyui: {
+            // `ref`/`releaseTag` come from the install's static manifest.json
+            // (the version the standalone env shipped with) and DON'T move on
+            // in-place ComfyUI updates. `commit` is live; `baseTag`/
+            // `commitsAhead`/`formattedVersion` are the resolved real version
+            // (nearest tag + N commits ahead) and are what to read for "what
+            // ComfyUI is actually running".
             ref: latest.comfyui.ref,
             commit: latest.comfyui.commit,
             releaseTag: latest.comfyui.releaseTag,
-            variant: latest.comfyui.variant
+            variant: latest.comfyui.variant,
+            baseTag: latest.comfyui.baseTag ?? null,
+            commitsAhead: latest.comfyui.commitsAhead ?? null,
+            formattedVersion: formatSnapshotVersion(latest.comfyui, 'detail')
           },
           customNodes: latest.customNodes.map((n) => ({
             id: n.id,
@@ -895,9 +904,25 @@ export async function buildInstallationDdContext(installationId: string) {
       updateChannelChanged: diff.updateChannelChanged
     }
     if (diff.comfyui) {
+      // `formattedVersion` (+ raw `baseTag`/`commitsAhead`) is the resolved real
+      // ComfyUI version on each side of the transition; `ref` is the static
+      // manifest value and doesn't move on in-place updates. See the
+      // latest-snapshot comfyui note above.
       entry.comfyui = {
-        from: { ref: diff.comfyui.from.ref, commit: diff.comfyui.from.commit },
-        to: { ref: diff.comfyui.to.ref, commit: diff.comfyui.to.commit }
+        from: {
+          ref: diff.comfyui.from.ref,
+          commit: diff.comfyui.from.commit,
+          baseTag: diff.comfyui.from.baseTag ?? null,
+          commitsAhead: diff.comfyui.from.commitsAhead ?? null,
+          formattedVersion: diff.comfyui.from.formattedVersion
+        },
+        to: {
+          ref: diff.comfyui.to.ref,
+          commit: diff.comfyui.to.commit,
+          baseTag: diff.comfyui.to.baseTag ?? null,
+          commitsAhead: diff.comfyui.to.commitsAhead ?? null,
+          formattedVersion: diff.comfyui.to.formattedVersion
+        }
       }
     }
     if (diff.updateChannel) {

--- a/src/main/lib/ipc/shared.ts
+++ b/src/main/lib/ipc/shared.ts
@@ -29,7 +29,7 @@ import {
   findAvailablePort, isPortListening, writePortLock, readPortLock, removePortLock,
   COMFY_BOOT_TIMEOUT_MS,
 } from '../process'
-import { detectGPU, validateHardware, checkNvidiaDriver, checkAmdDriver, selectPrimaryGpu, vendorMatches } from '../gpu'
+import { detectGPU, validateHardware, checkNvidiaDriver, checkAmdDriver, selectPrimaryGpu, vendorMatches, getWindowsGpuDriverVersions } from '../gpu'
 import { detectDesktopInstall, stageDesktopSnapshot } from '../desktopDetect'
 import { performLocalMigration, stageLocalSnapshot } from '../localMigration'
 import { getDiskSpace, getDirectorySize, validateInstallPath } from '../disk'
@@ -69,7 +69,7 @@ export {
   findPidsByPort, getProcessInfo, looksLikeComfyUI, setPortArg,
   findAvailablePort, isPortListening, writePortLock, readPortLock, removePortLock,
   COMFY_BOOT_TIMEOUT_MS,
-  detectGPU, validateHardware, checkNvidiaDriver, checkAmdDriver, selectPrimaryGpu, vendorMatches,
+  detectGPU, validateHardware, checkNvidiaDriver, checkAmdDriver, selectPrimaryGpu, vendorMatches, getWindowsGpuDriverVersions,
   detectDesktopInstall, stageDesktopSnapshot,
   performLocalMigration, stageLocalSnapshot,
   getDiskSpace, getDirectorySize, validateInstallPath,

--- a/src/renderer/src/lib/rendererBootstrap.ts
+++ b/src/renderer/src/lib/rendererBootstrap.ts
@@ -640,17 +640,11 @@ export function initializeRendererBootstrap(role: RendererRole = 'panel'): void 
     })
   }
 
-  // `comfy-boot-log` is an install-lifecycle event whose renderer-side handler
-  // converts it into a telemetry Action. Owned by the panel renderer (which
-  // drives the install/lifecycle UI); gating it to `'panel'` prevents the
-  // title-bar bootstrap from double-firing when both renderers are mounted.
-  //
-  // `comfy.desktop.comfyui.exited` and `session.instance_started` /
-  // `installation_started` / `snapshot_history` used to be emitted here too, but
-  // Desktop 2's unified window tears the panel down around exit/server-ready, so
-  // those renderer callbacks frequently never ran and the events vanished from
-  // PostHog. They now emit from the main process (`launch.ts` exit handlers and
-  // the `onInstanceStarted` callback) where they fire reliably.
+  // `comfy-boot-log` → telemetry Action, gated to `'panel'` so it fires once
+  // (not per host-window title-bar). It's safe here because it runs while the
+  // panel is still alive. `exited` / `instance_started` / `installation_started`
+  // / `snapshot_history` used to live here too but now emit from main, since
+  // Desktop 2 tears the panel down before those callbacks could fire.
   if (rendererRole === 'panel') {
     window.api.onComfyBootLog((data) => {
       trackTelemetryAction('comfy.desktop.comfyui.boot_log', {

--- a/src/renderer/src/lib/rendererBootstrap.ts
+++ b/src/renderer/src/lib/rendererBootstrap.ts
@@ -214,6 +214,38 @@ function scrubPipSpecs(pipPackages: Record<string, string>): Record<string, stri
   return scrubbed
 }
 
+interface SnapshotNodeFields {
+  id: string
+  type: string
+  dirName: string
+  enabled: boolean
+  version?: string
+  commit?: string
+}
+
+// Single source of truth for the snapshot custom-node shape sent to telemetry,
+// shared by the latest-snapshot and per-diff node arrays so they can't drift.
+// `id`/`dirName` are folder/project names (never absolute paths today) but are
+// run through `scrubAll` as emit-site defense-in-depth; `version`/`commit` are
+// git refs.
+function serializeSnapshotNode(n: SnapshotNodeFields): {
+  id: string
+  type: string
+  dirName: string
+  enabled: boolean
+  version: string | null
+  commit: string | null
+} {
+  return {
+    id: scrubAll(n.id),
+    type: n.type,
+    dirName: scrubAll(n.dirName),
+    enabled: n.enabled,
+    version: n.version ?? null,
+    commit: n.commit ?? null
+  }
+}
+
 function serializeForTelemetry(value: unknown): { json: string | null; truncated: boolean } {
   const json = JSON.stringify(value)
   if (json.length > MAX_TELEMETRY_JSON_LENGTH) return { json: null, truncated: true }
@@ -706,14 +738,7 @@ export function initializeRendererBootstrap(role: RendererRole = 'panel'): void 
                 trigger: latest_snapshot.trigger,
                 has_label: latest_snapshot.label != null,
                 comfyui: latest_snapshot.comfyui,
-                customNodes: latest_snapshot.customNodes.map((n) => ({
-                  id: n.id,
-                  type: n.type,
-                  dirName: n.dirName,
-                  enabled: n.enabled,
-                  version: n.version ?? null,
-                  commit: n.commit ?? null
-                })),
+                customNodes: latest_snapshot.customNodes.map(serializeSnapshotNode),
                 pipPackages: scrubPipSpecs(latest_snapshot.pipPackages),
                 python_version: latest_snapshot.pythonVersion ?? null,
                 update_channel: latest_snapshot.updateChannel ?? null
@@ -770,23 +795,13 @@ export function initializeRendererBootstrap(role: RendererRole = 'panel'): void 
               createdAt: d.createdAt,
               trigger: d.trigger,
               has_label: d.label != null,
-              nodesAdded: d.nodesAdded.map((n) => ({
-                id: n.id,
-                type: n.type,
-                dirName: n.dirName,
-                enabled: n.enabled,
-                version: n.version ?? null,
-                commit: n.commit ?? null
+              nodesAdded: d.nodesAdded.map(serializeSnapshotNode),
+              nodesRemoved: d.nodesRemoved.map(serializeSnapshotNode),
+              nodesChanged: d.nodesChanged.map((n) => ({
+                id: scrubAll(n.id),
+                from: n.from,
+                to: n.to
               })),
-              nodesRemoved: d.nodesRemoved.map((n) => ({
-                id: n.id,
-                type: n.type,
-                dirName: n.dirName,
-                enabled: n.enabled,
-                version: n.version ?? null,
-                commit: n.commit ?? null
-              })),
-              nodesChanged: d.nodesChanged,
               pipsAdded: d.pipsAdded.map((p) => ({ name: p.name, version: scrubAll(p.version) })),
               pipsRemoved: d.pipsRemoved.map((p) => ({
                 name: p.name,

--- a/src/renderer/src/lib/rendererBootstrap.ts
+++ b/src/renderer/src/lib/rendererBootstrap.ts
@@ -736,10 +736,13 @@ export function initializeRendererBootstrap(role: RendererRole = 'panel'): void 
             boot_time_ms: bootTimeMs ?? null,
             port_retries: portRetries,
             reboot_retries: rebootRetries,
-            // Top-level so it stays queryable in PostHog's UI and survives even
-            // when `latest_snapshot_json` is dropped by the size cap (heavy-node
+            // Top-level so they stay queryable in PostHog's UI and survive even
+            // when `latest_snapshot_json` is dropped by the size cap (heavy
             // installs are exactly the ones most likely to truncate).
             custom_nodes_count: latest_snapshot?.customNodes.length ?? null,
+            pip_packages_count: latest_snapshot
+              ? Object.keys(latest_snapshot.pipPackages).length
+              : null,
             latest_snapshot_json: latestSnapshotJson.json,
             latest_snapshot_json_truncated: latestSnapshotJson.truncated
           }

--- a/src/renderer/src/lib/rendererBootstrap.ts
+++ b/src/renderer/src/lib/rendererBootstrap.ts
@@ -202,50 +202,6 @@ function scrubTelemetryContext(context: TelemetryContext): TelemetryContext {
 // Kept under PostHog's 1 MB per-event hard limit.
 const MAX_TELEMETRY_JSON_LENGTH = 768 * 1024
 
-// Scrub every pip spec value (an editable/local install can embed a home-dir
-// path like `pkg @ file:///C:/Users/<name>/...`) while leaving package names
-// untouched. Runs at the emit site so the scrub is intentional and the
-// main-process safety net never has to redact a path mid-JSON-string.
-function scrubPipSpecs(pipPackages: Record<string, string>): Record<string, string> {
-  const scrubbed: Record<string, string> = {}
-  for (const [name, spec] of Object.entries(pipPackages)) {
-    scrubbed[name] = scrubAll(spec)
-  }
-  return scrubbed
-}
-
-interface SnapshotNodeFields {
-  id: string
-  type: string
-  dirName: string
-  enabled: boolean
-  version?: string
-  commit?: string
-}
-
-// Single source of truth for the snapshot custom-node shape sent to telemetry,
-// shared by the latest-snapshot and per-diff node arrays so they can't drift.
-// `id`/`dirName` are folder/project names (never absolute paths today) but are
-// run through `scrubAll` as emit-site defense-in-depth; `version`/`commit` are
-// git refs.
-function serializeSnapshotNode(n: SnapshotNodeFields): {
-  id: string
-  type: string
-  dirName: string
-  enabled: boolean
-  version: string | null
-  commit: string | null
-} {
-  return {
-    id: scrubAll(n.id),
-    type: n.type,
-    dirName: scrubAll(n.dirName),
-    enabled: n.enabled,
-    version: n.version ?? null,
-    commit: n.commit ?? null
-  }
-}
-
 function serializeForTelemetry(value: unknown): { json: string | null; truncated: boolean } {
   const json = JSON.stringify(value)
   if (json.length > MAX_TELEMETRY_JSON_LENGTH) return { json: null, truncated: true }
@@ -684,153 +640,23 @@ export function initializeRendererBootstrap(role: RendererRole = 'panel'): void 
     })
   }
 
-  // `comfy-exited` / `comfy-boot-log` / `instance-started` are install-
-  // lifecycle events whose renderer-side handlers convert them into
-  // telemetry Actions. These are owned by the panel renderer (which drives
-  // the install/lifecycle UI) — gating them to `'panel'` prevents the
-  // title-bar bootstrap from double-firing the broadcast `instance-started`
-  // event on Datadog/PostHog when both renderers are mounted.
+  // `comfy-boot-log` is an install-lifecycle event whose renderer-side handler
+  // converts it into a telemetry Action. Owned by the panel renderer (which
+  // drives the install/lifecycle UI); gating it to `'panel'` prevents the
+  // title-bar bootstrap from double-firing when both renderers are mounted.
+  //
+  // `comfy.desktop.comfyui.exited` and `session.instance_started` /
+  // `installation_started` / `snapshot_history` used to be emitted here too, but
+  // Desktop 2's unified window tears the panel down around exit/server-ready, so
+  // those renderer callbacks frequently never ran and the events vanished from
+  // PostHog. They now emit from the main process (`launch.ts` exit handlers and
+  // the `onInstanceStarted` callback) where they fire reliably.
   if (rendererRole === 'panel') {
-    window.api.onComfyExited((data) => {
-      trackTelemetryAction('comfy.desktop.comfyui.exited', {
-        installation_id: data.installationId,
-        crashed: data.crashed ?? false,
-        exit_code: data.exitCode ?? null,
-        last_stderr: data.lastStderr ?? null
-      })
-    })
-
     window.api.onComfyBootLog((data) => {
       trackTelemetryAction('comfy.desktop.comfyui.boot_log', {
         installation_id: data.installationId,
         boot_stderr: data.bootStderr
       })
-    })
-
-    window.api.onInstanceStarted((data) => {
-      const raw = data as unknown as Record<string, unknown>
-      const bootTimeMs = raw.bootTimeMs as number | undefined
-      // Spawn-retry counts folded onto the broadcast by `_addSession` (main).
-      // Carried here instead of a separate `server_ready` event: a boot that
-      // needed N port/reboot respawns before serving is a quality signal on
-      // the SAME boot the timing describes. Default 0 for the remote /
-      // skip-port paths that don't spawn-retry.
-      const portRetries = typeof raw.portRetries === 'number' ? raw.portRetries : 0
-      const rebootRetries = typeof raw.rebootRetries === 'number' ? raw.rebootRetries : 0
-      window.api
-        .getInstallationDdContext(data.installationId)
-        .then((ctx) => {
-          if (!ctx) return
-          const { snapshot_diffs, latest_snapshot, ...metadata } = ctx
-          // Forward the FULL latest snapshot so an installation's exact state
-          // (every custom node + pip package, with versions) is queryable, and
-          // earlier states can be reconstructed by walking `snapshot_diffs`
-          // back from it. The only genuine PII is the user-typed `label` (kept
-          // as a boolean `has_label`); package/node names and versions are
-          // public identifiers. Editable/local pip specs can embed a home-dir
-          // path (e.g. `pkg @ file:///C:/Users/<name>/...`), so each spec value
-          // is run through `scrubAll` here at the emit site (the main-process
-          // `scrubProperties` net only sees the serialized JSON string, where a
-          // backslash Windows path would be JSON-escaped past its regexes).
-          const latestSnapshotFull = latest_snapshot
-            ? {
-                createdAt: latest_snapshot.createdAt,
-                trigger: latest_snapshot.trigger,
-                has_label: latest_snapshot.label != null,
-                comfyui: latest_snapshot.comfyui,
-                customNodes: latest_snapshot.customNodes.map(serializeSnapshotNode),
-                pipPackages: scrubPipSpecs(latest_snapshot.pipPackages),
-                python_version: latest_snapshot.pythonVersion ?? null,
-                update_channel: latest_snapshot.updateChannel ?? null
-              }
-            : null
-          const latestSnapshotJson = serializeForTelemetry(latestSnapshotFull)
-          // Fires on EVERY ComfyUI instance boot (fresh install, restart, port
-          // realloc) — not on new-install completion. Despite its previous name
-          // (`session.installation_started`) it tracks per-instance boots, so
-          // dashboards built off the old name were over-counting new installs by
-          // ~2.3x (median fires/user/week, 656 max). Use `install.flow.opened`
-          // or `op.result` with `op_kind='install'` for actual install activity.
-          // The old name is also emitted below for one release cycle so existing
-          // PostHog dashboards stay alive while migration happens.
-          const instanceStartedProps = {
-            ...(metadata as unknown as Record<
-              string,
-              string | number | boolean | null | undefined
-            >),
-            boot_time_ms: bootTimeMs ?? null,
-            port_retries: portRetries,
-            reboot_retries: rebootRetries,
-            // Top-level so they stay queryable in PostHog's UI and survive even
-            // when `latest_snapshot_json` is dropped by the size cap (heavy
-            // installs are exactly the ones most likely to truncate).
-            custom_nodes_count: latest_snapshot?.customNodes.length ?? null,
-            pip_packages_count: latest_snapshot
-              ? Object.keys(latest_snapshot.pipPackages).length
-              : null,
-            latest_snapshot_json: latestSnapshotJson.json,
-            latest_snapshot_json_truncated: latestSnapshotJson.truncated
-          }
-          trackTelemetryAction(
-            'comfy.desktop.session.instance_started',
-            instanceStartedProps
-          )
-          // DEPRECATED 2026-06-12: misleadingly named — remove after 2026-07-01
-          // once any consumers have migrated to `session.instance_started`.
-          // Tracked in issue #1054.
-          trackTelemetryAction(
-            'comfy.desktop.session.installation_started',
-            instanceStartedProps
-          )
-          if (snapshot_diffs.length > 0) {
-            // Forward the FULL per-transition diffs (which nodes/packages were
-            // added/removed/changed, with versions) so the entire snapshot
-            // history can be reconstructed by applying these deltas backward
-            // from `latest_snapshot`. Drop only the user-typed `label` (kept as
-            // `has_label`); names/versions are public identifiers, and each pip
-            // spec value is run through `scrubAll` here at the emit site so a
-            // home-dir path in an editable/local install never ships. PostHog
-            // only, per the Datadog "failures-only" policy.
-            const snapshotDiffsFull = snapshot_diffs.map((d) => ({
-              createdAt: d.createdAt,
-              trigger: d.trigger,
-              has_label: d.label != null,
-              nodesAdded: d.nodesAdded.map(serializeSnapshotNode),
-              nodesRemoved: d.nodesRemoved.map(serializeSnapshotNode),
-              nodesChanged: d.nodesChanged.map((n) => ({
-                id: scrubAll(n.id),
-                from: n.from,
-                to: n.to
-              })),
-              pipsAdded: d.pipsAdded.map((p) => ({ name: p.name, version: scrubAll(p.version) })),
-              pipsRemoved: d.pipsRemoved.map((p) => ({
-                name: p.name,
-                version: scrubAll(p.version)
-              })),
-              pipsChanged: d.pipsChanged.map((p) => ({
-                name: p.name,
-                from: scrubAll(p.from),
-                to: scrubAll(p.to)
-              })),
-              comfyuiChanged: d.comfyuiChanged,
-              comfyui: d.comfyui ?? null,
-              updateChannelChanged: d.updateChannelChanged,
-              updateChannel: d.updateChannel ?? null
-            }))
-            const snapshotDiffsJson = serializeForTelemetry(snapshotDiffsFull)
-            try {
-              window.api.captureTelemetry('comfy.desktop.session.snapshot_history', {
-                installation_id: ctx.installation_id,
-                snapshot_count: snapshot_diffs.length,
-                snapshot_diffs_json: snapshotDiffsJson.json,
-                snapshot_diffs_json_truncated: snapshotDiffsJson.truncated
-              })
-            } catch {
-              // ignore
-            }
-          }
-        })
-        .catch(() => {})
     })
   }
 }

--- a/src/renderer/src/lib/rendererBootstrap.ts
+++ b/src/renderer/src/lib/rendererBootstrap.ts
@@ -202,6 +202,18 @@ function scrubTelemetryContext(context: TelemetryContext): TelemetryContext {
 // Kept under PostHog's 1 MB per-event hard limit.
 const MAX_TELEMETRY_JSON_LENGTH = 768 * 1024
 
+// Scrub every pip spec value (an editable/local install can embed a home-dir
+// path like `pkg @ file:///C:/Users/<name>/...`) while leaving package names
+// untouched. Runs at the emit site so the scrub is intentional and the
+// main-process safety net never has to redact a path mid-JSON-string.
+function scrubPipSpecs(pipPackages: Record<string, string>): Record<string, string> {
+  const scrubbed: Record<string, string> = {}
+  for (const [name, spec] of Object.entries(pipPackages)) {
+    scrubbed[name] = scrubAll(spec)
+  }
+  return scrubbed
+}
+
 function serializeForTelemetry(value: unknown): { json: string | null; truncated: boolean } {
   const json = JSON.stringify(value)
   if (json.length > MAX_TELEMETRY_JSON_LENGTH) return { json: null, truncated: true }
@@ -683,10 +695,11 @@ export function initializeRendererBootstrap(role: RendererRole = 'panel'): void 
           // earlier states can be reconstructed by walking `snapshot_diffs`
           // back from it. The only genuine PII is the user-typed `label` (kept
           // as a boolean `has_label`); package/node names and versions are
-          // public identifiers. Any home-dir path in an editable/local pip
-          // install (e.g. `pkg @ file:///C:/Users/<name>/...`) is redacted by
-          // `scrubAll` in the main-process `scrubProperties` safety net before
-          // the event ships.
+          // public identifiers. Editable/local pip specs can embed a home-dir
+          // path (e.g. `pkg @ file:///C:/Users/<name>/...`), so each spec value
+          // is run through `scrubAll` here at the emit site (the main-process
+          // `scrubProperties` net only sees the serialized JSON string, where a
+          // backslash Windows path would be JSON-escaped past its regexes).
           const latestSnapshotFull = latest_snapshot
             ? {
                 createdAt: latest_snapshot.createdAt,
@@ -701,7 +714,7 @@ export function initializeRendererBootstrap(role: RendererRole = 'panel'): void 
                   version: n.version ?? null,
                   commit: n.commit ?? null
                 })),
-                pipPackages: latest_snapshot.pipPackages,
+                pipPackages: scrubPipSpecs(latest_snapshot.pipPackages),
                 custom_nodes_count: latest_snapshot.customNodes.length,
                 pip_packages_count: Object.keys(latest_snapshot.pipPackages).length,
                 python_version: latest_snapshot.pythonVersion ?? null,
@@ -744,10 +757,10 @@ export function initializeRendererBootstrap(role: RendererRole = 'panel'): void 
             // added/removed/changed, with versions) so the entire snapshot
             // history can be reconstructed by applying these deltas backward
             // from `latest_snapshot`. Drop only the user-typed `label` (kept as
-            // `has_label`); names/versions are public identifiers, and any
-            // home-dir path in a pip spec is redacted by `scrubAll` in the
-            // main-process `scrubProperties` safety net. PostHog only, per the
-            // Datadog "failures-only" policy.
+            // `has_label`); names/versions are public identifiers, and each pip
+            // spec value is run through `scrubAll` here at the emit site so a
+            // home-dir path in an editable/local install never ships. PostHog
+            // only, per the Datadog "failures-only" policy.
             const snapshotDiffsFull = snapshot_diffs.map((d) => ({
               createdAt: d.createdAt,
               trigger: d.trigger,
@@ -769,9 +782,16 @@ export function initializeRendererBootstrap(role: RendererRole = 'panel'): void 
                 commit: n.commit ?? null
               })),
               nodesChanged: d.nodesChanged,
-              pipsAdded: d.pipsAdded,
-              pipsRemoved: d.pipsRemoved,
-              pipsChanged: d.pipsChanged,
+              pipsAdded: d.pipsAdded.map((p) => ({ name: p.name, version: scrubAll(p.version) })),
+              pipsRemoved: d.pipsRemoved.map((p) => ({
+                name: p.name,
+                version: scrubAll(p.version)
+              })),
+              pipsChanged: d.pipsChanged.map((p) => ({
+                name: p.name,
+                from: scrubAll(p.from),
+                to: scrubAll(p.to)
+              })),
               comfyuiChanged: d.comfyuiChanged,
               comfyui: d.comfyui ?? null,
               updateChannelChanged: d.updateChannelChanged,

--- a/src/renderer/src/lib/rendererBootstrap.ts
+++ b/src/renderer/src/lib/rendererBootstrap.ts
@@ -736,6 +736,10 @@ export function initializeRendererBootstrap(role: RendererRole = 'panel'): void 
             boot_time_ms: bootTimeMs ?? null,
             port_retries: portRetries,
             reboot_retries: rebootRetries,
+            // Top-level so it stays queryable in PostHog's UI and survives even
+            // when `latest_snapshot_json` is dropped by the size cap (heavy-node
+            // installs are exactly the ones most likely to truncate).
+            custom_nodes_count: latest_snapshot?.customNodes.length ?? null,
             latest_snapshot_json: latestSnapshotJson.json,
             latest_snapshot_json_truncated: latestSnapshotJson.truncated
           }

--- a/src/renderer/src/lib/rendererBootstrap.ts
+++ b/src/renderer/src/lib/rendererBootstrap.ts
@@ -715,8 +715,6 @@ export function initializeRendererBootstrap(role: RendererRole = 'panel'): void 
                   commit: n.commit ?? null
                 })),
                 pipPackages: scrubPipSpecs(latest_snapshot.pipPackages),
-                custom_nodes_count: latest_snapshot.customNodes.length,
-                pip_packages_count: Object.keys(latest_snapshot.pipPackages).length,
                 python_version: latest_snapshot.pythonVersion ?? null,
                 update_channel: latest_snapshot.updateChannel ?? null
               }

--- a/src/renderer/src/lib/rendererBootstrap.ts
+++ b/src/renderer/src/lib/rendererBootstrap.ts
@@ -678,23 +678,37 @@ export function initializeRendererBootstrap(role: RendererRole = 'panel'): void 
         .then((ctx) => {
           if (!ctx) return
           const { snapshot_diffs, latest_snapshot, ...metadata } = ctx
-          // `latest_snapshot` is a nested object (dropped by the telemetry IPC
-          // bridge) and its raw form carries a user-typed `label` plus
-          // custom-node `dirName`s. Forward a PII-safe compact summary instead:
-          // counts + a `has_label` flag, never the raw label / node paths.
-          const latestSnapshotSummary = latest_snapshot
+          // Forward the FULL latest snapshot so an installation's exact state
+          // (every custom node + pip package, with versions) is queryable, and
+          // earlier states can be reconstructed by walking `snapshot_diffs`
+          // back from it. The only genuine PII is the user-typed `label` (kept
+          // as a boolean `has_label`); package/node names and versions are
+          // public identifiers. Any home-dir path in an editable/local pip
+          // install (e.g. `pkg @ file:///C:/Users/<name>/...`) is redacted by
+          // `scrubAll` in the main-process `scrubProperties` safety net before
+          // the event ships.
+          const latestSnapshotFull = latest_snapshot
             ? {
                 createdAt: latest_snapshot.createdAt,
                 trigger: latest_snapshot.trigger,
                 has_label: latest_snapshot.label != null,
                 comfyui: latest_snapshot.comfyui,
+                customNodes: latest_snapshot.customNodes.map((n) => ({
+                  id: n.id,
+                  type: n.type,
+                  dirName: n.dirName,
+                  enabled: n.enabled,
+                  version: n.version ?? null,
+                  commit: n.commit ?? null
+                })),
+                pipPackages: latest_snapshot.pipPackages,
                 custom_nodes_count: latest_snapshot.customNodes.length,
                 pip_packages_count: Object.keys(latest_snapshot.pipPackages).length,
                 python_version: latest_snapshot.pythonVersion ?? null,
                 update_channel: latest_snapshot.updateChannel ?? null
               }
             : null
-          const latestSnapshotJson = serializeForTelemetry(latestSnapshotSummary)
+          const latestSnapshotJson = serializeForTelemetry(latestSnapshotFull)
           // Fires on EVERY ComfyUI instance boot (fresh install, restart, port
           // realloc) — not on new-install completion. Despite its previous name
           // (`session.installation_started`) it tracks per-instance boots, so
@@ -726,24 +740,44 @@ export function initializeRendererBootstrap(role: RendererRole = 'panel'): void 
             instanceStartedProps
           )
           if (snapshot_diffs.length > 0) {
-            // Raw `SnapshotDiffEntry` carries user-typed `label`s and custom-node
-            // `dirName`s, so we send a PII-safe compact summary (counts +
-            // `has_label`) serialized to a `_json` string. Product/census event:
-            // PostHog only, per the Datadog "failures-only" policy.
-            const snapshotDiffsSummary = snapshot_diffs.map((d) => ({
+            // Forward the FULL per-transition diffs (which nodes/packages were
+            // added/removed/changed, with versions) so the entire snapshot
+            // history can be reconstructed by applying these deltas backward
+            // from `latest_snapshot`. Drop only the user-typed `label` (kept as
+            // `has_label`); names/versions are public identifiers, and any
+            // home-dir path in a pip spec is redacted by `scrubAll` in the
+            // main-process `scrubProperties` safety net. PostHog only, per the
+            // Datadog "failures-only" policy.
+            const snapshotDiffsFull = snapshot_diffs.map((d) => ({
               createdAt: d.createdAt,
               trigger: d.trigger,
               has_label: d.label != null,
-              nodes_added: d.nodesAdded.length,
-              nodes_removed: d.nodesRemoved.length,
-              nodes_changed: d.nodesChanged.length,
-              pips_added: d.pipsAdded.length,
-              pips_removed: d.pipsRemoved.length,
-              pips_changed: d.pipsChanged.length,
-              comfyui_changed: d.comfyuiChanged,
-              update_channel_changed: d.updateChannelChanged
+              nodesAdded: d.nodesAdded.map((n) => ({
+                id: n.id,
+                type: n.type,
+                dirName: n.dirName,
+                enabled: n.enabled,
+                version: n.version ?? null,
+                commit: n.commit ?? null
+              })),
+              nodesRemoved: d.nodesRemoved.map((n) => ({
+                id: n.id,
+                type: n.type,
+                dirName: n.dirName,
+                enabled: n.enabled,
+                version: n.version ?? null,
+                commit: n.commit ?? null
+              })),
+              nodesChanged: d.nodesChanged,
+              pipsAdded: d.pipsAdded,
+              pipsRemoved: d.pipsRemoved,
+              pipsChanged: d.pipsChanged,
+              comfyuiChanged: d.comfyuiChanged,
+              comfyui: d.comfyui ?? null,
+              updateChannelChanged: d.updateChannelChanged,
+              updateChannel: d.updateChannel ?? null
             }))
-            const snapshotDiffsJson = serializeForTelemetry(snapshotDiffsSummary)
+            const snapshotDiffsJson = serializeForTelemetry(snapshotDiffsFull)
             try {
               window.api.captureTelemetry('comfy.desktop.session.snapshot_history', {
                 installation_id: ctx.installation_id,


### PR DESCRIPTION
## Summary

A set of related ComfyUI/Desktop telemetry improvements. Follow-up to #1175, expanded to also fix GPU/driver detection, restore full snapshot inventory reporting, and fix renderer-lifecycle events that were silently dropping. Four areas:

1. **Model-usage signal** — report the *loaded model class* with a `load_trigger`, replacing the ambiguous sampling-type enum, and drop per-person markers.
2. **Accelerator/GPU detection** — report *all* GPUs (not just the first), DirectML adapter names, and backfill AMD/Intel driver versions on Windows.
3. **Snapshot inventory** — restore the full per-installation snapshot (custom nodes + pip packages) and reconstructable diffs that an earlier counts-only change had stripped, with PII scrubbing done at the emit site, plus the resolved ComfyUI version.
4. **Reliable session-lifecycle events** — move `instance_started` / `installation_started` / `snapshot_history` / `comfyui.exited` emission from the panel renderer to the main process, because Desktop 2's unified window tears the panel down around server-ready/exit, so the renderer callbacks frequently never ran and the events vanished from PostHog.

All structured payloads ship as `*_json` strings under the telemetry bridge's large-string allow-list, with truncation guards and `*_truncated` flags. PostHog-only (Datadog mirrors failures only).

---

## 1. Model-usage: loaded class + load_trigger

The signal was originally keyed on ComfyUI's `model_type <ENUM>` log line (`EPS` / `FLUX` / `FLOW` / …). That enum is the **sampling type**, not the architecture — the same value covers many distinct models, so it can't answer "which model is actually being used."

We now parse the loaded class name (`x.model.__class__.__name__`) from ComfyUI's logs. For a z-image base workflow that's `Lumina2` (diffusion), `ZImageTEModel_` (text encoder), `AutoencodingEngine` (VAE).

- Emit **`model_class`** (loaded class name) instead of `model_type` / `dtype`.
- Add **`load_trigger`** to disambiguate the log lines a load/clone can come from:
  - `requested` — `Requested to load <ClassName>`: a **cold load** (model not resident). Misses runs that reuse an already-loaded model.
  - `dynamic_prepare` — `Model <ClassName> prepared for dynamic VRAM loading. …`: emitted per prepare when **dynamic VRAM (aimdo)** is enabled, capturing models staged across runs (per-run reuse the cold-load line misses). Absent when dynamic VRAM is off.
  - `deepclone` — `Creating deepclone of <ClassName> for <device>` / `Reusing loaded multigpu deepclone of <ClassName> for <device>`: a **deepclone-based multi-GPU feature** (MultiGPU CFG Split, per-device ControlNets, …) cloning the model onto another device. Carries a new **`target_device`** field (e.g. `cuda:1`) so cross-GPU spread is visible; presence of any `deepclone` row + distinct `installation_id` shows who uses these features. `target_device` is `null` for the two load triggers.
  - Counts kept per `(model_class, load_trigger, target_device)`.
- **Drop the per-person `used_model_<class>_at` `$set_once` markers** — they grow the person-property key space (one key per ever-seen class, never scrubbed) without adding signal; reach is derivable from distinct `installation_id` per `model_class`.
- Parser matches a whole Python identifier with a length cap; the distinct-class cardinality cap holds across the tap lifetime (not reset per flush) and stays under the per-event rate limit.

## 2. Accelerator / GPU detection

- `accelerator_detected` now reports **all** detected GPUs as parallel arrays (model / driver version / vendor), not just `controllers[0]` — which on Windows is frequently a virtual display adapter (Basic Render, RDP, Parsec) and never reflects the device PyTorch uses.
- Capture **DirectML adapter names**.
- **Backfill AMD/Intel driver versions from WMI** (`Win32_VideoController`) on Windows — `systeminformation` only fills `driverVersion` for NVIDIA there, leaving AMD/Intel blank.
- Doc comments aligned to the parallel-array shape.

## 3. Snapshot inventory + reconstructable diffs

An earlier change had reduced snapshot telemetry to counts only (`custom_nodes_count`, `nodes_added`, …), which made it impossible to see which custom nodes / pip packages an installation has, or to reconstruct earlier snapshots.

- **`latest_snapshot_json`** now carries the full latest snapshot: every custom node (id/type/dirName/enabled/version/commit) and the full pip package map.
- **`snapshot_diffs_json`** now carries the full per-transition deltas (added/removed/changed nodes + packages, comfyui ref changes, update-channel changes) so the entire history can be reconstructed by walking back from `latest_snapshot`.
- **Resolved ComfyUI version added** to the snapshot `comfyui` object (latest + each diff side): `baseTag`, `commitsAhead`, and a human-readable `formattedVersion`. The existing `ref`/`releaseTag` come from the install's static `manifest.json` (the version the standalone env *shipped with*) and don't move on in-place ComfyUI updates, so only `commit` tracked reality before; `formattedVersion` (e.g. `v0.20.1 + 3 commits (8ceb6fa)`) now reports what's actually running without mapping `commit` → release by hand.
- **PII handled at the emit site:** the user-typed snapshot `label` is reduced to a `has_label` boolean and never shipped raw; editable/local pip specs (which can embed `file:///C:/Users/<name>/…`) and node `id`/`dirName` are run through `scrubAll` before serialization (the main-process net only sees the already-serialized JSON string, where a backslash Windows path would be escaped past its regexes).
- A single `serializeSnapshotNode()` is shared across the latest-snapshot and per-diff node arrays so their shapes can't drift.
- **`custom_nodes_count` / `pip_packages_count` promoted to top-level** `instance_started` props — queryable in the PostHog UI and resilient to JSON-blob truncation (heavy installs are the ones most likely to truncate). The redundant in-blob counts (only ever in `v1.0.25-rc.*`, never public) were removed.
- The `installs_inventory` census event intentionally stays counts-only (it packs many installs per event).

## 4. Reliable session-lifecycle events (main-process emission)

`session.instance_started`, the deprecated `session.installation_started` shadow, `session.snapshot_history`, and `comfyui.exited` were emitted from the panel renderer's `onInstanceStarted` / `onComfyExited` callbacks. Desktop 2's unified window destroys/swaps the dashboard panel around server-ready and exit, so those callbacks frequently never fired — the four events were present on `v1.0.25-rc.1` and then effectively vanished from PostHog through rc.7, while main-process events (`boot_started` / `boot_completed` / `accelerator_detected`) kept landing.

- Move all four emissions to the **main process** where they fire regardless of renderer lifecycle, keeping the exact event names and property shapes so existing dashboards/SQL keep working.
- `instance_started` / `installation_started` / `snapshot_history` now fire from an `onInstanceStarted` callback invoked by `_addSession` (the same place that drives the `instance-started` broadcast), carrying the same boot-time/retry signal.
- `comfyui.exited` is emitted via `telemetry.emit` from both `launch.ts` exit handlers (PostHog + the Datadog crash-rate monitor).
- The renderer emissions are removed (no double-counting); `boot_log` stays in the renderer since it fires while the panel is still alive. The `comfy-exited` IPC that drives the crash UI is untouched.
- The installation snapshot/disk context builder is extracted into a shared `buildInstallationDdContext` reused by the existing `get-installation-dd-context` IPC handler and the new main-side emitter (no logic change).

Audit confirmed these four were the only events gated behind post-launch/exit renderer callbacks; all other renderer telemetry fires during bootstrap while the panel is alive.

## Verification

- Tap tests drive real lines for both model-usage triggers, the colored `[INFO]`-prefixed Desktop format, delta-flush, per-launch aggregation, and split-chunk cases.
- Snapshot/GPU paths validated against PostHog on `v1.0.25-rc.*` builds (NVIDIA single + dual-GPU, AMD, Intel; arrays, snapshot/diff JSON validity).
- The four moved session-lifecycle events confirmed firing with valid payloads on `v1.0.25-rc.8` (counts tracking `boot_completed`), after being effectively absent rc.3–rc.7.
- Full suite (2498 tests), typecheck, lint, and build all green.

## Follow-ups (separate issues)

- Storage/disk model + type telemetry enhancement: #1181
- Linux device-ID fragmentation: #1182
