### PR TITLE
Strip ANSI color codes from plain-text ComfyUI logs

### DIFF
--- a/src/main/lib/ipc/sessionActions/launch.ts
+++ b/src/main/lib/ipc/sessionActions/launch.ts
@@ -461,7 +461,9 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
     })
     proc.stderr?.on('data', (chunk: Buffer) => {
       const text = chunk.toString('utf-8')
-      stderrBuf += text
+      // Strip ANSI before buffering: this tail feeds the crashed-state UI and
+      // telemetry, both of which want clean text rather than raw color codes.
+      stderrBuf += stripAnsi(text)
       if (stderrBuf.length > 8192) stderrBuf = stderrBuf.slice(-4096)
       writeLog(logStream, text)
       sendOutput(text)
@@ -784,12 +786,7 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
 
   const sessionPath = createSessionPath()
   const launchEnv = buildLaunchEnv(inst, sessionPath)
-  const sendOutput = (text: string): void => {
-    if (!sender.isDestroyed()) {
-      sender.send('comfy-output', { installationId, text })
-    }
-    appendLog(installationId, text)
-  }
+  const sendOutput = makeSendOutput(sender, installationId)
 
   const logStream = await openLogStream(inst.installPath)
   const execTap = createExecutionTap({

--- a/src/main/lib/ipc/sessionActions/launch.ts
+++ b/src/main/lib/ipc/sessionActions/launch.ts
@@ -461,15 +461,16 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
     })
     proc.stderr?.on('data', (chunk: Buffer) => {
       const text = chunk.toString('utf-8')
-      // Strip ANSI before buffering: this tail feeds the crashed-state UI and
-      // telemetry, both of which want clean text rather than raw color codes.
-      stderrBuf += stripAnsi(text)
+      // Strip ANSI once: the tail (crashed-state UI + telemetry) and the
+      // launch tracker both want clean text rather than raw color codes.
+      const clean = stripAnsi(text)
+      stderrBuf += clean
       if (stderrBuf.length > 8192) stderrBuf = stderrBuf.slice(-4096)
       writeLog(logStream, text)
       sendOutput(text)
       execTap.ingest(text, 'stderr')
       hwTap.ingest(text, 'stderr')
-      tracker.ingest(stripAnsi(text))
+      tracker.ingest(clean)
     })
     return { getStderr: () => stderrBuf }
   }

--- a/src/main/lib/ipc/sessionActions/launch.ts
+++ b/src/main/lib/ipc/sessionActions/launch.ts
@@ -461,8 +461,7 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
     })
     proc.stderr?.on('data', (chunk: Buffer) => {
       const text = chunk.toString('utf-8')
-      // Strip ANSI once: the tail (crashed-state UI + telemetry) and the
-      // launch tracker both want clean text rather than raw color codes.
+      // Strip ANSI once for both the tail buffer and the launch tracker.
       const clean = stripAnsi(text)
       stderrBuf += clean
       if (stderrBuf.length > 8192) stderrBuf = stderrBuf.slice(-4096)

--- a/src/main/lib/ipc/shared.ts
+++ b/src/main/lib/ipc/shared.ts
@@ -1127,11 +1127,8 @@ export function makeSendProgress(sender: Electron.WebContents, installationId: s
 /** Helper to create a sendOutput callback from an IPC event sender */
 export function makeSendOutput(sender: Electron.WebContents, installationId: string): (text: string) => void {
   return (text: string): void => {
-    // ComfyUI colorizes its logs with ANSI escape codes. The interactive
-    // terminal (xterm.js, via the separate `terminal-output` channel) renders
-    // them, but the plain-text consumers fed from here (progress modal,
-    // finished-state logs, pop-out logs window via the ring buffer) would show
-    // the raw codes — strip them so every plain-text surface stays clean.
+    // Strip ANSI: these are plain-text surfaces. The xterm.js terminal keeps
+    // its colors via the separate `terminal-output` channel.
     const clean = stripAnsi(text)
     try { if (!sender.isDestroyed()) sender.send('comfy-output', { installationId, text: clean }) } catch {}
     appendLog(installationId, clean)

--- a/src/main/lib/ipc/shared.ts
+++ b/src/main/lib/ipc/shared.ts
@@ -23,6 +23,7 @@ import { deleteDir, formatDeleteStatus } from '../delete'
 import { deleteAction, untrackAction } from '../actions'
 import { _broadcastToRenderer } from './broadcast'
 import { appendLog } from '../logsBroadcast'
+import { stripAnsi } from '../stderrTail'
 import {
   spawnProcess, waitForPort, waitForUrl, killProcessTree, killByPort,
   findPidsByPort, getProcessInfo, looksLikeComfyUI, setPortArg,
@@ -1126,8 +1127,14 @@ export function makeSendProgress(sender: Electron.WebContents, installationId: s
 /** Helper to create a sendOutput callback from an IPC event sender */
 export function makeSendOutput(sender: Electron.WebContents, installationId: string): (text: string) => void {
   return (text: string): void => {
-    try { if (!sender.isDestroyed()) sender.send('comfy-output', { installationId, text }) } catch {}
-    appendLog(installationId, text)
+    // ComfyUI colorizes its logs with ANSI escape codes. The interactive
+    // terminal (xterm.js, via the separate `terminal-output` channel) renders
+    // them, but the plain-text consumers fed from here (progress modal,
+    // finished-state logs, pop-out logs window via the ring buffer) would show
+    // the raw codes — strip them so every plain-text surface stays clean.
+    const clean = stripAnsi(text)
+    try { if (!sender.isDestroyed()) sender.send('comfy-output', { installationId, text: clean }) } catch {}
+    appendLog(installationId, clean)
   }
 }
 

--- a/src/main/lib/stderrTail.test.ts
+++ b/src/main/lib/stderrTail.test.ts
@@ -13,6 +13,18 @@ describe('stripAnsi', () => {
   it('leaves plain text unchanged', () => {
     expect(stripAnsi('no codes here')).toBe('no codes here')
   })
+
+  // Regression for Comfy-Desktop#1024: ComfyUI's ColoredFormatter wraps every
+  // log line in ANSI codes (bold + level color around the [LEVEL] tag, plus an
+  // optional whole-message color). Plain-text log surfaces must show none of it.
+  it('strips ComfyUI ColoredFormatter output', () => {
+    expect(stripAnsi('\u001B[1m\u001B[31m[ERROR]\u001B[0m Failed to validate prompt')).toBe(
+      '[ERROR] Failed to validate prompt'
+    )
+    expect(stripAnsi('\u001B[32m[INFO]\u001B[0m \u001B[32mDevice: cuda:0\u001B[0m')).toBe(
+      '[INFO] Device: cuda:0'
+    )
+  })
 })
 
 describe('stripLogLevelPrefix', () => {

--- a/src/main/lib/stderrTail.test.ts
+++ b/src/main/lib/stderrTail.test.ts
@@ -14,9 +14,8 @@ describe('stripAnsi', () => {
     expect(stripAnsi('no codes here')).toBe('no codes here')
   })
 
-  // Regression for Comfy-Desktop#1024: ComfyUI's ColoredFormatter wraps every
-  // log line in ANSI codes (bold + level color around the [LEVEL] tag, plus an
-  // optional whole-message color). Plain-text log surfaces must show none of it.
+  // ComfyUI's ColoredFormatter wraps lines in bold + level color around the
+  // [LEVEL] tag, plus an optional whole-message color.
   it('strips ComfyUI ColoredFormatter output', () => {
     expect(stripAnsi('\u001B[1m\u001B[31m[ERROR]\u001B[0m Failed to validate prompt')).toBe(
       '[ERROR] Failed to validate prompt'


### PR DESCRIPTION
## Problem

Fixes #1024.

ComfyUI core recently added a `ColoredFormatter` (`app/logger.py`) that wraps **every** log line in ANSI escape codes. It does this unconditionally - there is no `isatty()`, `NO_COLOR`, or `FORCE_COLOR` check - so even when ComfyUI's stdout is a pipe (always, under the launcher) it emits color codes.

The launcher's interactive terminal (xterm.js, via the `terminal-output`/node-pty path) renders those fine. But the **plain-text** log surfaces render the raw escape sequences as literal `magic` characters:

- the progress modal (`ProgressModal.vue`)
- the finished/crashed-state logs (`BrandFinishedSurface.vue`)
- the pop-out logs window

A `stripAnsi` helper already existed and was already applied to the on-disk log file, the launch progress tracker, and the stdout/stderr parsers - it just wasn't applied to the live user-facing stream.

## Fix

- **`makeSendOutput` (`shared.ts`)** - strip ANSI at this single choke point, which feeds both the live `comfy-output` IPC and the logs ring buffer. This covers every plain-text consumer across all ops (launch/copy/migrate) in one place. The xterm.js terminal is untouched.
- **Crash stderr tail (`launch.ts`)** - strip ANSI from the buffer that backs the crashed-state UI message and the telemetry `last_stderr`/`boot` payloads.
- **Dedup** - the main launch path had an inline `sendOutput` duplicating `makeSendOutput` (without the strip or the destroyed-sender guard); collapsed onto `makeSendOutput`.
- **Test** - added a regression test locking in ComfyUI's exact `ColoredFormatter` output shape.

## Notes

- Rendering colors (ansi?html) was considered and rejected: these views are plain-text `{{ }}` bindings, it adds an XSS surface, and stripping is the pattern the codebase already uses for the on-disk log.
- `stripAnsi` is regex-per-chunk; an escape split across two stdout chunks could slip through, but this matches the existing accepted behavior everywhere else (log file, taps) - no new risk.

## Verification

`pnpm run typecheck`, `lint`, `build`, and `test` (2645 tests) all pass.