### PR TITLE
feat(storage): migrate remaining path displays to clickable StorageDirRow format

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1421,6 +1421,32 @@ input[type='checkbox']:checked::after {
   padding: 6px 8px;
   font-size: 14px;
 }
+/* Inline filesystem path rendered as a button that opens the folder in the OS
+ *  file manager. Resets the button chrome to plain text, truncates with an
+ *  ellipsis on one line, and underlines in the accent color on hover/focus.
+ *  Components add only their own sizing (e.g. `max-width` vs `flex`) or override
+ *  `color`/`font` where they must inherit a surrounding scale. Reused by every
+ *  clickable path display so they cannot drift apart. */
+.open-folder-link {
+  min-width: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font-size: 14px;
+  text-align: left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: pointer;
+}
+.open-folder-link:hover,
+.open-folder-link:focus-visible {
+  color: var(--accent);
+  text-decoration: underline;
+  outline: none;
+}
+
 /* Browse-only path: boxed row whose text opens the folder in the OS file
  *  manager (replaces the old readonly <input>). Only the text is clickable. */
 .detail-path-open-wrap {
@@ -1435,20 +1461,9 @@ input[type='checkbox']:checked::after {
   background: var(--surface);
 }
 .detail-path-open {
-  min-width: 0;
   max-width: 100%;
-  padding: 0;
-  border: none;
-  background: transparent;
-  color: var(--text);
-  font-size: 14px;
-  text-align: left;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  cursor: pointer;
 }
-/* Clickable non-editable path value. */
+/* Clickable non-editable path value (wraps instead of truncating). */
 .detail-field-value-open {
   margin-top: 1px;
   padding: 0;
@@ -1460,8 +1475,6 @@ input[type='checkbox']:checked::after {
   text-align: left;
   cursor: pointer;
 }
-.detail-path-open:hover,
-.detail-path-open:focus-visible,
 .detail-field-value-open:hover,
 .detail-field-value-open:focus-visible {
   color: var(--accent);

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1442,6 +1442,9 @@ input[type='checkbox']:checked::after {
 }
 .open-folder-link:hover,
 .open-folder-link:focus-visible {
+  /* background stays transparent against the global `button:hover` reset
+   *  (specificity 0,1,1) — only the text underlines in the accent color. */
+  background: transparent;
   color: var(--accent);
   text-decoration: underline;
   outline: none;
@@ -1477,6 +1480,7 @@ input[type='checkbox']:checked::after {
 }
 .detail-field-value-open:hover,
 .detail-field-value-open:focus-visible {
+  background: transparent;
   color: var(--accent);
   text-decoration: underline;
   outline: none;

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1421,6 +1421,53 @@ input[type='checkbox']:checked::after {
   padding: 6px 8px;
   font-size: 14px;
 }
+/* Browse-only path: boxed row whose text opens the folder in the OS file
+ *  manager (replaces the old readonly <input>). Only the text is clickable. */
+.detail-path-open-wrap {
+  display: flex;
+  align-items: center;
+  flex: 1;
+  min-width: 0;
+  margin-top: 4px;
+  padding: 6px 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+}
+.detail-path-open {
+  min-width: 0;
+  max-width: 100%;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font-size: 14px;
+  text-align: left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: pointer;
+}
+/* Clickable non-editable path value. */
+.detail-field-value-open {
+  margin-top: 1px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  font-size: 14px;
+  text-align: left;
+  cursor: pointer;
+}
+.detail-path-open:hover,
+.detail-path-open:focus-visible,
+.detail-field-value-open:hover,
+.detail-field-value-open:focus-visible {
+  color: var(--accent);
+  text-decoration: underline;
+  outline: none;
+}
 .detail-section-desc {
   font-size: 14px;
   color: var(--text-muted);

--- a/src/renderer/src/comfyTitlePopup/GlobalSettingsView.vue
+++ b/src/renderer/src/comfyTitlePopup/GlobalSettingsView.vue
@@ -159,6 +159,10 @@ function handleOpenInstallDir(): void {
   const p = fieldPath(installDirField.value)
   if (p) bridge?.globalSettingsOpenPath(p)
 }
+
+function handleOpenPath(path: string): void {
+  if (path) bridge?.globalSettingsOpenPath(path)
+}
 const appUpdateState = computed<AppUpdateState>(
   () => props.snapshot.appUpdate.state as unknown as AppUpdateState
 )
@@ -281,14 +285,22 @@ onMounted(() => {
         <template v-if="activeTab === 'general'">
           <!-- Locale picker first, no microsection header — it's a single
                control and the lone "Language" label on it is enough. -->
-          <SettingsSectionList :sections="languageSections" @update-field="handleUpdateField" />
+          <SettingsSectionList :sections="languageSections" @update-field="handleUpdateField" @open-path="handleOpenPath" />
 
           <GlobalSettingsMicroSection :title="t('settings.appBehavior', 'App Behavior')">
-            <SettingsSectionList :sections="generalSections" @update-field="handleUpdateField" />
+            <SettingsSectionList
+              :sections="generalSections"
+              @update-field="handleUpdateField"
+              @open-path="handleOpenPath"
+            />
           </GlobalSettingsMicroSection>
 
           <GlobalSettingsMicroSection :title="t('settings.privacy', 'Privacy')">
-            <SettingsSectionList :sections="telemetrySections" @update-field="handleUpdateField" />
+            <SettingsSectionList
+              :sections="telemetrySections"
+              @update-field="handleUpdateField"
+              @open-path="handleOpenPath"
+            />
           </GlobalSettingsMicroSection>
 
           <GlobalSettingsMicroSection :title="t('settings.community', 'Community')">
@@ -314,6 +326,7 @@ onMounted(() => {
             @update-now="handleUpdateNow"
             @check-for-update="handleCheckForUpdate"
             @update-field="handleUpdateField"
+            @open-path="handleOpenPath"
           />
         </template>
 
@@ -336,7 +349,11 @@ onMounted(() => {
           </GlobalSettingsMicroSection>
 
           <GlobalSettingsMicroSection :title="snapshot.i18n.advanced">
-            <SettingsSectionList :sections="advancedSections" @update-field="handleUpdateField" />
+            <SettingsSectionList
+              :sections="advancedSections"
+              @update-field="handleUpdateField"
+              @open-path="handleOpenPath"
+            />
           </GlobalSettingsMicroSection>
 
           <GlobalSettingsMicroSection :title="t('settings.cache', 'Cache')">

--- a/src/renderer/src/comfyTitlePopup/GlobalSettingsView.vue
+++ b/src/renderer/src/comfyTitlePopup/GlobalSettingsView.vue
@@ -133,8 +133,7 @@ async function handleBrowseCacheDir(): Promise<void> {
 }
 
 function handleOpenCacheDir(): void {
-  const p = fieldPath(cacheDirField.value)
-  if (p) bridge?.globalSettingsOpenPath(p)
+  handleOpenPath(fieldPath(cacheDirField.value))
 }
 const advancedSections = computed<DetailSection[]>(() => [
   { fields: props.snapshot.advancedFields as unknown as DetailField[] }
@@ -156,8 +155,7 @@ async function handleBrowseInstallDir(): Promise<void> {
 }
 
 function handleOpenInstallDir(): void {
-  const p = fieldPath(installDirField.value)
-  if (p) bridge?.globalSettingsOpenPath(p)
+  handleOpenPath(fieldPath(installDirField.value))
 }
 
 function handleOpenPath(path: string): void {

--- a/src/renderer/src/comfyTitlePopup/globalSettings/UpdatesSection.vue
+++ b/src/renderer/src/comfyTitlePopup/globalSettings/UpdatesSection.vue
@@ -31,6 +31,7 @@ const emit = defineEmits<{
   'update-now': []
   'check-for-update': []
   'update-field': [field: DetailField, value: unknown]
+  'open-path': [path: string]
 }>()
 
 const { t, d } = useI18n()
@@ -234,6 +235,7 @@ const progressDetail = computed<string | null>(() => {
       v-if="preferenceSections.length > 0"
       :sections="preferenceSections"
       @update-field="(field, value) => emit('update-field', field, value)"
+      @open-path="(path) => emit('open-path', path)"
     />
   </div>
 </template>

--- a/src/renderer/src/comfyTitlePopup/pickerSettingsApiShim.ts
+++ b/src/renderer/src/comfyTitlePopup/pickerSettingsApiShim.ts
@@ -12,6 +12,9 @@ import type { LocaleSource } from '../lib/useAppLocale'
 const API_MAP = {
   getDetailSections: 'pickerSettingsGetDetailSections',
   getDiskSpace: 'pickerSettingsGetDiskSpace',
+  // Open a folder in the OS file manager (clickable storage path rows). Reuses
+  // the popup's existing globalSettings open-path bridge.
+  openPath: 'globalSettingsOpenPath',
   updateInstallation: 'pickerSettingsUpdateInstallation',
   runAction: 'pickerSettingsRunAction',
   getFieldOptions: 'pickerSettingsGetFieldOptions',

--- a/src/renderer/src/components/DetailSection.test.ts
+++ b/src/renderer/src/components/DetailSection.test.ts
@@ -27,6 +27,8 @@ beforeEach(() => {
   window.api = {
     updateInstallation: vi.fn().mockResolvedValue({}),
     runAction: vi.fn().mockResolvedValue({ navigate: undefined }),
+    openPath: vi.fn().mockResolvedValue(undefined),
+    browseFolder: vi.fn().mockResolvedValue('/picked/dir'),
   } as unknown as typeof window.api
 })
 
@@ -68,5 +70,58 @@ describe('DetailSection', () => {
     const emitted = wrapper.emitted('run-action')!
     expect(emitted).toHaveLength(1)
     expect(emitted[0]![0]).toEqual(actions[0])
+  })
+
+  it('opens the folder when a browse-only path is clicked', async () => {
+    const wrapper = mountComponent({
+      fields: [
+        {
+          id: 'inputDir',
+          label: 'Input Directory',
+          value: '/home/user/input',
+          editable: true,
+          editType: 'path',
+          browseOnly: true,
+        },
+      ],
+    })
+    const pathBtn = wrapper.find('.detail-path-open')
+    expect(pathBtn.exists()).toBe(true)
+    expect(pathBtn.text()).toBe('/home/user/input')
+    await pathBtn.trigger('click')
+    expect(window.api.openPath).toHaveBeenCalledWith('/home/user/input')
+  })
+
+  it('keeps an editable text input for non-browse-only paths', () => {
+    const wrapper = mountComponent({
+      fields: [
+        {
+          id: 'inputDir',
+          label: 'Input Directory',
+          value: '/home/user/input',
+          editable: true,
+          editType: 'path',
+        },
+      ],
+    })
+    expect(wrapper.find('.detail-path-open').exists()).toBe(false)
+    expect(wrapper.find('input.detail-field-input').exists()).toBe(true)
+  })
+
+  it('makes a non-editable path value clickable to open', async () => {
+    const wrapper = mountComponent({
+      fields: [{ id: 'location', label: 'Location', value: '/opt/ComfyUI' }],
+    })
+    const btn = wrapper.find('.detail-field-value-open')
+    expect(btn.exists()).toBe(true)
+    await btn.trigger('click')
+    expect(window.api.openPath).toHaveBeenCalledWith('/opt/ComfyUI')
+  })
+
+  it('does not make a non-editable URL value clickable', () => {
+    const wrapper = mountComponent({
+      fields: [{ id: 'repo', label: 'Repository', value: 'https://github.com/x/y' }],
+    })
+    expect(wrapper.find('.detail-field-value-open').exists()).toBe(false)
   })
 })

--- a/src/renderer/src/components/DetailSection.vue
+++ b/src/renderer/src/components/DetailSection.vue
@@ -98,6 +98,22 @@ async function handleBrowseField(field: DetailField): Promise<void> {
     await handleFieldChange(field, dir)
   }
 }
+
+/** True when a non-editable value is safe to open in the OS file manager:
+ *  an explicit path field, or a local-looking path that isn't a URL or date. */
+function canOpenFieldValue(field: DetailField): boolean {
+  const v = field.value == null ? '' : String(field.value).trim()
+  if (!v || v === '—') return false
+  if (field.editType === 'path') return true
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(v)) return false // URL scheme
+  if (/^\d{1,4}[-/.]\d{1,2}[-/.]\d{1,4}/.test(v)) return false // date-ish
+  return v.includes('/') || v.includes('\\') || v.startsWith('~')
+}
+
+function handleOpenPath(value: unknown): void {
+  const p = value == null ? '' : String(value)
+  if (p) void window.api.openPath(p)
+}
 </script>
 
 <template>
@@ -205,14 +221,30 @@ v-if="f.editable && f.editType === 'select'" class="detail-field-input"
 v-else-if="f.editable && f.editType === 'boolean'" type="checkbox" class="detail-field-toggle"
                    :checked="f.value !== false" @change="handleFieldChange(f, ($event.target as HTMLInputElement).checked)">
             <div v-else-if="f.editable && f.editType === 'path'" class="path-input">
+              <div v-if="f.browseOnly" class="detail-path-open-wrap">
+                <button
+                  v-if="f.value"
+                  type="button"
+                  class="detail-path-open"
+                  :title="$t('actions.openDirectory', 'Open Directory')"
+                  @click="handleOpenPath(f.value)"
+                >{{ f.value }}</button>
+              </div>
               <input
-type="text" class="detail-field-input"
-                     :value="f.value ?? ''" :readonly="f.browseOnly" @change="!f.browseOnly && handleFieldChange(f, ($event.target as HTMLInputElement).value)">
+v-else type="text" class="detail-field-input"
+                     :value="f.value ?? ''" @change="handleFieldChange(f, ($event.target as HTMLInputElement).value)">
               <button @click="handleBrowseField(f)">{{ $t('common.browse') }}</button>
             </div>
             <input
 v-else-if="f.editable" type="text" class="detail-field-input"
                    :value="f.value ?? ''" @change="handleFieldChange(f, ($event.target as HTMLInputElement).value)">
+            <button
+              v-else-if="canOpenFieldValue(f)"
+              type="button"
+              class="detail-field-value detail-field-value-open"
+              :title="$t('actions.openDirectory', 'Open Directory')"
+              @click="handleOpenPath(f.value)"
+            >{{ f.value }}</button>
             <div v-else class="detail-field-value">{{ f.value }}</div>
           </template>
         </div>

--- a/src/renderer/src/components/DetailSection.vue
+++ b/src/renderer/src/components/DetailSection.vue
@@ -7,6 +7,7 @@ import InfoTooltip from './InfoTooltip.vue'
 import TooltipWrap from './TooltipWrap.vue'
 import ArgsBuilder from './ArgsBuilder.vue'
 import EnvVarsEditor from './EnvVarsEditor.vue'
+import { isOpenablePathString } from '../lib/openablePath'
 
 interface Props {
   title?: string
@@ -100,14 +101,12 @@ async function handleBrowseField(field: DetailField): Promise<void> {
 }
 
 /** True when a non-editable value is safe to open in the OS file manager:
- *  an explicit path field, or a local-looking path that isn't a URL or date. */
+ *  an explicit path field, or a local-looking path (not a URL, SSH remote, or
+ *  date). */
 function canOpenFieldValue(field: DetailField): boolean {
   const v = field.value == null ? '' : String(field.value).trim()
-  if (!v || v === '—') return false
-  if (field.editType === 'path') return true
-  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(v)) return false // URL scheme
-  if (/^\d{1,4}[-/.]\d{1,2}[-/.]\d{1,4}/.test(v)) return false // date-ish
-  return v.includes('/') || v.includes('\\') || v.startsWith('~')
+  if (field.editType === 'path') return v.length > 0
+  return isOpenablePathString(v)
 }
 
 function handleOpenPath(value: unknown): void {
@@ -227,6 +226,7 @@ v-else-if="f.editable && f.editType === 'boolean'" type="checkbox" class="detail
                   type="button"
                   class="detail-path-open"
                   :title="$t('actions.openDirectory', 'Open Directory')"
+                  :aria-label="`${$t('actions.openDirectory', 'Open Directory')}: ${f.value}`"
                   @click="handleOpenPath(f.value)"
                 >{{ f.value }}</button>
               </div>
@@ -243,6 +243,7 @@ v-else-if="f.editable" type="text" class="detail-field-input"
               type="button"
               class="detail-field-value detail-field-value-open"
               :title="$t('actions.openDirectory', 'Open Directory')"
+              :aria-label="`${$t('actions.openDirectory', 'Open Directory')}: ${f.value}`"
               @click="handleOpenPath(f.value)"
             >{{ f.value }}</button>
             <div v-else class="detail-field-value">{{ f.value }}</div>

--- a/src/renderer/src/components/DetailSection.vue
+++ b/src/renderer/src/components/DetailSection.vue
@@ -224,7 +224,7 @@ v-else-if="f.editable && f.editType === 'boolean'" type="checkbox" class="detail
                 <button
                   v-if="canOpenFieldValue(f)"
                   type="button"
-                  class="detail-path-open"
+                  class="open-folder-link detail-path-open"
                   :title="$t('actions.openDirectory', 'Open Directory')"
                   :aria-label="`${$t('actions.openDirectory', 'Open Directory')}: ${f.value}`"
                   @click="handleOpenPath(f.value)"

--- a/src/renderer/src/components/DetailSection.vue
+++ b/src/renderer/src/components/DetailSection.vue
@@ -110,7 +110,7 @@ function canOpenFieldValue(field: DetailField): boolean {
 }
 
 function handleOpenPath(value: unknown): void {
-  const p = value == null ? '' : String(value)
+  const p = value == null ? '' : String(value).trim()
   if (p) void window.api.openPath(p)
 }
 </script>
@@ -222,7 +222,7 @@ v-else-if="f.editable && f.editType === 'boolean'" type="checkbox" class="detail
             <div v-else-if="f.editable && f.editType === 'path'" class="path-input">
               <div v-if="f.browseOnly" class="detail-path-open-wrap">
                 <button
-                  v-if="f.value"
+                  v-if="canOpenFieldValue(f)"
                   type="button"
                   class="detail-path-open"
                   :title="$t('actions.openDirectory', 'Open Directory')"

--- a/src/renderer/src/components/InstallNamePath.test.ts
+++ b/src/renderer/src/components/InstallNamePath.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+
+import { en } from '../lib/i18nMessages.ts'
+import InstallNamePath from './InstallNamePath.vue'
+
+function makeI18n() {
+  return createI18n({ legacy: false, locale: 'en', messages: { en } })
+}
+
+function mountComponent(props: Record<string, unknown> = {}) {
+  return mount(InstallNamePath, {
+    props: {
+      name: 'ComfyUI',
+      path: '/home/user/ComfyUI',
+      defaultPath: '/home/user/ComfyUI',
+      pathIssues: [],
+      diskSpaceLoading: false,
+      diskSpace: null,
+      estimatedSize: 0,
+      ...props,
+    },
+    global: { plugins: [makeI18n()] },
+  })
+}
+
+describe('InstallNamePath', () => {
+  it('renders the install path as a clickable open button and emits open', async () => {
+    const wrapper = mountComponent({ path: '/home/user/ComfyUI' })
+    const pathBtn = wrapper.find('.path-open')
+    expect(pathBtn.exists()).toBe(true)
+    expect(pathBtn.text()).toBe('/home/user/ComfyUI')
+
+    await pathBtn.trigger('click')
+    expect(wrapper.emitted('open')).toHaveLength(1)
+  })
+
+  it('emits browse when the Browse button is clicked', async () => {
+    const wrapper = mountComponent()
+    const browseBtn = wrapper.findAll('.path-input button').find((b) => b.text().includes('Browse'))
+    expect(browseBtn).toBeTruthy()
+    await browseBtn!.trigger('click')
+    expect(wrapper.emitted('browse')).toHaveLength(1)
+  })
+
+  it('no longer renders a readonly text input for the path', () => {
+    const wrapper = mountComponent()
+    expect(wrapper.find('.path-input input[readonly]').exists()).toBe(false)
+  })
+})

--- a/src/renderer/src/components/InstallNamePath.vue
+++ b/src/renderer/src/components/InstallNamePath.vue
@@ -17,6 +17,7 @@ defineEmits<{
   'update:name': [value: string]
   'update:path': [value: string]
   browse: []
+  open: []
 }>()
 </script>
 
@@ -36,14 +37,16 @@ defineEmits<{
     v-if="!hideInstallPath"
     class="field"
   >
-    <label for="inst-path">{{ $t('newInstall.installLocation') }}</label>
+    <label>{{ $t('newInstall.installLocation') }}</label>
     <div class="path-input">
-      <input
-        id="inst-path"
-        :value="path"
-        type="text"
-        readonly
-      />
+      <div class="path-open-wrap">
+        <button
+          type="button"
+          class="path-open"
+          :title="$t('actions.openDirectory', 'Open Directory')"
+          @click="$emit('open')"
+        >{{ path }}</button>
+      </div>
       <button @click="$emit('browse')">{{ $t('common.browse') }}</button>
       <button
         v-if="path !== defaultPath"
@@ -58,3 +61,41 @@ defineEmits<{
     />
   </div>
 </template>
+
+<style scoped>
+/* Replaces the old readonly <input>: a boxed path row whose text opens the
+ *  folder in the OS file manager. Only the path text is the click target. */
+.path-open-wrap {
+  display: flex;
+  align-items: center;
+  flex: 1;
+  min-width: 0;
+  margin-top: 6px;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+}
+
+.path-open {
+  min-width: 0;
+  max-width: 100%;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font-size: 14px;
+  text-align: left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: pointer;
+}
+
+.path-open:hover,
+.path-open:focus-visible {
+  color: var(--accent);
+  text-decoration: underline;
+  outline: none;
+}
+</style>

--- a/src/renderer/src/components/InstallNamePath.vue
+++ b/src/renderer/src/components/InstallNamePath.vue
@@ -43,7 +43,7 @@ defineEmits<{
         <button
           v-if="path"
           type="button"
-          class="path-open"
+          class="open-folder-link path-open"
           :title="$t('actions.openDirectory', 'Open Directory')"
           :aria-label="`${$t('actions.openDirectory', 'Open Directory')}: ${path}`"
           @click="$emit('open')"
@@ -79,25 +79,8 @@ defineEmits<{
   background: var(--surface);
 }
 
+/* Inherits .open-folder-link; matches the shared color/font, only caps width. */
 .path-open {
-  min-width: 0;
   max-width: 100%;
-  padding: 0;
-  border: none;
-  background: transparent;
-  color: var(--text);
-  font-size: 14px;
-  text-align: left;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  cursor: pointer;
-}
-
-.path-open:hover,
-.path-open:focus-visible {
-  color: var(--accent);
-  text-decoration: underline;
-  outline: none;
 }
 </style>

--- a/src/renderer/src/components/InstallNamePath.vue
+++ b/src/renderer/src/components/InstallNamePath.vue
@@ -41,9 +41,11 @@ defineEmits<{
     <div class="path-input">
       <div class="path-open-wrap">
         <button
+          v-if="path"
           type="button"
           class="path-open"
           :title="$t('actions.openDirectory', 'Open Directory')"
+          :aria-label="`${$t('actions.openDirectory', 'Open Directory')}: ${path}`"
           @click="$emit('open')"
         >{{ path }}</button>
       </div>

--- a/src/renderer/src/components/settings/ComfyUISettingsContent.vue
+++ b/src/renderer/src/components/settings/ComfyUISettingsContent.vue
@@ -440,6 +440,9 @@ function openArgsPage(): void {
   subPageTransition.value = 'subpage-push'
   subPage.value = 'args'
 }
+function handleOpenPath(path: string): void {
+  if (path) void window.api.openPath(path)
+}
 function closeSubPage(): void {
   subPageTransition.value = 'subpage-pop'
   subPage.value = null
@@ -1067,6 +1070,7 @@ defineExpose({
                     @update-field="updateField"
                     @run-action="runAction"
                     @open-args-page="openArgsPage"
+                    @open-path="handleOpenPath"
                   />
                 </div>
               </Transition>

--- a/src/renderer/src/lib/openablePath.test.ts
+++ b/src/renderer/src/lib/openablePath.test.ts
@@ -34,6 +34,11 @@ describe('isOpenablePathString', () => {
     expect(isOpenablePathString('01-02-2024')).toBe(false)
   })
 
+  it('keeps date-prefixed paths openable', () => {
+    expect(isOpenablePathString('2024/01/02/models')).toBe(true)
+    expect(isOpenablePathString('2024-01-02/models')).toBe(true)
+  })
+
   it('rejects plain text without separators', () => {
     expect(isOpenablePathString('master')).toBe(false)
     expect(isOpenablePathString('ComfyUI')).toBe(false)

--- a/src/renderer/src/lib/openablePath.test.ts
+++ b/src/renderer/src/lib/openablePath.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { isOpenablePathString } from './openablePath'
+
+describe('isOpenablePathString', () => {
+  it('accepts POSIX absolute and home paths', () => {
+    expect(isOpenablePathString('/home/user/ComfyUI')).toBe(true)
+    expect(isOpenablePathString('~/ComfyUI')).toBe(true)
+  })
+
+  it('accepts Windows drive and UNC paths', () => {
+    expect(isOpenablePathString('C:\\Users\\me\\ComfyUI')).toBe(true)
+    expect(isOpenablePathString('C:/Users/me/ComfyUI')).toBe(true)
+    expect(isOpenablePathString('\\\\server\\share\\models')).toBe(true)
+  })
+
+  it('rejects empty and placeholder values', () => {
+    expect(isOpenablePathString('')).toBe(false)
+    expect(isOpenablePathString('   ')).toBe(false)
+    expect(isOpenablePathString('—')).toBe(false)
+  })
+
+  it('rejects URLs', () => {
+    expect(isOpenablePathString('https://github.com/comfyanonymous/ComfyUI')).toBe(false)
+    expect(isOpenablePathString('file:///home/user/x')).toBe(false)
+    expect(isOpenablePathString('http://localhost:8188/')).toBe(false)
+  })
+
+  it('rejects SSH / scp-style git remotes', () => {
+    expect(isOpenablePathString('git@github.com:comfyanonymous/ComfyUI.git')).toBe(false)
+  })
+
+  it('rejects date-like values that merely contain slashes', () => {
+    expect(isOpenablePathString('2024/01/02')).toBe(false)
+    expect(isOpenablePathString('01-02-2024')).toBe(false)
+  })
+
+  it('rejects plain text without separators', () => {
+    expect(isOpenablePathString('master')).toBe(false)
+    expect(isOpenablePathString('ComfyUI')).toBe(false)
+    expect(isOpenablePathString('v1.2.3')).toBe(false)
+  })
+})

--- a/src/renderer/src/lib/openablePath.ts
+++ b/src/renderer/src/lib/openablePath.ts
@@ -1,0 +1,19 @@
+/**
+ * Shared guard for "is this string safe to open in the OS file manager?".
+ *
+ * Used by the readonly path displays so that only real local filesystem paths
+ * become clickable open-folder targets — never URLs, SSH/Git remotes, or dates
+ * that merely contain slashes.
+ *
+ * Windows notes: drive paths (`C:\…`, `C:/…`) and UNC paths (`\\server\share`)
+ * are openable. A bare drive-relative value like `C:foo` (no separator) is not
+ * recognised as a path and stays non-clickable.
+ */
+export function isOpenablePathString(value: string): boolean {
+  const v = value.trim()
+  if (!v || v === '—') return false
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(v)) return false // URL scheme: http://, file://, …
+  if (/^[^\s/\\@]+@[^\s/\\@]+:/.test(v)) return false // scp/SSH remote: git@github.com:owner/repo
+  if (/^\d{1,4}[-/.]\d{1,2}[-/.]\d{1,4}/.test(v)) return false // date-ish: 2024/01/02, 01-02-2024
+  return v.includes('/') || v.includes('\\') || v.startsWith('~')
+}

--- a/src/renderer/src/lib/openablePath.ts
+++ b/src/renderer/src/lib/openablePath.ts
@@ -14,6 +14,6 @@ export function isOpenablePathString(value: string): boolean {
   if (!v || v === '—') return false
   if (/^[a-z][a-z0-9+.-]*:\/\//i.test(v)) return false // URL scheme: http://, file://, …
   if (/^[^\s/\\@]+@[^\s/\\@]+:/.test(v)) return false // scp/SSH remote: git@github.com:owner/repo
-  if (/^\d{1,4}[-/.]\d{1,2}[-/.]\d{1,4}/.test(v)) return false // date-ish: 2024/01/02, 01-02-2024
+  if (/^\d{1,4}[-/.]\d{1,2}[-/.]\d{1,4}$/.test(v)) return false // bare date-ish value only: 2024/01/02, 01-02-2024
   return v.includes('/') || v.includes('\\') || v.startsWith('~')
 }

--- a/src/renderer/src/views/InstallWizardModal.test.ts
+++ b/src/renderer/src/views/InstallWizardModal.test.ts
@@ -47,4 +47,15 @@ describe('InstallWizardModal install-location field', () => {
     await pathBtn.trigger('click')
     expect(window.api.openPath).toHaveBeenCalledWith('/home/user/ComfyUI')
   })
+
+  it('renders a blank install location as inert (non-clickable, never opens a folder)', async () => {
+    ;(window.api.getDefaultInstallDir as ReturnType<typeof vi.fn>).mockResolvedValue('')
+    const wrapper = mountModal()
+    ;(wrapper.vm as unknown as { open: () => Promise<void> }).open()
+    await flushPromises()
+
+    expect(wrapper.find('button.config-path-open').exists()).toBe(false)
+    expect(wrapper.find('.config-path-open--static').exists()).toBe(true)
+    expect(window.api.openPath).not.toHaveBeenCalled()
+  })
 })

--- a/src/renderer/src/views/InstallWizardModal.test.ts
+++ b/src/renderer/src/views/InstallWizardModal.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+
+import { en } from '../lib/i18nMessages.ts'
+import InstallWizardModal from './InstallWizardModal.vue'
+
+function makeI18n() {
+  return createI18n({ legacy: false, locale: 'en', messages: { en } })
+}
+
+function mountModal() {
+  return mount(InstallWizardModal, {
+    global: {
+      plugins: [makeI18n()],
+      stubs: { BrandTakeoverLayout: { template: '<div><slot /></div>' } },
+    },
+  })
+}
+
+beforeEach(() => {
+  window.api = {
+    openPath: vi.fn().mockResolvedValue(undefined),
+    browseFolder: vi.fn().mockResolvedValue('/home/user/Picked'),
+    detectGPU: vi.fn().mockResolvedValue(null),
+    getDefaultInstallDir: vi.fn().mockResolvedValue('/home/user/ComfyUI'),
+    getSources: vi.fn().mockResolvedValue([]),
+    validateHardware: vi.fn().mockResolvedValue({ supported: true }),
+    getSetting: vi.fn().mockResolvedValue(false),
+    getInstallationsSummary: vi.fn().mockResolvedValue({ localCount: 0 }),
+    getUniqueName: vi.fn().mockResolvedValue('ComfyUI'),
+    getDiskSpace: vi.fn().mockResolvedValue(null),
+    validateInstallPath: vi.fn().mockResolvedValue([]),
+  } as unknown as typeof window.api
+})
+
+describe('InstallWizardModal install-location field', () => {
+  it('renders the default install location as a clickable path that opens the folder', async () => {
+    const wrapper = mountModal()
+    ;(wrapper.vm as unknown as { open: () => Promise<void> }).open()
+    await flushPromises()
+
+    const pathBtn = wrapper.find('button.config-path-open')
+    expect(pathBtn.exists()).toBe(true)
+    expect(pathBtn.text()).toBe('/home/user/ComfyUI')
+
+    await pathBtn.trigger('click')
+    expect(window.api.openPath).toHaveBeenCalledWith('/home/user/ComfyUI')
+  })
+})

--- a/src/renderer/src/views/InstallWizardModal.vue
+++ b/src/renderer/src/views/InstallWizardModal.vue
@@ -904,6 +904,7 @@ defineExpose({ open })
                     type="button"
                     class="config-path-open"
                     :title="$t('actions.openDirectory', 'Open Directory')"
+                    :aria-label="`${$t('actions.openDirectory', 'Open Directory')}: ${instPath}`"
                     @click="handleOpenInstPath"
                   >{{ instPath }}</button>
                   <span v-else class="config-path-open config-path-open--static">{{

--- a/src/renderer/src/views/InstallWizardModal.vue
+++ b/src/renderer/src/views/InstallWizardModal.vue
@@ -661,6 +661,10 @@ async function handleBrowse(): Promise<void> {
   if (chosen) instPath.value = chosen
 }
 
+function handleOpenInstPath(): void {
+  if (instPath.value) void window.api.openPath(instPath.value)
+}
+
 async function handleSave(): Promise<void> {
   const source = currentSource.value
   if (!source) return
@@ -891,19 +895,20 @@ defineExpose({ open })
               class="config-field"
               :class="{ 'config-field--disabled': currentSource?.skipInstall }"
             >
-              <label class="config-label" for="inst-path">{{
-                $t('newInstall.installLocation')
-              }}</label>
+              <label class="config-label">{{ $t('newInstall.installLocation') }}</label>
               <div class="config-path-row">
                 <div class="brand-input config-path-input">
                   <HardDrive :size="14" aria-hidden="true" />
-                  <input
-                    id="inst-path"
-                    :value="instPath"
-                    type="text"
-                    readonly
-                    :disabled="!!currentSource?.skipInstall"
-                  />
+                  <button
+                    v-if="!currentSource?.skipInstall && instPath"
+                    type="button"
+                    class="config-path-open"
+                    :title="$t('actions.openDirectory', 'Open Directory')"
+                    @click="handleOpenInstPath"
+                  >{{ instPath }}</button>
+                  <span v-else class="config-path-open config-path-open--static">{{
+                    instPath
+                  }}</span>
                 </div>
                 <button
                   class="brand-tertiary"
@@ -1433,6 +1438,35 @@ defineExpose({ open })
   flex: 1 1 auto;
   min-width: 0;
   padding-inline: 12px;
+}
+/* Path text replaces the old readonly <input>; clicking it opens the selected
+ *  install directory in the OS file manager. Only the text is the click target. */
+.config-path-open {
+  min-width: 0;
+  flex: 0 1 auto;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: pointer;
+}
+.config-path-open:hover,
+.config-path-open:focus-visible {
+  color: var(--accent);
+  text-decoration: underline;
+  outline: none;
+}
+.config-path-open--static {
+  cursor: default;
+}
+.config-path-open--static:hover {
+  color: inherit;
+  text-decoration: none;
 }
 .config-path-row > button.brand-tertiary {
   padding-inline: 14px;

--- a/src/renderer/src/views/InstallWizardModal.vue
+++ b/src/renderer/src/views/InstallWizardModal.vue
@@ -902,12 +902,12 @@ defineExpose({ open })
                   <button
                     v-if="!currentSource?.skipInstall && instPath"
                     type="button"
-                    class="config-path-open"
+                    class="open-folder-link config-path-open"
                     :title="$t('actions.openDirectory', 'Open Directory')"
                     :aria-label="`${$t('actions.openDirectory', 'Open Directory')}: ${instPath}`"
                     @click="handleOpenInstPath"
                   >{{ instPath }}</button>
-                  <span v-else class="config-path-open config-path-open--static">{{
+                  <span v-else class="open-folder-link config-path-open config-path-open--static">{{
                     instPath
                   }}</span>
                 </div>
@@ -1441,26 +1441,12 @@ defineExpose({ open })
   padding-inline: 12px;
 }
 /* Path text replaces the old readonly <input>; clicking it opens the selected
- *  install directory in the OS file manager. Only the text is the click target. */
+ *  install directory in the OS file manager. Inherits .open-folder-link; only
+ *  the row-specific sizing/inheritance differ. */
 .config-path-open {
-  min-width: 0;
   flex: 0 1 auto;
-  padding: 0;
-  border: none;
-  background: transparent;
   color: inherit;
   font: inherit;
-  text-align: left;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  cursor: pointer;
-}
-.config-path-open:hover,
-.config-path-open:focus-visible {
-  color: var(--accent);
-  text-decoration: underline;
-  outline: none;
 }
 .config-path-open--static {
   cursor: default;

--- a/src/renderer/src/views/QuickInstallModal.vue
+++ b/src/renderer/src/views/QuickInstallModal.vue
@@ -71,6 +71,10 @@ async function handleBrowse(): Promise<void> {
   if (chosen) instPath.value = chosen
 }
 
+function handleOpenPath(): void {
+  if (instPath.value) void window.api.openPath(instPath.value)
+}
+
 /** Deep-strip Vue reactive proxies for safe IPC serialization */
 function rawSelections(): Record<string, FieldOption> {
   const result: Record<string, FieldOption> = {}
@@ -321,6 +325,7 @@ defineExpose({ open })
           @update:name="instName = $event"
           @update:path="instPath = $event"
           @browse="handleBrowse"
+          @open="handleOpenPath"
         />
       </template>
     </div>

--- a/src/renderer/src/views/TrackModal.test.ts
+++ b/src/renderer/src/views/TrackModal.test.ts
@@ -6,10 +6,11 @@ import TrackModal from './TrackModal.vue'
 import type { ProbeResult } from '../types/ipc'
 
 /**
- * The Install Directory field is browse-only: typing/pasting must not
- * change it. The only way to populate it is the Browse button, which
- * runs the probe and enables the "Track Install" button when an
- * existing install is detected.
+ * The Install Directory field is browse-only: it has no editable input, so
+ * typing/pasting is impossible. The only way to populate it is the Browse
+ * button, which runs the probe and enables the "Track Install" button when an
+ * existing install is detected. Once populated, the path text is clickable to
+ * open the folder in the OS file manager.
  */
 
 // Minimal catalog covering the keys the template reads. Missing keys fall
@@ -50,6 +51,7 @@ interface MockApi {
   browseFolder: ReturnType<typeof vi.fn>
   probeInstallation: ReturnType<typeof vi.fn>
   trackInstallation: ReturnType<typeof vi.fn>
+  openPath: ReturnType<typeof vi.fn>
 }
 
 const gitProbe: ProbeResult = {
@@ -67,6 +69,7 @@ function installMockApi(overrides: Partial<MockApi> = {}): MockApi {
     browseFolder: vi.fn().mockResolvedValue(undefined),
     probeInstallation: vi.fn().mockResolvedValue([gitProbe]),
     trackInstallation: vi.fn().mockResolvedValue({ ok: true }),
+    openPath: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   }
   ;(window as unknown as { api: MockApi }).api = api
@@ -102,28 +105,33 @@ describe('TrackModal — browse-only install directory', () => {
     vi.restoreAllMocks()
   })
 
-  it('renders the install-directory input as readonly', async () => {
+  it('renders a non-clickable placeholder (no editable input) before a folder is picked', async () => {
     const wrapper = mountTrack()
     ;(wrapper.vm as unknown as { open: () => void }).open()
     await flushPromises()
 
-    const input = wrapper.get('#track-path')
-    expect(input.attributes('readonly')).toBeDefined()
+    // Browse-only: the directory has no editable text input at all.
+    expect(wrapper.find('.track-path-input input').exists()).toBe(false)
+    // Empty → muted placeholder, not a clickable open button.
+    expect(wrapper.find('button.track-path-open').exists()).toBe(false)
+    expect(wrapper.find('.track-path-placeholder').exists()).toBe(true)
   })
 
-  it('does not probe when the user attempts to type into the field', async () => {
-    const api = installMockApi()
+  it('opens the folder in the file manager when the populated path text is clicked', async () => {
+    const api = installMockApi({
+      browseFolder: vi.fn().mockResolvedValue('/Users/jo/ComfyUI'),
+    })
     const wrapper = mountTrack()
     ;(wrapper.vm as unknown as { open: () => void }).open()
     await flushPromises()
 
-    // Programmatically dispatch an input event — readonly prevents real
-    // keyboard input but a stray input dispatch must not reach probe().
-    await wrapper.get('#track-path').trigger('input')
+    await wrapper.get('button.brand-tertiary').trigger('click')
     await flushPromises()
 
-    expect(api.probeInstallation).not.toHaveBeenCalled()
-    expect(trackButton(wrapper).attributes('disabled')).toBeDefined()
+    const pathBtn = wrapper.get('button.track-path-open')
+    expect(pathBtn.text()).toBe('/Users/jo/ComfyUI')
+    await pathBtn.trigger('click')
+    expect(api.openPath).toHaveBeenCalledWith('/Users/jo/ComfyUI')
   })
 
   it('probes and enables Track Install when a folder is picked via Browse', async () => {

--- a/src/renderer/src/views/TrackModal.vue
+++ b/src/renderer/src/views/TrackModal.vue
@@ -246,6 +246,7 @@ defineExpose({ open })
                   type="button"
                   class="track-path-open"
                   :title="$t('actions.openDirectory', 'Open Directory')"
+                  :aria-label="`${$t('actions.openDirectory', 'Open Directory')}: ${trackPath}`"
                   @click="handleOpenTrackPath"
                 >{{ trackPath }}</button>
                 <span v-else class="track-path-open track-path-placeholder">{{

--- a/src/renderer/src/views/TrackModal.vue
+++ b/src/renderer/src/views/TrackModal.vue
@@ -248,12 +248,12 @@ defineExpose({ open })
                 <button
                   v-if="trackPath"
                   type="button"
-                  class="track-path-open"
+                  class="open-folder-link track-path-open"
                   :title="$t('actions.openDirectory', 'Open Directory')"
                   :aria-label="`${$t('actions.openDirectory', 'Open Directory')}: ${trackPath}`"
                   @click="handleOpenTrackPath"
                 >{{ trackPath }}</button>
-                <span v-else class="track-path-open track-path-placeholder">{{
+                <span v-else class="open-folder-link track-path-open track-path-placeholder">{{
                   $t('track.selectDir')
                 }}</span>
               </div>
@@ -377,26 +377,12 @@ defineExpose({ open })
   padding-inline: 12px;
 }
 /* Path text replaces the old readonly <input>; clicking it opens the tracked
- *  directory in the OS file manager. Only the text is the click target. */
+ *  directory in the OS file manager. Inherits .open-folder-link; only the
+ *  row-specific sizing/inheritance differ. */
 .track-path-open {
-  min-width: 0;
   flex: 0 1 auto;
-  padding: 0;
-  border: none;
-  background: transparent;
   color: inherit;
   font: inherit;
-  text-align: left;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  cursor: pointer;
-}
-.track-path-open:hover,
-.track-path-open:focus-visible {
-  color: var(--accent);
-  text-decoration: underline;
-  outline: none;
 }
 .track-path-placeholder {
   color: var(--neutral-400);

--- a/src/renderer/src/views/TrackModal.vue
+++ b/src/renderer/src/views/TrackModal.vue
@@ -92,6 +92,10 @@ async function handleBrowse(): Promise<void> {
   }
 }
 
+function handleOpenTrackPath(): void {
+  if (trackPath.value) void window.api.openPath(trackPath.value)
+}
+
 async function probe(dirPath: string): Promise<void> {
   const generation = ++probeGeneration
   probing.value = true
@@ -233,17 +237,20 @@ defineExpose({ open })
       >
         <div class="brand-card__body">
           <div class="track-field">
-            <label class="track-label" for="track-path">{{ $t('track.installDir') }}</label>
+            <label class="track-label">{{ $t('track.installDir') }}</label>
             <div class="track-path-row">
               <div class="brand-input track-path-input">
                 <HardDrive :size="14" aria-hidden="true" />
-                <input
-                  id="track-path"
-                  :value="trackPath"
-                  type="text"
-                  readonly
-                  :placeholder="$t('track.selectDir')"
-                />
+                <button
+                  v-if="trackPath"
+                  type="button"
+                  class="track-path-open"
+                  :title="$t('actions.openDirectory', 'Open Directory')"
+                  @click="handleOpenTrackPath"
+                >{{ trackPath }}</button>
+                <span v-else class="track-path-open track-path-placeholder">{{
+                  $t('track.selectDir')
+                }}</span>
               </div>
               <button class="brand-tertiary" type="button" @click="handleBrowse">
                 {{ $t('common.browse') }}
@@ -363,6 +370,36 @@ defineExpose({ open })
   flex: 1 1 auto;
   min-width: 0;
   padding-inline: 12px;
+}
+/* Path text replaces the old readonly <input>; clicking it opens the tracked
+ *  directory in the OS file manager. Only the text is the click target. */
+.track-path-open {
+  min-width: 0;
+  flex: 0 1 auto;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: pointer;
+}
+.track-path-open:hover,
+.track-path-open:focus-visible {
+  color: var(--accent);
+  text-decoration: underline;
+  outline: none;
+}
+.track-path-placeholder {
+  color: var(--neutral-400);
+  cursor: default;
+}
+.track-path-placeholder:hover {
+  color: var(--neutral-400);
+  text-decoration: none;
 }
 .track-path-row > button.brand-tertiary {
   padding-inline: 14px;

--- a/src/renderer/src/views/comfyUISettings/PathField.test.ts
+++ b/src/renderer/src/views/comfyUISettings/PathField.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+
+import { en } from '../../lib/i18nMessages.ts'
+import PathField from './PathField.vue'
+import type { DetailField } from '../../types/ipc'
+
+function makeI18n() {
+  return createI18n({ legacy: false, locale: 'en', messages: { en } })
+}
+
+function mountField(field: DetailField) {
+  return mount(PathField, {
+    props: { field },
+    global: { plugins: [makeI18n()] },
+  })
+}
+
+beforeEach(() => {
+  window.api = {
+    openPath: vi.fn().mockResolvedValue(undefined),
+    browseFolder: vi.fn().mockResolvedValue('/picked/dir'),
+  } as unknown as typeof window.api
+})
+
+describe('PathField', () => {
+  it('renders a clickable StorageDirRow for browse-only paths', async () => {
+    const wrapper = mountField({
+      id: 'cacheDir',
+      label: 'Cache Directory',
+      value: '/home/user/.cache/comfy',
+      editType: 'path',
+      editable: true,
+      browseOnly: true,
+    })
+    const pathBtn = wrapper.find('.storage-dir-name')
+    expect(pathBtn.exists()).toBe(true)
+    expect(pathBtn.text()).toBe('/home/user/.cache/comfy')
+
+    await pathBtn.trigger('click')
+    expect(window.api.openPath).toHaveBeenCalledWith('/home/user/.cache/comfy')
+  })
+
+  it('does not call openPath when the browse-only path is empty', async () => {
+    const wrapper = mountField({
+      id: 'cacheDir',
+      label: 'Cache Directory',
+      value: '',
+      editType: 'path',
+      editable: true,
+      browseOnly: true,
+    })
+    await wrapper.find('.storage-dir-name').trigger('click')
+    expect(window.api.openPath).not.toHaveBeenCalled()
+  })
+
+  it('renders an editable input (not a StorageDirRow) for non-browse-only paths', () => {
+    const wrapper = mountField({
+      id: 'pypiMirror',
+      label: 'PyPI Mirror',
+      value: '/some/dir',
+      editType: 'path',
+      editable: true,
+    })
+    expect(wrapper.find('.storage-dir-name').exists()).toBe(false)
+    expect(wrapper.find('input').exists()).toBe(true)
+  })
+})

--- a/src/renderer/src/views/comfyUISettings/PathField.vue
+++ b/src/renderer/src/views/comfyUISettings/PathField.vue
@@ -3,10 +3,13 @@ import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { FolderOpen } from 'lucide-vue-next'
 import BaseInput from '../../components/ui/BaseInput.vue'
+import StorageDirRow from './StorageDirRow.vue'
 import type { DetailField } from '../../types/ipc'
 
 /**
- * Path field for the Settings drawer. `field.browseOnly === true` makes the input read-only so the value is only changed via Browse.
+ * Path field for the Settings drawer. `field.browseOnly === true` renders a
+ * clickable open-in-file-manager path row (the value is only changed via
+ * Browse); otherwise the path is an editable text input.
  */
 
 interface Props {
@@ -33,12 +36,22 @@ function handleChange(value: string): void {
   if (isBrowseOnly.value) return
   emit('update', props.field, value)
 }
+
+function handleOpen(): void {
+  if (stringValue.value) void window.api.openPath(stringValue.value)
+}
 </script>
 
 <template>
+  <StorageDirRow
+    v-if="isBrowseOnly"
+    :path="stringValue"
+    @open="handleOpen"
+    @browse="handleBrowse"
+  />
   <BaseInput
+    v-else
     :model-value="stringValue"
-    :readonly="isBrowseOnly"
     :aria-label="field.label || undefined"
     @change="handleChange"
   >

--- a/src/renderer/src/views/comfyUISettings/SettingsSectionList.test.ts
+++ b/src/renderer/src/views/comfyUISettings/SettingsSectionList.test.ts
@@ -17,6 +17,13 @@ function mountList(fields: DetailField[]) {
   })
 }
 
+function mountReadonly(fields: DetailField[]) {
+  return mount(SettingsSectionList, {
+    props: { sections: [{ fields }], readonly: true },
+    global: { plugins: [makeI18n()] },
+  })
+}
+
 describe('SettingsSectionList', () => {
   // When main attaches a field `description`, the renderer must surface it under the control.
   describe('field descriptions', () => {
@@ -82,6 +89,44 @@ describe('SettingsSectionList', () => {
       const trigger = wrapper.find('.info-tooltip-trigger')
       expect(trigger.exists()).toBe(true)
       expect(trigger.attributes('aria-label')).toContain('gitcode.com')
+    })
+  })
+
+  // Readonly path values render as a clickable open-folder button, keeping the
+  // copy button, and only fire `open-path` for real filesystem paths.
+  describe('readonly path rows', () => {
+    it('renders a clickable button that emits open-path for a path value', async () => {
+      const wrapper = mountReadonly([
+        { id: 'location', label: 'Location', value: '/home/user/ComfyUI', editType: 'path' },
+      ])
+      const btn = wrapper.find('button.settings-v2-field-readonly-open')
+      expect(btn.exists()).toBe(true)
+      expect(btn.text()).toBe('/home/user/ComfyUI')
+      await btn.trigger('click')
+      expect(wrapper.emitted('open-path')?.[0]).toEqual(['/home/user/ComfyUI'])
+    })
+
+    it('keeps the copy button alongside the path', () => {
+      const wrapper = mountReadonly([
+        { id: 'location', label: 'Location', value: '/home/user/ComfyUI', editType: 'path' },
+      ])
+      expect(wrapper.find('.settings-v2-readonly-path').exists()).toBe(true)
+      // BaseCopyButton renders a button; together with the open button there are two.
+      expect(wrapper.findAll('.settings-v2-readonly-path button').length).toBe(2)
+    })
+
+    it('does not make a URL value clickable', () => {
+      const wrapper = mountReadonly([
+        { id: 'repo', label: 'Repository', value: 'https://github.com/comfyanonymous/ComfyUI' },
+      ])
+      expect(wrapper.find('button.settings-v2-field-readonly-open').exists()).toBe(false)
+    })
+
+    it('does not make a date value clickable', () => {
+      const wrapper = mountReadonly([
+        { id: 'updated', label: 'Last updated', value: '2024/01/02' },
+      ])
+      expect(wrapper.find('button.settings-v2-field-readonly-open').exists()).toBe(false)
     })
   })
 })

--- a/src/renderer/src/views/comfyUISettings/SettingsSectionList.vue
+++ b/src/renderer/src/views/comfyUISettings/SettingsSectionList.vue
@@ -123,11 +123,12 @@ function isPathLikeValue(value: unknown): boolean {
 }
 
 /** Stricter than `isPathLikeValue`: only values safe to open in the OS file
- *  manager. `editType === 'path'` is always openable; otherwise the value must
- *  look like a local path (not a URL, SSH remote, or date). */
+ *  manager. `editType === 'path'` is openable when it holds a real value (not
+ *  empty or the `—` placeholder); otherwise the value must look like a local
+ *  path (not a URL, SSH remote, or date). */
 function canOpenFilesystemPath(field: DetailField): boolean {
   const v = asString(field.value).trim()
-  if (field.editType === 'path') return v.length > 0
+  if (field.editType === 'path') return v.length > 0 && v !== '—'
   return isOpenablePathString(v)
 }
 

--- a/src/renderer/src/views/comfyUISettings/SettingsSectionList.vue
+++ b/src/renderer/src/views/comfyUISettings/SettingsSectionList.vue
@@ -61,6 +61,9 @@ const emit = defineEmits<{
   'update-field': [field: DetailField, value: unknown]
   'run-action': [action: ActionDef]
   'open-args-page': [field: DetailField]
+  /** Open a filesystem path in the OS file manager; the host wires the IPC
+   *  (`window.api.openPath` in the panel, the bridge in the title popup). */
+  'open-path': [path: string]
 }>()
 
 const { t } = useI18n()
@@ -115,6 +118,18 @@ function isPathLikeValue(value: unknown): boolean {
   if (typeof value !== 'string') return false
   const v = value.trim()
   if (!v || v === '—') return false
+  return v.includes('/') || v.includes('\\') || v.startsWith('~')
+}
+
+/** Stricter than `isPathLikeValue`: only values safe to open in the OS file
+ *  manager. `editType === 'path'` is always openable; otherwise the value must
+ *  look like a local path and not a URL or a date. */
+function canOpenFilesystemPath(field: DetailField): boolean {
+  if (field.editType === 'path') return asString(field.value).trim().length > 0
+  const v = asString(field.value).trim()
+  if (!v || v === '—') return false
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(v)) return false // URL scheme (http://, file://, …)
+  if (/^\d{1,4}[-/.]\d{1,2}[-/.]\d{1,4}/.test(v)) return false // date-ish (2024/01/02, 01-02-2024)
   return v.includes('/') || v.includes('\\') || v.startsWith('~')
 }
 
@@ -260,9 +275,20 @@ function fieldOwnsLabel(field: DetailField): boolean {
             v-else-if="readonly && (field.editType === 'path' || isPathLikeValue(field.value))"
             class="settings-v2-readonly-path"
           >
-            <span class="settings-v2-field-readonly settings-v2-field-readonly-path">{{
-              readonlyDisplayValue(field)
-            }}</span>
+            <button
+              v-if="canOpenFilesystemPath(field)"
+              type="button"
+              class="settings-v2-field-readonly settings-v2-field-readonly-path settings-v2-field-readonly-open"
+              :title="t('models.openDir', 'Open folder')"
+              @click="emit('open-path', readonlyDisplayValue(field))"
+            >
+              {{ readonlyDisplayValue(field) }}
+            </button>
+            <span
+              v-else
+              class="settings-v2-field-readonly settings-v2-field-readonly-path"
+              >{{ readonlyDisplayValue(field) }}</span
+            >
             <BaseCopyButton :value="readonlyDisplayValue(field)" />
           </div>
 
@@ -624,6 +650,24 @@ function fieldOwnsLabel(field: DetailField): boolean {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* Clickable path that opens the folder in the OS file manager. Only the path
+ *  text is the click target (matches StorageDirRow / StatusFactPanel). */
+.settings-v2-field-readonly-open {
+  padding: 0;
+  border: none;
+  background: transparent;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.settings-v2-field-readonly-open:hover,
+.settings-v2-field-readonly-open:focus-visible {
+  color: var(--accent);
+  text-decoration: underline;
+  outline: none;
 }
 
 .settings-v2-field-readonly {

--- a/src/renderer/src/views/comfyUISettings/SettingsSectionList.vue
+++ b/src/renderer/src/views/comfyUISettings/SettingsSectionList.vue
@@ -12,6 +12,7 @@ import ArgsBuilderField from './ArgsBuilderField.vue'
 import InfoTooltip from '../../components/InfoTooltip.vue'
 import BaseCopyButton from '../../components/ui/BaseCopyButton.vue'
 import TooltipWrap from '../../components/TooltipWrap.vue'
+import { isOpenablePathString } from '../../lib/openablePath'
 import type { ActionDef, DetailField, DetailSection } from '../../types/ipc'
 
 /**
@@ -123,14 +124,11 @@ function isPathLikeValue(value: unknown): boolean {
 
 /** Stricter than `isPathLikeValue`: only values safe to open in the OS file
  *  manager. `editType === 'path'` is always openable; otherwise the value must
- *  look like a local path and not a URL or a date. */
+ *  look like a local path (not a URL, SSH remote, or date). */
 function canOpenFilesystemPath(field: DetailField): boolean {
-  if (field.editType === 'path') return asString(field.value).trim().length > 0
   const v = asString(field.value).trim()
-  if (!v || v === '—') return false
-  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(v)) return false // URL scheme (http://, file://, …)
-  if (/^\d{1,4}[-/.]\d{1,2}[-/.]\d{1,4}/.test(v)) return false // date-ish (2024/01/02, 01-02-2024)
-  return v.includes('/') || v.includes('\\') || v.startsWith('~')
+  if (field.editType === 'path') return v.length > 0
+  return isOpenablePathString(v)
 }
 
 function readonlyDisplayValue(field: DetailField): string {
@@ -280,6 +278,7 @@ function fieldOwnsLabel(field: DetailField): boolean {
               type="button"
               class="settings-v2-field-readonly settings-v2-field-readonly-path settings-v2-field-readonly-open"
               :title="t('models.openDir', 'Open folder')"
+              :aria-label="`${t('models.openDir', 'Open folder')}: ${readonlyDisplayValue(field)}`"
               @click="emit('open-path', readonlyDisplayValue(field))"
             >
               {{ readonlyDisplayValue(field) }}
@@ -653,8 +652,10 @@ function fieldOwnsLabel(field: DetailField): boolean {
 }
 
 /* Clickable path that opens the folder in the OS file manager. Only the path
- *  text is the click target (matches StorageDirRow / StatusFactPanel). */
+ *  text is the click target (matches StorageDirRow / StatusFactPanel), so the
+ *  button is sized to its text rather than filling the value column. */
 .settings-v2-field-readonly-open {
+  flex: 0 1 auto;
   padding: 0;
   border: none;
   background: transparent;


### PR DESCRIPTION
Closes #1032. Follow-up to #938.

## What

Makes every filesystem path displayed in the desktop app **clickable to open in the OS file manager** (Explorer/Finder), replacing the remaining readonly/disabled text inputs and plain non-clickable text. Only the path **text** is the click target, consistent with #938.

## Migrated offenders

- **`PathField.vue`** — browse-only settings paths now render a clickable `StorageDirRow` (open + browse). Editable paths stay an editable input.
- **`SettingsSectionList.vue`** — readonly path values become an open-folder button (keeping `BaseCopyButton`) and emit `open-path`. Hosts wire the IPC: `ComfyUISettingsContent` → `window.api.openPath`, `GlobalSettingsView`/`UpdatesSection` → the title-popup bridge. A stricter `canOpenFilesystemPath` predicate avoids treating URLs/dates as openable paths.
- **Install/Track brand-takeover flows** — `InstallNamePath.vue` (QuickInstallModal), `InstallWizardModal.vue`, `TrackModal.vue`: the directory text opens the folder. Empty (Track placeholder) and remote-mode (wizard) fields stay non-clickable. Browse/Reset/disk-info/validation unchanged. Wording like "Install Directory" preserved.
- **`DetailSection.vue`** (legacy, still mounted by DetailModal) — browse-only path inputs and confirmed-path values become clickable.

## Notes

- The `StorageDirRow` boxed component is reused where its styling fits; brand-takeover, status-grid, and legacy layouts use an equivalent text-button pattern rather than forcing one component to grow modal-specific modes.
- The TrackModal venv field shows a venv **name** (not a full path) and is intentionally left as-is.

## Tests

Added/extended tests for `PathField`, `SettingsSectionList` (open-path emit, copy preserved, URL/date not openable), `InstallNamePath`, `InstallWizardModal`, `TrackModal`, and `DetailSection`.

`pnpm typecheck` / `lint` / `build` / `test` all green (2678 passing).