### PR TITLE
fix(context-menu): add Save/Copy Image on right-click

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1173,6 +1173,8 @@
   "contextMenu": {
     "openLinkInBrowser": "Open Link in Browser",
     "copyLinkAddress": "Copy Link Address",
+    "saveImage": "Save Image",
+    "copyImage": "Copy Image",
     "cut": "Cut",
     "copy": "Copy",
     "paste": "Paste",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -1173,6 +1173,8 @@
   "contextMenu": {
     "openLinkInBrowser": "在浏览器中打开链接",
     "copyLinkAddress": "复制链接地址",
+    "saveImage": "保存图片",
+    "copyImage": "复制图片",
     "cut": "剪切",
     "copy": "复制",
     "paste": "粘贴",

--- a/src/main/lib/contextMenu.test.ts
+++ b/src/main/lib/contextMenu.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// contextMenu.ts imports electron at module load; mock it before importing.
+vi.mock('electron', () => ({
+  Menu: { buildFromTemplate: vi.fn() },
+  clipboard: { writeText: vi.fn() },
+  shell: { openExternal: vi.fn() },
+}))
+
+// i18n reads locale files off disk; keep labels deterministic and side-effect free.
+vi.mock('./i18n', () => ({
+  t: (key: string) => key,
+}))
+
+import { buildContextMenuItems, type ContextMenuActions, type ContextMenuParams } from './contextMenu'
+
+const noopActions: ContextMenuActions = {
+  saveImage: vi.fn(),
+  copyImage: vi.fn(),
+  openLink: vi.fn(),
+  copyLink: vi.fn(),
+}
+
+function makeParams(overrides: Partial<ContextMenuParams> = {}): ContextMenuParams {
+  return {
+    editFlags: {
+      canCut: false,
+      canCopy: false,
+      canPaste: false,
+      canSelectAll: false,
+    } as Electron.ContextMenuParams['editFlags'],
+    isEditable: false,
+    selectionText: '',
+    linkURL: '',
+    mediaType: 'none',
+    srcURL: '',
+    hasImageContents: false,
+    ...overrides,
+  }
+}
+
+const ids = (items: Electron.MenuItemConstructorOptions[]): string[] =>
+  items.map((i) => i.id ?? i.type ?? i.role).filter((x): x is string => typeof x === 'string')
+
+describe('buildContextMenuItems', () => {
+  it('returns no items when nothing is actionable', () => {
+    expect(buildContextMenuItems(makeParams(), noopActions)).toEqual([])
+  })
+
+  it('adds Save/Copy image entries for an image with contents', () => {
+    const items = buildContextMenuItems(
+      makeParams({ mediaType: 'image', hasImageContents: true, srcURL: 'http://x/y.png' }),
+      noopActions,
+    )
+    expect(ids(items)).toEqual(['saveImage', 'copyImage'])
+  })
+
+  it('ignores images without contents or src', () => {
+    expect(
+      buildContextMenuItems(makeParams({ mediaType: 'image', hasImageContents: false, srcURL: 'http://x/y.png' }), noopActions),
+    ).toEqual([])
+    expect(
+      buildContextMenuItems(makeParams({ mediaType: 'image', hasImageContents: true, srcURL: '' }), noopActions),
+    ).toEqual([])
+  })
+
+  it('wires Save Image to the action with the srcURL', () => {
+    const actions: ContextMenuActions = { ...noopActions, saveImage: vi.fn() }
+    const items = buildContextMenuItems(
+      makeParams({ mediaType: 'image', hasImageContents: true, srcURL: 'http://x/y.png' }),
+      actions,
+    )
+    const save = items.find((i) => i.id === 'saveImage')
+    ;(save?.click as () => void)?.()
+    expect(actions.saveImage).toHaveBeenCalledWith('http://x/y.png')
+  })
+
+  it('separates link and image blocks', () => {
+    const items = buildContextMenuItems(
+      makeParams({ linkURL: 'http://x', mediaType: 'image', hasImageContents: true, srcURL: 'http://x/y.png' }),
+      noopActions,
+    )
+    expect(ids(items)).toEqual(['openLink', 'copyLink', 'separator', 'saveImage', 'copyImage'])
+  })
+
+  it('separates an image block from editable items', () => {
+    const items = buildContextMenuItems(
+      makeParams({
+        mediaType: 'image',
+        hasImageContents: true,
+        srcURL: 'http://x/y.png',
+        isEditable: true,
+      }),
+      noopActions,
+    )
+    expect(ids(items)).toEqual([
+      'saveImage',
+      'copyImage',
+      'separator',
+      'cut',
+      'copy',
+      'paste',
+      'separator',
+      'selectAll',
+    ])
+  })
+
+  it('shows copy/select-all for a plain text selection', () => {
+    const items = buildContextMenuItems(makeParams({ selectionText: 'hello' }), noopActions)
+    expect(ids(items)).toEqual(['copy', 'selectAll'])
+  })
+})

--- a/src/main/lib/contextMenu.ts
+++ b/src/main/lib/contextMenu.ts
@@ -2,44 +2,93 @@ import { Menu, clipboard, shell } from 'electron'
 import type { BrowserWindow } from 'electron'
 import * as i18n from './i18n'
 
+/** Actions wired to the menu items; injected so the builder stays pure/testable. */
+export interface ContextMenuActions {
+  saveImage: (srcURL: string) => void
+  copyImage: () => void
+  openLink: (linkURL: string) => void
+  copyLink: (linkURL: string) => void
+}
+
+/** Subset of Electron's context-menu params the builder reads. */
+export type ContextMenuParams = Pick<
+  Electron.ContextMenuParams,
+  'editFlags' | 'isEditable' | 'selectionText' | 'linkURL' | 'mediaType' | 'srcURL' | 'hasImageContents'
+>
+
+/**
+ * Build the context-menu template for a right-click. Returns an empty array
+ * when nothing is actionable so callers can skip popping an empty menu.
+ *
+ * Images get Save/Copy entries so right-clicking an output image (including
+ * the fullscreen viewer) matches the browser's native "Save image" — the
+ * launcher overrides Chromium's default menu, so without this there is no
+ * way to save an image in-app.
+ */
+export function buildContextMenuItems(
+  params: ContextMenuParams,
+  actions: ContextMenuActions,
+): Electron.MenuItemConstructorOptions[] {
+  const { editFlags, isEditable, selectionText, linkURL, mediaType, srcURL, hasImageContents } = params
+  const hasSelection = selectionText.trim().length > 0
+  const hasLink = linkURL.length > 0
+  const hasImage = mediaType === 'image' && hasImageContents && srcURL.length > 0
+
+  const menuItems: Electron.MenuItemConstructorOptions[] = []
+
+  if (hasLink) {
+    menuItems.push(
+      { id: 'openLink', label: i18n.t('contextMenu.openLinkInBrowser'), click: () => actions.openLink(linkURL) },
+      { id: 'copyLink', label: i18n.t('contextMenu.copyLinkAddress'), click: () => actions.copyLink(linkURL) },
+    )
+  }
+
+  if (hasImage) {
+    if (menuItems.length > 0) menuItems.push({ type: 'separator' })
+    menuItems.push(
+      { id: 'saveImage', label: i18n.t('contextMenu.saveImage'), click: () => actions.saveImage(srcURL) },
+      { id: 'copyImage', label: i18n.t('contextMenu.copyImage'), click: () => actions.copyImage() },
+    )
+  }
+
+  if ((hasLink || hasImage) && (isEditable || hasSelection)) {
+    menuItems.push({ type: 'separator' })
+  }
+
+  if (isEditable) {
+    menuItems.push(
+      { label: i18n.t('contextMenu.cut'), role: 'cut', enabled: editFlags.canCut },
+      { label: i18n.t('contextMenu.copy'), role: 'copy', enabled: editFlags.canCopy },
+      { label: i18n.t('contextMenu.paste'), role: 'paste', enabled: editFlags.canPaste },
+      { type: 'separator' },
+      { label: i18n.t('contextMenu.selectAll'), role: 'selectAll', enabled: editFlags.canSelectAll },
+    )
+  } else if (hasSelection) {
+    menuItems.push(
+      { label: i18n.t('contextMenu.copy'), role: 'copy', enabled: editFlags.canCopy },
+      { label: i18n.t('contextMenu.selectAll'), role: 'selectAll', enabled: editFlags.canSelectAll },
+    )
+  }
+
+  return menuItems
+}
+
 export function attachContextMenu(
   comfyWindow: BrowserWindow,
   webContents?: Electron.WebContents,
 ): void {
-  ;(webContents || comfyWindow.webContents).on('context-menu', (_event, params) => {
-    const { editFlags, isEditable, selectionText, linkURL } = params
-    const hasSelection = selectionText.trim().length > 0
-    const hasLink = linkURL.length > 0
+  const wc = webContents || comfyWindow.webContents
+  wc.on('context-menu', (_event, params) => {
+    const menuItems = buildContextMenuItems(params, {
+      // Route through the comfy view's session so the save flows through the
+      // launcher's downloads tray (see attachSessionDownloadHandler).
+      saveImage: (srcURL) => wc.session.downloadURL(srcURL),
+      copyImage: () => wc.copyImageAt(params.x, params.y),
+      openLink: (linkURL) => shell.openExternal(linkURL),
+      copyLink: (linkURL) => clipboard.writeText(linkURL),
+    })
 
-    if (!isEditable && !hasSelection && !hasLink) return
-
-    const menuItems: Electron.MenuItemConstructorOptions[] = []
-
-    if (hasLink) {
-      menuItems.push(
-        { label: i18n.t('contextMenu.openLinkInBrowser'), click: () => shell.openExternal(linkURL) },
-        { label: i18n.t('contextMenu.copyLinkAddress'), click: () => clipboard.writeText(linkURL) },
-      )
-    }
-
-    if (hasLink && (isEditable || hasSelection)) {
-      menuItems.push({ type: 'separator' })
-    }
-
-    if (isEditable) {
-      menuItems.push(
-        { label: i18n.t('contextMenu.cut'), role: 'cut', enabled: editFlags.canCut },
-        { label: i18n.t('contextMenu.copy'), role: 'copy', enabled: editFlags.canCopy },
-        { label: i18n.t('contextMenu.paste'), role: 'paste', enabled: editFlags.canPaste },
-        { type: 'separator' },
-        { label: i18n.t('contextMenu.selectAll'), role: 'selectAll', enabled: editFlags.canSelectAll },
-      )
-    } else if (hasSelection) {
-      menuItems.push(
-        { label: i18n.t('contextMenu.copy'), role: 'copy', enabled: editFlags.canCopy },
-        { label: i18n.t('contextMenu.selectAll'), role: 'selectAll', enabled: editFlags.canSelectAll },
-      )
-    }
+    if (menuItems.length === 0) return
 
     Menu.buildFromTemplate(menuItems).popup({ window: comfyWindow })
   })


### PR DESCRIPTION
## Summary

Right-clicking an image in the desktop app — including the fullscreen image viewer — offered no way to save it, unlike in the browser. The launcher overrides Chromium's native context menu (`src/main/lib/contextMenu.ts`), and that handler only built items for links, editable fields, and text selections, bailing out early for images.

This adds **Save Image** and **Copy Image** entries when right-clicking an image:
- **Save Image** routes through `webContents.session.downloadURL(srcURL)` so the save flows through the launcher's existing downloads tray (`attachSessionDownloadHandler`).
- **Copy Image** uses `webContents.copyImageAt(x, y)`.

The menu-building logic is extracted into a pure `buildContextMenuItems()` function (mirroring `buildTitlePopupMenuItems` in `titlePopup.ts`) with unit tests.

Fixes #1195

## Changes
- `src/main/lib/contextMenu.ts` — image branch + extracted pure builder
- `src/main/lib/contextMenu.test.ts` — new unit tests (7 cases)
- `locales/en.json` / `locales/zh.json` — `contextMenu.saveImage` / `contextMenu.copyImage`

## Testing
- `pnpm run typecheck` ✅
- `pnpm run lint` ✅
- `pnpm run build` ✅
- `pnpm run test` ✅ (2670 passed, incl. 7 new)