### PR TITLE
feat: recommend Cloud for low-GPU first use

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -606,6 +606,7 @@
     "pickLead": "Choose the setup that fits how you work. You can switch later.",
     "cloudTagline": "Instant setup. Full power.",
     "cloudDesc": "Best for **most users** who want to work from anywhere with models verified for commercial license.",
+    "gpuRecommendation": "Recommended for your hardware",
     "localLabel": "Local",
     "localTagline": "Full control. Your hardware.",
     "localDesc": "Best for **power users** who want to manage versions, custom nodes, and offline workflows.",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -606,6 +606,7 @@
     "pickLead": "选择适合你工作方式的设置。之后仍可切换。",
     "cloudTagline": "即时设置。完整性能。",
     "cloudDesc": "最适合希望随时随地工作，并使用已验证商业许可模型的**大多数用户**。",
+    "gpuRecommendation": "根据你的硬件推荐",
     "localLabel": "本地",
     "localTagline": "完全控制。使用你的硬件。",
     "localDesc": "最适合希望管理版本、自定义节点和离线工作流的**高级用户**。",

--- a/src/main/lib/ipc/registerAppHandlers.ts
+++ b/src/main/lib/ipc/registerAppHandlers.ts
@@ -35,6 +35,7 @@ import { getDeviceId } from '../deviceId'
 import { getCloudCapacityStatusAsync } from '../cloudCapacity'
 import { getUserTierAsync } from '../userTier'
 import { getStableTags } from '../comfyui-releases'
+import { deriveGpuTier } from '../../../shared/gpuTier'
 
 export function registerAppHandlers(): void {
   // App version
@@ -261,6 +262,8 @@ export function registerAppHandlers(): void {
     const primaryGpu = selectPrimaryGpu(allGpus, gpu?.id ?? null)
     const primaryGpuModel = (primaryGpu?.model || null) ?? gpu?.model ?? null
     const primaryGpuVramMb = primaryGpu?.vram_mb ?? null
+    const primaryGpuVramGb = primaryGpuVramMb != null ? Math.round(primaryGpuVramMb / 1024) : null
+    const gpuTier = deriveGpuTier({ vendor: gpu?.id, vramGb: primaryGpuVramGb })
     // Only trust the primary controller's driver string when it actually
     // matches the detected compute vendor; selectPrimaryGpu may fall back to a
     // non-matching controller, which would otherwise mislabel the driver.
@@ -281,6 +284,8 @@ export function registerAppHandlers(): void {
       gpu_label: gpu?.label ?? null,
       gpu_model: primaryGpuModel,
       gpu_vram_mb: primaryGpuVramMb,
+      gpu_vram_gb: primaryGpuVramGb,
+      gpu_tier: gpuTier,
       gpus: allGpus,
       nvidia_driver_version: nvidiaCheck?.driverVersion ?? null,
       nvidia_driver_supported: nvidiaCheck?.supported ?? null,

--- a/src/main/lib/telemetry.ts
+++ b/src/main/lib/telemetry.ts
@@ -27,8 +27,8 @@
  *      get scrubbed by `scrubAll()` as a safety net, but the discipline is
  *      to send `directory_bucket: 'checkpoints'` not raw `directory: '/Users/x/foo'`.
  *      Use helpers in `src/renderer/src/lib/telemetry.ts` (`toSizeBucket`,
- *      `toCountBucket`, `toErrorBucket`, `toModelDirectoryBucket`,
- *      `deriveGpuTier`, etc.) — extend them instead of inlining new bucketing.
+ *      `toCountBucket`, `toErrorBucket`, `toModelDirectoryBucket`) and
+ *      `src/shared/gpuTier.ts` — extend them instead of inlining new bucketing.
  *   4. If the event is a *failure* (`*.error`, crash, install failure, etc.),
  *      add the event name to `DATADOG_MIRRORED_EVENT_NAMES` so it also
  *      reaches Datadog and a monitor can fire on it.

--- a/src/renderer/src/components/ChoiceCard.vue
+++ b/src/renderer/src/components/ChoiceCard.vue
@@ -13,13 +13,16 @@ withDefaults(
      *  rather than commits, leaving the commit to a parent Continue button. */
     selectable?: boolean
     selected?: boolean
+    /** Keeps an unselected radio in the tab order when its group has no selection. */
+    tabStop?: boolean
   }>(),
   {
     tagline: '',
     disabled: false,
     glow: false,
     selectable: false,
-    selected: false
+    selected: false,
+    tabStop: false
   }
 )
 
@@ -35,7 +38,7 @@ defineEmits<{ click: [] }>()
     ]"
     :role="selectable ? 'radio' : undefined"
     :aria-checked="selectable ? selected : undefined"
-    :tabindex="selectable ? (selected ? 0 : -1) : undefined"
+    :tabindex="selectable ? (selected || tabStop ? 0 : -1) : undefined"
     :disabled="disabled"
     @click="$emit('click')"
   >

--- a/src/renderer/src/lib/rendererBootstrap.ts
+++ b/src/renderer/src/lib/rendererBootstrap.ts
@@ -26,7 +26,6 @@
 import { datadogRum, type RumBeforeSend } from '@datadog/browser-rum'
 import { normalizeRumErrorEvent } from './datadogPathNormalization'
 import {
-  deriveGpuTier,
   TELEMETRY_ACTION_EVENT_NAME,
   type TelemetryActionEventDetail,
   type TelemetryContext
@@ -438,19 +437,16 @@ async function initializeProviders(): Promise<void> {
       // - nvidia_driver_version / nvidia_driver_supported
       // - cpu_manufacturer / cpu_physical_cores / cpu_speed_ghz
       // - os_arch
-      // Forward the full payload and derive `gpu_tier` / `gpu_vram_gb`
-      // / `gpu_count` / `gpu_driver_version` for cohort filtering. Main has
+      // Forward the full payload and derive `gpu_count` / `gpu_driver_version`
+      // for cohort filtering. Main has
       // already selected the real compute GPU (`gpu_model` / `gpu_vram_mb` /
       // per-vendor driver), so we use those instead of re-picking `gpus[0]`,
       // which can be a virtual display adapter.
-      const gpuVramMb = info.gpu_vram_mb
-      const gpuVramGb = gpuVramMb != null ? Math.round(gpuVramMb / 1024) : null
       const gpuDriverVersion =
         info.nvidia_driver_version ??
         info.amd_driver_version ??
         info.intel_driver_version ??
         null
-      const gpuTier = deriveGpuTier({ vendor: info.gpu_vendor, vramGb: gpuVramGb })
       // `gpus` / `installations` are arrays of objects. The telemetry IPC
       // bridge only accepts scalars and arrays of scalars, so a native array
       // of objects is silently dropped before it reaches PostHog. Serialize
@@ -461,11 +457,8 @@ async function initializeProviders(): Promise<void> {
       const installationsJson = serializeForTelemetry(installations)
       const enriched: Record<string, string | number | boolean | null | undefined> = {
         ...(infoRest as unknown as Record<string, string | number | boolean | null | undefined>),
-        gpu_vram_mb: gpuVramMb,
-        gpu_vram_gb: gpuVramGb,
         gpu_count: gpus.length,
         gpu_driver_version: gpuDriverVersion,
-        gpu_tier: gpuTier,
         gpus_json: gpusJson.json,
         gpus_json_truncated: gpusJson.truncated,
         installations_json: installationsJson.json,
@@ -486,10 +479,10 @@ async function initializeProviders(): Promise<void> {
           os_arch: info.os_arch,
           gpu_vendor: info.gpu_vendor,
           gpu_model: info.gpu_model,
-          gpu_vram_gb: gpuVramGb,
+          gpu_vram_gb: info.gpu_vram_gb,
           gpu_count: info.gpus.length,
           gpu_driver_version: gpuDriverVersion,
-          gpu_tier: gpuTier,
+          gpu_tier: info.gpu_tier,
           nvidia_driver_supported: info.nvidia_driver_supported,
           total_memory_gb: info.total_memory_gb,
           cpu_model: info.cpu_model,

--- a/src/renderer/src/lib/telemetry.test.ts
+++ b/src/renderer/src/lib/telemetry.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from 'vitest'
 import {
-  deriveGpuTier,
   toCountBucket,
   toErrorBucket,
   toFileExtension,
@@ -75,44 +74,5 @@ describe('toModelDirectoryBucket', () => {
     expect(toModelDirectoryBucket('C:\\models\\loras')).toBe('loras')
     expect(toModelDirectoryBucket('/models/some_custom_dir')).toBe('other')
     expect(toModelDirectoryBucket(undefined)).toBe('unknown')
-  })
-})
-
-describe('deriveGpuTier', () => {
-  it('returns apple for Apple-vendor GPUs regardless of VRAM', () => {
-    expect(deriveGpuTier({ vendor: 'apple', vramGb: null })).toBe('apple')
-    expect(deriveGpuTier({ vendor: 'Apple', vramGb: 8 })).toBe('apple')
-  })
-
-  it("returns apple for the canonical 'mps' GpuId that main reports for Apple Silicon", () => {
-    expect(deriveGpuTier({ vendor: 'mps', vramGb: null })).toBe('apple')
-    expect(deriveGpuTier({ vendor: 'MPS', vramGb: 64 })).toBe('apple')
-  })
-
-  it('returns high for NVIDIA / AMD with ≥ 24 GB VRAM', () => {
-    expect(deriveGpuTier({ vendor: 'nvidia', vramGb: 24 })).toBe('high')
-    expect(deriveGpuTier({ vendor: 'nvidia', vramGb: 80 })).toBe('high')
-    expect(deriveGpuTier({ vendor: 'amd', vramGb: 24 })).toBe('high')
-  })
-
-  it('returns mid for 12-23 GB VRAM', () => {
-    expect(deriveGpuTier({ vendor: 'nvidia', vramGb: 12 })).toBe('mid')
-    expect(deriveGpuTier({ vendor: 'nvidia', vramGb: 23 })).toBe('mid')
-  })
-
-  it('returns low for 6-11 GB VRAM', () => {
-    expect(deriveGpuTier({ vendor: 'nvidia', vramGb: 6 })).toBe('low')
-    expect(deriveGpuTier({ vendor: 'nvidia', vramGb: 11 })).toBe('low')
-  })
-
-  it('returns sub_low for NVIDIA / AMD < 6 GB and non-NVIDIA / non-AMD discrete cards', () => {
-    expect(deriveGpuTier({ vendor: 'nvidia', vramGb: 4 })).toBe('sub_low')
-    expect(deriveGpuTier({ vendor: 'intel', vramGb: 16 })).toBe('sub_low')
-  })
-
-  it('returns cpu_only when vendor or VRAM is missing', () => {
-    expect(deriveGpuTier({ vendor: null, vramGb: 8 })).toBe('cpu_only')
-    expect(deriveGpuTier({ vendor: 'nvidia', vramGb: 0 })).toBe('cpu_only')
-    expect(deriveGpuTier({ vendor: 'nvidia', vramGb: null })).toBe('cpu_only')
   })
 })

--- a/src/renderer/src/lib/telemetry.ts
+++ b/src/renderer/src/lib/telemetry.ts
@@ -75,23 +75,3 @@ export function toModelDirectoryBucket(directory: string | undefined): string {
 export function isTerminalModelDownloadStatus(status: ModelDownloadStatus): boolean {
   return status === 'completed' || status === 'error' || status === 'cancelled'
 }
-
-/** Coarse hardware tier for cohort filtering; raw gpu_model / gpu_vram_gb are also sent for finer slicing. */
-export type GpuTier = 'high' | 'mid' | 'low' | 'sub_low' | 'apple' | 'cpu_only'
-
-export function deriveGpuTier(opts: {
-  vendor: string | null | undefined
-  vramGb: number | null | undefined
-}): GpuTier {
-  const vendor = (opts.vendor ?? '').toLowerCase()
-  // Main reports 'mps' for Apple Silicon; also accept literal 'apple'.
-  if (vendor === 'apple' || vendor === 'mps') return 'apple'
-  const vram = opts.vramGb ?? 0
-  if (!vendor) return 'cpu_only'
-  if (vendor !== 'nvidia' && vendor !== 'amd') return 'sub_low'
-  if (vram <= 0) return 'cpu_only'
-  if (vram >= 24) return 'high'
-  if (vram >= 12) return 'mid'
-  if (vram >= 6) return 'low'
-  return 'sub_low'
-}

--- a/src/renderer/src/views/FirstUseTakeover.test.ts
+++ b/src/renderer/src/views/FirstUseTakeover.test.ts
@@ -32,12 +32,6 @@ vi.mock('../components/TakeoverHeader.vue', () => ({
 vi.mock('../components/ModalShell.vue', () => ({
   default: { template: '<div data-testid="stub-modal-shell"><slot /></div>' },
 }))
-vi.mock('../components/ChoiceCard.vue', () => ({
-  default: {
-    template:
-      '<div data-testid="stub-choice-card"><slot name="label-trailing" /><slot name="desc-trailing" /><slot /></div>',
-  },
-}))
 vi.mock('../components/WhyTryCloudModal.vue', () => ({
   default: { template: '<div data-testid="stub-why-cloud" />' },
 }))
@@ -133,9 +127,19 @@ describe('FirstUseTakeover start step', () => {
         .setValue(true)
       const btn = wrapper.find('[data-testid="first-use-continue"]')
       expect(btn.attributes('disabled')).toBeDefined()
+      const cloudChoice = wrapper.find('[data-testid="first-use-pick-cloud"]')
+      const localChoice = wrapper.find('[data-testid="first-use-pick-local"]')
+      expect(cloudChoice.attributes()).toMatchObject({
+        role: 'radio',
+        'aria-checked': 'false',
+        tabindex: '0',
+      })
+      expect(localChoice.attributes('tabindex')).toBe('-1')
 
-      await wrapper.find('[data-testid="first-use-pick-local"]').trigger('click')
+      await localChoice.trigger('click')
       expect(btn.attributes('disabled')).toBeUndefined()
+      expect(cloudChoice.attributes('tabindex')).toBe('-1')
+      expect(localChoice.attributes('tabindex')).toBe('0')
     },
   )
 
@@ -319,6 +323,75 @@ describe('FirstUseTakeover start step', () => {
     expect(emitTelemetryAction).not.toHaveBeenCalledWith(
       'comfy.desktop.first_use.gpu_reco_shown',
       expect.anything(),
+    )
+  })
+
+  it('does not track a recommendation that resolves after Continue starts', async () => {
+    let resolveSystemInfo:
+      | ((info: Awaited<ReturnType<typeof window.api.getSystemInfo>>) => void)
+      | undefined
+    let resolveSetting: (() => void) | undefined
+    ;(window.api.getSystemInfo as ReturnType<typeof vi.fn>).mockReturnValue(
+      new Promise((resolve) => {
+        resolveSystemInfo = resolve
+      }),
+    )
+    ;(window.api.setSetting as ReturnType<typeof vi.fn>).mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveSetting = resolve
+      }),
+    )
+    const wrapper = mountTakeover()
+    await flushPromises()
+    await wrapper
+      .find('[data-testid="first-use-consent-tos"] input[type="checkbox"]')
+      .setValue(true)
+    await wrapper.find('[data-testid="first-use-continue"]').trigger('click')
+
+    resolveSystemInfo?.({
+      gpu_vendor: 'nvidia',
+      gpu_label: 'NVIDIA',
+      gpu_model: 'NVIDIA GeForce GTX 1650',
+      gpu_vram_gb: 4,
+      gpu_tier: 'sub_low',
+    })
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="first-use-gpu-recommendation"]').exists()).toBe(false)
+    expect(emitTelemetryAction).not.toHaveBeenCalledWith(
+      'comfy.desktop.first_use.gpu_reco_shown',
+      expect.anything(),
+    )
+
+    resolveSetting?.()
+    await flushPromises()
+    expect(emitTelemetryAction).toHaveBeenCalledWith(
+      'comfy.desktop.first_use.fork_chosen',
+      expect.objectContaining({ gpu_tier: 'sub_low', reco_shown: false }),
+    )
+  })
+
+  it('uses no default for recommended hardware with a legacy install', async () => {
+    ;(window.api.getSystemInfo as ReturnType<typeof vi.fn>).mockResolvedValue({
+      gpu_vendor: 'nvidia',
+      gpu_label: 'NVIDIA',
+      gpu_model: 'NVIDIA GeForce GTX 1650',
+      gpu_vram_gb: 4,
+      gpu_tier: 'sub_low',
+    })
+    const wrapper = mountTakeover()
+    await (
+      wrapper.vm as unknown as { open: (opts: { hasLegacyDesktop: boolean }) => Promise<void> }
+    ).open({ hasLegacyDesktop: true })
+    await flushPromises()
+    await wrapper
+      .find('[data-testid="first-use-consent-tos"] input[type="checkbox"]')
+      .setValue(true)
+
+    expect(wrapper.find('[data-testid="first-use-gpu-recommendation"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="first-use-continue"]').attributes('disabled')).toBeDefined()
+    expect(wrapper.find('[data-testid="first-use-migrate-existing"]').attributes('aria-hidden')).toBe(
+      'true',
     )
   })
 

--- a/src/renderer/src/views/FirstUseTakeover.test.ts
+++ b/src/renderer/src/views/FirstUseTakeover.test.ts
@@ -105,7 +105,7 @@ function mountTakeover() {
 
 describe('FirstUseTakeover start step', () => {
   it.each(['sub_low', 'cpu_only'] as const)(
-    'shows and tracks the Cloud recommendation for %s hardware',
+    'shows and tracks the Cloud recommendation with no default for %s hardware',
     async (gpuTier) => {
       ;(window.api.getSystemInfo as ReturnType<typeof vi.fn>).mockResolvedValue({
         gpu_vendor: gpuTier === 'cpu_only' ? null : 'nvidia',
@@ -128,8 +128,45 @@ describe('FirstUseTakeover start step', () => {
           capacity_status: 'normal',
         },
       )
+      await wrapper
+        .find('[data-testid="first-use-consent-tos"] input[type="checkbox"]')
+        .setValue(true)
+      const btn = wrapper.find('[data-testid="first-use-continue"]')
+      expect(btn.attributes('disabled')).toBeDefined()
+
+      await wrapper.find('[data-testid="first-use-pick-local"]').trigger('click')
+      expect(btn.attributes('disabled')).toBeUndefined()
     },
   )
+
+  it('does not replace a choice made before hardware detection resolves', async () => {
+    let resolveSystemInfo:
+      | ((info: Awaited<ReturnType<typeof window.api.getSystemInfo>>) => void)
+      | undefined
+    ;(window.api.getSystemInfo as ReturnType<typeof vi.fn>).mockReturnValue(
+      new Promise((resolve) => {
+        resolveSystemInfo = resolve
+      }),
+    )
+    const wrapper = mountTakeover()
+    await wrapper.find('[data-testid="first-use-pick-cloud"]').trigger('click')
+
+    resolveSystemInfo?.({
+      gpu_vendor: 'nvidia',
+      gpu_label: 'NVIDIA',
+      gpu_model: 'NVIDIA GeForce GTX 1650',
+      gpu_vram_gb: 4,
+      gpu_tier: 'sub_low',
+    })
+    await flushPromises()
+    await wrapper
+      .find('[data-testid="first-use-consent-tos"] input[type="checkbox"]')
+      .setValue(true)
+
+    expect(wrapper.find('[data-testid="first-use-continue"]').attributes('disabled')).toBeUndefined()
+    await wrapper.find('[data-testid="first-use-continue"]').trigger('click')
+    expect(wrapper.emitted('complete-cloud')).toBeTruthy()
+  })
 
   it.each(['low', 'mid', 'high', 'apple'] as const)(
     'does not show the Cloud recommendation for %s hardware',
@@ -149,6 +186,10 @@ describe('FirstUseTakeover start step', () => {
         'comfy.desktop.first_use.gpu_reco_shown',
         expect.anything(),
       )
+      await wrapper
+        .find('[data-testid="first-use-consent-tos"] input[type="checkbox"]')
+        .setValue(true)
+      expect(wrapper.find('[data-testid="first-use-continue"]').attributes('disabled')).toBeUndefined()
     },
   )
 
@@ -207,6 +248,7 @@ describe('FirstUseTakeover start step', () => {
     await wrapper
       .find('[data-testid="first-use-consent-tos"] input[type="checkbox"]')
       .setValue(true)
+    await wrapper.find('[data-testid="first-use-pick-local"]').trigger('click')
     await wrapper.find('[data-testid="first-use-continue"]').trigger('click')
 
     expect(emitTelemetryAction).toHaveBeenCalledWith(
@@ -236,6 +278,7 @@ describe('FirstUseTakeover start step', () => {
     await wrapper
       .find('[data-testid="first-use-consent-tos"] input[type="checkbox"]')
       .setValue(true)
+    await wrapper.find('[data-testid="first-use-pick-local"]').trigger('click')
     await wrapper.find('[data-testid="first-use-continue"]').trigger('click')
 
     expect(emitTelemetryAction).toHaveBeenCalledWith(
@@ -607,6 +650,24 @@ describe('FirstUseTakeover desktop-first-use-fork-default experiment', () => {
       variant: 'cloud-default',
       source: 'cache'
     })
+  })
+
+  it('replaces the cloud-default variant with no default for recommended hardware', async () => {
+    ;(window.api.telemetryGetExperimentFlag as ReturnType<typeof vi.fn>).mockResolvedValue('cloud')
+    ;(window.api.getSystemInfo as ReturnType<typeof vi.fn>).mockResolvedValue({
+      gpu_vendor: 'nvidia',
+      gpu_label: 'NVIDIA',
+      gpu_model: 'NVIDIA GeForce GTX 1650',
+      gpu_vram_gb: 4,
+      gpu_tier: 'sub_low',
+    })
+    const wrapper = mountTakeover()
+    await flushPromises()
+    await wrapper
+      .find('[data-testid="first-use-consent-tos"] input[type="checkbox"]')
+      .setValue(true)
+
+    expect(wrapper.find('[data-testid="first-use-continue"]').attributes('disabled')).toBeDefined()
   })
 
   it("pre-selects nothing when the flag returns 'none' (no-default arm) and disables Continue until a card is picked", async () => {

--- a/src/renderer/src/views/FirstUseTakeover.test.ts
+++ b/src/renderer/src/views/FirstUseTakeover.test.ts
@@ -7,6 +7,25 @@ vi.mock('../lib/telemetry', () => ({
   emitTelemetryAction: vi.fn(),
 }))
 
+const capacityMock = vi.hoisted(() => ({
+  status: 'normal' as 'normal' | 'degraded' | 'disabled',
+  tier: 'unknown' as 'free' | 'paid' | 'unknown',
+}))
+
+vi.mock('../composables/useCloudCapacity', async () => {
+  const { computed } = await import('vue')
+  return {
+    useCloudCapacity: () => ({
+      status: computed(() => capacityMock.status),
+      tier: computed(() => capacityMock.tier),
+      whenReady: vi.fn().mockResolvedValue(undefined),
+      isDisabled: () => capacityMock.status === 'disabled',
+      isDegraded: () => capacityMock.status === 'degraded',
+      confirmEntry: vi.fn().mockResolvedValue(true),
+    }),
+  }
+})
+
 vi.mock('../components/TakeoverHeader.vue', () => ({
   default: { template: '<div data-testid="stub-takeover-header"><slot /></div>' },
 }))
@@ -16,7 +35,7 @@ vi.mock('../components/ModalShell.vue', () => ({
 vi.mock('../components/ChoiceCard.vue', () => ({
   default: {
     template:
-      '<div data-testid="stub-choice-card"><slot name="label-trailing" /><slot /></div>',
+      '<div data-testid="stub-choice-card"><slot name="label-trailing" /><slot name="desc-trailing" /><slot /></div>',
   },
 }))
 vi.mock('../components/WhyTryCloudModal.vue', () => ({
@@ -43,6 +62,7 @@ vi.mock('../components/BrandTakeoverLayout.vue', () => ({
 }))
 
 import FirstUseTakeover from './FirstUseTakeover.vue'
+import { emitTelemetryAction } from '../lib/telemetry'
 
 const i18n = createI18n({
   legacy: false,
@@ -53,11 +73,20 @@ const i18n = createI18n({
 })
 
 beforeEach(() => {
+  vi.mocked(emitTelemetryAction).mockClear()
+  capacityMock.status = 'normal'
+  capacityMock.tier = 'unknown'
   window.api = {
     setSetting: vi.fn().mockResolvedValue(undefined),
     getSetting: vi.fn().mockResolvedValue(true),
     getLocale: vi.fn().mockResolvedValue('en'),
-    detectGPU: vi.fn().mockResolvedValue(null),
+    getSystemInfo: vi.fn().mockResolvedValue({
+      gpu_vendor: 'nvidia',
+      gpu_label: 'NVIDIA',
+      gpu_model: 'NVIDIA GeForce RTX 4070',
+      gpu_vram_gb: 12,
+      gpu_tier: 'mid',
+    }),
     setFirstUseMode: vi.fn(),
     closeHostWindow: vi.fn().mockResolvedValue(undefined),
     // Default to undefined so the existing tests exercise the control
@@ -75,6 +104,137 @@ function mountTakeover() {
 }
 
 describe('FirstUseTakeover start step', () => {
+  it.each(['sub_low', 'cpu_only'] as const)(
+    'shows and tracks the Cloud recommendation for %s hardware',
+    async (gpuTier) => {
+      ;(window.api.getSystemInfo as ReturnType<typeof vi.fn>).mockResolvedValue({
+        gpu_vendor: gpuTier === 'cpu_only' ? null : 'nvidia',
+        gpu_label: gpuTier === 'cpu_only' ? null : 'NVIDIA',
+        gpu_model: gpuTier === 'cpu_only' ? null : 'NVIDIA GeForce GTX 1650',
+        gpu_vram_gb: gpuTier === 'cpu_only' ? null : 4,
+        gpu_tier: gpuTier,
+      })
+      const wrapper = mountTakeover()
+      await flushPromises()
+
+      expect(wrapper.find('[data-testid="first-use-gpu-recommendation"]').exists()).toBe(true)
+      expect(emitTelemetryAction).toHaveBeenCalledWith(
+        'comfy.desktop.first_use.gpu_reco_shown',
+        {
+          gpu_tier: gpuTier,
+          gpu_vendor: gpuTier === 'cpu_only' ? null : 'nvidia',
+          gpu_vram_gb: gpuTier === 'cpu_only' ? null : 4,
+          gpu_model_bucket:
+            gpuTier === 'cpu_only' ? 'unknown' : 'NVIDIA GeForce GTX 1650',
+          capacity_status: 'normal',
+        },
+      )
+    },
+  )
+
+  it.each(['low', 'mid', 'high', 'apple'] as const)(
+    'does not show the Cloud recommendation for %s hardware',
+    async (gpuTier) => {
+      ;(window.api.getSystemInfo as ReturnType<typeof vi.fn>).mockResolvedValue({
+        gpu_vendor: gpuTier === 'apple' ? 'mps' : 'nvidia',
+        gpu_label: gpuTier === 'apple' ? 'Apple Silicon' : 'NVIDIA',
+        gpu_model: 'Test GPU',
+        gpu_vram_gb: 12,
+        gpu_tier: gpuTier,
+      })
+      const wrapper = mountTakeover()
+      await flushPromises()
+
+      expect(wrapper.find('[data-testid="first-use-gpu-recommendation"]').exists()).toBe(false)
+      expect(emitTelemetryAction).not.toHaveBeenCalledWith(
+        'comfy.desktop.first_use.gpu_reco_shown',
+        expect.anything(),
+      )
+    },
+  )
+
+  it.each(['degraded', 'disabled'] as const)(
+    'suppresses the recommendation when Cloud capacity is %s',
+    async (capacityStatus) => {
+      capacityMock.status = capacityStatus
+      ;(window.api.getSystemInfo as ReturnType<typeof vi.fn>).mockResolvedValue({
+        gpu_vendor: 'nvidia',
+        gpu_label: 'NVIDIA',
+        gpu_model: 'NVIDIA GeForce GTX 1650',
+        gpu_vram_gb: 4,
+        gpu_tier: 'sub_low',
+      })
+      const wrapper = mountTakeover()
+      await flushPromises()
+
+      expect(wrapper.find('[data-testid="first-use-gpu-recommendation"]').exists()).toBe(false)
+    },
+  )
+
+  it('fails closed when system-info detection rejects', async () => {
+    ;(window.api.getSystemInfo as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('detection failed'),
+    )
+    const wrapper = mountTakeover()
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="first-use-gpu-recommendation"]').exists()).toBe(false)
+    expect(emitTelemetryAction).not.toHaveBeenCalledWith(
+      'comfy.desktop.first_use.gpu_reco_shown',
+      expect.anything(),
+    )
+  })
+
+  it('adds GPU tier and recommendation exposure to fork_chosen', async () => {
+    ;(window.api.getSystemInfo as ReturnType<typeof vi.fn>).mockResolvedValue({
+      gpu_vendor: 'nvidia',
+      gpu_label: 'NVIDIA',
+      gpu_model: 'NVIDIA GeForce GTX 1650',
+      gpu_vram_gb: 4,
+      gpu_tier: 'sub_low',
+    })
+    const wrapper = mountTakeover()
+    await flushPromises()
+    await wrapper
+      .find('[data-testid="first-use-consent-tos"] input[type="checkbox"]')
+      .setValue(true)
+    await wrapper.find('[data-testid="first-use-continue"]').trigger('click')
+
+    expect(emitTelemetryAction).toHaveBeenCalledWith(
+      'comfy.desktop.first_use.fork_chosen',
+      expect.objectContaining({ gpu_tier: 'sub_low', reco_shown: true }),
+    )
+  })
+
+  it('defers recommendation telemetry until first-use consent is accepted', async () => {
+    ;(window.api.getSetting as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
+    ;(window.api.getSystemInfo as ReturnType<typeof vi.fn>).mockResolvedValue({
+      gpu_vendor: 'nvidia',
+      gpu_label: 'NVIDIA',
+      gpu_model: 'NVIDIA GeForce GTX 1650',
+      gpu_vram_gb: 4,
+      gpu_tier: 'sub_low',
+    })
+    const wrapper = mountTakeover()
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="first-use-gpu-recommendation"]').exists()).toBe(true)
+    expect(emitTelemetryAction).not.toHaveBeenCalledWith(
+      'comfy.desktop.first_use.gpu_reco_shown',
+      expect.anything(),
+    )
+
+    await wrapper
+      .find('[data-testid="first-use-consent-tos"] input[type="checkbox"]')
+      .setValue(true)
+    await wrapper.find('[data-testid="first-use-continue"]').trigger('click')
+
+    expect(emitTelemetryAction).toHaveBeenCalledWith(
+      'comfy.desktop.first_use.gpu_reco_shown',
+      expect.objectContaining({ gpu_tier: 'sub_low' }),
+    )
+  })
+
   it('Continue triggers a nudge shake on the ToS row when terms are not accepted', async () => {
     const wrapper = mountTakeover()
     const tosRow = wrapper.find('[data-testid="first-use-consent-tos"]')
@@ -123,6 +283,7 @@ describe('FirstUseTakeover start step', () => {
 
   it('Express-install checkbox is visible on the default Local pick and hides only when Cloud is picked', async () => {
     const wrapper = mountTakeover()
+    await flushPromises()
     // The row stays mounted (reserved layout space, no jump on swap)
     // but is visually + a11y hidden whenever Cloud is the active pick.
     const express = () => wrapper.find('[data-testid="first-use-express-install"]')

--- a/src/renderer/src/views/FirstUseTakeover.test.ts
+++ b/src/renderer/src/views/FirstUseTakeover.test.ts
@@ -124,8 +124,7 @@ describe('FirstUseTakeover start step', () => {
           gpu_tier: gpuTier,
           gpu_vendor: gpuTier === 'cpu_only' ? null : 'nvidia',
           gpu_vram_gb: gpuTier === 'cpu_only' ? null : 4,
-          gpu_model_bucket:
-            gpuTier === 'cpu_only' ? 'unknown' : 'NVIDIA GeForce GTX 1650',
+          gpu_model: gpuTier === 'cpu_only' ? null : 'NVIDIA GeForce GTX 1650',
           capacity_status: 'normal',
         },
       )
@@ -185,6 +184,16 @@ describe('FirstUseTakeover start step', () => {
     )
   })
 
+  it('reuses the system-info request across takeover open resets', async () => {
+    const wrapper = mountTakeover()
+    await flushPromises()
+
+    await (wrapper.vm as unknown as { open: () => Promise<void> }).open()
+    await flushPromises()
+
+    expect(window.api.getSystemInfo).toHaveBeenCalledTimes(1)
+  })
+
   it('adds GPU tier and recommendation exposure to fork_chosen', async () => {
     ;(window.api.getSystemInfo as ReturnType<typeof vi.fn>).mockResolvedValue({
       gpu_vendor: 'nvidia',
@@ -232,6 +241,41 @@ describe('FirstUseTakeover start step', () => {
     expect(emitTelemetryAction).toHaveBeenCalledWith(
       'comfy.desktop.first_use.gpu_reco_shown',
       expect.objectContaining({ gpu_tier: 'sub_low' }),
+    )
+  })
+
+  it('does not track a recommendation that resolves after leaving the start step', async () => {
+    let resolveSystemInfo:
+      | ((info: Awaited<ReturnType<typeof window.api.getSystemInfo>>) => void)
+      | undefined
+    ;(window.api.getLocale as ReturnType<typeof vi.fn>).mockResolvedValue('zh-CN')
+    ;(window.api.getSystemInfo as ReturnType<typeof vi.fn>).mockReturnValue(
+      new Promise((resolve) => {
+        resolveSystemInfo = resolve
+      }),
+    )
+    const wrapper = mountTakeover()
+    await flushPromises()
+
+    await wrapper
+      .find('[data-testid="first-use-consent-tos"] input[type="checkbox"]')
+      .setValue(true)
+    await wrapper.find('[data-testid="first-use-continue"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('[data-testid="first-use-mirrors-accept"]').exists()).toBe(true)
+
+    resolveSystemInfo?.({
+      gpu_vendor: 'nvidia',
+      gpu_label: 'NVIDIA',
+      gpu_model: 'NVIDIA GeForce GTX 1650',
+      gpu_vram_gb: 4,
+      gpu_tier: 'sub_low',
+    })
+    await flushPromises()
+
+    expect(emitTelemetryAction).not.toHaveBeenCalledWith(
+      'comfy.desktop.first_use.gpu_reco_shown',
+      expect.anything(),
     )
   })
 

--- a/src/renderer/src/views/FirstUseTakeover.vue
+++ b/src/renderer/src/views/FirstUseTakeover.vue
@@ -125,6 +125,7 @@ const forkExperimentVariant = ref<ForkVariant | null>(null)
  *  card regardless; users can flip between cards before Continue. */
 const pickedChoice = ref<'cloud' | 'local' | null>('local')
 const forkChoiceInteracted = ref(false)
+const forkChoiceCommitted = ref(false)
 
 function selectForkChoice(choice: 'cloud' | 'local'): void {
   forkChoiceInteracted.value = true
@@ -324,6 +325,7 @@ const showGpuRecommendation = computed(() => {
   return (
     step.value === 'start' &&
     !skipPick.value &&
+    !forkChoiceCommitted.value &&
     capacityReady.value &&
     cloudCapacity.status.value === 'normal' &&
     (tier === 'sub_low' || tier === 'cpu_only')
@@ -430,6 +432,7 @@ async function onContinue(): Promise<void> {
   // but guard defensively so a programmatic click can't bypass.
   if (pickedChoice.value === null) return
   forkChoiceInteracted.value = true
+  forkChoiceCommitted.value = true
   // Keep `isContinuing` true past `routePostStart()` because the chain
   // handlers (express prep, cloud auto-launch, new-install swap) all
   // either unmount this takeover or swap to a sub-step within ms. The
@@ -647,6 +650,7 @@ async function open(opts: OpenOpts = {}): Promise<void> {
   termsDoc.value = null
   acceptedTos.value = false
   forkChoiceInteracted.value = false
+  forkChoiceCommitted.value = false
   // Safe baseline: Local pre-selected. The variant-aware apply call
   // below overrides to Cloud (`'cloud-default'` arm) or null
   // (`'no-default'` arm) when neither hard gate (legacy-desktop,
@@ -817,6 +821,7 @@ defineExpose({ open, resetContinue })
             :class="{ 'start-card-cloud--capacity-disabled': cloudCapacity.isDisabled() }"
             selectable
             :selected="pickedChoice === 'cloud'"
+            :tab-stop="pickedChoice === null"
             :aria-disabled="cloudCapacity.isDisabled() ? true : undefined"
             glow
             :label="$t('cloud.label')"

--- a/src/renderer/src/views/FirstUseTakeover.vue
+++ b/src/renderer/src/views/FirstUseTakeover.vue
@@ -124,6 +124,12 @@ const forkExperimentVariant = ref<ForkVariant | null>(null)
  *  Continue activates). Cloud is rendered as an equal-weight peer
  *  card regardless; users can flip between cards before Continue. */
 const pickedChoice = ref<'cloud' | 'local' | null>('local')
+const forkChoiceInteracted = ref(false)
+
+function selectForkChoice(choice: 'cloud' | 'local'): void {
+  forkChoiceInteracted.value = true
+  pickedChoice.value = choice
+}
 
 // Capacity-protection switch for Cloud (PostHog flag
 // `desktop-cloud-capacity`). At first-use, we follow the flag
@@ -196,6 +202,7 @@ function applyForkExperimentDefault(variant: ForkVariant): void {
     initialDefaultChoice.value = 'local'
     return
   }
+  if (forkChoiceInteracted.value) return
   if (variant === 'cloud-default') {
     pickedChoice.value = 'cloud'
     initialDefaultChoice.value = 'cloud'
@@ -341,7 +348,12 @@ function emitGpuRecommendationIfConsented(): void {
 }
 
 watch(showGpuRecommendation, (shown) => {
-  if (!shown || gpuRecommendationContext || !systemInfo.value) return
+  if (!shown) return
+  if (!forkChoiceInteracted.value) {
+    pickedChoice.value = null
+    initialDefaultChoice.value = null
+  }
+  if (gpuRecommendationContext || !systemInfo.value) return
   gpuRecommendationContext = {
     gpu_tier: systemInfo.value.gpu_tier,
     gpu_vendor: systemInfo.value.gpu_vendor,
@@ -417,6 +429,7 @@ async function onContinue(): Promise<void> {
   // no pick to commit. The button is already :disabled in this state,
   // but guard defensively so a programmatic click can't bypass.
   if (pickedChoice.value === null) return
+  forkChoiceInteracted.value = true
   // Keep `isContinuing` true past `routePostStart()` because the chain
   // handlers (express prep, cloud auto-launch, new-install swap) all
   // either unmount this takeover or swap to a sub-step within ms. The
@@ -560,7 +573,7 @@ function onWhyCloudTryCloud(): void {
   // selection to Cloud but leaves the user on the screen so they can
   // accept T&C and press Continue. The legal gate is non-negotiable —
   // we can't auto-commit on the user's behalf.
-  pickedChoice.value = 'cloud'
+  selectForkChoice('cloud')
 }
 
 function chooseMigrate(): void {
@@ -594,7 +607,7 @@ function onStartCardsKeydown(e: KeyboardEvent): void {
   const nextChoice = order[next]
   if (!nextChoice) return
   e.preventDefault()
-  pickedChoice.value = nextChoice
+  selectForkChoice(nextChoice)
   void nextTick(() => {
     const radios = (e.currentTarget as HTMLElement | null)?.querySelectorAll<HTMLElement>(
       '[role="radio"]'
@@ -633,6 +646,7 @@ async function open(opts: OpenOpts = {}): Promise<void> {
   whyCloudOpen.value = false
   termsDoc.value = null
   acceptedTos.value = false
+  forkChoiceInteracted.value = false
   // Safe baseline: Local pre-selected. The variant-aware apply call
   // below overrides to Cloud (`'cloud-default'` arm) or null
   // (`'no-default'` arm) when neither hard gate (legacy-desktop,
@@ -815,7 +829,7 @@ defineExpose({ open, resetContinue })
             "
             :description="$t(cloudDescriptionKey)"
             data-testid="first-use-pick-cloud"
-            @click="cloudCapacity.isDisabled() ? null : (pickedChoice = 'cloud')"
+            @click="cloudCapacity.isDisabled() ? null : selectForkChoice('cloud')"
           >
             <template #label-trailing>
               <Tooltip :text="$t('firstUse.whyTryCloud')">
@@ -847,7 +861,7 @@ defineExpose({ open, resetContinue })
             :tagline="$t('firstUse.localTagline')"
             :description="$t('firstUse.localDesc')"
             data-testid="first-use-pick-local"
-            @click="pickedChoice = 'local'"
+            @click="selectForkChoice('local')"
           />
         </div>
         <!-- Modifier checkboxes (Migrate + Express). Wrapped in a

--- a/src/renderer/src/views/FirstUseTakeover.vue
+++ b/src/renderer/src/views/FirstUseTakeover.vue
@@ -249,7 +249,7 @@ const migrateExisting = ref(true)
 const showMigrateExisting = computed(
   () => pickedChoice.value === 'local' && hasLegacyDesktop.value
 )
-/** Detected GPU vendor — populated by `window.api.detectGPU()` on
+/** Detected GPU vendor — populated by `window.api.getSystemInfo()` on
  *  `open()`. Surfaces as an inline confirmation line under the Express
  *  checkbox so users on the wrong hardware can untick Express before
  *  the install kicks off. `null` when detection fails or returns no
@@ -310,10 +310,12 @@ const hasLegacyDesktop = ref(false)
  *  missing value means the IPC failed, so the recommendation stays hidden. */
 const systemInfo = ref<SystemInfo | null>(null)
 let systemInfoRequest = 0
+let systemInfoPromise: Promise<SystemInfo> | null = null
 const persistedTelemetryEnabled = ref<boolean | undefined>(undefined)
 const showGpuRecommendation = computed(() => {
   const tier = systemInfo.value?.gpu_tier
   return (
+    step.value === 'start' &&
     !skipPick.value &&
     capacityReady.value &&
     cloudCapacity.status.value === 'normal' &&
@@ -344,11 +346,19 @@ watch(showGpuRecommendation, (shown) => {
     gpu_tier: systemInfo.value.gpu_tier,
     gpu_vendor: systemInfo.value.gpu_vendor,
     gpu_vram_gb: systemInfo.value.gpu_vram_gb,
-    gpu_model_bucket: systemInfo.value.gpu_model ?? 'unknown',
+    gpu_model: systemInfo.value.gpu_model,
     capacity_status: cloudCapacity.status.value
   }
   emitGpuRecommendationIfConsented()
 })
+
+function loadSystemInfo(): Promise<SystemInfo> {
+  systemInfoPromise ??= window.api.getSystemInfo().catch((error) => {
+    systemInfoPromise = null
+    throw error
+  })
+  return systemInfoPromise
+}
 const whyCloudOpen = ref(false)
 /** Which legal document to show when the terms modal is open, or null
  *  when the modal is closed. The two consent-row links on the Terms
@@ -679,8 +689,7 @@ async function open(opts: OpenOpts = {}): Promise<void> {
       locale.value = next
     })
     .catch(() => {})
-  void window.api
-    .getSystemInfo()
+  void loadSystemInfo()
     .then((info) => {
       if (request !== systemInfoRequest) return
       systemInfo.value = info

--- a/src/renderer/src/views/FirstUseTakeover.vue
+++ b/src/renderer/src/views/FirstUseTakeover.vue
@@ -56,8 +56,9 @@ import TermsModal from '../components/TermsModal.vue'
 import Tooltip from '../components/ui/Tooltip.vue'
 import BrandTakeoverLayout from '../components/BrandTakeoverLayout.vue'
 import InlineRichText from '../components/InlineRichText.vue'
-import { emitTelemetryAction } from '../lib/telemetry'
+import { emitTelemetryAction, type TelemetryContext } from '../lib/telemetry'
 import { useCloudCapacity } from '../composables/useCloudCapacity'
+import type { SystemInfo } from '../../../types/ipc'
 
 type Step = 'start' | 'mirrors' | 'localBranch'
 
@@ -305,6 +306,49 @@ const skipPick = ref(false)
  *  new-install takeover. Detection lives in main; the host plumbs the
  *  flag in via `open()`. */
 const hasLegacyDesktop = ref(false)
+/** Hardware facts resolved through the shared main-process classifier. A
+ *  missing value means the IPC failed, so the recommendation stays hidden. */
+const systemInfo = ref<SystemInfo | null>(null)
+let systemInfoRequest = 0
+const persistedTelemetryEnabled = ref<boolean | undefined>(undefined)
+const showGpuRecommendation = computed(() => {
+  const tier = systemInfo.value?.gpu_tier
+  return (
+    !skipPick.value &&
+    capacityReady.value &&
+    cloudCapacity.status.value === 'normal' &&
+    (tier === 'sub_low' || tier === 'cpu_only')
+  )
+})
+let gpuRecommendationTracked = false
+let gpuRecommendationContext: TelemetryContext | null = null
+
+function emitGpuRecommendationIfConsented(): void {
+  if (
+    gpuRecommendationTracked ||
+    !gpuRecommendationContext ||
+    persistedTelemetryEnabled.value !== true
+  ) {
+    return
+  }
+  gpuRecommendationTracked = true
+  emitTelemetryAction(
+    'comfy.desktop.first_use.gpu_reco_shown',
+    gpuRecommendationContext
+  )
+}
+
+watch(showGpuRecommendation, (shown) => {
+  if (!shown || gpuRecommendationContext || !systemInfo.value) return
+  gpuRecommendationContext = {
+    gpu_tier: systemInfo.value.gpu_tier,
+    gpu_vendor: systemInfo.value.gpu_vendor,
+    gpu_vram_gb: systemInfo.value.gpu_vram_gb,
+    gpu_model_bucket: systemInfo.value.gpu_model ?? 'unknown',
+    capacity_status: cloudCapacity.status.value
+  }
+  emitGpuRecommendationIfConsented()
+})
 const whyCloudOpen = ref(false)
 /** Which legal document to show when the terms modal is open, or null
  *  when the modal is closed. The two consent-row links on the Terms
@@ -377,6 +421,8 @@ async function onContinue(): Promise<void> {
     telemetry_enabled: telemetryEnabled.value,
     locale: locale.value
   })
+  persistedTelemetryEnabled.value = telemetryEnabled.value
+  emitGpuRecommendationIfConsented()
   emitTelemetryAction('comfy.desktop.first_use.fork_chosen', {
     choice: pickedChoice.value,
     has_legacy_desktop: hasLegacyDesktop.value,
@@ -398,7 +444,9 @@ async function onContinue(): Promise<void> {
     // bounce-after-cloud rate per variant. The key is captured too so
     // future experiments running concurrently can be split apart.
     experiment_key: FORK_DEFAULT_EXPERIMENT_KEY,
-    experiment_variant: forkExperimentVariant.value
+    experiment_variant: forkExperimentVariant.value,
+    gpu_tier: systemInfo.value?.gpu_tier ?? null,
+    reco_shown: gpuRecommendationContext !== null
   })
 
   if (isChinese.value) {
@@ -601,6 +649,9 @@ async function open(opts: OpenOpts = {}): Promise<void> {
   // whose Continue spinner is still flagged. Reset here so the
   // replayed start screen surfaces a fresh, clickable CTA.
   isContinuing.value = false
+  detectedGpuLabel.value = null
+  systemInfo.value = null
+  const request = ++systemInfoRequest
   // Reset funnel-completion bookkeeping so a takeover replay measures
   // duration / steps from the replay, not from the original mount.
   mountedAt = Date.now()
@@ -616,7 +667,9 @@ async function open(opts: OpenOpts = {}): Promise<void> {
   // a destructive default).
   const existing = (await window.api.getSetting('telemetryEnabled')) as boolean | undefined
   telemetryEnabled.value = existing !== false
-  // Locale + GPU detection run non-blocking so the start hero paints on
+  persistedTelemetryEnabled.value = existing
+  emitGpuRecommendationIfConsented()
+  // Locale + hardware detection run non-blocking so the start hero paints on
   // the first frame even if main is slow to resolve (e.g. cold IPC, no
   // GPU on CI). Sensible defaults (`'en'`, `null`) are already in place;
   // the reactive updates surface the real values when they arrive.
@@ -627,9 +680,11 @@ async function open(opts: OpenOpts = {}): Promise<void> {
     })
     .catch(() => {})
   void window.api
-    .detectGPU()
-    .then((g) => {
-      detectedGpuLabel.value = g?.label ?? null
+    .getSystemInfo()
+    .then((info) => {
+      if (request !== systemInfoRequest) return
+      systemInfo.value = info
+      detectedGpuLabel.value = info.gpu_label
     })
     .catch(() => {})
 }
@@ -765,6 +820,15 @@ defineExpose({ open, resetContinue })
                   <Info :size="14" />
                 </button>
               </Tooltip>
+            </template>
+            <template v-if="showGpuRecommendation" #desc-trailing>
+              <div
+                class="start-gpu-recommendation"
+                data-testid="first-use-gpu-recommendation"
+              >
+                <Check :size="14" :stroke-width="2.5" aria-hidden="true" />
+                <span>{{ $t('firstUse.gpuRecommendation') }}</span>
+              </div>
             </template>
           </ChoiceCard>
           <ChoiceCard
@@ -1105,6 +1169,14 @@ defineExpose({ open, resetContinue })
 .start-cloud-info:focus-visible {
   outline: 2px solid var(--focus-ring);
   outline-offset: 2px;
+}
+.start-gpu-recommendation {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--success);
+  font-size: 12px;
+  font-weight: 600;
 }
 
 /* Modifier-checkbox container. Both rows (Migrate + Express) live

--- a/src/shared/gpuTier.test.ts
+++ b/src/shared/gpuTier.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { deriveGpuTier } from './gpuTier'
+
+describe('deriveGpuTier', () => {
+  it('returns apple for Apple-vendor GPUs regardless of VRAM', () => {
+    expect(deriveGpuTier({ vendor: 'apple', vramGb: null })).toBe('apple')
+    expect(deriveGpuTier({ vendor: 'Apple', vramGb: 8 })).toBe('apple')
+  })
+
+  it("returns apple for the canonical 'mps' GpuId that main reports for Apple Silicon", () => {
+    expect(deriveGpuTier({ vendor: 'mps', vramGb: null })).toBe('apple')
+    expect(deriveGpuTier({ vendor: 'MPS', vramGb: 64 })).toBe('apple')
+  })
+
+  it('returns high for NVIDIA / AMD with at least 24 GB VRAM', () => {
+    expect(deriveGpuTier({ vendor: 'nvidia', vramGb: 24 })).toBe('high')
+    expect(deriveGpuTier({ vendor: 'nvidia', vramGb: 80 })).toBe('high')
+    expect(deriveGpuTier({ vendor: 'amd', vramGb: 24 })).toBe('high')
+  })
+
+  it('returns mid for 12-23 GB VRAM', () => {
+    expect(deriveGpuTier({ vendor: 'nvidia', vramGb: 12 })).toBe('mid')
+    expect(deriveGpuTier({ vendor: 'nvidia', vramGb: 23 })).toBe('mid')
+  })
+
+  it('returns low for 6-11 GB VRAM', () => {
+    expect(deriveGpuTier({ vendor: 'nvidia', vramGb: 6 })).toBe('low')
+    expect(deriveGpuTier({ vendor: 'nvidia', vramGb: 11 })).toBe('low')
+  })
+
+  it('returns sub_low for NVIDIA / AMD below 6 GB and other GPU vendors', () => {
+    expect(deriveGpuTier({ vendor: 'nvidia', vramGb: 4 })).toBe('sub_low')
+    expect(deriveGpuTier({ vendor: 'intel', vramGb: 16 })).toBe('sub_low')
+  })
+
+  it('returns cpu_only when vendor or VRAM is missing', () => {
+    expect(deriveGpuTier({ vendor: null, vramGb: 8 })).toBe('cpu_only')
+    expect(deriveGpuTier({ vendor: 'nvidia', vramGb: 0 })).toBe('cpu_only')
+    expect(deriveGpuTier({ vendor: 'nvidia', vramGb: null })).toBe('cpu_only')
+  })
+})

--- a/src/shared/gpuTier.ts
+++ b/src/shared/gpuTier.ts
@@ -1,0 +1,19 @@
+/** Coarse hardware tier for cohort filtering and GPU-aware surfaces. */
+export type GpuTier = 'high' | 'mid' | 'low' | 'sub_low' | 'apple' | 'cpu_only'
+
+export function deriveGpuTier(opts: {
+  vendor: string | null | undefined
+  vramGb: number | null | undefined
+}): GpuTier {
+  const vendor = (opts.vendor ?? '').toLowerCase()
+  // Main reports 'mps' for Apple Silicon; also accept literal 'apple'.
+  if (vendor === 'apple' || vendor === 'mps') return 'apple'
+  const vram = opts.vramGb ?? 0
+  if (!vendor) return 'cpu_only'
+  if (vendor !== 'nvidia' && vendor !== 'amd') return 'sub_low'
+  if (vram <= 0) return 'cpu_only'
+  if (vram >= 24) return 'high'
+  if (vram >= 12) return 'mid'
+  if (vram >= 6) return 'low'
+  return 'sub_low'
+}

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -2,6 +2,7 @@
 // This file is the single source of truth — do not duplicate these types elsewhere.
 
 import type { FirstUseMode } from '../shared/firstUseMode'
+import type { GpuTier } from '../shared/gpuTier'
 export type { FirstUseMode }
 
 // Unsubscribe function returned by event listeners
@@ -625,6 +626,9 @@ export interface SystemInfo {
   gpu_model: string | null
   /** VRAM of the selected primary (real compute) GPU, not `gpus[0]`. */
   gpu_vram_mb: number | null
+  /** Rounded VRAM of the selected primary GPU, in GiB. */
+  gpu_vram_gb: number | null
+  gpu_tier: GpuTier
   gpus: SystemGpuInfo[]
   nvidia_driver_version: string | null
   nvidia_driver_supported: boolean | null


### PR DESCRIPTION
## Summary

- show a compact “Recommended for your hardware” line on the first-use Cloud card only for `sub_low` and `cpu_only` tiers
- read the shared classifier through `get-system-info` when the takeover opens, while preserving the existing Express-install GPU hint
- reuse one system-info request across same-instance `open()` resets instead of repeating the full OS/CPU/GPU scan
- fail closed when hardware IPC fails, and suppress the recommendation unless Cloud capacity is `normal`
- leave neither Cloud nor Local selected for users who see the GPU recommendation, while preserving an explicit choice made before detection finishes
- keep the first enabled choice keyboard-reachable when neither radio is selected
- emit `comfy.desktop.first_use.gpu_reco_shown` with hardware/capacity context and extend `fork_chosen` with `gpu_tier` and `reco_shown`
- preserve the existing fork defaults for users outside the recommendation cohort and add English/Chinese copy
- prevent delayed hardware responses from recording exposure after the user leaves the start step or commits a choice

## Telemetry consent

Recommendation rendering is independent of telemetry consent. Only analytics emission is consent-gated: already-consented users emit immediately, first-time users emit after accepting telemetry, and opt-outs emit nothing.

## Stack

This is stacked on #1289 (DESK2-140), which adds the shared GPU classifier and `get-system-info` fields. Review this PR against its current base branch for the focused FE-1348 diff.

The design/copy ticket DES-548 is still Todo, so the recommendation text is intentionally conservative and contains no model-specific hardware claim.

## Validation

- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test` — 189 files passed; 2,831 tests passed, 1 skipped

<img width="820" height="278" alt="Screenshot 2026-07-21 at 9 29 45 PM" src="https://github.com/user-attachments/assets/de11df2a-67c8-4b41-82a9-231f46999570" />