### PR TITLE
Mention snapshot-undo path in ComfyUI update confirm modal

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -850,7 +850,7 @@
     "updateConfirmMessageLatest": "Update {installed} to the latest master commit ({latest})?",
     "updateConfirmMessageDowngrade": "Roll back from {installed} to stable {latest}? Newer commits will be removed.",
     "updateBreakingWarning": "⚠️ This may break your custom nodes and workflows.",
-    "updateSnapshotUndoHint": "💾 To undo, restore the current snapshot from the Snapshots tab.",
+    "updateSnapshotUndoHint": "💾 To undo, restore the snapshot saved before the update from the Snapshots tab.",
     "updateConfirmMessagePicked": "Update ComfyUI to **{tag}**?",
     "updatingTitle": "Updating to {version}",
     "downgradingTitle": "Downgrading to {version}",

--- a/locales/en.json
+++ b/locales/en.json
@@ -850,6 +850,7 @@
     "updateConfirmMessageLatest": "Update {installed} to the latest master commit ({latest})?",
     "updateConfirmMessageDowngrade": "Roll back from {installed} to stable {latest}? Newer commits will be removed.",
     "updateBreakingWarning": "⚠️ This may break your custom nodes and workflows.",
+    "updateSnapshotUndoHint": "💾 To undo, restore the current snapshot from the Snapshots tab.",
     "updateConfirmMessagePicked": "Update ComfyUI to **{tag}**?",
     "updatingTitle": "Updating to {version}",
     "downgradingTitle": "Downgrading to {version}",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -850,7 +850,7 @@
     "updateConfirmMessageLatest": "将 {installed} 更新到最新 master 提交（{latest}）？",
     "updateConfirmMessageDowngrade": "从 {installed} 回滚到稳定版 {latest}？较新的提交将被移除。",
     "updateBreakingWarning": "⚠️ 这可能会破坏你的自定义节点和工作流。",
-    "updateSnapshotUndoHint": "💾 如需撤销，可在快照标签页恢复当前快照。",
+    "updateSnapshotUndoHint": "💾 如需撤销，可在快照标签页恢复更新前保存的快照。",
     "updateConfirmMessagePicked": "将 ComfyUI 更新到 **{tag}**？",
     "updatingTitle": "正在更新到 {version}",
     "downgradingTitle": "正在降级到 {version}",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -850,6 +850,7 @@
     "updateConfirmMessageLatest": "将 {installed} 更新到最新 master 提交（{latest}）？",
     "updateConfirmMessageDowngrade": "从 {installed} 回滚到稳定版 {latest}？较新的提交将被移除。",
     "updateBreakingWarning": "⚠️ 这可能会破坏你的自定义节点和工作流。",
+    "updateSnapshotUndoHint": "💾 如需撤销，可在快照标签页恢复当前快照。",
     "updateConfirmMessagePicked": "将 ComfyUI 更新到 **{tag}**？",
     "updatingTitle": "正在更新到 {version}",
     "downgradingTitle": "正在降级到 {version}",

--- a/src/main/sources/standalone/updateSections.test.ts
+++ b/src/main/sources/standalone/updateSections.test.ts
@@ -36,6 +36,7 @@ interface UpdateAction {
   id: string
   progressTitle: string
   data?: { channel?: string; isDowngrade?: boolean }
+  confirm?: { title?: string; message?: string }
 }
 interface ChannelOption {
   value: string
@@ -144,6 +145,14 @@ describe('updateSections — update-comfyui action payload', () => {
     const action = getUpdateAction(baseInstall({ updateChannel: 'stable' }), 'stable')
     expect(action!.data?.channel).toBe('stable')
     expect(action!.data?.isDowngrade).toBeDefined()
+  })
+
+  it('confirm copy carries the breakage warning and the snapshot-undo hint', () => {
+    // The update is reversible via the auto-saved pre-update snapshot; the
+    // confirm copy must surface both the risk and the undo path.
+    const action = getUpdateAction(baseInstall({ updateChannel: 'stable' }), 'stable')
+    expect(action!.confirm?.message).toContain('standalone.updateBreakingWarning')
+    expect(action!.confirm?.message).toContain('standalone.updateSnapshotUndoHint')
   })
 })
 

--- a/src/main/sources/standalone/updateSections.ts
+++ b/src/main/sources/standalone/updateSections.ts
@@ -136,12 +136,14 @@ export function getDetailSections(installation: InstallationRecord): Record<stri
       // version-diff / rollback copy.
       // Every in-place update path carries the breakage warning — custom
       // nodes / saved workflows can pin to specific ComfyUI internals that
-      // shift across releases. Lives in the confirm copy itself (not the
-      // collapsible details) so the user can't dismiss past it accidentally.
+      // shift across releases. Pair it with the snapshot-undo hint so the
+      // user knows the update is reversible. Both live in the confirm copy
+      // itself (not the collapsible details) so the user can't dismiss past
+      // them accidentally.
       const baseConfirmMessage = isSwitching
         ? t('channelCards.movingTo', { channel: `**${card.label}**` })
         : t(msgKey, { installed: boldInstalled, latest: boldLatest })
-      const confirmMessage = `${baseConfirmMessage}\n\n${t('standalone.updateBreakingWarning')}`
+      const confirmMessage = `${baseConfirmMessage}\n\n${t('standalone.updateBreakingWarning')}\n${t('standalone.updateSnapshotUndoHint')}`
       actions.push({
         id: 'update-comfyui', label: t('standalone.updateNow'), style: 'primary', enabled: installed,
         tooltip: t('tooltips.updateNow'),


### PR DESCRIPTION
## What

The ComfyUI update confirmation modal already warns that updating `may break your custom nodes and workflows` but never tells the user the update is reversible. This adds a hint to the confirm copy pointing at the **current snapshot** in the **Snapshots** tab as the undo path.

A pre-update snapshot is always captured before `update-comfyui` runs (`preUpdateSnapshot: true` in `actions.ts`), so the hint is accurate for every in-place update path (same-channel update, channel switch, and downgrade). The non-destructive `Copy & Update` path is intentionally left unchanged.

## Changes

- New i18n string `standalone.updateSnapshotUndoHint` in `en.json` and `zh.json`.
- Appended it after the existing breaking-change warning in the `update-comfyui` confirm message (`updateSections.ts`).
- Added a test asserting the confirm copy carries both the breakage warning and the snapshot-undo hint.

## Verification

`pnpm run typecheck`, `pnpm run lint`, `pnpm run build`, and `pnpm run test` (2664 tests) all pass.

Closes #1183