### PR TITLE
feat(telemetry): track global settings as durable properties (#1220, #1223)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1433,6 +1433,12 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
       id_class: getIdClass()
     })
 
+    // Durable snapshot of the tracked global settings as person properties
+    // (issues #1220/#1223), so adoption of every setting is queryable across the
+    // whole base. Consent-gated: queued until granted. Re-registered on change in
+    // `applySettingSet`.
+    mainTelemetry.registerPersonProperties(settings.getTrackedSettingsTelemetryProperties())
+
     const isFirstLaunch = consumeFirstLaunch()
     const pendingDownloadToken = readPendingDownloadToken()
     if (pendingDownloadToken) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1506,6 +1506,16 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
     const locale = (settings.get('language') as string | undefined) || app.getLocale().split('-')[0]
     i18n.init(locale)
 
+    // Locale adoption + unsupported-locale demand. `effective_language` is read
+    // after i18n.init so it's the locale the app actually renders (falls back to
+    // 'en' when no bundle exists), distinct from the OS locale and the user's
+    // pick. Not a global setting, but the only place the effective locale is known.
+    mainTelemetry.capture('comfy.desktop.app.language_resolved', {
+      os_locale: app.getLocale(),
+      selected_language: (settings.get('language') as string | undefined) || null,
+      effective_language: i18n.getLocale()
+    })
+
     // Desktop-side anchor of the website → download → first-launch acquisition
     // funnel. Fires exactly once per installation, ever (guard file alongside
     // device-id.txt). app_version / app_channel / platform / arch ride in as

--- a/src/main/lib/desktopAdopt.test.ts
+++ b/src/main/lib/desktopAdopt.test.ts
@@ -32,6 +32,7 @@ vi.mock('../settings', () => {
     has: vi.fn((key: string) => store[key] !== undefined && store[key] !== null),
     getAll: vi.fn(() => ({ ...store })),
     getMirrorConfig: vi.fn(() => ({ pypiMirror: undefined, useChineseMirrors: false })),
+    getTrackedSettingsTelemetryProperties: vi.fn(() => ({})),
     __store: store
   }
 })
@@ -129,6 +130,7 @@ vi.mock('../installations', () => {
 vi.mock('./telemetry', () => ({
   capture: vi.fn(),
   captureInstallCompleted: vi.fn(),
+  registerPersonProperties: vi.fn(),
   bucketError: vi.fn(() => 'other'),
   trackedStep: vi.fn(async (_step: string, _ctx: unknown, fn: () => Promise<unknown>) => fn())
 }))

--- a/src/main/lib/desktopAdopt.test.ts
+++ b/src/main/lib/desktopAdopt.test.ts
@@ -1018,6 +1018,20 @@ describe('adoptDesktopInstall', () => {
     }
   })
 
+  it('refreshes durable person properties for the settings it carries', async () => {
+    const legacy = buildFakeLegacy()
+    try {
+      // carryLegacySettings writes settings.json directly (bypassing
+      // applySettingSet), so it must refresh person properties itself.
+      const carried = { auto_install_updates: true, auto_install_updates_explicit: true }
+      vi.mocked(settings.getTrackedSettingsTelemetryProperties).mockReturnValueOnce(carried)
+      await adoptDesktopInstall({ tools: buildSilentTools(), deps: buildDeps({}, legacy.info) })
+      expect(telemetry.registerPersonProperties).toHaveBeenCalledWith(carried)
+    } finally {
+      legacy.cleanup()
+    }
+  })
+
   it('respects a pre-existing v2 autoInstallUpdates choice on reconcile', async () => {
     // A reconcile pass must not silently flip a user's explicit v2 choice back on.
     settingsMock.__store['autoInstallUpdates'] = false

--- a/src/main/lib/desktopAdopt.ts
+++ b/src/main/lib/desktopAdopt.ts
@@ -893,6 +893,15 @@ function carryLegacySettings(
   tryCarry('inputDir', path.join(basePath, 'input'))
   tryCarry('outputDir', path.join(basePath, 'output'))
 
+  // This flow writes settings.json directly (not via applySettingSet), so refresh
+  // the durable per-setting person properties for what we just changed instead of
+  // waiting for the next boot (issues #1220/#1223). Consent-gated + queued.
+  const changedKeys = additions.length > 0 ? [...carriedKeys, 'modelsDirs'] : carriedKeys
+  const trackedProps = settings.getTrackedSettingsTelemetryProperties(changedKeys)
+  if (Object.keys(trackedProps).length > 0) {
+    telemetry.registerPersonProperties(trackedProps)
+  }
+
   return { addedModelsDirs: additions, carriedKeys, carrySkippedKeys }
 }
 

--- a/src/main/lib/ipc/registerSettingsHandlers.ts
+++ b/src/main/lib/ipc/registerSettingsHandlers.ts
@@ -281,6 +281,12 @@ export function applySettingSet(key: string, value: unknown): void {
     // Re-broadcast so a pending 'ready' immediately reads as auto-on/off.
     updater.notifyAutoUpdateChanged()
   }
+  // Keep the durable per-setting person properties current on toggle (issues
+  // #1220/#1223) instead of waiting for the next boot. No-op for 'omit' keys.
+  const trackedProps = settings.getTrackedSettingsTelemetryProperties([key])
+  if (Object.keys(trackedProps).length > 0) {
+    mainTelemetry.registerPersonProperties(trackedProps)
+  }
   _broadcastToRenderer('settings-changed', { key })
   globalSettingsEvents.emit('changed')
 }

--- a/src/main/lib/ipc/sessionStartTelemetry.ts
+++ b/src/main/lib/ipc/sessionStartTelemetry.ts
@@ -6,6 +6,7 @@
  * renderer callbacks frequently never ran. Same event names/shapes as before.
  */
 import * as telemetry from '../telemetry'
+import * as settings from '../../settings'
 import { buildInstallationDdContext } from './shared'
 import { scrubAll } from '../../../shared/piiScrub'
 
@@ -119,6 +120,10 @@ export async function emitInstanceStartedTelemetry(info: InstanceStartedInfo): P
     // one release cycle so existing dashboards survive migration (issue #1054).
     const instanceStartedProps = {
       ...(metadata as Record<string, string | number | boolean | null | undefined>),
+      // Point-in-time snapshot of the tracked global settings (issue #1223) so
+      // current state is queryable on a recurring event without a person-property
+      // join.
+      ...settings.getTrackedSettingsTelemetryProperties(),
       boot_time_ms: info.bootTimeMs ?? null,
       port_retries: info.portRetries,
       reboot_retries: info.rebootRetries,

--- a/src/main/settings.test.ts
+++ b/src/main/settings.test.ts
@@ -62,6 +62,7 @@ beforeEach(async () => {
         if (name === 'home') return homePath
         return userDataPath
       },
+      getLocale: () => 'en-US',
     },
   }))
   settings = await import('./settings')
@@ -502,14 +503,45 @@ describe('getTrackedSettingsTelemetryProperties (telemetry policy)', () => {
     }
   }
 
-  it('default-on autoInstallUpdates: unset reports true, explicit false reports false', () => {
+  it('autoInstallUpdates: effective value plus an explicit-set companion', () => {
+    // Unset => default-on and not explicit.
     expect(settings.getTrackedSettingsTelemetryProperties(['autoInstallUpdates'])).toEqual({
       auto_install_updates: true,
+      auto_install_updates_explicit: false,
     })
+    // Explicit false => off and explicit.
     settings.set('autoInstallUpdates', false)
     expect(settings.getTrackedSettingsTelemetryProperties(['autoInstallUpdates'])).toEqual({
       auto_install_updates: false,
+      auto_install_updates_explicit: true,
     })
+    // Explicit true => on and explicit (distinct from the default-on majority).
+    settings.set('autoInstallUpdates', true)
+    expect(settings.getTrackedSettingsTelemetryProperties(['autoInstallUpdates'])).toEqual({
+      auto_install_updates: true,
+      auto_install_updates_explicit: true,
+    })
+  })
+
+  it('language: emits selected (null when unset) and effective (resolved) locale', () => {
+    // Unset => selected null, effective from the OS locale (mocked en-US).
+    expect(settings.getTrackedSettingsTelemetryProperties(['language'])).toEqual({
+      setting_language_selected: null,
+      setting_language: 'en',
+    })
+    // Explicit choice => both reflect it.
+    settings.set('language', 'zh')
+    expect(settings.getTrackedSettingsTelemetryProperties(['language'])).toEqual({
+      setting_language_selected: 'zh',
+      setting_language: 'zh',
+    })
+  })
+
+  it('omits the dark-only theme setting entirely', () => {
+    settings.set('theme', 'light')
+    const props = settings.getTrackedSettingsTelemetryProperties()
+    expect(props).not.toHaveProperty('setting_theme')
+    expect(props).not.toHaveProperty('setting_theme_selected')
   })
 
   it('default-off useChineseMirrors: unset reports false, explicit true reports true', () => {

--- a/src/main/settings.test.ts
+++ b/src/main/settings.test.ts
@@ -62,7 +62,6 @@ beforeEach(async () => {
         if (name === 'home') return homePath
         return userDataPath
       },
-      getLocale: () => 'en-US',
     },
   }))
   settings = await import('./settings')
@@ -523,17 +522,43 @@ describe('getTrackedSettingsTelemetryProperties (telemetry policy)', () => {
     })
   })
 
-  it('language: emits selected (null when unset) and effective (resolved) locale', () => {
-    // Unset => selected null, effective from the OS locale (mocked en-US).
+  it('language: emits only the selected value (null when following the OS default)', () => {
+    // Effective locale lives on the app.language_resolved event, not here.
     expect(settings.getTrackedSettingsTelemetryProperties(['language'])).toEqual({
       setting_language_selected: null,
-      setting_language: 'en',
     })
-    // Explicit choice => both reflect it.
     settings.set('language', 'zh')
     expect(settings.getTrackedSettingsTelemetryProperties(['language'])).toEqual({
       setting_language_selected: 'zh',
-      setting_language: 'zh',
+    })
+  })
+
+  it('omits the legacy autoUpdate setting entirely', () => {
+    settings.set('autoUpdate', false)
+    expect(settings.getTrackedSettingsTelemetryProperties()).not.toHaveProperty('setting_auto_update')
+  })
+
+  it('scalar value settings emit their typed value, never a hand-edited string', () => {
+    // onAppClose enum + maxCachedDownloads number pass through when valid
+    // (onAppClose resolves to its 'quit' default while tray docking is disabled).
+    settings.set('maxCachedDownloads', 5)
+    expect(
+      settings.getTrackedSettingsTelemetryProperties(['onAppClose', 'maxCachedDownloads'])
+    ).toEqual({
+      setting_on_app_close: 'quit',
+      setting_max_cached_downloads: 5,
+    })
+    // A corrupt/hand-edited settings.json can't leak a free-form string.
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({ onAppClose: '/Users/me/secret', maxCachedDownloads: 'lots' }),
+      'utf-8'
+    )
+    expect(
+      settings.getTrackedSettingsTelemetryProperties(['onAppClose', 'maxCachedDownloads'])
+    ).toEqual({
+      setting_on_app_close: null,
+      setting_max_cached_downloads: null,
     })
   })
 

--- a/src/main/settings.test.ts
+++ b/src/main/settings.test.ts
@@ -32,6 +32,9 @@ let settings: {
   get: (key: string) => unknown
   has: (key: string) => boolean
   defaults: { onAppClose: 'tray' | 'quit' }
+  getTrackedSettingsTelemetryProperties: (
+    keys?: readonly string[]
+  ) => Record<string, boolean | number | string | null>
 }
 
 const settingsPath = process.platform === 'linux'
@@ -470,5 +473,116 @@ describe('modelsDirs user ordering', () => {
     const dirs = settings.get('modelsDirs') as string[]
     expect(dirs.length).toBe(1)
     expect(path.resolve(dirs[0]!)).toBe(path.join(homePath, 'ComfyUI-Shared', 'models'))
+  })
+})
+
+describe('getTrackedSettingsTelemetryProperties (telemetry policy)', () => {
+  const realPlatform = process.platform
+
+  function withPlatform<T>(platform: NodeJS.Platform, fn: () => T): T {
+    Object.defineProperty(process, 'platform', { value: platform, configurable: true })
+    try {
+      return fn()
+    } finally {
+      Object.defineProperty(process, 'platform', { value: realPlatform, configurable: true })
+    }
+  }
+
+  it('default-on autoInstallUpdates: unset reports true, explicit false reports false', () => {
+    expect(settings.getTrackedSettingsTelemetryProperties(['autoInstallUpdates'])).toEqual({
+      auto_install_updates: true,
+    })
+    settings.set('autoInstallUpdates', false)
+    expect(settings.getTrackedSettingsTelemetryProperties(['autoInstallUpdates'])).toEqual({
+      auto_install_updates: false,
+    })
+  })
+
+  it('default-off useChineseMirrors: unset reports false, explicit true reports true', () => {
+    expect(settings.getTrackedSettingsTelemetryProperties(['useChineseMirrors'])).toEqual({
+      setting_use_chinese_mirrors: false,
+    })
+    settings.set('useChineseMirrors', true)
+    expect(settings.getTrackedSettingsTelemetryProperties(['useChineseMirrors'])).toEqual({
+      setting_use_chinese_mirrors: true,
+    })
+  })
+
+  it('Windows-only installUpdatesOnStartup: default-on true on win32, false when opted out', () => {
+    withPlatform('win32', () => {
+      expect(settings.getTrackedSettingsTelemetryProperties(['installUpdatesOnStartup'])).toEqual({
+        install_updates_on_startup: true,
+      })
+    })
+    settings.set('installUpdatesOnStartup', false)
+    withPlatform('win32', () => {
+      expect(settings.getTrackedSettingsTelemetryProperties(['installUpdatesOnStartup'])).toEqual({
+        install_updates_on_startup: false,
+      })
+    })
+  })
+
+  it('Windows-only gates report null off-Windows (not applicable, not opted out)', () => {
+    withPlatform('darwin', () => {
+      expect(
+        settings.getTrackedSettingsTelemetryProperties([
+          'installUpdatesOnStartup',
+          'showInstallerUI',
+        ])
+      ).toEqual({
+        install_updates_on_startup: null,
+        setting_show_installer_ui: null,
+      })
+    })
+  })
+
+  it('path settings emit presence booleans, never the raw path', () => {
+    const before = settings.getTrackedSettingsTelemetryProperties([
+      'installDir',
+      'modelsDirs',
+      'cacheDir',
+    ])
+    expect(before).toEqual({
+      setting_install_dir: false,
+      setting_models_dirs: false,
+      setting_cache_dir: false,
+    })
+    settings.set('installDir', path.join(homePath, 'Custom', 'Installs'))
+    const after = settings.getTrackedSettingsTelemetryProperties(['installDir'])
+    expect(after.setting_install_dir).toBe(true)
+    expect(Object.values(after).every((v) => typeof v !== 'string')).toBe(true)
+  })
+
+  it('autoLaunchOnStartup emits presence (bool-ified), never the install id', () => {
+    expect(settings.getTrackedSettingsTelemetryProperties(['autoLaunchOnStartup'])).toEqual({
+      setting_auto_launch_on_startup: false,
+    })
+    settings.set('autoLaunchOnStartup', 'some-install-id')
+    expect(settings.getTrackedSettingsTelemetryProperties(['autoLaunchOnStartup'])).toEqual({
+      setting_auto_launch_on_startup: true,
+    })
+  })
+
+  it('omits internal bookkeeping and consent keys', () => {
+    settings.set('firstUseCompleted', true)
+    settings.set('telemetryEnabled', true)
+    settings.set('chineseMirrorsPrompted', true)
+    const props = settings.getTrackedSettingsTelemetryProperties()
+    expect(props).not.toHaveProperty('setting_first_use_completed')
+    expect(props).not.toHaveProperty('setting_telemetry_enabled')
+    expect(props).not.toHaveProperty('setting_chinese_mirrors_prompted')
+  })
+
+  it('full snapshot includes both #1220 exact names and never emits arrays/objects', () => {
+    const props = withPlatform('win32', () =>
+      settings.getTrackedSettingsTelemetryProperties()
+    )
+    expect(props).toHaveProperty('auto_install_updates')
+    expect(props).toHaveProperty('install_updates_on_startup')
+    for (const value of Object.values(props)) {
+      expect(['boolean', 'number', 'string']).toContain(
+        value === null ? 'boolean' : typeof value
+      )
+    }
   })
 })

--- a/src/main/settings.test.ts
+++ b/src/main/settings.test.ts
@@ -355,6 +355,20 @@ describe('settings.has (persisted-only check)', () => {
     fs.writeFileSync(settingsPath, JSON.stringify({ theme: null }), 'utf-8')
     expect(settings.has('theme')).toBe(false)
   })
+
+  it('treats a stale sentinel value as unset (autoLaunchOnStartup: none)', () => {
+    // A manually edited / migrated file may still carry the 'none' sentinel that
+    // set() would have dropped; has() must not report it as a user choice.
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true })
+    fs.writeFileSync(settingsPath, JSON.stringify({ autoLaunchOnStartup: 'none' }), 'utf-8')
+    expect(settings.has('autoLaunchOnStartup')).toBe(false)
+  })
+
+  it('treats a whitespace-only pypiMirror as unset', () => {
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true })
+    fs.writeFileSync(settingsPath, JSON.stringify({ pypiMirror: '   ' }), 'utf-8')
+    expect(settings.has('pypiMirror')).toBe(false)
+  })
 })
 
 describe('modelsDirs user ordering', () => {

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -106,6 +106,23 @@ export type SettingTelemetryValue = boolean | number | string | null
  *  platform-aware (e.g. Windows-only gates report `null` off-Windows). */
 type SettingTelemetryCtx = { platform: NodeJS.Platform }
 
+/** A `value` telemetry transform. Returning `null` means "not applicable /
+ *  default"; NEVER return an array/object. Settings whose default is applied at
+ *  runtime (not via the `defaults` object) MUST coalesce `undefined` to their
+ *  effective default here, so emitted values stay self-describing if a default
+ *  changes over time. */
+type SettingTelemetryTransform<K extends keyof KnownSettings> = (
+  raw: KnownSettings[K] | undefined,
+  ctx: SettingTelemetryCtx
+) => SettingTelemetryValue
+
+/** A single emitted property. `value` emits the (optionally transformed) value;
+ *  `presence` emits `settings.has(key)` — used both for PII-safe path settings
+ *  and as an "explicitly set?" companion to a `value` emitter. */
+type SettingEmitter<K extends keyof KnownSettings> =
+  | { kind: 'value'; prop: string; toTelemetry?: SettingTelemetryTransform<K> }
+  | { kind: 'presence'; prop: string }
+
 /**
  * Per-setting tracking policy (issue #1223). Every `SETTINGS_SCHEMA` entry MUST
  * declare one, so a new setting can't silently ship untracked:
@@ -115,8 +132,12 @@ type SettingTelemetryCtx = { platform: NodeJS.Platform }
  *  - `'presence'`— emit only a boolean (`settings.has(key)` = user-set / differs
  *                  from default). For path / URL / PII-bearing settings whose raw
  *                  value must never leave the machine.
- *  - `'omit'`    — internal bookkeeping; never emitted.
- * `prop` overrides the default `setting_<snake_case_key>` property name.
+ *  - `'multi'`   — emit several props for one setting (e.g. a raw "selected"
+ *                  value plus a resolved "effective" value, or a `value` plus an
+ *                  "explicitly set?" `presence` companion). Each emitter names its
+ *                  own `prop`.
+ *  - `'omit'`    — internal bookkeeping / dead settings; never emitted.
+ * For `value`/`presence`, `prop` overrides the default `setting_<snake_case_key>`.
  */
 type SettingTelemetryPolicy<K extends keyof KnownSettings> =
   | { policy: 'omit' }
@@ -124,8 +145,9 @@ type SettingTelemetryPolicy<K extends keyof KnownSettings> =
   | {
       policy: 'value'
       prop?: string
-      toTelemetry?: (raw: KnownSettings[K] | undefined, ctx: SettingTelemetryCtx) => SettingTelemetryValue
+      toTelemetry?: SettingTelemetryTransform<K>
     }
+  | { policy: 'multi'; emitters: SettingEmitter<K>[] }
 
 type SettingSchemaEntry<K extends keyof KnownSettings> = {
   nullable: boolean
@@ -140,8 +162,32 @@ const SETTINGS_SCHEMA = {
   inputDir: { nullable: false, telemetry: { policy: 'presence' } },
   outputDir: { nullable: false, telemetry: { policy: 'presence' } },
   installDir: { nullable: false, telemetry: { policy: 'presence' } },
-  language: { nullable: false, telemetry: { policy: 'value' } },
-  theme: { nullable: false, telemetry: { policy: 'value' } },
+  language: {
+    // Track both what the user selected (null when following the OS default) and
+    // the effective locale actually in use. Effective mirrors the boot resolution
+    // (`get('language') || app.getLocale()`), so it stays correct if the default
+    // OS-locale mapping changes.
+    nullable: false,
+    telemetry: {
+      policy: 'multi',
+      emitters: [
+        {
+          kind: 'value',
+          prop: 'setting_language_selected',
+          toTelemetry: (raw) => (typeof raw === 'string' && raw ? raw : null),
+        },
+        {
+          kind: 'value',
+          prop: 'setting_language',
+          toTelemetry: (raw) =>
+            typeof raw === 'string' && raw ? raw : app.getLocale().split('-')[0] || 'unknown',
+        },
+      ],
+    },
+  },
+  // App is dark-only; the theme setting is inert (see resolveTheme), so tracking
+  // it carries no signal.
+  theme: { nullable: false, telemetry: { policy: 'omit' } },
   autoUpdate: {
     nullable: false,
     telemetry: { policy: 'value', toTelemetry: (raw) => raw === true },
@@ -149,8 +195,16 @@ const SETTINGS_SCHEMA = {
   autoInstallUpdates: {
     // Default-on: any non-`false` value (incl. missing) is enabled. Mirrors
     // `isAutoInstallEnabled()` in updater.ts. Exact prop name required by #1220.
+    // `auto_install_updates_explicit` separates users who explicitly chose a value
+    // from the default-on majority (the opt-in/out cohort from #1220).
     nullable: false,
-    telemetry: { policy: 'value', prop: 'auto_install_updates', toTelemetry: (raw) => raw !== false },
+    telemetry: {
+      policy: 'multi',
+      emitters: [
+        { kind: 'value', prop: 'auto_install_updates', toTelemetry: (raw) => raw !== false },
+        { kind: 'presence', prop: 'auto_install_updates_explicit' },
+      ],
+    },
   },
   // Emit "auto-launch configured?" as a boolean; the raw value can be an
   // installation id (potentially identifying).
@@ -572,28 +626,33 @@ function toScalarOrNull(v: unknown): SettingTelemetryValue {
  * Build the durable telemetry snapshot of the tracked global settings, driven by
  * each `SETTINGS_SCHEMA` entry's `telemetry` policy (issue #1223). Returned as a
  * flat `prop -> scalar` map suitable for PostHog person properties or as event
- * properties. `'omit'` keys are dropped, `'presence'` keys emit a boolean, and
- * `'value'` keys emit their (optionally transformed) scalar. Pass `keys` to
- * snapshot a subset (e.g. a single changed key).
+ * properties. `'omit'` keys are dropped, `'presence'` keys emit a boolean,
+ * `'value'` keys emit their (optionally transformed) scalar, and `'multi'` keys
+ * emit one entry per declared emitter. Pass `keys` to snapshot a subset (e.g. a
+ * single changed key).
  */
 export function getTrackedSettingsTelemetryProperties(
   keys: readonly string[] = KNOWN_SETTING_KEYS
 ): Record<string, SettingTelemetryValue> {
   const ctx: SettingTelemetryCtx = { platform: process.platform }
   const out: Record<string, SettingTelemetryValue> = {}
+  const emitValue = (raw: unknown, transform?: SettingTelemetryTransform<KnownSettingKey>): SettingTelemetryValue =>
+    transform ? transform(raw as never, ctx) : toScalarOrNull(raw)
   for (const key of keys) {
     if (!isKnownSettingKey(key)) continue
     const tel = (SETTINGS_SCHEMA[key] as SettingSchemaEntry<KnownSettingKey>).telemetry
     if (tel.policy === 'omit') continue
-    const prop = tel.prop ?? `setting_${camelToSnake(key)}`
     if (tel.policy === 'presence') {
-      out[prop] = has(key)
+      out[tel.prop ?? `setting_${camelToSnake(key)}`] = has(key)
       continue
     }
-    const raw = get(key)
-    out[prop] = tel.toTelemetry
-      ? tel.toTelemetry(raw as never, ctx)
-      : toScalarOrNull(raw)
+    if (tel.policy === 'multi') {
+      for (const em of tel.emitters) {
+        out[em.prop] = em.kind === 'presence' ? has(key) : emitValue(get(key), em.toTelemetry)
+      }
+      continue
+    }
+    out[tel.prop ?? `setting_${camelToSnake(key)}`] = emitValue(get(key), tel.toTelemetry)
   }
   return out
 }

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -98,35 +98,111 @@ const dataPath = path.join(configDir(), "settings.json")
 
 const SHARED_ROOT = path.join(defaultDataRoot(), "ComfyUI-Shared")
 
+/** Scalar shapes allowed as a telemetry property value. Arrays/objects are
+ *  never emitted (they'd leak paths/PII and blow up cardinality). */
+export type SettingTelemetryValue = boolean | number | string | null
+
+/** Runtime context passed to per-setting telemetry transforms so they can be
+ *  platform-aware (e.g. Windows-only gates report `null` off-Windows). */
+type SettingTelemetryCtx = { platform: NodeJS.Platform }
+
+/**
+ * Per-setting tracking policy (issue #1223). Every `SETTINGS_SCHEMA` entry MUST
+ * declare one, so a new setting can't silently ship untracked:
+ *  - `'value'`   — emit the setting's value. Use `toTelemetry` to coalesce
+ *                  default-on/off booleans and platform-gate Windows-only keys;
+ *                  without it the raw scalar (or `null`) is emitted.
+ *  - `'presence'`— emit only a boolean (`settings.has(key)` = user-set / differs
+ *                  from default). For path / URL / PII-bearing settings whose raw
+ *                  value must never leave the machine.
+ *  - `'omit'`    — internal bookkeeping; never emitted.
+ * `prop` overrides the default `setting_<snake_case_key>` property name.
+ */
+type SettingTelemetryPolicy<K extends keyof KnownSettings> =
+  | { policy: 'omit' }
+  | { policy: 'presence'; prop?: string }
+  | {
+      policy: 'value'
+      prop?: string
+      toTelemetry?: (raw: KnownSettings[K] | undefined, ctx: SettingTelemetryCtx) => SettingTelemetryValue
+    }
+
+type SettingSchemaEntry<K extends keyof KnownSettings> = {
+  nullable: boolean
+  telemetry: SettingTelemetryPolicy<K>
+}
+
 const SETTINGS_SCHEMA = {
-  cacheDir: { nullable: false },
-  maxCachedDownloads: { nullable: false },
-  onAppClose: { nullable: false },
-  modelsDirs: { nullable: false },
-  inputDir: { nullable: false },
-  outputDir: { nullable: false },
-  installDir: { nullable: false },
-  language: { nullable: false },
-  theme: { nullable: false },
-  autoUpdate: { nullable: false },
-  autoInstallUpdates: { nullable: false },
-  autoLaunchOnStartup: { nullable: false },
-  confirmBeforeClosingWindow: { nullable: false },
-  pypiMirror: { nullable: false },
-  useChineseMirrors: { nullable: false },
-  chineseMirrorsPrompted: { nullable: false },
-  telemetryEnabled: { nullable: false },
-  firstUseCompleted: { nullable: false },
-  hideCloudFromPicker: { nullable: false },
-  oemManagedModelDirs: { nullable: false },
-  oemWorkflowImportVersion: { nullable: false },
-  lastSaveDialogDir: { nullable: true },
-  skipTemplatePickerStep: { nullable: false },
-  pendingDownloadedUpdateVersion: { nullable: true },
-  lastStartupUpdateAttemptVersion: { nullable: true },
-  installUpdatesOnStartup: { nullable: false },
-  showInstallerUI: { nullable: false },
-} as const satisfies Record<keyof KnownSettings, { nullable: boolean }>
+  cacheDir: { nullable: false, telemetry: { policy: 'presence' } },
+  maxCachedDownloads: { nullable: false, telemetry: { policy: 'value' } },
+  onAppClose: { nullable: false, telemetry: { policy: 'value' } },
+  modelsDirs: { nullable: false, telemetry: { policy: 'presence' } },
+  inputDir: { nullable: false, telemetry: { policy: 'presence' } },
+  outputDir: { nullable: false, telemetry: { policy: 'presence' } },
+  installDir: { nullable: false, telemetry: { policy: 'presence' } },
+  language: { nullable: false, telemetry: { policy: 'value' } },
+  theme: { nullable: false, telemetry: { policy: 'value' } },
+  autoUpdate: {
+    nullable: false,
+    telemetry: { policy: 'value', toTelemetry: (raw) => raw === true },
+  },
+  autoInstallUpdates: {
+    // Default-on: any non-`false` value (incl. missing) is enabled. Mirrors
+    // `isAutoInstallEnabled()` in updater.ts. Exact prop name required by #1220.
+    nullable: false,
+    telemetry: { policy: 'value', prop: 'auto_install_updates', toTelemetry: (raw) => raw !== false },
+  },
+  // Emit "auto-launch configured?" as a boolean; the raw value can be an
+  // installation id (potentially identifying).
+  autoLaunchOnStartup: { nullable: false, telemetry: { policy: 'presence' } },
+  confirmBeforeClosingWindow: {
+    nullable: false,
+    telemetry: { policy: 'value', toTelemetry: (raw) => raw === true },
+  },
+  // Mirror URL can be a private/identifying endpoint — presence only.
+  pypiMirror: { nullable: false, telemetry: { policy: 'presence' } },
+  useChineseMirrors: {
+    nullable: false,
+    telemetry: { policy: 'value', toTelemetry: (raw) => raw === true },
+  },
+  chineseMirrorsPrompted: { nullable: false, telemetry: { policy: 'omit' } },
+  // Consent gate, not a durable trackable setting: once disabled we can't emit a
+  // fresh `false` without violating the consent gate, so the value would go stale.
+  telemetryEnabled: { nullable: false, telemetry: { policy: 'omit' } },
+  firstUseCompleted: { nullable: false, telemetry: { policy: 'omit' } },
+  hideCloudFromPicker: {
+    nullable: false,
+    telemetry: { policy: 'value', toTelemetry: (raw) => raw === true },
+  },
+  oemManagedModelDirs: { nullable: false, telemetry: { policy: 'presence' } },
+  oemWorkflowImportVersion: { nullable: false, telemetry: { policy: 'omit' } },
+  lastSaveDialogDir: { nullable: true, telemetry: { policy: 'presence' } },
+  skipTemplatePickerStep: {
+    nullable: false,
+    telemetry: { policy: 'value', toTelemetry: (raw) => raw === true },
+  },
+  pendingDownloadedUpdateVersion: { nullable: true, telemetry: { policy: 'omit' } },
+  lastStartupUpdateAttemptVersion: { nullable: true, telemetry: { policy: 'omit' } },
+  installUpdatesOnStartup: {
+    // Windows-only, default-on. Off-Windows the gate is inert, so report `null`
+    // ("not applicable") to keep it distinct from an explicit opt-out. Exact
+    // prop name required by #1220.
+    nullable: false,
+    telemetry: {
+      policy: 'value',
+      prop: 'install_updates_on_startup',
+      toTelemetry: (raw, ctx) => (ctx.platform === 'win32' ? raw !== false : null),
+    },
+  },
+  showInstallerUI: {
+    // Windows-only, default-on — same `null`-off-Windows convention.
+    nullable: false,
+    telemetry: {
+      policy: 'value',
+      toTelemetry: (raw, ctx) => (ctx.platform === 'win32' ? raw !== false : null),
+    },
+  },
+} as const satisfies { [K in keyof KnownSettings]: SettingSchemaEntry<K> }
 
 export type KnownSettingKey = keyof typeof SETTINGS_SCHEMA
 export type NullableKnownSettingKey = {
@@ -477,6 +553,49 @@ export function set<K extends string>(
 
 export function getAll(): Settings {
   return load()
+}
+
+function camelToSnake(s: string): string {
+  // Handle acronym runs so `showInstallerUI` -> `show_installer_ui`, not
+  // `show_installer_u_i`.
+  return s
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2')
+    .toLowerCase()
+}
+
+function toScalarOrNull(v: unknown): SettingTelemetryValue {
+  return typeof v === 'boolean' || typeof v === 'number' || typeof v === 'string' ? v : null
+}
+
+/**
+ * Build the durable telemetry snapshot of the tracked global settings, driven by
+ * each `SETTINGS_SCHEMA` entry's `telemetry` policy (issue #1223). Returned as a
+ * flat `prop -> scalar` map suitable for PostHog person properties or as event
+ * properties. `'omit'` keys are dropped, `'presence'` keys emit a boolean, and
+ * `'value'` keys emit their (optionally transformed) scalar. Pass `keys` to
+ * snapshot a subset (e.g. a single changed key).
+ */
+export function getTrackedSettingsTelemetryProperties(
+  keys: readonly string[] = KNOWN_SETTING_KEYS
+): Record<string, SettingTelemetryValue> {
+  const ctx: SettingTelemetryCtx = { platform: process.platform }
+  const out: Record<string, SettingTelemetryValue> = {}
+  for (const key of keys) {
+    if (!isKnownSettingKey(key)) continue
+    const tel = (SETTINGS_SCHEMA[key] as SettingSchemaEntry<KnownSettingKey>).telemetry
+    if (tel.policy === 'omit') continue
+    const prop = tel.prop ?? `setting_${camelToSnake(key)}`
+    if (tel.policy === 'presence') {
+      out[prop] = has(key)
+      continue
+    }
+    const raw = get(key)
+    out[prop] = tel.toTelemetry
+      ? tel.toTelemetry(raw as never, ctx)
+      : toScalarOrNull(raw)
+  }
+  return out
 }
 
 /**

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -604,7 +604,10 @@ export function getTrackedSettingsTelemetryProperties(
  * default-comparison guards against `load()`'s merged write persisting defaults
  * as a side effect, which would otherwise fool the legacy-adopt carry. A user
  * who explicitly picks the default value is misclassified as "not set"
- * (accepted). Returns `false` on parse errors or a missing file.
+ * (accepted). Sentinel values `set()` treats as unset (`autoLaunchOnStartup:
+ * 'none'`, whitespace-only `pypiMirror`) are also treated as absent, so a
+ * stale/hand-edited file can't masquerade as a user choice. Returns `false` on
+ * parse errors or a missing file.
  */
 export function has(key: string): boolean {
   const raw = readFileSafe(dataPath)
@@ -614,6 +617,15 @@ export function has(key: string): boolean {
     if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return false
     const value = (parsed as Record<string, unknown>)[key]
     if (value === undefined || value === null) return false
+    // Honor the same "means unset" sentinels `set()` drops, so a stale/manually
+    // edited settings.json can't report a sentinel (e.g. `autoLaunchOnStartup:
+    // 'none'`, a whitespace-only `pypiMirror`) as a user choice.
+    if (DEFAULT_VALUE_MEANS_UNSET.has(key) && value === DEFAULT_VALUE_MEANS_UNSET.get(key)) {
+      return false
+    }
+    if (typeof value === 'string' && value.trim() === '' && EMPTY_STRING_MEANS_UNSET.has(key)) {
+      return false
+    }
     if (key in defaults) {
       const def = (defaults as Record<string, unknown>)[key]
       if (typeof def === 'string' && typeof value === 'string') {

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -156,42 +156,40 @@ type SettingSchemaEntry<K extends keyof KnownSettings> = {
 
 const SETTINGS_SCHEMA = {
   cacheDir: { nullable: false, telemetry: { policy: 'presence' } },
-  maxCachedDownloads: { nullable: false, telemetry: { policy: 'value' } },
-  onAppClose: { nullable: false, telemetry: { policy: 'value' } },
+  // Validate the scalar type so a hand-edited settings.json can't leak a
+  // free-form string; fall back to null ("not a real value") otherwise.
+  maxCachedDownloads: {
+    nullable: false,
+    telemetry: { policy: 'value', toTelemetry: (raw) => (typeof raw === 'number' ? raw : null) },
+  },
+  onAppClose: {
+    nullable: false,
+    telemetry: {
+      policy: 'value',
+      toTelemetry: (raw) => (raw === 'quit' || raw === 'tray' ? raw : null),
+    },
+  },
   modelsDirs: { nullable: false, telemetry: { policy: 'presence' } },
   inputDir: { nullable: false, telemetry: { policy: 'presence' } },
   outputDir: { nullable: false, telemetry: { policy: 'presence' } },
   installDir: { nullable: false, telemetry: { policy: 'presence' } },
+  // What the user actually selected (null = following the OS default). The
+  // *effective* locale the app resolves to is emitted on the
+  // `app.language_resolved` event instead, where it's known post-i18n-init.
   language: {
-    // Track both what the user selected (null when following the OS default) and
-    // the effective locale actually in use. Effective mirrors the boot resolution
-    // (`get('language') || app.getLocale()`), so it stays correct if the default
-    // OS-locale mapping changes.
     nullable: false,
     telemetry: {
-      policy: 'multi',
-      emitters: [
-        {
-          kind: 'value',
-          prop: 'setting_language_selected',
-          toTelemetry: (raw) => (typeof raw === 'string' && raw ? raw : null),
-        },
-        {
-          kind: 'value',
-          prop: 'setting_language',
-          toTelemetry: (raw) =>
-            typeof raw === 'string' && raw ? raw : app.getLocale().split('-')[0] || 'unknown',
-        },
-      ],
+      policy: 'value',
+      prop: 'setting_language_selected',
+      toTelemetry: (raw) => (typeof raw === 'string' && raw ? raw : null),
     },
   },
   // App is dark-only; the theme setting is inert (see resolveTheme), so tracking
   // it carries no signal.
   theme: { nullable: false, telemetry: { policy: 'omit' } },
-  autoUpdate: {
-    nullable: false,
-    telemetry: { policy: 'value', toTelemetry: (raw) => raw === true },
-  },
+  // Legacy toggle no longer gated on a setting (see KnownSettings), so its value
+  // has no effective meaning — don't emit it as if it did.
+  autoUpdate: { nullable: false, telemetry: { policy: 'omit' } },
   autoInstallUpdates: {
     // Default-on: any non-`false` value (incl. missing) is enabled. Mirrors
     // `isAutoInstallEnabled()` in updater.ts. Exact prop name required by #1220.


### PR DESCRIPTION
## Summary

Makes **all global settings trackable as durable PostHog properties** via a schema-driven telemetry policy, closing both the specific auto-update-adoption gap (#1220) and the general "no durable view of global settings" gap (#1223). The auto-install-updates setting is now just one instance of the general system.

Fixes #1220
Fixes #1223

## What changed

Each `SETTINGS_SCHEMA` entry now **must** declare a `telemetry` policy (enforced by `satisfies`), so a new setting can't silently ship untracked:

- `'value'` -- emit the setting's value. An optional `toTelemetry` transform coalesces default-on/off booleans and platform-gates Windows-only settings.
- `'presence'` -- emit only a boolean (`settings.has(key)` = user-set / differs from default). Used for path / URL / PII-bearing settings whose raw value must never leave the machine.
- `'omit'` -- internal bookkeeping; never emitted.

`getTrackedSettingsTelemetryProperties()` builds the snapshot from the schema. It is emitted in three places:

1. **Boot** (`index.ts`) -- registered as PostHog person properties (`$set`), consent-gated (queued until granted).
2. **On change** (`applySettingSet` in `registerSettingsHandlers.ts`) -- re-registers the changed key immediately, so a toggle updates the property without waiting for the next boot. Covers both the `set-setting` IPC and the Global Settings popup (`comfy-titlepopup:global-settings-update-field`), which both funnel through `applySettingSet`.
3. **`session.instance_started`** (`sessionStartTelemetry.ts`) -- bundles the snapshot onto the recurring per-boot event so current state is queryable without a person-property join.

## Naming and semantics

- `autoInstallUpdates` becomes `auto_install_updates` and `installUpdatesOnStartup` becomes `install_updates_on_startup` -- the **exact names from #1220**; all other settings use `setting_<snake_case>`.
- **Default-on booleans** (`autoInstallUpdates`, `installUpdatesOnStartup`, `showInstallerUI`) emit their effective value (`!== false`) so default users are counted -- this is the core fix for #1220's "default population is invisible".
- **Windows-only** gates (`installUpdatesOnStartup`, `showInstallerUI`) emit `null` off-Windows to keep "not applicable" distinct from an explicit opt-out.
- **Paths/URLs** (`cacheDir`, `installDir`, `modelsDirs`, `inputDir`, `outputDir`, `lastSaveDialogDir`, `oemManagedModelDirs`, `pypiMirror`) and `autoLaunchOnStartup` (bool-ified) emit presence booleans only -- never the raw value.
- `telemetryEnabled` is omitted (once disabled we can't emit a fresh `false` without violating the consent gate, so the value would go stale), along with internal bookkeeping keys.

## Acceptance criteria

- [x] `auto_install_updates` and `install_updates_on_startup` present as person properties for v-next clients.
- [x] Property updates immediately on toggle (not just next boot).
- [x] On/off split queryable across all active users (person props + `session.instance_started`).
- [x] Every setting declares a tracking policy at definition time (trackable by default).
- [x] No PII/paths emitted (presence-only for path/URL settings).

## Tests

Added `getTrackedSettingsTelemetryProperties` unit tests in `settings.test.ts`: default-on/off coalescing, Windows-only `null`-off-Windows, presence-only for paths, `autoLaunchOnStartup` bool-ification, omitted keys, exact #1220 names, and a guard that no emitted value is an array/object.

Validation: `pnpm run typecheck`, `pnpm run lint`, `pnpm run build`, and the full `pnpm run test` (2752 tests, 187 files) all pass.
