### PR TITLE
fix(naming): stop duplicate-suffix compounding + report instance name (#1055, #1009)

### DIFF
--- a/src/main/installations.test.ts
+++ b/src/main/installations.test.ts
@@ -654,3 +654,47 @@ describe('installations.clearPendingTemplateOpen', () => {
     expect(await installations.clearPendingTemplateOpen('does-not-exist')).toBe(false)
   })
 })
+
+describe('installations.uniqueName', () => {
+  const recs = (...names: string[]): InstallationRecord[] =>
+    names.map((name, i) => ({ id: `id-${i}`, name }) as InstallationRecord)
+
+  it('returns the base name unchanged when it is free', async () => {
+    const { uniqueName } = await loadInstallations()
+    expect(uniqueName('ComfyUI', recs('Other'))).toBe('ComfyUI')
+  })
+
+  it('appends " (1)" when the base name is taken', async () => {
+    const { uniqueName } = await loadInstallations()
+    expect(uniqueName('ComfyUI', recs('ComfyUI'))).toBe('ComfyUI (1)')
+  })
+
+  it('finds the next free suffix when lower ones are taken', async () => {
+    const { uniqueName } = await loadInstallations()
+    expect(uniqueName('ComfyUI', recs('ComfyUI', 'ComfyUI (1)', 'ComfyUI (2)'))).toBe('ComfyUI (3)')
+  })
+
+  it('renumbers an already-suffixed name instead of compounding it', async () => {
+    const { uniqueName } = await loadInstallations()
+    // The bug: "ComfyUI (1)" used to become "ComfyUI (1) (1)".
+    expect(uniqueName('ComfyUI (1)', recs('ComfyUI', 'ComfyUI (1)'))).toBe('ComfyUI (2)')
+  })
+
+  it('does not compound even after repeated chaining of the deduped name', async () => {
+    const { uniqueName } = await loadInstallations()
+    const first = uniqueName('ComfyUI', recs('ComfyUI')) // "ComfyUI (1)"
+    // Feeding the deduped name back in while it is now taken must not nest.
+    expect(uniqueName(first, recs('ComfyUI', 'ComfyUI (1)'))).toBe('ComfyUI (2)')
+  })
+
+  it('preserves an intentional " (N)" name when it is actually free', async () => {
+    const { uniqueName } = await loadInstallations()
+    expect(uniqueName('ComfyUI (1)', recs('ComfyUI'))).toBe('ComfyUI (1)')
+  })
+
+  it('excludes the renamed install from the conflict set', async () => {
+    const { uniqueName } = await loadInstallations()
+    const existing = recs('ComfyUI') // id-0
+    expect(uniqueName('ComfyUI', existing, 'id-0')).toBe('ComfyUI')
+  })
+})

--- a/src/main/installations.test.ts
+++ b/src/main/installations.test.ts
@@ -676,7 +676,6 @@ describe('installations.uniqueName', () => {
 
   it('renumbers an already-suffixed name instead of compounding it', async () => {
     const { uniqueName } = await loadInstallations()
-    // The bug: "ComfyUI (1)" used to become "ComfyUI (1) (1)".
     expect(uniqueName('ComfyUI (1)', recs('ComfyUI', 'ComfyUI (1)'))).toBe('ComfyUI (2)')
   })
 

--- a/src/main/installations.ts
+++ b/src/main/installations.ts
@@ -143,9 +143,14 @@ export async function hasNameConflict(id: string, name: string): Promise<boolean
 export function uniqueName(baseName: string, existing: InstallationRecord[], excludeId?: string): string {
   const names = new Set(existing.filter((i) => i.id !== excludeId).map((i) => i.name))
   if (!names.has(baseName)) return baseName
+  // On conflict, strip a trailing " (N)" so an already-suffixed name renumbers
+  // cleanly ("ComfyUI (1)" → "ComfyUI (2)") instead of compounding into
+  // "ComfyUI (1) (1)". A name with no conflict is returned untouched above, so
+  // an intentional " (N)" name is preserved when it's actually free.
+  const stem = baseName.replace(/ \(\d+\)$/, '')
   let suffix = 1
-  while (names.has(`${baseName} (${suffix})`)) suffix++
-  return `${baseName} (${suffix})`
+  while (names.has(`${stem} (${suffix})`)) suffix++
+  return `${stem} (${suffix})`
 }
 
 export async function add(installation: Record<string, unknown>): Promise<InstallationRecord> {

--- a/src/main/lib/desktopAdopt.ts
+++ b/src/main/lib/desktopAdopt.ts
@@ -28,6 +28,7 @@ import type { InstallationRecord } from '../installations'
 import * as settings from '../settings'
 import * as telemetry from './telemetry'
 import { scrubAll } from '../../shared/piiScrub'
+import { DEFAULT_INSTALL_NAME } from '../../shared/defaultInstallName'
 import * as i18n from './i18n'
 import {
   KNOWN_MODEL_FOLDERS,
@@ -50,7 +51,7 @@ const SNAPSHOTS_REL = '.snapshots'
 // Keeping the name plain — instead of "Adopted from Legacy Desktop" —
 // matches user expectation that the picker shows their app, not the
 // provenance story.
-const ADOPT_INSTALL_NAME = 'ComfyUI'
+const ADOPT_INSTALL_NAME = DEFAULT_INSTALL_NAME
 const COMFY_SETTINGS_FILE = 'comfy.settings.json'
 const DESKTOP_CONFIG_FILE = 'config.json'
 const EXTRA_MODELS_YAML = 'extra_models_config.yaml'

--- a/src/main/lib/ipc/registerInstallationHandlers.ts
+++ b/src/main/lib/ipc/registerInstallationHandlers.ts
@@ -48,6 +48,7 @@ import {
   stopTemplateTrayMirror,
 } from '../../sources/standalone/templateDownloadTask'
 import { recordIpcInvocation } from '../e2eOverrides'
+import { DEFAULT_INSTALL_NAME } from '../../../shared/defaultInstallName'
 
 /** Fire-and-forget: refresh the shared ComfyUI release cache for the
  *  channels these installs use, then re-broadcast `installations-changed`
@@ -194,7 +195,7 @@ export function registerInstallationHandlers(): void {
   })
 
   ipcMain.handle('add-installation', async (_event, data: Record<string, unknown>) => {
-    data.name = await uniqueName((data.name as string) || 'ComfyUI')
+    data.name = await uniqueName((data.name as string) || DEFAULT_INSTALL_NAME)
     if (data.installPath) {
       const dirName = sanitizeDirName(data.name as string)
       data.installPath = allocateUniqueDir(data.installPath as string, dirName)

--- a/src/main/lib/ipc/registerSnapshotHandlers.ts
+++ b/src/main/lib/ipc/registerSnapshotHandlers.ts
@@ -38,6 +38,7 @@ import {
 import type { LatestTagOverride, SnapshotExportEnvelope, FieldOption, Snapshot } from './shared'
 import type { CopyEvent } from '../../../types/ipc'
 import * as telemetry from '../telemetry'
+import { DEFAULT_INSTALL_NAME } from '../../../shared/defaultInstallName'
 
 async function _findReferenceRepo(): Promise<{
   comfyuiDir: string
@@ -566,7 +567,7 @@ export function registerSnapshotHandlers(): void {
         // core commit; updateChannel mirrors the snapshot as the manual pref.
         ...frozenSnapshotInstallOverrides(targetSnapshot.updateChannel)
       }
-      const baseName = customName || envelope.installationName || 'ComfyUI'
+      const baseName = customName || envelope.installationName || DEFAULT_INSTALL_NAME
       const name = await uniqueName(baseName)
       const dirName = sanitizeDirName(name)
       const installDir = defaultInstallDir()

--- a/src/main/lib/localMigration.ts
+++ b/src/main/lib/localMigration.ts
@@ -12,6 +12,7 @@ import type { MigrationTools, StandaloneTargetSelection } from './standaloneMigr
 import type { Snapshot, SnapshotExportEnvelope } from './snapshots'
 import type { InstallationRecord } from '../installations'
 import * as i18n from './i18n'
+import { DEFAULT_INSTALL_NAME } from '../../shared/defaultInstallName'
 
 /** Find a Python executable in a portable install (python_embeded/ at the portable root). */
 function findPortablePython(installPath: string): string | null {
@@ -129,7 +130,6 @@ export async function performLocalMigration(
     throw new Error(i18n.t('migrate.noComfyUIDir'))
   }
 
-  const sourceLabel = sourceId === 'portable' ? 'Portable' : 'Git Clone'
   const hasPreStaged = !!(actionData?.snapshotPath && typeof actionData.snapshotPath === 'string' && fs.existsSync(actionData.snapshotPath as string))
 
   sendMigrationSteps(sendProgress, {
@@ -160,7 +160,7 @@ export async function performLocalMigration(
   const target = actionData?.target as StandaloneTargetSelection | undefined
 
   return migrateToStandaloneFromSnapshot({
-    installNameBase: `ComfyUI (from ${sourceLabel})`,
+    installNameBase: DEFAULT_INSTALL_NAME,
     stagedSnapshot: { path: stagedFile, owned: ownsStagedFile },
     sourcePaths: {
       userDir: path.join(comfyUIDir, 'user'),

--- a/src/main/popups/pickerSettingsHandlers.ts
+++ b/src/main/popups/pickerSettingsHandlers.ts
@@ -72,6 +72,10 @@ export function registerPickerSettingsIpc(): void {
 
   ipcMain.handle(CH.getStableTags, (event) => dispatchInvoke('get-stable-tags', event))
 
+  ipcMain.handle(CH.getUniqueName, (event, payload: { baseName?: unknown }) =>
+    dispatchInvoke('get-unique-name', event, payload?.baseName),
+  )
+
   ipcMain.handle(CH.stopComfyUI, (event, payload: { installationId?: unknown }) =>
     dispatchInvoke('stop-comfyui', event, payload?.installationId),
   )

--- a/src/main/sources/standalone/updateSections.test.ts
+++ b/src/main/sources/standalone/updateSections.test.ts
@@ -37,7 +37,7 @@ interface UpdateAction {
   progressTitle: string
   data?: { channel?: string; isDowngrade?: boolean }
   confirm?: { title?: string; message?: string }
-  prompt?: { defaultValue?: string }
+  prompt?: { defaultValue?: string; uniquifyDefault?: boolean }
 }
 interface ChannelOption {
   value: string
@@ -204,16 +204,18 @@ describe('updateSections — channel picker reflects de-facto channel', () => {
 })
 
 describe('updateSections — copy (duplicate) prompt default', () => {
-  interface ActionWithPrompt { id: string; prompt?: { defaultValue?: string } }
+  interface ActionWithPrompt { id: string; prompt?: { defaultValue?: string; uniquifyDefault?: boolean } }
   interface ActionsSection { title?: string; actions?: ActionWithPrompt[] }
 
-  it('pre-fills the duplicate prompt with the source name (number suffix added on save, not "(Copy)")', () => {
+  it('pre-fills the duplicate prompt with the source name, flagged to resolve to the numbered name on show', () => {
     const sections = getDetailSections(baseInstall({ name: 'My Comfy' })) as unknown as ActionsSection[]
     const copy = sections
       .flatMap((s) => s.actions ?? [])
       .find((a) => a.id === 'copy')
     expect(copy).toBeDefined()
     expect(copy!.prompt?.defaultValue).toBe('My Comfy')
+    // uniquifyDefault tells the renderer to show the name it will actually get.
+    expect(copy!.prompt?.uniquifyDefault).toBe(true)
   })
 
   it('pre-fills the copy & update prompt with the source name only, never the target version (which goes stale)', () => {
@@ -225,8 +227,9 @@ describe('updateSections — copy (duplicate) prompt default', () => {
       'copy-update'
     )
     expect(copyUpdate).toBeDefined()
-    expect(copyUpdate!.prompt?.defaultValue).toBe('My Comfy')
     // Guard against version-stamping regressions like "My Comfy (v0.3.20+12)".
-    expect(copyUpdate!.prompt?.defaultValue).not.toContain('(')
+    expect(copyUpdate!.prompt?.defaultValue).toBe('My Comfy')
+    // Flagged so the renderer shows the numbered name it will actually be saved as.
+    expect(copyUpdate!.prompt?.uniquifyDefault).toBe(true)
   })
 })

--- a/src/main/sources/standalone/updateSections.test.ts
+++ b/src/main/sources/standalone/updateSections.test.ts
@@ -37,6 +37,7 @@ interface UpdateAction {
   progressTitle: string
   data?: { channel?: string; isDowngrade?: boolean }
   confirm?: { title?: string; message?: string }
+  prompt?: { defaultValue?: string }
 }
 interface ChannelOption {
   value: string
@@ -45,12 +46,16 @@ interface ChannelOption {
 interface UpdateField { id: string; options: ChannelOption[] }
 interface UpdateSection { tab: string; fields?: UpdateField[] }
 
-function getUpdateAction(installation: InstallationRecord, channel: 'stable' | 'latest'): UpdateAction | undefined {
+function getChannelAction(installation: InstallationRecord, channel: 'stable' | 'latest', actionId: string): UpdateAction | undefined {
   const sections = getDetailSections(installation) as unknown as UpdateSection[]
   const updates = sections.find((s) => s.tab === 'update')
   const channelField = updates?.fields?.find((f) => f.id === 'updateChannel')
   const option = channelField?.options?.find((o) => o.value === channel)
-  return option?.data?.actions?.find((a) => a.id === 'update-comfyui')
+  return option?.data?.actions?.find((a) => a.id === actionId)
+}
+
+function getUpdateAction(installation: InstallationRecord, channel: 'stable' | 'latest'): UpdateAction | undefined {
+  return getChannelAction(installation, channel, 'update-comfyui')
 }
 
 function baseInstall(overrides: Partial<InstallationRecord> = {}): InstallationRecord {
@@ -209,5 +214,19 @@ describe('updateSections — copy (duplicate) prompt default', () => {
       .find((a) => a.id === 'copy')
     expect(copy).toBeDefined()
     expect(copy!.prompt?.defaultValue).toBe('My Comfy')
+  })
+
+  it('pre-fills the copy & update prompt with the source name only, never the target version (which goes stale)', () => {
+    // commitsAhead makes the effective channel `latest`, so the `latest` card
+    // exposes the copy-update action for an install that's on stable.
+    const copyUpdate = getChannelAction(
+      baseInstall({ name: 'My Comfy', updateChannel: 'stable' }),
+      'latest',
+      'copy-update'
+    )
+    expect(copyUpdate).toBeDefined()
+    expect(copyUpdate!.prompt?.defaultValue).toBe('My Comfy')
+    // Guard against version-stamping regressions like "My Comfy (v0.3.20+12)".
+    expect(copyUpdate!.prompt?.defaultValue).not.toContain('(')
   })
 })

--- a/src/main/sources/standalone/updateSections.test.ts
+++ b/src/main/sources/standalone/updateSections.test.ts
@@ -188,3 +188,17 @@ describe('updateSections — channel picker reflects de-facto channel', () => {
     expect((field as unknown as { value: string }).value).toBe('latest')
   })
 })
+
+describe('updateSections — copy (duplicate) prompt default', () => {
+  interface ActionWithPrompt { id: string; prompt?: { defaultValue?: string } }
+  interface ActionsSection { title?: string; actions?: ActionWithPrompt[] }
+
+  it('pre-fills the duplicate prompt with the source name (number suffix added on save, not "(Copy)")', () => {
+    const sections = getDetailSections(baseInstall({ name: 'My Comfy' })) as unknown as ActionsSection[]
+    const copy = sections
+      .flatMap((s) => s.actions ?? [])
+      .find((a) => a.id === 'copy')
+    expect(copy).toBeDefined()
+    expect(copy!.prompt?.defaultValue).toBe('My Comfy')
+  })
+})

--- a/src/main/sources/standalone/updateSections.ts
+++ b/src/main/sources/standalone/updateSections.ts
@@ -176,7 +176,10 @@ export function getDetailSections(installation: InstallationRecord): Record<stri
           title: t('standalone.copyAndUpdateTitle'),
           message: (isSwitching ? switchPrefix : '') + t('standalone.copyAndUpdateMessage', { installed: boldInstalled, latest: boldLatest }),
           placeholder: t('standalone.copyAndUpdatePlaceholder'),
-          defaultValue: `${installation.name} (${latestDisplay})`,
+          // Default to the source name (never the target version, which goes
+          // stale the moment the copy is updated again). `uniqueName()` appends
+          // " (N)" on save so the copy is numbered, not version-stamped.
+          defaultValue: installation.name,
           confirmLabel: t('standalone.copyAndUpdateConfirm'),
           required: true,
           field: 'name',

--- a/src/main/sources/standalone/updateSections.ts
+++ b/src/main/sources/standalone/updateSections.ts
@@ -225,7 +225,10 @@ export function getDetailSections(installation: InstallationRecord): Record<stri
           prompt: {
             title: t('actions.copyInstallationTitle'),
             message: t('actions.copyInstallationMessage'),
-            defaultValue: `${installation.name} (Copy)`,
+            // Pre-fill with the source name; uniqueName() appends a number
+            // suffix on save ("ComfyUI" → "ComfyUI (1)") so duplicates are
+            // numbered consistently instead of getting a "(Copy)" label.
+            defaultValue: installation.name,
             confirmLabel: t('actions.copyInstallationConfirm'),
             required: true,
             field: 'name',

--- a/src/main/sources/standalone/updateSections.ts
+++ b/src/main/sources/standalone/updateSections.ts
@@ -177,9 +177,10 @@ export function getDetailSections(installation: InstallationRecord): Record<stri
           message: (isSwitching ? switchPrefix : '') + t('standalone.copyAndUpdateMessage', { installed: boldInstalled, latest: boldLatest }),
           placeholder: t('standalone.copyAndUpdatePlaceholder'),
           // Default to the source name (never the target version, which goes
-          // stale the moment the copy is updated again). `uniqueName()` appends
-          // " (N)" on save so the copy is numbered, not version-stamped.
+          // stale the moment the copy is updated again). `uniquifyDefault` shows
+          // the numbered name it will actually get on save (e.g. "ComfyUI (8)").
           defaultValue: installation.name,
+          uniquifyDefault: true,
           confirmLabel: t('standalone.copyAndUpdateConfirm'),
           required: true,
           field: 'name',
@@ -230,10 +231,11 @@ export function getDetailSections(installation: InstallationRecord): Record<stri
           prompt: {
             title: t('actions.copyInstallationTitle'),
             message: t('actions.copyInstallationMessage'),
-            // Pre-fill with the source name; uniqueName() appends a number
-            // suffix on save ("ComfyUI" → "ComfyUI (1)") so duplicates are
-            // numbered consistently instead of getting a "(Copy)" label.
+            // Pre-fill with the numbered name the duplicate will actually get on
+            // save ("ComfyUI" → "ComfyUI (1)"), via uniqueName(), instead of a
+            // "(Copy)" label or a stale suggestion that differs from the result.
             defaultValue: installation.name,
+            uniquifyDefault: true,
             confirmLabel: t('actions.copyInstallationConfirm'),
             required: true,
             field: 'name',

--- a/src/preload/comfyTitlePopupPreload.ts
+++ b/src/preload/comfyTitlePopupPreload.ts
@@ -281,6 +281,7 @@ export interface ComfyTitlePopupBridge {
     selections: Record<string, unknown>,
   ): Promise<Record<string, unknown>[]>
   pickerSettingsGetStableTags(): Promise<string[]>
+  pickerSettingsGetUniqueName(baseName: string): Promise<string>
   pickerSettingsGetInstallations(): Promise<Record<string, unknown>[]>
   pickerSettingsGetInstallationSize(installationId: string): Promise<{ sizeBytes: number }>
   pickerSettingsStopComfyUI(installationId: string): Promise<void>
@@ -661,6 +662,7 @@ const bridge: ComfyTitlePopupBridge = {
     ipcRenderer.invoke(CH.getFieldOptions, { sourceId, fieldId, selections }),
   pickerSettingsGetInstallations: () => ipcRenderer.invoke(CH.getInstallations),
   pickerSettingsGetStableTags: () => ipcRenderer.invoke(CH.getStableTags),
+  pickerSettingsGetUniqueName: (baseName) => ipcRenderer.invoke(CH.getUniqueName, { baseName }),
   pickerSettingsGetInstallationSize: (installationId) =>
     ipcRenderer.invoke(CH.getInstallationSize, { installationId }),
   pickerSettingsStopComfyUI: (installationId) =>

--- a/src/renderer/src/comfyTitlePopup/pickerSettingsApiShim.ts
+++ b/src/renderer/src/comfyTitlePopup/pickerSettingsApiShim.ts
@@ -20,6 +20,7 @@ const API_MAP = {
   getFieldOptions: 'pickerSettingsGetFieldOptions',
   getInstallations: 'pickerSettingsGetInstallations',
   getStableTags: 'pickerSettingsGetStableTags',
+  getUniqueName: 'pickerSettingsGetUniqueName',
   getInstallationSize: 'pickerSettingsGetInstallationSize',
   stopComfyUI: 'pickerSettingsStopComfyUI',
   cancelOperation: 'pickerSettingsCancelOperation',

--- a/src/renderer/src/composables/actionShoppingList.test.ts
+++ b/src/renderer/src/composables/actionShoppingList.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { runPromptChain } from './actionShoppingList'
+import type { ActionDef } from '../types/ipc'
+
+// Minimal driver stub: runPromptChain only ever touches `.prompt`.
+function makeDriver(returnValue: string | null) {
+  const prompt = vi.fn().mockResolvedValue(returnValue)
+  return { driver: { prompt } as unknown as Parameters<typeof runPromptChain>[1], prompt }
+}
+
+function copyAction(overrides: Partial<ActionDef['prompt']> = {}): ActionDef {
+  return {
+    id: 'copy',
+    label: 'Copy',
+    prompt: {
+      field: 'name',
+      title: 'Copy',
+      defaultValue: 'ComfyUI (2)',
+      ...overrides,
+    },
+  } as ActionDef
+}
+
+beforeEach(() => {
+  window.api = {
+    getUniqueName: vi.fn().mockResolvedValue('ComfyUI (8)'),
+  } as unknown as typeof window.api
+})
+
+describe('runPromptChain — uniquifyDefault', () => {
+  it('shows the deduped name when uniquifyDefault is set (matches what save assigns)', async () => {
+    const { driver, prompt } = makeDriver('ComfyUI (8)')
+    const result = await runPromptChain(copyAction({ uniquifyDefault: true }), driver)
+
+    expect(window.api.getUniqueName).toHaveBeenCalledWith('ComfyUI (2)')
+    // The prompt is pre-filled with the resolved unique name, not the raw source name.
+    expect(prompt).toHaveBeenCalledWith(expect.objectContaining({ defaultValue: 'ComfyUI (8)' }))
+    expect(result?.data?.name).toBe('ComfyUI (8)')
+  })
+
+  it('leaves the default untouched when uniquifyDefault is not set (e.g. rename)', async () => {
+    const { driver, prompt } = makeDriver('ComfyUI (2)')
+    await runPromptChain(copyAction(), driver)
+
+    expect(window.api.getUniqueName).not.toHaveBeenCalled()
+    expect(prompt).toHaveBeenCalledWith(expect.objectContaining({ defaultValue: 'ComfyUI (2)' }))
+  })
+
+  it('falls back to the raw default if getUniqueName rejects (save-time dedup still applies)', async () => {
+    vi.mocked(window.api.getUniqueName).mockRejectedValueOnce(new Error('ipc down'))
+    const { driver, prompt } = makeDriver('ComfyUI (2)')
+    await runPromptChain(copyAction({ uniquifyDefault: true }), driver)
+
+    expect(prompt).toHaveBeenCalledWith(expect.objectContaining({ defaultValue: 'ComfyUI (2)' }))
+  })
+
+  it('returns null (cancels the chain) when the user dismisses the prompt', async () => {
+    const { driver } = makeDriver(null)
+    const result = await runPromptChain(copyAction({ uniquifyDefault: true }), driver)
+    expect(result).toBeNull()
+  })
+})

--- a/src/renderer/src/composables/actionShoppingList.ts
+++ b/src/renderer/src/composables/actionShoppingList.ts
@@ -131,11 +131,22 @@ export async function runPromptChain(
 ): Promise<ActionDef | null> {
   if (!action.prompt) return action
   const showPrompt = pickPrompt(driver)
+  // For create-a-new-install prompts, resolve the default to the name that
+  // would actually be assigned right now (e.g. "ComfyUI (2)" → "ComfyUI (8)"
+  // when the lower numbers are taken) so the suggestion matches reality.
+  let defaultValue = action.prompt.defaultValue
+  if (action.prompt.uniquifyDefault && defaultValue) {
+    try {
+      defaultValue = await window.api.getUniqueName(defaultValue)
+    } catch {
+      // Fall back to the raw default; save-time dedup still guarantees uniqueness.
+    }
+  }
   const value = await showPrompt({
     title: action.prompt.title || action.label,
     message: action.prompt.message || '',
     placeholder: action.prompt.placeholder,
-    defaultValue: action.prompt.defaultValue,
+    defaultValue,
     confirmLabel: action.prompt.confirmLabel || action.label,
     required: action.prompt.required,
     messageDetails: action.prompt.messageDetails,

--- a/src/renderer/src/panel/useFirstUseChain.test.ts
+++ b/src/renderer/src/panel/useFirstUseChain.test.ts
@@ -69,7 +69,9 @@ function buildApi(overrides: Partial<TestApi> = {}): TestApi {
       .fn()
       .mockResolvedValue({ sourceId: 'standalone', sourceCategory: 'local' }),
     getUniqueName: vi.fn().mockResolvedValue('ComfyUI'),
-    addInstallation: vi.fn().mockResolvedValue({ ok: true, entry: { id: 'inst-express-1' } }),
+    addInstallation: vi
+      .fn()
+      .mockResolvedValue({ ok: true, entry: { id: 'inst-express-1', name: 'ComfyUI' } }),
     installInstance: vi.fn().mockResolvedValue(undefined),
     setFirstUseMode: vi.fn(),
     setSetting: vi.fn().mockResolvedValue(undefined),

--- a/src/renderer/src/panel/useFirstUseChain.ts
+++ b/src/renderer/src/panel/useFirstUseChain.ts
@@ -4,6 +4,7 @@ import { useProgressStore } from '../stores/progressStore'
 import { useLauncherPrefs } from '../composables/useLauncherPrefs'
 import { useMigrateAction } from '../composables/useMigrateAction'
 import { useOverlay } from '../composables/useOverlay'
+import { DEFAULT_INSTALL_NAME } from '../../../shared/defaultInstallName'
 import { emitTelemetryAction } from '../lib/telemetry'
 import type { FieldOption, Installation, ShowProgressOpts, Source } from '../types/ipc'
 import type { ChooserLaunchOutcome } from './useChooserHandoff'
@@ -373,7 +374,7 @@ export function useFirstUseChain(opts: FirstUseChainOpts): FirstUseChainApi {
       }
 
       const instData = await window.api.buildInstallation(standalone.id, selections)
-      const name = await window.api.getUniqueName('ComfyUI')
+      const name = await window.api.getUniqueName(DEFAULT_INSTALL_NAME)
       const installPath = installDir ?? ''
 
       const result = await window.api.addInstallation({

--- a/src/renderer/src/panel/useFirstUseChain.ts
+++ b/src/renderer/src/panel/useFirstUseChain.ts
@@ -395,7 +395,7 @@ export function useFirstUseChain(opts: FirstUseChainOpts): FirstUseChainApi {
       // window the same way the Configure handoff does.
       await opts.handleShowProgress({
         installationId: result.entry.id,
-        title: `Installing — ${name}`,
+        title: `Installing — ${result.entry.name}`,
         apiCall: () => window.api.installInstance(result.entry!.id, true),
         autoLaunchOnFinish: true,
         opKind: 'install'

--- a/src/renderer/src/views/InstallWizardModal.vue
+++ b/src/renderer/src/views/InstallWizardModal.vue
@@ -781,7 +781,7 @@ async function handleSave(): Promise<void> {
     // Hand off WITHOUT emitting `close` first: the host swaps the overlay in place; closing first would flash the dashboard underneath.
     emit('show-progress', {
       installationId: result.entry.id,
-      title: `${t('newInstall.installing')} — ${name}`,
+      title: `${t('newInstall.installing')} — ${result.entry.name}`,
       apiCall: () => window.api.installInstance(result.entry!.id),
       autoLaunchOnFinish: true,
       opKind: 'install'

--- a/src/renderer/src/views/InstallWizardModal.vue
+++ b/src/renderer/src/views/InstallWizardModal.vue
@@ -12,6 +12,7 @@ import type {
   ShowProgressOpts
 } from '../types/ipc'
 import { stripVariantPrefix, sortedCardOptions } from '../lib/variants'
+import { DEFAULT_INSTALL_NAME } from '../../../shared/defaultInstallName'
 import { emitTelemetryAction, toSizeBucket, toVariantBucket } from '../lib/telemetry'
 import {
   trackGuardrailBlocked,
@@ -379,7 +380,7 @@ async function open(opts: OpenOpts = {}): Promise<void> {
   cameFromLocalBranch.value = opts.cameFromLocalBranch === true
   suggestedName.value = ''
   void window.api
-    .getUniqueName('ComfyUI')
+    .getUniqueName(DEFAULT_INSTALL_NAME)
     .then((name) => {
       suggestedName.value = name
     })
@@ -693,8 +694,7 @@ async function handleSave(): Promise<void> {
   // The renderer doesn't sync a separate consent field.
 
   const instData = await window.api.buildInstallation(source.id, rawSelections())
-  const baseName =
-    instName.value.trim() || (source.id === 'standalone' ? 'ComfyUI' : `ComfyUI (${source.label})`)
+  const baseName = instName.value.trim() || DEFAULT_INSTALL_NAME
   const name = await window.api.getUniqueName(baseName)
 
   if (source.skipInstall) {

--- a/src/renderer/src/views/QuickInstallModal.vue
+++ b/src/renderer/src/views/QuickInstallModal.vue
@@ -258,7 +258,7 @@ async function handleInstall(): Promise<void> {
     if (result.entry) {
       emit('show-progress', {
         installationId: result.entry.id,
-        title: `${t('newInstall.installing')} — ${name}`,
+        title: `${t('newInstall.installing')} — ${result.entry.name}`,
         apiCall: () => window.api.installInstance(result.entry!.id),
         autoLaunchOnFinish: true,
         opKind: 'install'

--- a/src/renderer/src/views/QuickInstallModal.vue
+++ b/src/renderer/src/views/QuickInstallModal.vue
@@ -6,6 +6,7 @@ import { useModal } from '../composables/useModal'
 import type { Source, FieldOption, ShowProgressOpts } from '../types/ipc'
 import { emitTelemetryAction, toVariantBucket } from '../lib/telemetry'
 import { stripVariantPrefix, sortedCardOptions } from '../lib/variants'
+import { DEFAULT_INSTALL_NAME } from '../../../shared/defaultInstallName'
 import VariantCardGrid from '../components/VariantCardGrid.vue'
 import {
   trackGuardrailBlocked,
@@ -240,7 +241,7 @@ async function handleInstall(): Promise<void> {
     }
 
     const instData = await window.api.buildInstallation('standalone', rawSelections())
-    const baseName = instName.value.trim() || 'ComfyUI'
+    const baseName = instName.value.trim() || DEFAULT_INSTALL_NAME
     const name = await window.api.getUniqueName(baseName)
 
     const result = await window.api.addInstallation({

--- a/src/renderer/src/views/TrackModal.vue
+++ b/src/renderer/src/views/TrackModal.vue
@@ -5,6 +5,7 @@ import { HardDrive } from 'lucide-vue-next'
 import { useModal } from '../composables/useModal'
 import BrandTakeoverLayout from '../components/BrandTakeoverLayout.vue'
 import TakeoverBack from '../components/TakeoverBack.vue'
+import { DEFAULT_INSTALL_NAME } from '../../../shared/defaultInstallName'
 import { BaseSelect, type BaseSelectOption } from '../components/ui'
 
 import type { ProbeResult } from '../types/ipc'
@@ -77,7 +78,7 @@ function open(): void {
   probing.value = false
   isOpen.value = true
   void window.api
-    .getUniqueName('ComfyUI')
+    .getUniqueName(DEFAULT_INSTALL_NAME)
     .then((name) => {
       suggestedName.value = name
     })
@@ -189,7 +190,7 @@ async function handleBrowseVenv(): Promise<void> {
 async function handleSave(): Promise<void> {
   if (!selectedProbe.value) return
 
-  const name = trackName.value.trim() || `ComfyUI (${selectedProbe.value.sourceLabel})`
+  const name = trackName.value.trim() || DEFAULT_INSTALL_NAME
 
   const rawProbe = JSON.parse(JSON.stringify(toRaw(selectedProbe.value))) as Record<string, unknown>
   if (venvOverride.value !== null) {

--- a/src/shared/defaultInstallName.ts
+++ b/src/shared/defaultInstallName.ts
@@ -1,0 +1,9 @@
+/**
+ * Default display name for a newly created ComfyUI instance.
+ *
+ * Every create / track / migrate / duplicate flow starts from this stem and
+ * lets `uniqueName()` append " (N)" on conflict, so installs read as "ComfyUI",
+ * "ComfyUI (1)", … Keep the name plain: no install type, source label, or
+ * version. That metadata is shown elsewhere and only goes stale inside the name.
+ */
+export const DEFAULT_INSTALL_NAME = 'ComfyUI'

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -244,6 +244,11 @@ export interface PromptDef {
   field: string
   required?: boolean | string
   messageDetails?: ModalDetailGroup[]
+  /** When true, the shown `defaultValue` is first run through
+   *  `getUniqueName()` so the pre-filled name matches what will actually be
+   *  assigned on save. Set on flows that create a NEW install (copy /
+   *  copy-update); never on rename, where keeping the current name is valid. */
+  uniquifyDefault?: boolean
 }
 
 export interface ModalDetailGroup {
@@ -1612,5 +1617,6 @@ export const PICKER_SETTINGS_CHANNELS = {
   relaunchApp: 'comfy-titlepopup:picker-settings-relaunch-app',
   getLocaleMessages: 'comfy-titlepopup:picker-settings-get-locale-messages',
   getLocale: 'comfy-titlepopup:picker-settings-get-locale',
-  getStableTags: 'comfy-titlepopup:picker-settings-get-stable-tags'
+  getStableTags: 'comfy-titlepopup:picker-settings-get-stable-tags',
+  getUniqueName: 'comfy-titlepopup:picker-settings-get-unique-name'
 } as const


### PR DESCRIPTION
Closes #1055
Closes #1009
Closes #631

## Summary

Fixes the instance-naming inconsistencies behind two related issues:

- **#1055** — *Anything that creates a new ComfyUI instance should ask + report what name will be used.*
- **#1009** — *Duplicate names inconsistent, likely due to code duplication instead of going through same path.*
- **#631** — *Make default names for installs better: don't pollute the name with install type or a soon-stale ComfyUI version.*

Both trace back to the same root cause in the dedup helper, so they're addressed together.

## Root cause

Every instance is registered through `installations.add()`, which calls `uniqueName()` to append a ` (N)` suffix on a name clash. But `uniqueName()` treated *whatever it was handed* as the literal stem. Several create flows dedup more than once (the renderer pre-computes a name via `get-unique-name`, then the `add-installation` handler dedups, then `installations.add()` dedups again). When an already-suffixed name like `ComfyUI (1)` was fed back in **and that name was now taken** (e.g. a concurrent create, or pre-existing), the loop produced `ComfyUI (1) (1)` instead of `ComfyUI (2)`.

This is the same nested-suffix problem flagged as the open question in the #1009 investigation.

## Changes

1. **`uniqueName()` — stop compounding** (`src/main/installations.ts`)
   On conflict, strip a trailing ` (N)` to recover the true stem before searching for the next free suffix, so `ComfyUI (1)` → `ComfyUI (2)`, never `ComfyUI (1) (1)`. This makes dedup **idempotent under chaining**, fixing the bug regardless of how many times it runs. A name with no conflict is still returned untouched, so an intentional ` (N)` name is preserved when it's actually free.

2. **Duplicate prompt default (#1009)** (`src/main/sources/standalone/updateSections.ts`)
   Changed the "Duplicate Instance" prompt default from `${name} (Copy)` to just `${name}`. `uniqueName()` now appends the number suffix on save (`ComfyUI` → `ComfyUI (1)`), so duplicates are numbered consistently instead of getting a `(Copy)` label.

3. **Report the authoritative name (#1055)** (`QuickInstallModal.vue`, `InstallWizardModal.vue`, `useFirstUseChain.ts`)
   These flows showed the renderer's *pre-dedup guess* in the install progress title, which could drift from the name actually stored. They now display `result.entry.name` — the authoritative name returned by `installations.add()` — so the reported name always matches reality. (`LoadSnapshotModal` already did this.)

4. **Copy & Update — stop version-stamping the name (#631)** (`updateSections.ts`)
   The "Copy & Update" prompt defaulted to `${name} (${targetVersion})`, e.g. `ComfyUI (0.3.40)`. That version is stale the moment the copy is updated again. It now defaults to the source name; `uniqueName()` numbers it on save (`ComfyUI (1)`), so the name never carries a version.

5. **Drop install-type/source-label pollution from default names (#631)**
   Track Existing (`TrackModal.vue`), the Install Wizard (`InstallWizardModal.vue`), and local Desktop-1→standalone migration (`localMigration.ts`) defaulted to names like `ComfyUI (Standalone)`, `ComfyUI (Portable)`, or `ComfyUI (from Git Clone)`. The install type is already surfaced elsewhere in the UI, so these now default to plain `ComfyUI` (numbered on save). Matches the intent already applied in the adopt flow.

6. **Unify the base-name stem** — added a shared `DEFAULT_INSTALL_NAME` constant (`src/shared/defaultInstallName.ts`) used by every create / track / migrate / duplicate / adopt path, so base-name generation has one source of truth and can't drift again. (#1009's root complaint was duplicated name logic; this PR both makes dedup idempotent *and* removes the duplication in the stem itself.)

7. **Tests** — added `uniqueName` unit tests (free / taken / next-free / renumber-not-compound / repeated-chaining / preserve-intentional / exclude-self) and a test asserting the duplicate prompt default is the source name.

## Scope notes

- The flows that create instances and already prompt for a name (Quick Install, Install Wizard, Track Existing, Load Snapshot, Duplicate, Copy & Update) keep their name fields — the "ask" half of #1055 is already satisfied there.
- The two deliberately zero-friction onboarding paths (express first-use and Desktop 1.0→2.0 migration) intentionally don't add a name prompt; they now **report** the resolved name instead. If you'd prefer an explicit/editable name step in those flows too, happy to add it in a follow-up.

## Verification

`pnpm run typecheck`, `pnpm run lint`, `pnpm run build`, and `pnpm run test` all pass (2753 tests, incl. a new copy-update default test).


## Known limitations / possible follow-ups

These were surfaced during review and intentionally left out to keep this PR focused; happy to do them as follow-ups if wanted:

- **Duplicate/copy progress title still names the source install.** The copy action's progress title is built from a shared path (`useComfyUISettings.ts` / `DetailModal.vue`: `${rawTitle} — ${inst.name}`) used by every detail action, and `ActionResult` only returns `newInstallationId`, not the new name. So duplicating `ComfyUI` shows "Copying Installation — ComfyUI" while the created install is `ComfyUI (1)`. The final name is still visible immediately in the installs list. Reporting the new name here would mean extending `ActionResult` with `newInstallationName` and threading it through the copy handlers.
- **Pre-existing multi-group names.** `uniqueName` strips a single trailing ` (N)` on conflict. A name already shaped like `ComfyUI (1) (2)` (only creatable by the old bug) can still renumber imperfectly. Stripping all trailing ` (N)` groups would fix that but risks mangling legitimate names like `Release (2024)`, so the conservative single-strip is used.
