### PR TITLE
feat(diagnostics): persistent global app log + native crash capture (#1108)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -23,7 +23,7 @@ import {
   recordDashboardSurface
 } from './lib/lastSession'
 import { registerProcessErrorHandlers } from './lib/processErrorHandlers'
-import { initAppLog } from './lib/appLog'
+import { initAppLog, flushOperationOutput } from './lib/appLog'
 import { registerTitleTooltipIpc } from './popups/titleTooltip'
 import { registerTitleCoachmarkIpc } from './popups/titleCoachmark'
 import { openSystemModal, openSystemModalAsync, openSystemModalChoiceAsync, registerSystemModalIpc } from './popups/systemModal'
@@ -1321,10 +1321,10 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
     // handlers before anything else runs, so the earliest console output and
     // any startup crash are captured.
     initAppLog()
+    registerProcessErrorHandlers()
     console.info(
       `App started v${APP_VERSION} pid=${process.pid} platform=${process.platform} crashDumps=${app.getPath('crashDumps')}`
     )
-    registerProcessErrorHandlers()
 
     // Test-only hooks for the E2E suite. Registered before any host
     // opens so seeded state (downloads, install-update overrides,
@@ -2308,6 +2308,7 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
     // restore it. Synchronous: the app exits without awaiting promises, so an
     // async write would be torn down mid-flight and lose a just-made change.
     flushLastSessionSync()
+    flushOperationOutput()
     cleanupTempDownloads()
   })
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -24,6 +24,7 @@ import {
 } from './lib/lastSession'
 import { registerProcessErrorHandlers } from './lib/processErrorHandlers'
 import { initAppLog, flushOperationOutput } from './lib/appLog'
+import { pruneCrashDumps } from './lib/crashDumps'
 import { registerTitleTooltipIpc } from './popups/titleTooltip'
 import { registerTitleCoachmarkIpc } from './popups/titleCoachmark'
 import { openSystemModal, openSystemModalAsync, openSystemModalChoiceAsync, registerSystemModalIpc } from './popups/systemModal'
@@ -1322,6 +1323,9 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
     // any startup crash are captured.
     initAppLog()
     registerProcessErrorHandlers()
+    // Bound the local crash-dump folder; Crashpad's own pruning is coarse in
+    // upload-disabled mode and a crash-looping user can pile up multi-MB dumps.
+    pruneCrashDumps()
     console.info(
       `App started v${APP_VERSION} pid=${process.pid} platform=${process.platform} crashDumps=${app.getPath('crashDumps')}`
     )

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, Menu, ipcMain, net, dialog } from 'electron'
+import { app, Menu, ipcMain, net, dialog, crashReporter } from 'electron'
 import type { BrowserWindow, WebContentsView } from 'electron'
 import type { Tray } from 'electron'
 import path from 'path'
@@ -23,6 +23,7 @@ import {
   recordDashboardSurface
 } from './lib/lastSession'
 import { registerProcessErrorHandlers } from './lib/processErrorHandlers'
+import { initAppLog } from './lib/appLog'
 import { registerTitleTooltipIpc } from './popups/titleTooltip'
 import { registerTitleCoachmarkIpc } from './popups/titleCoachmark'
 import { openSystemModal, openSystemModalAsync, openSystemModalChoiceAsync, registerSystemModalIpc } from './popups/systemModal'
@@ -149,6 +150,15 @@ import {
 } from './host/panelView'
 
 export type { ComfyPanelKey } from './host/registry'
+
+// Collect native crash minidumps (GPU / renderer / V8 OOM segfaults that
+// never reach a JS handler) into app.getPath('crashDumps'). Kept local — we
+// don't upload, we ask the user to send them. Must start before app ready.
+try {
+  crashReporter.start({ uploadToServer: false })
+} catch {
+  // Never let crash-reporter setup block app startup.
+}
 
 todesktop.init({ autoUpdater: false })
 
@@ -1345,6 +1355,12 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
 
     migrateXdgPaths()
     persistWinDataRootChoice()
+    // Open the durable global app log before anything else logs, so the
+    // error handlers below (and all subsequent console output) are captured.
+    initAppLog()
+    console.info(
+      `App started v${APP_VERSION} pid=${process.pid} platform=${process.platform} crashDumps=${app.getPath('crashDumps')}`
+    )
     registerProcessErrorHandlers()
 
     // Strip Electron's default menu before any BrowserWindow opens so

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1317,6 +1317,15 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
   })
 
   app.whenReady().then(async () => {
+    // Open the durable global app log and install the main-process error
+    // handlers before anything else runs, so the earliest console output and
+    // any startup crash are captured.
+    initAppLog()
+    console.info(
+      `App started v${APP_VERSION} pid=${process.pid} platform=${process.platform} crashDumps=${app.getPath('crashDumps')}`
+    )
+    registerProcessErrorHandlers()
+
     // Test-only hooks for the E2E suite. Registered before any host
     // opens so seeded state (downloads, install-update overrides,
     // app-update state) is visible to the very first title-bar paint.
@@ -1355,13 +1364,6 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
 
     migrateXdgPaths()
     persistWinDataRootChoice()
-    // Open the durable global app log before anything else logs, so the
-    // error handlers below (and all subsequent console output) are captured.
-    initAppLog()
-    console.info(
-      `App started v${APP_VERSION} pid=${process.pid} platform=${process.platform} crashDumps=${app.getPath('crashDumps')}`
-    )
-    registerProcessErrorHandlers()
 
     // Strip Electron's default menu before any BrowserWindow opens so
     // OAuth / cloud-login popups (and every other window) can't reach

--- a/src/main/lib/appLog.test.ts
+++ b/src/main/lib/appLog.test.ts
@@ -14,6 +14,7 @@ import {
   writeAppLog,
   writeAppLogSync,
   writeOperationOutput,
+  flushOperationOutput,
   getAppLogPath,
   resetAppLogForTest
 } from './appLog'
@@ -36,7 +37,7 @@ describe('appLog', () => {
 
   it('is a no-op before init', () => {
     writeAppLog('INFO', 'should not write')
-    writeOperationOutput('nope')
+    writeOperationOutput('inst-1', 'nope')
     expect(fs.existsSync(path.join(tmpDir, 'app.log'))).toBe(false)
   })
 
@@ -91,17 +92,36 @@ describe('appLog', () => {
   it('tees operation output once a line completes', () => {
     initAppLog({ dir: tmpDir })
     expect(getAppLogPath()).toBe(path.join(tmpDir, 'app.log'))
-    writeOperationOutput('> uv pip install torch\n')
+    writeOperationOutput('inst-1', '> uv pip install torch\n')
     expect(read()).toContain('> uv pip install torch')
   })
 
   it('scrubs a credential split across two operation chunks', () => {
     initAppLog({ dir: tmpDir })
     // The secret straddles the chunk boundary; per-chunk scrubbing would miss it.
-    writeOperationOutput('downloading from https://user:to')
-    writeOperationOutput('ken@mirror.example/simple\n')
+    writeOperationOutput('inst-1', 'downloading from https://user:to')
+    writeOperationOutput('inst-1', 'ken@mirror.example/simple\n')
     const out = read()
     expect(out).toContain('//[REDACTED]@')
     expect(out).not.toContain('user:token@')
+  })
+
+  it('does not interleave partial lines from concurrent installations', () => {
+    initAppLog({ dir: tmpDir })
+    writeOperationOutput('inst-a', 'alpha-')
+    writeOperationOutput('inst-b', 'beta-')
+    writeOperationOutput('inst-a', 'one\n')
+    writeOperationOutput('inst-b', 'two\n')
+    const out = read()
+    expect(out).toContain('alpha-one')
+    expect(out).toContain('beta-two')
+  })
+
+  it('flushes the final unterminated line on flushOperationOutput', () => {
+    initAppLog({ dir: tmpDir })
+    writeOperationOutput('inst-1', 'no trailing newline here')
+    expect(read()).not.toContain('no trailing newline here')
+    flushOperationOutput()
+    expect(read()).toContain('no trailing newline here')
   })
 })

--- a/src/main/lib/appLog.test.ts
+++ b/src/main/lib/appLog.test.ts
@@ -124,4 +124,14 @@ describe('appLog', () => {
     flushOperationOutput()
     expect(read()).toContain('no trailing newline here')
   })
+
+  it('flushes only the targeted installation, leaving others buffered', () => {
+    initAppLog({ dir: tmpDir })
+    writeOperationOutput('inst-a', 'partial-a')
+    writeOperationOutput('inst-b', 'partial-b')
+    flushOperationOutput('inst-a')
+    const out = read()
+    expect(out).toContain('partial-a')
+    expect(out).not.toContain('partial-b')
+  })
 })

--- a/src/main/lib/appLog.test.ts
+++ b/src/main/lib/appLog.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+
+// appLog imports `app` from electron only for the default log dir; tests
+// inject an explicit dir so the mock just needs to exist.
+vi.mock('electron', () => ({
+  app: { getPath: () => os.tmpdir() }
+}))
+
+import {
+  initAppLog,
+  writeAppLog,
+  writeAppLogSync,
+  writeOperationOutput,
+  flushAppLog,
+  getAppLogPath,
+  resetAppLogForTest
+} from './appLog'
+
+describe('appLog', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'app-log-'))
+  })
+
+  afterEach(() => {
+    resetAppLogForTest()
+    if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  function read(): string {
+    return fs.readFileSync(path.join(tmpDir, 'app.log'), 'utf8')
+  }
+
+  it('is a no-op before init', () => {
+    writeAppLog('INFO', 'should not write')
+    writeOperationOutput('nope')
+    expect(fs.existsSync(path.join(tmpDir, 'app.log'))).toBe(false)
+  })
+
+  it('writes a synchronous crash line that survives without a flush', () => {
+    initAppLog({ dir: tmpDir })
+    writeAppLogSync('CRITICAL', 'boom')
+    expect(read()).toContain('[CRITICAL] boom')
+  })
+
+  it('strips ANSI escape codes before writing', () => {
+    initAppLog({ dir: tmpDir })
+    writeAppLogSync('INFO', '\u001b[31mred\u001b[0m text')
+    expect(read()).toContain('red text')
+    expect(read()).not.toContain('\u001b[31m')
+  })
+
+  it('scrubs credentials and usernames before writing', () => {
+    initAppLog({ dir: tmpDir })
+    writeAppLogSync('INFO', 'pip install --index-url https://user:tok@mirror.example/simple')
+    writeAppLogSync('INFO', 'C:\\Users\\alice\\AppData\\comfy')
+    const out = read()
+    expect(out).toContain('//[REDACTED]@')
+    expect(out).not.toContain('user:tok@')
+    expect(out).toContain('C:\\Users\\[REDACTED]')
+    expect(out).not.toContain('alice')
+  })
+
+  it('captures patched console output after init', async () => {
+    initAppLog({ dir: tmpDir })
+    console.error('handler exploded', { code: 2 })
+    await flushAppLog()
+    expect(read()).toContain('[ERROR] handler exploded')
+  })
+
+  it('rotates the previous session log on init and keeps history', () => {
+    initAppLog({ dir: tmpDir })
+    writeAppLogSync('INFO', 'session one')
+    resetAppLogForTest()
+
+    initAppLog({ dir: tmpDir })
+    writeAppLogSync('INFO', 'session two')
+
+    const files = fs.readdirSync(tmpDir)
+    const rotated = files.filter((f) =>
+      /^app\.log_\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z\.log$/.test(f)
+    )
+    expect(rotated).toHaveLength(1)
+    expect(fs.readFileSync(path.join(tmpDir, rotated[0]!), 'utf8')).toContain('session one')
+    expect(read()).toContain('session two')
+    expect(read()).not.toContain('session one')
+  })
+
+  it('tees operation output verbatim', async () => {
+    initAppLog({ dir: tmpDir })
+    expect(getAppLogPath()).toBe(path.join(tmpDir, 'app.log'))
+    writeOperationOutput('> uv pip install torch\n')
+    await flushAppLog()
+    expect(read()).toContain('> uv pip install torch')
+  })
+})

--- a/src/main/lib/appLog.test.ts
+++ b/src/main/lib/appLog.test.ts
@@ -125,6 +125,24 @@ describe('appLog', () => {
     expect(read()).toContain('no trailing newline here')
   })
 
+  it('never rotates on the crash path, so a crash line past the cap is not dropped', () => {
+    const isRotated = (f: string): boolean =>
+      /^app\.log_\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z\.log$/.test(f)
+    initAppLog({ dir: tmpDir })
+    // Fill the live log to exactly the 5 MB cap (the line's `[ts] [INFO] ..\n`
+    // framing adds 35 bytes) without crossing it, so no rotation happens here.
+    writeAppLog('INFO', 'x'.repeat(5 * 1024 * 1024 - 35))
+    expect(fs.readdirSync(tmpDir).filter(isRotated)).toHaveLength(0)
+    // The crash line crosses the cap; rotation here could fail and drop it, so
+    // the crash path must append in place instead of rotating.
+    writeAppLogSync('CRITICAL', 'final breath')
+    expect(fs.readdirSync(tmpDir).filter(isRotated)).toHaveLength(0)
+    expect(read()).toContain('[CRITICAL] final breath')
+    // A later normal write is free to rotate the overage.
+    writeAppLog('INFO', 'after crash')
+    expect(fs.readdirSync(tmpDir).filter(isRotated)).toHaveLength(1)
+  })
+
   it('flushes only the targeted installation, leaving others buffered', () => {
     initAppLog({ dir: tmpDir })
     writeOperationOutput('inst-a', 'partial-a')

--- a/src/main/lib/appLog.test.ts
+++ b/src/main/lib/appLog.test.ts
@@ -143,6 +143,22 @@ describe('appLog', () => {
     expect(fs.readdirSync(tmpDir).filter(isRotated)).toHaveLength(1)
   })
 
+  it('flushes a buffered tail on the crash path without rotating past the cap', () => {
+    const isRotated = (f: string): boolean =>
+      /^app\.log_\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z\.log$/.test(f)
+    initAppLog({ dir: tmpDir })
+    // A partial operation line with no trailing newline stays buffered.
+    writeOperationOutput('inst-1', 'dying mid-line, no newline')
+    // Fill the live log to exactly the 5 MB cap.
+    writeAppLog('INFO', 'x'.repeat(5 * 1024 * 1024 - 35))
+    expect(fs.readdirSync(tmpDir).filter(isRotated)).toHaveLength(0)
+    // The crash-path flush (as called from processErrorHandlers) must append
+    // the tail in place rather than rotate, which could drop it.
+    flushOperationOutput(undefined, { rotate: false })
+    expect(fs.readdirSync(tmpDir).filter(isRotated)).toHaveLength(0)
+    expect(read()).toContain('dying mid-line, no newline')
+  })
+
   it('flushes only the targeted installation, leaving others buffered', () => {
     initAppLog({ dir: tmpDir })
     writeOperationOutput('inst-a', 'partial-a')

--- a/src/main/lib/appLog.test.ts
+++ b/src/main/lib/appLog.test.ts
@@ -14,7 +14,6 @@ import {
   writeAppLog,
   writeAppLogSync,
   writeOperationOutput,
-  flushAppLog,
   getAppLogPath,
   resetAppLogForTest
 } from './appLog'
@@ -65,10 +64,9 @@ describe('appLog', () => {
     expect(out).not.toContain('alice')
   })
 
-  it('captures patched console output after init', async () => {
+  it('captures patched console output after init', () => {
     initAppLog({ dir: tmpDir })
     console.error('handler exploded', { code: 2 })
-    await flushAppLog()
     expect(read()).toContain('[ERROR] handler exploded')
   })
 
@@ -90,11 +88,20 @@ describe('appLog', () => {
     expect(read()).not.toContain('session one')
   })
 
-  it('tees operation output verbatim', async () => {
+  it('tees operation output once a line completes', () => {
     initAppLog({ dir: tmpDir })
     expect(getAppLogPath()).toBe(path.join(tmpDir, 'app.log'))
     writeOperationOutput('> uv pip install torch\n')
-    await flushAppLog()
     expect(read()).toContain('> uv pip install torch')
+  })
+
+  it('scrubs a credential split across two operation chunks', () => {
+    initAppLog({ dir: tmpDir })
+    // The secret straddles the chunk boundary; per-chunk scrubbing would miss it.
+    writeOperationOutput('downloading from https://user:to')
+    writeOperationOutput('ken@mirror.example/simple\n')
+    const out = read()
+    expect(out).toContain('//[REDACTED]@')
+    expect(out).not.toContain('user:token@')
   })
 })

--- a/src/main/lib/appLog.ts
+++ b/src/main/lib/appLog.ts
@@ -12,12 +12,19 @@
  * dir. It captures:
  *
  *   - main-process `console.*` (patched in `initAppLog`),
- *   - uncaught errors / process-gone events (written synchronously from the
- *     error handlers so the crash cause survives the dying process),
+ *   - uncaught errors / process-gone events (so the crash cause is durable
+ *     even when the process is about to die),
  *   - the full operation output stream (teed from `appendLog`).
  *
  * Everything is ANSI-stripped and run through `scrubAll` before hitting disk
  * so credentials in index URLs and usernames in paths never get persisted.
+ *
+ * All writes are synchronous against a single append (`O_APPEND`) file
+ * descriptor. Synchronous writes mean the crash path (uncaught exception /
+ * process-gone) lands on disk before the dying process exits — a buffered
+ * stream write would be lost. A single append fd avoids interleaving and
+ * lets rotation close/rename/reopen deterministically (important on Windows,
+ * where renaming a file with an open handle fails).
  *
  * Writes are no-ops until `initAppLog()` runs, which keeps the module inert
  * in unit tests (and during the brief window before the app is ready) unless
@@ -35,15 +42,22 @@ const BASE_NAME = 'app.log'
 const MAX_BYTES = 5 * 1024 * 1024 // rotate mid-session past 5 MB
 const MAX_FILES = 50 // match comfyui.log retention
 const ROTATED_RE = /^app\.log_\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z\.log$/
+// Flush a not-yet-terminated operation line once it grows past this so a
+// chunk stream that never emits a newline can't buffer unbounded.
+const MAX_PENDING_LINE = 64 * 1024
 
 const CONSOLE_LEVELS = ['log', 'info', 'warn', 'error', 'debug'] as const
 type ConsoleLevel = (typeof CONSOLE_LEVELS)[number]
 
 let logDir: string | null = null
-let stream: fs.WriteStream | null = null
+let fd: number | null = null
 let currentBytes = 0
 let initialized = false
 let consolePatched = false
+// Carry for the operation-output tee so a credential split across two
+// process chunks ("https://user:to" + "ken@host") is still scrubbed: we
+// only write (and scrub) whole lines, keeping the partial tail buffered.
+let opPending = ''
 const originalConsole = new Map<ConsoleLevel, (...args: unknown[]) => void>()
 
 /** Resolve the directory the global log lives in. Falls back to Electron's
@@ -66,105 +80,97 @@ export function initAppLog(opts?: { dir?: string }): void {
   logDir = opts?.dir ?? app.getPath('logs')
   try {
     fs.mkdirSync(logDir, { recursive: true })
+    // Rotates the previous session's app.log (if any) and opens a fresh fd.
     rotateAppLogSync()
-    stream = openStream()
-    currentBytes = 0
   } catch {
     // If we can't open the log, keep going as a no-op rather than crash.
-    stream = null
+    closeFd()
   }
   initialized = true
   patchConsole()
 }
 
-/** Buffered append for normal runtime logging. */
+/** Append a runtime log line. Synchronous; safe on the crash path. */
 export function writeAppLog(level: string, text: string): void {
   if (!initialized) return
-  appendAsync(formatLine(level, text))
+  write(formatLine(level, text))
 }
 
 /**
- * Synchronous append for the crash path. A buffered stream write would be
- * lost when an uncaught exception or process-gone event kills the process
- * before the buffer flushes, so the error handlers use this to guarantee
- * the cause reaches disk.
+ * Append a log line from the crash path (uncaught exception / process-gone).
+ * Identical to `writeAppLog` — writes are already synchronous — but named so
+ * call sites document that the line must survive an imminent process exit.
  */
 export function writeAppLogSync(level: string, text: string): void {
   if (!initialized) return
-  appendSync(formatLine(level, text))
+  write(formatLine(level, text))
 }
 
-/** Tee operation output (already chunked, no per-line framing) to disk. */
+/**
+ * Tee operation output (raw, possibly partial process chunks) to disk. Only
+ * whole lines are written so cross-chunk secrets are scrubbed intact; the
+ * trailing partial line is held until the next chunk completes it.
+ */
 export function writeOperationOutput(text: string): void {
   if (!initialized || !text) return
-  appendAsync(text)
-}
-
-/** Flush buffered (non-sync) writes to disk. Resolves once the stream has
- *  drained everything queued so far. */
-export function flushAppLog(): Promise<void> {
-  return new Promise((resolve) => {
-    if (!stream || stream.writableEnded) {
-      resolve()
-      return
-    }
-    stream.write('', () => resolve())
-  })
-}
-
-/** Open the append stream with an error listener so a transient FS error
- *  (disk full, locked file) is swallowed instead of crashing the app. */
-function openStream(): fs.WriteStream {
-  const s = fs.createWriteStream(getAppLogPath(), { flags: 'a' })
-  s.on('error', () => {})
-  return s
+  opPending += text
+  let nl = opPending.indexOf('\n')
+  while (nl !== -1) {
+    write(opPending.slice(0, nl + 1))
+    opPending = opPending.slice(nl + 1)
+    nl = opPending.indexOf('\n')
+  }
+  if (opPending.length > MAX_PENDING_LINE) {
+    write(opPending)
+    opPending = ''
+  }
 }
 
 function formatLine(level: string, text: string): string {
   return `[${new Date().toISOString()}] [${level}] ${text}\n`
 }
 
-function appendAsync(raw: string): void {
+function write(raw: string): void {
+  if (fd === null) return
   const clean = scrubAll(stripAnsi(raw))
-  currentBytes += Buffer.byteLength(clean)
-  if (stream && !stream.writableEnded) {
-    try {
-      stream.write(clean)
-    } catch {
-      // Stream may have torn down; fall back to a synchronous append.
-      try {
-        fs.appendFileSync(getAppLogPath(), clean)
-      } catch {}
-    }
-  } else {
-    try {
-      fs.appendFileSync(getAppLogPath(), clean)
-    } catch {}
+  const len = Buffer.byteLength(clean)
+  // Rotate before writing so the live file never exceeds the cap mid-write.
+  if (currentBytes + len > MAX_BYTES) rotateAppLogSync()
+  if (fd === null) return
+  try {
+    fs.writeSync(fd, clean)
+    currentBytes += len
+  } catch {
+    // Disk full / locked file — drop the line rather than crash the app.
   }
-  if (currentBytes > MAX_BYTES) rotateAppLogSync()
 }
 
-function appendSync(raw: string): void {
-  const clean = scrubAll(stripAnsi(raw))
+function openFd(): void {
   try {
-    fs.appendFileSync(getAppLogPath(), clean)
-  } catch {}
-  currentBytes += Buffer.byteLength(clean)
-  if (currentBytes > MAX_BYTES) rotateAppLogSync()
+    fd = fs.openSync(getAppLogPath(), 'a')
+  } catch {
+    fd = null
+  }
+}
+
+function closeFd(): void {
+  if (fd !== null) {
+    try {
+      fs.closeSync(fd)
+    } catch {}
+    fd = null
+  }
 }
 
 /**
- * Synchronous rotation: prune the oldest rotated files past the retention
- * cap, rename the live log to a timestamped sibling, and reopen a fresh
- * stream. Synchronous so it stays consistent when called from the crash
- * path or mid-write.
+ * Synchronous rotation: close the live fd, prune the oldest rotated files
+ * past the retention cap, rename the live log to a timestamped sibling, and
+ * reopen a fresh fd. Synchronous throughout so the handle is closed before
+ * the rename (required on Windows) and `currentBytes` stays consistent.
  */
 function rotateAppLogSync(): void {
   if (!logDir) return
-  try {
-    stream?.end()
-  } catch {}
-  stream = null
+  closeFd()
   try {
     const names = fs
       .readdirSync(logDir)
@@ -182,11 +188,7 @@ function rotateAppLogSync(): void {
       fs.renameSync(getAppLogPath(), path.join(logDir, `${BASE_NAME}_${timestamp}.log`))
     }
   } catch {}
-  try {
-    stream = openStream()
-  } catch {
-    stream = null
-  }
+  openFd()
   currentBytes = 0
 }
 
@@ -211,12 +213,10 @@ export function resetAppLogForTest(): void {
     console[level] = original
   }
   originalConsole.clear()
-  try {
-    stream?.destroy()
-  } catch {}
-  stream = null
+  closeFd()
   logDir = null
   currentBytes = 0
+  opPending = ''
   initialized = false
   consolePatched = false
 }

--- a/src/main/lib/appLog.ts
+++ b/src/main/lib/appLog.ts
@@ -81,12 +81,12 @@ export function writeAppLog(level: string, text: string): void {
 
 /**
  * Append a log line from the crash path (uncaught exception / process-gone).
- * Identical to `writeAppLog` — writes are already synchronous — but named so
- * call sites document that the line must survive an imminent process exit.
+ * Synchronous, and skips rotation so a failed rename/reopen can never drop the
+ * final record before an imminent process exit.
  */
 export function writeAppLogSync(level: string, text: string): void {
   if (!initialized) return
-  write(formatLine(level, text))
+  write(formatLine(level, text), { rotate: false })
 }
 
 /**
@@ -114,15 +114,16 @@ export function writeOperationOutput(installationId: string, text: string): void
 }
 
 /** Emit any buffered partial line for an installation (or all installations
- *  when no id is given). Call at operation end / app shutdown so the final
- *  unterminated line isn't dropped. */
-export function flushOperationOutput(installationId?: string): void {
+ *  when no id is given). Call at operation/session end so a final unterminated
+ *  line is durable and a later operation reusing the id can't be appended onto
+ *  it. Pass `{ rotate: false }` from the crash path to match `writeAppLogSync`. */
+export function flushOperationOutput(installationId?: string, opts?: { rotate?: boolean }): void {
   if (!initialized) return
   const ids = installationId ? [installationId] : [...opPendingById.keys()]
   for (const id of ids) {
     const pending = opPendingById.get(id)
     opPendingById.delete(id)
-    if (pending) write(pending.endsWith('\n') ? pending : `${pending}\n`)
+    if (pending) write(pending.endsWith('\n') ? pending : `${pending}\n`, opts)
   }
 }
 
@@ -130,12 +131,15 @@ function formatLine(level: string, text: string): string {
   return `[${new Date().toISOString()}] [${level}] ${text}\n`
 }
 
-function write(raw: string): void {
+function write(raw: string, opts?: { rotate?: boolean }): void {
   if (fd === null) return
   const clean = scrubAll(stripAnsi(raw))
   const len = Buffer.byteLength(clean)
   // Rotate before writing so the live file never exceeds the cap mid-write.
-  if (currentBytes + len > MAX_BYTES) rotateAppLogSync()
+  // Crash-path writes opt out: rotation closes the live fd to rename/reopen,
+  // and a failed reopen would drop the final record. Letting the file run
+  // slightly over the cap (a later normal write rotates it) is safer.
+  if (opts?.rotate !== false && currentBytes + len > MAX_BYTES) rotateAppLogSync()
   if (fd === null) return
   try {
     fs.writeSync(fd, clean)

--- a/src/main/lib/appLog.ts
+++ b/src/main/lib/appLog.ts
@@ -1,0 +1,222 @@
+/**
+ * Persistent, rotating global application log.
+ *
+ * The launcher previously had no durable record of what the *app itself*
+ * did: `console.*` from the main process went nowhere, and operation output
+ * (install / update / migrate / restore) lived only in an in-memory ring
+ * buffer that vanished on modal close, app restart, or background runs with
+ * no window. The only on-disk log was the per-session `comfyui.log`, which
+ * covers the running ComfyUI process, not the app.
+ *
+ * This module owns a single global `app.log` in Electron's per-user logs
+ * dir. It captures:
+ *
+ *   - main-process `console.*` (patched in `initAppLog`),
+ *   - uncaught errors / process-gone events (written synchronously from the
+ *     error handlers so the crash cause survives the dying process),
+ *   - the full operation output stream (teed from `appendLog`).
+ *
+ * Everything is ANSI-stripped and run through `scrubAll` before hitting disk
+ * so credentials in index URLs and usernames in paths never get persisted.
+ *
+ * Writes are no-ops until `initAppLog()` runs, which keeps the module inert
+ * in unit tests (and during the brief window before the app is ready) unless
+ * a log dir has been wired up.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import { format } from 'node:util'
+import { app } from 'electron'
+import { stripAnsi } from './stderrTail'
+import { scrubAll } from '../../shared/piiScrub'
+
+const BASE_NAME = 'app.log'
+const MAX_BYTES = 5 * 1024 * 1024 // rotate mid-session past 5 MB
+const MAX_FILES = 50 // match comfyui.log retention
+const ROTATED_RE = /^app\.log_\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z\.log$/
+
+const CONSOLE_LEVELS = ['log', 'info', 'warn', 'error', 'debug'] as const
+type ConsoleLevel = (typeof CONSOLE_LEVELS)[number]
+
+let logDir: string | null = null
+let stream: fs.WriteStream | null = null
+let currentBytes = 0
+let initialized = false
+let consolePatched = false
+const originalConsole = new Map<ConsoleLevel, (...args: unknown[]) => void>()
+
+/** Resolve the directory the global log lives in. Falls back to Electron's
+ *  per-user logs path when init hasn't picked a dir yet. */
+export function getAppLogDir(): string {
+  return logDir ?? app.getPath('logs')
+}
+
+export function getAppLogPath(): string {
+  return path.join(getAppLogDir(), BASE_NAME)
+}
+
+/**
+ * Open the global log, rotate the previous session's file, and begin
+ * capturing `console.*`. Safe to call once; subsequent calls are no-ops.
+ * `dir` is injectable for tests.
+ */
+export function initAppLog(opts?: { dir?: string }): void {
+  if (initialized) return
+  logDir = opts?.dir ?? app.getPath('logs')
+  try {
+    fs.mkdirSync(logDir, { recursive: true })
+    rotateAppLogSync()
+    stream = openStream()
+    currentBytes = 0
+  } catch {
+    // If we can't open the log, keep going as a no-op rather than crash.
+    stream = null
+  }
+  initialized = true
+  patchConsole()
+}
+
+/** Buffered append for normal runtime logging. */
+export function writeAppLog(level: string, text: string): void {
+  if (!initialized) return
+  appendAsync(formatLine(level, text))
+}
+
+/**
+ * Synchronous append for the crash path. A buffered stream write would be
+ * lost when an uncaught exception or process-gone event kills the process
+ * before the buffer flushes, so the error handlers use this to guarantee
+ * the cause reaches disk.
+ */
+export function writeAppLogSync(level: string, text: string): void {
+  if (!initialized) return
+  appendSync(formatLine(level, text))
+}
+
+/** Tee operation output (already chunked, no per-line framing) to disk. */
+export function writeOperationOutput(text: string): void {
+  if (!initialized || !text) return
+  appendAsync(text)
+}
+
+/** Flush buffered (non-sync) writes to disk. Resolves once the stream has
+ *  drained everything queued so far. */
+export function flushAppLog(): Promise<void> {
+  return new Promise((resolve) => {
+    if (!stream || stream.writableEnded) {
+      resolve()
+      return
+    }
+    stream.write('', () => resolve())
+  })
+}
+
+/** Open the append stream with an error listener so a transient FS error
+ *  (disk full, locked file) is swallowed instead of crashing the app. */
+function openStream(): fs.WriteStream {
+  const s = fs.createWriteStream(getAppLogPath(), { flags: 'a' })
+  s.on('error', () => {})
+  return s
+}
+
+function formatLine(level: string, text: string): string {
+  return `[${new Date().toISOString()}] [${level}] ${text}\n`
+}
+
+function appendAsync(raw: string): void {
+  const clean = scrubAll(stripAnsi(raw))
+  currentBytes += Buffer.byteLength(clean)
+  if (stream && !stream.writableEnded) {
+    try {
+      stream.write(clean)
+    } catch {
+      // Stream may have torn down; fall back to a synchronous append.
+      try {
+        fs.appendFileSync(getAppLogPath(), clean)
+      } catch {}
+    }
+  } else {
+    try {
+      fs.appendFileSync(getAppLogPath(), clean)
+    } catch {}
+  }
+  if (currentBytes > MAX_BYTES) rotateAppLogSync()
+}
+
+function appendSync(raw: string): void {
+  const clean = scrubAll(stripAnsi(raw))
+  try {
+    fs.appendFileSync(getAppLogPath(), clean)
+  } catch {}
+  currentBytes += Buffer.byteLength(clean)
+  if (currentBytes > MAX_BYTES) rotateAppLogSync()
+}
+
+/**
+ * Synchronous rotation: prune the oldest rotated files past the retention
+ * cap, rename the live log to a timestamped sibling, and reopen a fresh
+ * stream. Synchronous so it stays consistent when called from the crash
+ * path or mid-write.
+ */
+function rotateAppLogSync(): void {
+  if (!logDir) return
+  try {
+    stream?.end()
+  } catch {}
+  stream = null
+  try {
+    const names = fs
+      .readdirSync(logDir)
+      .filter((n) => ROTATED_RE.test(n))
+      .sort()
+    while (names.length >= MAX_FILES) {
+      const oldest = names.shift()
+      if (!oldest) break
+      try {
+        fs.unlinkSync(path.join(logDir, oldest))
+      } catch {}
+    }
+    if (fs.existsSync(getAppLogPath())) {
+      const timestamp = new Date().toISOString().replaceAll(/[.:]/g, '-')
+      fs.renameSync(getAppLogPath(), path.join(logDir, `${BASE_NAME}_${timestamp}.log`))
+    }
+  } catch {}
+  try {
+    stream = openStream()
+  } catch {
+    stream = null
+  }
+  currentBytes = 0
+}
+
+function patchConsole(): void {
+  if (consolePatched) return
+  consolePatched = true
+  for (const level of CONSOLE_LEVELS) {
+    const original = console[level].bind(console) as (...args: unknown[]) => void
+    originalConsole.set(level, original)
+    console[level] = (...args: unknown[]): void => {
+      original(...args)
+      try {
+        writeAppLog(level === 'log' ? 'INFO' : level.toUpperCase(), format(...args))
+      } catch {}
+    }
+  }
+}
+
+/** Test hook: restore console and reset module state between tests. */
+export function resetAppLogForTest(): void {
+  for (const [level, original] of originalConsole) {
+    console[level] = original
+  }
+  originalConsole.clear()
+  try {
+    stream?.destroy()
+  } catch {}
+  stream = null
+  logDir = null
+  currentBytes = 0
+  initialized = false
+  consolePatched = false
+}

--- a/src/main/lib/appLog.ts
+++ b/src/main/lib/appLog.ts
@@ -1,34 +1,15 @@
 /**
- * Persistent, rotating global application log.
+ * Persistent, rotating global `app.log` in Electron's per-user logs dir.
  *
- * The launcher previously had no durable record of what the *app itself*
- * did: `console.*` from the main process went nowhere, and operation output
- * (install / update / migrate / restore) lived only in an in-memory ring
- * buffer that vanished on modal close, app restart, or background runs with
- * no window. The only on-disk log was the per-session `comfyui.log`, which
- * covers the running ComfyUI process, not the app.
+ * Captures main-process `console.*`, uncaught errors / process-gone events,
+ * and teed operation output. Everything is ANSI-stripped and `scrubAll`-ed
+ * before write so credentials and usernames are not persisted.
  *
- * This module owns a single global `app.log` in Electron's per-user logs
- * dir. It captures:
- *
- *   - main-process `console.*` (patched in `initAppLog`),
- *   - uncaught errors / process-gone events (so the crash cause is durable
- *     even when the process is about to die),
- *   - the full operation output stream (teed from `appendLog`).
- *
- * Everything is ANSI-stripped and run through `scrubAll` before hitting disk
- * so credentials in index URLs and usernames in paths never get persisted.
- *
- * All writes are synchronous against a single append (`O_APPEND`) file
- * descriptor. Synchronous writes mean the crash path (uncaught exception /
- * process-gone) lands on disk before the dying process exits — a buffered
- * stream write would be lost. A single append fd avoids interleaving and
- * lets rotation close/rename/reopen deterministically (important on Windows,
- * where renaming a file with an open handle fails).
- *
- * Writes are no-ops until `initAppLog()` runs, which keeps the module inert
- * in unit tests (and during the brief window before the app is ready) unless
- * a log dir has been wired up.
+ * Writes are synchronous against a single `O_APPEND` fd: the crash path lands
+ * on disk before the dying process exits (a buffered write would be lost), and
+ * a single fd lets rotation close/rename/reopen deterministically (renaming a
+ * file with an open handle fails on Windows). Writes are no-ops until
+ * `initAppLog()` runs, keeping the module inert in unit tests.
  */
 
 import fs from 'fs'
@@ -54,10 +35,12 @@ let fd: number | null = null
 let currentBytes = 0
 let initialized = false
 let consolePatched = false
-// Carry for the operation-output tee so a credential split across two
-// process chunks ("https://user:to" + "ken@host") is still scrubbed: we
-// only write (and scrub) whole lines, keeping the partial tail buffered.
-let opPending = ''
+// Per-installation carry for the operation-output tee so a credential split
+// across two process chunks ("https://user:to" + "ken@host") is still
+// scrubbed: we only write (and scrub) whole lines, keeping the partial tail
+// buffered. Keyed by installationId so concurrent installs don't interleave
+// partial lines into each other.
+const opPendingById = new Map<string, string>()
 const originalConsole = new Map<ConsoleLevel, (...args: unknown[]) => void>()
 
 /** Resolve the directory the global log lives in. Falls back to Electron's
@@ -107,22 +90,39 @@ export function writeAppLogSync(level: string, text: string): void {
 }
 
 /**
- * Tee operation output (raw, possibly partial process chunks) to disk. Only
- * whole lines are written so cross-chunk secrets are scrubbed intact; the
- * trailing partial line is held until the next chunk completes it.
+ * Tee operation output (raw, possibly partial process chunks) to disk for a
+ * given installation. Only whole lines are written so cross-chunk secrets are
+ * scrubbed intact; the trailing partial line is held (per installation) until
+ * the next chunk completes it, the pending tail exceeds `MAX_PENDING_LINE`, or
+ * `flushOperationOutput` is called.
  */
-export function writeOperationOutput(text: string): void {
+export function writeOperationOutput(installationId: string, text: string): void {
   if (!initialized || !text) return
-  opPending += text
-  let nl = opPending.indexOf('\n')
+  let pending = (opPendingById.get(installationId) ?? '') + text
+  let nl = pending.indexOf('\n')
   while (nl !== -1) {
-    write(opPending.slice(0, nl + 1))
-    opPending = opPending.slice(nl + 1)
-    nl = opPending.indexOf('\n')
+    write(pending.slice(0, nl + 1))
+    pending = pending.slice(nl + 1)
+    nl = pending.indexOf('\n')
   }
-  if (opPending.length > MAX_PENDING_LINE) {
-    write(opPending)
-    opPending = ''
+  if (pending.length > MAX_PENDING_LINE) {
+    write(pending.endsWith('\n') ? pending : `${pending}\n`)
+    pending = ''
+  }
+  if (pending) opPendingById.set(installationId, pending)
+  else opPendingById.delete(installationId)
+}
+
+/** Emit any buffered partial line for an installation (or all installations
+ *  when no id is given). Call at operation end / app shutdown so the final
+ *  unterminated line isn't dropped. */
+export function flushOperationOutput(installationId?: string): void {
+  if (!initialized) return
+  const ids = installationId ? [installationId] : [...opPendingById.keys()]
+  for (const id of ids) {
+    const pending = opPendingById.get(id)
+    opPendingById.delete(id)
+    if (pending) write(pending.endsWith('\n') ? pending : `${pending}\n`)
   }
 }
 
@@ -216,7 +216,7 @@ export function resetAppLogForTest(): void {
   closeFd()
   logDir = null
   currentBytes = 0
-  opPending = ''
+  opPendingById.clear()
   initialized = false
   consolePatched = false
 }

--- a/src/main/lib/crashDumps.test.ts
+++ b/src/main/lib/crashDumps.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, it, expect, vi } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+
+vi.mock('electron', () => ({
+  app: { getPath: () => os.tmpdir() }
+}))
+
+import { pruneCrashDumps } from './crashDumps'
+
+describe('pruneCrashDumps', () => {
+  let tmpDir: string
+
+  afterEach(() => {
+    if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  /** Create `name` with an mtime `ageMs` in the past so ordering is deterministic. */
+  function makeDump(dir: string, name: string, ageMs: number): string {
+    const file = path.join(dir, name)
+    fs.writeFileSync(file, 'dump')
+    const t = Date.now() - ageMs
+    fs.utimesSync(file, t / 1000, t / 1000)
+    return file
+  }
+
+  it('keeps the newest maxFiles and deletes the rest', () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'crashdumps-'))
+    const newest = makeDump(tmpDir, 'a.dmp', 0)
+    const mid = makeDump(tmpDir, 'b.dmp', 10_000)
+    const oldest = makeDump(tmpDir, 'c.dmp', 20_000)
+
+    const deleted = pruneCrashDumps({ dir: tmpDir, maxFiles: 2 })
+
+    expect(deleted).toBe(1)
+    expect(fs.existsSync(newest)).toBe(true)
+    expect(fs.existsSync(mid)).toBe(true)
+    expect(fs.existsSync(oldest)).toBe(false)
+  })
+
+  it('recurses into Crashpad subdirectories', () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'crashdumps-'))
+    const reports = path.join(tmpDir, 'reports')
+    fs.mkdirSync(reports)
+    const newest = makeDump(reports, 'a.dmp', 0)
+    const oldest = makeDump(reports, 'b.dmp', 10_000)
+
+    const deleted = pruneCrashDumps({ dir: tmpDir, maxFiles: 1 })
+
+    expect(deleted).toBe(1)
+    expect(fs.existsSync(newest)).toBe(true)
+    expect(fs.existsSync(oldest)).toBe(false)
+  })
+
+  it('only touches .dmp files', () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'crashdumps-'))
+    fs.writeFileSync(path.join(tmpDir, 'settings.dat'), 'keep')
+    makeDump(tmpDir, 'a.dmp', 0)
+    makeDump(tmpDir, 'b.dmp', 10_000)
+
+    pruneCrashDumps({ dir: tmpDir, maxFiles: 1 })
+
+    expect(fs.existsSync(path.join(tmpDir, 'settings.dat'))).toBe(true)
+  })
+
+  it('is a no-op when under the cap or the dir is missing', () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'crashdumps-'))
+    makeDump(tmpDir, 'a.dmp', 0)
+    expect(pruneCrashDumps({ dir: tmpDir, maxFiles: 10 })).toBe(0)
+    expect(pruneCrashDumps({ dir: path.join(tmpDir, 'nope'), maxFiles: 1 })).toBe(0)
+  })
+})

--- a/src/main/lib/crashDumps.ts
+++ b/src/main/lib/crashDumps.ts
@@ -13,7 +13,10 @@ import fs from 'fs'
 import path from 'path'
 import { app } from 'electron'
 
-const MAX_CRASH_DUMPS = 10
+// Keep just the few most recent dumps: the latest crash is what matters for
+// diagnosis, a couple of priors help spot a pattern, and at ~1-5 MB each we
+// don't want the folder to balloon for a crash-looping user.
+const MAX_CRASH_DUMPS = 3
 
 export function getCrashDumpsDir(): string {
   return app.getPath('crashDumps')
@@ -45,7 +48,8 @@ function collectDumps(dir: string): { file: string; mtimeMs: number }[] {
 
 /**
  * Delete all but the newest `maxFiles` crash dumps. `dir` and `maxFiles` are
- * injectable for tests; defaults are the Electron crashDumps path and 10.
+ * injectable for tests; defaults are the Electron crashDumps path and
+ * `MAX_CRASH_DUMPS`.
  */
 export function pruneCrashDumps(opts?: { dir?: string; maxFiles?: number }): number {
   const dir = opts?.dir ?? getCrashDumpsDir()

--- a/src/main/lib/crashDumps.ts
+++ b/src/main/lib/crashDumps.ts
@@ -1,0 +1,70 @@
+/**
+ * Retention sweep for Crashpad minidumps in `app.getPath('crashDumps')`.
+ *
+ * `crashReporter.start({ uploadToServer: false })` keeps dumps purely local,
+ * where Crashpad's own pruning is coarse and built around the upload
+ * lifecycle — a crash-looping user can accumulate many multi-MB `.dmp` files.
+ * This keeps only the newest `maxFiles` dumps (by mtime; Crashpad names files
+ * with UUIDs, not timestamps) and deletes the rest. Best-effort: any error is
+ * swallowed so a failed sweep never blocks startup.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import { app } from 'electron'
+
+const MAX_CRASH_DUMPS = 10
+
+export function getCrashDumpsDir(): string {
+  return app.getPath('crashDumps')
+}
+
+/** Recursively collect `*.dmp` files under `dir` with their mtimes. */
+function collectDumps(dir: string): { file: string; mtimeMs: number }[] {
+  const out: { file: string; mtimeMs: number }[] = []
+  let entries: fs.Dirent[]
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true })
+  } catch {
+    return out
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      out.push(...collectDumps(full))
+    } else if (entry.isFile() && entry.name.toLowerCase().endsWith('.dmp')) {
+      try {
+        out.push({ file: full, mtimeMs: fs.statSync(full).mtimeMs })
+      } catch {
+        // File vanished between readdir and stat; skip it.
+      }
+    }
+  }
+  return out
+}
+
+/**
+ * Delete all but the newest `maxFiles` crash dumps. `dir` and `maxFiles` are
+ * injectable for tests; defaults are the Electron crashDumps path and 10.
+ */
+export function pruneCrashDumps(opts?: { dir?: string; maxFiles?: number }): number {
+  const dir = opts?.dir ?? getCrashDumpsDir()
+  const maxFiles = opts?.maxFiles ?? MAX_CRASH_DUMPS
+  if (maxFiles < 0) return 0
+
+  const dumps = collectDumps(dir)
+  if (dumps.length <= maxFiles) return 0
+
+  // Newest first, then drop everything past the retention cap.
+  dumps.sort((a, b) => b.mtimeMs - a.mtimeMs)
+  let deleted = 0
+  for (const { file } of dumps.slice(maxFiles)) {
+    try {
+      fs.unlinkSync(file)
+      deleted++
+    } catch {
+      // Locked / already gone; leave it for the next sweep.
+    }
+  }
+  return deleted
+}

--- a/src/main/lib/ipc/shared.ts
+++ b/src/main/lib/ipc/shared.ts
@@ -1159,12 +1159,14 @@ export async function stopRunning(
     _stoppingInstallationIds.add(installationId)
     _broadcastToRenderer('instance-stopping', { installationId })
     onEnterStopping?.({ installationId })
-    flushOperationOutput(installationId)
     if (session.port) removePortLock(session.port)
     _runningSessions.delete(installationId)
     if (session.proc && !session.proc.killed) {
       await killProcessTree(session.proc)
     }
+    // Flush after the kill so shutdown output emitted while dying is captured
+    // and can't bleed into the next run for this id.
+    flushOperationOutput(installationId)
     _stoppingInstallationIds.delete(installationId)
     _broadcastToRenderer('instance-stopped', { installationId })
     sessionLifecycleEvents.emit('changed')
@@ -1174,7 +1176,6 @@ export async function stopRunning(
       _stoppingInstallationIds.add(id)
       _broadcastToRenderer('instance-stopping', { installationId: id })
       onEnterStopping?.({ installationId: id })
-      flushOperationOutput(id)
     }
     for (const [, session] of sessions) {
       if (session.port) removePortLock(session.port)
@@ -1187,6 +1188,11 @@ export async function stopRunning(
       }
     }
     await Promise.all(kills)
+    // Flush after the kills so shutdown output is captured and can't bleed
+    // into the next run for these ids.
+    for (const [id] of sessions) {
+      flushOperationOutput(id)
+    }
     for (const [id] of sessions) {
       _stoppingInstallationIds.delete(id)
       _broadcastToRenderer('instance-stopped', { installationId: id })

--- a/src/main/lib/ipc/shared.ts
+++ b/src/main/lib/ipc/shared.ts
@@ -23,6 +23,7 @@ import { deleteDir, formatDeleteStatus } from '../delete'
 import { deleteAction, untrackAction } from '../actions'
 import { _broadcastToRenderer } from './broadcast'
 import { appendLog } from '../logsBroadcast'
+import { flushOperationOutput } from '../appLog'
 import { stripAnsi } from '../stderrTail'
 import {
   spawnProcess, waitForPort, waitForUrl, killProcessTree, killByPort,
@@ -777,6 +778,10 @@ export function _addSession(
 export function _removeSession(installationId: string): void {
   const session = _runningSessions.get(installationId)
   if (!session) return
+  // The session's output stream has ended: flush its buffered tail so a final
+  // unterminated line is durable and a later run for this id can't be appended
+  // onto it.
+  flushOperationOutput(installationId)
   if (session.port) removePortLock(session.port)
   _runningSessions.delete(installationId)
   _broadcastToRenderer('instance-stopped', { installationId })
@@ -1154,6 +1159,7 @@ export async function stopRunning(
     _stoppingInstallationIds.add(installationId)
     _broadcastToRenderer('instance-stopping', { installationId })
     onEnterStopping?.({ installationId })
+    flushOperationOutput(installationId)
     if (session.port) removePortLock(session.port)
     _runningSessions.delete(installationId)
     if (session.proc && !session.proc.killed) {
@@ -1168,6 +1174,7 @@ export async function stopRunning(
       _stoppingInstallationIds.add(id)
       _broadcastToRenderer('instance-stopping', { installationId: id })
       onEnterStopping?.({ installationId: id })
+      flushOperationOutput(id)
     }
     for (const [, session] of sessions) {
       if (session.port) removePortLock(session.port)

--- a/src/main/lib/logsBroadcast.ts
+++ b/src/main/lib/logsBroadcast.ts
@@ -65,7 +65,7 @@ export function appendLog(installationId: string, text: string): void {
   if (!text) return
   // Tee into the durable global app log so operation output survives the
   // modal/app lifecycle and background runs with no window.
-  writeOperationOutput(text)
+  writeOperationOutput(installationId, text)
   const state = ensureState(installationId)
   state.buffer.push(text)
   state.bufferSize += text.length

--- a/src/main/lib/logsBroadcast.ts
+++ b/src/main/lib/logsBroadcast.ts
@@ -28,6 +28,7 @@
  */
 
 import type { WebContents } from 'electron'
+import { writeOperationOutput } from './appLog'
 
 const MAX_BUFFER_CHARS = 256 * 1024 // 256 KB per install — generous, fits any reasonable scrollback
 
@@ -62,6 +63,9 @@ function evictUntilBelowCap(state: InstallLogState): void {
  */
 export function appendLog(installationId: string, text: string): void {
   if (!text) return
+  // Tee into the durable global app log so operation output survives the
+  // modal/app lifecycle and background runs with no window.
+  writeOperationOutput(text)
   const state = ensureState(installationId)
   state.buffer.push(text)
   state.bufferSize += text.length

--- a/src/main/lib/processErrorHandlers.ts
+++ b/src/main/lib/processErrorHandlers.ts
@@ -3,7 +3,7 @@ import * as mainTelemetry from './telemetry'
 import { _broadcastToRenderer } from './ipc/shared'
 import type { DatadogForwardedError } from '../../types/ipc'
 import { scrubAll } from '../../shared/piiScrub'
-import { writeAppLogSync } from './appLog'
+import { writeAppLogSync, flushOperationOutput } from './appLog'
 
 /**
  * Main-process error funnel: scrub, fan out to renderer for Datadog RUM,
@@ -69,6 +69,10 @@ export function registerProcessErrorHandlers(): void {
       'CRITICAL',
       `uncaughtException: ${serialized.message}${serialized.stack ? `\n${serialized.stack}` : ''}`
     )
+    // The process is about to die: flush any buffered operation/session tails
+    // (install/update/migrate output that hasn't hit a newline) so the last
+    // lines before the crash are durable. No-rotate to match the crash path.
+    flushOperationOutput(undefined, { rotate: false })
     forwardDatadogError({
       source: 'main-uncaught-exception',
       message: serialized.message,

--- a/src/main/lib/processErrorHandlers.ts
+++ b/src/main/lib/processErrorHandlers.ts
@@ -3,6 +3,7 @@ import * as mainTelemetry from './telemetry'
 import { _broadcastToRenderer } from './ipc/shared'
 import type { DatadogForwardedError } from '../../types/ipc'
 import { scrubAll } from '../../shared/piiScrub'
+import { writeAppLogSync } from './appLog'
 
 /**
  * Main-process error funnel: scrub, fan out to renderer for Datadog RUM,
@@ -62,6 +63,12 @@ export function registerProcessErrorHandlers(): void {
 
   process.on('uncaughtExceptionMonitor', (error) => {
     const serialized = serializeUnknownError(error)
+    // Synchronous write first: a buffered stream write would be lost when the
+    // process dies before flushing, and this is exactly the cause we need.
+    writeAppLogSync(
+      'CRITICAL',
+      `uncaughtException: ${serialized.message}${serialized.stack ? `\n${serialized.stack}` : ''}`
+    )
     forwardDatadogError({
       source: 'main-uncaught-exception',
       message: serialized.message,
@@ -73,6 +80,10 @@ export function registerProcessErrorHandlers(): void {
 
   process.on('unhandledRejection', (reason) => {
     const serialized = serializeUnknownError(reason)
+    writeAppLogSync(
+      'ERROR',
+      `unhandledRejection: ${serialized.message}${serialized.stack ? `\n${serialized.stack}` : ''}`
+    )
     forwardDatadogError({
       source: 'main-unhandled-rejection',
       message: serialized.message,
@@ -84,6 +95,15 @@ export function registerProcessErrorHandlers(): void {
 
   app.on('child-process-gone', (_event, details) => {
     const extra = details as unknown as Record<string, unknown>
+    // Captures GPU / utility / pepper-plugin crashes — native faults that
+    // never surface as a JS exception and are a prime suspect for
+    // "spontaneously crashes after a few seconds" reports.
+    writeAppLogSync(
+      details.reason === 'clean-exit' ? 'INFO' : 'ERROR',
+      `child-process-gone type=${details.type} reason=${details.reason} exitCode=${details.exitCode}` +
+        `${extra['name'] ? ` name=${String(extra['name'])}` : ''}` +
+        `${extra['serviceName'] ? ` service=${String(extra['serviceName'])}` : ''}`
+    )
     forwardDatadogError({
       source: 'main-child-process-gone',
       message: `Child process ${details.type} exited: ${details.reason}`,
@@ -95,6 +115,27 @@ export function registerProcessErrorHandlers(): void {
         exitCode: details.exitCode,
         name: extra['name'],
         serviceName: extra['serviceName'],
+      },
+    })
+  })
+
+  app.on('render-process-gone', (_event, _webContents, details) => {
+    // Renderer crashes (Vue UI dying, OOM, integrity failure) are a separate
+    // event from child-process-gone and were not previously captured at the
+    // app level. `clean-exit` is normal teardown, so don't treat it as a fault.
+    if (details.reason === 'clean-exit') return
+    writeAppLogSync(
+      'CRITICAL',
+      `render-process-gone reason=${details.reason} exitCode=${details.exitCode}`
+    )
+    forwardDatadogError({
+      source: 'main-render-process-gone',
+      message: `Renderer process gone: ${details.reason} (exit ${details.exitCode})`,
+      level: 'critical',
+      context: {
+        origin: 'main-process',
+        reason: details.reason,
+        exitCode: details.exitCode,
       },
     })
   })

--- a/src/main/popups/titlePopup.ts
+++ b/src/main/popups/titlePopup.ts
@@ -19,6 +19,7 @@ import * as i18n from '../lib/i18n'
 import * as settings from '../settings'
 import { defaultInstallDir } from '../lib/paths'
 import { convertLevelToZoomPercent } from '../lib/zoom'
+import { getAppLogDir } from '../lib/appLog'
 import {
   openPath as openPathHelper,
   getAppVersion,
@@ -2961,6 +2962,12 @@ export function registerTitlePopupIpc(bindings: TitlePopupHostBindings): void {
     const targetPath = payload?.path
     if (typeof targetPath !== 'string' || targetPath.length === 0) return
     void openPathHelper(targetPath)
+  })
+
+  // Open the global app-log folder so users can grab logs for a bug report.
+  ipcMain.on('comfy-titlepopup:global-settings-open-logs-folder', (event) => {
+    if (!settingsEntryFor(event.sender.id)) return
+    void openPathHelper(getAppLogDir())
   })
 
   // Reveal a file in the OS file manager (highlights it in its parent folder),

--- a/src/preload/comfyTitlePopupPreload.ts
+++ b/src/preload/comfyTitlePopupPreload.ts
@@ -247,6 +247,8 @@ export interface ComfyTitlePopupBridge {
   globalSettingsSetModelsDirs(dirs: string[]): Promise<{ ok: boolean }>
   globalSettingsBrowseFolder(defaultPath?: string): Promise<string | null>
   globalSettingsOpenPath(path: string): void
+  /** Open the global app-log folder in the OS file manager. */
+  globalSettingsOpenLogsFolder(): void
   /** Reveal a file in the OS file manager (highlights it in its parent folder). */
   globalSettingsRevealPath(path: string): void
   /** http/https only (enforced main-side). */
@@ -626,6 +628,9 @@ const bridge: ComfyTitlePopupBridge = {
     ipcRenderer.invoke('comfy-titlepopup:global-settings-browse-folder', { defaultPath }),
   globalSettingsOpenPath: (path) => {
     ipcRenderer.send('comfy-titlepopup:global-settings-open-path', { path })
+  },
+  globalSettingsOpenLogsFolder: () => {
+    ipcRenderer.send('comfy-titlepopup:global-settings-open-logs-folder')
   },
   globalSettingsRevealPath: (path) => {
     ipcRenderer.send('comfy-titlepopup:global-settings-reveal-path', { path })

--- a/src/renderer/src/comfyTitlePopup/GlobalSettingsView.vue
+++ b/src/renderer/src/comfyTitlePopup/GlobalSettingsView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { HardDrive, RefreshCcw, Settings2, SlidersHorizontal, X } from 'lucide-vue-next'
+import { FileText, HardDrive, RefreshCcw, Settings2, SlidersHorizontal, X } from 'lucide-vue-next'
 import UpdatesSection from './globalSettings/UpdatesSection.vue'
 import GlobalSettingsMicroSection from './globalSettings/GlobalSettingsMicroSection.vue'
 import GlobalStorageSections from './globalSettings/GlobalStorageSections.vue'
@@ -70,6 +70,7 @@ interface GlobalSettingsBridge {
   ): Promise<{ ok: boolean; message?: string }>
   globalSettingsBrowseFolder(defaultPath?: string): Promise<string | null>
   globalSettingsOpenPath(path: string): void
+  globalSettingsOpenLogsFolder(): void
   globalSettingsOpenExternal(url: string): void
   globalSettingsSetModelsDirs(dirs: string[]): Promise<{ ok: boolean }>
   globalSettingsCheckForUpdate(): Promise<{ available: boolean; version?: string; error?: string }>
@@ -172,6 +173,10 @@ async function handleUpdateField(field: DetailField, value: unknown): Promise<vo
 function handleOpenExternal(url: string): void {
   if (!url) return
   bridge?.globalSettingsOpenExternal(url)
+}
+
+function handleOpenLogsFolder(): void {
+  bridge?.globalSettingsOpenLogsFolder()
 }
 
 async function handleUpdateNow(): Promise<void> {
@@ -343,6 +348,13 @@ onMounted(() => {
               @browse="handleBrowseCacheDir"
             />
           </GlobalSettingsMicroSection>
+
+          <GlobalSettingsMicroSection :title="t('settings.diagnostics', 'Diagnostics')">
+            <button type="button" class="gs-logs-btn" @click="handleOpenLogsFolder">
+              <FileText :size="14" aria-hidden="true" />
+              <span>{{ t('settings.openLogsFolder', 'Open logs folder') }}</span>
+            </button>
+          </GlobalSettingsMicroSection>
         </template>
       </section>
     </div>
@@ -374,6 +386,23 @@ onMounted(() => {
   font-size: 16px;
   font-weight: 700;
   color: color-mix(in oklab, var(--text) 90%, transparent);
+}
+
+.gs-logs-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border: 1px solid color-mix(in oklab, var(--text) 12%, transparent);
+  background: color-mix(in oklab, var(--text) 4%, transparent);
+  border-radius: 8px;
+  color: var(--neutral-100);
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.gs-logs-btn:hover {
+  background: color-mix(in oklab, var(--text) 8%, transparent);
 }
 
 .gs-close {


### PR DESCRIPTION
## Summary

Adds a persistent, rotating **global application log** plus **native crash capture** so the launcher's own activity (and the crashes it can suffer) leave a durable, redacted artifact on disk. Closes #1108.

Previously the only on-disk log was the per-installation `comfyui.log`; the app itself had no `electron-log` equivalent, `console.*` from the main process went nowhere, and operation output lived only in a 256 KB in-memory ring buffer that vanished on modal close, restart, or background runs with no window.

## Crash-class coverage

This is built to be robust enough to diagnose **spontaneous crashes that never throw a JS error** (GPU/native/OOM), not just JS exceptions:

| Crash type | Captured by | Survives the crash? |
|---|---|---|
| native / GPU / V8 OOM segfault | `crashReporter` minidumps (`crashDumps/`) | yes (OS-level) |
| GPU / utility process | `child-process-gone` → `app.log` (sync write) | yes |
| renderer crash | `render-process-gone` → `app.log` (sync write) | yes (newly handled at app level) |
| main-process JS uncaught | `uncaughtExceptionMonitor` → `app.log` (sync write) | yes |
| normal console / operation output | `app.log` (buffered stream) | yes (on restart) |

Crash-path writes are **synchronous** (`appendFileSync`) so the cause reaches disk before the process dies — a buffered stream write would be lost.

## What's included

- **`src/main/lib/appLog.ts`** — new module owning a rotating `app.log` in `app.getPath('logs')`. Captures patched `console.*`, ANSI-stripped (`stripAnsi`) and redacted (`scrubAll`) before write. Per-launch rotation reusing the `comfyui.log` pattern, a 5 MB mid-session size cap, and 50-file retention. Stream has an `error` listener so a transient FS error can't crash the app.
- **`src/main/index.ts`** — `crashReporter.start({ uploadToServer: false })` before app-ready (local minidumps, not uploaded), `initAppLog()` first thing in `whenReady`, and a startup line logging version/pid/platform/crashDumps path.
- **`src/main/lib/processErrorHandlers.ts`** — added an app-level `render-process-gone` handler (renderer crashes were not previously captured at the app level) and synchronous `app.log` writes with reason/exitCode in all process-gone handlers.
- **`src/main/lib/logsBroadcast.ts`** — one-line tee of `appendLog` into the global log, so full update/migrate/restore/install output (incl. `uv pip install`) is persisted, including background/startup runs with no window.
- **Redaction** — reuses `scrubAll` (`scrubPII` + `scrubSecrets`): credentials in pip index/mirror URLs and usernames in absolute paths are scrubbed before write.
- **Affordance** — "Open logs folder" button in Settings → Advanced → Diagnostics (new IPC), since the OS menu is stripped on Windows.

## Relationships

- Unblocks #376 (diagnostic report) — provides the main-process log it wants to bundle.
- Complements #888 (console UI) — durable backing store the UI can read.
- Does **not** replace #1106 (surfacing the failing substep output in the error message); both are needed.

## Tests

7 new unit tests in `src/main/lib/appLog.test.ts`: no-op before init, synchronous crash-line write, ANSI stripping, credential/username redaction, console capture, per-launch rotation + retention, and operation-output tee.

## Verification

`pnpm run typecheck`, `pnpm run lint`, `pnpm run test` (2651 tests), and `pnpm run build` all pass.
