### PR TITLE
fix(auth): require a same-origin call on the loopback bridge callback

### DIFF
--- a/src/main/auth/firebaseBridge/server.test.ts
+++ b/src/main/auth/firebaseBridge/server.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
+import { request as httpRequest } from 'node:http'
+
 import { BRIDGE_PORT, startBridgeServer } from './server'
 
 describe('startBridgeServer', () => {
@@ -84,5 +86,100 @@ describe('startBridgeServer', () => {
     // Assert the constant, not a live bind — the contract with the Google
     // OAuth client's redirect-URI allowlist is the constant itself.
     expect(BRIDGE_PORT).toBe(9876)
+  })
+
+  describe('POST /callback origin enforcement', () => {
+    const USER = { uid: 'uid-1', email: 'a@b.c', stsTokenManager: { refreshToken: 'r' } }
+
+    /** Raw request so headers arrive exactly as sent (undici strips Origin). */
+    function rawPost(
+      url: string,
+      headers: Record<string, string>
+    ): Promise<{ status: number }> {
+      const target = new URL('callback', url)
+      const body = JSON.stringify({ user: USER })
+      return new Promise((resolve, reject) => {
+        const req = httpRequest(
+          {
+            hostname: target.hostname,
+            port: target.port,
+            path: target.pathname,
+            method: 'POST',
+            headers: { 'Content-Length': Buffer.byteLength(body), ...headers }
+          },
+          (res) => {
+            res.resume()
+            res.on('end', () => resolve({ status: res.statusCode ?? 0 }))
+          }
+        )
+        req.on('error', reject)
+        req.end(body)
+      })
+    }
+
+    /** Did the flow complete? Must be false for every rejected request. */
+    async function signedIn(handle: { signInPromise: Promise<unknown> }): Promise<boolean> {
+      return await Promise.race([
+        handle.signInPromise.then(() => true),
+        new Promise<boolean>((r) => setTimeout(() => r(false), 50))
+      ])
+    }
+
+    // The one shape that reaches a loopback server cross-site with no CORS
+    // preflight: a form POST, whose content-type is CORS-"simple".
+    it('rejects a cross-site form POST and signs nobody in', async () => {
+      const handle = await startBridgeServer({ env: 'prod', providerId: 'github.com', port: 0 })
+      try {
+        const res = await rawPost(handle.url, {
+          'Content-Type': 'text/plain;charset=UTF-8',
+          Origin: 'https://evil.example.com',
+          'Sec-Fetch-Site': 'cross-site'
+        })
+        expect(res.status).toBe(403)
+        expect(await signedIn(handle)).toBe(false)
+      } finally {
+        handle.close()
+      }
+    })
+
+    it('rejects a JSON POST from a foreign origin', async () => {
+      const handle = await startBridgeServer({ env: 'prod', providerId: 'github.com', port: 0 })
+      try {
+        const res = await rawPost(handle.url, {
+          'Content-Type': 'application/json',
+          Origin: 'https://evil.example.com'
+        })
+        expect(res.status).toBe(403)
+        expect(await signedIn(handle)).toBe(false)
+      } finally {
+        handle.close()
+      }
+    })
+
+    it('rejects a POST with neither Origin nor Sec-Fetch-Site (fails closed)', async () => {
+      const handle = await startBridgeServer({ env: 'prod', providerId: 'github.com', port: 0 })
+      try {
+        const res = await rawPost(handle.url, { 'Content-Type': 'application/json' })
+        expect(res.status).toBe(403)
+        expect(await signedIn(handle)).toBe(false)
+      } finally {
+        handle.close()
+      }
+    })
+
+    it('accepts the genuine same-origin JSON call from the bridge page', async () => {
+      const handle = await startBridgeServer({ env: 'prod', providerId: 'github.com', port: 0 })
+      try {
+        const res = await rawPost(handle.url, {
+          'Content-Type': 'application/json',
+          Origin: new URL(handle.url).origin,
+          'Sec-Fetch-Site': 'same-origin'
+        })
+        expect(res.status).toBe(204)
+        await expect(handle.signInPromise).resolves.toMatchObject({ user: USER })
+      } finally {
+        handle.close()
+      }
+    })
   })
 })

--- a/src/main/auth/firebaseBridge/server.ts
+++ b/src/main/auth/firebaseBridge/server.ts
@@ -12,6 +12,49 @@ import {
 
 const MAX_BODY_BYTES = 64 * 1024
 
+/**
+ * True only for a genuine same-origin call from the bridge page we serve.
+ *
+ * The loopback socket check cannot help here: every page in every browser on
+ * this machine also reaches us from 127.0.0.1. Since `/callback` accepts a
+ * signed-in user, it needs positive proof of the caller, so require the three
+ * things our own `fetch('/callback', {method:'POST', headers:{'Content-Type':
+ * 'application/json'}})` always sends and that a cross-site caller cannot all
+ * produce:
+ *
+ *  - `Content-Type: application/json` — the load-bearing one. A cross-site
+ *    request can only reach us without a CORS preflight by staying within the
+ *    "simple request" content-types (text/plain, form-encoded, multipart). We
+ *    serve no OPTIONS handler, so demanding JSON means any cross-site attempt
+ *    must preflight, and the preflight fails.
+ *  - `Sec-Fetch-Site: same-origin` — a forbidden header; a page cannot forge it.
+ *    Absent on browsers that don't send it, so it is checked only when present.
+ *  - `Origin` — must be this server's own loopback origin when supplied.
+ */
+export function isSameOriginBridgeCall(req: IncomingMessage, port: number): boolean {
+  const contentType = String(req.headers['content-type'] ?? '')
+    .split(';')[0]!
+    .trim()
+    .toLowerCase()
+  if (contentType !== 'application/json') return false
+
+  const site = req.headers['sec-fetch-site']
+  if (typeof site === 'string' && site !== 'same-origin') return false
+
+  const origin = req.headers.origin
+  if (typeof origin === 'string' && origin.length > 0) {
+    const allowed = [`http://localhost:${port}`, `http://127.0.0.1:${port}`]
+    if (!allowed.includes(origin.toLowerCase())) return false
+    return true
+  }
+
+  // No Origin. Accept only when the browser positively attests same-origin;
+  // otherwise fail closed. Every browser sends Origin on a cross-origin POST,
+  // and same-origin POSTs send Origin and/or Sec-Fetch-Site, so this rejects
+  // only callers that are not the bridge page.
+  return site === 'same-origin'
+}
+
 async function readJsonBody(req: IncomingMessage): Promise<unknown> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = []
@@ -168,6 +211,15 @@ export function startBridgeServer(opts: StartBridgeOpts): Promise<BridgeHandle> 
       if (req.method === 'POST' && path === '/callback') {
         if (providerId !== 'github.com') {
           res.statusCode = 404
+          res.end()
+          return
+        }
+        // The loopback check above cannot distinguish our own bridge page from
+        // any other page in any browser on this machine — they all arrive from
+        // 127.0.0.1. This endpoint accepts a signed-in user, so require proof
+        // the request really is our page: a same-origin JSON fetch. Fail closed.
+        if (!isSameOriginBridgeCall(req, (server!.address() as AddressInfo).port)) {
+          res.statusCode = 403
           res.end()
           return
         }


### PR DESCRIPTION
## What

The loopback sign-in bridge's `POST /callback` accepts a signed-in Firebase user and injects it into the app session. Its only validation was that the request arrived on the **loopback socket**.

That check can't do the job it looks like it's doing: every page in every browser on the machine also reaches the server from `127.0.0.1`. So it cannot distinguish the bridge page we serve from any other page the user happens to have open. The handler read no `Origin`, no `Sec-Fetch-Site`, and never enforced a content-type — `readJsonBody` parses the body regardless.

This makes the endpoint require positive proof that the caller is the page we served: a **same-origin JSON fetch**, which is exactly what the bridge page already sends.

## The checks

- **`Content-Type: application/json`** — the load-bearing one. A cross-site caller can only reach a loopback server *without* a CORS preflight by staying inside the "simple" content-types (`text/plain`, form-encoded, multipart). We serve no `OPTIONS` handler, so demanding JSON forces a preflight that cannot succeed.
- **`Sec-Fetch-Site: same-origin`** when present — a forbidden header, so a page cannot forge it.
- **`Origin`** must be our own loopback origin when present.

Fails closed when neither `Origin` nor `Sec-Fetch-Site` attests same-origin.

No behaviour change for the real flow: the bridge page's `fetch('/callback', {method:'POST', headers:{'Content-Type':'application/json'}})` already satisfies all three.

## Testing

Tests drive the **real server over raw `node:http`** — undici strips `Origin`, so `fetch` can't express these cases:

| Request | Result |
|---|---|
| Cross-site form POST (`text/plain`) | 403, no sign-in |
| JSON POST from a foreign origin | 403, no sign-in |
| POST with neither `Origin` nor `Sec-Fetch-Site` | 403, no sign-in |
| Genuine same-origin JSON call | 204, resolves |

Each asserts the sign-in flow did **not** complete, not just the status code. Removing the guard fails all three. Full `src/main/auth` suite green (41), typecheck + lint clean.

## Notes

Found while reviewing #1222. Independent of that PR — this hardens the existing bridge, which #1222 keeps as its fallback path.