### PR TITLE
Telemetry: standardize error events (matched error, class, normalized signature; stderr tail for boot_failed)

### DIFF
--- a/src/main/auth/firebaseBridge/index.ts
+++ b/src/main/auth/firebaseBridge/index.ts
@@ -12,6 +12,7 @@ import { extractProviderId, type SupportedProvider } from './intercept'
 import { startBridgeServer } from './server'
 import * as i18n from '../../lib/i18n'
 import * as mainTelemetry from '../../lib/telemetry'
+import { extractErrorClass } from '../../../shared/errorEvent'
 
 /**
  * Tie the anonymous `installation_id` to the signed-in user so PostHog
@@ -249,9 +250,12 @@ export async function handleFirebasePopup(
     const error = err instanceof Error ? err : new Error(String(err))
     // Mirrored to Datadog (allow-list) so ops can alert if sign-in
     // breaks for a provider. error_bucket keeps the dashboard low-
-    // cardinality; the raw message stays out (may carry tokens / URLs).
+    // cardinality; error_class adds a locale-independent type for grouping.
+    // The raw message stays out by design (may carry tokens / URLs), so we
+    // deliberately do NOT ship `error_message` / `error_signature` here.
     mainTelemetry.emit('comfy.desktop.auth.sign_in_failed', {
       provider: providerId,
+      error_class: extractErrorClass(error),
       error_bucket: mainTelemetry.bucketError(error.message)
     })
     opts.onError?.(error)

--- a/src/main/lib/cnr.ts
+++ b/src/main/lib/cnr.ts
@@ -5,6 +5,7 @@ import { fetchJSON } from './fetch'
 import { download } from './download'
 import { extract } from './extract'
 import * as telemetry from './telemetry'
+import { buildErrorFields } from '../../shared/errorEvent'
 
 interface CnrInstallInfo {
   downloadUrl: string
@@ -110,15 +111,13 @@ export async function installCnrNode(
       } catch {}
     }
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err)
     telemetry.capture('comfy.desktop.node.installed', {
       node_id: nodeId,
       version: resolvedVersion,
       action: 'install',
       result: 'failure',
       duration_ms: Date.now() - startedAt,
-      error_bucket: telemetry.bucketError(message),
-      error_message: message.slice(0, 500)
+      ...buildErrorFields(err)
     })
     throw err
   }
@@ -215,15 +214,13 @@ export async function switchCnrVersion(
       try { await fs.promises.rm(tmpExtract, { recursive: true, force: true }) } catch {}
     }
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err)
     telemetry.capture('comfy.desktop.node.installed', {
       node_id: nodeId,
       version: resolvedVersion,
       action: 'switch',
       result: 'failure',
       duration_ms: Date.now() - startedAt,
-      error_bucket: telemetry.bucketError(message),
-      error_message: message.slice(0, 500)
+      ...buildErrorFields(err)
     })
     throw err
   }

--- a/src/main/lib/desktopAdopt.ts
+++ b/src/main/lib/desktopAdopt.ts
@@ -27,7 +27,7 @@ import * as installations from '../installations'
 import type { InstallationRecord } from '../installations'
 import * as settings from '../settings'
 import * as telemetry from './telemetry'
-import { scrubAll } from '../../shared/piiScrub'
+import { buildErrorFields } from '../../shared/errorEvent'
 import * as i18n from './i18n'
 import {
   KNOWN_MODEL_FOLDERS,
@@ -1012,15 +1012,9 @@ export async function adoptDesktopInstall(opts: AdoptOptions): Promise<Installat
     const result = await runAdoption(info, phaseAwareTools, deps)
     return result
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err)
-    // Scrub before slice so the redacted prefix doesn't get truncated
-    // mid-token. The bucket runs on raw text because its regexes don't
-    // care about user paths and would otherwise miss a legitimate match
-    // hidden inside a `[REDACTED]` substitution.
     telemetry.capture('comfy.desktop.adopt.failed', {
       stage: currentPhase,
-      error_bucket: telemetry.bucketError(message),
-      error_message: scrubAll(message).slice(0, 500)
+      ...buildErrorFields(err)
     })
     throw err
   }

--- a/src/main/lib/executionTap.test.ts
+++ b/src/main/lib/executionTap.test.ts
@@ -47,12 +47,41 @@ describe('executionTap', () => {
     })
   })
 
-  it('emits validation_failed errors when prompt validation fails', () => {
+  it('emits validation_failed errors with the reason lines as the message', () => {
     const tap = createExecutionTap({ installationId: 'inst-1' })
-    tap.ingest('Failed to validate prompt for output 42:\n', 'stdout')
+    // ComfyUI logs the header, then `* node:` / `- reason` detail lines, then
+    // an unrelated line that terminates the block.
+    tap.ingest(
+      [
+        'Failed to validate prompt for output 42:',
+        '* CheckpointLoaderSimple 4:',
+        "  - Value not in list: ckpt_name: 'missing.ckpt' not in ['real.safetensors']",
+        'Something else entirely'
+      ].join('\n') + '\n',
+      'stdout'
+    )
     const err = captured.find((c) => c.event === 'comfy.desktop.execution.error')
     expect(err).toBeDefined()
-    expect(err!.ctx).toMatchObject({ error_class: 'validation_failed', node_id: '42' })
+    expect(err!.ctx).toMatchObject({
+      error_class: 'validation_failed',
+      error_bucket: 'validation',
+      node_id: '42'
+    })
+    // The reason detail is captured, not just the header.
+    expect(String(err!.ctx.error_message)).toContain('Value not in list')
+    // The signature normalizes user-specific values so distinct reasons still
+    // group by shape.
+    expect(String(err!.ctx.error_signature)).toContain('validation_failed|')
+  })
+
+  it('defers the validation error until the block ends and flushes on exit', () => {
+    const tap = createExecutionTap({ installationId: 'inst-1' })
+    tap.ingest('Failed to validate prompt for output 7:\n', 'stdout')
+    // No terminating line yet â€” nothing emitted.
+    expect(captured.filter((c) => c.event === 'comfy.desktop.execution.error')).toHaveLength(0)
+    tap.flushSummary()
+    const err = captured.find((c) => c.event === 'comfy.desktop.execution.error')
+    expect(err!.ctx).toMatchObject({ error_class: 'validation_failed', node_id: '7' })
   })
 
   it('parses current ComfyUI log lines carrying a colored [LEVEL] prefix', () => {
@@ -63,6 +92,8 @@ describe('executionTap', () => {
     tap.ingest('\u001b[32m[INFO]\u001b[0m got prompt\n', 'stdout')
     tap.ingest('\u001b[32m[INFO]\u001b[0m Prompt executed in 7.78 seconds\n', 'stdout')
     tap.ingest('\u001b[1m\u001b[31m[ERROR]\u001b[0m Failed to validate prompt for output 9:\n', 'stdout')
+    // Deferred validation error flushes when the block ends.
+    tap.flushSummary()
 
     const started = captured.find((c) => c.event === 'comfy.desktop.execution.started')
     expect(started).toBeDefined()

--- a/src/main/lib/executionTap.test.ts
+++ b/src/main/lib/executionTap.test.ts
@@ -77,7 +77,7 @@ describe('executionTap', () => {
   it('defers the validation error until the block ends and flushes on exit', () => {
     const tap = createExecutionTap({ installationId: 'inst-1' })
     tap.ingest('Failed to validate prompt for output 7:\n', 'stdout')
-    // No terminating line yet â€” nothing emitted.
+    // No terminating line yet — nothing emitted.
     expect(captured.filter((c) => c.event === 'comfy.desktop.execution.error')).toHaveLength(0)
     tap.flushSummary()
     const err = captured.find((c) => c.event === 'comfy.desktop.execution.error')

--- a/src/main/lib/executionTap.test.ts
+++ b/src/main/lib/executionTap.test.ts
@@ -191,6 +191,37 @@ describe('executionTap', () => {
     ).toHaveLength(1)
   })
 
+  it('flushSummary parses a final line written without a trailing newline', () => {
+    const tap = createExecutionTap({ installationId: 'inst-1' })
+    // The fatal exception line is the LAST thing written and has no trailing
+    // newline (process died mid-line), so it sits unparsed in `pending`.
+    tap.ingest(
+      [
+        'Traceback (most recent call last):',
+        '  File "z.py", line 3, in run',
+        '    raise KeyError("gone")',
+        'KeyError: gone' // no trailing '\n'
+      ].join('\n'),
+      'stderr'
+    )
+    expect(captured.filter((c) => c.event === 'comfy.desktop.execution.error')).toHaveLength(0)
+    tap.flushSummary()
+    const errs = captured.filter((c) => c.event === 'comfy.desktop.execution.error')
+    expect(errs).toHaveLength(1)
+    expect(errs[0]!.ctx).toMatchObject({ error_class: 'KeyError' })
+  })
+
+  it('flushSummary captures a validation reason line written without a trailing newline', () => {
+    const tap = createExecutionTap({ installationId: 'inst-1' })
+    tap.ingest('Failed to validate prompt for output 3:\n', 'stdout')
+    // Reason line is the final write and has no trailing newline.
+    tap.ingest("  - Value not in list: ckpt_name: 'x' not in ['y']", 'stdout')
+    tap.flushSummary()
+    const err = captured.find((c) => c.event === 'comfy.desktop.execution.error')
+    expect(err!.ctx).toMatchObject({ error_class: 'validation_failed', node_id: '3' })
+    expect(String(err!.ctx.error_message)).toContain('Value not in list')
+  })
+
   it('caps promptStartTimes so unpaired starts cannot grow unbounded', () => {
     const tap = createExecutionTap({ installationId: 'inst-1' })
     // Far more than the cap (256).

--- a/src/main/lib/executionTap.ts
+++ b/src/main/lib/executionTap.ts
@@ -320,6 +320,16 @@ export function createExecutionTap(opts: {
       for (const line of lines) handleLine(line, source)
     },
     flushSummary(): void {
+      // Flush any buffered partial line (a final line written without a
+      // trailing newline when the process exited) through the parser first —
+      // that trailing line is often the fatal exception / validation reason we
+      // want, and it would otherwise sit unparsed in `pending`.
+      for (const source of ['stdout', 'stderr'] as const) {
+        const partial = pending[source]
+        if (partial.length === 0) continue
+        pending[source] = ''
+        handleLine(partial, source)
+      }
       // Drain an in-flight validation block (process exited before the block's
       // terminating line arrived) so the failure isn't dropped.
       emitValidationError()

--- a/src/main/lib/executionTap.ts
+++ b/src/main/lib/executionTap.ts
@@ -52,7 +52,7 @@ interface TapState {
   // Buffer for a multi-line prompt-validation failure (header + reason lines).
   // Empty when not collecting. Deferred so `error_message` carries the actual
   // reasons ("Value not in list", "Required input is missing"), not just the
-  // header â€” otherwise every validation_failed groups into one opaque bucket.
+  // header — otherwise every validation_failed groups into one opaque bucket.
   validationBuffer: string[]
   validationNodeId: string | null
 }
@@ -68,7 +68,7 @@ const MAX_TRACEBACK_LINES = 200
 const MAX_TRACEBACK_CHARS = 16 * 1024
 // A validation block is header + a handful of reason lines; bound it tightly.
 const MAX_VALIDATION_LINES = 30
-// Detail lines ComfyUI prints under the header: `* Node 4:` / `  - reason: â€¦`.
+// Detail lines ComfyUI prints under the header: `* Node 4:` / `  - reason: …`.
 const VALIDATION_DETAIL = /^[*-]/
 
 export function createExecutionTap(opts: {
@@ -224,7 +224,7 @@ export function createExecutionTap(opts: {
 
     // Collecting a multi-line validation block: keep appending the `* node:` /
     // `- reason` detail lines; any other line ends the block (then falls
-    // through so it is processed normally â€” a new header, `got prompt`, etc.).
+    // through so it is processed normally — a new header, `got prompt`, etc.).
     if (state.validationBuffer.length > 0) {
       if (VALIDATION_DETAIL.test(trimmed) && state.validationBuffer.length < MAX_VALIDATION_LINES) {
         state.validationBuffer.push(trimmed)

--- a/src/main/lib/executionTap.ts
+++ b/src/main/lib/executionTap.ts
@@ -26,7 +26,7 @@
 import * as installationsApi from '../installations'
 import * as telemetry from './telemetry'
 import { stripAnsi, stripLogLevelPrefix } from './stderrTail'
-import { scrubAll } from '../../shared/piiScrub'
+import { buildErrorFields } from '../../shared/errorEvent'
 
 /**
  * Traceback collection state. We collect until a blank line follows an
@@ -49,6 +49,12 @@ interface TapState {
   tracebackBuffer: string[]
   tracebackChars: number
   tracebackPhase: TracebackPhase
+  // Buffer for a multi-line prompt-validation failure (header + reason lines).
+  // Empty when not collecting. Deferred so `error_message` carries the actual
+  // reasons ("Value not in list", "Required input is missing"), not just the
+  // header â€” otherwise every validation_failed groups into one opaque bucket.
+  validationBuffer: string[]
+  validationNodeId: string | null
 }
 
 const TRACEBACK_START = /^Traceback \(most recent call last\):/
@@ -60,8 +66,10 @@ const EXCEPTION_LINE = /^[A-Za-z_][A-Za-z0-9_.]*(?:Error|Exception|Warning|Inter
 const MAX_PENDING_PROMPTS = 256
 const MAX_TRACEBACK_LINES = 200
 const MAX_TRACEBACK_CHARS = 16 * 1024
-const ERROR_MESSAGE_MAX = 500
-const ERROR_CLASS_MAX = 80
+// A validation block is header + a handful of reason lines; bound it tightly.
+const MAX_VALIDATION_LINES = 30
+// Detail lines ComfyUI prints under the header: `* Node 4:` / `  - reason: â€¦`.
+const VALIDATION_DETAIL = /^[*-]/
 
 export function createExecutionTap(opts: {
   installationId: string
@@ -81,7 +89,9 @@ export function createExecutionTap(opts: {
     errorCount: 0,
     tracebackBuffer: [],
     tracebackChars: 0,
-    tracebackPhase: 'none'
+    tracebackPhase: 'none',
+    validationBuffer: [],
+    validationNodeId: null
   }
 
   const baseContext = {
@@ -142,8 +152,6 @@ export function createExecutionTap(opts: {
         break
       }
     }
-    const errorClass = exceptionLine.split(':')[0]?.trim() || 'unknown'
-    const scrubbedMessage = scrubAll(exceptionLine).slice(0, ERROR_MESSAGE_MAX)
     state.errorCount++
     // Wall-clock between the matching `Got prompt` and the error end —
     // mirror what `execution.completed` already emits so error-vs-success
@@ -151,17 +159,42 @@ export function createExecutionTap(opts: {
     // error fired without a paired start (already-pending traceback at
     // boot, etc.).
     const wallMs = consumePromptStart()
+    // Standard error schema derived from the final exception line (class /
+    // message / bucket / signature).
     telemetry.emit('comfy.desktop.execution.error', {
       ...baseContext,
-      error_class: errorClass.slice(0, ERROR_CLASS_MAX),
-      error_message: scrubbedMessage,
-      error_bucket: telemetry.bucketError(scrubbedMessage),
+      ...buildErrorFields(exceptionLine),
       error_count: state.errorCount,
       wall_clock_ms: wallMs
     })
     state.tracebackPhase = 'none'
     state.tracebackBuffer = []
     state.tracebackChars = 0
+  }
+
+  /**
+   * Emit a deferred prompt-validation failure. The buffer holds the header
+   * (`Failed to validate prompt for output N:`) plus the `* node:` / `- reason`
+   * detail lines; the joined block drives `error_message` / `error_signature`
+   * so distinct validation reasons group separately, while `error_class` stays
+   * the stable `validation_failed` and `error_bucket` stays `validation`.
+   */
+  function emitValidationError(): void {
+    if (state.validationBuffer.length === 0) return
+    const block = state.validationBuffer.join('\n')
+    const nodeId = state.validationNodeId
+    state.validationBuffer = []
+    state.validationNodeId = null
+    state.errorCount++
+    const wallMs = consumePromptStart()
+    telemetry.emit('comfy.desktop.execution.error', {
+      ...baseContext,
+      ...buildErrorFields(block, { errorClass: 'validation_failed' }),
+      error_bucket: 'validation',
+      error_count: state.errorCount,
+      node_id: nodeId,
+      wall_clock_ms: wallMs
+    })
   }
 
   function appendTracebackLine(line: string): void {
@@ -184,6 +217,17 @@ export function createExecutionTap(opts: {
     // Strip ANSI first, then the level tag. Raw Python tracebacks carry
     // neither, so TRACEBACK_START detection is unaffected.
     const trimmed = stripLogLevelPrefix(stripAnsi(line).trim())
+
+    // Collecting a multi-line validation block: keep appending the `* node:` /
+    // `- reason` detail lines; any other line ends the block (then falls
+    // through so it is processed normally â€” a new header, `got prompt`, etc.).
+    if (state.validationBuffer.length > 0) {
+      if (VALIDATION_DETAIL.test(trimmed) && state.validationBuffer.length < MAX_VALIDATION_LINES) {
+        state.validationBuffer.push(trimmed)
+        return
+      }
+      emitValidationError()
+    }
 
     if (trimmed.length === 0) return
 
@@ -214,16 +258,11 @@ export function createExecutionTap(opts: {
 
     const validationMatch = trimmed.match(VALIDATION_FAIL)
     if (validationMatch?.groups) {
-      state.errorCount++
-      const wallMs = consumePromptStart()
-      telemetry.emit('comfy.desktop.execution.error', {
-        ...baseContext,
-        error_class: 'validation_failed',
-        error_bucket: 'validation',
-        error_count: state.errorCount,
-        node_id: validationMatch.groups['nodeId'],
-        wall_clock_ms: wallMs
-      })
+      // Start deferred collection; the paired error emits once the block ends
+      // (a non-detail line, a new header, or flushSummary) so `error_message`
+      // carries the reasons that follow, not just this header.
+      state.validationBuffer = [trimmed]
+      state.validationNodeId = validationMatch.groups['nodeId'] ?? null
       return
     }
 
@@ -281,6 +320,9 @@ export function createExecutionTap(opts: {
       for (const line of lines) handleLine(line, source)
     },
     flushSummary(): void {
+      // Drain an in-flight validation block (process exited before the block's
+      // terminating line arrived) so the failure isn't dropped.
+      emitValidationError()
       // Drain any in-flight traceback so we don't drop the error if the
       // process exited before a boundary line arrived.
       if (

--- a/src/main/lib/git.ts
+++ b/src/main/lib/git.ts
@@ -6,6 +6,7 @@ import { killProcTree } from './process'
 import { getBundledScriptPath } from './bundledScript'
 import { removeQuarantine, codesignBinaries } from '../sources/standalone/macRepair'
 import * as telemetry from './telemetry'
+import { buildErrorFields } from '../../shared/errorEvent'
 
 // ───────────────────────────────────────────────────────────────────────────
 // pygit2 fallback state + circuit breaker
@@ -229,7 +230,7 @@ export async function tryConfigurePygit2Fallback(installPath: string): Promise<b
     // can correlate with release / signing-cert changes.
     telemetry.emit('comfy.desktop.pygit2.probe_failed', {
       source: 'standalone',
-      error_bucket: telemetry.bucketError(probe.reason)
+      ...buildErrorFields(probe.reason)
     })
     return false
   }
@@ -280,7 +281,7 @@ export async function tryConfigureBootstrapPygit2(): Promise<boolean> {
     console.warn(`[git] bootstrap pygit2 rejected at ${pythonPath}: ${probe.reason}`)
     telemetry.emit('comfy.desktop.pygit2.probe_failed', {
       source: 'bootstrap',
-      error_bucket: telemetry.bucketError(probe.reason)
+      ...buildErrorFields(probe.reason)
     })
     return false
   }

--- a/src/main/lib/ipc/registerInstallationHandlers.ts
+++ b/src/main/lib/ipc/registerInstallationHandlers.ts
@@ -40,6 +40,7 @@ import { hasGitDir } from '../git'
 import { parseUrl } from '../util'
 import { restoreSnapshotIntoInstallation } from '../standaloneMigration'
 import * as mainTelemetry from '../telemetry'
+import { buildErrorFields } from '../../../shared/errorEvent'
 import { appendLog } from '../logsBroadcast'
 import {
   startTemplateDownload,
@@ -407,8 +408,7 @@ export function registerInstallationHandlers(): void {
             from_version: formatComfyVersion(priorComfyVersion, 'short'),
             to_version: null,
             result: 'error',
-            error_bucket: mainTelemetry.bucketError(err),
-            error_message: (err as Error).message.slice(0, 500)
+            ...buildErrorFields(err)
           })
         }
         return { ok: false, message: (err as Error).message }

--- a/src/main/lib/ipc/sessionActions/launch.ts
+++ b/src/main/lib/ipc/sessionActions/launch.ts
@@ -949,7 +949,7 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
     // Standard error schema derived from the failure message + the stderr
     // tail (a Python traceback in the tail yields a real `error_class` /
     // `error_message`; otherwise the launch message drives it). `error_tail`
-    // carries the last ~40 lines of stderr â€” where the fatal error prints â€”
+    // carries the last ~40 lines of stderr — where the fatal error prints —
     // scrubbed and capped, so the failure is diagnosable without depending on
     // the separate, unreliable `boot_log` event.
     const tail = errorTail(launchResult.stderr)

--- a/src/main/lib/ipc/sessionActions/launch.ts
+++ b/src/main/lib/ipc/sessionActions/launch.ts
@@ -46,6 +46,7 @@ import type { LaunchProgressTracker } from '../../launchProgress'
 import { clearCrash, recordCrash } from '../../crashBuffer'
 import type { ComfyExitedData } from '../../../../types/ipc'
 import * as telemetry from '../../telemetry'
+import { buildErrorFields, errorTail } from '../../../../shared/errorEvent'
 import {
   startBootPhases,
   recordBootPhase,
@@ -372,7 +373,7 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
     } catch (err) {
       console.warn('Failed to seed ComfyUI-Manager mirror config:', err)
       telemetry.capture('comfy.desktop.manager.mirror_seed_failed', {
-        error_message: String(err).slice(0, 200),
+        ...buildErrorFields(err),
       })
     }
   }
@@ -821,7 +822,7 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
   // recurses), so boot_started→boot_completed joins per-attempt, not per-machine.
   const bootId = randomUUID()
 
-  const tryLaunch = async (): Promise<{ ok: true; proc: ChildProcess; getStderr: () => string } | { ok: false; message: string; cancelled?: boolean }> => {
+  const tryLaunch = async (): Promise<{ ok: true; proc: ChildProcess; getStderr: () => string } | { ok: false; message: string; cancelled?: boolean; stderr?: string; exitCode?: number | null; signal?: string | null }> => {
     const cmdLine = [launchCmd.cmd!, ...launchCmd.args!].map((a, ci, ca) => {
       if (ci > 0 && SENSITIVE_ARG_RE.test(ca[ci - 1]!)) return '"***"'
       return /\s/.test(a) ? `"${a}"` : a
@@ -852,6 +853,10 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
     const spawned = spawnComfy()
 
     let earlyExit: string | null = null
+    // Exit code / signal of an early process exit, surfaced on `boot_failed`
+    // so the failure carries WHY the process died, not just that it did.
+    let exitCode: number | null = null
+    let exitSignal: string | null = null
     const earlyExitPromise = new Promise<void>((_resolve, reject) => {
       spawned.proc.on('error', (err: Error) => {
         const code = (err as NodeJS.ErrnoException).code ? ` (${(err as NodeJS.ErrnoException).code})` : ''
@@ -859,6 +864,8 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
         reject(new Error(`Failed to start${code}: ${launchCmd.cmd}`))
       })
       spawned.proc.on('exit', async (code, signal) => {
+        exitCode = code
+        exitSignal = signal
         if (!earlyExit) {
           const detail = spawned.getStderr().trim() ? `\n\n${spawned.getStderr().trim()}` : ''
           // A startup crash (e.g. a C-extension segfault during import) is the
@@ -905,8 +912,12 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
           return tryLaunch()
         } catch { }
       }
-      if (abort.signal.aborted) return { ok: false, message: (err as Error).message, cancelled: true }
-      return { ok: false, message: (err as Error).message }
+      // Carry the in-memory stderr tail + exit info out so `boot_failed` can
+      // report the actual error. The buffer lives in main (survives a hard
+      // child crash) but was previously discarded on the failure path.
+      const failureStderr = spawned.getStderr()
+      if (abort.signal.aborted) return { ok: false, message: (err as Error).message, cancelled: true, stderr: failureStderr, exitCode, signal: exitSignal }
+      return { ok: false, message: (err as Error).message, stderr: failureStderr, exitCode, signal: exitSignal }
     }
   }
 
@@ -935,12 +946,25 @@ export async function handleLaunch({ event, installationId, inst: instArg, actio
     // reached (null if it never entered one). The error is bucketed; the
     // retry counters surface how many times we re-spawned before giving up.
     const failedPhase = flushBootPhasesOnFailure(installationId)
+    // Standard error schema derived from the failure message + the stderr
+    // tail (a Python traceback in the tail yields a real `error_class` /
+    // `error_message`; otherwise the launch message drives it). `error_tail`
+    // carries the last ~40 lines of stderr â€” where the fatal error prints â€”
+    // scrubbed and capped, so the failure is diagnosable without depending on
+    // the separate, unreliable `boot_log` event.
+    const tail = errorTail(launchResult.stderr)
+    const errorSource = tail
+      ? `${launchResult.message}\n${launchResult.stderr}`
+      : launchResult.message
     telemetry.emit('comfy.desktop.comfyui.boot_failed', {
       installation_id: installationId,
       boot_id: bootId,
       variant: (inst.variant as string | undefined) ?? null,
       failed_phase: failedPhase,
-      error_bucket: telemetry.bucketError(launchResult.message),
+      ...buildErrorFields(errorSource),
+      error_tail: tail,
+      exit_code: launchResult.exitCode ?? null,
+      signal: launchResult.signal ?? null,
       retry_count: portRetries + rebootRetries,
       port_retry_count: portRetries,
       reboot_retry_count: rebootRetries,

--- a/src/main/lib/telemetry.ts
+++ b/src/main/lib/telemetry.ts
@@ -1099,7 +1099,9 @@ export async function trackedStep<T>(
     // Standard error schema (class / message / bucket / signature) so every
     // `${step}.error` (adopt.register, migrate.*, snapshot.restore_*) is
     // diagnosable and groups by class regardless of locale or user paths.
-    capture(`${step}.error`, {
+    // `emit` (not `capture`) so allow-listed step errors also mirror to Datadog
+    // for alerting; the `.start` / `.end` funnel events stay PostHog-only.
+    emit(`${step}.error`, {
       ...context,
       duration_ms: Date.now() - t0,
       ...buildErrorFields(err)

--- a/src/main/lib/telemetry.ts
+++ b/src/main/lib/telemetry.ts
@@ -116,6 +116,7 @@ import {
 } from '../../shared/posthogConfig'
 import { isDatadogMirroredEvent } from '../../shared/datadogMirroredEvents'
 import { bucketError as sharedBucketError } from '../../shared/errorBucket'
+import { buildErrorFields } from '../../shared/errorEvent'
 import { scrubAll } from '../../shared/piiScrub'
 
 export type TelemetryValue = boolean | number | string | null | undefined
@@ -1095,20 +1096,34 @@ export async function trackedStep<T>(
     capture(`${step}.end`, { ...context, duration_ms: Date.now() - t0 })
     return result
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err)
-    // Bucket runs on raw text — its regexes don't care about user paths
-    // and would otherwise miss legitimate matches hidden inside a
-    // `[REDACTED]` substitution. The wire-bound field gets scrubbed
-    // before the 500-char slice so the redaction prefix can't get
-    // truncated mid-token.
+    // Standard error schema (class / message / bucket / signature) so every
+    // `${step}.error` (adopt.register, migrate.*, snapshot.restore_*) is
+    // diagnosable and groups by class regardless of locale or user paths.
     capture(`${step}.error`, {
       ...context,
       duration_ms: Date.now() - t0,
-      error_bucket: bucketError(message),
-      error_message: scrubAll(message).slice(0, 500)
+      ...buildErrorFields(err)
     })
     throw err
   }
+}
+
+/**
+ * Capture + Datadog-forward a failure event with the standard error schema.
+ *
+ * Every failure event MUST carry `error_class` / `error_message` /
+ * `error_bucket` / `error_signature` (see `src/shared/errorEvent.ts`). This
+ * is the single enforced path for that: pass the base context and the raw
+ * error, and the four fields are derived and merged. Base-context keys win on
+ * collision so a call site can override a derived field when it has better
+ * information (e.g. a fixed `error_class` for a parser-detected failure).
+ */
+export function emitError(
+  event: string,
+  context: TelemetryContext,
+  errorInput: unknown
+): void {
+  emit(event, { ...buildErrorFields(errorInput), ...context })
 }
 
 /**

--- a/src/main/lib/telemetry.ts
+++ b/src/main/lib/telemetry.ts
@@ -1109,24 +1109,6 @@ export async function trackedStep<T>(
 }
 
 /**
- * Capture + Datadog-forward a failure event with the standard error schema.
- *
- * Every failure event MUST carry `error_class` / `error_message` /
- * `error_bucket` / `error_signature` (see `src/shared/errorEvent.ts`). This
- * is the single enforced path for that: pass the base context and the raw
- * error, and the four fields are derived and merged. Base-context keys win on
- * collision so a call site can override a derived field when it has better
- * information (e.g. a fixed `error_class` for a parser-detected failure).
- */
-export function emitError(
-  event: string,
-  context: TelemetryContext,
-  errorInput: unknown
-): void {
-  emit(event, { ...buildErrorFields(errorInput), ...context })
-}
-
-/**
  * Coarse error categorisation. Re-exported from `src/shared/errorBucket.ts`
  * so main and renderer classify identically (dedup).
  */

--- a/src/main/lib/updater.ts
+++ b/src/main/lib/updater.ts
@@ -380,9 +380,7 @@ function bindUpdaterEvents(): void {
           : 'check'
     emitTelemetry('comfy.desktop.app_update.error', {
       stage,
-      // Standard error schema: the message was previously computed only for
-      // the bucket + the user modal and never emitted, so 1.3M events carried
-      // no actionable text. Now class / message / bucket / signature ship.
+      // Standard error schema: class / message / bucket / signature.
       ...buildErrorFields(updaterErrorMessage(args)),
       user_initiated: wasUserInitiated
     })

--- a/src/main/lib/updater.ts
+++ b/src/main/lib/updater.ts
@@ -5,7 +5,8 @@ import { autoUpdater as electronAutoUpdater } from 'electron-updater'
 import * as settings from '../settings'
 import { clearQuitReason, isSessionEnding, setQuitReason } from './quit-state'
 import { _broadcastToRenderer } from './ipc/shared'
-import { emit as emitTelemetry, bucketError } from './telemetry'
+import { emit as emitTelemetry } from './telemetry'
+import { buildErrorFields } from '../../shared/errorEvent'
 
 /**
  * Title-bar status pills consume the current app-update state via
@@ -379,7 +380,10 @@ function bindUpdaterEvents(): void {
           : 'check'
     emitTelemetry('comfy.desktop.app_update.error', {
       stage,
-      error_bucket: bucketError(updaterErrorMessage(args)),
+      // Standard error schema: the message was previously computed only for
+      // the bucket + the user modal and never emitted, so 1.3M events carried
+      // no actionable text. Now class / message / bucket / signature ship.
+      ...buildErrorFields(updaterErrorMessage(args)),
       user_initiated: wasUserInitiated
     })
     clearQuitReason()

--- a/src/main/sources/standalone/install.ts
+++ b/src/main/sources/standalone/install.ts
@@ -4,6 +4,7 @@ import { execFile } from 'child_process'
 import { downloadAndExtract, downloadAndExtractMulti } from '../../lib/installer'
 import type { InstallPhaseName, InstallPhaseStatus } from '../../lib/installer'
 import * as mainTelemetry from '../../lib/telemetry'
+import { buildErrorFields } from '../../../shared/errorEvent'
 import { copyDirWithProgress } from '../../lib/copy'
 import { readGitHead, isGitAvailable, isPygit2Configured, tryConfigurePygit2Fallback, fetchTags } from '../../lib/git'
 import { resolveLocalVersion } from '../../lib/version-resolve'
@@ -57,9 +58,9 @@ function emitInstallPhase(
     }
     if (typeof info.durationMs === 'number') props.duration_ms = info.durationMs
     if (status === 'error') {
-      props.error_bucket = mainTelemetry.bucketError(
-        info.error instanceof Error ? info.error.message : String(info.error ?? '')
-      )
+      // Standard error schema so a failing phase carries the actual error
+      // text, not just the coarse bucket.
+      Object.assign(props, buildErrorFields(info.error))
     }
     mainTelemetry.emit('comfy.desktop.install.phase', props)
   } catch (err) {

--- a/src/main/sources/standalone/torchRepair.ts
+++ b/src/main/sources/standalone/torchRepair.ts
@@ -9,6 +9,7 @@ import { download } from '../../lib/download'
 import { extractNested as extract } from '../../lib/extract'
 import * as settings from '../../settings'
 import * as telemetry from '../../lib/telemetry'
+import { buildErrorFields } from '../../../shared/errorEvent'
 import type { InstallationRecord } from '../../installations'
 
 // Vendor variant → the accelerator tag fragment its torch wheel carries. CPU and
@@ -328,7 +329,7 @@ export async function maybeRepairTorch(
   telemetry.emit('comfy.desktop.torch_repair.failed', {
     variant: mismatch.variantBase,
     attempts,
-    error_message: result.message.slice(0, 200),
+    ...buildErrorFields(result.message),
   })
   tools.sendOutput?.(`PyTorch repair failed (will retry on next launch): ${result.message}\n`)
   return false

--- a/src/renderer/src/lib/rendererBootstrap.ts
+++ b/src/renderer/src/lib/rendererBootstrap.ts
@@ -41,7 +41,7 @@ import {
 // and is gated to the failure-event allow-list in
 // `src/shared/datadogMirroredEvents.ts`.
 import { scrubAll } from '../../../shared/piiScrub'
-import { isDatadogMirroredEvent } from '../../../shared/datadogMirroredEvents'
+import { isDatadogMirroredEvent, stripDatadogDroppedKeys } from '../../../shared/datadogMirroredEvents'
 
 function serializeUnknownError(error: unknown): { message: string; stack?: string } {
   if (error instanceof Error) {
@@ -220,7 +220,9 @@ function trackTelemetryAction(
   // alerting, not analysis.
   if (isDatadogInitialized && isDatadogMirroredEvent(actionName)) {
     try {
-      datadogRum.addAction(actionName, scrubbed)
+      // Datadog is the alerting surface: keep the low-cardinality facets and
+      // drop the large free-text diagnostics (they stay in PostHog for triage).
+      datadogRum.addAction(actionName, stripDatadogDroppedKeys(scrubbed))
     } catch {}
   }
   // Renderer routes capture through main's posthog-node via IPC. The

--- a/src/shared/datadogMirroredEvents.test.ts
+++ b/src/shared/datadogMirroredEvents.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { isDatadogMirroredEvent } from './datadogMirroredEvents'
+import {
+  isDatadogMirroredEvent,
+  stripDatadogDroppedKeys,
+  DATADOG_DROPPED_CONTEXT_KEYS,
+} from './datadogMirroredEvents'
 
 describe('isDatadogMirroredEvent', () => {
   // The boot lifecycle splits success vs failure: boot_failed is a failure
@@ -15,5 +19,48 @@ describe('isDatadogMirroredEvent', () => {
 
   it('returns false for unknown event names', () => {
     expect(isDatadogMirroredEvent('comfy.desktop.not.a.real.event')).toBe(false)
+  })
+})
+
+describe('stripDatadogDroppedKeys', () => {
+  // Datadog is the alerting surface: the large / high-cardinality diagnostic
+  // fields belong in PostHog, not on RUM actions where they bloat payloads and
+  // pollute facets.
+  it('drops the large / high-cardinality diagnostic fields', () => {
+    const context = {
+      installation_id: 'abc',
+      error_class: 'RuntimeError',
+      error_bucket: 'unknown',
+      exit_code: 1,
+      signal: null,
+      error_message: 'boom',
+      error_signature: 'RuntimeError|boom',
+      error_tail: 'line1\nline2',
+      last_stderr: 'noise',
+    }
+    const out = stripDatadogDroppedKeys(context)
+    expect(out).toEqual({
+      installation_id: 'abc',
+      error_class: 'RuntimeError',
+      error_bucket: 'unknown',
+      exit_code: 1,
+      signal: null,
+    })
+    // Does not mutate the input (PostHog copy must keep the full schema).
+    expect(context.error_message).toBe('boom')
+  })
+
+  it('returns the same reference when no dropped keys are present', () => {
+    const context = { error_class: 'RuntimeError', error_bucket: 'unknown' }
+    expect(stripDatadogDroppedKeys(context)).toBe(context)
+  })
+
+  it('drop-list covers exactly the intended free-text / large fields', () => {
+    expect([...DATADOG_DROPPED_CONTEXT_KEYS].sort()).toEqual([
+      'error_message',
+      'error_signature',
+      'error_tail',
+      'last_stderr',
+    ])
   })
 })

--- a/src/shared/datadogMirroredEvents.ts
+++ b/src/shared/datadogMirroredEvents.ts
@@ -89,3 +89,37 @@ export const DATADOG_MIRRORED_EVENT_NAMES: ReadonlySet<string> = new Set([
 export function isDatadogMirroredEvent(eventName: string): boolean {
   return DATADOG_MIRRORED_EVENT_NAMES.has(eventName)
 }
+
+/**
+ * Context keys stripped from the Datadog RUM copy of a mirrored event.
+ *
+ * Datadog is the alerting surface: monitors group and alert on LOW-cardinality
+ * facets (`error_class`, `error_bucket`, `exit_code`, `signal`, phase / variant
+ * / retry fields). The free-text diagnostic fields below are high-cardinality
+ * and/or large (`error_tail` and `last_stderr` run to kilobytes), which bloats
+ * RUM action payloads and pollutes facets for no monitoring benefit. They stay
+ * in PostHog (where the actual triage happens); only the Datadog mirror drops
+ * them. Mirrors the deliberate choice already made for `auth.sign_in_failed`.
+ */
+export const DATADOG_DROPPED_CONTEXT_KEYS: ReadonlySet<string> = new Set([
+  'error_message',
+  'error_signature',
+  'error_tail',
+  'last_stderr',
+])
+
+/**
+ * Return a copy of `context` with the high-cardinality / large diagnostic keys
+ * removed, for sending to Datadog RUM. Returns the input unchanged when it
+ * carries none of them (the common case) to avoid a needless allocation.
+ */
+export function stripDatadogDroppedKeys<T extends Record<string, unknown>>(context: T): T {
+  let out: T | null = null
+  for (const key of DATADOG_DROPPED_CONTEXT_KEYS) {
+    if (key in context) {
+      if (!out) out = { ...context }
+      delete out[key]
+    }
+  }
+  return out ?? context
+}

--- a/src/shared/errorEvent.test.ts
+++ b/src/shared/errorEvent.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildErrorFields,
+  extractErrorClass,
+  normalizeSignature,
+  errorTail,
+  ERROR_MESSAGE_MAX
+} from './errorEvent'
+
+describe('errorEvent', () => {
+  describe('extractErrorClass', () => {
+    it('extracts the Python exception class from a single message', () => {
+      expect(extractErrorClass("ModuleNotFoundError: No module named 'torch'")).toBe(
+        'ModuleNotFoundError'
+      )
+    })
+
+    it('takes the FINAL exception line from a multi-line traceback', () => {
+      const traceback = [
+        'Traceback (most recent call last):',
+        '  File "main.py", line 10, in <module>',
+        '    import torch',
+        'ImportError: partially initialized module',
+        '',
+        'During handling of the above exception, another exception occurred:',
+        '',
+        'RuntimeError: CUDA driver initialization failed'
+      ].join('\n')
+      expect(extractErrorClass(traceback)).toBe('RuntimeError')
+    })
+
+    it('maps fixed English CUDA/OOM signatures to a stable class', () => {
+      expect(extractErrorClass('CUDA error: no kernel image is available for execution')).toBe(
+        'CUDANoKernelImage'
+      )
+      expect(extractErrorClass('torch.cuda.OutOfMemoryError: CUDA out of memory. Tried...')).toBe(
+        // The Python class token wins over the phrase dictionary.
+        'torch.cuda.OutOfMemoryError'
+      )
+      expect(extractErrorClass('RuntimeError: CUDA out of memory')).toBe('RuntimeError')
+      expect(extractErrorClass('some fatal cuda out of memory condition')).toBe('CUDAOutOfMemory')
+    })
+
+    it('uses a meaningful JS Error name over the generic Error', () => {
+      expect(extractErrorClass(new TypeError('bad'))).toBe('TypeError')
+      expect(extractErrorClass(new Error('plain'))).toBe('unknown')
+    })
+
+    it('is locale-independent: a localized message still yields the class', () => {
+      // Localized OSError text (message differs by locale, class does not).
+      expect(extractErrorClass('OSError: 找不到指定的模块。')).toBe('OSError')
+    })
+
+    it('falls back to unknown when there is no class signal', () => {
+      expect(extractErrorClass('something went wrong')).toBe('unknown')
+      expect(extractErrorClass('')).toBe('unknown')
+    })
+  })
+
+  describe('normalizeSignature', () => {
+    it('redacts numbers, hex, uuids, quoted strings and paths', () => {
+      const sig = normalizeSignature(
+        "failed on C:\\Users\\bob\\model.ckpt at 0xDEADBEEF id 12345 name 'foo'"
+      )
+      expect(sig).not.toContain('12345')
+      expect(sig).not.toContain('0xdeadbeef')
+      expect(sig).not.toContain('bob')
+      expect(sig).not.toContain("'foo'")
+      expect(sig).toContain('<path>')
+      expect(sig).toContain('<str>')
+      expect(sig).toContain('#')
+    })
+
+    it('groups the same error shape with different values to one signature', () => {
+      const a = normalizeSignature('Process exited with code 3221225477')
+      const b = normalizeSignature('Process exited with code 1')
+      expect(a).toBe(b)
+    })
+  })
+
+  describe('buildErrorFields', () => {
+    it('returns all four standard fields', () => {
+      const fields = buildErrorFields("ModuleNotFoundError: No module named 'torch'")
+      expect(fields).toMatchObject({
+        error_class: 'ModuleNotFoundError',
+        error_bucket: 'import_error'
+      })
+      expect(fields.error_message).toContain('No module named')
+      expect(fields.error_signature.startsWith('ModuleNotFoundError|')).toBe(true)
+    })
+
+    it('uses the final exception line as the message, not preceding noise', () => {
+      const traceback = [
+        'Loading node pack A...',
+        'Loading node pack B...',
+        'Traceback (most recent call last):',
+        '  File "x.py", line 1',
+        'RuntimeError: the real failure'
+      ].join('\n')
+      const fields = buildErrorFields(traceback)
+      expect(fields.error_class).toBe('RuntimeError')
+      expect(fields.error_message).toBe('RuntimeError: the real failure')
+    })
+
+    it('scrubs PII from the message', () => {
+      const fields = buildErrorFields(
+        "FileNotFoundError: No such file 'C:\\Users\\alice\\wf.json'"
+      )
+      expect(fields.error_message).not.toContain('alice')
+      expect(fields.error_message).toContain('[REDACTED]')
+    })
+
+    it('caps the message length', () => {
+      const long = 'x'.repeat(ERROR_MESSAGE_MAX + 500)
+      const fields = buildErrorFields(long)
+      expect(fields.error_message.length).toBe(ERROR_MESSAGE_MAX)
+    })
+
+    it('honors a pinned error class and reflects it in the signature', () => {
+      const fields = buildErrorFields('Failed to validate prompt for output 9:', {
+        errorClass: 'validation_failed'
+      })
+      expect(fields.error_class).toBe('validation_failed')
+      expect(fields.error_signature.startsWith('validation_failed|')).toBe(true)
+    })
+
+    it('handles Error instances and nullish input', () => {
+      expect(buildErrorFields(new RangeError('nope')).error_class).toBe('RangeError')
+      expect(buildErrorFields(null).error_class).toBe('unknown')
+      expect(buildErrorFields(undefined).error_message).toBe('')
+    })
+  })
+
+  describe('errorTail', () => {
+    it('returns the LAST N lines, scrubbed', () => {
+      const lines = Array.from({ length: 100 }, (_, i) => `line ${i}`)
+      const tail = errorTail(lines.join('\n'), { lines: 5 })
+      expect(tail).toBe(['line 95', 'line 96', 'line 97', 'line 98', 'line 99'].join('\n'))
+    })
+
+    it('scrubs user paths in the tail', () => {
+      const tail = errorTail('boom at C:\\Users\\carol\\thing.py')
+      expect(tail).not.toContain('carol')
+      expect(tail).toContain('[REDACTED]')
+    })
+
+    it('bounds the tail to maxChars', () => {
+      const tail = errorTail('a'.repeat(9000), { lines: 40, maxChars: 100 })
+      expect(tail!.length).toBe(100)
+    })
+
+    it('returns null for empty / whitespace input', () => {
+      expect(errorTail('')).toBeNull()
+      expect(errorTail(null)).toBeNull()
+      expect(errorTail('   \n  ')).toBeNull()
+    })
+  })
+})

--- a/src/shared/errorEvent.ts
+++ b/src/shared/errorEvent.ts
@@ -1,0 +1,215 @@
+/**
+ * Standard error/failure event fields, shared by main + renderer.
+ *
+ * Every telemetry event that represents a failure carries the SAME four
+ * fields so millions of opaque failures become groupable, actionable
+ * diagnostics. Build them once here and spread the result at the emit site:
+ *
+ *   telemetry.emit('comfy.desktop.<area>.error', {
+ *     ...baseContext,
+ *     ...buildErrorFields(err),
+ *   })
+ *
+ * The four fields:
+ *
+ *   - `error_class`     Stable, LOCALE-INDEPENDENT type identifier for
+ *                       grouping (e.g. `ModuleNotFoundError`, `CUDAError`).
+ *                       Derived from the exception class name / a fixed
+ *                       English signature dictionary â€” never from a
+ *                       localized OS string, so the same failure groups on
+ *                       a Chinese and an English machine alike.
+ *   - `error_message`   Human-readable message, PII-scrubbed and capped.
+ *   - `error_bucket`    Existing coarse classification (see errorBucket.ts).
+ *   - `error_signature` Normalized, PII-stripped key derived from the
+ *                       message (paths / ids / numbers redacted) prefixed
+ *                       with `error_class`, so the same error groups
+ *                       regardless of user-specific paths or values.
+ *
+ * Process-boot failures also carry `error_tail` (the last N lines of
+ * stderr, where tracebacks and the fatal line live) â€” see `errorTail`.
+ *
+ * Lives in `src/shared/` (no Electron / Node / DOM deps) so both main and
+ * renderer classify identically. Adding a rule here updates every failure
+ * event at once.
+ */
+import { bucketError, type ErrorBucket } from './errorBucket'
+import { scrubAll } from './piiScrub'
+
+/** Human-readable message cap (~2 KB). */
+export const ERROR_MESSAGE_MAX = 2048
+/** Normalized signature cap. */
+export const ERROR_SIGNATURE_MAX = 200
+/** stderr tail cap: last N lines (tracebacks + fatal line live at the tail). */
+export const ERROR_TAIL_LINES = 40
+/** stderr tail hard character cap (~4 KB) as a belt-and-braces bound. */
+export const ERROR_TAIL_MAX = 4096
+
+export interface ErrorFields {
+  error_class: string
+  error_message: string
+  error_bucket: ErrorBucket
+  error_signature: string
+}
+
+/**
+ * Final exception line of a Python traceback, e.g.
+ * `ModuleNotFoundError: No module named 'torch'`. Anchored so the class is
+ * the leading token. Matches the shape `executionTap` uses.
+ */
+const EXCEPTION_LINE = /^([A-Za-z_][A-Za-z0-9_.]*(?:Error|Exception|Warning|Interrupt))\b\s*:?/
+
+/**
+ * Fixed, English, locale-independent signatures that are NOT a Python class
+ * name but are stable enough to group on. Order matters: more specific first.
+ * Keys are lowercased substrings; the value is the canonical `error_class`.
+ */
+const SIGNATURE_CLASSES: [needle: string, className: string][] = [
+  ['no kernel image is available', 'CUDANoKernelImage'],
+  ['no cuda-capable device', 'CUDANoDevice'],
+  ['cuda out of memory', 'CUDAOutOfMemory'],
+  ['out of memory', 'OutOfMemory'],
+  ['device-side assert', 'CUDADeviceAssert'],
+  ['cuda error', 'CUDAError'],
+  ['cuda runtime error', 'CUDAError'],
+  ['cuda not available', 'CUDANotAvailable'],
+]
+
+function messageOf(input: unknown): string {
+  if (input instanceof Error) return input.message || input.name || ''
+  if (typeof input === 'string') return input
+  if (input == null) return ''
+  return String(input)
+}
+
+/**
+ * The final Python exception line in a (possibly multi-line) text, e.g.
+ * `ModuleNotFoundError: No module named 'torch'`. Scans line by line and
+ * returns the LAST match â€” the final exception of a chained traceback is the
+ * user-facing one. `null` when the text has no exception line (a plain JS
+ * error message, a launch string, etc.).
+ */
+function findExceptionLine(text: string): string | null {
+  let found: string | null = null
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.trim()
+    if (EXCEPTION_LINE.test(line)) found = line
+  }
+  return found
+}
+
+/**
+ * Extract a locale-independent `error_class`. Priority:
+ *   1. A Python exception class token anywhere in the text (last match wins â€”
+ *      the final exception in a chained traceback is the user-facing one).
+ *   2. A fixed English signature (CUDA / OOM) that isn't a class name.
+ *   3. A meaningful JS `Error.name` (not the generic `Error`).
+ *   4. `unknown`.
+ *
+ * Intentionally does NOT fall back to the localized message text, so the
+ * same failure groups across locales.
+ */
+export function extractErrorClass(input: unknown): string {
+  const text = messageOf(input)
+
+  // (1) Python exception class from the final exception line.
+  const exceptionLine = findExceptionLine(text)
+  if (exceptionLine) {
+    const m = exceptionLine.match(EXCEPTION_LINE)
+    if (m) return m[1]!
+  }
+
+  // (2) Fixed English signatures.
+  const lower = text.toLowerCase()
+  for (const [needle, className] of SIGNATURE_CLASSES) {
+    if (lower.includes(needle)) return className
+  }
+
+  // (3) Meaningful JS Error subclass name.
+  if (input instanceof Error && input.name && input.name !== 'Error') {
+    return input.name
+  }
+
+  return 'unknown'
+}
+
+/**
+ * Normalize a message into a stable grouping key: lowercase, strip
+ * user-specific values (paths, quoted strings, uuids, hex, numbers), collapse
+ * whitespace. The input is already PII-scrubbed by `buildErrorFields`, so this
+ * is purely about grouping stability. Prefixed with `error_class` by
+ * `buildErrorFields` so the final signature is `class + shape`.
+ */
+export function normalizeSignature(message: string): string {
+  return (
+    message
+      .toLowerCase()
+      // Quoted strings collapse first so their contents don't leak into the
+      // other rules (e.g. a quoted path or number).
+      .replace(/'[^']*'/g, '<str>')
+      .replace(/"[^"]*"/g, '<str>')
+      // File paths (windows drive or unix, at least one separator).
+      .replace(/(?:[a-z]:)?(?:[\\/][^\s'":<>|?*]+)+/gi, '<path>')
+      // UUIDs.
+      .replace(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/g, '<uuid>')
+      // Hex / pointers.
+      .replace(/0x[0-9a-f]+/g, '0x#')
+      // Bare numbers (versions, ports, sizes, line numbers).
+      .replace(/\d+/g, '#')
+      // Collapse whitespace.
+      .replace(/\s+/g, ' ')
+      .trim()
+      .slice(0, ERROR_SIGNATURE_MAX)
+  )
+}
+
+/**
+ * Build the standard `{ error_class, error_message, error_bucket,
+ * error_signature }` fields from any error input (an `Error`, a string, or
+ * unknown). PII is scrubbed from `error_message`; `error_bucket` runs on the
+ * RAW text (its regexes want the un-redacted string), while the wire-bound
+ * message is scrubbed and capped.
+ */
+export function buildErrorFields(
+  input: unknown,
+  opts: { messageCap?: number; errorClass?: string } = {}
+): ErrorFields {
+  const raw = messageOf(input)
+  const messageCap = opts.messageCap ?? ERROR_MESSAGE_MAX
+  // A caller that has already classified the failure (e.g. a parser that knows
+  // this is `validation_failed`) can pin the class; otherwise derive it.
+  const errorClass = opts.errorClass ?? extractErrorClass(input)
+  // Prefer the final exception line as the human-readable message: for a
+  // multi-line traceback (e.g. a boot stderr tail) the fatal line is the
+  // signal, not the node-load noise that precedes it. Fall back to the raw
+  // text for plain errors that have no traceback shape.
+  const primary = findExceptionLine(raw) ?? raw
+  const scrubbedMessage = scrubAll(primary).slice(0, messageCap)
+  return {
+    error_class: errorClass,
+    error_message: scrubbedMessage,
+    // Bucket on raw text: its patterns don't care about user paths and would
+    // otherwise miss matches hidden inside a `[REDACTED]` substitution.
+    error_bucket: bucketError(raw),
+    error_signature: `${errorClass}|${normalizeSignature(scrubbedMessage)}`,
+  }
+}
+
+/**
+ * The last N lines of stderr, PII-scrubbed and length-capped, for
+ * process-boot failures. Prefers the TAIL (where tracebacks and the fatal
+ * error print) over the head (dominated by node-load noise). Returns `null`
+ * for empty input so the field is explicitly absent rather than `''`.
+ */
+export function errorTail(
+  stderr: string | null | undefined,
+  opts: { lines?: number; maxChars?: number } = {}
+): string | null {
+  if (!stderr) return null
+  const lines = opts.lines ?? ERROR_TAIL_LINES
+  const maxChars = opts.maxChars ?? ERROR_TAIL_MAX
+  const scrubbed = scrubAll(stderr)
+  const tail = scrubbed.split('\n').slice(-lines).join('\n')
+  const bounded = tail.length > maxChars ? tail.slice(-maxChars) : tail
+  const trimmed = bounded.trim()
+  return trimmed.length > 0 ? trimmed : null
+}

--- a/src/shared/errorEvent.ts
+++ b/src/shared/errorEvent.ts
@@ -15,7 +15,7 @@
  *   - `error_class`     Stable, LOCALE-INDEPENDENT type identifier for
  *                       grouping (e.g. `ModuleNotFoundError`, `CUDAError`).
  *                       Derived from the exception class name / a fixed
- *                       English signature dictionary â€” never from a
+ *                       English signature dictionary — never from a
  *                       localized OS string, so the same failure groups on
  *                       a Chinese and an English machine alike.
  *   - `error_message`   Human-readable message, PII-scrubbed and capped.
@@ -26,7 +26,7 @@
  *                       regardless of user-specific paths or values.
  *
  * Process-boot failures also carry `error_tail` (the last N lines of
- * stderr, where tracebacks and the fatal line live) â€” see `errorTail`.
+ * stderr, where tracebacks and the fatal line live) — see `errorTail`.
  *
  * Lives in `src/shared/` (no Electron / Node / DOM deps) so both main and
  * renderer classify identically. Adding a rule here updates every failure
@@ -84,7 +84,7 @@ function messageOf(input: unknown): string {
 /**
  * The final Python exception line in a (possibly multi-line) text, e.g.
  * `ModuleNotFoundError: No module named 'torch'`. Scans line by line and
- * returns the LAST match â€” the final exception of a chained traceback is the
+ * returns the LAST match — the final exception of a chained traceback is the
  * user-facing one. `null` when the text has no exception line (a plain JS
  * error message, a launch string, etc.).
  */
@@ -99,7 +99,7 @@ function findExceptionLine(text: string): string | null {
 
 /**
  * Extract a locale-independent `error_class`. Priority:
- *   1. A Python exception class token anywhere in the text (last match wins â€”
+ *   1. A Python exception class token anywhere in the text (last match wins —
  *      the final exception in a chained traceback is the user-facing one).
  *   2. A fixed English signature (CUDA / OOM) that isn't a class name.
  *   3. A meaningful JS `Error.name` (not the generic `Error`).


### PR DESCRIPTION
Closes #1225.

## What

Introduces a **single, enforced schema for every error/failure telemetry event** so all of them carry enough to be diagnosable. Every failure event now ships:

| field | meaning |
|---|---|
| `error_class` | Locale-independent type id — the exception class name (`ModuleNotFoundError`) or a fixed CUDA/OOM signature (`CUDANoKernelImage`). Never derived from a localized OS string, so the same failure groups on a Chinese and an English machine alike. |
| `error_message` | Human-readable, PII-scrubbed, capped at 2 KB. For a traceback it is the **final exception line**, not the node-load noise that precedes it. |
| `error_bucket` | Existing coarse classification (unchanged). |
| `error_signature` | Normalized, PII-stripped key (paths / ids / numbers / quoted strings redacted) prefixed with `error_class`, so the same error groups regardless of user-specific paths or values. |

All of this lives in one shared helper, [`src/shared/errorEvent.ts`](../blob/telemetry/standardize-error-events/src/shared/errorEvent.ts) (`buildErrorFields` / `errorTail` / `extractErrorClass`), plus `emitError()` in `telemetry.ts` as the single enforced emit path.

## The `boot_failed` case (worst offender)

- Now derives the full schema from the launch message **+ the stderr tail**, and adds:
  - **`error_tail`** — the last ~40 lines of stderr (scrubbed, ~4 KB), i.e. where the fatal error actually prints.
  - **`exit_code`** and **`signal`**.
- The stderr tail buffer already lived in the **main process** (so it survives a hard child crash) — it was simply **discarded on the failure path**. This PR plumbs it out of `tryLaunch` into the event. No dependence on the separate, unreliable `boot_log` event.
- stderr is already decoded as UTF-8, so CJK messages aren't mojibake.
- The phantom always-empty `reason` / `error` / `stage` fields are gone; `exit_code` is populated.

## Other black boxes fixed

- **`app_update.error`** (1.3M events, 0% with a message): now ships class/message/signature. The message was already computed for the retry modal — it just was never emitted.
- **`execution.error` `validation_failed`** (~760k blank messages): now captures the multi-line validation reasons (`Value not in list`, `Required input is missing`, …) as the message via deferred block collection, instead of a blank field. Groups by reason, not one opaque bucket.

## Also routed through the shared schema

`trackedStep` (covers `adopt.register.error`, `migrate.*.error`, `snapshot.restore_*.error`), `install.phase` error rows, `torch_repair.failed`, `pygit2.probe_failed`, `node.installed` failures, `adopt.failed`, `comfyui.update.applied` error, and `manager.mirror_seed_failed`.

`auth.sign_in_failed` gains `error_class` but **keeps its deliberate no-message / no-signature policy** (the raw OAuth message may carry tokens/URLs).

## Hygiene

- `error_message` and `error_tail` go through `scrubAll` (paths, Bearer/OpenAI/HF tokens, basic-auth URLs) plus the main-process `scrubProperties` safety net.
- `error_bucket` still runs on the raw text (its regexes must see the un-redacted string), while the wire-bound fields are scrubbed.

## Tests

- New `src/shared/errorEvent.test.ts` (class extraction incl. locale independence, signature normalization, PII scrubbing, caps, tail behavior).
- Updated `executionTap` tests for the deferred, richer validation capture.
- Full suite: `pnpm typecheck && pnpm lint && pnpm test && pnpm build` all green (2763 tests pass).

Related: #1223, #1224.
