### PR TITLE
feat: add toggle to control ComfyUI version-update notifications (default off)

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -438,7 +438,7 @@
     "autoUpdate": "Check for updates on startup",
     "autoInstallUpdates": "Automatically install Desktop updates",
     "showComfyVersionUpdates": "Show ComfyUI version updates",
-    "showComfyVersionUpdatesDescription": "Show new-release and version-update notifications inside ComfyUI. Turn this off to rely on Comfy Desktop's own update notifications instead.",
+    "showComfyVersionUpdatesDescription": "Show new-release and version-update notifications inside ComfyUI. Off by default because Comfy Desktop has its own update notifications.",
     "appBehavior": "App Behavior",
     "autoLaunchOnStartup": "Auto-launch on startup",
     "autoLaunchOnStartupDescription": "Pick an instance to launch automatically when Comfy Desktop opens. Defaults to None.",

--- a/locales/en.json
+++ b/locales/en.json
@@ -437,6 +437,8 @@
     "closeQuitDownloads": "Downloading",
     "autoUpdate": "Check for updates on startup",
     "autoInstallUpdates": "Automatically install Desktop updates",
+    "showComfyVersionUpdates": "Show ComfyUI version updates",
+    "showComfyVersionUpdatesDescription": "Show new-release and version-update notifications inside ComfyUI. Turn this off to rely on Comfy Desktop's own update notifications instead.",
     "appBehavior": "App Behavior",
     "autoLaunchOnStartup": "Auto-launch on startup",
     "autoLaunchOnStartupDescription": "Pick an instance to launch automatically when Comfy Desktop opens. Defaults to None.",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -438,7 +438,7 @@
     "autoUpdate": "启动时检查更新",
     "autoInstallUpdates": "自动安装桌面端更新",
     "showComfyVersionUpdates": "显示 ComfyUI 版本更新",
-    "showComfyVersionUpdatesDescription": "在 ComfyUI 内显示新版本和版本更新通知。关闭后将改为依赖 Comfy Desktop 自身的更新通知。",
+    "showComfyVersionUpdatesDescription": "在 ComfyUI 内显示新版本和版本更新通知。默认关闭，因为 Comfy Desktop 有自己的更新通知。",
     "appBehavior": "应用行为",
     "autoLaunchOnStartup": "启动时自动打开",
     "autoLaunchOnStartupDescription": "选择 Comfy Desktop 打开时自动启动的实例。默认为“无”。",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -437,6 +437,8 @@
     "closeQuitDownloads": "下载中",
     "autoUpdate": "启动时检查更新",
     "autoInstallUpdates": "自动安装桌面端更新",
+    "showComfyVersionUpdates": "显示 ComfyUI 版本更新",
+    "showComfyVersionUpdatesDescription": "在 ComfyUI 内显示新版本和版本更新通知。关闭后将改为依赖 Comfy Desktop 自身的更新通知。",
     "appBehavior": "应用行为",
     "autoLaunchOnStartup": "启动时自动打开",
     "autoLaunchOnStartupDescription": "选择 Comfy Desktop 打开时自动启动的实例。默认为“无”。",

--- a/src/main/lib/ipc/registerSettingsHandlers.ts
+++ b/src/main/lib/ipc/registerSettingsHandlers.ts
@@ -113,7 +113,7 @@ export function buildSettingsSections(
           id: 'showComfyVersionUpdates',
           label: i18n.t('settings.showComfyVersionUpdates'),
           type: 'boolean',
-          value: s.showComfyVersionUpdates !== false,
+          value: s.showComfyVersionUpdates === true,
           tooltip: i18n.t('settings.showComfyVersionUpdatesDescription')
         },
         // onAppClose field hidden while docking-to-tray is disabled.

--- a/src/main/lib/ipc/registerSettingsHandlers.ts
+++ b/src/main/lib/ipc/registerSettingsHandlers.ts
@@ -99,15 +99,22 @@ export function buildSettingsSections(
           tooltip: i18n.t('settings.hideCloudFromPickerDescription')
         },
 
-        // autoInstallUpdates is filtered out of generalFields by
-        // buildGlobalSettingsSnapshot — it renders inside the Updates
-        // tab. Keeping the field definition here so the schema stays
+        // autoInstallUpdates and showComfyVersionUpdates are filtered out of
+        // generalFields by buildGlobalSettingsSnapshot — they render inside the
+        // Updates tab. Keeping the field definitions here so the schema stays
         // single-source.
         {
           id: 'autoInstallUpdates',
           label: i18n.t('settings.autoInstallUpdates'),
           type: 'boolean',
           value: s.autoInstallUpdates !== false
+        },
+        {
+          id: 'showComfyVersionUpdates',
+          label: i18n.t('settings.showComfyVersionUpdates'),
+          type: 'boolean',
+          value: s.showComfyVersionUpdates !== false,
+          tooltip: i18n.t('settings.showComfyVersionUpdatesDescription')
         },
         // onAppClose field hidden while docking-to-tray is disabled.
         ...(isChinese ? [chineseMirrorsField] : [])

--- a/src/main/lib/ipc/sessionActions/launch.test.ts
+++ b/src/main/lib/ipc/sessionActions/launch.test.ts
@@ -23,26 +23,35 @@ const installOf = (sourceId: string) => ({ sourceId }) as InstallationRecord
 
 describe('desktopFeatureFlags', () => {
   it('always injects the unconditional desktop flags', () => {
-    const flags = desktopFeatureFlags(installOf('standalone'), false)
+    const flags = desktopFeatureFlags(installOf('standalone'), false, true)
     expect(flags.show_signin_button).toBe('true')
     expect(flags.supports_terminal).toBe('true')
   })
 
   it('injects enable_telemetry only for standalone installs that opted in', () => {
-    expect(desktopFeatureFlags(installOf('standalone'), true).enable_telemetry).toBe('true')
+    expect(desktopFeatureFlags(installOf('standalone'), true, true).enable_telemetry).toBe('true')
   })
 
   it('omits enable_telemetry when telemetry is disabled (default off)', () => {
-    expect(desktopFeatureFlags(installOf('standalone'), false)).not.toHaveProperty(
+    expect(desktopFeatureFlags(installOf('standalone'), false, true)).not.toHaveProperty(
       'enable_telemetry'
     )
   })
 
   it('omits enable_telemetry for non-standalone installs even when opted in', () => {
-    expect(desktopFeatureFlags(installOf('portable'), true)).not.toHaveProperty(
+    expect(desktopFeatureFlags(installOf('portable'), true, true)).not.toHaveProperty(
       'enable_telemetry'
     )
-    expect(desktopFeatureFlags(installOf('git'), true)).not.toHaveProperty('enable_telemetry')
+    expect(desktopFeatureFlags(installOf('git'), true, true)).not.toHaveProperty('enable_telemetry')
+  })
+
+  it('reflects the showVersionUpdates argument in show_version_updates', () => {
+    expect(desktopFeatureFlags(installOf('standalone'), false, true).show_version_updates).toBe(
+      'true'
+    )
+    expect(desktopFeatureFlags(installOf('standalone'), false, false).show_version_updates).toBe(
+      'false'
+    )
   })
 })
 

--- a/src/main/lib/ipc/sessionActions/launch.ts
+++ b/src/main/lib/ipc/sessionActions/launch.ts
@@ -63,7 +63,8 @@ import type { WriteStream } from 'fs'
 // --list-feature-flags registry so we never inject unrecognized keys.
 export function desktopFeatureFlags(
   inst: InstallationRecord,
-  telemetryEnabled: boolean
+  telemetryEnabled: boolean,
+  showVersionUpdates: boolean
 ): Record<string, string> {
   const flags: Record<string, string> = {
     show_signin_button: 'true',
@@ -71,6 +72,10 @@ export function desktopFeatureFlags(
     // may surface its bottom-panel terminal. The actual transport is the
     // __comfyDesktop2.Terminal bridge; the flag only gates visibility.
     supports_terminal: 'true',
+    // Seeds the frontend's Comfy.Notification.ShowVersionUpdates default so
+    // Desktop, which has its own update/What's-New UI, can suppress the
+    // redundant in-frontend release notifications (the user can still override).
+    show_version_updates: String(showVersionUpdates),
   }
   // Telemetry is opt-in (default off) and only signaled for managed standalone
   // installs — never for portable or user-managed git clones.
@@ -350,7 +355,11 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
         if (schema.knownFlags.has('feature-flag') && schema.knownFlags.has('list-feature-flags')) {
           const registry = await getComfyFeatureFlagRegistry(launchCmd.cmd, mainPyAbs, launchCmd.cwd, installationId, version)
           const flagEntries = Object.entries(
-            desktopFeatureFlags(inst, settings.get('telemetryEnabled') === true)
+            desktopFeatureFlags(
+              inst,
+              settings.get('telemetryEnabled') === true,
+              settings.get('showComfyVersionUpdates') !== false
+            )
           )
           for (const [key, value] of flagEntries) {
             if (key in registry) {

--- a/src/main/lib/ipc/sessionActions/launch.ts
+++ b/src/main/lib/ipc/sessionActions/launch.ts
@@ -358,7 +358,7 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
             desktopFeatureFlags(
               inst,
               settings.get('telemetryEnabled') === true,
-              settings.get('showComfyVersionUpdates') !== false
+              settings.get('showComfyVersionUpdates') === true
             )
           )
           for (const [key, value] of flagEntries) {

--- a/src/main/popups/titlePopup.ts
+++ b/src/main/popups/titlePopup.ts
@@ -2071,15 +2071,11 @@ function buildGlobalSettingsSnapshot(
   const generalRaw = findSettingsFields(settingsSections, 'settings.general', 0)
   // Locale picker lives above the "App Behavior" microsection without a
   // header of its own, so it gets pulled out of generalFields here.
-  const desktopUpdateFields = generalRaw.filter(
-    (f) => f.id === 'autoInstallUpdates' || f.id === 'showComfyVersionUpdates'
-  )
+  const desktopUpdateFieldIds = new Set(['autoInstallUpdates', 'showComfyVersionUpdates'])
+  const desktopUpdateFields = generalRaw.filter((f) => desktopUpdateFieldIds.has(String(f.id)))
   const languageFields = generalRaw.filter((f) => f.id === 'language')
   const generalFields = generalRaw.filter(
-    (f) =>
-      f.id !== 'autoInstallUpdates' &&
-      f.id !== 'showComfyVersionUpdates' &&
-      f.id !== 'language'
+    (f) => !desktopUpdateFieldIds.has(String(f.id)) && f.id !== 'language'
   )
   const telemetryFields = findSettingsFields(settingsSections, 'settings.telemetry', 1)
   const cache = findSettingsFields(settingsSections, 'settings.cache', 2)

--- a/src/main/popups/titlePopup.ts
+++ b/src/main/popups/titlePopup.ts
@@ -2071,10 +2071,15 @@ function buildGlobalSettingsSnapshot(
   const generalRaw = findSettingsFields(settingsSections, 'settings.general', 0)
   // Locale picker lives above the "App Behavior" microsection without a
   // header of its own, so it gets pulled out of generalFields here.
-  const desktopUpdateFields = generalRaw.filter((f) => f.id === 'autoInstallUpdates')
+  const desktopUpdateFields = generalRaw.filter(
+    (f) => f.id === 'autoInstallUpdates' || f.id === 'showComfyVersionUpdates'
+  )
   const languageFields = generalRaw.filter((f) => f.id === 'language')
   const generalFields = generalRaw.filter(
-    (f) => f.id !== 'autoInstallUpdates' && f.id !== 'language'
+    (f) =>
+      f.id !== 'autoInstallUpdates' &&
+      f.id !== 'showComfyVersionUpdates' &&
+      f.id !== 'language'
   )
   const telemetryFields = findSettingsFields(settingsSections, 'settings.telemetry', 1)
   const cache = findSettingsFields(settingsSections, 'settings.cache', 2)

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -24,6 +24,12 @@ export interface KnownSettings {
   /** When true (default), Desktop updates download and install silently; when
    *  false, the user is prompted before any download/install. */
   autoInstallUpdates?: boolean
+  /** Default for whether the embedded ComfyUI frontend shows new-release /
+   *  version-update notifications. Injected at launch as the
+   *  `show_version_updates` feature flag, which seeds the frontend's
+   *  `Comfy.Notification.ShowVersionUpdates` default (the user can still
+   *  override it inside ComfyUI). Defaults to true (show). */
+  showComfyVersionUpdates?: boolean
   /** Opt-in auto-launch on Desktop startup. Values:
    *  - `'none'` (default) — land on the dashboard, current behavior.
    *  - `'last'` — launch the install with the largest `lastLaunchedAt`.
@@ -110,6 +116,7 @@ const SETTINGS_SCHEMA = {
   theme: { nullable: false },
   autoUpdate: { nullable: false },
   autoInstallUpdates: { nullable: false },
+  showComfyVersionUpdates: { nullable: false },
   autoLaunchOnStartup: { nullable: false },
   confirmBeforeClosingWindow: { nullable: false },
   pypiMirror: { nullable: false },

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -28,7 +28,8 @@ export interface KnownSettings {
    *  version-update notifications. Injected at launch as the
    *  `show_version_updates` feature flag, which seeds the frontend's
    *  `Comfy.Notification.ShowVersionUpdates` default (the user can still
-   *  override it inside ComfyUI). Defaults to true (show). */
+   *  override it inside ComfyUI). Defaults to false (off) — Comfy Desktop
+   *  has its own update notifications. */
   showComfyVersionUpdates?: boolean
   /** Opt-in auto-launch on Desktop startup. Values:
    *  - `'none'` (default) — land on the dashboard, current behavior.


### PR DESCRIPTION
Fixes #1194

Adds a **Show ComfyUI version updates** toggle (Updates settings tab, default **off**) that injects the `show_version_updates` feature flag into the embedded ComfyUI at launch. The flag seeds the frontend's `Comfy.Notification.ShowVersionUpdates` default. Comfy Desktop has its own update / What's-New UI, so the in-frontend release notifications are off by default; a user can opt in via this toggle. The ComfyUI setting still overrides it.

### Changes
- `settings.ts` — new `showComfyVersionUpdates` setting (default **off**).
- `desktopFeatureFlags()` — injects `show_version_updates=<bool>` from the setting.
- `registerSettingsHandlers.ts` / `titlePopup.ts` — render the toggle in the Updates tab (with a shared field-id set so the snapshot grouping can't drift).
- `locales/en.json` + `locales/zh.json` — labels/description.
- Unit test for the injected flag.

The flag is only injected when the running ComfyUI advertises it via `--list-feature-flags` (existing registry guard), so it is a no-op on older ComfyUI.

### Cross-repo dependencies
- Comfy-Org/ComfyUI#14646 — registers the `show_version_updates` flag (default off).
- Comfy-Org/ComfyUI_frontend#13171 — gates the notifications on the setting and reads the flag as its default.