### PR TITLE
fix(templates): show starter-template downloads in the downloads drawer

### DIFF
--- a/src/main/lib/comfyDownloadManager.ts
+++ b/src/main/lib/comfyDownloadManager.ts
@@ -155,6 +155,17 @@ const templateTrayMirrorByInstall = new Map<string, Map<string, DownloadProgress
  */
 export function setTemplateTrayMirror(installationId: string, entries: DownloadProgress[]): void {
   const prev = templateTrayMirrorByInstall.get(installationId)
+  // Empty set clears this install's rows. Don't keep (or create) an empty
+  // bucket: while a download is still resolving it has no files yet, and a
+  // lingering empty bucket would both leak and emit `tray-state-changed` on
+  // every poll with nothing to show.
+  if (entries.length === 0) {
+    if (!prev) return
+    for (const url of prev.keys()) createdAtByUrl.delete(url)
+    templateTrayMirrorByInstall.delete(installationId)
+    downloadEvents.emit('tray-state-changed')
+    return
+  }
   const nextUrls = new Set(entries.map((e) => e.url))
   if (prev) {
     for (const url of prev.keys()) {

--- a/src/main/lib/ipc/registerInstallationHandlers.ts
+++ b/src/main/lib/ipc/registerInstallationHandlers.ts
@@ -45,6 +45,7 @@ import {
   startTemplateDownload,
   abortTemplateDownload,
   requestSkipTemplateDownload,
+  stopTemplateTrayMirror,
 } from '../../sources/standalone/templateDownloadTask'
 import { recordIpcInvocation } from '../e2eOverrides'
 
@@ -339,8 +340,10 @@ export function registerInstallationHandlers(): void {
       } catch (err) {
         _operationAborts.delete(installationId)
         // Install failed or was cancelled — tear down the background template
-        // download too (the models would have nowhere to land).
+        // download too (the models would have nowhere to land) and drop its
+        // tray rows, since no comfy window will ever attach to clean them up.
         abortTemplateDownload(installationId)
+        stopTemplateTrayMirror(installationId)
         if (abort.signal.aborted) {
           if (isComfyUpdate) {
             mainTelemetry.emit('comfy.desktop.comfyui.update.applied', {

--- a/src/main/sources/standalone/templateDownloadCore.test.ts
+++ b/src/main/sources/standalone/templateDownloadCore.test.ts
@@ -254,6 +254,25 @@ describe('templateStateToTrayEntries', () => {
     expect(rows[1]!.progress).toBeCloseTo(0.25)
   })
 
+  it('marks unfinished files cancelled/errored when the task itself settled', () => {
+    // A cancelled or errored task must not leave unfinished files as
+    // 'downloading' — `getDownloadsTrayState` would count them active forever.
+    const cancelled = templateStateToTrayEntries(state({
+      status: 'cancelled',
+      files: [
+        file({ name: 'a', received: 2 * GB, total: 2 * GB, done: true }),
+        file({ name: 'b', received: 1 * GB, total: 4 * GB }),
+      ],
+    }))
+    expect(cancelled.map((r) => r.status)).toEqual(['completed', 'cancelled'])
+
+    const errored = templateStateToTrayEntries(state({
+      status: 'error',
+      files: [file({ name: 'b', received: 0, total: 4 * GB })],
+    }))
+    expect(errored[0]!.status).toBe('error')
+  })
+
   it('keys each row by a stable synthetic url so the tray updates in place', () => {
     const [row] = templateStateToTrayEntries(state({
       files: [file({ name: 'model.safetensors', directory: 'checkpoints' })],

--- a/src/main/sources/standalone/templateDownloadCore.ts
+++ b/src/main/sources/standalone/templateDownloadCore.ts
@@ -85,7 +85,7 @@ export interface TemplateTrayEntry {
   filename: string
   directory: string
   progress: number
-  status: 'downloading' | 'completed' | 'error'
+  status: 'downloading' | 'completed' | 'error' | 'cancelled'
   receivedBytes: number
   totalBytes: number
   speedBytesPerSec: number
@@ -109,12 +109,20 @@ export function templateStateToTrayEntries(
   const etaSeconds = state.etaSecs >= 0 ? state.etaSecs : 0
   let liveRowAssigned = false
 
+  // When the task itself has settled (cancel / error) before every file
+  // finished — e.g. an abort mid-pool or a disk-space pre-flight that errors
+  // with files already listed but none downloaded — the still-unfinished files
+  // must inherit that terminal status. Otherwise they'd map to 'downloading'
+  // and `getDownloadsTrayState` would count them as active forever.
+  const unfinishedStatus: TemplateTrayEntry['status'] | null =
+    state.status === 'cancelled' ? 'cancelled' : state.status === 'error' ? 'error' : null
+
   return state.files.map((file) => {
     const status: TemplateTrayEntry['status'] = file.failed
       ? 'error'
       : file.done
         ? 'completed'
-        : 'downloading'
+        : (unfinishedStatus ?? 'downloading')
     const progress = file.total > 0 ? Math.min(1, file.received / file.total) : 0
     const isLiveRow = status === 'downloading' && !liveRowAssigned
     if (isLiveRow) liveRowAssigned = true

--- a/src/main/sources/standalone/templateDownloadGate.test.ts
+++ b/src/main/sources/standalone/templateDownloadGate.test.ts
@@ -36,7 +36,9 @@ import {
   startTemplateDownload,
   getTemplateDownloadState,
 } from './templateDownloadTask'
+import { setTemplateTrayMirror } from '../../lib/comfyDownloadManager'
 
+const mockSetTrayMirror = vi.mocked(setTemplateTrayMirror)
 const sendOutput = vi.fn()
 
 function makeInstall(id: string) {
@@ -61,6 +63,7 @@ describe('awaitTemplateDownloadSettled', () => {
     resolveTemplateModels.mockReset()
     download.mockReset()
     sendOutput.mockReset()
+    mockSetTrayMirror.mockReset()
     getDiskSpace.mockReset().mockResolvedValue({ free: 1e15, total: 1e15 })
   })
   afterEach(() => {
@@ -129,6 +132,20 @@ describe('awaitTemplateDownloadSettled', () => {
     requestSkipTemplateDownload('skip-1')
     await vi.advanceTimersByTimeAsync(300) // one poll tick
     await expect(settled).resolves.toBe('skipped')
+  })
+
+  it('mirrors the download into the tray from the start, before any Skip (#1173)', async () => {
+    resolveTemplateModels.mockResolvedValue([{ filename: 'm.safetensors', directory: 'checkpoints', url: 'u' }])
+    download.mockImplementation(() => new Promise<void>(() => { /* hangs */ }))
+    startTemplateDownload(makeInstall('mirror-1'), 0, { sendOutput })
+    await flush()
+    await vi.advanceTimersByTimeAsync(600) // let the 500 ms mirror poll tick
+
+    // Reflected into the downloads tray without anyone requesting a skip.
+    expect(mockSetTrayMirror).toHaveBeenCalledWith(
+      'mirror-1',
+      expect.arrayContaining([expect.objectContaining({ filename: 'm.safetensors' })]),
+    )
   })
 
   it("resolves 'aborted' when the gate's own signal aborts (launch teardown)", async () => {

--- a/src/main/sources/standalone/templateDownloadTask.ts
+++ b/src/main/sources/standalone/templateDownloadTask.ts
@@ -94,10 +94,14 @@ const _trayMirrors = new Map<string, ReturnType<typeof setInterval>>()
 export function mirrorTemplateDownloadToTray(installationId: string): void {
   if (_trayMirrors.has(installationId)) return
 
+  // Install-scope the synthetic row urls: `createdAtByUrl` and the renderer
+  // download store are keyed by url globally, so two installs pulling the same
+  // template model would otherwise clobber each other.
+  const urlPrefix = `template-model://${encodeURIComponent(installationId)}/`
   const publish = (): boolean => {
     const state = _templateDownloads.get(installationId)
     if (!state) return true
-    setTemplateTrayMirror(installationId, templateStateToTrayEntries(state))
+    setTemplateTrayMirror(installationId, templateStateToTrayEntries(state, urlPrefix))
     return isTerminal(state.status)
   }
 

--- a/src/main/sources/standalone/templateDownloadTask.ts
+++ b/src/main/sources/standalone/templateDownloadTask.ts
@@ -230,6 +230,12 @@ export function startTemplateDownload(
     }
     log(`[templates] Download task failed: ${(err as Error).message}\n`)
   })
+
+  // Reflect the download into the title-bar downloads tray for its whole
+  // lifetime — not just after a Skip — so a slow multi-GB pull is visible while
+  // it runs instead of being silently hidden. Idempotent: the launch gate's
+  // later Skip call is a no-op once this is active.
+  mirrorTemplateDownloadToTray(installationId)
 }
 
 async function runTask(


### PR DESCRIPTION
## Problem

Fixes #1173.

Starter-template model downloads were **completely hidden** from the downloads drawer/tray. With slow internet you'd have no indication a multi-GB download had even started.

## Root cause

Template downloads run in a **separate main-process download engine** (`lib/download.ts` — resume-capable via `.dl-meta`, bounded-concurrency pool, idle-timeout watchdog, R2 mirror fallback). This separation is justified: the downloads start at *install time*, before any ComfyUI `BrowserWindow`/session exists, so they cannot use the renderer-driven Electron `DownloadItem` pipeline that feeds the drawer.

The drawer state itself, however, is plain main-process data — and the read-only bridge that reflects a template download into it (`mirrorTemplateDownloadToTray`) was only wired to the **Skip** action. So during install and any non-skip launch, nothing showed.

## Fix

Start the existing, idempotent tray mirror at **download start** instead of only on Skip. The download is now reflected into the drawer for its whole lifetime; the launch-stepper phase and the Skip flow are unchanged (the later Skip call becomes a no-op).

One-line behavioral change in `startTemplateDownload` + a regression test.

## Verification

- `pnpm typecheck` ✅  `pnpm lint` ✅  `pnpm build` ✅
- `pnpm test` — 2664 passed (incl. new `#1173` mirror test)