### PR TITLE
Reduce desktop update polling cadence

### DIFF
--- a/src/main/lib/updater.test.ts
+++ b/src/main/lib/updater.test.ts
@@ -6,6 +6,7 @@ let mockAppImage: string | undefined
 let mockIsPackaged = true
 let mockExePath = '/opt/Comfy Desktop/comfyui-desktop-2'
 let mockAppVersion = '1.0.0'
+let powerMonitorListeners: Record<string, Array<() => void>> = {}
 
 vi.mock('electron', () => ({
   app: {
@@ -21,6 +22,12 @@ vi.mock('electron', () => ({
   },
   ipcMain: {
     handle: vi.fn()
+  },
+  powerMonitor: {
+    on: vi.fn((event: string, listener: () => void) => {
+      powerMonitorListeners[event] = powerMonitorListeners[event] || []
+      powerMonitorListeners[event].push(listener)
+    })
   },
   BrowserWindow: {
     getAllWindows: () => []
@@ -54,6 +61,118 @@ async function bootUpdater(): Promise<typeof UpdaterModule> {
   mod.register()
   return mod
 }
+
+describe('background update check scheduling', () => {
+  let fakeUpdater: { on: ReturnType<typeof vi.fn>; checkForUpdates: ReturnType<typeof vi.fn> }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-09T12:00:00Z'))
+    vi.resetModules()
+    powerMonitorListeners = {}
+    fakeUpdater = {
+      on: vi.fn(),
+      checkForUpdates: vi.fn(async () => ({ updateInfo: null }))
+    }
+    vi.doMock('@todesktop/runtime', () => ({ default: { autoUpdater: fakeUpdater } }))
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  function fireResume(): void {
+    for (const listener of powerMonitorListeners['resume'] || []) listener()
+  }
+
+  it('adds bounded jitter around the six-hour background cadence', async () => {
+    const updater = await import('./updater')
+
+    expect(updater.getNextBackgroundUpdateCheckDelay(() => 0)).toBe(5.5 * 60 * 60 * 1000)
+    expect(updater.getNextBackgroundUpdateCheckDelay(() => 0.5)).toBe(6 * 60 * 60 * 1000)
+    expect(updater.getNextBackgroundUpdateCheckDelay(() => 1)).toBe(6.5 * 60 * 60 * 1000)
+  })
+
+  it('checks shortly after startup and then uses the jittered cadence', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+    await bootUpdater()
+
+    await vi.advanceTimersByTimeAsync(1999)
+    expect(fakeUpdater.checkForUpdates).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(fakeUpdater.checkForUpdates).toHaveBeenCalledTimes(1)
+    expect(fakeUpdater.checkForUpdates).toHaveBeenLastCalledWith(
+      expect.objectContaining({ source: 'auto-check' })
+    )
+
+    await vi.advanceTimersByTimeAsync(5.5 * 60 * 60 * 1000 - 1)
+    expect(fakeUpdater.checkForUpdates).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(fakeUpdater.checkForUpdates).toHaveBeenCalledTimes(2)
+  })
+
+  it('checks after resume when the last check is stale', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(1)
+    await bootUpdater()
+    await vi.advanceTimersByTimeAsync(2000)
+
+    await vi.advanceTimersByTimeAsync(6 * 60 * 60 * 1000 - 1)
+    fireResume()
+    await Promise.resolve()
+    expect(fakeUpdater.checkForUpdates).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(1)
+    fireResume()
+    await Promise.resolve()
+    expect(fakeUpdater.checkForUpdates).toHaveBeenCalledTimes(2)
+    expect(fakeUpdater.checkForUpdates).toHaveBeenLastCalledWith(
+      expect.objectContaining({ source: 'resume-check' })
+    )
+
+    await vi.advanceTimersByTimeAsync(30 * 60 * 1000)
+    expect(fakeUpdater.checkForUpdates).toHaveBeenCalledTimes(2)
+
+    await vi.advanceTimersByTimeAsync(6 * 60 * 60 * 1000)
+    expect(fakeUpdater.checkForUpdates).toHaveBeenCalledTimes(3)
+  })
+
+  it('does not check after resume when a manual check is still fresh', async () => {
+    await bootUpdater()
+    await vi.advanceTimersByTimeAsync(2000)
+    const updater = await import('./updater')
+
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000)
+    await updater.runCheck('manual-check')
+    fireResume()
+    await Promise.resolve()
+
+    expect(fakeUpdater.checkForUpdates).toHaveBeenCalledTimes(2)
+    expect(fakeUpdater.checkForUpdates).toHaveBeenLastCalledWith(
+      expect.objectContaining({ source: 'manual-check' })
+    )
+  })
+
+  it('restarts the background cadence after a manual check', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.5)
+    const updater = await bootUpdater()
+    await vi.advanceTimersByTimeAsync(2000)
+
+    await vi.advanceTimersByTimeAsync(5 * 60 * 60 * 1000)
+    await updater.runCheck('manual-check')
+
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000)
+    expect(fakeUpdater.checkForUpdates).toHaveBeenCalledTimes(2)
+
+    await vi.advanceTimersByTimeAsync(5 * 60 * 60 * 1000)
+    expect(fakeUpdater.checkForUpdates).toHaveBeenCalledTimes(3)
+    expect(fakeUpdater.checkForUpdates).toHaveBeenLastCalledWith(
+      expect.objectContaining({ source: 'auto-check' })
+    )
+  })
+})
 
 describe('isSystemPackageInstall (via get-update-capabilities)', () => {
   let registeredHandlers: Record<string, (...args: unknown[]) => unknown>

--- a/src/main/lib/updater.ts
+++ b/src/main/lib/updater.ts
@@ -1,4 +1,4 @@
-import { app, ipcMain } from 'electron'
+import { app, ipcMain, powerMonitor } from 'electron'
 import semver from 'semver'
 import todesktop from '@todesktop/runtime'
 import { autoUpdater as electronAutoUpdater } from 'electron-updater'
@@ -74,6 +74,27 @@ function _shouldEmitAppUpdateOnce(event: string, version: string | null): boolea
 let _userInitiatedDownload = false
 const _stateChangeCallbacks = new Set<(state: AppUpdateState) => void>()
 let _listenersBound = false
+let _lastUpdateCheckStartedAt: number | null = null
+let _rescheduleBackgroundUpdateCheck: (() => void) | null = null
+
+const STARTUP_UPDATE_CHECK_DELAY_MS = 2 * 1000
+const BACKGROUND_UPDATE_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000
+const BACKGROUND_UPDATE_CHECK_JITTER_MS = 30 * 60 * 1000
+
+export function getNextBackgroundUpdateCheckDelay(random: () => number = Math.random): number {
+  return (
+    BACKGROUND_UPDATE_CHECK_INTERVAL_MS + (random() * 2 - 1) * BACKGROUND_UPDATE_CHECK_JITTER_MS
+  )
+}
+
+export function isUpdateCheckStale(
+  lastCheckStartedAt: number | null,
+  now: number = Date.now()
+): boolean {
+  return (
+    lastCheckStartedAt !== null && now - lastCheckStartedAt >= BACKGROUND_UPDATE_CHECK_INTERVAL_MS
+  )
+}
 
 function _setUpdateState(next: AppUpdateState): void {
   _appUpdateState = next
@@ -447,7 +468,7 @@ function bindUpdaterEvents(): void {
 
 /** Triggers that originate from explicit user intent (the title-bar
  *  "Check for Updates" menu and the auto-off available-pill confirm
- *  modal). Background triggers (`auto-check` every 10 min, plus any
+ *  modal). Background triggers (`auto-check` every ~6 hours, resume checks, plus any
  *  app-open / dashboard-revisit / IPP-click code path that quietly
  *  re-runs a check) are implementation details and would otherwise
  *  fire on every periodic interval without carrying analytical
@@ -462,6 +483,8 @@ const USER_INITIATED_CHECK_TRIGGERS = new Set(['manual-check', 'download-button'
 async function checkForUpdate(
   source: string
 ): Promise<{ available: boolean; version?: string; error?: string }> {
+  _lastUpdateCheckStartedAt = Date.now()
+  _rescheduleBackgroundUpdateCheck?.()
   const updater = getAutoUpdater()
   if (!updater) {
     if (USER_INITIATED_CHECK_TRIGGERS.has(source)) {
@@ -871,9 +894,37 @@ export function register(): void {
   // user-controllable `autoInstallUpdates` setting only gates whether
   // a discovered update silently downloads + installs vs prompts the
   // user; the check loop itself is no longer user-disablable.
-  const runAutoCheck = (): void => {
-    runCheck('auto-check').catch(() => {})
+  let nextBackgroundCheck: ReturnType<typeof setTimeout> | null = null
+  let backgroundCheckInFlight = false
+
+  function scheduleNextBackgroundCheck(): void {
+    if (nextBackgroundCheck) clearTimeout(nextBackgroundCheck)
+    nextBackgroundCheck = setTimeout(
+      () => runBackgroundCheck('auto-check'),
+      getNextBackgroundUpdateCheckDelay()
+    )
   }
-  setTimeout(runAutoCheck, 2000)
-  setInterval(runAutoCheck, 10 * 60 * 1000)
+  function runBackgroundCheck(source: 'auto-check' | 'resume-check'): void {
+    if (backgroundCheckInFlight) {
+      scheduleNextBackgroundCheck()
+      return
+    }
+    backgroundCheckInFlight = true
+    runCheck(source)
+      .catch(() => {})
+      .finally(() => {
+        backgroundCheckInFlight = false
+      })
+  }
+
+  _rescheduleBackgroundUpdateCheck = scheduleNextBackgroundCheck
+
+  nextBackgroundCheck = setTimeout(
+    () => runBackgroundCheck('auto-check'),
+    STARTUP_UPDATE_CHECK_DELAY_MS
+  )
+  powerMonitor.on('resume', () => {
+    if (!isUpdateCheckStale(_lastUpdateCheckStartedAt)) return
+    runBackgroundCheck('resume-check')
+  })
 }


### PR DESCRIPTION
## What changed

- preserve the update check shortly after startup and all manual check paths
- replace 10-minute polling with a recursive 6-hour cadence plus ±30 minutes of jitter
- check after system resume when the last update check is at least 6 hours old
- rearm the background timer after any check and avoid overlapping background checks
- add focused deterministic tests for startup timing, jitter bounds, cadence, manual rearming, and resume behavior

## Why

A continuously running client currently checks for Desktop updates 144 times per day. This reduces background traffic to roughly four checks per day while retaining prompt startup/manual checks and preventing clients from synchronizing.

The existing auto-install opt-out behavior is unchanged.

## Validation

- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test` (188 files, 2,770 passed, 1 skipped)
