### PR TITLE
feat: share GPU tier classifier via IPC

### DIFF
--- a/src/main/lib/ipc/registerAppHandlers.ts
+++ b/src/main/lib/ipc/registerAppHandlers.ts
@@ -35,6 +35,7 @@ import { getDeviceId } from '../deviceId'
 import { getCloudCapacityStatusAsync } from '../cloudCapacity'
 import { getUserTierAsync } from '../userTier'
 import { getStableTags } from '../comfyui-releases'
+import { deriveGpuTier } from '../../../shared/gpuTier'
 
 export function registerAppHandlers(): void {
   // App version
@@ -261,6 +262,8 @@ export function registerAppHandlers(): void {
     const primaryGpu = selectPrimaryGpu(allGpus, gpu?.id ?? null)
     const primaryGpuModel = (primaryGpu?.model || null) ?? gpu?.model ?? null
     const primaryGpuVramMb = primaryGpu?.vram_mb ?? null
+    const primaryGpuVramGb = primaryGpuVramMb != null ? Math.round(primaryGpuVramMb / 1024) : null
+    const gpuTier = deriveGpuTier({ vendor: gpu?.id, vramGb: primaryGpuVramGb })
     // Only trust the primary controller's driver string when it actually
     // matches the detected compute vendor; selectPrimaryGpu may fall back to a
     // non-matching controller, which would otherwise mislabel the driver.
@@ -281,6 +284,8 @@ export function registerAppHandlers(): void {
       gpu_label: gpu?.label ?? null,
       gpu_model: primaryGpuModel,
       gpu_vram_mb: primaryGpuVramMb,
+      gpu_vram_gb: primaryGpuVramGb,
+      gpu_tier: gpuTier,
       gpus: allGpus,
       nvidia_driver_version: nvidiaCheck?.driverVersion ?? null,
       nvidia_driver_supported: nvidiaCheck?.supported ?? null,

--- a/src/main/lib/telemetry.ts
+++ b/src/main/lib/telemetry.ts
@@ -27,8 +27,8 @@
  *      get scrubbed by `scrubAll()` as a safety net, but the discipline is
  *      to send `directory_bucket: 'checkpoints'` not raw `directory: '/Users/x/foo'`.
  *      Use helpers in `src/renderer/src/lib/telemetry.ts` (`toSizeBucket`,
- *      `toCountBucket`, `toErrorBucket`, `toModelDirectoryBucket`,
- *      `deriveGpuTier`, etc.) — extend them instead of inlining new bucketing.
+ *      `toCountBucket`, `toErrorBucket`, `toModelDirectoryBucket`) and
+ *      `src/shared/gpuTier.ts` — extend them instead of inlining new bucketing.
  *   4. If the event is a *failure* (`*.error`, crash, install failure, etc.),
  *      add the event name to `DATADOG_MIRRORED_EVENT_NAMES` so it also
  *      reaches Datadog and a monitor can fire on it.

--- a/src/renderer/src/lib/rendererBootstrap.ts
+++ b/src/renderer/src/lib/rendererBootstrap.ts
@@ -26,7 +26,6 @@
 import { datadogRum, type RumBeforeSend } from '@datadog/browser-rum'
 import { normalizeRumErrorEvent } from './datadogPathNormalization'
 import {
-  deriveGpuTier,
   TELEMETRY_ACTION_EVENT_NAME,
   type TelemetryActionEventDetail,
   type TelemetryContext
@@ -438,19 +437,16 @@ async function initializeProviders(): Promise<void> {
       // - nvidia_driver_version / nvidia_driver_supported
       // - cpu_manufacturer / cpu_physical_cores / cpu_speed_ghz
       // - os_arch
-      // Forward the full payload and derive `gpu_tier` / `gpu_vram_gb`
-      // / `gpu_count` / `gpu_driver_version` for cohort filtering. Main has
+      // Forward the full payload and derive `gpu_count` / `gpu_driver_version`
+      // for cohort filtering. Main has
       // already selected the real compute GPU (`gpu_model` / `gpu_vram_mb` /
       // per-vendor driver), so we use those instead of re-picking `gpus[0]`,
       // which can be a virtual display adapter.
-      const gpuVramMb = info.gpu_vram_mb
-      const gpuVramGb = gpuVramMb != null ? Math.round(gpuVramMb / 1024) : null
       const gpuDriverVersion =
         info.nvidia_driver_version ??
         info.amd_driver_version ??
         info.intel_driver_version ??
         null
-      const gpuTier = deriveGpuTier({ vendor: info.gpu_vendor, vramGb: gpuVramGb })
       // `gpus` / `installations` are arrays of objects. The telemetry IPC
       // bridge only accepts scalars and arrays of scalars, so a native array
       // of objects is silently dropped before it reaches PostHog. Serialize
@@ -461,11 +457,8 @@ async function initializeProviders(): Promise<void> {
       const installationsJson = serializeForTelemetry(installations)
       const enriched: Record<string, string | number | boolean | null | undefined> = {
         ...(infoRest as unknown as Record<string, string | number | boolean | null | undefined>),
-        gpu_vram_mb: gpuVramMb,
-        gpu_vram_gb: gpuVramGb,
         gpu_count: gpus.length,
         gpu_driver_version: gpuDriverVersion,
-        gpu_tier: gpuTier,
         gpus_json: gpusJson.json,
         gpus_json_truncated: gpusJson.truncated,
         installations_json: installationsJson.json,
@@ -486,10 +479,10 @@ async function initializeProviders(): Promise<void> {
           os_arch: info.os_arch,
           gpu_vendor: info.gpu_vendor,
           gpu_model: info.gpu_model,
-          gpu_vram_gb: gpuVramGb,
+          gpu_vram_gb: info.gpu_vram_gb,
           gpu_count: info.gpus.length,
           gpu_driver_version: gpuDriverVersion,
-          gpu_tier: gpuTier,
+          gpu_tier: info.gpu_tier,
           nvidia_driver_supported: info.nvidia_driver_supported,
           total_memory_gb: info.total_memory_gb,
           cpu_model: info.cpu_model,

--- a/src/renderer/src/lib/telemetry.test.ts
+++ b/src/renderer/src/lib/telemetry.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from 'vitest'
 import {
-  deriveGpuTier,
   toCountBucket,
   toErrorBucket,
   toFileExtension,
@@ -75,44 +74,5 @@ describe('toModelDirectoryBucket', () => {
     expect(toModelDirectoryBucket('C:\\models\\loras')).toBe('loras')
     expect(toModelDirectoryBucket('/models/some_custom_dir')).toBe('other')
     expect(toModelDirectoryBucket(undefined)).toBe('unknown')
-  })
-})
-
-describe('deriveGpuTier', () => {
-  it('returns apple for Apple-vendor GPUs regardless of VRAM', () => {
-    expect(deriveGpuTier({ vendor: 'apple', vramGb: null })).toBe('apple')
-    expect(deriveGpuTier({ vendor: 'Apple', vramGb: 8 })).toBe('apple')
-  })
-
-  it("returns apple for the canonical 'mps' GpuId that main reports for Apple Silicon", () => {
-    expect(deriveGpuTier({ vendor: 'mps', vramGb: null })).toBe('apple')
-    expect(deriveGpuTier({ vendor: 'MPS', vramGb: 64 })).toBe('apple')
-  })
-
-  it('returns high for NVIDIA / AMD with ≥ 24 GB VRAM', () => {
-    expect(deriveGpuTier({ vendor: 'nvidia', vramGb: 24 })).toBe('high')
-    expect(deriveGpuTier({ vendor: 'nvidia', vramGb: 80 })).toBe('high')
-    expect(deriveGpuTier({ vendor: 'amd', vramGb: 24 })).toBe('high')
-  })
-
-  it('returns mid for 12-23 GB VRAM', () => {
-    expect(deriveGpuTier({ vendor: 'nvidia', vramGb: 12 })).toBe('mid')
-    expect(deriveGpuTier({ vendor: 'nvidia', vramGb: 23 })).toBe('mid')
-  })
-
-  it('returns low for 6-11 GB VRAM', () => {
-    expect(deriveGpuTier({ vendor: 'nvidia', vramGb: 6 })).toBe('low')
-    expect(deriveGpuTier({ vendor: 'nvidia', vramGb: 11 })).toBe('low')
-  })
-
-  it('returns sub_low for NVIDIA / AMD < 6 GB and non-NVIDIA / non-AMD discrete cards', () => {
-    expect(deriveGpuTier({ vendor: 'nvidia', vramGb: 4 })).toBe('sub_low')
-    expect(deriveGpuTier({ vendor: 'intel', vramGb: 16 })).toBe('sub_low')
-  })
-
-  it('returns cpu_only when vendor or VRAM is missing', () => {
-    expect(deriveGpuTier({ vendor: null, vramGb: 8 })).toBe('cpu_only')
-    expect(deriveGpuTier({ vendor: 'nvidia', vramGb: 0 })).toBe('cpu_only')
-    expect(deriveGpuTier({ vendor: 'nvidia', vramGb: null })).toBe('cpu_only')
   })
 })

--- a/src/renderer/src/lib/telemetry.ts
+++ b/src/renderer/src/lib/telemetry.ts
@@ -75,23 +75,3 @@ export function toModelDirectoryBucket(directory: string | undefined): string {
 export function isTerminalModelDownloadStatus(status: ModelDownloadStatus): boolean {
   return status === 'completed' || status === 'error' || status === 'cancelled'
 }
-
-/** Coarse hardware tier for cohort filtering; raw gpu_model / gpu_vram_gb are also sent for finer slicing. */
-export type GpuTier = 'high' | 'mid' | 'low' | 'sub_low' | 'apple' | 'cpu_only'
-
-export function deriveGpuTier(opts: {
-  vendor: string | null | undefined
-  vramGb: number | null | undefined
-}): GpuTier {
-  const vendor = (opts.vendor ?? '').toLowerCase()
-  // Main reports 'mps' for Apple Silicon; also accept literal 'apple'.
-  if (vendor === 'apple' || vendor === 'mps') return 'apple'
-  const vram = opts.vramGb ?? 0
-  if (!vendor) return 'cpu_only'
-  if (vendor !== 'nvidia' && vendor !== 'amd') return 'sub_low'
-  if (vram <= 0) return 'cpu_only'
-  if (vram >= 24) return 'high'
-  if (vram >= 12) return 'mid'
-  if (vram >= 6) return 'low'
-  return 'sub_low'
-}

--- a/src/shared/gpuTier.test.ts
+++ b/src/shared/gpuTier.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { deriveGpuTier } from './gpuTier'
+
+describe('deriveGpuTier', () => {
+  it('returns apple for Apple-vendor GPUs regardless of VRAM', () => {
+    expect(deriveGpuTier({ vendor: 'apple', vramGb: null })).toBe('apple')
+    expect(deriveGpuTier({ vendor: 'Apple', vramGb: 8 })).toBe('apple')
+  })
+
+  it("returns apple for the canonical 'mps' GpuId that main reports for Apple Silicon", () => {
+    expect(deriveGpuTier({ vendor: 'mps', vramGb: null })).toBe('apple')
+    expect(deriveGpuTier({ vendor: 'MPS', vramGb: 64 })).toBe('apple')
+  })
+
+  it('returns high for NVIDIA / AMD with at least 24 GB VRAM', () => {
+    expect(deriveGpuTier({ vendor: 'nvidia', vramGb: 24 })).toBe('high')
+    expect(deriveGpuTier({ vendor: 'nvidia', vramGb: 80 })).toBe('high')
+    expect(deriveGpuTier({ vendor: 'amd', vramGb: 24 })).toBe('high')
+  })
+
+  it('returns mid for 12-23 GB VRAM', () => {
+    expect(deriveGpuTier({ vendor: 'nvidia', vramGb: 12 })).toBe('mid')
+    expect(deriveGpuTier({ vendor: 'nvidia', vramGb: 23 })).toBe('mid')
+  })
+
+  it('returns low for 6-11 GB VRAM', () => {
+    expect(deriveGpuTier({ vendor: 'nvidia', vramGb: 6 })).toBe('low')
+    expect(deriveGpuTier({ vendor: 'nvidia', vramGb: 11 })).toBe('low')
+  })
+
+  it('returns sub_low for NVIDIA / AMD below 6 GB and other GPU vendors', () => {
+    expect(deriveGpuTier({ vendor: 'nvidia', vramGb: 4 })).toBe('sub_low')
+    expect(deriveGpuTier({ vendor: 'intel', vramGb: 16 })).toBe('sub_low')
+  })
+
+  it('returns cpu_only when vendor or VRAM is missing', () => {
+    expect(deriveGpuTier({ vendor: null, vramGb: 8 })).toBe('cpu_only')
+    expect(deriveGpuTier({ vendor: 'nvidia', vramGb: 0 })).toBe('cpu_only')
+    expect(deriveGpuTier({ vendor: 'nvidia', vramGb: null })).toBe('cpu_only')
+  })
+})

--- a/src/shared/gpuTier.ts
+++ b/src/shared/gpuTier.ts
@@ -1,0 +1,19 @@
+/** Coarse hardware tier for cohort filtering and GPU-aware surfaces. */
+export type GpuTier = 'high' | 'mid' | 'low' | 'sub_low' | 'apple' | 'cpu_only'
+
+export function deriveGpuTier(opts: {
+  vendor: string | null | undefined
+  vramGb: number | null | undefined
+}): GpuTier {
+  const vendor = (opts.vendor ?? '').toLowerCase()
+  // Main reports 'mps' for Apple Silicon; also accept literal 'apple'.
+  if (vendor === 'apple' || vendor === 'mps') return 'apple'
+  const vram = opts.vramGb ?? 0
+  if (!vendor) return 'cpu_only'
+  if (vendor !== 'nvidia' && vendor !== 'amd') return 'sub_low'
+  if (vram <= 0) return 'cpu_only'
+  if (vram >= 24) return 'high'
+  if (vram >= 12) return 'mid'
+  if (vram >= 6) return 'low'
+  return 'sub_low'
+}

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -2,6 +2,7 @@
 // This file is the single source of truth — do not duplicate these types elsewhere.
 
 import type { FirstUseMode } from '../shared/firstUseMode'
+import type { GpuTier } from '../shared/gpuTier'
 export type { FirstUseMode }
 
 // Unsubscribe function returned by event listeners
@@ -625,6 +626,9 @@ export interface SystemInfo {
   gpu_model: string | null
   /** VRAM of the selected primary (real compute) GPU, not `gpus[0]`. */
   gpu_vram_mb: number | null
+  /** Rounded VRAM of the selected primary GPU, in GiB. */
+  gpu_vram_gb: number | null
+  gpu_tier: GpuTier
   gpus: SystemGpuInfo[]
   nvidia_driver_version: string | null
   nvidia_driver_supported: boolean | null


### PR DESCRIPTION
## Summary

- move `deriveGpuTier` from renderer-only telemetry code into `src/shared`
- add `gpu_tier` and `gpu_vram_gb` to the `get-system-info` IPC response alongside the canonical `gpu_model`
- consume the main-process values in renderer telemetry instead of re-deriving them
- move the tier boundary coverage into shared tests

## Why

Main-process and renderer surfaces need one authoritative GPU tier classifier. Returning the derived tier, selected GPU model, and VRAM through `get-system-info` prevents surfaces from duplicating the PostHog cohort logic and drifting over time.

## Impact

GPU-aware surfaces can consume `gpu_tier`, `gpu_model`, and `gpu_vram_gb` directly from the existing system-info API. Existing telemetry retains the same tier vocabulary and boundaries.

## Validation

- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test` — 189 files passed; 2,814 tests passed, 1 skipped

Linear: [DESK2-140](https://linear.app/comfyorg/issue/DESK2-140/d-25-shared-gpu-tier-classifier-ipc-plumbing)