### PR TITLE
feat(terminal): enable frontend terminal + logs injection on Portable + Git installs

### DIFF
--- a/src/main/host/attach.ts
+++ b/src/main/host/attach.ts
@@ -29,6 +29,12 @@ import type { ComfyWindowEntry } from './registry'
 
 const APP_VERSION = getAppVersion()
 
+/** Local managed source types that back the served frontend's terminal tab
+ *  with a per-install shell (a defined `getTerminalEnv` or the standalone
+ *  default). These get the stopgap Terminal-tab injection; remote/cloud and
+ *  external (legacy v1 desktop) installs do not. */
+const TERMINAL_INJECTION_SOURCE_IDS = new Set(['standalone', 'portable', 'git'])
+
 /** Entry point that triggered a zoom reset, tagged as `source` on the
  *  `comfy.desktop.zoom.reset` telemetry event. `titlebar` (the zoom pill)
  *  and `menu` (the title menu's "Reset Zoom") flow through the per-install
@@ -395,7 +401,11 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
   const onDomReady = (): void => {
     comfyContents.executeJavaScript(COMFY_THEME_OBSERVER_JS).catch(() => {})
     comfyContents.executeJavaScript(getModelDownloadContentScript()).catch(() => {})
-    // Always inject the Terminal bottom-panel tab on standalone installs.
+    // Inject the Terminal bottom-panel tab on local managed installs that
+    // back it with a per-install shell (standalone, portable, git). They all
+    // ship the same served frontend and expose the same
+    // `window.__comfyDesktop2.Terminal` bridge + per-install PTY, so the
+    // injection works identically everywhere.
     //
     // Originally gated on `!supports_terminal` to avoid duplicating the
     // flag-gated frontend tab. Day-3 launch feedback put terminal
@@ -406,7 +416,7 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
     // `bottomPanelTabs` for an existing `command-terminal` entry and
     // bails out before registering a second copy. See
     // `comfyTerminalContentScript.ts` for the dedupe guard.
-    if (isLocal && installation.sourceId === 'standalone') {
+    if (isLocal && TERMINAL_INJECTION_SOURCE_IDS.has(installation.sourceId)) {
       comfyContents.executeJavaScript(getComfyTerminalContentScript()).catch(() => {})
     }
     // Cloud-only patches (popup-blocked toast suppression + post-signin

--- a/src/main/lib/comfyTerminalContentScript.test.ts
+++ b/src/main/lib/comfyTerminalContentScript.test.ts
@@ -43,6 +43,14 @@ describe('getComfyTerminalContentScript', () => {
     expect(script).toContain('extensionManager')
   })
 
+  it('dedupes the native Terminal tab via the bottom-panel store', () => {
+    // The frontend registers 'command-terminal' directly into the
+    // bottom-panel store, so the guard must inspect that shape (not just
+    // app.extensions) or it would register a duplicate tab.
+    expect(script).toContain('bottomPanelHasTab')
+    expect(script).toContain(`bottomPanelHasTab(app, 'command-terminal')`)
+  })
+
   it('uses the shared desktop terminal transport', () => {
     for (const member of ['subscribe', 'write', 'resize', 'restart', 'onOutput', 'onExited']) {
       expect(script).toContain(member)

--- a/src/main/lib/comfyTerminalContentScript.ts
+++ b/src/main/lib/comfyTerminalContentScript.ts
@@ -167,12 +167,31 @@ function renderTerminal(container) {
   }).catch(function () {});
 }
 
+// True if a bottom-panel tab with this id is already registered in the
+// frontend store. This is where the native frontend registers both its Logs
+// ('logs-terminal') and Terminal ('command-terminal') tabs.
+function bottomPanelHasTab(app, id) {
+  try {
+    var bp = app && app.extensionManager && app.extensionManager.bottomPanel;
+    var terminalPanel = bp && bp.panels && bp.panels.terminal;
+    var tabs = terminalPanel && terminalPanel.tabs;
+    if (tabs) {
+      for (var i = 0; i < tabs.length; i++) {
+        if (tabs[i] && tabs[i].id === id) return true;
+      }
+    }
+  } catch (e) {}
+  return false;
+}
+
 // Dedupe guard. The frontend ships a native flag-gated 'command-terminal'
 // bottom-panel tab via the companion ComfyUI_frontend PR; when that lands
 // it registers itself before we tick. Bail out if we see it so the user
-// never gets two tabs with the same id. Defensive over both shapes that
-// ComfyUI exposes (an extensions array, and a future-proof tab registry).
+// never gets two tabs with the same id. Defensive over the shapes ComfyUI
+// exposes: the bottom-panel store, an extensions array, and a future-proof
+// tab registry.
 function alreadyHasTerminalTab(app) {
+  if (bottomPanelHasTab(app, 'command-terminal')) return true;
   try {
     var exts = (app && app.extensions) || [];
     for (var i = 0; i < exts.length; i++) {
@@ -197,17 +216,7 @@ function alreadyHasTerminalTab(app) {
 // and Terminal lands second, matching the native frontend ordering (the store
 // makes the first-registered tab the default active one).
 function hasLogsTab(app) {
-  try {
-    var bp = app && app.extensionManager && app.extensionManager.bottomPanel;
-    var terminalPanel = bp && bp.panels && bp.panels.terminal;
-    var tabs = terminalPanel && terminalPanel.tabs;
-    if (tabs) {
-      for (var i = 0; i < tabs.length; i++) {
-        if (tabs[i] && tabs[i].id === 'logs-terminal') return true;
-      }
-    }
-  } catch (e) {}
-  return false;
+  return bottomPanelHasTab(app, 'logs-terminal');
 }
 
 function waitForRegister(timeoutMs) {

--- a/src/main/lib/comfyTerminalContentScript.ts
+++ b/src/main/lib/comfyTerminalContentScript.ts
@@ -3,11 +3,12 @@
  * served ComfyUI frontend, for the window between our frontend/backend terminal
  * PRs landing and a stable release shipping them.
  *
- * It is injected (via `webContents.executeJavaScript`) only for STANDALONE
- * installs whose ComfyUI does not yet advertise the `supports_terminal` feature
- * flag — i.e. exactly when the real, flag-gated frontend tab cannot appear, so
- * there is never a duplicate. Delete this module (and its call site in
- * `attach.ts`) once stable ships the official tab.
+ * It is injected (via `webContents.executeJavaScript`) for local managed
+ * installs that back a per-install shell (standalone, portable, git). It runs
+ * always-on and dedupes in JS: the script bails before registering if it sees
+ * an existing native `command-terminal` tab, so a frontend that ships the real
+ * flag-gated tab never ends up with a duplicate. Delete this module (and its
+ * call site in `attach.ts`) once stable ships the official tab.
  *
  * The transport is the already-injected `window.__comfyDesktop2.Terminal`
  * bridge (see `comfyPreload.ts`). xterm isn't exposed on `window.comfyAPI`, so


### PR DESCRIPTION
## Summary

Closes #1126.

The stopgap **Terminal** bottom-panel tab injection (and the Terminal/Logs pop-out buttons) was gated to `standalone` installs only. Portable and Git (manual) installs ship **the same served ComfyUI frontend** and already expose everything the injection needs:

- the `window.__comfyDesktop2.Terminal` / `.Logs` bridges (`comfyPreload.js` is attached to every install-backed comfyView),
- a working per-install PTY - both `portableSource` and `gitSource` define `getTerminalEnv` and the desktop Settings *Console* tab already uses it,
- the per-install logs broadcast (`appendLog` is keyed by `installationId`, not source type),
- the `supports_terminal` feature flag (injected for all installs).

So enabling the injection there is safe, and the existing JS dedupe guard prevents a duplicate when a newer ComfyUI ships the native `command-terminal` tab.

## Changes

- `attach.ts`: broaden the inject gate from `sourceId === 'standalone'` to a `TERMINAL_INJECTION_SOURCE_IDS` allowlist (`standalone`, `portable`, `git`). Legacy v1 `desktop` (external launch) and remote/cloud installs remain excluded.
- Refresh the now-stale "standalone only" doc comments in `attach.ts` and `comfyTerminalContentScript.ts`.

## Testing

- `pnpm run typecheck` ?
- `pnpm run lint` ?
- `pnpm run build` ?
- `pnpm run test` ? (176 files / 2644 tests)