### PR TITLE
fix(theme): force dark theme regardless of setting or OS appearance

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, Menu, ipcMain, net, dialog, crashReporter } from 'electron'
+import { app, Menu, ipcMain, net, dialog, crashReporter, nativeTheme } from 'electron'
 import type { BrowserWindow, WebContentsView } from 'electron'
 import type { Tray } from 'electron'
 import path from 'path'
@@ -1323,6 +1323,10 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
     // any startup crash are captured.
     initAppLog()
     registerProcessErrorHandlers()
+    // App is dark-only: force Chromium/native surfaces (OS dialogs, menus) dark
+    // regardless of the OS appearance, matching the dark-only app UI (see
+    // resolveTheme). Set before any window opens.
+    nativeTheme.themeSource = 'dark'
     // Bound the local crash-dump folder; Crashpad's own pruning is coarse in
     // upload-disabled mode and a crash-looping user can pile up multi-MB dumps.
     pruneCrashDumps()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1323,9 +1323,7 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
     // any startup crash are captured.
     initAppLog()
     registerProcessErrorHandlers()
-    // App is dark-only: force Chromium/native surfaces (OS dialogs, menus) dark
-    // regardless of the OS appearance, matching the dark-only app UI (see
-    // resolveTheme). Set before any window opens.
+    // Force native surfaces (dialogs, menus) dark before any window opens (see resolveTheme).
     nativeTheme.themeSource = 'dark'
     // Bound the local crash-dump folder; Crashpad's own pruning is coarse in
     // upload-disabled mode and a crash-looping user can pile up multi-MB dumps.

--- a/src/main/lib/ipc/shared.ts
+++ b/src/main/lib/ipc/shared.ts
@@ -1076,11 +1076,7 @@ export async function migrateDefaults(): Promise<void> {
 }
 
 export function resolveTheme(): ResolvedTheme {
-  // The app is dark-only. Ignore the `theme` setting and OS appearance entirely
-  // so a stale `theme: 'light'` in settings.json or a light-mode OS can't leak a
-  // broken light UI (the title bar, native controls, splash and brand elements
-  // are all dark-only). The `theme` plumbing stays wired; re-enabling light mode
-  // means restoring this resolution and completing the dark-only overrides.
+  // App is dark-only — ignore the `theme` setting and OS appearance.
   return 'dark'
 }
 

--- a/src/main/lib/ipc/shared.ts
+++ b/src/main/lib/ipc/shared.ts
@@ -1075,12 +1075,13 @@ export async function migrateDefaults(): Promise<void> {
   }
 }
 
-const VALID_THEMES: readonly string[] = ['system', 'dark', 'light'] satisfies readonly Theme[]
-
 export function resolveTheme(): ResolvedTheme {
-  const raw = settings.get('theme') as string | undefined
-  const theme: Theme = raw && VALID_THEMES.includes(raw) ? (raw as Theme) : 'system'
-  return theme === 'system' ? (nativeTheme.shouldUseDarkColors ? 'dark' : 'light') : theme
+  // The app is dark-only. Ignore the `theme` setting and OS appearance entirely
+  // so a stale `theme: 'light'` in settings.json or a light-mode OS can't leak a
+  // broken light UI (the title bar, native controls, splash and brand elements
+  // are all dark-only). The `theme` plumbing stays wired; re-enabling light mode
+  // means restoring this resolution and completing the dark-only overrides.
+  return 'dark'
 }
 
 // Single-flight: overlapping calls (boot, periodic timer, manual refresh) share one run


### PR DESCRIPTION
## Summary

The app is intended to be **dark-only** (the theme picker is already hidden), but light was still reachable — producing a broken, high-contrast UI.

[`resolveTheme()`](https://github.com/Comfy-Org/Comfy-Desktop/blob/main/src/main/lib/ipc/shared.ts) honored the persisted `theme` setting and resolved `'system'` (or unset) against the OS:

```ts
const theme = raw && VALID_THEMES.includes(raw) ? raw : 'system'
return theme === 'system' ? (nativeTheme.shouldUseDarkColors ? 'dark' : 'light') : theme
```

So light leaked through in two real cases:

1. A stale / migrated `settings.json` with `theme: 'light'`.
2. `theme` unset or `'system'` on a **light-mode OS** (`shouldUseDarkColors === false`).

In both, the panel content renders light while the title bar, native window controls, splash screen and brand elements stay dark-only — a broken experience.

## Change

- `resolveTheme()` now always returns `'dark'` — it's the single source of truth for the app UI (drives `get-resolved-theme` → the renderer's `data-theme`, the `theme-changed` broadcasts, and all title-bar overlays), so this guarantees dark regardless of the setting or OS.
- Pin `nativeTheme.themeSource = 'dark'` at boot so native OS surfaces (dialogs, menus) are dark too — "dark no matter what on their system."

Non-destructive: users' `settings.json` is untouched, and the theme plumbing stays wired, so re-enabling light mode later just means restoring the resolution and finishing the dark-only overrides.

## Notes

- The renderer drives appearance entirely off `data-theme` (no `prefers-color-scheme` dependency), so forcing `resolveTheme()` fully controls the UI.
- No existing tests referenced theme resolution; typecheck, lint, build, and the full test suite (2744 tests) pass.

Separate from the telemetry work in #1236 (which now omits the dark-only `theme` setting from tracking).
