### PR TITLE
fix(adopt): restore Legacy Desktop settings from workspace

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2148,7 +2148,7 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
     registerDownloadHandlers()
     registerAssetDownloadHandlers({ findInstallationIdForWindow })
     cleanupTempDownloads()
-    ipc.register({
+    await ipc.register({
       onLaunch,
       onStop,
       onComfyExited,

--- a/src/main/lib/desktopAdopt.test.ts
+++ b/src/main/lib/desktopAdopt.test.ts
@@ -859,7 +859,13 @@ describe('adoptDesktopInstall', () => {
   it('does not replace launch args edited after adoption', async () => {
     const legacy = buildFakeLegacy({
       configFiles: {
-        'comfy.settings.json': JSON.stringify({ 'Comfy.Server.LaunchArgs': { cpu: '' } })
+        'comfy.settings.json': JSON.stringify({
+          'Comfy.Server.LaunchArgs': {
+            cpu: '',
+            'input-directory': 'D:\\legacy-input',
+            'output-directory': 'D:\\legacy-output'
+          }
+        })
       }
     })
     try {
@@ -872,12 +878,16 @@ describe('adoptDesktopInstall', () => {
         adopted: true,
         adoptedBaseDir: legacy.basePath,
         adoptedSelectedDevice: 'cpu',
-        launchArgs: '--port 9000 --enable-manager'
+        launchArgs: '--port 9000 --enable-manager',
+        inputDir: path.join(legacy.basePath, 'input'),
+        outputDir: path.join(legacy.basePath, 'output')
       })
 
       expect(await reconcileAdoptedSettings()).toBe(1)
       const [record] = installationsMock.__records
       expect(record!.launchArgs).toBe('--port 9000 --enable-manager')
+      expect(record!.inputDir).toBe('D:\\legacy-input')
+      expect(record!.outputDir).toBe('D:\\legacy-output')
       expect(record!.adoptedSettingsVersion).toBe(1)
     } finally {
       legacy.cleanup()

--- a/src/main/lib/desktopAdopt.test.ts
+++ b/src/main/lib/desktopAdopt.test.ts
@@ -114,7 +114,12 @@ vi.mock('../installations', () => {
     }),
     list: vi.fn(async () => records.slice()),
     get: vi.fn(async (id: string) => records.find((r) => r.id === id) ?? null),
-    update: vi.fn(),
+    update: vi.fn(async (id: string, data: Record<string, unknown>) => {
+      const entry = records.find((r) => r.id === id)
+      if (!entry) return null
+      Object.assign(entry, data)
+      return entry
+    }),
     remove: vi.fn(async (id: string) => {
       const idx = records.findIndex((r) => r.id === id)
       if (idx >= 0) records.splice(idx, 1)
@@ -146,6 +151,7 @@ import {
   deriveLaunchArgs,
   computeModelsDirsToCarry,
   getLegacyVenvUvPath,
+  reconcileAdoptedSettings,
   type AdoptTools,
   type AdoptDeps,
   type UserChoice
@@ -168,6 +174,7 @@ interface InstallationsMock {
   __reset: () => void
   add: ReturnType<typeof vi.fn>
   list: ReturnType<typeof vi.fn>
+  update: ReturnType<typeof vi.fn>
 }
 const settingsMock = settings as unknown as SettingsMock
 const installationsMock = installations as unknown as InstallationsMock
@@ -226,7 +233,12 @@ function buildFakeLegacy(
     fs.writeFileSync(path.join(venvBin, pyName), '')
   }
   for (const [name, content] of Object.entries(opts.configFiles ?? {})) {
-    fs.writeFileSync(path.join(configDir, name), content)
+    const target =
+      name === 'comfy.settings.json'
+        ? path.join(basePath, 'user', 'default', name)
+        : path.join(configDir, name)
+    fs.mkdirSync(path.dirname(target), { recursive: true })
+    fs.writeFileSync(target, content)
   }
   for (const [name, content] of Object.entries(opts.baseFiles ?? {})) {
     const target = path.join(basePath, name)
@@ -546,6 +558,19 @@ describe('deriveLaunchArgs', () => {
     expect(launchArgs).toContain('--port 9999')
     expect(launchArgs).not.toContain('--port 8000')
   })
+
+  it('preserves CPU mode from selectedDevice when the settings entry is missing', () => {
+    const { launchArgs } = deriveLaunchArgs({}, 'cpu')
+    expect(launchArgs.split(' ')).toContain('--cpu')
+  })
+
+  it('does not override an explicit disabled CPU setting', () => {
+    const { launchArgs } = deriveLaunchArgs(
+      { 'Comfy.Server.LaunchArgs': { cpu: false } },
+      'cpu'
+    )
+    expect(launchArgs.split(' ')).not.toContain('--cpu')
+  })
 })
 
 describe('computeModelsDirsToCarry', () => {
@@ -727,6 +752,181 @@ describe('adoptDesktopInstall', () => {
       // Marker written
       const marker = fs.readFileSync(path.join(legacy.basePath, '.comfyui-desktop-2'), 'utf-8')
       expect(marker).toBe(record.id)
+    } finally {
+      legacy.cleanup()
+    }
+  })
+
+  it('reads and backs up settings from the legacy workspace', async () => {
+    const canonicalSettings = JSON.stringify({
+      'Comfy.Server.LaunchArgs': { cpu: '', port: '8123' }
+    })
+    const legacy = buildFakeLegacy({
+      configFiles: {
+        'config.json': JSON.stringify({ selectedDevice: 'cpu' }),
+        'comfy.settings.json': canonicalSettings
+      }
+    })
+    try {
+      fs.writeFileSync(
+        path.join(legacy.configDir, 'comfy.settings.json'),
+        JSON.stringify({ 'Comfy.Server.LaunchArgs': { 'gpu-only': '', port: '9999' } })
+      )
+
+      const record = await adoptDesktopInstall({
+        tools: buildSilentTools(),
+        deps: buildDeps({}, legacy.info)
+      })
+
+      expect(record.launchArgs).toContain('--cpu')
+      expect(record.launchArgs).toContain('--port 8123')
+      expect(record.launchArgs).not.toContain('--gpu-only')
+      expect(record.launchArgs).not.toContain('--port 9999')
+
+      const [backupDir] = fs.readdirSync(path.join(legacy.configDir, 'legacy-backup'))
+      const backup = fs.readFileSync(
+        path.join(legacy.configDir, 'legacy-backup', backupDir!, 'comfy.settings.json'),
+        'utf-8'
+      )
+      expect(backup).toBe(canonicalSettings)
+    } finally {
+      legacy.cleanup()
+    }
+  })
+
+  it('preserves CPU mode from config.json when comfy.settings.json is missing', async () => {
+    const legacy = buildFakeLegacy({
+      configFiles: { 'config.json': JSON.stringify({ selectedDevice: 'cpu' }) }
+    })
+    try {
+      const record = await adoptDesktopInstall({
+        tools: buildSilentTools(),
+        deps: buildDeps({}, legacy.info)
+      })
+      expect((record.launchArgs as string).split(' ')).toContain('--cpu')
+      expect(record.adoptedSettingsVersion).toBe(1)
+    } finally {
+      legacy.cleanup()
+    }
+  })
+
+  it('repairs adopted records that still contain generated defaults', async () => {
+    const legacy = buildFakeLegacy({
+      configFiles: {
+        'comfy.settings.json': JSON.stringify({
+          'Comfy.Server.LaunchArgs': {
+            cpu: '',
+            port: '8123',
+            'input-directory': 'D:\\legacy-input',
+            'output-directory': 'D:\\legacy-output'
+          },
+          'Comfy-Desktop.UV.PypiInstallMirror': 'https://example.com/simple/'
+        })
+      }
+    })
+    try {
+      installationsMock.__records.push({
+        id: 'affected-adoption',
+        name: 'ComfyUI',
+        createdAt: new Date().toISOString(),
+        sourceId: 'standalone',
+        installPath: path.join(legacy.basePath, 'managed-source'),
+        adopted: true,
+        adoptedBaseDir: legacy.basePath,
+        adoptedSelectedDevice: 'cpu',
+        launchArgs: '--port 8000 --enable-manager',
+        inputDir: path.join(legacy.basePath, 'input'),
+        outputDir: 'D:\\v2-output'
+      })
+
+      expect(await reconcileAdoptedSettings()).toBe(1)
+      const [record] = installationsMock.__records
+      expect(record!.launchArgs).toContain('--cpu')
+      expect(record!.launchArgs).toContain('--port 8123')
+      expect(record!.inputDir).toBe('D:\\legacy-input')
+      expect(record!.outputDir).toBe('D:\\v2-output')
+      expect(record!.adoptedSettingsVersion).toBe(1)
+      expect(settingsMock.__store['pypiMirror']).toBe('https://example.com/simple/')
+
+      installationsMock.update.mockClear()
+      expect(await reconcileAdoptedSettings()).toBe(0)
+      expect(installationsMock.update).not.toHaveBeenCalled()
+    } finally {
+      legacy.cleanup()
+    }
+  })
+
+  it('does not replace launch args edited after adoption', async () => {
+    const legacy = buildFakeLegacy({
+      configFiles: {
+        'comfy.settings.json': JSON.stringify({ 'Comfy.Server.LaunchArgs': { cpu: '' } })
+      }
+    })
+    try {
+      installationsMock.__records.push({
+        id: 'edited-adoption',
+        name: 'ComfyUI',
+        createdAt: new Date().toISOString(),
+        sourceId: 'standalone',
+        installPath: path.join(legacy.basePath, 'managed-source'),
+        adopted: true,
+        adoptedBaseDir: legacy.basePath,
+        adoptedSelectedDevice: 'cpu',
+        launchArgs: '--port 9000 --enable-manager'
+      })
+
+      expect(await reconcileAdoptedSettings()).toBe(1)
+      const [record] = installationsMock.__records
+      expect(record!.launchArgs).toBe('--port 9000 --enable-manager')
+      expect(record!.adoptedSettingsVersion).toBe(1)
+    } finally {
+      legacy.cleanup()
+    }
+  })
+
+  it('retries adopted settings repair after a malformed settings file', async () => {
+    const legacy = buildFakeLegacy({
+      configFiles: { 'comfy.settings.json': '{' }
+    })
+    try {
+      installationsMock.__records.push({
+        id: 'unreadable-settings-adoption',
+        name: 'ComfyUI',
+        createdAt: new Date().toISOString(),
+        sourceId: 'standalone',
+        installPath: path.join(legacy.basePath, 'managed-source'),
+        adopted: true,
+        adoptedBaseDir: legacy.basePath,
+        adoptedSelectedDevice: 'cpu',
+        launchArgs: '--port 8000 --enable-manager'
+      })
+
+      expect(await reconcileAdoptedSettings()).toBe(0)
+      expect(installationsMock.update).not.toHaveBeenCalled()
+      expect(installationsMock.__records[0]).not.toHaveProperty('adoptedSettingsVersion')
+    } finally {
+      legacy.cleanup()
+    }
+  })
+
+  it('repairs a missing settings file from the persisted CPU device', async () => {
+    const legacy = buildFakeLegacy()
+    try {
+      installationsMock.__records.push({
+        id: 'missing-settings-adoption',
+        name: 'ComfyUI',
+        createdAt: new Date().toISOString(),
+        sourceId: 'standalone',
+        installPath: path.join(legacy.basePath, 'managed-source'),
+        adopted: true,
+        adoptedBaseDir: legacy.basePath,
+        adoptedSelectedDevice: 'cpu',
+        launchArgs: '--port 8000 --enable-manager'
+      })
+
+      expect(await reconcileAdoptedSettings()).toBe(1)
+      expect(installationsMock.__records[0]!.launchArgs).toContain('--cpu')
+      expect(installationsMock.__records[0]!.adoptedSettingsVersion).toBe(1)
     } finally {
       legacy.cleanup()
     }
@@ -1295,7 +1495,7 @@ describe('adoptDesktopInstall', () => {
     }
   })
 
-  it('backs up legacy userData files into legacy-backup/<ts>', async () => {
+  it('backs up legacy state files into legacy-backup/<ts>', async () => {
     const legacy = buildFakeLegacy({
       configFiles: {
         'config.json': '{"basePath":"x"}',

--- a/src/main/lib/desktopAdopt.ts
+++ b/src/main/lib/desktopAdopt.ts
@@ -957,18 +957,18 @@ export async function reconcileAdoptedSettings(): Promise<number> {
       // Only generated defaults are safe to replace; preserve launch args edited in v2.
       if (existing.launchArgs === generatedDefaultArgs) {
         patch.launchArgs = derived.launchArgs
-        if (
-          derived.pathOverrides.inputDir &&
-          existing.inputDir === path.join(basePath, 'input')
-        ) {
-          patch.inputDir = derived.pathOverrides.inputDir
-        }
-        if (
-          derived.pathOverrides.outputDir &&
-          existing.outputDir === path.join(basePath, 'output')
-        ) {
-          patch.outputDir = derived.pathOverrides.outputDir
-        }
+      }
+      if (
+        derived.pathOverrides.inputDir &&
+        existing.inputDir === path.join(basePath, 'input')
+      ) {
+        patch.inputDir = derived.pathOverrides.inputDir
+      }
+      if (
+        derived.pathOverrides.outputDir &&
+        existing.outputDir === path.join(basePath, 'output')
+      ) {
+        patch.outputDir = derived.pathOverrides.outputDir
       }
 
       if (await installations.update(existing.id, patch)) repaired += 1

--- a/src/main/lib/desktopAdopt.ts
+++ b/src/main/lib/desktopAdopt.ts
@@ -57,6 +57,16 @@ const DESKTOP_CONFIG_FILE = 'config.json'
 const EXTRA_MODELS_YAML = 'extra_models_config.yaml'
 const WINDOW_FILE = 'window.json'
 const VENV_VALIDATE_TIMEOUT_MS = 30_000
+const ADOPTED_SETTINGS_VERSION = 1
+
+function legacyComfySettingsPath(basePath: string): string {
+  return path.join(basePath, 'user', 'default', COMFY_SETTINGS_FILE)
+}
+
+interface LegacyComfySettingsRead {
+  settings: Record<string, unknown>
+  status: 'ok' | 'missing' | 'error'
+}
 
 export type AdoptPromptKind = 'tcc' | 'venv-broken' | 'source-missing' | 'confirm-adopt'
 
@@ -304,7 +314,10 @@ function normalizeLaunchValue(value: unknown): string | null {
  * the string and returned in `pathOverrides` so the caller can promote
  * them into the per-install `inputDir` / `outputDir` fields.
  */
-export function deriveLaunchArgs(comfySettings: Record<string, unknown>): DerivedLaunchArgs {
+export function deriveLaunchArgs(
+  comfySettings: Record<string, unknown>,
+  selectedDevice?: string | null
+): DerivedLaunchArgs {
   const asMap = (raw: unknown): Record<string, unknown> =>
     raw && typeof raw === 'object' && !Array.isArray(raw) ? (raw as Record<string, unknown>) : {}
 
@@ -313,6 +326,8 @@ export function deriveLaunchArgs(comfySettings: Record<string, unknown>): Derive
 
   // ServerConfigValues is the base; LaunchArgs overrides on key conflicts.
   const mergedMap: Record<string, unknown> = { ...serverConfigValues, ...launchArgsMap }
+  // selectedDevice is persisted separately and survives missing or damaged settings files.
+  if (selectedDevice === 'cpu' && !('cpu' in mergedMap)) mergedMap.cpu = true
 
   const parts: string[] = []
   const pathOverrides: DerivedLaunchArgs['pathOverrides'] = {}
@@ -354,15 +369,18 @@ export function deriveLaunchArgs(comfySettings: Record<string, unknown>): Derive
  * Read & coerce the subset of legacy front-end settings the orchestrator
  * actually uses. Missing values fall back to legacy defaults.
  */
-function readLegacyComfySettings(configDir: string): Record<string, unknown> {
+function readLegacyComfySettings(basePath: string): LegacyComfySettingsRead {
   try {
-    const raw = fs.readFileSync(path.join(configDir, COMFY_SETTINGS_FILE), 'utf-8')
+    const raw = fs.readFileSync(legacyComfySettingsPath(basePath), 'utf-8')
     const parsed: unknown = JSON.parse(raw)
     if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-      return parsed as Record<string, unknown>
+      return { settings: parsed as Record<string, unknown>, status: 'ok' }
     }
-  } catch {}
-  return {}
+    return { settings: {}, status: 'error' }
+  } catch (err) {
+    const status = (err as NodeJS.ErrnoException).code === 'ENOENT' ? 'missing' : 'error'
+    return { settings: {}, status }
+  }
 }
 
 function readLegacyComfyPrefs(raw: Record<string, unknown>): LegacyComfySettings {
@@ -525,11 +543,12 @@ function isUnderRoot(child: string, root: string): boolean {
 }
 
 /**
- * Best-effort copy of legacy userData files into a timestamped backup folder.
+ * Best-effort copy of legacy state files into a timestamped backup folder.
  * Logged on failure but never throws so adoption can continue.
  */
 async function backupLegacyState(
   configDir: string,
+  basePath: string,
   timestamp: string,
   sendOutput: (t: string) => void
 ): Promise<void> {
@@ -540,9 +559,13 @@ async function backupLegacyState(
     sendOutput(`Warning: could not create backup dir: ${(err as Error).message}\n`)
     return
   }
-  const files = [DESKTOP_CONFIG_FILE, COMFY_SETTINGS_FILE, EXTRA_MODELS_YAML, WINDOW_FILE]
-  for (const file of files) {
-    const src = path.join(configDir, file)
+  const files = [
+    { file: DESKTOP_CONFIG_FILE, src: path.join(configDir, DESKTOP_CONFIG_FILE) },
+    { file: COMFY_SETTINGS_FILE, src: legacyComfySettingsPath(basePath) },
+    { file: EXTRA_MODELS_YAML, src: path.join(configDir, EXTRA_MODELS_YAML) },
+    { file: WINDOW_FILE, src: path.join(configDir, WINDOW_FILE) }
+  ]
+  for (const { file, src } of files) {
     const dst = path.join(destDir, file)
     try {
       if (fs.existsSync(src)) await fs.promises.copyFile(src, dst)
@@ -822,14 +845,16 @@ interface CarryReport {
  */
 function carryLegacySettings(
   basePath: string,
-  configDir: string,
+  configDir: string | null,
   legacy: LegacyComfySettings,
   sendOutput: (t: string) => void
 ): CarryReport {
   let extraYamlContent: string | null = null
-  try {
-    extraYamlContent = fs.readFileSync(path.join(configDir, EXTRA_MODELS_YAML), 'utf-8')
-  } catch {}
+  if (configDir) {
+    try {
+      extraYamlContent = fs.readFileSync(path.join(configDir, EXTRA_MODELS_YAML), 'utf-8')
+    } catch {}
+  }
 
   const currentModelsDirs = (settings.get('modelsDirs') as string[] | undefined) ?? [
     ...settings.defaults.modelsDirs
@@ -903,6 +928,56 @@ function carryLegacySettings(
   }
 
   return { addedModelsDirs: additions, carriedKeys, carrySkippedKeys }
+}
+
+/** Restore legacy settings on adopted records that still contain generated defaults. */
+export async function reconcileAdoptedSettings(): Promise<number> {
+  const all = await installations.list()
+  let repaired = 0
+  const generatedDefaultArgs = deriveLaunchArgs({}).launchArgs
+
+  for (const existing of all) {
+    if (existing.adopted !== true || existing.sourceId !== 'standalone') continue
+    if (existing.adoptedSettingsVersion === ADOPTED_SETTINGS_VERSION) continue
+
+    try {
+      const basePath = existing.adoptedBaseDir as string | undefined
+      if (!basePath) continue
+      const selectedDevice = existing.adoptedSelectedDevice as string | undefined
+      const settingsRead = readLegacyComfySettings(basePath)
+      if (settingsRead.status === 'error') continue
+      const rawComfySettings = settingsRead.settings
+      const derived = deriveLaunchArgs(rawComfySettings, selectedDevice)
+
+      carryLegacySettings(basePath, null, readLegacyComfyPrefs(rawComfySettings), () => {})
+
+      const patch: Record<string, unknown> = {
+        adoptedSettingsVersion: ADOPTED_SETTINGS_VERSION
+      }
+      // Only generated defaults are safe to replace; preserve launch args edited in v2.
+      if (existing.launchArgs === generatedDefaultArgs) {
+        patch.launchArgs = derived.launchArgs
+        if (
+          derived.pathOverrides.inputDir &&
+          existing.inputDir === path.join(basePath, 'input')
+        ) {
+          patch.inputDir = derived.pathOverrides.inputDir
+        }
+        if (
+          derived.pathOverrides.outputDir &&
+          existing.outputDir === path.join(basePath, 'output')
+        ) {
+          patch.outputDir = derived.pathOverrides.outputDir
+        }
+      }
+
+      if (await installations.update(existing.id, patch)) repaired += 1
+    } catch (err) {
+      console.warn(`Failed to reconcile adopted settings for ${existing.id}:`, err)
+    }
+  }
+
+  return repaired
 }
 
 /**
@@ -1059,7 +1134,7 @@ async function runAdoption(
 
   sendProgress('backup', { percent: 0 })
   await telemetry.trackedStep('comfy.desktop.adopt.backup', {}, async () => {
-    await backupLegacyState(info.configDir, timestamp, sendOutput)
+    await backupLegacyState(info.configDir, info.basePath, timestamp, sendOutput)
   })
 
   if (process.platform === 'darwin') {
@@ -1213,9 +1288,9 @@ async function runAdoption(
     }
   )
 
-  const rawComfySettings = readLegacyComfySettings(info.configDir)
+  const settingsRead = readLegacyComfySettings(info.basePath)
+  const rawComfySettings = settingsRead.settings
   const prefs = readLegacyComfyPrefs(rawComfySettings)
-  const derived = deriveLaunchArgs(rawComfySettings)
   const legacyDesktopConfig = readLegacyDesktopConfig(info.configDir)
   const legacyAppVersion = readLegacyAppVersion(info.executablePath)
   const detectedGpu =
@@ -1226,6 +1301,7 @@ async function runAdoption(
     typeof legacyDesktopConfig['selectedDevice'] === 'string'
       ? (legacyDesktopConfig['selectedDevice'] as string)
       : null
+  const derived = deriveLaunchArgs(rawComfySettings, selectedDevice)
 
   sendProgress('settings', { percent: 0 })
   const carry = await telemetry.trackedStep('comfy.desktop.adopt.carry_settings', {}, async () => {
@@ -1252,6 +1328,9 @@ async function runAdoption(
       adoptedBaseDir: info.basePath,
       adoptedPythonPath: pythonPath,
       adoptedSourceMode: sourceMode!,
+      ...(settingsRead.status !== 'error'
+        ? { adoptedSettingsVersion: ADOPTED_SETTINGS_VERSION }
+        : {}),
       ...(legacyAppVersion ? { adoptedFromLegacyVersion: legacyAppVersion } : {}),
       // Hardware hints stashed for a future "rebuild as managed standalone"
       // flow that needs to preselect the right variant — no v2 consumer

--- a/src/main/lib/ipc/index.ts
+++ b/src/main/lib/ipc/index.ts
@@ -34,6 +34,7 @@ import { setTerminalEnvResolver } from '../terminal'
 import { registerLogsHandlers } from './registerLogsHandlers'
 import { registerCrashHandlers } from './registerCrashHandlers'
 import { registerTelemetryHandlers } from './registerTelemetryHandlers'
+import { reconcileAdoptedSettings } from '../desktopAdopt'
 
 export {
   getAppVersion,
@@ -56,7 +57,7 @@ function wireReleaseCacheBroadcast(): void {
   })
 }
 
-export function register(callbacks: RegisterCallbacks = {}): void {
+export function register(callbacks: RegisterCallbacks = {}): Promise<void> {
   setCallbacks(callbacks)
   wireReleaseCacheBroadcast()
 
@@ -97,7 +98,13 @@ export function register(callbacks: RegisterCallbacks = {}): void {
     }
   }
 
-  migrateDefaults()
+  const startupMaintenance = migrateDefaults()
+    .then(async () => {
+      await reconcileAdoptedSettings()
+    })
+    .catch((err) => {
+      console.warn('[ipc] Failed to migrate startup defaults or adopted settings:', err)
+    })
 
   // Sweep leftover empty local install dirs (aborted installs) on startup.
   // Only reclaim dirs that exist but are effectively empty — never a missing
@@ -260,4 +267,5 @@ export function register(callbacks: RegisterCallbacks = {}): void {
   registerLogsHandlers()
   registerCrashHandlers()
   registerTelemetryHandlers()
+  return startupMaintenance
 }


### PR DESCRIPTION
## Summary

- read Legacy Desktop's `comfy.settings.json` from the canonical `<basePath>/user/default` workspace path and back up that same file
- preserve CPU installs by deriving `--cpu` from the persisted `selectedDevice` when the settings entry is absent
- repair records already adopted with generated default args before startup auto-launch, while preserving launch and path settings edited in Desktop 2.0

## Root cause

Legacy Desktop stores frontend and launch settings under its ComfyUI workspace. The adoption flow instead looked for `comfy.settings.json` in the Electron config directory, so it silently migrated an empty settings object. For CPU installations this dropped `--cpu`, then launched a CPU-only Torch environment through the CUDA path.

## Safety

- canonical workspace settings take precedence; a decoy config-directory file is ignored
- explicit `cpu: false` is preserved
- already-adopted records are changed only when their launch args still exactly match the generated defaults from the broken migration
- v2-edited input/output paths and launch args are not overwritten
- malformed or transiently unreadable settings are retried on the next startup

## Validation

- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test` (188 files, 2812 tests)