### PR TITLE
feat(comfybuilder): install a selected distribution artifact on desktop

### DIFF
--- a/src/main/comfybuilder/artifactDownload.test.ts
+++ b/src/main/comfybuilder/artifactDownload.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment node
+import { createHash } from 'node:crypto'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+
+// The artifact download itself is exercised end-to-end in the integration test
+// (real `net` → node http bridge). Here we mock main's `download()` so the unit
+// test never imports electron and can drive the sha256-verify branch directly.
+const KNOWN_BYTES = Buffer.from('comfybuilder-artifact-bytes')
+const KNOWN_SHA256 = createHash('sha256').update(KNOWN_BYTES).digest('hex')
+
+vi.mock('../lib/download', () => ({
+  download: vi.fn(async (_url: string, destPath: string) => {
+    fs.writeFileSync(destPath, KNOWN_BYTES)
+    return destPath
+  }),
+}))
+
+import { downloadArtifact, resolveSignedDownloadUrl } from './artifactDownload'
+import { startMockBuilderApi } from '../../test/comfybuilder/mockBuilderApi'
+import type { MockBuilderApi } from '../../test/comfybuilder/mockBuilderApi'
+
+describe('resolveSignedDownloadUrl', () => {
+  let api: MockBuilderApi
+
+  beforeAll(async () => {
+    api = await startMockBuilderApi()
+  })
+  afterAll(async () => {
+    await api.stop()
+  })
+
+  it('returns the presigned downloadUrl for an artifact', async () => {
+    const url = await resolveSignedDownloadUrl('artifact-123', { baseUrl: api.baseUrl })
+    expect(url).toBe(`${api.baseUrl}/archive.tgz`)
+  })
+
+  it('tolerates a trailing slash on the base URL', async () => {
+    const url = await resolveSignedDownloadUrl('artifact-123', { baseUrl: `${api.baseUrl}/` })
+    expect(url).toBe(`${api.baseUrl}/archive.tgz`)
+  })
+
+  it('throws on a non-2xx response', async () => {
+    // An extra path segment shifts the route so the resolve endpoint 404s.
+    await expect(
+      resolveSignedDownloadUrl('artifact-123', { baseUrl: `${api.baseUrl}/nope` }),
+    ).rejects.toThrow(/HTTP 404/)
+  })
+})
+
+describe('downloadArtifact', () => {
+  let tmpDir: string
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cb-dl-'))
+  })
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('downloads and returns the destination path', async () => {
+    const destPath = path.join(tmpDir, 'ok.tar.gz')
+    const result = await downloadArtifact({ signedUrl: 'https://example.test/a', destPath })
+    expect(result).toBe(destPath)
+    expect(fs.readFileSync(destPath)).toEqual(KNOWN_BYTES)
+  })
+
+  it('passes when the sha256 matches (with a sha256: prefix)', async () => {
+    const destPath = path.join(tmpDir, 'match.tar.gz')
+    await expect(
+      downloadArtifact({ signedUrl: 'https://example.test/a', destPath, expectedSha256: `sha256:${KNOWN_SHA256}` }),
+    ).resolves.toBe(destPath)
+  })
+
+  it('throws on a sha256 mismatch', async () => {
+    const destPath = path.join(tmpDir, 'bad.tar.gz')
+    await expect(
+      downloadArtifact({ signedUrl: 'https://example.test/a', destPath, expectedSha256: 'deadbeef' }),
+    ).rejects.toThrow(/checksum mismatch/)
+  })
+})

--- a/src/main/comfybuilder/artifactDownload.ts
+++ b/src/main/comfybuilder/artifactDownload.ts
@@ -1,13 +1,12 @@
 /**
- * ComfyBuilder artifact download helpers — main process only.
+ * ComfyBuilder artifact download helpers (main process only).
  *
- * Two steps, both auth-free: the ComfyBuilder API returns a short-lived
- * presigned URL whose signature carries its own authorization, so neither the
- * resolve request nor the download itself sends a bearer token.
- *
- *   1. `resolveSignedDownloadUrl` — GET the signed download link for an artifact.
- *   2. `downloadArtifact` — stream that link to disk via main's `download()`,
- *      with an optional post-download sha256 integrity check.
+ *   1. `resolveSignedDownloadUrl`: GET the signed download link for an artifact.
+ *      The deployed builder gateway auth-gates this call, so it sends a Cloud
+ *      JWT when given one. The returned presigned URL is what's auth-free: its
+ *      signature carries its own authorization.
+ *   2. `downloadArtifact`: stream that presigned URL to disk via main's
+ *      `download()`, with an optional post-download sha256 integrity check.
  */
 import { createHash } from 'crypto'
 import { createReadStream, rmSync } from 'fs'

--- a/src/main/comfybuilder/artifactDownload.ts
+++ b/src/main/comfybuilder/artifactDownload.ts
@@ -1,0 +1,99 @@
+/**
+ * ComfyBuilder artifact download helpers — main process only.
+ *
+ * Two steps, both auth-free: the ComfyBuilder API returns a short-lived
+ * presigned URL whose signature carries its own authorization, so neither the
+ * resolve request nor the download itself sends a bearer token.
+ *
+ *   1. `resolveSignedDownloadUrl` — GET the signed download link for an artifact.
+ *   2. `downloadArtifact` — stream that link to disk via main's `download()`,
+ *      with an optional post-download sha256 integrity check.
+ */
+import { createHash } from 'crypto'
+import { createReadStream } from 'fs'
+
+import { download } from '../lib/download'
+import type { DownloadProgress } from '../lib/download'
+import type { SignedDownload } from './types'
+
+export interface ResolveSignedDownloadOptions {
+  /** ComfyBuilder API base, e.g. `https://platformapi.comfy.org/builder`. */
+  baseUrl: string
+  signal?: AbortSignal
+}
+
+function trimTrailingSlash(url: string): string {
+  return url.replace(/\/+$/, '')
+}
+
+/**
+ * Resolve an artifact's presigned archive URL:
+ * `GET {baseUrl}/v1/build-artifacts/{id}/download` → `downloadUrl`.
+ */
+export async function resolveSignedDownloadUrl(
+  artifactId: string,
+  { baseUrl, signal }: ResolveSignedDownloadOptions,
+): Promise<string> {
+  const url = `${trimTrailingSlash(baseUrl)}/v1/build-artifacts/${encodeURIComponent(artifactId)}/download`
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: { Accept: 'application/json' },
+    ...(signal ? { signal } : {}),
+  })
+  if (!response.ok) {
+    throw new Error(`Failed to resolve signed download URL for artifact ${artifactId}: HTTP ${response.status}`)
+  }
+  const body = (await response.json()) as Partial<SignedDownload>
+  if (!body || typeof body.downloadUrl !== 'string' || body.downloadUrl.length === 0) {
+    throw new Error(`Signed download response for artifact ${artifactId} did not include a downloadUrl.`)
+  }
+  return body.downloadUrl
+}
+
+export interface DownloadArtifactParams {
+  /** Presigned URL from {@link resolveSignedDownloadUrl}. */
+  signedUrl: string
+  destPath: string
+  onProgress?: (progress: DownloadProgress) => void
+  signal?: AbortSignal
+  /** Expected archive sha256 (hex, optionally `sha256:`-prefixed). Verified when set. */
+  expectedSha256?: string
+}
+
+/** Normalize a sha256 to bare lowercase hex (drops an optional `sha256:` prefix). */
+function normalizeSha256(value: string): string {
+  return value.replace(/^sha256:/i, '').trim().toLowerCase()
+}
+
+function computeSha256(filePath: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const hash = createHash('sha256')
+    const stream = createReadStream(filePath)
+    stream.on('error', reject)
+    stream.on('data', (chunk) => hash.update(chunk))
+    stream.on('end', () => resolve(hash.digest('hex')))
+  })
+}
+
+/**
+ * Download an artifact archive to `destPath` via main's `download()`, then
+ * (when `expectedSha256` is set) verify the bytes match, throwing on mismatch.
+ */
+export async function downloadArtifact({
+  signedUrl,
+  destPath,
+  onProgress,
+  signal,
+  expectedSha256,
+}: DownloadArtifactParams): Promise<string> {
+  await download(signedUrl, destPath, onProgress ?? null, signal ? { signal } : {})
+
+  if (expectedSha256) {
+    const expected = normalizeSha256(expectedSha256)
+    const actual = await computeSha256(destPath)
+    if (actual !== expected) {
+      throw new Error(`Artifact checksum mismatch: expected sha256 ${expected}, got ${actual}`)
+    }
+  }
+  return destPath
+}

--- a/src/main/comfybuilder/artifactDownload.ts
+++ b/src/main/comfybuilder/artifactDownload.ts
@@ -10,7 +10,7 @@
  *      with an optional post-download sha256 integrity check.
  */
 import { createHash } from 'crypto'
-import { createReadStream } from 'fs'
+import { createReadStream, rmSync } from 'fs'
 
 import { download } from '../lib/download'
 import type { DownloadProgress } from '../lib/download'
@@ -26,6 +26,9 @@ function trimTrailingSlash(url: string): string {
   return url.replace(/\/+$/, '')
 }
 
+/** Cap the resolve request so a hung API cannot stall the install forever. */
+const RESOLVE_TIMEOUT_MS = 30_000
+
 /**
  * Resolve an artifact's presigned archive URL:
  * `GET {baseUrl}/v1/build-artifacts/{id}/download` → `downloadUrl`.
@@ -35,10 +38,11 @@ export async function resolveSignedDownloadUrl(
   { baseUrl, signal }: ResolveSignedDownloadOptions,
 ): Promise<string> {
   const url = `${trimTrailingSlash(baseUrl)}/v1/build-artifacts/${encodeURIComponent(artifactId)}/download`
+  const timeout = AbortSignal.timeout(RESOLVE_TIMEOUT_MS)
   const response = await fetch(url, {
     method: 'GET',
     headers: { Accept: 'application/json' },
-    ...(signal ? { signal } : {}),
+    signal: signal ? AbortSignal.any([signal, timeout]) : timeout,
   })
   if (!response.ok) {
     throw new Error(`Failed to resolve signed download URL for artifact ${artifactId}: HTTP ${response.status}`)
@@ -92,6 +96,8 @@ export async function downloadArtifact({
     const expected = normalizeSha256(expectedSha256)
     const actual = await computeSha256(destPath)
     if (actual !== expected) {
+      // Drop the tainted bytes so a retry cannot reuse them from the cache.
+      rmSync(destPath, { force: true })
       throw new Error(`Artifact checksum mismatch: expected sha256 ${expected}, got ${actual}`)
     }
   }

--- a/src/main/comfybuilder/artifactDownload.ts
+++ b/src/main/comfybuilder/artifactDownload.ts
@@ -20,6 +20,9 @@ export interface ResolveSignedDownloadOptions {
   /** ComfyBuilder API base, e.g. `https://platformapi.comfy.org/builder`. */
   baseUrl: string
   signal?: AbortSignal
+  /** Cloud JWT for the deployed builder gateway. The resolve endpoint sits behind
+   *  auth (the returned presigned URL is what's auth-free, not this call). */
+  authToken?: string
 }
 
 function trimTrailingSlash(url: string): string {
@@ -35,13 +38,15 @@ const RESOLVE_TIMEOUT_MS = 30_000
  */
 export async function resolveSignedDownloadUrl(
   artifactId: string,
-  { baseUrl, signal }: ResolveSignedDownloadOptions,
+  { baseUrl, signal, authToken }: ResolveSignedDownloadOptions,
 ): Promise<string> {
   const url = `${trimTrailingSlash(baseUrl)}/v1/build-artifacts/${encodeURIComponent(artifactId)}/download`
   const timeout = AbortSignal.timeout(RESOLVE_TIMEOUT_MS)
+  const headers: Record<string, string> = { Accept: 'application/json' }
+  if (authToken) headers.Authorization = `Bearer ${authToken}`
   const response = await fetch(url, {
     method: 'GET',
-    headers: { Accept: 'application/json' },
+    headers,
     signal: signal ? AbortSignal.any([signal, timeout]) : timeout,
   })
   if (!response.ok) {

--- a/src/main/comfybuilder/types.ts
+++ b/src/main/comfybuilder/types.ts
@@ -1,0 +1,28 @@
+/**
+ * ComfyBuilder OpenAPI shapes the Desktop install path consumes.
+ * Mirrors the `Artifact` + `SignedDownload` schemas in comfy-builder's
+ * `openapi.yaml` (kept intentionally to just the fields Desktop reads).
+ */
+
+export type ArtifactOs = 'linux' | 'windows' | 'mac'
+export type ArtifactGpu = 'nvidia' | 'amd' | 'cpu' | 'mps'
+
+/** A single built target for a distribution version. */
+export interface Artifact {
+  id: string
+  os: ArtifactOs
+  gpu: ArtifactGpu
+  /** Accelerator build variant, e.g. `cu128`. Part of the target identity. */
+  accelVariant: string
+  /** Storage ref of the built archive. */
+  outputRef?: string
+  /** Hex sha256 of the archive, optionally `sha256:`-prefixed. Verified post-download. */
+  outputSha256?: string
+  status: string
+}
+
+/** Short-lived presigned GET link to an artifact's archive in storage. */
+export interface SignedDownload {
+  downloadUrl: string
+  expiresAt: string
+}

--- a/src/main/sources/comfybuilder/index.ts
+++ b/src/main/sources/comfybuilder/index.ts
@@ -4,8 +4,11 @@
  * A ComfyBuilder artifact unpacks to a ready `venv/` + `ComfyUI/` at the install
  * root, so the download/extract/validate stage (`./install`) and the env
  * consumption (`./launch`: no-op postInstall + launch the archive's `venv/`) are
- * bespoke. The dashboard/list/probe glue is still reused from the standalone
- * source, which is layout-agnostic for those paths.
+ * bespoke. The list/launch glue is reused from the standalone source; the detail
+ * view is reused too, but it reads a standalone `ComfyUI/.venv`/`standalone-env/`
+ * that a `venv/` install lacks, so torch/python render blank and the Update tab
+ * is inert (a pinned-env install has nothing to update). A first-class detail
+ * view is a follow-up.
  *
  * Intentionally minimal: no list UI, no OAuth, no version picker. `hidden` keeps
  * it out of the install wizard; records are created programmatically from a
@@ -35,7 +38,8 @@ export const comfybuilder: SourcePlugin = {
 
   buildInstallation(selections: Record<string, FieldOption | undefined>): Record<string, unknown> {
     // The chosen artifact rides on the selection's `data`; the creator flattens
-    // `artifact` + `comfybuilderBaseUrl` onto the record for `install` to read.
+    // `artifact` + `comfybuilderBaseUrl` + `comfybuilderAuthToken` onto the
+    // record for `install` to read.
     const data = (selections.artifact?.data ?? {}) as Record<string, unknown>
     return { launchMode: 'window', ...data }
   },

--- a/src/main/sources/comfybuilder/index.ts
+++ b/src/main/sources/comfybuilder/index.ts
@@ -47,5 +47,6 @@ export const comfybuilder: SourcePlugin = {
   getLaunchCommand: standalone.getLaunchCommand,
   probeInstallation: standalone.probeInstallation,
   getDetailSections: standalone.getDetailSections,
+  getListActions: standalone.getListActions,
   handleAction: standalone.handleAction,
 }

--- a/src/main/sources/comfybuilder/index.ts
+++ b/src/main/sources/comfybuilder/index.ts
@@ -1,11 +1,11 @@
 /**
  * ComfyBuilder source plugin.
  *
- * A ComfyBuilder artifact unpacks to the same `standalone-env/` + `ComfyUI/.venv`
- * layout as a standalone install, so everything past the artifact download is the
- * standalone source, reused verbatim: `postInstall` (env create + package copy),
- * `getLaunchCommand`, `getTerminalEnv` (its default), and `probeInstallation`.
- * Only the download/extract/validate stage (`./install`) is bespoke.
+ * A ComfyBuilder artifact unpacks to a ready `venv/` + `ComfyUI/` at the install
+ * root, so the download/extract/validate stage (`./install`) and the env
+ * consumption (`./launch`: no-op postInstall + launch the archive's `venv/`) are
+ * bespoke. The dashboard/list/probe glue is still reused from the standalone
+ * source, which is layout-agnostic for those paths.
  *
  * Intentionally minimal: no list UI, no OAuth, no version picker. `hidden` keeps
  * it out of the install wizard; records are created programmatically from a
@@ -13,6 +13,7 @@
  */
 import { standalone } from '../standalone'
 import { install } from './install'
+import { getLaunchCommand, postInstall } from './launch'
 import type { FieldOption, SourcePlugin } from '../../types/sources'
 
 export const comfybuilder: SourcePlugin = {
@@ -42,9 +43,10 @@ export const comfybuilder: SourcePlugin = {
   // Bespoke artifact download/extract/validate.
   install,
 
-  // Everything past the download is identical to a standalone install.
-  postInstall: standalone.postInstall,
-  getLaunchCommand: standalone.getLaunchCommand,
+  // Env-reshape: the archive ships a ready `venv/`, so post-extract is a no-op
+  // and launch drives that venv directly (NOT the standalone `.venv` rebuild).
+  postInstall,
+  getLaunchCommand,
   probeInstallation: standalone.probeInstallation,
   getDetailSections: standalone.getDetailSections,
   getListActions: standalone.getListActions,

--- a/src/main/sources/comfybuilder/index.ts
+++ b/src/main/sources/comfybuilder/index.ts
@@ -1,0 +1,51 @@
+/**
+ * ComfyBuilder source plugin.
+ *
+ * A ComfyBuilder artifact unpacks to the same `standalone-env/` + `ComfyUI/.venv`
+ * layout as a standalone install, so everything past the artifact download is the
+ * standalone source, reused verbatim: `postInstall` (env create + package copy),
+ * `getLaunchCommand`, `getTerminalEnv` (its default), and `probeInstallation`.
+ * Only the download/extract/validate stage (`./install`) is bespoke.
+ *
+ * Intentionally minimal: no list UI, no OAuth, no version picker. `hidden` keeps
+ * it out of the install wizard; records are created programmatically from a
+ * chosen artifact.
+ */
+import { standalone } from '../standalone'
+import { install } from './install'
+import type { FieldOption, SourcePlugin } from '../../types/sources'
+
+export const comfybuilder: SourcePlugin = {
+  id: 'comfybuilder',
+  label: 'ComfyBuilder',
+  category: 'local',
+  hidden: true,
+  fields: [],
+
+  // Reuse the standalone install stepper (download → extract → setup → cleanup);
+  // the artifact ships a pinned env, so there is no post-install auto-update.
+  get installSteps() {
+    return standalone.installSteps?.filter((step) => step.phase !== 'update')
+  },
+
+  getDefaults() {
+    return { launchMode: 'window', portConflict: 'auto' }
+  },
+
+  buildInstallation(selections: Record<string, FieldOption | undefined>): Record<string, unknown> {
+    // The chosen artifact rides on the selection's `data`; the creator flattens
+    // `artifact` + `comfybuilderBaseUrl` onto the record for `install` to read.
+    const data = (selections.artifact?.data ?? {}) as Record<string, unknown>
+    return { launchMode: 'window', ...data }
+  },
+
+  // Bespoke artifact download/extract/validate.
+  install,
+
+  // Everything past the download is identical to a standalone install.
+  postInstall: standalone.postInstall,
+  getLaunchCommand: standalone.getLaunchCommand,
+  probeInstallation: standalone.probeInstallation,
+  getDetailSections: standalone.getDetailSections,
+  handleAction: standalone.handleAction,
+}

--- a/src/main/sources/comfybuilder/install.integration.test.ts
+++ b/src/main/sources/comfybuilder/install.integration.test.ts
@@ -1,0 +1,303 @@
+// @vitest-environment node
+//
+// Integration test for the ComfyBuilder install glue.
+//
+// (a) CI path — drives the real `installArtifact` (+ the `install()` record
+//     wrapper) against a small FABRICATED `standalone-env`/`ComfyUI`/manifest
+//     tarball served by the mock Builder API: the artifact is downloaded over
+//     HTTP (electron `net` is bridged to node http so the real `download()`
+//     streams bytes to disk), extracted with the real 7za nested extractor, and
+//     its manifest validated for real. The reused standalone post-extract phases
+//     are NOT run here (a real `uv venv` + package copy is infeasible in CI).
+//
+// (b) Real-archive boot — opt-in, gated on darwin AND `CB_TEST_ARCHIVE`. Points
+//     the mock at the real archive, runs the REAL `installArtifact` + standalone
+//     `postInstall`, then spawns the launch command and polls `/object_info`,
+//     asserting ComfyUI reports > 0 nodes.
+import { execFileSync, spawn } from 'node:child_process'
+import type { ChildProcess } from 'node:child_process'
+import fs from 'node:fs'
+import http from 'node:http'
+import type { ClientRequest } from 'node:http'
+import os from 'node:os'
+import path from 'node:path'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { create as tarCreate } from 'tar'
+
+// electron `net` is inert under vitest; bridge it to node http so the real
+// `download()` streams bytes from the mock server. Other members are stubbed
+// only so transitively-loaded modules can import them.
+vi.mock('electron', async () => {
+  const nodeHttp = (await vi.importActual('node:http')) as { request(url: string): ClientRequest }
+  return {
+    app: {
+      isPackaged: false,
+      getPath: (_name: string) => os.tmpdir(),
+      getVersion: () => '0.0.0-test',
+      getLocale: () => 'en',
+      getName: () => 'comfy-desktop-test',
+      on: vi.fn(),
+    },
+    ipcMain: { handle: vi.fn(), on: vi.fn(), off: vi.fn() },
+    dialog: {},
+    shell: {},
+    BrowserWindow: { getAllWindows: () => [] },
+    nativeTheme: { on: vi.fn(), shouldUseDarkColors: false },
+    net: { request: (url: string) => nodeHttp.request(url) },
+  }
+})
+
+// Keep download()'s Chinese-mirror retry path off.
+vi.mock('../../settings', () => ({
+  get: vi.fn(() => undefined),
+  set: vi.fn(async () => {}),
+  getAll: vi.fn(() => ({})),
+  getMirrorConfig: vi.fn(() => ({ pypiMirror: undefined, useChineseMirrors: false })),
+}))
+
+import { ComfyBuilderInstallError, install, installArtifact } from './install'
+import type { InstallArtifactTools } from './install'
+import { createCache } from '../../lib/cache'
+import type { Artifact } from '../../comfybuilder/types'
+import type { InstallationRecord } from '../../installations'
+import type { InstallTools } from '../../types/sources'
+import { startMockBuilderApi } from '../../../test/comfybuilder/mockBuilderApi'
+import type { MockBuilderApi } from '../../../test/comfybuilder/mockBuilderApi'
+
+function makeArtifact(overrides: Partial<Artifact> = {}): Artifact {
+  return { id: 'artifact-1', os: 'mac', gpu: 'mps', accelVariant: '', status: 'succeeded', ...overrides }
+}
+
+function makeInstallation(installPath: string): InstallationRecord {
+  return {
+    id: 'inst-cb-1',
+    name: 'ComfyBuilder Test',
+    createdAt: new Date(0).toISOString(),
+    installPath,
+    sourceId: 'comfybuilder',
+  }
+}
+
+function makeArtifactTools(cacheDir: string): InstallArtifactTools {
+  return { sendProgress: vi.fn(), cache: createCache(cacheDir, 5) }
+}
+
+function makeInstallTools(cacheDir: string): InstallTools {
+  return {
+    sendProgress: vi.fn(),
+    download: vi.fn(async () => ''),
+    cache: createCache(cacheDir, 5),
+    extract: vi.fn(async () => {}),
+  }
+}
+
+/** Build a fabricated Desktop-layout tarball. Omit `withManifest` for the bad case. */
+async function writeFixtureArtifact(destPath: string, withManifest: boolean): Promise<void> {
+  const staging = fs.mkdtempSync(path.join(os.tmpdir(), 'cb-fixture-src-'))
+  try {
+    fs.mkdirSync(path.join(staging, 'standalone-env', 'bin'), { recursive: true })
+    fs.writeFileSync(path.join(staging, 'standalone-env', 'bin', 'python3'), '')
+    fs.mkdirSync(path.join(staging, 'ComfyUI'), { recursive: true })
+    fs.writeFileSync(path.join(staging, 'ComfyUI', 'main.py'), '')
+    const entries = ['standalone-env', 'ComfyUI']
+    if (withManifest) {
+      const manifest = { id: 'mac-mps', version: '1.0.0', comfyui_ref: 'master', python_version: '3.11.9' }
+      fs.writeFileSync(path.join(staging, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`)
+      entries.push('manifest.json')
+    }
+    await tarCreate(
+      { gzip: true, file: destPath, cwd: staging, portable: true, mtime: new Date('2026-01-01T00:00:00.000Z') },
+      entries,
+    )
+  } finally {
+    fs.rmSync(staging, { recursive: true, force: true })
+  }
+}
+
+describe('installArtifact (fabricated fixture)', () => {
+  let goodApi: MockBuilderApi
+  let badApi: MockBuilderApi
+  let fixturesDir: string
+  let tmpRoot: string
+
+  beforeAll(async () => {
+    fixturesDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cb-fixtures-'))
+    const goodPath = path.join(fixturesDir, 'good-artifact.tar.gz')
+    const badPath = path.join(fixturesDir, 'bad-artifact.tar.gz')
+    await writeFixtureArtifact(goodPath, true)
+    await writeFixtureArtifact(badPath, false)
+    goodApi = await startMockBuilderApi({ archivePath: goodPath })
+    badApi = await startMockBuilderApi({ archivePath: badPath })
+  })
+
+  afterAll(async () => {
+    await goodApi.stop()
+    await badApi.stop()
+    fs.rmSync(fixturesDir, { recursive: true, force: true })
+  })
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cb-install-'))
+  })
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+  })
+
+  it('resolves, downloads, extracts, and validates the manifest', async () => {
+    const installPath = path.join(tmpRoot, 'install')
+    const installation = makeInstallation(installPath)
+    await expect(
+      installArtifact({
+        installation,
+        artifact: makeArtifact(),
+        tools: makeArtifactTools(path.join(tmpRoot, 'cache')),
+        baseUrl: goodApi.baseUrl,
+      }),
+    ).resolves.toBeUndefined()
+
+    expect(fs.statSync(path.join(installPath, 'standalone-env')).isDirectory()).toBe(true)
+    expect(fs.statSync(path.join(installPath, 'ComfyUI')).isDirectory()).toBe(true)
+    expect(fs.existsSync(path.join(installPath, 'manifest.json'))).toBe(true)
+  })
+
+  it('aborts with invalid-manifest and removes partial extracted files', async () => {
+    const installPath = path.join(tmpRoot, 'install')
+    const installation = makeInstallation(installPath)
+
+    let caught: unknown
+    try {
+      await installArtifact({
+        installation,
+        artifact: makeArtifact({ id: 'artifact-bad' }),
+        tools: makeArtifactTools(path.join(tmpRoot, 'cache')),
+        baseUrl: badApi.baseUrl,
+      })
+    } catch (err) {
+      caught = err
+    }
+
+    expect(caught).toBeInstanceOf(ComfyBuilderInstallError)
+    expect((caught as ComfyBuilderInstallError).kind).toBe('invalid-manifest')
+    expect(fs.existsSync(path.join(installPath, 'standalone-env'))).toBe(false)
+    expect(fs.existsSync(path.join(installPath, 'ComfyUI'))).toBe(false)
+    expect(fs.existsSync(path.join(installPath, 'manifest.json'))).toBe(false)
+  })
+
+  it('install(inst, tools): reads the artifact off the record and installs', async () => {
+    const installPath = path.join(tmpRoot, 'install')
+    const installation: InstallationRecord = {
+      ...makeInstallation(installPath),
+      artifact: makeArtifact(),
+      comfybuilderBaseUrl: goodApi.baseUrl,
+    }
+    await expect(install(installation, makeInstallTools(path.join(tmpRoot, 'cache')))).resolves.toBeUndefined()
+    expect(fs.existsSync(path.join(installPath, 'manifest.json'))).toBe(true)
+  })
+
+  it('install(inst, tools): throws invalid-artifact when the record has no artifact', async () => {
+    const installPath = path.join(tmpRoot, 'install')
+    const installation = makeInstallation(installPath)
+    let caught: unknown
+    try {
+      await install(installation, makeInstallTools(path.join(tmpRoot, 'cache')))
+    } catch (err) {
+      caught = err
+    }
+    expect(caught).toBeInstanceOf(ComfyBuilderInstallError)
+    expect((caught as ComfyBuilderInstallError).kind).toBe('invalid-artifact')
+    expect(fs.existsSync(installPath)).toBe(false)
+  })
+})
+
+// --- (b) opt-in real-archive boot -------------------------------------------
+
+const CB_TEST_ARCHIVE = process.env.CB_TEST_ARCHIVE
+const runRealBoot = process.platform === 'darwin' && !!CB_TEST_ARCHIVE
+
+/** Poll `/object_info` until ComfyUI reports > 0 nodes or the budget elapses. */
+function pollObjectInfo(port: number, budgetMs: number): Promise<number> {
+  const deadline = Date.now() + budgetMs
+  return new Promise((resolve, reject) => {
+    const attempt = (): void => {
+      const req = http.get({ host: '127.0.0.1', port, path: '/object_info', timeout: 5000 }, (res) => {
+        const chunks: Buffer[] = []
+        res.on('data', (c: Buffer) => chunks.push(c))
+        res.on('end', () => {
+          try {
+            const parsed = JSON.parse(Buffer.concat(chunks).toString('utf8')) as Record<string, unknown>
+            const count = Object.keys(parsed).length
+            if (res.statusCode === 200 && count > 0) return resolve(count)
+          } catch {
+            // not ready yet
+          }
+          retry()
+        })
+      })
+      req.on('error', retry)
+      req.on('timeout', () => req.destroy())
+    }
+    const retry = (): void => {
+      if (Date.now() > deadline) return reject(new Error('ComfyUI did not report nodes before the deadline'))
+      setTimeout(attempt, 1500)
+    }
+    attempt()
+  })
+}
+
+describe.runIf(runRealBoot)('installArtifact + postInstall real-archive boot', () => {
+  let api: MockBuilderApi
+  let tmpRoot: string
+  let child: ChildProcess | undefined
+
+  beforeAll(async () => {
+    api = await startMockBuilderApi({ archivePath: CB_TEST_ARCHIVE! })
+  })
+  afterAll(async () => {
+    if (child && !child.killed) child.kill('SIGKILL')
+    await api.stop()
+    if (tmpRoot) fs.rmSync(tmpRoot, { recursive: true, force: true })
+  })
+
+  it('downloads → extracts → validates → builds env → boots ComfyUI (> 0 nodes)', async () => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cb-boot-'))
+    const installPath = path.join(tmpRoot, 'install')
+    const installation: InstallationRecord = { ...makeInstallation(installPath), installPath, version: 'master' }
+
+    // Real download/extract/validate from the real archive.
+    await installArtifact({
+      installation,
+      artifact: makeArtifact({ id: 'mac-mps-real' }),
+      tools: makeArtifactTools(path.join(tmpRoot, 'cache')),
+      baseUrl: api.baseUrl,
+    })
+
+    // Env-reshape seam (test-only): main's createEnv runs
+    // `<installPath>/standalone-env/bin/uv`, which the real archive does NOT
+    // bundle. Symlink the system uv so postInstall's `uv venv` can run.
+    // TODO(builder): archive must bundle standalone-env/bin/uv (reshape bridge).
+    const uvTarget = path.join(installPath, 'standalone-env', 'bin', 'uv')
+    if (!fs.existsSync(uvTarget)) {
+      const systemUv = execFileSync('which', ['uv']).toString().trim()
+      fs.symlinkSync(systemUv, uvTarget)
+      console.warn(`TODO(builder): archive must bundle standalone-env/bin/uv (reshape bridge). Symlinked system uv ${systemUv} for this test.`)
+    }
+
+    // Real standalone postInstall: uv venv + package copy (no auto-update, since
+    // the record has no autoUpdateComfyUI, so the torch sync phase is skipped).
+    const { postInstall } = await import('../standalone/install')
+    await postInstall(installation, { sendProgress: vi.fn(), update: async () => {} })
+
+    // Launch via the reused standalone launch command and poll /object_info.
+    const { standalone } = await import('../standalone')
+    const port = 18188
+    const launchInstallation: InstallationRecord = { ...installation, launchArgs: `--cpu --port ${port}` }
+    const launch = standalone.getLaunchCommand(launchInstallation)
+    expect(launch?.cmd).toBeTruthy()
+
+    child = spawn(launch!.cmd!, launch!.args ?? [], { cwd: launch!.cwd, stdio: 'inherit' })
+
+    const nodeCount = await pollObjectInfo(port, 600_000)
+    console.log(`ComfyUI booted with ${nodeCount} nodes`)
+    expect(nodeCount).toBeGreaterThan(0)
+  }, 1_200_000)
+})

--- a/src/main/sources/comfybuilder/install.integration.test.ts
+++ b/src/main/sources/comfybuilder/install.integration.test.ts
@@ -2,7 +2,7 @@
 //
 // Integration test for the ComfyBuilder install glue.
 //
-// (a) CI path — drives the real `installArtifact` (+ the `install()` record
+// (a) CI path: drives the real `installArtifact` (+ the `install()` record
 //     wrapper) against a small FABRICATED `venv/`/`ComfyUI/` tarball (the shape
 //     comfy-builder tars; no in-archive manifest) served by the mock Builder API:
 //     the artifact is downloaded over HTTP (electron `net` is bridged to node
@@ -11,7 +11,7 @@
 //     standalone post-extract phases are NOT run here (a real `uv venv` + package
 //     copy is infeasible in CI).
 //
-// (b) Real-archive boot — opt-in, gated on darwin AND `CB_TEST_ARCHIVE`. Points
+// (b) Real-archive boot: opt-in, gated on darwin AND `CB_TEST_ARCHIVE`. Points
 //     the mock at the real archive, runs the REAL `installArtifact` + the
 //     comfybuilder `postInstall` (no-op) + `getLaunchCommand` (the archive's own
 //     `venv/`), then spawns it and polls `/object_info`, asserting > 0 nodes.
@@ -334,7 +334,7 @@ describe.runIf(runRealBoot)('installArtifact → launch real-archive boot', () =
     })
 
     // Env-reshape: the archive ships a ready `venv/`, so postInstall is a no-op
-    // and launch drives that venv's python directly — no rebuild, no uv.
+    // and launch drives that venv's python directly; no rebuild, no uv.
     const { postInstall, getLaunchCommand } = await import('./launch')
     await postInstall(installation, { sendProgress: vi.fn(), update: async () => {} })
 

--- a/src/main/sources/comfybuilder/install.integration.test.ts
+++ b/src/main/sources/comfybuilder/install.integration.test.ts
@@ -3,12 +3,13 @@
 // Integration test for the ComfyBuilder install glue.
 //
 // (a) CI path — drives the real `installArtifact` (+ the `install()` record
-//     wrapper) against a small FABRICATED `standalone-env`/`ComfyUI`/manifest
-//     tarball served by the mock Builder API: the artifact is downloaded over
-//     HTTP (electron `net` is bridged to node http so the real `download()`
-//     streams bytes to disk), extracted with the real 7za nested extractor, and
-//     its manifest validated for real. The reused standalone post-extract phases
-//     are NOT run here (a real `uv venv` + package copy is infeasible in CI).
+//     wrapper) against a small FABRICATED `venv/`/`ComfyUI/` tarball (the shape
+//     comfy-builder tars; no in-archive manifest) served by the mock Builder API:
+//     the artifact is downloaded over HTTP (electron `net` is bridged to node
+//     http so the real `download()` streams bytes to disk), extracted with the
+//     real 7za nested extractor, and its layout validated for real. The reused
+//     standalone post-extract phases are NOT run here (a real `uv venv` + package
+//     copy is infeasible in CI).
 //
 // (b) Real-archive boot — opt-in, gated on darwin AND `CB_TEST_ARCHIVE`. Points
 //     the mock at the real archive, runs the REAL `installArtifact` + standalone
@@ -97,19 +98,23 @@ function sha256File(filePath: string): string {
   return createHash('sha256').update(fs.readFileSync(filePath)).digest('hex')
 }
 
-/** Build a fabricated Desktop-layout tarball. Omit `withManifest` for the bad case. */
-async function writeFixtureArtifact(destPath: string, withManifest: boolean): Promise<void> {
+/**
+ * Build a fabricated archive in the shape comfy-builder actually tars
+ * (buildexec/assemble.go): top-level `venv/` + `ComfyUI/` + a lockfile, and NO
+ * in-archive manifest (it's DB/GCS-sealed). Omit `withVenv` for the bad case
+ * (a build that failed to produce the env dir).
+ */
+async function writeFixtureArtifact(destPath: string, withVenv: boolean): Promise<void> {
   const staging = fs.mkdtempSync(path.join(os.tmpdir(), 'cb-fixture-src-'))
   try {
-    fs.mkdirSync(path.join(staging, 'standalone-env', 'bin'), { recursive: true })
-    fs.writeFileSync(path.join(staging, 'standalone-env', 'bin', 'python3'), '')
     fs.mkdirSync(path.join(staging, 'ComfyUI'), { recursive: true })
     fs.writeFileSync(path.join(staging, 'ComfyUI', 'main.py'), '')
-    const entries = ['standalone-env', 'ComfyUI']
-    if (withManifest) {
-      const manifest = { id: 'mac-mps', version: '1.0.0', comfyui_ref: 'master', python_version: '3.11.9' }
-      fs.writeFileSync(path.join(staging, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`)
-      entries.push('manifest.json')
+    fs.writeFileSync(path.join(staging, 'uv.lock'), 'version = 1\n')
+    const entries = ['ComfyUI', 'uv.lock']
+    if (withVenv) {
+      fs.mkdirSync(path.join(staging, 'venv', 'bin'), { recursive: true })
+      fs.writeFileSync(path.join(staging, 'venv', 'bin', 'python3'), '')
+      entries.push('venv')
     }
     await tarCreate(
       { gzip: true, file: destPath, cwd: staging, portable: true, mtime: new Date('2026-01-01T00:00:00.000Z') },
@@ -161,7 +166,7 @@ describe('installArtifact (fabricated fixture)', () => {
     fs.rmSync(tmpRoot, { recursive: true, force: true })
   })
 
-  it('resolves, downloads, extracts, and validates the manifest', async () => {
+  it('resolves, downloads, extracts, and validates the layout', async () => {
     const installPath = path.join(tmpRoot, 'install')
     const installation = makeInstallation(installPath)
     await expect(
@@ -173,12 +178,11 @@ describe('installArtifact (fabricated fixture)', () => {
       }),
     ).resolves.toBeUndefined()
 
-    expect(fs.statSync(path.join(installPath, 'standalone-env')).isDirectory()).toBe(true)
+    expect(fs.statSync(path.join(installPath, 'venv')).isDirectory()).toBe(true)
     expect(fs.statSync(path.join(installPath, 'ComfyUI')).isDirectory()).toBe(true)
-    expect(fs.existsSync(path.join(installPath, 'manifest.json'))).toBe(true)
   })
 
-  it('aborts with invalid-manifest and removes partial extracted files', async () => {
+  it('aborts with invalid-layout and removes partial extracted files', async () => {
     const installPath = path.join(tmpRoot, 'install')
     const installation = makeInstallation(installPath)
 
@@ -195,10 +199,9 @@ describe('installArtifact (fabricated fixture)', () => {
     }
 
     expect(caught).toBeInstanceOf(ComfyBuilderInstallError)
-    expect((caught as ComfyBuilderInstallError).kind).toBe('invalid-manifest')
-    expect(fs.existsSync(path.join(installPath, 'standalone-env'))).toBe(false)
+    expect((caught as ComfyBuilderInstallError).kind).toBe('invalid-layout')
+    expect(fs.existsSync(path.join(installPath, 'venv'))).toBe(false)
     expect(fs.existsSync(path.join(installPath, 'ComfyUI'))).toBe(false)
-    expect(fs.existsSync(path.join(installPath, 'manifest.json'))).toBe(false)
   })
 
   it('install(inst, tools): reads the artifact off the record and installs', async () => {
@@ -209,7 +212,7 @@ describe('installArtifact (fabricated fixture)', () => {
       comfybuilderBaseUrl: goodApi.baseUrl,
     }
     await expect(install(installation, makeInstallTools(path.join(tmpRoot, 'cache')))).resolves.toBeUndefined()
-    expect(fs.existsSync(path.join(installPath, 'manifest.json'))).toBe(true)
+    expect(fs.existsSync(path.join(installPath, 'venv'))).toBe(true)
   })
 
   it('install(inst, tools): throws invalid-artifact when the record has no artifact', async () => {

--- a/src/main/sources/comfybuilder/install.integration.test.ts
+++ b/src/main/sources/comfybuilder/install.integration.test.ts
@@ -12,10 +12,10 @@
 //     copy is infeasible in CI).
 //
 // (b) Real-archive boot — opt-in, gated on darwin AND `CB_TEST_ARCHIVE`. Points
-//     the mock at the real archive, runs the REAL `installArtifact` + standalone
-//     `postInstall`, then spawns the launch command and polls `/object_info`,
-//     asserting ComfyUI reports > 0 nodes.
-import { execFileSync, spawn } from 'node:child_process'
+//     the mock at the real archive, runs the REAL `installArtifact` + the
+//     comfybuilder `postInstall` (no-op) + `getLaunchCommand` (the archive's own
+//     `venv/`), then spawns it and polls `/object_info`, asserting > 0 nodes.
+import { spawn } from 'node:child_process'
 import type { ChildProcess } from 'node:child_process'
 import { createHash } from 'node:crypto'
 import fs from 'node:fs'
@@ -306,7 +306,7 @@ function pollObjectInfo(port: number, budgetMs: number): Promise<number> {
   })
 }
 
-describe.runIf(runRealBoot)('installArtifact + postInstall real-archive boot', () => {
+describe.runIf(runRealBoot)('installArtifact → launch real-archive boot', () => {
   let api: MockBuilderApi
   let tmpRoot: string
   let child: ChildProcess | undefined
@@ -320,40 +320,26 @@ describe.runIf(runRealBoot)('installArtifact + postInstall real-archive boot', (
     if (tmpRoot) fs.rmSync(tmpRoot, { recursive: true, force: true })
   })
 
-  it('downloads → extracts → validates → builds env → boots ComfyUI (> 0 nodes)', async () => {
+  it('downloads → extracts → validates → launches the archive venv → boots ComfyUI (> 0 nodes)', async () => {
     tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cb-boot-'))
     const installPath = path.join(tmpRoot, 'install')
-    const installation: InstallationRecord = { ...makeInstallation(installPath), installPath, version: 'master' }
+    const installation: InstallationRecord = { ...makeInstallation(installPath), installPath }
 
-    // Real download/extract/validate from the real archive (sha now mandatory).
+    // Real download/extract/validate from the real archive (sha mandatory).
     await installArtifact({
       installation,
-      artifact: makeArtifact({ id: 'mac-mps-real', outputSha256: sha256File(CB_TEST_ARCHIVE!) }),
+      artifact: makeArtifact({ id: 'real-archive', outputSha256: sha256File(CB_TEST_ARCHIVE!) }),
       tools: makeArtifactTools(path.join(tmpRoot, 'cache')),
       baseUrl: api.baseUrl,
     })
 
-    // Env-reshape seam (test-only): main's createEnv runs
-    // `<installPath>/standalone-env/bin/uv`, which the real archive does NOT
-    // bundle. Symlink the system uv so postInstall's `uv venv` can run.
-    // TODO(builder): archive must bundle standalone-env/bin/uv (reshape bridge).
-    const uvTarget = path.join(installPath, 'standalone-env', 'bin', 'uv')
-    if (!fs.existsSync(uvTarget)) {
-      const systemUv = execFileSync('which', ['uv']).toString().trim()
-      fs.symlinkSync(systemUv, uvTarget)
-      console.warn(`TODO(builder): archive must bundle standalone-env/bin/uv (reshape bridge). Symlinked system uv ${systemUv} for this test.`)
-    }
-
-    // Real standalone postInstall: uv venv + package copy (no auto-update, since
-    // the record has no autoUpdateComfyUI, so the torch sync phase is skipped).
-    const { postInstall } = await import('../standalone/install')
+    // Env-reshape: the archive ships a ready `venv/`, so postInstall is a no-op
+    // and launch drives that venv's python directly — no rebuild, no uv.
+    const { postInstall, getLaunchCommand } = await import('./launch')
     await postInstall(installation, { sendProgress: vi.fn(), update: async () => {} })
 
-    // Launch via the reused standalone launch command and poll /object_info.
-    const { standalone } = await import('../standalone')
     const port = 18188
-    const launchInstallation: InstallationRecord = { ...installation, launchArgs: `--cpu --port ${port}` }
-    const launch = standalone.getLaunchCommand(launchInstallation)
+    const launch = getLaunchCommand({ ...installation, launchArgs: `--cpu --port ${port}` })
     expect(launch?.cmd).toBeTruthy()
 
     child = spawn(launch!.cmd!, launch!.args ?? [], { cwd: launch!.cwd, stdio: 'inherit' })

--- a/src/main/sources/comfybuilder/install.integration.test.ts
+++ b/src/main/sources/comfybuilder/install.integration.test.ts
@@ -16,6 +16,7 @@
 //     asserting ComfyUI reports > 0 nodes.
 import { execFileSync, spawn } from 'node:child_process'
 import type { ChildProcess } from 'node:child_process'
+import { createHash } from 'node:crypto'
 import fs from 'node:fs'
 import http from 'node:http'
 import type { ClientRequest } from 'node:http'
@@ -91,6 +92,11 @@ function makeInstallTools(cacheDir: string): InstallTools {
   }
 }
 
+/** Hex sha256 of a file, matching what the artifact's `outputSha256` carries. */
+function sha256File(filePath: string): string {
+  return createHash('sha256').update(fs.readFileSync(filePath)).digest('hex')
+}
+
 /** Build a fabricated Desktop-layout tarball. Omit `withManifest` for the bad case. */
 async function writeFixtureArtifact(destPath: string, withManifest: boolean): Promise<void> {
   const staging = fs.mkdtempSync(path.join(os.tmpdir(), 'cb-fixture-src-'))
@@ -117,22 +123,34 @@ async function writeFixtureArtifact(destPath: string, withManifest: boolean): Pr
 describe('installArtifact (fabricated fixture)', () => {
   let goodApi: MockBuilderApi
   let badApi: MockBuilderApi
+  let garbageApi: MockBuilderApi
   let fixturesDir: string
   let tmpRoot: string
+  let goodSha: string
+  let badSha: string
+  let garbageSha: string
 
   beforeAll(async () => {
     fixturesDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cb-fixtures-'))
     const goodPath = path.join(fixturesDir, 'good-artifact.tar.gz')
     const badPath = path.join(fixturesDir, 'bad-artifact.tar.gz')
+    const garbagePath = path.join(fixturesDir, 'garbage-artifact.tar.gz')
     await writeFixtureArtifact(goodPath, true)
     await writeFixtureArtifact(badPath, false)
+    // Non-archive bytes: sha verification passes, extraction fails.
+    fs.writeFileSync(garbagePath, Buffer.from('not a real tar.gz archive'))
+    goodSha = sha256File(goodPath)
+    badSha = sha256File(badPath)
+    garbageSha = sha256File(garbagePath)
     goodApi = await startMockBuilderApi({ archivePath: goodPath })
     badApi = await startMockBuilderApi({ archivePath: badPath })
+    garbageApi = await startMockBuilderApi({ archivePath: garbagePath })
   })
 
   afterAll(async () => {
     await goodApi.stop()
     await badApi.stop()
+    await garbageApi.stop()
     fs.rmSync(fixturesDir, { recursive: true, force: true })
   })
 
@@ -149,7 +167,7 @@ describe('installArtifact (fabricated fixture)', () => {
     await expect(
       installArtifact({
         installation,
-        artifact: makeArtifact(),
+        artifact: makeArtifact({ outputSha256: goodSha }),
         tools: makeArtifactTools(path.join(tmpRoot, 'cache')),
         baseUrl: goodApi.baseUrl,
       }),
@@ -168,7 +186,7 @@ describe('installArtifact (fabricated fixture)', () => {
     try {
       await installArtifact({
         installation,
-        artifact: makeArtifact({ id: 'artifact-bad' }),
+        artifact: makeArtifact({ id: 'artifact-bad', outputSha256: badSha }),
         tools: makeArtifactTools(path.join(tmpRoot, 'cache')),
         baseUrl: badApi.baseUrl,
       })
@@ -187,7 +205,7 @@ describe('installArtifact (fabricated fixture)', () => {
     const installPath = path.join(tmpRoot, 'install')
     const installation: InstallationRecord = {
       ...makeInstallation(installPath),
-      artifact: makeArtifact(),
+      artifact: makeArtifact({ outputSha256: goodSha }),
       comfybuilderBaseUrl: goodApi.baseUrl,
     }
     await expect(install(installation, makeInstallTools(path.join(tmpRoot, 'cache')))).resolves.toBeUndefined()
@@ -206,6 +224,47 @@ describe('installArtifact (fabricated fixture)', () => {
     expect(caught).toBeInstanceOf(ComfyBuilderInstallError)
     expect((caught as ComfyBuilderInstallError).kind).toBe('invalid-artifact')
     expect(fs.existsSync(installPath)).toBe(false)
+  })
+
+  it('rejects an artifact with no outputSha256 and installs nothing', async () => {
+    const installPath = path.join(tmpRoot, 'install')
+    const installation = makeInstallation(installPath)
+
+    let caught: unknown
+    try {
+      await installArtifact({
+        installation,
+        artifact: makeArtifact(), // no outputSha256
+        tools: makeArtifactTools(path.join(tmpRoot, 'cache')),
+        baseUrl: goodApi.baseUrl,
+      })
+    } catch (err) {
+      caught = err
+    }
+
+    expect(caught).toBeInstanceOf(ComfyBuilderInstallError)
+    expect((caught as ComfyBuilderInstallError).kind).toBe('invalid-artifact')
+    expect((caught as ComfyBuilderInstallError).message).toMatch(/outputSha256/)
+    expect(fs.existsSync(installPath)).toBe(false)
+  })
+
+  it('cleans up the install dir when extraction fails on a garbage archive', async () => {
+    const installPath = path.join(tmpRoot, 'install')
+    const installation = makeInstallation(installPath)
+
+    // sha matches (verification passes), but the bytes are not a real archive so
+    // extraction throws -> cleanupPartialInstall must remove the extracted roots.
+    await expect(
+      installArtifact({
+        installation,
+        artifact: makeArtifact({ id: 'artifact-garbage', outputSha256: garbageSha }),
+        tools: makeArtifactTools(path.join(tmpRoot, 'cache')),
+        baseUrl: garbageApi.baseUrl,
+      }),
+    ).rejects.toThrow()
+
+    const leftover = fs.existsSync(installPath) ? fs.readdirSync(installPath) : []
+    expect(leftover).toEqual([])
   })
 })
 
@@ -263,10 +322,10 @@ describe.runIf(runRealBoot)('installArtifact + postInstall real-archive boot', (
     const installPath = path.join(tmpRoot, 'install')
     const installation: InstallationRecord = { ...makeInstallation(installPath), installPath, version: 'master' }
 
-    // Real download/extract/validate from the real archive.
+    // Real download/extract/validate from the real archive (sha now mandatory).
     await installArtifact({
       installation,
-      artifact: makeArtifact({ id: 'mac-mps-real' }),
+      artifact: makeArtifact({ id: 'mac-mps-real', outputSha256: sha256File(CB_TEST_ARCHIVE!) }),
       tools: makeArtifactTools(path.join(tmpRoot, 'cache')),
       baseUrl: api.baseUrl,
     })

--- a/src/main/sources/comfybuilder/install.ts
+++ b/src/main/sources/comfybuilder/install.ts
@@ -1,5 +1,5 @@
 /**
- * ComfyBuilder install glue — main process only.
+ * ComfyBuilder install glue (main process only).
  *
  * Given a chosen ComfyBuilder artifact, download → extract → validate into the
  * install directory:
@@ -13,7 +13,7 @@
  *
  * The archive is what comfy-builder actually tars (buildexec/assemble.go): a
  * top-level `venv/` + `ComfyUI/` (plus a lockfile, and `syslib/` when present).
- * The manifest is NOT in the archive — comfy-builder seals it into the DB/GCS
+ * The manifest is NOT in the archive: comfy-builder seals it into the DB/GCS
  * (freeze.go), so the version metadata Desktop needs rides on the artifact/version
  * record from the API, not on a file inside the tarball.
  */
@@ -32,7 +32,7 @@ import type { InstallTools } from '../../types/sources'
 /**
  * The archive-layout contract: the two directories comfy-builder tars at the
  * top level. Isolated to one constant so a builder rename is a one-line change.
- * The archive's `venv/` is a complete, relocatable env — `./launch` consumes it
+ * The archive's `venv/` is a complete, relocatable env that `./launch` consumes
  * directly (no post-extract env build), so this stage only lands + validates it.
  */
 const ARTIFACT_DIRS = ['venv', 'ComfyUI'] as const
@@ -50,7 +50,7 @@ export class ComfyBuilderInstallError extends Error {
   }
 }
 
-/** Tools the artifact stage needs — a subset of the standard install bundle. */
+/** Tools the artifact stage needs (a subset of the standard install bundle). */
 export interface InstallArtifactTools {
   sendProgress: (step: string, data: { percent: number; status: string }) => void
   cache: Cache
@@ -150,9 +150,9 @@ export async function installArtifact(params: InstallArtifactParams): Promise<vo
     expectedSha256: artifact.outputSha256,
   })
 
-  // 3+4. Extract (.tar.gz -> nested tar -> files) then validate the layout +
-  // manifest. Any failure in either phase cleans up the extracted roots so a
-  // retry starts from a clean install dir.
+  // 3+4. Extract (.tar.gz -> nested tar -> files) then validate the layout. Any
+  // failure in either phase cleans up the extracted roots so a retry starts from
+  // a clean install dir.
   if (signal?.aborted) throw new Error('Cancelled')
   fs.mkdirSync(installPath, { recursive: true })
   try {

--- a/src/main/sources/comfybuilder/install.ts
+++ b/src/main/sources/comfybuilder/install.ts
@@ -32,12 +32,8 @@ import type { InstallTools } from '../../types/sources'
 /**
  * The archive-layout contract: the two directories comfy-builder tars at the
  * top level. Isolated to one constant so a builder rename is a one-line change.
- *
- * NOTE (env-reshape follow-up): the reused standalone `postInstall`/launch still
- * expect a `standalone-env/` master env to copy into `ComfyUI/.venv`, whereas the
- * builder ships a single ready `venv/`. Bridging the two (and bundling `uv` into
- * the venv) is a separate change that needs a real builder archive to validate;
- * this stage only lands + validates the download.
+ * The archive's `venv/` is a complete, relocatable env — `./launch` consumes it
+ * directly (no post-extract env build), so this stage only lands + validates it.
  */
 const ARTIFACT_DIRS = ['venv', 'ComfyUI'] as const
 
@@ -110,8 +106,8 @@ function cacheSlug(artifactId: string): string {
  * Install a chosen ComfyBuilder artifact end to end (resolve → download →
  * extract → validate). Throws {@link ComfyBuilderInstallError} on an invalid
  * artifact record (before any network I/O) or invalid extracted contents (after
- * cleaning up partial files). The venv/package phases run afterwards via the
- * source's reused standalone `postInstall`.
+ * cleaning up partial files). Launch then drives the extracted `venv/` directly
+ * (see `./launch`); there is no post-extract env build.
  */
 export async function installArtifact(params: InstallArtifactParams): Promise<void> {
   const { installation, artifact, tools, signedUrl, baseUrl, authToken } = params

--- a/src/main/sources/comfybuilder/install.ts
+++ b/src/main/sources/comfybuilder/install.ts
@@ -70,6 +70,8 @@ export interface InstallArtifactParams {
   signedUrl?: string
   /** ComfyBuilder API base for resolving the signed URL; required when `signedUrl` is absent. */
   baseUrl?: string
+  /** Cloud JWT for the deployed builder gateway (the resolve endpoint is auth-gated). */
+  authToken?: string
 }
 
 function isExistingDir(dirPath: string): boolean {
@@ -112,7 +114,7 @@ function cacheSlug(artifactId: string): string {
  * source's reused standalone `postInstall`.
  */
 export async function installArtifact(params: InstallArtifactParams): Promise<void> {
-  const { installation, artifact, tools, signedUrl, baseUrl } = params
+  const { installation, artifact, tools, signedUrl, baseUrl, authToken } = params
   const { sendProgress, cache, signal } = tools
   const { installPath } = installation
 
@@ -130,7 +132,12 @@ export async function installArtifact(params: InstallArtifactParams): Promise<vo
 
   // 1. Resolve the presigned archive URL (skipped when one was passed in).
   const resolvedUrl =
-    signedUrl ?? (await resolveSignedDownloadUrl(artifact.id, { baseUrl: baseUrl!, ...(signal ? { signal } : {}) }))
+    signedUrl ??
+    (await resolveSignedDownloadUrl(artifact.id, {
+      baseUrl: baseUrl!,
+      ...(signal ? { signal } : {}),
+      ...(authToken ? { authToken } : {}),
+    }))
 
   // 2. Download the archive into the download cache.
   const cacheBase = cache.getCachePath(`comfybuilder_${cacheSlug(artifact.id)}`)
@@ -185,11 +192,13 @@ export async function install(installation: InstallationRecord, tools: InstallTo
   const artifact = readArtifact(installation)
   const baseUrl = typeof installation.comfybuilderBaseUrl === 'string' ? installation.comfybuilderBaseUrl : undefined
   const signedUrl = typeof installation.signedUrl === 'string' ? installation.signedUrl : undefined
+  const authToken = typeof installation.comfybuilderAuthToken === 'string' ? installation.comfybuilderAuthToken : undefined
   await installArtifact({
     installation,
     artifact,
     tools: { sendProgress, cache, ...(signal ? { signal } : {}) },
     ...(signedUrl ? { signedUrl } : {}),
     ...(baseUrl ? { baseUrl } : {}),
+    ...(authToken ? { authToken } : {}),
   })
 }

--- a/src/main/sources/comfybuilder/install.ts
+++ b/src/main/sources/comfybuilder/install.ts
@@ -1,0 +1,216 @@
+/**
+ * ComfyBuilder install glue — main process only.
+ *
+ * Given a chosen ComfyBuilder artifact, download → extract → validate into the
+ * install directory:
+ *
+ *   1. Resolve the artifact's presigned archive URL (unless one was passed in).
+ *   2. Download the archive into the download cache (sha256-verified when the
+ *      artifact carries `outputSha256`).
+ *   3. Extract the archive (shared nested-extract path) into the install dir.
+ *   4. Validate the extracted layout + `manifest.json`; on failure the partial
+ *      files are removed and a typed {@link ComfyBuilderInstallError} is thrown.
+ *
+ * A ComfyBuilder artifact unpacks to the same `standalone-env/` + `ComfyUI/`
+ * layout as a standalone install, so the post-extract phases (env create →
+ * package copy) are the standalone source's `postInstall`, reused verbatim and
+ * wired onto the source in `./index` — never duplicated here.
+ */
+import fs from 'fs'
+import path from 'path'
+
+import { downloadArtifact, resolveSignedDownloadUrl } from '../../comfybuilder/artifactDownload'
+import type { Artifact } from '../../comfybuilder/types'
+import type { InstallationRecord } from '../../installations'
+import type { Cache } from '../../lib/cache'
+import type { DownloadProgress } from '../../lib/download'
+import { extractNested } from '../../lib/extract'
+import type { ExtractProgress } from '../../lib/extract'
+import { MANIFEST_FILE } from '../standalone/envPaths'
+import type { InstallTools } from '../../types/sources'
+
+/**
+ * The archive-layout contract. A future builder that ships a `venv/` instead of
+ * a pre-extracted `standalone-env/`, or drops the in-tar manifest, is a one-line
+ * change here — nothing else in the install path assumes the layout.
+ */
+const ARTIFACT_DIRS = ['standalone-env', 'ComfyUI'] as const
+const REQUIRED_MANIFEST_FIELDS = ['id', 'version', 'comfyui_ref', 'python_version'] as const
+
+/** Why an install failed, so callers can branch on `kind`. */
+export type ComfyBuilderInstallErrorKind = 'invalid-artifact' | 'invalid-manifest'
+
+/** Typed install failure (bad artifact record vs. bad extracted contents). */
+export class ComfyBuilderInstallError extends Error {
+  readonly kind: ComfyBuilderInstallErrorKind
+  constructor(kind: ComfyBuilderInstallErrorKind, message: string) {
+    super(message)
+    this.name = 'ComfyBuilderInstallError'
+    this.kind = kind
+  }
+}
+
+/** Tools the artifact stage needs — a subset of the standard install bundle. */
+export interface InstallArtifactTools {
+  sendProgress: (step: string, data: { percent: number; status: string }) => void
+  cache: Cache
+  signal?: AbortSignal
+}
+
+export interface InstallArtifactParams {
+  installation: InstallationRecord
+  /** The chosen artifact (OpenAPI shape). */
+  artifact: Artifact
+  tools: InstallArtifactTools
+  /** Presigned URL to download; skips the resolve step when set (e.g. tests). */
+  signedUrl?: string
+  /** ComfyBuilder API base for resolving the signed URL; required when `signedUrl` is absent. */
+  baseUrl?: string
+}
+
+function isExistingDir(dirPath: string): boolean {
+  try {
+    return fs.statSync(dirPath).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+/** Read + JSON-parse the extracted `manifest.json`, throwing a typed error when
+ *  it is missing, unreadable, or not a JSON object. */
+function readManifest(installPath: string): Record<string, unknown> {
+  const manifestPath = path.join(installPath, MANIFEST_FILE)
+  let raw: string
+  try {
+    raw = fs.readFileSync(manifestPath, 'utf8')
+  } catch {
+    throw new ComfyBuilderInstallError('invalid-manifest', `Extracted artifact is missing ${MANIFEST_FILE}.`)
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    throw new ComfyBuilderInstallError('invalid-manifest', `${MANIFEST_FILE} is not valid JSON.`)
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new ComfyBuilderInstallError('invalid-manifest', `${MANIFEST_FILE} must be a JSON object.`)
+  }
+  return parsed as Record<string, unknown>
+}
+
+/** Assert the extracted tree matches the archive-layout contract:
+ *  `standalone-env/`, `ComfyUI/`, and a well-formed `manifest.json`. */
+function validateExtractedArtifact(installPath: string): void {
+  for (const dir of ARTIFACT_DIRS) {
+    if (!isExistingDir(path.join(installPath, dir))) {
+      throw new ComfyBuilderInstallError('invalid-manifest', `Extracted artifact is missing the ${dir}/ directory.`)
+    }
+  }
+  const manifest = readManifest(installPath)
+  for (const field of REQUIRED_MANIFEST_FIELDS) {
+    const value = manifest[field]
+    if (typeof value !== 'string' || value.length === 0) {
+      throw new ComfyBuilderInstallError('invalid-manifest', `${MANIFEST_FILE} is missing a valid "${field}".`)
+    }
+  }
+}
+
+/** Remove the extracted artifact roots so a failed install leaves nothing behind. */
+async function cleanupPartialInstall(installPath: string): Promise<void> {
+  const entries: readonly string[] = [...ARTIFACT_DIRS, MANIFEST_FILE]
+  await Promise.all(
+    entries.map((entry) =>
+      fs.promises.rm(path.join(installPath, entry), { recursive: true, force: true }).catch(() => {}),
+    ),
+  )
+}
+
+/** Cache-folder-safe slug for an artifact id (which may contain path chars). */
+function cacheSlug(artifactId: string): string {
+  return artifactId.replace(/[^a-zA-Z0-9._-]/g, '_')
+}
+
+/**
+ * Install a chosen ComfyBuilder artifact end to end (resolve → download →
+ * extract → validate). Throws {@link ComfyBuilderInstallError} on an invalid
+ * artifact record (before any network I/O) or invalid extracted contents (after
+ * cleaning up partial files). The venv/package phases run afterwards via the
+ * source's reused standalone `postInstall`.
+ */
+export async function installArtifact(params: InstallArtifactParams): Promise<void> {
+  const { installation, artifact, tools, signedUrl, baseUrl } = params
+  const { sendProgress, cache, signal } = tools
+  const { installPath } = installation
+
+  if (!artifact || typeof artifact.id !== 'string' || artifact.id.length === 0) {
+    throw new ComfyBuilderInstallError('invalid-artifact', 'No artifact id was provided for this install.')
+  }
+  if (!signedUrl && !baseUrl) {
+    throw new ComfyBuilderInstallError('invalid-artifact', 'A signedUrl or baseUrl is required to download the artifact.')
+  }
+
+  // 1. Resolve the presigned archive URL (skipped when one was passed in).
+  const resolvedUrl =
+    signedUrl ?? (await resolveSignedDownloadUrl(artifact.id, { baseUrl: baseUrl!, ...(signal ? { signal } : {}) }))
+
+  // 2. Download the archive into the download cache.
+  const cacheBase = cache.getCachePath(`comfybuilder_${cacheSlug(artifact.id)}`)
+  fs.mkdirSync(cacheBase, { recursive: true })
+  const archivePath = path.join(cacheBase, 'artifact.tar.gz')
+
+  sendProgress('download', { percent: 0, status: 'Downloading artifact…' })
+  await downloadArtifact({
+    signedUrl: resolvedUrl,
+    destPath: archivePath,
+    onProgress: (p: DownloadProgress) =>
+      sendProgress('download', { percent: p.percent, status: `Downloading… ${p.receivedMB} / ${p.totalMB} MB` }),
+    ...(signal ? { signal } : {}),
+    ...(artifact.outputSha256 ? { expectedSha256: artifact.outputSha256 } : {}),
+  })
+
+  // 3. Extract (.tar.gz → nested tar → files) into the install directory.
+  if (signal?.aborted) throw new Error('Cancelled')
+  fs.mkdirSync(installPath, { recursive: true })
+  sendProgress('extract', { percent: 0, status: 'Extracting…' })
+  await extractNested(
+    archivePath,
+    installPath,
+    (p: ExtractProgress) => sendProgress('extract', { percent: p.percent, status: `Extracting… ${p.percent}%` }),
+    signal ? { signal } : {},
+  )
+
+  // 4. Validate the extracted layout + manifest; abort + clean up on failure.
+  try {
+    validateExtractedArtifact(installPath)
+  } catch (err) {
+    await cleanupPartialInstall(installPath)
+    throw err
+  }
+}
+
+/** Read the {@link Artifact} the wizard/creator flattened onto the record. */
+function readArtifact(installation: InstallationRecord): Artifact {
+  const artifact = installation.artifact
+  if (!artifact || typeof artifact !== 'object' || typeof (artifact as Artifact).id !== 'string') {
+    throw new ComfyBuilderInstallError('invalid-artifact', 'This install has no ComfyBuilder artifact to install.')
+  }
+  return artifact as Artifact
+}
+
+/**
+ * Source-plugin install entry point. Unpacks the artifact + resolve inputs the
+ * creator stored on the record, then runs the download/extract/validate stage.
+ */
+export async function install(installation: InstallationRecord, tools: InstallTools): Promise<void> {
+  const { sendProgress, cache, signal } = tools
+  const artifact = readArtifact(installation)
+  const baseUrl = typeof installation.comfybuilderBaseUrl === 'string' ? installation.comfybuilderBaseUrl : undefined
+  const signedUrl = typeof installation.signedUrl === 'string' ? installation.signedUrl : undefined
+  await installArtifact({
+    installation,
+    artifact,
+    tools: { sendProgress, cache, ...(signal ? { signal } : {}) },
+    ...(signedUrl ? { signedUrl } : {}),
+    ...(baseUrl ? { baseUrl } : {}),
+  })
+}

--- a/src/main/sources/comfybuilder/install.ts
+++ b/src/main/sources/comfybuilder/install.ts
@@ -8,13 +8,14 @@
  *   2. Download the archive into the download cache (sha256-verified against the
  *      artifact's required `outputSha256`).
  *   3. Extract the archive (shared nested-extract path) into the install dir.
- *   4. Validate the extracted layout + `manifest.json`; on failure the partial
- *      files are removed and a typed {@link ComfyBuilderInstallError} is thrown.
+ *   4. Validate the extracted layout; on failure the partial files are removed
+ *      and a typed {@link ComfyBuilderInstallError} is thrown.
  *
- * A ComfyBuilder artifact unpacks to the same `standalone-env/` + `ComfyUI/`
- * layout as a standalone install, so the post-extract phases (env create →
- * package copy) are the standalone source's `postInstall`, reused verbatim and
- * wired onto the source in `./index` — never duplicated here.
+ * The archive is what comfy-builder actually tars (buildexec/assemble.go): a
+ * top-level `venv/` + `ComfyUI/` (plus a lockfile, and `syslib/` when present).
+ * The manifest is NOT in the archive — comfy-builder seals it into the DB/GCS
+ * (freeze.go), so the version metadata Desktop needs rides on the artifact/version
+ * record from the API, not on a file inside the tarball.
  */
 import fs from 'fs'
 import path from 'path'
@@ -26,19 +27,22 @@ import type { Cache } from '../../lib/cache'
 import type { DownloadProgress } from '../../lib/download'
 import { extractNested } from '../../lib/extract'
 import type { ExtractProgress } from '../../lib/extract'
-import { MANIFEST_FILE } from '../standalone/envPaths'
 import type { InstallTools } from '../../types/sources'
 
 /**
- * The archive-layout contract. A future builder that ships a `venv/` instead of
- * a pre-extracted `standalone-env/`, or drops the in-tar manifest, is a one-line
- * change here — nothing else in the install path assumes the layout.
+ * The archive-layout contract: the two directories comfy-builder tars at the
+ * top level. Isolated to one constant so a builder rename is a one-line change.
+ *
+ * NOTE (env-reshape follow-up): the reused standalone `postInstall`/launch still
+ * expect a `standalone-env/` master env to copy into `ComfyUI/.venv`, whereas the
+ * builder ships a single ready `venv/`. Bridging the two (and bundling `uv` into
+ * the venv) is a separate change that needs a real builder archive to validate;
+ * this stage only lands + validates the download.
  */
-const ARTIFACT_DIRS = ['standalone-env', 'ComfyUI'] as const
-const REQUIRED_MANIFEST_FIELDS = ['id', 'version', 'comfyui_ref', 'python_version'] as const
+const ARTIFACT_DIRS = ['venv', 'ComfyUI'] as const
 
 /** Why an install failed, so callers can branch on `kind`. */
-export type ComfyBuilderInstallErrorKind = 'invalid-artifact' | 'invalid-manifest'
+export type ComfyBuilderInstallErrorKind = 'invalid-artifact' | 'invalid-layout'
 
 /** Typed install failure (bad artifact record vs. bad extracted contents). */
 export class ComfyBuilderInstallError extends Error {
@@ -76,50 +80,20 @@ function isExistingDir(dirPath: string): boolean {
   }
 }
 
-/** Read + JSON-parse the extracted `manifest.json`, throwing a typed error when
- *  it is missing, unreadable, or not a JSON object. */
-function readManifest(installPath: string): Record<string, unknown> {
-  const manifestPath = path.join(installPath, MANIFEST_FILE)
-  let raw: string
-  try {
-    raw = fs.readFileSync(manifestPath, 'utf8')
-  } catch {
-    throw new ComfyBuilderInstallError('invalid-manifest', `Extracted artifact is missing ${MANIFEST_FILE}.`)
-  }
-  let parsed: unknown
-  try {
-    parsed = JSON.parse(raw)
-  } catch {
-    throw new ComfyBuilderInstallError('invalid-manifest', `${MANIFEST_FILE} is not valid JSON.`)
-  }
-  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    throw new ComfyBuilderInstallError('invalid-manifest', `${MANIFEST_FILE} must be a JSON object.`)
-  }
-  return parsed as Record<string, unknown>
-}
-
 /** Assert the extracted tree matches the archive-layout contract:
- *  `standalone-env/`, `ComfyUI/`, and a well-formed `manifest.json`. */
+ *  `venv/` + `ComfyUI/`. */
 function validateExtractedArtifact(installPath: string): void {
   for (const dir of ARTIFACT_DIRS) {
     if (!isExistingDir(path.join(installPath, dir))) {
-      throw new ComfyBuilderInstallError('invalid-manifest', `Extracted artifact is missing the ${dir}/ directory.`)
-    }
-  }
-  const manifest = readManifest(installPath)
-  for (const field of REQUIRED_MANIFEST_FIELDS) {
-    const value = manifest[field]
-    if (typeof value !== 'string' || value.length === 0) {
-      throw new ComfyBuilderInstallError('invalid-manifest', `${MANIFEST_FILE} is missing a valid "${field}".`)
+      throw new ComfyBuilderInstallError('invalid-layout', `Extracted artifact is missing the ${dir}/ directory.`)
     }
   }
 }
 
 /** Remove the extracted artifact roots so a failed install leaves nothing behind. */
 async function cleanupPartialInstall(installPath: string): Promise<void> {
-  const entries: readonly string[] = [...ARTIFACT_DIRS, MANIFEST_FILE]
   await Promise.all(
-    entries.map((entry) =>
+    ARTIFACT_DIRS.map((entry) =>
       fs.promises.rm(path.join(installPath, entry), { recursive: true, force: true }).catch(() => {}),
     ),
   )

--- a/src/main/sources/comfybuilder/install.ts
+++ b/src/main/sources/comfybuilder/install.ts
@@ -5,8 +5,8 @@
  * install directory:
  *
  *   1. Resolve the artifact's presigned archive URL (unless one was passed in).
- *   2. Download the archive into the download cache (sha256-verified when the
- *      artifact carries `outputSha256`).
+ *   2. Download the archive into the download cache (sha256-verified against the
+ *      artifact's required `outputSha256`).
  *   3. Extract the archive (shared nested-extract path) into the install dir.
  *   4. Validate the extracted layout + `manifest.json`; on failure the partial
  *      files are removed and a typed {@link ComfyBuilderInstallError} is thrown.
@@ -148,6 +148,11 @@ export async function installArtifact(params: InstallArtifactParams): Promise<vo
   if (!signedUrl && !baseUrl) {
     throw new ComfyBuilderInstallError('invalid-artifact', 'A signedUrl or baseUrl is required to download the artifact.')
   }
+  // Integrity is mandatory: without an expected hash the download cannot be
+  // verified, so refuse rather than install unverified bytes.
+  if (typeof artifact.outputSha256 !== 'string' || artifact.outputSha256.length === 0) {
+    throw new ComfyBuilderInstallError('invalid-artifact', 'artifact is missing outputSha256; refusing to install unverified bytes')
+  }
 
   // 1. Resolve the presigned archive URL (skipped when one was passed in).
   const resolvedUrl =
@@ -165,22 +170,22 @@ export async function installArtifact(params: InstallArtifactParams): Promise<vo
     onProgress: (p: DownloadProgress) =>
       sendProgress('download', { percent: p.percent, status: `Downloading… ${p.receivedMB} / ${p.totalMB} MB` }),
     ...(signal ? { signal } : {}),
-    ...(artifact.outputSha256 ? { expectedSha256: artifact.outputSha256 } : {}),
+    expectedSha256: artifact.outputSha256,
   })
 
-  // 3. Extract (.tar.gz → nested tar → files) into the install directory.
+  // 3+4. Extract (.tar.gz -> nested tar -> files) then validate the layout +
+  // manifest. Any failure in either phase cleans up the extracted roots so a
+  // retry starts from a clean install dir.
   if (signal?.aborted) throw new Error('Cancelled')
   fs.mkdirSync(installPath, { recursive: true })
-  sendProgress('extract', { percent: 0, status: 'Extracting…' })
-  await extractNested(
-    archivePath,
-    installPath,
-    (p: ExtractProgress) => sendProgress('extract', { percent: p.percent, status: `Extracting… ${p.percent}%` }),
-    signal ? { signal } : {},
-  )
-
-  // 4. Validate the extracted layout + manifest; abort + clean up on failure.
   try {
+    sendProgress('extract', { percent: 0, status: 'Extracting…' })
+    await extractNested(
+      archivePath,
+      installPath,
+      (p: ExtractProgress) => sendProgress('extract', { percent: p.percent, status: `Extracting… ${p.percent}%` }),
+      signal ? { signal } : {},
+    )
     validateExtractedArtifact(installPath)
   } catch (err) {
     await cleanupPartialInstall(installPath)

--- a/src/main/sources/comfybuilder/launch.test.ts
+++ b/src/main/sources/comfybuilder/launch.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment node
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: { isPackaged: false, getPath: () => os.tmpdir(), getName: () => 'test', getVersion: () => '0', on: vi.fn() },
+}))
+
+import { getLaunchCommand, postInstall, builderPythonPath } from './launch'
+import type { InstallationRecord } from '../../installations'
+
+const isWin = process.platform === 'win32'
+
+function makeInstall(installPath: string, extra: Partial<InstallationRecord> = {}): InstallationRecord {
+  return { id: 'i', name: 'n', createdAt: new Date(0).toISOString(), installPath, sourceId: 'comfybuilder', ...extra }
+}
+
+/** Lay down the archive's `venv/` python + `ComfyUI/main.py`. */
+function layoutInstall(installPath: string): void {
+  const pyDir = path.dirname(builderPythonPath(installPath))
+  fs.mkdirSync(pyDir, { recursive: true })
+  fs.writeFileSync(builderPythonPath(installPath), '')
+  fs.mkdirSync(path.join(installPath, 'ComfyUI'), { recursive: true })
+  fs.writeFileSync(path.join(installPath, 'ComfyUI', 'main.py'), '')
+}
+
+describe('comfybuilder launch', () => {
+  let dir: string
+  beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cb-launch-')) })
+  afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }) })
+
+  it('builderPythonPath points at the archive venv per platform', () => {
+    const p = builderPythonPath(dir)
+    expect(p).toBe(isWin ? path.join(dir, 'venv', 'python.exe') : path.join(dir, 'venv', 'bin', 'python3'))
+  })
+
+  it('getLaunchCommand drives the venv python against ComfyUI/main.py', () => {
+    const installPath = path.join(dir, 'install')
+    layoutInstall(installPath)
+    const cmd = getLaunchCommand(makeInstall(installPath, { launchArgs: '--cpu --port 9001' }))
+    expect(cmd?.cmd).toBe(builderPythonPath(installPath))
+    expect(cmd?.args).toEqual(['-s', path.join('ComfyUI', 'main.py'), '--cpu', '--port', '9001'])
+    expect(cmd?.cwd).toBe(installPath)
+    expect(cmd?.port).toBe(9001)
+  })
+
+  it('returns null when the venv python is missing', () => {
+    const installPath = path.join(dir, 'install')
+    fs.mkdirSync(path.join(installPath, 'ComfyUI'), { recursive: true })
+    fs.writeFileSync(path.join(installPath, 'ComfyUI', 'main.py'), '')
+    expect(getLaunchCommand(makeInstall(installPath))).toBeNull()
+  })
+
+  it('returns null when ComfyUI/main.py is missing', () => {
+    const installPath = path.join(dir, 'install')
+    const pyDir = path.dirname(builderPythonPath(installPath))
+    fs.mkdirSync(pyDir, { recursive: true })
+    fs.writeFileSync(builderPythonPath(installPath), '')
+    expect(getLaunchCommand(makeInstall(installPath))).toBeNull()
+  })
+
+  it('postInstall is a no-op that resolves (no env rebuild)', async () => {
+    const installPath = path.join(dir, 'install')
+    layoutInstall(installPath)
+    await expect(postInstall(makeInstall(installPath), { sendProgress: vi.fn(), update: async () => {} })).resolves.toBeUndefined()
+  })
+})

--- a/src/main/sources/comfybuilder/launch.test.ts
+++ b/src/main/sources/comfybuilder/launch.test.ts
@@ -46,18 +46,12 @@ describe('comfybuilder launch', () => {
     expect(cmd?.port).toBe(9001)
   })
 
-  it('returns null when the venv python is missing', () => {
+  it.each([
+    ['venv python missing', (p: string) => { fs.mkdirSync(path.join(p, 'ComfyUI'), { recursive: true }); fs.writeFileSync(path.join(p, 'ComfyUI', 'main.py'), '') }],
+    ['ComfyUI/main.py missing', (p: string) => { fs.mkdirSync(path.dirname(builderPythonPath(p)), { recursive: true }); fs.writeFileSync(builderPythonPath(p), '') }],
+  ])('returns null when %s', (_name, setup) => {
     const installPath = path.join(dir, 'install')
-    fs.mkdirSync(path.join(installPath, 'ComfyUI'), { recursive: true })
-    fs.writeFileSync(path.join(installPath, 'ComfyUI', 'main.py'), '')
-    expect(getLaunchCommand(makeInstall(installPath))).toBeNull()
-  })
-
-  it('returns null when ComfyUI/main.py is missing', () => {
-    const installPath = path.join(dir, 'install')
-    const pyDir = path.dirname(builderPythonPath(installPath))
-    fs.mkdirSync(pyDir, { recursive: true })
-    fs.writeFileSync(builderPythonPath(installPath), '')
+    setup(installPath)
     expect(getLaunchCommand(makeInstall(installPath))).toBeNull()
   })
 

--- a/src/main/sources/comfybuilder/launch.ts
+++ b/src/main/sources/comfybuilder/launch.ts
@@ -1,11 +1,11 @@
 /**
- * ComfyBuilder env consumption — the "env-reshape".
+ * ComfyBuilder env consumption (the "env-reshape").
  *
  * Unlike a standalone install (a `standalone-env/` master env copied into
  * `ComfyUI/.venv` by `postInstall`), a comfy-builder archive ships ONE ready,
  * relocatable `venv/` at the install root (python + torch + all deps already
- * installed). So there is nothing to build: `postInstall` is a no-op (bar a unix
- * exec-bit fix) and launch drives the archive's `venv/` python directly.
+ * installed). So there is nothing to build: `postInstall` is a no-op and launch
+ * drives the archive's `venv/` python directly.
  */
 import fs from 'fs'
 import path from 'path'
@@ -15,28 +15,16 @@ import type { InstallationRecord } from '../../installations'
 import type { LaunchCommand, PostInstallTools } from '../../types/sources'
 import { extractPort, parseArgs } from '../../lib/util'
 
-/** The archive's bundled interpreter: `venv/python.exe` on Windows,
- *  `venv/bin/python3` elsewhere. */
+/** The archive's bundled interpreter. */
 export function builderPythonPath(installPath: string): string {
   return process.platform === 'win32'
     ? path.join(installPath, 'venv', 'python.exe')
     : path.join(installPath, 'venv', 'bin', 'python3')
 }
 
-/**
- * No env build — the archive's `venv/` is already complete. Only restore the
- * unix exec bit on the venv's bin/ (a nested tar extract can drop it); on Windows
- * there is nothing to do.
- */
-export async function postInstall(_installation: InstallationRecord, _tools: PostInstallTools): Promise<void> {
-  if (process.platform === 'win32') return
-  const binDir = path.join(_installation.installPath, 'venv', 'bin')
-  try {
-    for (const entry of fs.readdirSync(binDir)) {
-      try { fs.chmodSync(path.join(binDir, entry), 0o755) } catch {}
-    }
-  } catch {}
-}
+/** No-op: the archive ships a complete, ready `venv/`, so there is no env to build.
+ *  `extractNested` uses native tar, which preserves the venv's exec bits. */
+export async function postInstall(_installation: InstallationRecord, _tools: PostInstallTools): Promise<void> {}
 
 /** Launch ComfyUI with the archive's own venv python (no `.venv` rebuild). */
 export function getLaunchCommand(installation: InstallationRecord): LaunchCommand | null {

--- a/src/main/sources/comfybuilder/launch.ts
+++ b/src/main/sources/comfybuilder/launch.ts
@@ -1,0 +1,56 @@
+/**
+ * ComfyBuilder env consumption — the "env-reshape".
+ *
+ * Unlike a standalone install (a `standalone-env/` master env copied into
+ * `ComfyUI/.venv` by `postInstall`), a comfy-builder archive ships ONE ready,
+ * relocatable `venv/` at the install root (python + torch + all deps already
+ * installed). So there is nothing to build: `postInstall` is a no-op (bar a unix
+ * exec-bit fix) and launch drives the archive's `venv/` python directly.
+ */
+import fs from 'fs'
+import path from 'path'
+
+import { DEFAULT_LAUNCH_ARGS } from '../standalone/envPaths'
+import type { InstallationRecord } from '../../installations'
+import type { LaunchCommand, PostInstallTools } from '../../types/sources'
+import { extractPort, parseArgs } from '../../lib/util'
+
+/** The archive's bundled interpreter: `venv/python.exe` on Windows,
+ *  `venv/bin/python3` elsewhere. */
+export function builderPythonPath(installPath: string): string {
+  return process.platform === 'win32'
+    ? path.join(installPath, 'venv', 'python.exe')
+    : path.join(installPath, 'venv', 'bin', 'python3')
+}
+
+/**
+ * No env build — the archive's `venv/` is already complete. Only restore the
+ * unix exec bit on the venv's bin/ (a nested tar extract can drop it); on Windows
+ * there is nothing to do.
+ */
+export async function postInstall(_installation: InstallationRecord, _tools: PostInstallTools): Promise<void> {
+  if (process.platform === 'win32') return
+  const binDir = path.join(_installation.installPath, 'venv', 'bin')
+  try {
+    for (const entry of fs.readdirSync(binDir)) {
+      try { fs.chmodSync(path.join(binDir, entry), 0o755) } catch {}
+    }
+  } catch {}
+}
+
+/** Launch ComfyUI with the archive's own venv python (no `.venv` rebuild). */
+export function getLaunchCommand(installation: InstallationRecord): LaunchCommand | null {
+  const pythonPath = builderPythonPath(installation.installPath)
+  if (!fs.existsSync(pythonPath)) return null
+  const mainPy = path.join(installation.installPath, 'ComfyUI', 'main.py')
+  if (!fs.existsSync(mainPy)) return null
+
+  const userArgs = ((installation.launchArgs as string | undefined) ?? DEFAULT_LAUNCH_ARGS).trim()
+  const parsed = userArgs.length > 0 ? parseArgs(userArgs) : []
+  return {
+    cmd: pythonPath,
+    args: ['-s', path.join('ComfyUI', 'main.py'), ...parsed],
+    cwd: installation.installPath,
+    port: extractPort(parsed),
+  }
+}

--- a/src/main/sources/index.ts
+++ b/src/main/sources/index.ts
@@ -4,8 +4,9 @@ import { gitSource } from './git'
 import { remote } from './remote'
 import { cloud } from './cloud'
 import { desktop } from './desktop'
+import { comfybuilder } from './comfybuilder'
 import type { SourcePlugin } from '../types/sources'
 
-const sources: SourcePlugin[] = [standalone, portable, gitSource, cloud, remote, desktop]
+const sources: SourcePlugin[] = [standalone, portable, gitSource, cloud, remote, desktop, comfybuilder]
 
 export default sources

--- a/src/test/comfybuilder/mockBuilderApi.ts
+++ b/src/test/comfybuilder/mockBuilderApi.ts
@@ -1,0 +1,98 @@
+/**
+ * Minimal static ComfyBuilder API for tests. No OAuth, no tokens — the real
+ * download path is presigned-URL based, so the mock just points the resolve
+ * route at a plain archive route it streams with a Content-Length.
+ *
+ *   GET /v1/build-artifacts/:id/download  -> { downloadUrl: <baseUrl>/archive.tgz, expiresAt }
+ *   GET /archive.tgz                       -> streams `archivePath` (200, Content-Length)
+ *
+ * Both bind to an ephemeral loopback port (`listen(0)`); `stop()` force-closes
+ * keep-alive sockets so a run never hangs on teardown.
+ */
+import { createReadStream, statSync } from 'node:fs'
+import { createServer } from 'node:http'
+import type { IncomingMessage, Server, ServerResponse } from 'node:http'
+
+export interface MockBuilderApi {
+  baseUrl: string
+  stop(): Promise<void>
+}
+
+export interface StartMockBuilderApiOptions {
+  /** Archive tarball streamed by the `/archive.tgz` route. Omit for resolve-only tests. */
+  archivePath?: string
+}
+
+const ARCHIVE_ROUTE = '/archive.tgz'
+
+function listen(server: Server): Promise<string> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      if (address && typeof address === 'object') {
+        resolve(`http://127.0.0.1:${address.port}`)
+      } else {
+        reject(new Error('mock builder api did not expose a numeric port'))
+      }
+    })
+  })
+}
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { 'content-type': 'application/json' })
+  res.end(JSON.stringify(body))
+}
+
+export async function startMockBuilderApi(options: StartMockBuilderApiOptions = {}): Promise<MockBuilderApi> {
+  const { archivePath } = options
+  let baseUrl = ''
+
+  function handle(req: IncomingMessage, res: ServerResponse): void {
+    const url = new URL(req.url ?? '/', baseUrl || 'http://127.0.0.1')
+    const segments = url.pathname.split('/').filter(Boolean)
+
+    // GET /v1/build-artifacts/:id/download -> signed URL pointing at the archive route.
+    if (
+      req.method === 'GET' &&
+      segments.length === 4 &&
+      segments[0] === 'v1' &&
+      segments[1] === 'build-artifacts' &&
+      segments[3] === 'download'
+    ) {
+      sendJson(res, 200, {
+        downloadUrl: `${baseUrl}${ARCHIVE_ROUTE}`,
+        expiresAt: new Date(Date.now() + 30 * 60 * 1000).toISOString(),
+      })
+      return
+    }
+
+    // GET /archive.tgz -> stream the archive with a Content-Length.
+    if (req.method === 'GET' && url.pathname === ARCHIVE_ROUTE) {
+      if (!archivePath) {
+        sendJson(res, 404, { message: 'no archive configured for this mock' })
+        return
+      }
+      res.writeHead(200, {
+        'content-type': 'application/octet-stream',
+        'content-length': String(statSync(archivePath).size),
+      })
+      createReadStream(archivePath).pipe(res)
+      return
+    }
+
+    sendJson(res, 404, { message: `no route for ${req.method} ${url.pathname}` })
+  }
+
+  const server = createServer(handle)
+  baseUrl = await listen(server)
+
+  return {
+    baseUrl,
+    stop: () =>
+      new Promise<void>((resolve, reject) => {
+        server.closeAllConnections()
+        server.close((err) => (err ? reject(err) : resolve()))
+      }),
+  }
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -24,6 +24,7 @@
   },
   "include": [
     "src/**/*.test.ts",
+    "src/test/**/*",
     "locales/*.json"
   ]
 }


### PR DESCRIPTION
## TL;DR
Installs a chosen ComfyBuilder distribution artifact onto Comfy Desktop and makes it launchable: resolve a signed download URL (auth-gated), download + sha256-verify the archive, extract it, validate the layout, then launch the archive's bundled `venv/` directly. No distribution list, version picker, or OAuth in this PR (separate follow-ups). Proven end to end against real staging archives: the 1 GB linux/cpu archive installs + validates, and the windows/cpu archive boots ComfyUI to 818 nodes on a real Windows host.

## Intent (why)
The Internal Desktop Distribution milestone needs Comfy Desktop to install a distribution that comfy-builder produced and run it. This PR delivers the riskiest slice: given a selected artifact, pull it and turn it into a runnable ComfyUI install. The distribution/version listing UI and sign-in are deliberately separate; this is the install + launch logic they will call once a user has selected an artifact.

## Decision
- Scope is exactly download to install to launch of a given artifact.
- The archive is what comfy-builder actually tars (`buildexec/assemble.go`): a top-level `venv/` + `ComfyUI/` (plus a lockfile, and `syslib/` when present), with NO in-archive manifest (comfy-builder seals it into the DB/GCS). So the layout check is `venv/` + `ComfyUI/`; the manifest and its recipe fields are not read from the tarball (and are not exposed on the artifact API either).
- Env-reshape: the archive ships one ready, relocatable `venv/` (python + torch + all deps), so there is nothing to build. `postInstall` is a no-op and launch drives `venv/python.exe` (Windows) / `venv/bin/python3` (unix) against `ComfyUI/main.py`. This replaces the standalone source's `standalone-env/` master-into-`ComfyUI/.venv` rebuild.
- sha256 verification stays mandatory: an artifact without `outputSha256` is rejected before any download; a mismatch drops the tainted bytes.
- The deployed builder gateway auth-gates the resolve endpoint, so `resolveSignedDownloadUrl` sends a Cloud JWT (`comfybuilderAuthToken` on the record) when given one; the returned presigned URL is auth-free.
- Reuse over reinvention: list/launch glue is reused from the standalone source. The detail view is reused too but reads a standalone `.venv` a `venv/` install lacks, so torch/python render blank and the Update tab is inert (a pinned-env install has nothing to update); a first-class detail view is a follow-up.

## Illustration
```mermaid
flowchart LR
  A[Chosen artifact] --> B[resolve signed URL + Cloud JWT]
  B --> C[download + sha256-verify]
  C --> D[extract 7za nested]
  D --> E[validate venv/ + ComfyUI/]
  E --> F[launch venv python -> ComfyUI/main.py]
  E -. missing dir .-> X[cleanup partial + typed error]
```

## Implementation Details
Files: `src/main/comfybuilder/{types,artifactDownload}.ts`, `src/main/sources/comfybuilder/{install,launch,index}.ts`, a mock builder API under `src/test/comfybuilder/`, plus registration in `src/main/sources/index.ts`.

Validation:
- Real staging linux/cpu archive (1 GB): the real `installArtifact` (real download + sha256-verify + 7za extract + validate) passes.
- Real staging windows/cpu archive: extracted on a real Windows VM and launched via the exact command `getLaunchCommand` emits; ComfyUI boots to 818 nodes (torch needs the VC++ Redistributable, which the Desktop installer provides).
- Unit + integration: `launch.test.ts` (venv path per platform, launch args/cwd/port, null guards, no-op postInstall), the fabricated-fixture install path (venv/+ComfyUI/, `invalid-layout` cleanup), typecheck (4 configs) + lint + full suite green.
- Opt-in real-archive boot test (`CB_TEST_ARCHIVE`, darwin) drives installArtifact -> comfybuilder postInstall -> getLaunchCommand -> boot.

Follow-ups (out of scope, shared surfaces): distribution list + version picker + OAuth; a first-class comfybuilder detail view; the builder exposing an archive-bytes sha on the artifact API.
