### PR TITLE
feat(telemetry): tag events with client + deployment platform axes

### DIFF
--- a/src/main/lib/cloudEntry.ts
+++ b/src/main/lib/cloudEntry.ts
@@ -58,7 +58,10 @@ export function noteCloudEntered(): void {
     markCloudEntered()
     telemetry.registerPersonProperties({ has_launched_cloud: true })
   }
-  telemetry.emit('comfy.desktop.cloud.entered', { first_time: firstTime, deployment: 'cloud' })
+  telemetry.emit('comfy.desktop.cloud.entered', {
+    first_time: firstTime,
+    deployment: 'cloud' satisfies telemetry.Deployment
+  })
 }
 
 /** @internal — exposed for tests. */

--- a/src/main/lib/cloudEntry.ts
+++ b/src/main/lib/cloudEntry.ts
@@ -58,7 +58,7 @@ export function noteCloudEntered(): void {
     markCloudEntered()
     telemetry.registerPersonProperties({ has_launched_cloud: true })
   }
-  telemetry.emit('comfy.desktop.cloud.entered', { first_time: firstTime })
+  telemetry.emit('comfy.desktop.cloud.entered', { first_time: firstTime, deployment: 'cloud' })
 }
 
 /** @internal — exposed for tests. */

--- a/src/main/lib/executionTap.ts
+++ b/src/main/lib/executionTap.ts
@@ -91,7 +91,7 @@ export function createExecutionTap(opts: {
     // The tap tails a locally-spawned ComfyUI process, so every event it
     // emits is local execution by construction. Cloud executions never pass
     // through here — the cloud frontend/backend report those directly.
-    deployment: 'local'
+    deployment: 'local' satisfies telemetry.Deployment
   }
 
   function pushPromptStart(): void {

--- a/src/main/lib/executionTap.ts
+++ b/src/main/lib/executionTap.ts
@@ -87,7 +87,11 @@ export function createExecutionTap(opts: {
   const baseContext = {
     installation_id: state.installationId,
     variant: state.variant,
-    release: state.release
+    release: state.release,
+    // The tap tails a locally-spawned ComfyUI process, so every event it
+    // emits is local execution by construction. Cloud executions never pass
+    // through here — the cloud frontend/backend report those directly.
+    deployment: 'local'
   }
 
   function pushPromptStart(): void {

--- a/src/main/lib/ipc/registerTelemetryHandlers.test.ts
+++ b/src/main/lib/ipc/registerTelemetryHandlers.test.ts
@@ -24,6 +24,9 @@ vi.mock('../../host/registry', () => ({
 }))
 
 vi.mock('../telemetry', () => ({
+  // Real (pure) narrowing logic, mirrored here because importOriginal would
+  // pull in telemetry.ts's electron/posthog-node imports under the stub mock.
+  asDeployment: (v: unknown) => (v === 'local' || v === 'cloud' || v === 'remote' ? v : null),
   bindUserId: mocks.bindUserId,
   capture: mocks.capture,
   captureException: mocks.captureException,
@@ -206,5 +209,31 @@ describe('registerTelemetryHandlers', () => {
 
     const sent = mocks.capture.mock.calls[0]![1] as Record<string, unknown>
     expect(sent.deployment).toBeUndefined()
+  })
+
+  it('strips an invalid payload deployment even from non-comfyView senders', () => {
+    mocks.findEntryByComfySender.mockReturnValue(null)
+
+    listener('telemetry:capture')(
+      { sender: { id: 7 } },
+      { event: 'popout.event', properties: { deployment: 'banana' } }
+    )
+
+    const sent = mocks.capture.mock.calls[0]![1] as Record<string, unknown>
+    expect(sent.deployment).toBeUndefined()
+  })
+
+  it('applies the same platform-axes handling to relayed exceptions', () => {
+    mocks.findEntryByComfySender.mockReturnValue({ sourceCategory: 'local' })
+
+    listener('telemetry:captureException')(
+      { sender: { id: 8 } },
+      { message: 'boom', properties: { client: 'web', deployment: 'cloud' } }
+    )
+
+    const [err, sent] = mocks.captureException.mock.calls[0]! as [Error, Record<string, unknown>]
+    expect(err.message).toBe('boom')
+    expect(sent.deployment).toBe('local')
+    expect(sent.client).toBeUndefined()
   })
 })

--- a/src/main/lib/ipc/registerTelemetryHandlers.test.ts
+++ b/src/main/lib/ipc/registerTelemetryHandlers.test.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => ({
   bindUserId: vi.fn(),
   capture: vi.fn(),
   captureException: vi.fn(),
+  findEntryByComfySender: vi.fn(),
   getFlag: vi.fn(),
   handle: vi.fn(),
   on: vi.fn(),
@@ -16,6 +17,10 @@ vi.mock('electron', () => ({
     handle: mocks.handle,
     on: mocks.on
   }
+}))
+
+vi.mock('../../host/registry', () => ({
+  findEntryByComfySender: mocks.findEntryByComfySender
 }))
 
 vi.mock('../telemetry', () => ({
@@ -132,5 +137,46 @@ describe('registerTelemetryHandlers', () => {
     expect(sent.blob_json).toBe('j'.repeat(2048))
     expect(sent.key_124).toBe(124)
     expect(sent.key_125).toBeUndefined()
+  })
+
+  it('tags relayed events with the deployment of the sender comfyView install', () => {
+    const sender = { id: 1 }
+    mocks.findEntryByComfySender.mockReturnValue({ sourceCategory: 'cloud' })
+
+    listener('telemetry:capture')({ sender }, { event: 'execution_start', properties: { a: 1 } })
+
+    expect(mocks.findEntryByComfySender).toHaveBeenCalledWith(sender)
+    const sent = mocks.capture.mock.calls[0]![1] as Record<string, unknown>
+    expect(sent).toEqual({ deployment: 'cloud', a: 1 })
+  })
+
+  it('leaves events untagged when the sender is not an attached comfyView', () => {
+    mocks.findEntryByComfySender.mockReturnValue(null)
+
+    listener('telemetry:capture')({ sender: { id: 2 } }, { event: 'launcher.click', properties: {} })
+
+    const sent = mocks.capture.mock.calls[0]![1] as Record<string, unknown>
+    expect(sent.deployment).toBeUndefined()
+  })
+
+  it('lets an explicit payload deployment win over the sender-derived tag', () => {
+    mocks.findEntryByComfySender.mockReturnValue({ sourceCategory: 'local' })
+
+    listener('telemetry:capture')(
+      { sender: { id: 3 } },
+      { event: 'execution_start', properties: { deployment: 'cloud' } }
+    )
+
+    const sent = mocks.capture.mock.calls[0]![1] as Record<string, unknown>
+    expect(sent.deployment).toBe('cloud')
+  })
+
+  it('ignores unknown source categories rather than emitting a junk tag', () => {
+    mocks.findEntryByComfySender.mockReturnValue({ sourceCategory: null })
+
+    listener('telemetry:capture')({ sender: { id: 4 } }, { event: 'execution_start', properties: {} })
+
+    const sent = mocks.capture.mock.calls[0]![1] as Record<string, unknown>
+    expect(sent.deployment).toBeUndefined()
   })
 })

--- a/src/main/lib/ipc/registerTelemetryHandlers.test.ts
+++ b/src/main/lib/ipc/registerTelemetryHandlers.test.ts
@@ -159,7 +159,10 @@ describe('registerTelemetryHandlers', () => {
     expect(sent.deployment).toBeUndefined()
   })
 
-  it('lets an explicit payload deployment win over the sender-derived tag', () => {
+  it('overwrites a payload deployment with the sender-derived value', () => {
+    // A hosted frontend may forward stale posthog-js super properties (e.g. a
+    // cloud bundle's deployment=cloud) — main's attachment lookup is the
+    // ground truth for which install actually emitted the event.
     mocks.findEntryByComfySender.mockReturnValue({ sourceCategory: 'local' })
 
     listener('telemetry:capture')(
@@ -168,7 +171,32 @@ describe('registerTelemetryHandlers', () => {
     )
 
     const sent = mocks.capture.mock.calls[0]![1] as Record<string, unknown>
-    expect(sent.deployment).toBe('cloud')
+    expect(sent.deployment).toBe('local')
+  })
+
+  it('keeps a payload deployment when the sender is not an attached comfyView', () => {
+    mocks.findEntryByComfySender.mockReturnValue(null)
+
+    listener('telemetry:capture')(
+      { sender: { id: 5 } },
+      { event: 'popout.event', properties: { deployment: 'local' } }
+    )
+
+    const sent = mocks.capture.mock.calls[0]![1] as Record<string, unknown>
+    expect(sent.deployment).toBe('local')
+  })
+
+  it('strips a payload client so the SDK default (desktop) applies', () => {
+    mocks.findEntryByComfySender.mockReturnValue(null)
+
+    listener('telemetry:capture')(
+      { sender: { id: 6 } },
+      { event: 'execution_start', properties: { client: 'web', a: 1 } }
+    )
+
+    const sent = mocks.capture.mock.calls[0]![1] as Record<string, unknown>
+    expect(sent.client).toBeUndefined()
+    expect(sent.a).toBe(1)
   })
 
   it('ignores unknown source categories rather than emitting a junk tag', () => {

--- a/src/main/lib/ipc/registerTelemetryHandlers.ts
+++ b/src/main/lib/ipc/registerTelemetryHandlers.ts
@@ -121,14 +121,24 @@ function asPersonProps(value: unknown): Record<string, mainTelemetry.TelemetryVa
 }
 
 /**
- * `deployment` tag for relayed events, resolved from the SENDER rather than
- * trusted from the payload: a hosted ComfyUI frontend doesn't know (and
- * shouldn't have to know) whether its install is local, cloud, or remote,
- * but main does — via the comfyView → install attachment. Per-sender (not a
- * process-global default) so two windows in different modes tag correctly.
- * Launcher-UI senders have no comfyView entry and stay untagged — their
- * events are app-level, not deployment-scoped. A `deployment` already
- * present in the payload wins (see the merge order at the call sites).
+ * Platform axes (`client` / `deployment`) for relayed events are
+ * HOST-AUTHORITATIVE, never trusted from the payload:
+ *
+ * - `client` is stripped from every relayed payload so the SDK default
+ *   ('desktop') applies. Anything arriving over this IPC channel was by
+ *   definition emitted from inside the desktop app — but a hosted frontend
+ *   bundle that also runs in a browser (the cloud frontend) registers
+ *   `client` as a posthog-js super property, and if a future EventSink-style
+ *   tap ever forwards posthog-js state through the bridge, its value
+ *   ('web') would be wrong here.
+ * - `deployment` is resolved from the SENDER: a hosted ComfyUI frontend
+ *   doesn't know (and shouldn't have to know) whether its install is local,
+ *   cloud, or remote, but main does — via the comfyView → install
+ *   attachment. Per-sender (not a process-global default) so two windows in
+ *   different modes tag correctly. When the sender resolves, its value
+ *   overwrites any payload `deployment` for the same reason as `client`.
+ *   Launcher-UI senders have no comfyView entry and stay untagged — their
+ *   events are app-level, not deployment-scoped.
  */
 function deploymentForSender(sender: WebContents | undefined): string | null {
   if (!sender) return null
@@ -136,20 +146,21 @@ function deploymentForSender(sender: WebContents | undefined): string | null {
   return category === 'local' || category === 'cloud' || category === 'remote' ? category : null
 }
 
-function withDeployment(
+function withPlatformAxes(
   properties: mainTelemetry.TelemetryContext,
   sender: WebContents | undefined
 ): mainTelemetry.TelemetryContext {
+  delete properties['client']
   const deployment = deploymentForSender(sender)
   if (deployment === null) return properties
-  return { deployment, ...properties }
+  return { ...properties, deployment }
 }
 
 export function registerTelemetryHandlers(): void {
   ipcMain.on('telemetry:capture', (event, payload: CapturePayload) => {
     const eventName = asString(payload?.event)
     if (!eventName) return
-    mainTelemetry.capture(eventName, withDeployment(asProps(payload.properties), event?.sender))
+    mainTelemetry.capture(eventName, withPlatformAxes(asProps(payload.properties), event?.sender))
   })
 
   ipcMain.on('telemetry:captureException', (event, payload: CaptureExceptionPayload) => {
@@ -157,7 +168,10 @@ export function registerTelemetryHandlers(): void {
     const stackStr = asString(payload?.stack) ?? undefined
     const err = new Error(message)
     if (stackStr) err.stack = stackStr
-    mainTelemetry.captureException(err, withDeployment(asProps(payload?.properties), event?.sender))
+    mainTelemetry.captureException(
+      err,
+      withPlatformAxes(asProps(payload?.properties), event?.sender)
+    )
   })
 
   ipcMain.on('telemetry:registerProperties', (_event, properties: unknown) => {

--- a/src/main/lib/ipc/registerTelemetryHandlers.ts
+++ b/src/main/lib/ipc/registerTelemetryHandlers.ts
@@ -140,10 +140,9 @@ function asPersonProps(value: unknown): Record<string, mainTelemetry.TelemetryVa
  *   Launcher-UI senders have no comfyView entry and stay untagged — their
  *   events are app-level, not deployment-scoped.
  */
-function deploymentForSender(sender: WebContents | undefined): string | null {
+function deploymentForSender(sender: WebContents | undefined): mainTelemetry.Deployment | null {
   if (!sender) return null
-  const category = findEntryByComfySender(sender)?.sourceCategory
-  return category === 'local' || category === 'cloud' || category === 'remote' ? category : null
+  return mainTelemetry.asDeployment(findEntryByComfySender(sender)?.sourceCategory)
 }
 
 function withPlatformAxes(
@@ -152,8 +151,13 @@ function withPlatformAxes(
 ): mainTelemetry.TelemetryContext {
   delete properties['client']
   const deployment = deploymentForSender(sender)
-  if (deployment === null) return properties
-  return { ...properties, deployment }
+  if (deployment !== null) return { ...properties, deployment }
+  // Unknown sender (launcher UI, popouts): a payload deployment may pass
+  // through, but only if it's a valid axis value — junk is stripped.
+  if (mainTelemetry.asDeployment(properties['deployment']) === null) {
+    delete properties['deployment']
+  }
+  return properties
 }
 
 export function registerTelemetryHandlers(): void {

--- a/src/main/lib/ipc/registerTelemetryHandlers.ts
+++ b/src/main/lib/ipc/registerTelemetryHandlers.ts
@@ -1,7 +1,8 @@
 // IPC for renderer-originated telemetry: the renderer routes through main so
 // identity, consent, and dedup live in one place. Capture messages are
 // fire-and-forget (ipcMain.on).
-import { ipcMain } from 'electron'
+import { ipcMain, type WebContents } from 'electron'
+import { findEntryByComfySender } from '../../host/registry'
 import * as mainTelemetry from '../telemetry'
 import {
   getFlagAsync as getExperimentFlagAsync,
@@ -119,19 +120,44 @@ function asPersonProps(value: unknown): Record<string, mainTelemetry.TelemetryVa
   return asTelemetryObject(value, false, false)
 }
 
+/**
+ * `deployment` tag for relayed events, resolved from the SENDER rather than
+ * trusted from the payload: a hosted ComfyUI frontend doesn't know (and
+ * shouldn't have to know) whether its install is local, cloud, or remote,
+ * but main does — via the comfyView → install attachment. Per-sender (not a
+ * process-global default) so two windows in different modes tag correctly.
+ * Launcher-UI senders have no comfyView entry and stay untagged — their
+ * events are app-level, not deployment-scoped. A `deployment` already
+ * present in the payload wins (see the merge order at the call sites).
+ */
+function deploymentForSender(sender: WebContents | undefined): string | null {
+  if (!sender) return null
+  const category = findEntryByComfySender(sender)?.sourceCategory
+  return category === 'local' || category === 'cloud' || category === 'remote' ? category : null
+}
+
+function withDeployment(
+  properties: mainTelemetry.TelemetryContext,
+  sender: WebContents | undefined
+): mainTelemetry.TelemetryContext {
+  const deployment = deploymentForSender(sender)
+  if (deployment === null) return properties
+  return { deployment, ...properties }
+}
+
 export function registerTelemetryHandlers(): void {
-  ipcMain.on('telemetry:capture', (_event, payload: CapturePayload) => {
+  ipcMain.on('telemetry:capture', (event, payload: CapturePayload) => {
     const eventName = asString(payload?.event)
     if (!eventName) return
-    mainTelemetry.capture(eventName, asProps(payload.properties))
+    mainTelemetry.capture(eventName, withDeployment(asProps(payload.properties), event?.sender))
   })
 
-  ipcMain.on('telemetry:captureException', (_event, payload: CaptureExceptionPayload) => {
+  ipcMain.on('telemetry:captureException', (event, payload: CaptureExceptionPayload) => {
     const message = asString(payload?.message) ?? 'Unknown renderer error'
     const stackStr = asString(payload?.stack) ?? undefined
     const err = new Error(message)
     if (stackStr) err.stack = stackStr
-    mainTelemetry.captureException(err, asProps(payload?.properties))
+    mainTelemetry.captureException(err, withDeployment(asProps(payload?.properties), event?.sender))
   })
 
   ipcMain.on('telemetry:registerProperties', (_event, properties: unknown) => {

--- a/src/main/lib/ipc/sessionStartTelemetry.ts
+++ b/src/main/lib/ipc/sessionStartTelemetry.ts
@@ -119,10 +119,10 @@ export async function emitInstanceStartedTelemetry(info: InstanceStartedInfo): P
     // one release cycle so existing dashboards survive migration (issue #1054).
     const instanceStartedProps = {
       ...(metadata as Record<string, string | number | boolean | null | undefined>),
-      // local | cloud | remote, derived from the install's source plugin —
-      // the cross-surface axis analysts filter on (paired with `client`,
-      // which the telemetry defaults pin to 'desktop' for this pipe).
-      deployment: sourceMap[ctx.source_id]?.category ?? null,
+      // The cross-surface axis analysts filter on (paired with `client`,
+      // which the telemetry defaults pin to 'desktop'). Narrowed through
+      // asDeployment since a source plugin's category is an open string.
+      deployment: telemetry.asDeployment(sourceMap[ctx.source_id]?.category),
       boot_time_ms: info.bootTimeMs ?? null,
       port_retries: info.portRetries,
       reboot_retries: info.rebootRetries,

--- a/src/main/lib/ipc/sessionStartTelemetry.ts
+++ b/src/main/lib/ipc/sessionStartTelemetry.ts
@@ -6,7 +6,7 @@
  * renderer callbacks frequently never ran. Same event names/shapes as before.
  */
 import * as telemetry from '../telemetry'
-import { buildInstallationDdContext } from './shared'
+import { buildInstallationDdContext, sourceMap } from './shared'
 import { scrubAll } from '../../../shared/piiScrub'
 
 // Mirror the bridge's large-`_json` ceiling: ship intact or omit + flag
@@ -119,6 +119,10 @@ export async function emitInstanceStartedTelemetry(info: InstanceStartedInfo): P
     // one release cycle so existing dashboards survive migration (issue #1054).
     const instanceStartedProps = {
       ...(metadata as Record<string, string | number | boolean | null | undefined>),
+      // local | cloud | remote, derived from the install's source plugin —
+      // the cross-surface axis analysts filter on (paired with `client`,
+      // which the telemetry defaults pin to 'desktop' for this pipe).
+      deployment: sourceMap[ctx.source_id]?.category ?? null,
       boot_time_ms: info.bootTimeMs ?? null,
       port_retries: info.portRetries,
       reboot_retries: info.rebootRetries,

--- a/src/main/lib/telemetry.test.ts
+++ b/src/main/lib/telemetry.test.ts
@@ -226,7 +226,7 @@ describe('telemetry default event properties', () => {
     telemetry._resetForTest()
   })
 
-  it('injects app_version, app_channel, app_env, platform, arch on every capture', () => {
+  it('injects app_version, app_channel, app_env, platform, arch, client on every capture', () => {
     telemetry.initTelemetry({ appVersion: '0.7.0-beta.3', appEnv: 'prod', isPackaged: true })
     telemetry.identify('id')
     telemetry.setConsentState('granted')
@@ -242,7 +242,8 @@ describe('telemetry default event properties', () => {
       app_env: 'prod',
       is_packaged: true,
       platform: process.platform,
-      arch: process.arch
+      arch: process.arch,
+      client: 'desktop'
     })
   })
 

--- a/src/main/lib/telemetry.test.ts
+++ b/src/main/lib/telemetry.test.ts
@@ -274,6 +274,22 @@ describe('telemetry default event properties', () => {
     expect(captured[0]!.properties).toMatchObject({ app_version: 'override-value' })
   })
 
+  it('merges the same defaults into captureException payloads', () => {
+    telemetry.initTelemetry({ appVersion: '1.0.0', appEnv: 'prod', isPackaged: true })
+    telemetry.identify('id')
+    telemetry.setConsentState('granted')
+    exceptions.length = 0
+
+    telemetry.captureException(new Error('boom'), { foo: 'bar' })
+
+    expect(exceptions).toHaveLength(1)
+    expect(exceptions[0]!.properties).toMatchObject({
+      foo: 'bar',
+      app_version: '1.0.0',
+      client: 'desktop'
+    })
+  })
+
   it('stamps installation_id (the bound device id) on every captured event', () => {
     telemetry.initTelemetry({ appVersion: '1.0.0', appEnv: 'prod', isPackaged: true })
     telemetry.identify('install-abc123')

--- a/src/main/lib/telemetry.ts
+++ b/src/main/lib/telemetry.ts
@@ -216,7 +216,8 @@ function canEmit(): boolean {
 /**
  * Default properties merged into every `capture()` payload. Seeded at
  * `initTelemetry()` time from `InitOptions` with `app_version`,
- * `app_channel`, `app_env`, `platform`, `arch`, and `is_packaged` so
+ * `app_channel`, `app_env`, `platform`, `arch`, `is_packaged`, and
+ * `client` so
  * per-event filters / breakdowns work without a join against the person
  * profile (PostHog person properties are joined at query time and are
  * point-in-time as of write — releasing a new app version while the user
@@ -464,7 +465,13 @@ export function initTelemetry(opts: InitOptions): void {
     app_env: opts.appEnv,
     is_packaged: opts.isPackaged,
     platform: process.platform,
-    arch: process.arch
+    arch: process.arch,
+    // Cross-surface analytics axis shared with the cloud frontend and CLI:
+    // `client` says which surface emitted the event (desktop | web | cli),
+    // `deployment` (attached per-event where known) says which backend ran
+    // the work (local | cloud | remote). Everything through this pipe is by
+    // definition the desktop app.
+    client: 'desktop'
   }
 
   // Suppress event capture on unpackaged (developer / `pnpm dev`) runs.

--- a/src/main/lib/telemetry.ts
+++ b/src/main/lib/telemetry.ts
@@ -231,6 +231,20 @@ function canEmit(): boolean {
 let defaultEventProperties: Record<string, TelemetryValue> = {}
 
 /**
+ * The `deployment` analytics axis: which backend ran the work. Paired with
+ * the `client` default event property (desktop | web | cli) to identify the
+ * product surface (MAR-51). Shared by every site that tags `deployment` so
+ * the enum can't drift.
+ */
+export type Deployment = 'local' | 'cloud' | 'remote'
+
+/** Narrow an untrusted value (payload property, source-plugin category) to a
+ *  valid `Deployment`, or `null` — never let junk reach the shared axis. */
+export function asDeployment(value: unknown): Deployment | null {
+  return value === 'local' || value === 'cloud' || value === 'remote' ? value : null
+}
+
+/**
  * Coarse release-channel classification derived from a semver-ish
  * `appVersion`. `-beta` / `-canary` / `-alpha` markers map to their
  * channel; a missing suffix is `stable`; an unrecognised suffix is
@@ -466,11 +480,8 @@ export function initTelemetry(opts: InitOptions): void {
     is_packaged: opts.isPackaged,
     platform: process.platform,
     arch: process.arch,
-    // Cross-surface analytics axis shared with the cloud frontend and CLI:
-    // `client` says which surface emitted the event (desktop | web | cli),
-    // `deployment` (attached per-event where known) says which backend ran
-    // the work (local | cloud | remote). Everything through this pipe is by
-    // definition the desktop app.
+    // Cross-surface analytics axis (MAR-51); this pipe is always the desktop
+    // app. `deployment` (see the `Deployment` type) is its per-event pair.
     client: 'desktop'
   }
 
@@ -978,7 +989,9 @@ export function captureException(error: unknown, properties: TelemetryContext = 
   // Exceptions are reliability data; suppress them outside `'granted'`.
   if (consentState !== 'granted') return
   try {
-    client!.captureException(error, distinctId, properties)
+    // Same default merge as capture() so exception events stay filterable by
+    // the shared axes (app_version, client, ...) instead of arriving bare.
+    client!.captureException(error, distinctId, { ...defaultEventProperties, ...properties })
   } catch {
     // ignore
   }


### PR DESCRIPTION
## Problem

Filtering PostHog for the three product surfaces — **desktop local**, **desktop cloud**, **web cloud** — currently requires a different hack per pipe:

| Surface | Only way to filter today |
|---|---|
| Desktop local | `$lib = 'posthog-node'` + guessing |
| Desktop cloud | `$lib = 'web'` + `Electron` substring in `$raw_user_agent` |
| Web cloud | `$lib = 'web'` + *not* Electron |

The server-side `environment` property (from the X-Comfy-Env header work) conflates two independent axes — which surface the user is on vs. where execution happens — which is why its values sprawled (`local-desktop2-standalone`, `local-git`, `local-portable`, …).

## Change

Standardize two orthogonal event properties on the desktop pipe:

- **`client`** — which surface emitted the event: `desktop | web | cli`. Pinned to `'desktop'` in the default event properties (`telemetry.ts`), so every event routed through the main-process PostHog client carries it, including frontend events relayed over IPC.
- **`deployment`** — which backend ran the work: `local | cloud | remote`. Attached wherever the main process knows it:
  - **Relayed frontend/renderer events** (`registerTelemetryHandlers.ts`): resolve the sender `webContents` → attached install → source category. Per-sender rather than a process-global default, so two windows in different modes tag correctly. Launcher-UI events stay untagged — they're app-level, not deployment-scoped. An explicit `deployment` in the payload wins.
  - **`executionTap` events**: `'local'` by construction (the tap tails a locally-spawned ComfyUI process).
  - **`session.instance_started`**: derived from the install's source plugin category.
  - **`cloud.entered`**: `'cloud'`.

The three platforms then fall out as clean property filters: `client=desktop, deployment=local` / `client=desktop, deployment=cloud` / `client=web, deployment=cloud`.

## Companion work (other repos, not this PR)

- Cloud frontend: `posthog.register({ client: isElectron ? 'desktop' : 'web', deployment: 'cloud' })` — replaces UA sniffing for desktop-cloud vs web-cloud.
- Cloud backend: map `X-Comfy-Env` values onto the same enum and forward the client's `client` value.

## Testing

- `vitest run` on the three touched test files — 102 passing, including new coverage for sender-derived tagging (comfyView sender → tagged, launcher sender → untagged, explicit payload wins, unknown category → no junk tag).
- Full `pnpm typecheck` + `pnpm lint` (pre-commit hook).

Ref [MAR-51](https://linear.app/comfyorg/issue/MAR-51/foundation-desktop-sdk-dual-send-to-posthog-alongside-mixpanel)

## Update: platform axes are host-authoritative for relayed events

Review question (Ben): could a hosted frontend's posthog-js super properties (e.g. the cloud bundle's `deployment: 'cloud'`) ride along in bridge-forwarded events and mislabel local-desktop traffic?

Today, no — `HostTelemetrySink` forwards only the explicit per-event metadata; posthog-js super properties never cross the bridge. But the original merge order here trusted a payload `deployment`/`client` over the sender-derived values, which would become wrong if a future EventSink-style tap forwards posthog-js state. Hardened so main is the ground truth for relayed events:

- `deployment`: the sender-derived value now **overwrites** any payload value when the sender resolves to an attached comfyView (payload survives only for non-comfyView senders like popouts).
- `client`: stripped from every relayed payload so the SDK default (`'desktop'`) applies — anything arriving on this IPC channel was emitted from inside the app.
