### PR TITLE
Make Add Existing Install detect standalone/portable in nested ComfyUI folder (#1118)

### DIFF
--- a/src/main/sources/common/nestedRoot.test.ts
+++ b/src/main/sources/common/nestedRoot.test.ts
@@ -1,0 +1,39 @@
+import path from 'path'
+import { describe, expect, it } from 'vitest'
+
+import { resolveNestedComfyUIParent } from './nestedRoot'
+
+describe('resolveNestedComfyUIParent', () => {
+  const always = (): boolean => true
+  const never = (): boolean => false
+
+  it('returns the parent when the dir is ComfyUI and the parent has the marker', () => {
+    const dir = path.join('root', 'ComfyUI')
+    expect(resolveNestedComfyUIParent(dir, always)).toBe('root')
+  })
+
+  it('matches ComfyUI case-insensitively', () => {
+    const dir = path.join('root', 'comfyui')
+    expect(resolveNestedComfyUIParent(dir, always)).toBe('root')
+  })
+
+  it('returns null when the dir is not named ComfyUI', () => {
+    const dir = path.join('root', 'models')
+    expect(resolveNestedComfyUIParent(dir, always)).toBeNull()
+  })
+
+  it('returns null when the parent lacks the marker', () => {
+    const dir = path.join('root', 'ComfyUI')
+    expect(resolveNestedComfyUIParent(dir, never)).toBeNull()
+  })
+
+  it('passes the parent path to the marker predicate', () => {
+    const dir = path.join('root', 'ComfyUI')
+    let seen = ''
+    resolveNestedComfyUIParent(dir, (parent) => {
+      seen = parent
+      return true
+    })
+    expect(seen).toBe('root')
+  })
+})

--- a/src/main/sources/common/nestedRoot.ts
+++ b/src/main/sources/common/nestedRoot.ts
@@ -1,0 +1,21 @@
+import path from 'path'
+
+/**
+ * Resolve the install root when the user pointed at the nested `ComfyUI/` folder
+ * inside a managed install (standalone or portable). Returns the parent only
+ * when the picked directory is named `ComfyUI` and the parent satisfies
+ * `parentHasMarker` (the source's own layout check). Returns null otherwise.
+ *
+ * Shared by the standalone and portable probes so the ascend rule stays
+ * consistent across them.
+ */
+export function resolveNestedComfyUIParent(
+  dirPath: string,
+  parentHasMarker: (parent: string) => boolean,
+): string | null {
+  const parent = path.dirname(dirPath)
+  if (parent !== dirPath && path.basename(dirPath).toLowerCase() === 'comfyui' && parentHasMarker(parent)) {
+    return parent
+  }
+  return null
+}

--- a/src/main/sources/portable.probe.test.ts
+++ b/src/main/sources/portable.probe.test.ts
@@ -1,0 +1,66 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: { isPackaged: false, getPath: () => '' },
+  ipcMain: { handle: vi.fn() },
+}))
+
+import { portable } from './portable'
+
+/** Build a portable layout (python_embeded/ + ComfyUI/). */
+function makePortable(root: string): void {
+  fs.mkdirSync(path.join(root, 'python_embeded'), { recursive: true })
+  fs.mkdirSync(path.join(root, 'ComfyUI'), { recursive: true })
+  fs.writeFileSync(path.join(root, 'ComfyUI', 'main.py'), '')
+}
+
+describe('portable probeInstallation', () => {
+  let tmp: string
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'portable-probe-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true })
+  })
+
+  it('detects a portable install at the root and records the root', async () => {
+    const root = path.join(tmp, 'ComfyUI_windows_portable')
+    makePortable(root)
+
+    const result = await portable.probeInstallation!(root)
+    expect(result).not.toBeNull()
+    expect(result!.installPath).toBe(root)
+  })
+
+  it('detects a portable install when pointed at the parent folder', async () => {
+    const root = path.join(tmp, 'ComfyUI_windows_portable')
+    makePortable(root)
+
+    const result = await portable.probeInstallation!(tmp)
+    expect(result).not.toBeNull()
+    // Resolves down to the real root, not the parent the user picked.
+    expect(result!.installPath).toBe(root)
+  })
+
+  it('detects a portable install when pointed at the nested ComfyUI folder', async () => {
+    const root = path.join(tmp, 'ComfyUI_windows_portable')
+    makePortable(root)
+
+    const result = await portable.probeInstallation!(path.join(root, 'ComfyUI'))
+    expect(result).not.toBeNull()
+    // Resolves up to the real root, not the nested ComfyUI folder.
+    expect(result!.installPath).toBe(root)
+  })
+
+  it('returns null for an unrelated directory', async () => {
+    const plain = path.join(tmp, 'plain')
+    fs.mkdirSync(plain, { recursive: true })
+    expect(await portable.probeInstallation!(plain)).toBeNull()
+  })
+})
+

--- a/src/main/sources/portable.probe.test.ts
+++ b/src/main/sources/portable.probe.test.ts
@@ -62,5 +62,25 @@ describe('portable probeInstallation', () => {
     fs.mkdirSync(plain, { recursive: true })
     expect(await portable.probeInstallation!(plain)).toBeNull()
   })
+
+  it('does not resolve up from a non-ComfyUI sibling inside a portable root', async () => {
+    const root = path.join(tmp, 'ComfyUI_windows_portable')
+    makePortable(root)
+    fs.mkdirSync(path.join(root, 'update'), { recursive: true })
+    // Pointing at a sibling of ComfyUI must not track the portable root.
+    expect(await portable.probeInstallation!(path.join(root, 'update'))).toBeNull()
+  })
+
+  it('resolves the nested portable root, not the parent, for a nested portable layout', async () => {
+    // outer/downloads/<portable>/ — picking outer/downloads must resolve the
+    // nested portable via the down-scan, never jump up to a parent.
+    const downloads = path.join(tmp, 'downloads')
+    const nested = path.join(downloads, 'ComfyUI_windows_portable')
+    makePortable(nested)
+
+    const result = await portable.probeInstallation!(downloads)
+    expect(result).not.toBeNull()
+    expect(result!.installPath).toBe(nested)
+  })
 })
 

--- a/src/main/sources/portable.ts
+++ b/src/main/sources/portable.ts
@@ -41,9 +41,6 @@ interface GitHubAsset {
 
 function findPortableRoot(installPath: string): string | null {
   if (fs.existsSync(path.join(installPath, 'python_embeded'))) return installPath
-  // User pointed at the nested `ComfyUI/` folder — the root is one level up.
-  const parent = path.dirname(installPath)
-  if (parent !== installPath && fs.existsSync(path.join(parent, 'python_embeded'))) return parent
   let entries: fs.Dirent[]
   try {
     entries = fs.readdirSync(installPath, { withFileTypes: true })
@@ -56,6 +53,25 @@ function findPortableRoot(installPath: string): string | null {
       const sub = path.join(installPath, entry.name)
       if (fs.existsSync(path.join(sub, 'python_embeded'))) return sub
     }
+  }
+  return null
+}
+
+/**
+ * Probe-only root resolution. Adds an upward check to {@link findPortableRoot}
+ * for when the user pointed at the nested `ComfyUI/` folder of a portable
+ * install. Kept separate so the runtime helper's resolution is unchanged.
+ */
+function findPortableProbeRoot(dirPath: string): string | null {
+  const root = findPortableRoot(dirPath)
+  if (root) return root
+  const parent = path.dirname(dirPath)
+  if (
+    parent !== dirPath &&
+    path.basename(dirPath).toLowerCase() === 'comfyui' &&
+    fs.existsSync(path.join(parent, 'python_embeded'))
+  ) {
+    return parent
   }
   return null
 }
@@ -260,7 +276,7 @@ export const portable: SourcePlugin = {
   },
 
   probeInstallation(dirPath: string): Record<string, unknown> | null {
-    const root = findPortableRoot(dirPath)
+    const root = findPortableProbeRoot(dirPath)
     if (!root) return null
     // Record the portable root, not whatever the user picked — they may have
     // pointed at the nested `ComfyUI/` folder or the parent of the install.

--- a/src/main/sources/portable.ts
+++ b/src/main/sources/portable.ts
@@ -12,6 +12,7 @@ import { fetchLatestRelease, truncateNotes } from '../lib/comfyui-releases'
 import { buildChannelCards, buildChannelLabelMap } from '../lib/channel-cards'
 import type { ChannelDef } from '../lib/channel-cards'
 import { buildLaunchSettingsFields, buildStorageFields } from './common/launchSettingsFields'
+import { resolveNestedComfyUIParent } from './common/nestedRoot'
 import type { InstallationRecord } from '../installations'
 import type {
   SourcePlugin,
@@ -65,15 +66,8 @@ function findPortableRoot(installPath: string): string | null {
 function findPortableProbeRoot(dirPath: string): string | null {
   const root = findPortableRoot(dirPath)
   if (root) return root
-  const parent = path.dirname(dirPath)
-  if (
-    parent !== dirPath &&
-    path.basename(dirPath).toLowerCase() === 'comfyui' &&
-    fs.existsSync(path.join(parent, 'python_embeded'))
-  ) {
-    return parent
-  }
-  return null
+  // User pointed at the nested `ComfyUI/` folder — the root is one level up.
+  return resolveNestedComfyUIParent(dirPath, (parent) => fs.existsSync(path.join(parent, 'python_embeded')))
 }
 
 export const portable: SourcePlugin = {

--- a/src/main/sources/portable.ts
+++ b/src/main/sources/portable.ts
@@ -41,6 +41,9 @@ interface GitHubAsset {
 
 function findPortableRoot(installPath: string): string | null {
   if (fs.existsSync(path.join(installPath, 'python_embeded'))) return installPath
+  // User pointed at the nested `ComfyUI/` folder — the root is one level up.
+  const parent = path.dirname(installPath)
+  if (parent !== installPath && fs.existsSync(path.join(parent, 'python_embeded'))) return parent
   let entries: fs.Dirent[]
   try {
     entries = fs.readdirSync(installPath, { withFileTypes: true })
@@ -257,8 +260,11 @@ export const portable: SourcePlugin = {
   },
 
   probeInstallation(dirPath: string): Record<string, unknown> | null {
-    if (findPortableRoot(dirPath)) return { version: 'unknown', asset: '', launchArgs: DEFAULT_LAUNCH_ARGS, launchMode: 'window', browserPartition: 'unique' }
-    return null
+    const root = findPortableRoot(dirPath)
+    if (!root) return null
+    // Record the portable root, not whatever the user picked — they may have
+    // pointed at the nested `ComfyUI/` folder or the parent of the install.
+    return { version: 'unknown', asset: '', installPath: root, launchArgs: DEFAULT_LAUNCH_ARGS, launchMode: 'window', browserPartition: 'unique' }
   },
 
   async handleAction(

--- a/src/main/sources/standalone/install.probe.test.ts
+++ b/src/main/sources/standalone/install.probe.test.ts
@@ -66,4 +66,11 @@ describe('standalone probeInstallation', () => {
     fs.writeFileSync(path.join(comfy, 'main.py'), '')
     expect(await probeInstallation(comfy)).toBeNull()
   })
+
+  it('does not resolve up from a non-ComfyUI sibling inside a standalone', async () => {
+    const root = path.join(tmp, 'install')
+    makeStandalone(root)
+    // Pointing at standalone-env/ (a sibling of ComfyUI) must not track the root.
+    expect(await probeInstallation(path.join(root, 'standalone-env'))).toBeNull()
+  })
 })

--- a/src/main/sources/standalone/install.probe.test.ts
+++ b/src/main/sources/standalone/install.probe.test.ts
@@ -1,0 +1,69 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: { getPath: () => '' },
+  ipcMain: { handle: vi.fn() },
+}))
+
+import { probeInstallation } from './install'
+
+/** Build a standalone layout (standalone-env/ + manifest.json + ComfyUI/main.py). */
+function makeStandalone(root: string): void {
+  fs.mkdirSync(path.join(root, 'standalone-env'), { recursive: true })
+  fs.mkdirSync(path.join(root, 'ComfyUI'), { recursive: true })
+  fs.writeFileSync(path.join(root, 'ComfyUI', 'main.py'), '')
+  fs.writeFileSync(
+    path.join(root, 'manifest.json'),
+    JSON.stringify({ comfyui_ref: 'v0.1.0', version: 'win-nvidia-1', id: 'win-nvidia', python_version: '3.12' }),
+  )
+}
+
+describe('standalone probeInstallation', () => {
+  let tmp: string
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'standalone-probe-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true })
+  })
+
+  it('detects a standalone install at the root and records the root', async () => {
+    const root = path.join(tmp, 'install')
+    makeStandalone(root)
+
+    const result = await probeInstallation(root)
+    expect(result).not.toBeNull()
+    expect(result!.installPath).toBe(root)
+    expect(result!.version).toBe('v0.1.0')
+    expect(result!.variant).toBe('win-nvidia')
+  })
+
+  it('detects a standalone install when pointed at the nested ComfyUI folder', async () => {
+    const root = path.join(tmp, 'install')
+    makeStandalone(root)
+
+    const result = await probeInstallation(path.join(root, 'ComfyUI'))
+    expect(result).not.toBeNull()
+    // installPath must be the root, not the nested ComfyUI folder.
+    expect(result!.installPath).toBe(root)
+    expect(result!.version).toBe('v0.1.0')
+  })
+
+  it('returns null for an unrelated directory', async () => {
+    const plain = path.join(tmp, 'plain')
+    fs.mkdirSync(plain, { recursive: true })
+    expect(await probeInstallation(plain)).toBeNull()
+  })
+
+  it('returns null for a bare ComfyUI folder with no standalone parent', async () => {
+    const comfy = path.join(tmp, 'ComfyUI')
+    fs.mkdirSync(comfy, { recursive: true })
+    fs.writeFileSync(path.join(comfy, 'main.py'), '')
+    expect(await probeInstallation(comfy)).toBeNull()
+  })
+})

--- a/src/main/sources/standalone/install.ts
+++ b/src/main/sources/standalone/install.ts
@@ -20,6 +20,7 @@ import {
 } from './envPaths'
 import type { InstallationRecord } from '../../installations'
 import { tagsEqual, type ComfyVersion } from '../../lib/version'
+import { resolveNestedComfyUIParent } from '../common/nestedRoot'
 import type { InstallTools, PostInstallTools } from '../../types/sources'
 
 const BULKY_PREFIXES = ['torch', 'nvidia', 'triton', 'cuda']
@@ -308,11 +309,7 @@ function findStandaloneRoot(dirPath: string): string | null {
     fs.existsSync(path.join(root, 'ComfyUI', 'main.py'))
   if (hasMarkers(dirPath)) return dirPath
   // User pointed at the nested `ComfyUI/` folder — the root is one level up.
-  const parent = path.dirname(dirPath)
-  if (parent !== dirPath && path.basename(dirPath).toLowerCase() === 'comfyui' && hasMarkers(parent)) {
-    return parent
-  }
-  return null
+  return resolveNestedComfyUIParent(dirPath, hasMarkers)
 }
 
 export async function probeInstallation(dirPath: string): Promise<Record<string, unknown> | null> {

--- a/src/main/sources/standalone/install.ts
+++ b/src/main/sources/standalone/install.ts
@@ -296,20 +296,35 @@ export async function postInstall(installation: InstallationRecord, { sendProgre
   // phase, so the bytes overlap env setup instead of blocking the install.
 }
 
+/**
+ * Resolve the standalone root for a probed directory. Returns the directory
+ * itself when it holds the standalone markers (`standalone-env/` +
+ * `ComfyUI/main.py`), or its parent when the user pointed at the nested
+ * `ComfyUI/` folder inside a standalone install. Returns null otherwise.
+ */
+function findStandaloneRoot(dirPath: string): string | null {
+  const hasMarkers = (root: string): boolean =>
+    fs.existsSync(path.join(root, 'standalone-env')) &&
+    fs.existsSync(path.join(root, 'ComfyUI', 'main.py'))
+  if (hasMarkers(dirPath)) return dirPath
+  const parent = path.dirname(dirPath)
+  if (parent !== dirPath && hasMarkers(parent)) return parent
+  return null
+}
+
 export async function probeInstallation(dirPath: string): Promise<Record<string, unknown> | null> {
-  const envExists = fs.existsSync(path.join(dirPath, 'standalone-env'))
-  const mainExists = fs.existsSync(path.join(dirPath, 'ComfyUI', 'main.py'))
-  if (!envExists || !mainExists) return null
-  const hasVenv = fs.existsSync(path.join(dirPath, 'ComfyUI', '.venv'))
-  const hasLegacyEnvs = fs.existsSync(path.join(dirPath, 'envs'))
-  const hasGit = fs.existsSync(path.join(dirPath, 'ComfyUI', '.git'))
+  const root = findStandaloneRoot(dirPath)
+  if (!root) return null
+  const hasVenv = fs.existsSync(path.join(root, 'ComfyUI', '.venv'))
+  const hasLegacyEnvs = fs.existsSync(path.join(root, 'envs'))
+  const hasGit = fs.existsSync(path.join(root, 'ComfyUI', '.git'))
 
   let version = 'unknown'
   let releaseTag = ''
   let variant = ''
   let pythonVersion = ''
   try {
-    const data = JSON.parse(fs.readFileSync(path.join(dirPath, MANIFEST_FILE), 'utf8')) as Record<string, string>
+    const data = JSON.parse(fs.readFileSync(path.join(root, MANIFEST_FILE), 'utf8')) as Record<string, string>
     version = data.comfyui_ref || version
     releaseTag = data.version || releaseTag
     variant = data.id || variant
@@ -318,7 +333,7 @@ export async function probeInstallation(dirPath: string): Promise<Record<string,
 
   let comfyVersion: ComfyVersion | undefined
   if (hasGit) {
-    const comfyuiDir = path.join(dirPath, 'ComfyUI')
+    const comfyuiDir = path.join(root, 'ComfyUI')
     const commit = readGitHead(comfyuiDir)
     if (commit) {
       const manifestTag = version !== 'unknown' ? version : undefined
@@ -333,6 +348,9 @@ export async function probeInstallation(dirPath: string): Promise<Record<string,
     variant,
     pythonVersion,
     hasGit,
+    // Record the standalone root, not whatever the user picked — they may have
+    // pointed at the nested `ComfyUI/` folder. Runtime paths resolve off this.
+    installPath: root,
     launchArgs: DEFAULT_LAUNCH_ARGS,
     launchMode: 'window',
     ...(hasLegacyEnvs && !hasVenv ? { needsEnvMigration: true } : {}),

--- a/src/main/sources/standalone/install.ts
+++ b/src/main/sources/standalone/install.ts
@@ -307,8 +307,11 @@ function findStandaloneRoot(dirPath: string): string | null {
     fs.existsSync(path.join(root, 'standalone-env')) &&
     fs.existsSync(path.join(root, 'ComfyUI', 'main.py'))
   if (hasMarkers(dirPath)) return dirPath
+  // User pointed at the nested `ComfyUI/` folder — the root is one level up.
   const parent = path.dirname(dirPath)
-  if (parent !== dirPath && hasMarkers(parent)) return parent
+  if (parent !== dirPath && path.basename(dirPath).toLowerCase() === 'comfyui' && hasMarkers(parent)) {
+    return parent
+  }
   return null
 }
 

--- a/src/renderer/src/views/TrackModal.test.ts
+++ b/src/renderer/src/views/TrackModal.test.ts
@@ -159,3 +159,56 @@ describe('TrackModal — browse-only install directory', () => {
     expect(trackButton(wrapper).attributes('disabled')).toBeDefined()
   })
 })
+
+describe('TrackModal — install path resolution on save', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('records the probe-resolved root when the user picked a nested folder', async () => {
+    const standaloneProbe: ProbeResult = {
+      sourceId: 'standalone',
+      sourceLabel: 'Standalone',
+      version: 'v0.1.0',
+      installPath: '/Users/jo/standalone',
+    }
+    const api = installMockApi({
+      // User browses to the nested ComfyUI folder; the probe corrects the root.
+      browseFolder: vi.fn().mockResolvedValue('/Users/jo/standalone/ComfyUI'),
+      probeInstallation: vi.fn().mockResolvedValue([standaloneProbe]),
+    })
+    const wrapper = mountTrack()
+    ;(wrapper.vm as unknown as { open: () => void }).open()
+    await flushPromises()
+
+    await wrapper.get('button.brand-tertiary').trigger('click')
+    await flushPromises()
+
+    await trackButton(wrapper).trigger('click')
+    await flushPromises()
+
+    expect(api.trackInstallation).toHaveBeenCalledTimes(1)
+    const data = api.trackInstallation.mock.calls[0]![0] as Record<string, unknown>
+    expect(data.installPath).toBe('/Users/jo/standalone')
+  })
+
+  it('falls back to the picked folder when the probe has no resolved root', async () => {
+    const api = installMockApi({
+      browseFolder: vi.fn().mockResolvedValue('/Users/jo/ComfyUI'),
+      // gitProbe has no installPath.
+    })
+    const wrapper = mountTrack()
+    ;(wrapper.vm as unknown as { open: () => void }).open()
+    await flushPromises()
+
+    await wrapper.get('button.brand-tertiary').trigger('click')
+    await flushPromises()
+
+    await trackButton(wrapper).trigger('click')
+    await flushPromises()
+
+    expect(api.trackInstallation).toHaveBeenCalledTimes(1)
+    const data = api.trackInstallation.mock.calls[0]![0] as Record<string, unknown>
+    expect(data.installPath).toBe('/Users/jo/ComfyUI')
+  })
+})

--- a/src/renderer/src/views/TrackModal.vue
+++ b/src/renderer/src/views/TrackModal.vue
@@ -191,10 +191,14 @@ async function handleSave(): Promise<void> {
   if (venvOverride.value !== null) {
     rawProbe.venvPath = venvOverride.value
   }
+  // A probe may resolve the real install root when the user pointed at a nested
+  // folder (e.g. the `ComfyUI/` dir of a standalone/portable install). Prefer
+  // that over the raw picked path so runtime paths resolve correctly.
+  const installPath = (rawProbe.installPath as string | undefined) || trackPath.value
   const data: Record<string, unknown> = {
     name,
-    installPath: trackPath.value,
-    ...rawProbe
+    ...rawProbe,
+    installPath
   }
 
   const result = await window.api.trackInstallation(data)

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -423,6 +423,10 @@ export interface ProbeResult {
   version?: string
   repo?: string
   branch?: string
+  /** Resolved install root. Set when the probe corrected the user-picked path
+   *  (e.g. they pointed at the nested `ComfyUI/` folder of a standalone or
+   *  portable install). When present, it should be recorded as the installPath. */
+  installPath?: string
   [key: string]: unknown
 }
 


### PR DESCRIPTION
Fixes #1118.

## Problem

**Add Existing Install** probes only the exact directory the user picks. Standalone and portable installs nest ComfyUI inside a root:

```
Standalone <root>/                 Portable <root>/
├── standalone-env/   (marker)     ├── python_embeded/   (marker)
├── manifest.json     (marker)     └── ComfyUI/
└── ComfyUI/                           ├── main.py
    ├── main.py                        └── .git/  (sometimes)
    └── .git/  (git false-positive)
```

When a user points at the inner `ComfyUI/` folder, the standalone/portable markers live one level up, so those probes miss and the inner `.git` makes it match the **git** source — it's reported as a *git manual* install.

## Fix

- **Standalone** (`standalone/install.ts`): new `findStandaloneRoot` resolves upward (picked dir or its parent), runs all checks against the root, and returns `installPath: root`.
- **Portable** (`portable.ts`): `findPortableRoot` now also checks one level **up** (in addition to self + one level down); the probe returns `installPath: root`.
- **Renderer** (`TrackModal.vue` + `ProbeResult` type): `handleSave` records the probe-resolved `installPath` when present, falling back to the picked path. This matters because standalone runtime paths resolve off `installPath` (e.g. `installPath/standalone-env/python.exe`), so it must be the real root.

Because `standalone` and `portable` come before `git` in the sources array, they now win as the default detected type; git remains selectable as a fallback.

**Existing tracked installations are untouched** — this only changes how new probes report and what installPath they record.

## Tests
- `install.probe.test.ts` / `portable.probe.test.ts`: detect root, detect when pointed at nested `ComfyUI/` (and, for portable, the parent), correct `installPath`, null for unrelated dirs.
- `TrackModal.test.ts`: save records the probe-resolved root; falls back to picked path when absent.

`typecheck` / `lint` / `build` / `test` (2673 tests) all pass.