### PR TITLE
fix(templates): make picker thumbnail prefetch actually warm the cache

### DIFF
--- a/src/main/sources/standalone/index.test.ts
+++ b/src/main/sources/standalone/index.test.ts
@@ -16,6 +16,7 @@ vi.mock('../../lib/comfyui-releases', () => ({
 }))
 
 import { standalone, buildPinnedVariant } from './index'
+import { resetTemplateCatalogCache } from './templateCatalog'
 import { CURATED_TEMPLATES, NO_TEMPLATE_VALUE, INDEX_URL } from './curatedTemplates'
 import { fetchJSON } from '../../lib/fetch'
 import { getLatestStableTag } from '../../lib/comfyui-releases'
@@ -193,6 +194,11 @@ describe('standalone.buildInstallation', () => {
 // --- getFieldOptions('bundledTemplate') — curated + hydrated picker options ---
 
 describe('standalone.getFieldOptions bundledTemplate', () => {
+  beforeEach(() => {
+    mockedFetchJSON.mockReset()
+    resetTemplateCatalogCache()
+  })
+
   it('leads with the skip sentinel, then one option per curated template', async () => {
     mockedFetchJSON.mockResolvedValue([])
     const options = await standalone.getFieldOptions!('bundledTemplate', {}, {})

--- a/src/main/sources/standalone/templateCatalog.test.ts
+++ b/src/main/sources/standalone/templateCatalog.test.ts
@@ -220,4 +220,17 @@ describe('loadTemplateCatalog', () => {
     await loadTemplateCatalog()
     expect(mockedFetchJSON).toHaveBeenCalledTimes(2)
   })
+
+  it('refetches once the TTL lapses', async () => {
+    vi.useFakeTimers()
+    try {
+      mockedFetchJSON.mockResolvedValue([])
+      await loadTemplateCatalog()
+      vi.advanceTimersByTime(60_001)
+      await loadTemplateCatalog()
+      expect(mockedFetchJSON).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })

--- a/src/main/sources/standalone/templateCatalog.test.ts
+++ b/src/main/sources/standalone/templateCatalog.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 vi.mock('../../lib/fetch', () => ({ fetchJSON: vi.fn() }))
 
-import { loadTemplateCatalog } from './templateCatalog'
+import { loadTemplateCatalog, resetTemplateCatalogCache } from './templateCatalog'
 import {
   CURATED_TEMPLATES,
   TEMPLATE_MODALITY_ORDER,
@@ -24,7 +24,10 @@ function indexFor(overrides: Record<string, Record<string, unknown>>, category =
 }
 
 describe('loadTemplateCatalog', () => {
-  beforeEach(() => mockedFetchJSON.mockReset())
+  beforeEach(() => {
+    mockedFetchJSON.mockReset()
+    resetTemplateCatalogCache()
+  })
 
   it('returns every curated template, ordered by modality', async () => {
     mockedFetchJSON.mockResolvedValue([])
@@ -198,5 +201,23 @@ describe('loadTemplateCatalog', () => {
     for (const card of catalog) {
       expect(TEMPLATE_MODALITY_ORDER).toContain(card.modality)
     }
+  })
+
+  it('coalesces concurrent reads into a single index fetch', async () => {
+    mockedFetchJSON.mockResolvedValue([])
+    const [a, b] = await Promise.all([loadTemplateCatalog(), loadTemplateCatalog()])
+    expect(mockedFetchJSON).toHaveBeenCalledTimes(1)
+    expect(a).toBe(b)
+  })
+
+  it('serves a cached result on a follow-up read, then refetches after reset', async () => {
+    mockedFetchJSON.mockResolvedValue([])
+    await loadTemplateCatalog()
+    await loadTemplateCatalog()
+    expect(mockedFetchJSON).toHaveBeenCalledTimes(1)
+
+    resetTemplateCatalogCache()
+    await loadTemplateCatalog()
+    expect(mockedFetchJSON).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/main/sources/standalone/templateCatalog.ts
+++ b/src/main/sources/standalone/templateCatalog.ts
@@ -191,7 +191,35 @@ function byModalityOrder(a: HydratedTemplate, b: HydratedTemplate): number {
  * So renaming/removing a template upstream, or fat-fingering the manifest, can
  * only ever shrink the offering — it can't crash the picker.
  */
-export async function loadTemplateCatalog(): Promise<HydratedTemplate[]> {
+/** Coalesces the wizard's field-options read and the thumbnail warm-up — which
+ *  fire together at picker open — into one index fetch; a later open refetches. */
+const CATALOG_TTL_MS = 60_000
+let catalogInFlight: Promise<HydratedTemplate[]> | null = null
+let catalogCache: { at: number; value: HydratedTemplate[] } | null = null
+
+export function loadTemplateCatalog(): Promise<HydratedTemplate[]> {
+  if (catalogCache && Date.now() - catalogCache.at < CATALOG_TTL_MS) {
+    return Promise.resolve(catalogCache.value)
+  }
+  if (catalogInFlight) return catalogInFlight
+  catalogInFlight = loadTemplateCatalogUncached()
+    .then((value) => {
+      catalogCache = { at: Date.now(), value }
+      return value
+    })
+    .finally(() => {
+      catalogInFlight = null
+    })
+  return catalogInFlight
+}
+
+/** Drops the memoized catalog so the next read refetches. Test-only. */
+export function resetTemplateCatalogCache(): void {
+  catalogInFlight = null
+  catalogCache = null
+}
+
+async function loadTemplateCatalogUncached(): Promise<HydratedTemplate[]> {
   let byId: Map<string, IndexLocation>
   try {
     byId = indexById(await fetchJSON(INDEX_URL))

--- a/src/renderer/src/panel/PanelApp.test.ts
+++ b/src/renderer/src/panel/PanelApp.test.ts
@@ -308,6 +308,9 @@ function installMockApi(initial?: {
     closeHostWindow: vi.fn(async () => {}),
     focusComfyWindow: vi.fn(async () => {}),
     getListActions: vi.fn(async () => []),
+    // Picker thumbnail warm-up fetches the bundled-template options on the
+    // first-use cold-start path; returning users must never trigger it.
+    getFieldOptions: vi.fn(async () => []),
     openGlobalSettings: vi.fn(),
     openInstancePicker: vi.fn()
   }
@@ -516,6 +519,23 @@ describe('PanelApp', () => {
     await flushPromises()
     expect(wrapper.find('[data-testid="first-use-takeover"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="chooser-view"]').exists()).toBe(false)
+  })
+
+  it('warms picker thumbnails on the first-use cold-start path', async () => {
+    mockState.settings.firstUseCompleted = false
+    window.history.replaceState({}, '', '/?panel=chooser')
+    mountPanel()
+    await flushPromises()
+    const api = (window as unknown as { api: { getFieldOptions: ReturnType<typeof vi.fn> } }).api
+    expect(api.getFieldOptions).toHaveBeenCalledWith('standalone', 'bundledTemplate', {}, {})
+  })
+
+  it('does NOT warm picker thumbnails for returning users', async () => {
+    window.history.replaceState({}, '', '/?panel=chooser&firstUseCompleted=true')
+    mountPanel()
+    await flushPromises()
+    const api = (window as unknown as { api: { getFieldOptions: ReturnType<typeof vi.fn> } }).api
+    expect(api.getFieldOptions).not.toHaveBeenCalled()
   })
 
   it('marks firstUseCompleted=true and closes the takeover on Cloud-branch pick', async () => {

--- a/src/renderer/src/panel/PanelApp.test.ts
+++ b/src/renderer/src/panel/PanelApp.test.ts
@@ -527,6 +527,7 @@ describe('PanelApp', () => {
     mountPanel()
     await flushPromises()
     const api = (window as unknown as { api: { getFieldOptions: ReturnType<typeof vi.fn> } }).api
+    expect(api.getFieldOptions).toHaveBeenCalledTimes(1)
     expect(api.getFieldOptions).toHaveBeenCalledWith('standalone', 'bundledTemplate', {}, {})
   })
 

--- a/src/renderer/src/panel/PanelApp.vue
+++ b/src/renderer/src/panel/PanelApp.vue
@@ -471,6 +471,8 @@ onMounted(async () => {
       (!urlFirstUseCompleted && (!launcherPrefsLoaded.value || !firstUseCompleted.value))
 
     if (shouldOpenFirstUse && !isFlowPanel(initialPanel)) {
+      // Warm before opening so the prefetch queue is pumping as the picker mounts.
+      void warmTemplateThumbnails()
       void openFirstUseTakeover()
     }
 

--- a/src/renderer/src/panel/PanelApp.vue
+++ b/src/renderer/src/panel/PanelApp.vue
@@ -158,13 +158,14 @@ const {
   switchPanel
 } = overlays
 
-// Warm picker thumbnails during idle so the install wizard shows images, not
-// loaders; defers while an instance/overlay is active so it never competes.
+// Defers only for a running instance, not an open overlay — the picker lives
+// inside the new-install takeover, which is exactly when we want it warm.
 const { prefetch: prefetchThumbnails } = useThumbnailPrefetch({
-  isBusy: () => sessionStore.runningTabCount > 0 || currentOverlay.value !== null
+  isBusy: () => sessionStore.runningTabCount > 0
 })
 
 async function warmTemplateThumbnails(): Promise<void> {
+  if (firstUseCompleted.value) return
   try {
     const options = await window.api.getFieldOptions('standalone', 'bundledTemplate', {}, {})
     prefetchThumbnails(
@@ -497,6 +498,8 @@ onMounted(async () => {
     // `firstUseCompleted` stays false until the explicit completion
     // path runs.
     if (!firstUseCompleted.value && !isFlowPanel(initialPanel)) {
+      // Warm before opening so the prefetch queue is pumping as the picker mounts.
+      void warmTemplateThumbnails()
       void openFirstUseTakeover()
     }
   } catch (err) {
@@ -508,8 +511,6 @@ onMounted(async () => {
     // after a partial-bootstrap failure.
     resolveBootstrap?.()
     resolveBootstrap = null
-    // Fire-and-forget after the panel is interactive; self-defers when busy.
-    void warmTemplateThumbnails()
   }
 })
 

--- a/src/renderer/src/panel/PanelApp.vue
+++ b/src/renderer/src/panel/PanelApp.vue
@@ -164,19 +164,24 @@ const { prefetch: prefetchThumbnails } = useThumbnailPrefetch({
   isBusy: () => sessionStore.runningTabCount > 0
 })
 
-async function warmTemplateThumbnails(): Promise<void> {
-  if (firstUseCompleted.value) return
-  try {
-    const options = await window.api.getFieldOptions('standalone', 'bundledTemplate', {}, {})
-    prefetchThumbnails(
-      options.map((o) => {
-        const url = o.data?.thumbnailUrl
-        return typeof url === 'string' ? url : null
-      })
-    )
-  } catch {
-    // Best-effort warm-up; the picker still loads thumbnails on demand.
-  }
+let warmTemplateThumbnailsOnce: Promise<void> | null = null
+function warmTemplateThumbnails(): Promise<void> {
+  if (firstUseCompleted.value) return Promise.resolve()
+  // Both first-use branches can reach this on one cold start; warm just once.
+  warmTemplateThumbnailsOnce ??= (async () => {
+    try {
+      const options = await window.api.getFieldOptions('standalone', 'bundledTemplate', {}, {})
+      prefetchThumbnails(
+        options.map((o) => {
+          const url = o.data?.thumbnailUrl
+          return typeof url === 'string' ? url : null
+        })
+      )
+    } catch {
+      // Best-effort warm-up; the picker still loads thumbnails on demand.
+    }
+  })()
+  return warmTemplateThumbnailsOnce
 }
 
 // E2E surface: tests drive UI-level flows (e.g. inject a finished


### PR DESCRIPTION
## Summary

Makes the starter-template picker thumbnails load instantly by fixing the idle prefetch so it actually warms the HTTP cache before the picker renders.

## Changes

- Prefetch now defers only for a running instance, not an open overlay — the picker lives inside the new-install takeover, which is exactly when we want its thumbnails warming.
- Warm-up fires before the takeover opens (gated on first-use), so the queue is pumping as the picker mounts.
- Memoized `loadTemplateCatalog()` (in-flight dedupe + 60s TTL) so the warm-up and the wizard share one index fetch instead of two — also speeds the wizard itself.

## Testing

- Added catalog coalescing + cache-then-refetch coverage; `useThumbnailPrefetch` tests unchanged. 29 pass.
- Manual: in the fresh-install flow with Network throttled, thumbnails serve from cache when the picker renders and the index is fetched once.
