### PR TITLE
fix(settings): make global Storage tab folder icons match the central pill's Storage tab

### DIFF
--- a/src/renderer/src/comfyTitlePopup/GlobalSettingsView.test.ts
+++ b/src/renderer/src/comfyTitlePopup/GlobalSettingsView.test.ts
@@ -195,6 +195,27 @@ describe('GlobalSettingsView', () => {
     expect(bridge.updateFieldCalls).toEqual([{ id: 'inputDir', value: '/picked/in' }])
   })
 
+  // Every dir in the global Storage tab is shared, so all rows carry the shared
+  // glyph — matching the per-instance Storage tab (StoragePane.vue).
+  it('Storage tab marks shared models and input/output dirs with the shared glyph', async () => {
+    installMockBridge()
+    const snapshot = makeSnapshot({
+      sharedDirectoriesFields: [
+        { id: 'inputDir', label: 'Input Directory', value: '/shared/in', type: 'path' },
+        { id: 'outputDir', label: 'Output Directory', value: '/shared/out', type: 'path' },
+      ],
+    })
+    const wrapper = mountView(snapshot)
+    await wrapper.findAll('.gs-tab').find((t) => t.text() === 'Storage')!.trigger('click')
+    await nextTick()
+    const modelRows = wrapper.findAll('.models-dir-row')
+    expect(modelRows.length).toBeGreaterThan(0)
+    expect(modelRows.every((r) => r.find('.storage-item-icon.is-shared').exists())).toBe(true)
+    const dirRows = wrapper.findAll('.storage-dir-row')
+    expect(dirRows).toHaveLength(2)
+    expect(dirRows.every((r) => r.find('.storage-item-icon.is-shared').exists())).toBe(true)
+  })
+
   it('Storage tab opens a Shared Directory in the OS file manager when clicked', async () => {
     const bridge = installMockBridge()
     const snapshot = makeSnapshot({

--- a/src/renderer/src/comfyTitlePopup/globalSettings/GlobalStorageSections.vue
+++ b/src/renderer/src/comfyTitlePopup/globalSettings/GlobalStorageSections.vue
@@ -60,6 +60,12 @@ const sharedDirFields = computed<Record<string, DetailField>>(() => {
 const sharedInputField = computed(() => sharedDirFields.value.inputDir)
 const sharedOutputField = computed(() => sharedDirFields.value.outputDir)
 
+/** Every dir here is globally shared, so flag them all to render the shared
+ *  glyph — matching the per-instance Storage tab (StoragePane.vue). */
+const sharedModelDirs = computed(() =>
+  props.snapshot.modelsDirs.map((d) => ({ ...d, shared: true }))
+)
+
 function sharedFieldPath(field: DetailField | undefined): string {
   return typeof field?.value === 'string' ? field.value : ''
 }
@@ -143,7 +149,7 @@ async function handleChangeModelsDir(index: number): Promise<void> {
     :tooltip="t('tooltips.sharedModels')"
   >
     <ModelsDirList
-      :dirs="snapshot.modelsDirs"
+      :dirs="sharedModelDirs"
       @change="handleChangeModelsDir"
       @remove="handleRemoveModelsDir"
       @make-primary="handleMakePrimary"
@@ -157,6 +163,7 @@ async function handleChangeModelsDir(index: number): Promise<void> {
       v-if="sharedInputField"
       :label="sharedInputField.label || t('media.inputDir', 'Input Directory')"
       :path="sharedFieldPath(sharedInputField)"
+      shared
       @open="handleOpenPath(sharedFieldPath(sharedInputField))"
       @browse="handleBrowseSharedInput"
     />
@@ -164,6 +171,7 @@ async function handleChangeModelsDir(index: number): Promise<void> {
       v-if="sharedOutputField"
       :label="sharedOutputField.label || t('media.outputDir', 'Output Directory')"
       :path="sharedFieldPath(sharedOutputField)"
+      shared
       @open="handleOpenPath(sharedFieldPath(sharedOutputField))"
       @browse="handleBrowseSharedOutput"
     />


### PR DESCRIPTION
## Summary

Fixes #1122.

The global (Desktop) settings **Storage** tab rendered shared model and input/output directories with the plain `Folder` icon, while the per-instance Storage tab (`StoragePane.vue`, reached via the central pill) marks the same globally-shared dirs with the `FolderSymlink` "shared" glyph. This made the two Storage tabs inconsistent.

Every directory shown in the global Storage tab is globally shared, so this PR flags them all to render the shared glyph, matching the per-instance tab.

## Changes

- `GlobalStorageSections.vue`:
  - Map `snapshot.modelsDirs` through a `sharedModelDirs` computed that sets `shared: true`, and pass that to `<ModelsDirList>`.
  - Add the `shared` prop to the shared input/output `<StorageDirRow>` rows.
- Cache dir / default install location rows in `GlobalSettingsView.vue` are **not** shared folders and keep the plain `Folder` icon (unchanged).
- Added a `GlobalSettingsView.test.ts` case asserting every Storage-tab row carries `.storage-item-icon.is-shared`.

Renderer-only, icon-glyph change — no behavior or IPC changes.

## Verification

- `pnpm run typecheck` ✅
- `pnpm run lint` ✅
- `pnpm run test` ✅ (2664 tests)
- `pnpm run build` ✅
