### PR TITLE
feat(comfybuilder): distribution functionality library (list, install, stage models, launch)

### DIFF
--- a/src/main/comfybuilder/client.test.ts
+++ b/src/main/comfybuilder/client.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ComfyBuilderApiError, ComfyBuilderClient } from './client'
+import type { TokenProvider } from './types'
+
+const auth = (token: string | null, onUnauthorized = vi.fn()): TokenProvider => ({
+  getAccessToken: async () => token,
+  onUnauthorized,
+})
+
+function mockFetch(status: number, body: unknown): typeof fetch {
+  return vi.fn(async () => new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })) as unknown as typeof fetch
+}
+
+describe('ComfyBuilderClient', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('lists distributions with a Bearer token at the right path', async () => {
+    const f = mockFetch(200, { distributions: [{ id: 'd1', name: 'Dist One' }] })
+    vi.stubGlobal('fetch', f)
+    const client = new ComfyBuilderClient({ baseUrl: 'https://api.test/builder', auth: auth('tok-123') })
+    const dists = await client.listDistributions()
+    expect(dists).toEqual([{ id: 'd1', name: 'Dist One' }])
+    const call = (f as unknown as ReturnType<typeof vi.fn>).mock.calls[0]!
+    expect(call[0]).toBe('https://api.test/builder/v1/distributions')
+    expect((call[1].headers as Record<string, string>).Authorization).toBe('Bearer tok-123')
+  })
+
+  it('resolveDownloadUrl returns the presigned url', async () => {
+    vi.stubGlobal('fetch', mockFetch(200, { downloadUrl: 'https://gcs/signed', expiresAt: 'x' }))
+    const client = new ComfyBuilderClient({ auth: auth('t') })
+    expect(await client.resolveDownloadUrl('a1')).toBe('https://gcs/signed')
+  })
+
+  it('fetchModelManifest hits the version manifest path and normalizes absent fields', async () => {
+    const f = mockFetch(200, { models: [{ type: 'checkpoints', filename: 'sd.safetensors', downloadUrl: 'https://x/sd' }] })
+    vi.stubGlobal('fetch', f)
+    const client = new ComfyBuilderClient({ baseUrl: 'https://api.test/builder', auth: auth('t') })
+    const m = await client.fetchModelManifest('ver-9')
+    expect(m.models).toHaveLength(1)
+    expect(m.modelPolicy).toBeNull()
+    expect(m.partnerNodePolicy).toBeNull()
+    const call = (f as unknown as ReturnType<typeof vi.fn>).mock.calls[0]!
+    expect(call[0]).toBe('https://api.test/builder/v1/distribution-versions/ver-9/manifest')
+  })
+
+  it('throws unauthorized (no network) when signed out', async () => {
+    const f = mockFetch(200, {})
+    vi.stubGlobal('fetch', f)
+    const client = new ComfyBuilderClient({ auth: auth(null) })
+    await expect(client.listDistributions()).rejects.toMatchObject({ kind: 'unauthorized' })
+    expect(f).not.toHaveBeenCalled()
+  })
+
+  it('maps 401 to unauthorized and calls onUnauthorized', async () => {
+    const onUnauthorized = vi.fn()
+    vi.stubGlobal('fetch', mockFetch(401, { message: 'nope' }))
+    const client = new ComfyBuilderClient({ auth: auth('stale', onUnauthorized) })
+    await expect(client.listVersions('d1')).rejects.toBeInstanceOf(ComfyBuilderApiError)
+    expect(onUnauthorized).toHaveBeenCalledOnce()
+  })
+
+  it('maps 404 to not-found and 500 to server', async () => {
+    vi.stubGlobal('fetch', mockFetch(404, {}))
+    await expect(new ComfyBuilderClient({ auth: auth('t') }).getVersion('v1')).rejects.toMatchObject({ kind: 'not-found' })
+    vi.stubGlobal('fetch', mockFetch(500, {}))
+    await expect(new ComfyBuilderClient({ auth: auth('t') }).getVersion('v1')).rejects.toMatchObject({ kind: 'server' })
+  })
+
+  it('maps 403 to forbidden WITHOUT signing the user out', async () => {
+    const onUnauthorized = vi.fn()
+    vi.stubGlobal('fetch', mockFetch(403, {}))
+    await expect(new ComfyBuilderClient({ auth: auth('t', onUnauthorized) }).listDistributions()).rejects.toMatchObject({ kind: 'forbidden' })
+    expect(onUnauthorized).not.toHaveBeenCalled()
+  })
+
+  it('maps an empty/non-JSON 2xx body to a typed server error', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch)
+    await expect(new ComfyBuilderClient({ auth: auth('t') }).listDistributions()).rejects.toMatchObject({ kind: 'server' })
+  })
+
+  it('a throwing onUnauthorized does not mask the unauthorized error', async () => {
+    vi.stubGlobal('fetch', mockFetch(401, {}))
+    const client = new ComfyBuilderClient({ auth: auth('t', vi.fn(() => { throw new Error('boom') })) })
+    await expect(client.listVersions('d1')).rejects.toMatchObject({ kind: 'unauthorized' })
+  })
+})

--- a/src/main/comfybuilder/client.ts
+++ b/src/main/comfybuilder/client.ts
@@ -1,0 +1,143 @@
+/**
+ * ComfyBuilder catalog client - the read side of the functionality library.
+ *
+ * Lists distributions -> versions -> artifacts and resolves an artifact's
+ * presigned download URL, over the deployed builder gateway. Every request
+ * carries a bearer token from the injected {@link TokenProvider}; the token
+ * never leaves this process and is never returned to callers. Failures surface
+ * as a typed {@link ComfyBuilderApiError} whose `kind` a caller can branch on.
+ */
+import type {
+  Artifact,
+  Distribution,
+  DistributionVersion,
+  ModelManifest,
+  TokenProvider,
+} from './types'
+
+/** Prod builder gateway. Pass `baseUrl` to target staging or a mock. */
+export const DEFAULT_BASE_URL = 'https://platformapi.comfy.org/builder'
+
+const DEFAULT_TIMEOUT_MS = 30_000
+
+export type ComfyBuilderErrorKind = 'unauthorized' | 'forbidden' | 'not-found' | 'network' | 'server'
+
+export class ComfyBuilderApiError extends Error {
+  override name = 'ComfyBuilderApiError'
+  readonly kind: ComfyBuilderErrorKind
+  readonly status?: number
+  constructor(kind: ComfyBuilderErrorKind, message: string, status?: number) {
+    super(message)
+    this.kind = kind
+    if (status !== undefined) this.status = status
+  }
+}
+
+export interface ComfyBuilderClientOptions {
+  /** Gateway base URL including the `/builder` mount. Defaults to prod. */
+  baseUrl?: string
+  /** Auth seam: the UI's token source. */
+  auth: TokenProvider
+  /** Per-request timeout in ms. Defaults to 30s. */
+  timeoutMs?: number
+}
+
+interface DistributionsResponse { distributions?: Distribution[] }
+interface VersionsResponse { versions?: DistributionVersion[] }
+interface VersionDetailResponse { version?: number; artifacts?: Artifact[] }
+interface SignedDownloadResponse { downloadUrl?: string }
+
+/** The catalog + download-resolve surface the UI calls to populate its tiles. */
+export class ComfyBuilderClient {
+  private readonly baseUrl: string
+  private readonly auth: TokenProvider
+  private readonly timeoutMs: number
+
+  constructor(options: ComfyBuilderClientOptions) {
+    this.baseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, '')
+    this.auth = options.auth
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  }
+
+  /** Every distribution visible to the signed-in workspace. */
+  async listDistributions(): Promise<Distribution[]> {
+    const body = await this.get<DistributionsResponse>('/v1/distributions')
+    return body.distributions ?? []
+  }
+
+  /** Versions (build history) of one distribution. */
+  async listVersions(distributionId: string): Promise<DistributionVersion[]> {
+    const body = await this.get<VersionsResponse>(`/v1/distributions/${encodeURIComponent(distributionId)}/versions`)
+    return body.versions ?? []
+  }
+
+  /** One version's per-target artifacts (plus its version number). */
+  async getVersion(versionId: string): Promise<{ version: number | undefined; artifacts: Artifact[] }> {
+    const body = await this.get<VersionDetailResponse>(`/v1/distribution-versions/${encodeURIComponent(versionId)}`)
+    return { version: body.version, artifacts: body.artifacts ?? [] }
+  }
+
+  /**
+   * A version's models + runtime policies, projected from its sealed manifest.
+   * Each model carries a ready-to-GET `downloadUrl` and its target model
+   * directory; a client stages these before starting ComfyUI. An empty `models`
+   * array is normal (a version may declare none).
+   */
+  async fetchModelManifest(versionId: string): Promise<ModelManifest> {
+    const body = await this.get<Partial<ModelManifest>>(
+      `/v1/distribution-versions/${encodeURIComponent(versionId)}/manifest`,
+    )
+    return {
+      models: body.models ?? [],
+      modelPolicy: body.modelPolicy ?? null,
+      partnerNodePolicy: body.partnerNodePolicy ?? null,
+    }
+  }
+
+  /** Resolve an artifact's short-lived presigned archive URL. */
+  async resolveDownloadUrl(artifactId: string): Promise<string> {
+    const body = await this.get<SignedDownloadResponse>(`/v1/build-artifacts/${encodeURIComponent(artifactId)}/download`)
+    if (typeof body.downloadUrl !== 'string' || body.downloadUrl.length === 0) {
+      throw new ComfyBuilderApiError('server', `No downloadUrl for artifact ${artifactId}`)
+    }
+    return body.downloadUrl
+  }
+
+  private async get<T>(path: string): Promise<T> {
+    const token = await this.auth.getAccessToken()
+    if (!token) throw new ComfyBuilderApiError('unauthorized', 'Not signed in to ComfyBuilder')
+
+    let res: Response
+    try {
+      res = await fetch(`${this.baseUrl}${path}`, {
+        headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(this.timeoutMs),
+      })
+    } catch (err) {
+      throw new ComfyBuilderApiError('network', `Request to ${path} failed: ${(err as Error).message}`)
+    }
+
+    // 401 = dead token: prompt re-auth. 403 = authenticated but lacks access to
+    // this resource; a single forbidden item must NOT sign the user out.
+    if (res.status === 401) {
+      try { this.auth.onUnauthorized?.() } catch { /* an injected callback must not mask the typed error */ }
+      throw new ComfyBuilderApiError('unauthorized', `Not authorized for ${path}`, 401)
+    }
+    if (res.status === 403) throw new ComfyBuilderApiError('forbidden', `Forbidden: ${path}`, 403)
+    if (res.status === 404) throw new ComfyBuilderApiError('not-found', `${path} not found`, 404)
+    if (!res.ok) throw new ComfyBuilderApiError('server', `${path} failed: HTTP ${res.status}`, res.status)
+
+    // A 2xx with an empty / non-JSON / null body must surface as a typed error,
+    // never a raw SyntaxError or a downstream `body.foo` TypeError.
+    let body: unknown
+    try {
+      body = await res.json()
+    } catch {
+      throw new ComfyBuilderApiError('server', `${path} returned a non-JSON body`)
+    }
+    if (body === null || typeof body !== 'object') {
+      throw new ComfyBuilderApiError('server', `${path} returned an unexpected body`)
+    }
+    return body as T
+  }
+}

--- a/src/main/comfybuilder/index.ts
+++ b/src/main/comfybuilder/index.ts
@@ -1,0 +1,44 @@
+/**
+ * ComfyBuilder functionality library - public surface.
+ *
+ * A standalone, UI-agnostic library for the Desktop <-> comfy-builder flow:
+ * list distributions/versions/artifacts, pick the artifact for the host,
+ * download + install it, and build its launch command. It has NO dependency on
+ * Electron IPC, Vue, or the installations store; the UI plugs in by supplying a
+ * {@link TokenProvider} and calling these functions.
+ *
+ * Typical UI wiring:
+ * ```ts
+ * const client = new ComfyBuilderClient({ baseUrl, auth: tokenStoreAdapter })
+ * const dists = await client.listDistributions()               // render tiles
+ * const { artifacts } = await client.getVersion(versionId)
+ * const artifact = selectArtifactForHost(artifacts, { os: hostOs(), gpu })
+ * await installArtifact({ artifact, client, installPath, cacheDir, onProgress })
+ * const launch = buildLaunchSpec(installPath, { launchArgs })
+ * ```
+ */
+export { ComfyBuilderClient, ComfyBuilderApiError, DEFAULT_BASE_URL } from './client'
+export type { ComfyBuilderClientOptions, ComfyBuilderErrorKind } from './client'
+export { hostOs, selectArtifactForHost } from './targets'
+export { installArtifact, ComfyBuilderInstallError, sha256File, normalizeSha256 } from './install'
+export type { InstallArtifactOptions, ComfyBuilderInstallErrorKind } from './install'
+export { stageModels, installModelsRoot, StageModelsError } from './models'
+export type { StageModelsOptions, StageModelsErrorKind } from './models'
+export { resolveModelManifest } from './modelManifest'
+export { buildLaunchSpec, venvPython } from './launch'
+export type { LaunchOptions } from './launch'
+export type {
+  Artifact,
+  ArtifactGpu,
+  ArtifactOs,
+  Distribution,
+  DistributionVersion,
+  Host,
+  InstallProgress,
+  LaunchSpec,
+  ModelDescriptor,
+  ModelManifest,
+  ModelPolicy,
+  StageProgress,
+  TokenProvider,
+} from './types'

--- a/src/main/comfybuilder/install.test.ts
+++ b/src/main/comfybuilder/install.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment node
+import os from 'node:os'
+import path from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+
+// The guard tests never reach download/extract; stub them so importing install.ts
+// does not pull Electron (`net`) or 7zip-bin into this unit test.
+vi.mock('../lib/download', () => ({ download: vi.fn() }))
+vi.mock('../lib/extract', () => ({ extractNested: vi.fn() }))
+
+import { installArtifact } from './install'
+import type { Artifact } from './types'
+
+const artifact = (overrides: Partial<Artifact> = {}): Artifact => ({ id: 'a1', os: 'linux', gpu: 'cpu', accelVariant: 'cpu', status: 'ready', ...overrides })
+
+describe('installArtifact guards', () => {
+  it('rejects a missing artifact id before any work', async () => {
+    const client = { resolveDownloadUrl: vi.fn() }
+    await expect(installArtifact({ artifact: { ...artifact(), id: '' }, client, installPath: '/x', cacheDir: os.tmpdir() }))
+      .rejects.toMatchObject({ kind: 'invalid-artifact' })
+    expect(client.resolveDownloadUrl).not.toHaveBeenCalled()
+  })
+
+  // TODO: flip back to fail-closed once the builder populates outputSha256.
+  it.each([
+    ['absent', undefined],
+    ['blank', '   '],
+    ['prefix-only', 'sha256:'],
+  ])('proceeds (unverified) when outputSha256 is %s', async (name, sha) => {
+    const client = { resolveDownloadUrl: vi.fn(async () => 'https://example.test/a.tar.gz') }
+    // Gets past the hash gate: the stubbed extract writes no layout, so it fails
+    // on the layout check rather than on the missing hash.
+    await expect(installArtifact({ artifact: artifact({ outputSha256: sha }), client, installPath: path.join(os.tmpdir(), `cb-${name}`), cacheDir: os.tmpdir() }))
+      .rejects.toMatchObject({ kind: 'invalid-layout' })
+    expect(client.resolveDownloadUrl).toHaveBeenCalled()
+  })
+})

--- a/src/main/comfybuilder/install.ts
+++ b/src/main/comfybuilder/install.ts
@@ -1,0 +1,160 @@
+/**
+ * Install: the write side of the functionality library.
+ *
+ * Given a chosen {@link Artifact}, turn it into a runnable install directory:
+ * resolve the presigned URL, download, verify sha256, extract, validate the
+ * layout. The archive is what comfy-builder tars: a top-level `venv/` +
+ * `ComfyUI/` (a ready, relocatable env), so there is no post-extract env build;
+ * launch drives that `venv/` directly (see `./launch`).
+ *
+ * Integrity: when the artifact carries an `outputSha256` the bytes must match or
+ * nothing is extracted. A MISSING hash is currently installed unverified because
+ * the builder does not populate it yet (see the TODO in `installArtifact`); that
+ * becomes fail-closed once it does. The archive downloads to a per-run temp under `cacheDir`
+ * so concurrent installs of the same artifact cannot corrupt each other, and on
+ * any failure only files THIS run created are cleaned up: a failed re-install
+ * never destroys a previously-working environment.
+ */
+import { createHash, randomBytes } from 'crypto'
+import fs from 'fs'
+import { createReadStream } from 'fs'
+import path from 'path'
+
+import { download } from '../lib/download'
+import type { DownloadProgress } from '../lib/download'
+import { extractNested } from '../lib/extract'
+import type { ExtractProgress } from '../lib/extract'
+import type { ComfyBuilderClient } from './client'
+import type { Artifact, InstallProgress } from './types'
+
+/** The directories every well-formed archive extracts to. */
+const ARTIFACT_DIRS = ['venv', 'ComfyUI'] as const
+
+export type ComfyBuilderInstallErrorKind = 'invalid-artifact' | 'invalid-layout' | 'checksum-mismatch'
+
+export class ComfyBuilderInstallError extends Error {
+  override name = 'ComfyBuilderInstallError'
+  readonly kind: ComfyBuilderInstallErrorKind
+  constructor(kind: ComfyBuilderInstallErrorKind, message: string) {
+    super(message)
+    this.kind = kind
+  }
+}
+
+export interface InstallArtifactOptions {
+  artifact: Artifact
+  /** Resolves the presigned download URL. */
+  client: Pick<ComfyBuilderClient, 'resolveDownloadUrl'>
+  /** Directory the archive extracts into (becomes the runnable install). */
+  installPath: string
+  /** Scratch dir for the download; the temp archive is removed after extraction. */
+  cacheDir: string
+  onProgress?: (p: InstallProgress) => void
+  signal?: AbortSignal
+}
+
+/** A real directory (not a symlink). Rejecting a symlinked layout dir guards
+ *  against a `venv -> /` style archive escaping `installPath`. */
+function isRealDir(p: string): boolean {
+  try {
+    return fs.lstatSync(p).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+/** Cache-folder-safe slug for an artifact id (which may contain path chars). */
+function cacheSlug(artifactId: string): string {
+  return artifactId.replace(/[^a-zA-Z0-9._-]/g, '_')
+}
+
+/** Streaming lowercase-hex sha256 of a file. Exported so model staging verifies
+ *  downloads the same way archive install does. Resolves on 'close' (not 'end')
+ *  so the fd is released before a following rmSync, avoiding EBUSY on Windows. */
+export function sha256File(filePath: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const hash = createHash('sha256')
+    const stream = createReadStream(filePath)
+    stream.on('error', reject)
+    stream.on('data', (chunk) => hash.update(chunk))
+    stream.on('close', () => resolve(hash.digest('hex')))
+  })
+}
+
+/** Normalize a manifest hash for comparison: strip an optional `sha256:` prefix,
+ *  trim, lowercase. Returns '' when there is no usable hash. */
+export function normalizeSha256(raw: string | undefined): string {
+  return raw?.replace(/^sha256:/i, '').trim().toLowerCase() ?? ''
+}
+
+function assertLayout(installPath: string): void {
+  for (const dir of ARTIFACT_DIRS) {
+    if (!isRealDir(path.join(installPath, dir))) {
+      throw new ComfyBuilderInstallError('invalid-layout', `Extracted artifact is missing a real ${dir}/ directory.`)
+    }
+  }
+}
+
+/** Remove only entries created this run, so a failed install never deletes a
+ *  pre-existing environment or unrelated contents of a shared directory. */
+async function cleanupCreated(installPath: string, preexisting: ReadonlySet<string>): Promise<void> {
+  const entries = await fs.promises.readdir(installPath).catch(() => [] as string[])
+  await Promise.all(
+    entries
+      .filter((e) => !preexisting.has(e))
+      .map((e) => fs.promises.rm(path.join(installPath, e), { recursive: true, force: true }).catch(() => {})),
+  )
+}
+
+/**
+ * Download + verify + extract + validate an artifact into `installPath`. Throws
+ * {@link ComfyBuilderInstallError} on a bad artifact, a checksum mismatch, or a
+ * bad extracted layout. A missing hash is a warning, not an error: see above.
+ */
+export async function installArtifact(opts: InstallArtifactOptions): Promise<void> {
+  const { artifact, client, installPath, cacheDir, onProgress, signal } = opts
+  if (!artifact?.id) throw new ComfyBuilderInstallError('invalid-artifact', 'No artifact id was provided.')
+
+  // A hash that IS present is always enforced (see the compare below).
+  // TODO: fail closed on a missing hash too. The builder does not populate
+  // outputSha256 yet, so for the initial rollout a missing hash installs
+  // unverified rather than blocking every install.
+  const expected = normalizeSha256(artifact.outputSha256)
+  if (!expected) {
+    console.warn('[comfybuilder] artifact has no outputSha256; installing without integrity verification')
+  }
+
+  onProgress?.({ phase: 'resolve', percent: 0 })
+  const url = await client.resolveDownloadUrl(artifact.id)
+
+  // Per-run temp: isolates concurrent installs of the same artifact and is
+  // removed after extraction (cacheDir is scratch, not a persistent cache).
+  fs.mkdirSync(cacheDir, { recursive: true })
+  const archivePath = path.join(cacheDir, `comfybuilder_${cacheSlug(artifact.id)}_${randomBytes(6).toString('hex')}.tar.gz`)
+
+  try {
+    onProgress?.({ phase: 'download', percent: 0 })
+    await download(url, archivePath, (p: DownloadProgress) => onProgress?.({ phase: 'download', percent: p.percent, detail: `${p.receivedMB} / ${p.totalMB} MB` }), signal ? { signal } : {})
+
+    if (expected) {
+      const actual = await sha256File(archivePath)
+      if (actual !== expected) {
+        throw new ComfyBuilderInstallError('checksum-mismatch', `Artifact checksum mismatch: expected ${expected}, got ${actual}`)
+      }
+    }
+
+    if (signal?.aborted) throw new Error('Cancelled')
+    fs.mkdirSync(installPath, { recursive: true })
+    const preexisting = new Set<string>(await fs.promises.readdir(installPath).catch(() => [] as string[]))
+    try {
+      onProgress?.({ phase: 'extract', percent: 0 })
+      await extractNested(archivePath, installPath, (p: ExtractProgress) => onProgress?.({ phase: 'extract', percent: p.percent }), signal ? { signal } : {})
+      assertLayout(installPath)
+    } catch (err) {
+      await cleanupCreated(installPath, preexisting)
+      throw err
+    }
+  } finally {
+    await fs.promises.rm(archivePath, { force: true }).catch(() => {})
+  }
+}

--- a/src/main/comfybuilder/launch.test.ts
+++ b/src/main/comfybuilder/launch.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment node
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { buildLaunchSpec, venvPython } from './launch'
+
+const isWin = process.platform === 'win32'
+
+function layout(installPath: string, opts: { python?: boolean; main?: boolean } = { python: true, main: true }): void {
+  if (opts.python !== false) {
+    fs.mkdirSync(path.dirname(venvPython(installPath)), { recursive: true })
+    fs.writeFileSync(venvPython(installPath), '')
+  }
+  if (opts.main !== false) {
+    fs.mkdirSync(path.join(installPath, 'ComfyUI'), { recursive: true })
+    fs.writeFileSync(path.join(installPath, 'ComfyUI', 'main.py'), '')
+  }
+}
+
+describe('launch', () => {
+  let dir: string
+  beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cbc-launch-')) })
+  afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }) })
+
+  it('venvPython points at the archive venv per platform', () => {
+    expect(venvPython(dir)).toBe(isWin ? path.join(dir, 'venv', 'python.exe') : path.join(dir, 'venv', 'bin', 'python3'))
+  })
+
+  it('builds a spec that drives the venv python against ComfyUI/main.py', () => {
+    const p = path.join(dir, 'install')
+    layout(p)
+    const spec = buildLaunchSpec(p, { launchArgs: '--cpu --port 9001' })
+    expect(spec).toEqual({
+      cmd: venvPython(p),
+      args: ['-s', path.join('ComfyUI', 'main.py'), '--cpu', '--port', '9001'],
+      cwd: p,
+      port: 9001,
+    })
+  })
+
+  it.each([
+    ['python missing', { python: false }],
+    ['main.py missing', { main: false }],
+  ])('returns null when %s', (_name, opts) => {
+    const p = path.join(dir, 'install')
+    layout(p, opts)
+    expect(buildLaunchSpec(p)).toBeNull()
+  })
+})

--- a/src/main/comfybuilder/launch.ts
+++ b/src/main/comfybuilder/launch.ts
@@ -1,0 +1,47 @@
+/**
+ * Launch - build the command that runs an installed archive.
+ *
+ * The archive ships a ready, relocatable `venv/`, so launch drives that venv's
+ * python directly against `ComfyUI/main.py` (no rebuild, no `.venv`). Returns a
+ * plain {@link LaunchSpec} the UI can spawn however it likes; returns null until
+ * a successful install has produced the interpreter + entrypoint.
+ */
+import fs from 'fs'
+import path from 'path'
+
+import { extractPort, parseArgs } from '../lib/util'
+import type { LaunchSpec } from './types'
+
+const DEFAULT_LAUNCH_ARGS = '--enable-manager'
+
+/** The archive's bundled interpreter. */
+export function venvPython(installPath: string): string {
+  return process.platform === 'win32'
+    ? path.join(installPath, 'venv', 'python.exe')
+    : path.join(installPath, 'venv', 'bin', 'python3')
+}
+
+export interface LaunchOptions {
+  /** Extra ComfyUI args, e.g. `--cpu --port 8188`. Defaults to `--enable-manager`. */
+  launchArgs?: string
+}
+
+/**
+ * Build the launch command for an installed archive, or null when the venv
+ * python or `ComfyUI/main.py` is missing (i.e. not installed yet).
+ */
+export function buildLaunchSpec(installPath: string, opts: LaunchOptions = {}): LaunchSpec | null {
+  const python = venvPython(installPath)
+  if (!fs.existsSync(python)) return null
+  const mainPy = path.join(installPath, 'ComfyUI', 'main.py')
+  if (!fs.existsSync(mainPy)) return null
+
+  const raw = (opts.launchArgs ?? DEFAULT_LAUNCH_ARGS).trim()
+  const parsed = raw.length > 0 ? parseArgs(raw) : []
+  return {
+    cmd: python,
+    args: ['-s', path.join('ComfyUI', 'main.py'), ...parsed],
+    cwd: installPath,
+    port: extractPort(parsed),
+  }
+}

--- a/src/main/comfybuilder/modelManifest.test.ts
+++ b/src/main/comfybuilder/modelManifest.test.ts
@@ -1,0 +1,97 @@
+// @vitest-environment node
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { resolveModelManifest } from './modelManifest'
+import type { ModelManifest } from './types'
+
+const MANIFEST: ModelManifest = {
+  models: [{ type: 'loras', filename: 'l.safetensors', downloadUrl: 'https://signed/l' }],
+  modelPolicy: null,
+  partnerNodePolicy: null,
+}
+
+// A client stub with just the two methods the resolver calls.
+function client(over: Partial<{ listVersions: unknown; fetchModelManifest: unknown }> = {}) {
+  return {
+    listVersions: vi.fn(async () => [{ id: 'ver-1', version: 1, status: 'complete' }]),
+    fetchModelManifest: vi.fn(async () => MANIFEST),
+    ...over,
+  } as never
+}
+
+afterEach(() => {
+  delete process.env.COMFY_BUILDER_MODELS_MANIFEST
+  delete process.env.E2E
+  vi.restoreAllMocks()
+})
+
+describe('resolveModelManifest', () => {
+  it('resolves the version id then fetches its manifest', async () => {
+    const c = client({
+      listVersions: vi.fn(async () => [{ id: 'ver-42', version: 3, status: 'complete' }]),
+      fetchModelManifest: vi.fn(async () => MANIFEST),
+    })
+    const m = await resolveModelManifest(c, 'd1', '3')
+    expect((c as unknown as { fetchModelManifest: ReturnType<typeof vi.fn> }).fetchModelManifest).toHaveBeenCalledWith('ver-42')
+    expect(m.models).toEqual(MANIFEST.models)
+  })
+
+  it('pins the COMPLETE version when a failed row shares the number', async () => {
+    const c = client({
+      listVersions: vi.fn(async () => [
+        { id: 'ver-bad', version: 5, status: 'failed' },
+        { id: 'ver-good', version: 5, status: 'complete' },
+      ]),
+    })
+    await resolveModelManifest(c, 'd1', '5')
+    expect((c as unknown as { fetchModelManifest: ReturnType<typeof vi.fn> }).fetchModelManifest).toHaveBeenCalledWith('ver-good')
+  })
+
+  it('stages nothing when no matching version resolves', async () => {
+    const c = client({ listVersions: vi.fn(async () => [{ id: 'ver-1', version: 1, status: 'complete' }]) })
+    const m = await resolveModelManifest(c, 'd1', '99')
+    expect(m.models).toEqual([])
+    expect((c as unknown as { fetchModelManifest: ReturnType<typeof vi.fn> }).fetchModelManifest).not.toHaveBeenCalled()
+  })
+
+  it('degrades to empty (never throws) when the fetch fails', async () => {
+    const c = client({ fetchModelManifest: vi.fn(async () => { throw new Error('boom') }) })
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const m = await resolveModelManifest(c, 'd1', '1')
+    expect(m).toEqual({ models: [], modelPolicy: null, partnerNodePolicy: null })
+  })
+
+  it('honors an inline-JSON override only under E2E (the test seam)', async () => {
+    const override: ModelManifest = {
+      models: [{ type: 'checkpoints', filename: 'x.safetensors', downloadUrl: 'https://h/x' }],
+      modelPolicy: null,
+      partnerNodePolicy: null,
+    }
+    process.env.COMFY_BUILDER_MODELS_MANIFEST = JSON.stringify(override)
+    process.env.E2E = '1'
+    const c = client()
+    const m = await resolveModelManifest(c, 'd1', '1')
+    expect(m.models).toEqual(override.models)
+    expect((c as unknown as { listVersions: ReturnType<typeof vi.fn> }).listVersions).not.toHaveBeenCalled()
+  })
+
+  it('ignores the override in a non-E2E build (falls through to the endpoint)', async () => {
+    process.env.COMFY_BUILDER_MODELS_MANIFEST = JSON.stringify({ models: [{ type: 'x', filename: 'evil', downloadUrl: 'https://evil/x' }] })
+    const m = await resolveModelManifest(client(), 'd1', '1')
+    expect(m.models).toEqual(MANIFEST.models) // the fetched manifest, not the injected one
+  })
+
+  it('honors a file-path override under E2E', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cb-mf-'))
+    const file = path.join(dir, 'manifest.json')
+    fs.writeFileSync(file, JSON.stringify({ models: [{ type: 'vae', filename: 'v.pt', downloadUrl: 'https://h/v' }] }))
+    process.env.COMFY_BUILDER_MODELS_MANIFEST = file
+    process.env.E2E = '1'
+    const m = await resolveModelManifest(client(), 'd1', '1')
+    expect(m.models[0]!.filename).toBe('v.pt')
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+})

--- a/src/main/comfybuilder/modelManifest.ts
+++ b/src/main/comfybuilder/modelManifest.ts
@@ -1,0 +1,72 @@
+/**
+ * Model-manifest resolution: the models to stage for an install.
+ *
+ * The source of truth is the builder `/manifest` endpoint, keyed by version id.
+ * The install record carries the version NUMBER, so the id is resolved from the
+ * versions list first (pinned to the COMPLETE version the archive came from). A
+ * fetch failure degrades to an empty manifest rather than failing an install
+ * whose archive already downloaded, so a transient blip never wastes the build.
+ *
+ * `COMFY_BUILDER_MODELS_MANIFEST` (E2E only) overrides the endpoint with an
+ * explicit manifest so a hermetic e2e can point every model at a local server.
+ */
+import fs from 'fs'
+
+import type { ComfyBuilderClient } from './client'
+import type { ModelManifest } from './types'
+
+const EMPTY: ModelManifest = { models: [], modelPolicy: null, partnerNodePolicy: null }
+
+// A version whose build finished, matching the set the install artifact was
+// selected from, so the manifest is read off the same version the archive came
+// from (never a failed row that shares the number).
+const COMPLETE_VERSION_STATUSES = new Set(['complete', 'completed', 'ready', 'succeeded', 'success'])
+
+/** Parse an override that is inline JSON (`{...}`) or a path to a JSON file. */
+function loadOverride(value: string): ModelManifest {
+  const raw = value.trimStart().startsWith('{') ? value : fs.readFileSync(value, 'utf8')
+  const parsed = JSON.parse(raw) as Partial<ModelManifest>
+  return {
+    models: parsed.models ?? [],
+    modelPolicy: parsed.modelPolicy ?? null,
+    partnerNodePolicy: parsed.partnerNodePolicy ?? null,
+  }
+}
+
+/** Map a version NUMBER to the id of its COMPLETE version, or null. */
+async function resolveVersionId(
+  client: Pick<ComfyBuilderClient, 'listVersions'>,
+  distributionId: string,
+  versionNumber: string,
+): Promise<string | null> {
+  const versions = await client.listVersions(distributionId)
+  const match = versions.find(
+    (v) =>
+      String(v.version) === versionNumber &&
+      typeof v.status === 'string' &&
+      COMPLETE_VERSION_STATUSES.has(v.status.toLowerCase()),
+  )
+  return match?.id ?? null
+}
+
+/**
+ * The models to stage for an install. Returns an empty manifest (stage nothing)
+ * when the version has none, cannot be resolved, or the fetch fails.
+ */
+export async function resolveModelManifest(
+  client: Pick<ComfyBuilderClient, 'listVersions' | 'fetchModelManifest'>,
+  distributionId: string,
+  version: string,
+): Promise<ModelManifest> {
+  // Test seam, E2E-gated so a shipped build can't be fed attacker-chosen models.
+  const override = process.env.COMFY_BUILDER_MODELS_MANIFEST
+  if (override && process.env.E2E === '1') return loadOverride(override)
+
+  try {
+    const versionId = await resolveVersionId(client, distributionId, version)
+    return versionId ? await client.fetchModelManifest(versionId) : EMPTY
+  } catch (err) {
+    console.warn('[comfybuilder] model manifest fetch failed; staging no models:', err)
+    return EMPTY
+  }
+}

--- a/src/main/comfybuilder/models.test.ts
+++ b/src/main/comfybuilder/models.test.ts
@@ -1,0 +1,167 @@
+// @vitest-environment node
+import { createHash } from 'crypto'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// Stub the heavy libs so importing `./models` (via `./install`) does not pull
+// Electron. Every test injects its own `download`, so the real one is unused.
+vi.mock('../lib/download', () => ({ download: vi.fn() }))
+vi.mock('../lib/extract', () => ({ extractNested: vi.fn() }))
+
+import { stageModels, installModelsRoot } from './models'
+import type { ModelDescriptor } from './types'
+
+const sha = (buf: Buffer): string => createHash('sha256').update(buf).digest('hex')
+
+const tmpRoots: string[] = []
+function freshInstall(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cb-models-'))
+  tmpRoots.push(dir)
+  return dir
+}
+afterEach(() => {
+  for (const d of tmpRoots.splice(0)) fs.rmSync(d, { recursive: true, force: true })
+})
+
+/** A download stub that writes `bytes` to the requested path (the `.partial`). */
+function fakeDownload(bytes: Buffer) {
+  return vi.fn(async (_url: string, dest: string) => {
+    fs.mkdirSync(path.dirname(dest), { recursive: true })
+    fs.writeFileSync(dest, bytes)
+    return dest
+  })
+}
+
+const model = (o: Partial<ModelDescriptor> = {}): ModelDescriptor => ({
+  type: 'checkpoints',
+  filename: 'm.safetensors',
+  downloadUrl: 'https://models.test/m.safetensors',
+  ...o,
+})
+
+describe('stageModels', () => {
+  it('downloads, verifies, and places each model at models/<type>/<filename>', async () => {
+    const install = freshInstall()
+    const bytes = Buffer.from('weights-A')
+    const dl = fakeDownload(bytes)
+    await stageModels({
+      models: [model({ type: 'vae', filename: 'v.pt', sha256: sha(bytes), downloadUrl: 'https://x/v.pt' })],
+      installPath: install,
+      download: dl,
+    })
+    const dest = path.join(installModelsRoot(install), 'vae', 'v.pt')
+    expect(fs.existsSync(dest)).toBe(true)
+    expect(fs.readFileSync(dest)).toEqual(bytes)
+    expect(fs.existsSync(`${dest}.partial`)).toBe(false)
+  })
+
+  it('fails with checksum-mismatch and leaves no file when bytes do not match the hash', async () => {
+    const install = freshInstall()
+    const dl = fakeDownload(Buffer.from('corrupt'))
+    await expect(
+      stageModels({ models: [model({ sha256: sha(Buffer.from('expected')) })], installPath: install, download: dl }),
+    ).rejects.toMatchObject({ kind: 'model-checksum-mismatch' })
+    const dest = path.join(installModelsRoot(install), 'checkpoints', 'm.safetensors')
+    expect(fs.existsSync(dest)).toBe(false)
+    expect(fs.existsSync(`${dest}.partial`)).toBe(false)
+  })
+
+  it('installs without verification when the model has no sha256', async () => {
+    const install = freshInstall()
+    const dl = fakeDownload(Buffer.from('unverified'))
+    await stageModels({ models: [model({ filename: 'n.pt' })], installPath: install, download: dl })
+    expect(fs.existsSync(path.join(installModelsRoot(install), 'checkpoints', 'n.pt'))).toBe(true)
+  })
+
+  it.each([
+    ['type', { type: '../evil' }],
+    ['type sep', { type: 'a/b' }],
+    ['filename', { filename: '../../etc/passwd' }],
+    ['filename sep', { filename: 'a/b.pt' }],
+  ])('rejects an unsafe %s before any download', async (_name, bad) => {
+    const install = freshInstall()
+    const dl = fakeDownload(Buffer.from('x'))
+    await expect(stageModels({ models: [model(bad)], installPath: install, download: dl })).rejects.toMatchObject({
+      kind: 'invalid-model',
+    })
+    expect(dl).not.toHaveBeenCalled()
+  })
+
+  it('rejects a non-https download URL before any download', async () => {
+    const install = freshInstall()
+    const dl = fakeDownload(Buffer.from('x'))
+    await expect(
+      stageModels({ models: [model({ downloadUrl: 'http://insecure/m.safetensors' })], installPath: install, download: dl }),
+    ).rejects.toMatchObject({ kind: 'invalid-model' })
+    expect(dl).not.toHaveBeenCalled()
+  })
+
+  it('refuses to write through a model dir that symlinks outside the install', async () => {
+    const install = freshInstall()
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'cb-escape-'))
+    tmpRoots.push(outside)
+    // A malicious archive ships ComfyUI/models/<type> as a symlink escaping the install.
+    const modelsRoot = installModelsRoot(install)
+    fs.mkdirSync(modelsRoot, { recursive: true })
+    fs.symlinkSync(outside, path.join(modelsRoot, 'evil'))
+    const dl = fakeDownload(Buffer.from('payload'))
+    await expect(
+      stageModels({ models: [model({ type: 'evil', filename: 'x.pth' })], installPath: install, download: dl }),
+    ).rejects.toMatchObject({ kind: 'invalid-model' })
+    // Nothing was written into the escape target.
+    expect(fs.existsSync(path.join(outside, 'x.pth'))).toBe(false)
+    expect(fs.existsSync(path.join(outside, 'x.pth.partial'))).toBe(false)
+  })
+
+  it('skips a model already present with a matching hash (idempotent re-run)', async () => {
+    const install = freshInstall()
+    const bytes = Buffer.from('already-here')
+    const dest = path.join(installModelsRoot(install), 'loras', 'l.safetensors')
+    fs.mkdirSync(path.dirname(dest), { recursive: true })
+    fs.writeFileSync(dest, bytes)
+    const dl = fakeDownload(Buffer.from('should-not-run'))
+    await stageModels({
+      models: [model({ type: 'loras', filename: 'l.safetensors', sha256: sha(bytes) })],
+      installPath: install,
+      download: dl,
+    })
+    expect(dl).not.toHaveBeenCalled()
+    expect(fs.readFileSync(dest)).toEqual(bytes)
+  })
+
+  it('re-fetches a present-but-wrong file instead of trusting bad bytes', async () => {
+    const install = freshInstall()
+    const good = Buffer.from('good-bytes')
+    const dest = path.join(installModelsRoot(install), 'checkpoints', 'm.safetensors')
+    fs.mkdirSync(path.dirname(dest), { recursive: true })
+    fs.writeFileSync(dest, Buffer.from('stale-wrong'))
+    const dl = fakeDownload(good)
+    await stageModels({ models: [model({ sha256: sha(good) })], installPath: install, download: dl })
+    expect(dl).toHaveBeenCalledTimes(1)
+    expect(fs.readFileSync(dest)).toEqual(good)
+  })
+
+  it('reports per-model progress with a 1-based index and total', async () => {
+    const install = freshInstall()
+    const seen: Array<{ index: number; total: number; percent: number }> = []
+    await stageModels({
+      models: [model({ filename: 'a.pt' }), model({ filename: 'b.pt' })],
+      installPath: install,
+      download: fakeDownload(Buffer.from('z')),
+      onProgress: (p) => seen.push({ index: p.index, total: p.total, percent: p.percent }),
+    })
+    expect(seen.some((s) => s.index === 1 && s.total === 2)).toBe(true)
+    expect(seen.some((s) => s.index === 2 && s.total === 2 && s.percent === 100)).toBe(true)
+  })
+
+  it('honors an already-aborted signal', async () => {
+    const install = freshInstall()
+    const dl = fakeDownload(Buffer.from('x'))
+    await expect(
+      stageModels({ models: [model()], installPath: install, download: dl, signal: AbortSignal.abort() }),
+    ).rejects.toThrow(/cancel/i)
+    expect(dl).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/comfybuilder/models.ts
+++ b/src/main/comfybuilder/models.ts
@@ -1,0 +1,176 @@
+/**
+ * Model staging: the models half of a distribution install.
+ *
+ * A distribution archive carries only code and the environment (`venv/` +
+ * `ComfyUI/`), never model weights. After the archive extracts, this stages the
+ * distribution's declared models into the install's own ComfyUI model tree so
+ * they are present before ComfyUI starts, mirroring how comfy-deploy provisions
+ * weights onto a volume before boot.
+ *
+ * Placement is `<installPath>/ComfyUI/models/<type>/<filename>`, the install's
+ * built-in model root. That root is always on ComfyUI's model search path, so a
+ * staged model is found whether or not the user shares a global model library.
+ *
+ * Integrity mirrors archive install: a model whose manifest carries a sha256 is
+ * verified byte-for-byte and a mismatch fails the install; a model with no hash
+ * installs unverified (the source, typically a public URL, supplied none). Each
+ * model downloads to a `.partial` sibling that is renamed into place only after
+ * it verifies, so an interrupted install never leaves a truncated model looking
+ * complete, and a re-run resumes or re-fetches rather than trusting bad bytes.
+ */
+import fs from 'fs'
+import path from 'path'
+
+import { download } from '../lib/download'
+import type { DownloadProgress } from '../lib/download'
+import { sha256File, normalizeSha256 } from './install'
+import type { ModelDescriptor, StageProgress } from './types'
+
+export type StageModelsErrorKind = 'invalid-model' | 'model-checksum-mismatch'
+
+export class StageModelsError extends Error {
+  override name = 'StageModelsError'
+  readonly kind: StageModelsErrorKind
+  constructor(kind: StageModelsErrorKind, message: string) {
+    super(message)
+    this.kind = kind
+  }
+}
+
+/** The download surface used, narrowed so a test can inject a fake. */
+type DownloadFn = (
+  url: string,
+  destPath: string,
+  onProgress: ((p: DownloadProgress) => void) | null,
+  options?: { signal?: AbortSignal },
+) => Promise<string>
+
+export interface StageModelsOptions {
+  models: readonly ModelDescriptor[]
+  /** The install root (the dir that contains `ComfyUI/`). */
+  installPath: string
+  onProgress?: (p: StageProgress) => void
+  signal?: AbortSignal
+  /** Injectable download for tests; defaults to the real primitive. */
+  download?: DownloadFn
+}
+
+/** A single path segment that cannot escape its parent: no separators, no `..`,
+ *  no drive/absolute markers. Guards `models/<type>/<filename>` against a
+ *  manifest that tries to traverse out of the model tree. */
+function isSafeSegment(seg: string): boolean {
+  if (!seg || seg === '.' || seg === '..') return false
+  if (seg.includes('/') || seg.includes('\\') || seg.includes('\0')) return false
+  if (path.isAbsolute(seg) || /^[a-zA-Z]:/.test(seg)) return false
+  return true
+}
+
+/** A model URL must be https, or http to loopback. A remote plaintext (or
+ *  downgradeable) source is MITM-substitutable, and a substituted `.pth`/`.ckpt`
+ *  is arbitrary-code on load, so it is enforced independently of the sha256.
+ *  Loopback http carries no network and never leaves the machine, so it is
+ *  allowed (a local model cache or the test server). */
+function isAllowedUrl(url: string): boolean {
+  try {
+    const u = new URL(url)
+    if (u.protocol === 'https:') return true
+    return u.protocol === 'http:' && ['127.0.0.1', '::1', 'localhost'].includes(u.hostname)
+  } catch {
+    return false
+  }
+}
+
+/** The real path of `dir` is inside `root` (defends against a symlinked model
+ *  subdir in the extracted archive redirecting a write outside the install). */
+function isContained(root: string, dir: string): boolean {
+  try {
+    const realRoot = fs.realpathSync(root)
+    const realDir = fs.realpathSync(dir)
+    return realDir === realRoot || realDir.startsWith(realRoot + path.sep)
+  } catch {
+    return false
+  }
+}
+
+/** The install's built-in ComfyUI models root, `<installPath>/ComfyUI/models`. */
+export function installModelsRoot(installPath: string): string {
+  return path.join(installPath, 'ComfyUI', 'models')
+}
+
+/**
+ * Download + verify + place each model under `<installPath>/ComfyUI/models`.
+ * Throws {@link StageModelsError} on an unsafe path or a checksum mismatch. A
+ * model already present with a matching hash is skipped, so a resumed or
+ * repeated install does not re-download what is already staged.
+ */
+export async function stageModels(opts: StageModelsOptions): Promise<void> {
+  const { models, installPath, onProgress, signal } = opts
+  const doDownload = opts.download ?? download
+  const total = models.length
+  const modelsRoot = installModelsRoot(installPath)
+
+  for (let i = 0; i < total; i++) {
+    if (signal?.aborted) throw new Error('Cancelled')
+    const model = models[i]!
+    const index = i + 1
+
+    if (!isSafeSegment(model.type) || !isSafeSegment(model.filename)) {
+      throw new StageModelsError('invalid-model', `Model ${model.type}/${model.filename} has an unsafe path.`)
+    }
+    if (!isAllowedUrl(model.downloadUrl)) {
+      throw new StageModelsError('invalid-model', `Model ${model.type}/${model.filename} download URL must be https.`)
+    }
+
+    const destDir = path.join(modelsRoot, model.type)
+    // Create the target dir first, then confirm it really resolves inside the
+    // install: a malicious archive can ship `ComfyUI/models/<type>` as a symlink
+    // pointing outside, and writing through it would escape the install.
+    fs.mkdirSync(destDir, { recursive: true })
+    if (!isContained(installPath, destDir)) {
+      throw new StageModelsError('invalid-model', `Model directory ${model.type} escapes the install.`)
+    }
+
+    const dest = path.join(destDir, model.filename)
+    const expected = normalizeSha256(model.sha256)
+
+    // Already staged: a byte-verified file (or, when the manifest gave no hash,
+    // any existing file) is left as-is so a re-run is cheap and idempotent.
+    if (fs.existsSync(dest)) {
+      if (!expected || (await sha256File(dest)) === expected) {
+        onProgress?.({ index, total, filename: model.filename, percent: 100 })
+        continue
+      }
+      // Present but wrong: drop it and re-fetch rather than trust bad bytes.
+      await fs.promises.rm(dest, { force: true }).catch(() => {})
+    }
+
+    // Download to a sibling, verify, then rename into place: an interrupted
+    // transfer never leaves a truncated model at the real name, and the rename
+    // is atomic on the same filesystem. Drop a symlinked leftover partial so a
+    // pre-planted link can't redirect the write; a plain partial resumes.
+    const partial = `${dest}.partial`
+    if (fs.existsSync(partial) && fs.lstatSync(partial).isSymbolicLink()) {
+      await fs.promises.rm(partial, { force: true }).catch(() => {})
+    }
+    onProgress?.({ index, total, filename: model.filename, percent: 0 })
+    await doDownload(
+      model.downloadUrl,
+      partial,
+      (p: DownloadProgress) => onProgress?.({ index, total, filename: model.filename, percent: p.percent }),
+      signal ? { signal } : {},
+    )
+
+    if (expected) {
+      const actual = await sha256File(partial)
+      if (actual !== expected) {
+        await fs.promises.rm(partial, { force: true }).catch(() => {})
+        throw new StageModelsError(
+          'model-checksum-mismatch',
+          `Model ${model.type}/${model.filename} checksum mismatch: expected ${expected}, got ${actual}`,
+        )
+      }
+    }
+    await fs.promises.rename(partial, dest)
+    onProgress?.({ index, total, filename: model.filename, percent: 100 })
+  }
+}

--- a/src/main/comfybuilder/targets.test.ts
+++ b/src/main/comfybuilder/targets.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest'
+import { hostOs, selectArtifactForHost } from './targets'
+import type { Artifact, Host } from './types'
+
+function art(o: Artifact['os'], g: Artifact['gpu'], overrides: Partial<Artifact> = {}): Artifact {
+  return { id: `${o}-${g}`, os: o, gpu: g, accelVariant: g === 'nvidia' ? 'cu128' : g, status: 'ready', ...overrides }
+}
+
+const catalog: Artifact[] = [
+  art('linux', 'cpu'),
+  art('linux', 'nvidia'),
+  art('windows', 'cpu'),
+  art('windows', 'nvidia'),
+]
+
+describe('hostOs', () => {
+  it('maps process.platform to a build-target os', () => {
+    const expected = process.platform === 'win32' ? 'windows' : process.platform === 'darwin' ? 'mac' : 'linux'
+    expect(hostOs()).toBe(expected)
+  })
+})
+
+describe('selectArtifactForHost', () => {
+  it.each<[string, Host, string | null]>([
+    ['exact os+gpu (windows/nvidia)', { os: 'windows', gpu: 'nvidia' }, 'windows-nvidia'],
+    ['cpu fallback (windows host, cpu gpu)', { os: 'windows', gpu: 'cpu' }, 'windows-cpu'],
+    ['nvidia host falls back to cpu when no nvidia', { os: 'mac', gpu: 'nvidia' }, null],
+    ['no artifact for the host os (mac)', { os: 'mac', gpu: 'mps' }, null],
+    ['linux nvidia', { os: 'linux', gpu: 'nvidia' }, 'linux-nvidia'],
+  ])('%s', (_name, host, expectedId) => {
+    expect(selectArtifactForHost(catalog, host)?.id ?? null).toBe(expectedId)
+  })
+
+  it('prefers exact gpu over the cpu fallback', () => {
+    const both = [art('linux', 'cpu'), art('linux', 'nvidia')]
+    expect(selectArtifactForHost(both, { os: 'linux', gpu: 'nvidia' })?.gpu).toBe('nvidia')
+  })
+
+  it('ignores non-ready artifacts', () => {
+    const notReady = [art('linux', 'nvidia', { status: 'building' })]
+    expect(selectArtifactForHost(notReady, { os: 'linux', gpu: 'nvidia' })).toBeNull()
+  })
+
+  it('an nvidia host still installs a cpu-only build', () => {
+    const cpuOnly = [art('windows', 'cpu')]
+    expect(selectArtifactForHost(cpuOnly, { os: 'windows', gpu: 'nvidia' })?.gpu).toBe('cpu')
+  })
+
+  it('prefers the matching accelVariant among same-gpu builds', () => {
+    const cudas = [art('linux', 'nvidia', { id: 'cu118', accelVariant: 'cu118' }), art('linux', 'nvidia', { id: 'cu128', accelVariant: 'cu128' })]
+    expect(selectArtifactForHost(cudas, { os: 'linux', gpu: 'nvidia', accelVariant: 'cu128' })?.id).toBe('cu128')
+  })
+
+  it('is deterministic (not input-order dependent) when accel ties', () => {
+    const a = art('linux', 'nvidia', { id: 'cu118', accelVariant: 'cu118' })
+    const b = art('linux', 'nvidia', { id: 'cu128', accelVariant: 'cu128' })
+    const host = { os: 'linux', gpu: 'nvidia' } as const
+    expect(selectArtifactForHost([a, b], host)?.id).toBe(selectArtifactForHost([b, a], host)?.id)
+  })
+})

--- a/src/main/comfybuilder/targets.ts
+++ b/src/main/comfybuilder/targets.ts
@@ -1,0 +1,67 @@
+/**
+ * Target resolution - pure host <-> artifact matching.
+ *
+ * A version fans out into per-target artifacts (os x gpu x accel). The UI picks
+ * ONE distribution + version; this module picks the artifact for the host, so a
+ * user never chooses `windows/cpu` vs `windows/nvidia` by hand. Pure functions,
+ * no I/O; the caller supplies the host GPU (Desktop already detects it).
+ */
+import type { Artifact, ArtifactGpu, ArtifactOs, Host } from './types'
+
+/** The host OS as a build-target token, from Node's `process.platform`. */
+export function hostOs(): ArtifactOs {
+  switch (process.platform) {
+    case 'win32':
+      return 'windows'
+    case 'darwin':
+      return 'mac'
+    default:
+      return 'linux'
+  }
+}
+
+/**
+ * Rank an artifact's GPU against the host's, higher is better. An exact match
+ * wins; a CPU artifact is the universal fallback (every host can run it); an
+ * NVIDIA host tolerates a CPU build but never the reverse.
+ */
+function gpuScore(artifactGpu: ArtifactGpu, hostGpu: ArtifactGpu): number {
+  if (artifactGpu === hostGpu) return 2
+  if (artifactGpu === 'cpu') return 1
+  return -1
+}
+
+/**
+ * Score an artifact for the host: GPU fit is dominant; a matching `accelVariant`
+ * (e.g. cu128) breaks ties among same-GPU builds, then `accelVariant` string
+ * order makes the choice deterministic (never input-order dependent).
+ */
+function score(a: Artifact, host: Host): number {
+  const gpu = gpuScore(a.gpu, host.gpu)
+  if (gpu < 0) return gpu
+  const accelMatch = host.accelVariant && a.accelVariant === host.accelVariant ? 1 : 0
+  return gpu * 2 + accelMatch
+}
+
+/**
+ * Pick the best `ready` artifact for the host: OS must match, then GPU fit
+ * (exact, else CPU fallback), then a preferred `accelVariant`, then a
+ * deterministic tie-break. Returns null when the version has no runnable
+ * artifact for this machine (e.g. a windows-only build on mac).
+ */
+export function selectArtifactForHost(artifacts: readonly Artifact[], host: Host): Artifact | null {
+  let best: Artifact | null = null
+  let bestScore = 0
+  for (const a of artifacts) {
+    if (a.status !== 'ready' || a.os !== host.os) continue
+    const s = score(a, host)
+    if (s <= 0) continue
+    // Strictly greater wins; on an exact tie, the lexicographically smaller
+    // accelVariant wins so selection is deterministic across input orderings.
+    if (s > bestScore || (s === bestScore && best !== null && a.accelVariant < best.accelVariant)) {
+      best = a
+      bestScore = s
+    }
+  }
+  return best
+}

--- a/src/main/comfybuilder/types.ts
+++ b/src/main/comfybuilder/types.ts
@@ -1,0 +1,124 @@
+/**
+ * ComfyBuilder functionality library - domain types.
+ *
+ * The wire shapes this library reads from the comfy-builder API (mirrors the
+ * relevant halves of its `openapi.yaml`), plus the small seams the UI plugs into
+ * (a {@link TokenProvider} for auth, progress callbacks for install). Nothing
+ * here depends on Electron, IPC, Vue, or the installations store.
+ */
+
+export type ArtifactOs = 'linux' | 'windows' | 'mac'
+export type ArtifactGpu = 'nvidia' | 'amd' | 'cpu' | 'mps'
+
+/** A distribution: a named, versioned ComfyUI environment recipe. */
+export interface Distribution {
+  id: string
+  name: string
+  description?: string
+  numCustomNodes?: number
+  numModels?: number
+  updatedAt?: string
+}
+
+/** One immutable build of a distribution (fans out into per-target artifacts). */
+export interface DistributionVersion {
+  id: string
+  /** Monotonic version number within the distribution. */
+  version: number
+  status: string
+  createdAt?: string
+}
+
+/** A single built target: one os x gpu x accel archive of a version. */
+export interface Artifact {
+  id: string
+  os: ArtifactOs
+  gpu: ArtifactGpu
+  /** Accelerator build variant, e.g. `cu128`. Part of the target identity. */
+  accelVariant: string
+  status: string
+  /** Storage ref of the built archive. */
+  outputRef?: string
+  /** Hex sha256 of the archive (optionally `sha256:`-prefixed). Verified post-download. */
+  outputSha256?: string
+}
+
+/** The machine an install targets: which artifact to pick. */
+export interface Host {
+  os: ArtifactOs
+  gpu: ArtifactGpu
+  /** Preferred accelerator build (e.g. `cu128`) when a gpu ships several. Optional. */
+  accelVariant?: string
+}
+
+/**
+ * The auth seam. The UI owns sign-in and token storage; this library only reads
+ * a bearer token when it needs one. Willie's `tokenStore` implements this.
+ */
+export interface TokenProvider {
+  /** Current access token, or null when signed out. */
+  getAccessToken(): Promise<string | null>
+  /** Optional: called when the API rejects the token so the UI can re-auth. */
+  onUnauthorized?(): void
+}
+
+/** A launch command spec (interpreter + args + cwd), free of Electron types. */
+export interface LaunchSpec {
+  cmd: string
+  args: string[]
+  cwd: string
+  port: number
+}
+
+/** Install progress, surfaced to the UI's progress bar. */
+export interface InstallProgress {
+  phase: 'resolve' | 'download' | 'extract'
+  percent: number
+  detail?: string
+}
+
+/**
+ * One model the distribution pre-installs, projected from the version's sealed
+ * manifest by the builder API (mirrors its `DistributionModel` schema). `type`
+ * is the ComfyUI model directory the file installs into (e.g. `checkpoints`),
+ * so the file lands at `models/<type>/<filename>`. `downloadUrl` is ready to GET
+ * as-is (a public source URL, or a short-lived presigned URL for a private one).
+ */
+export interface ModelDescriptor {
+  type: string
+  filename: string
+  /** Hex sha256 of the content, when known. Absent for a public model whose
+   *  author supplied none, in which case it installs without verification. */
+  sha256?: string
+  downloadUrl: string
+  /** When `downloadUrl` expires (presigned URLs only). Advisory. */
+  expiresAt?: string
+}
+
+/** A runtime allow/deny list (`DistributionPolicy` on the wire). Advisory
+ *  metadata the client may later enforce; staging does not gate on it. */
+export interface ModelPolicy {
+  mode: 'allowlist' | 'blocklist'
+  list?: string[]
+}
+
+/**
+ * The model + policy view of a distribution version (the builder API's
+ * `DistributionManifest`). A client stages `models` before starting ComfyUI; the
+ * archive itself carries only code and the environment, never weights.
+ */
+export interface ModelManifest {
+  models: ModelDescriptor[]
+  modelPolicy?: ModelPolicy | null
+  partnerNodePolicy?: ModelPolicy | null
+}
+
+/** Per-model staging progress, surfaced to the UI while models download. */
+export interface StageProgress {
+  /** 1-based index of the model currently downloading. */
+  index: number
+  total: number
+  filename: string
+  /** Percent of the current model (0-100). */
+  percent: number
+}


### PR DESCRIPTION
> Scope: the UI-agnostic comfybuilder functionality library. Includes model staging (download, sha256 verify, place under `ComfyUI/models/<type>/<filename>`) and the manifest resolver; the source-plugin wiring that calls them lives in the UI PR. (Model handling was consolidated here from the former separate PR so functionality and UI stay cleanly split.)

## TL;DR
A standalone, UI-agnostic functionality library for the Desktop ↔ comfy-builder flow: list distributions/versions/artifacts, pick the artifact for the host, download + install it, and build its launch command. No dependency on Electron IPC, Vue, or the installations store, so the distribution UI plugs in by supplying a token provider and calling these functions. Proven end to end on a real Windows host against real staging: installs a distribution, boots ComfyUI (855 nodes), and runs a workflow to completion.

## Intent (why)
The Internal Desktop Distribution milestone splits into two halves: the UX (sign-in, distribution tiles, wizard) and the functionality (talk to comfy-builder, download, install, launch). This PR is the functionality half, factored as a clean library so the UI is a thin adapter over it rather than being coupled to the builder API shape and archive mechanics. It is the engine the distribution UI calls; presentation and install-state policy stay in the UI.

## Decision
- Data + actions only. The library returns raw distributions/versions/artifacts and performs install/launch; per-distribution policy (installable / latest / blocked) stays in the UI.
- Auth via an injected `TokenProvider`. The UI owns sign-in and token storage; the library only reads a bearer token when it needs one, and the token never leaves the main process.
- Archive contract is `venv/` + `ComfyUI/`. The archive ships one ready, relocatable `venv/`, so there is no post-extract env build; launch drives that venv's python directly (`buildLaunchSpec`).
- Targets are auto-picked by os x gpu (with a cpu fallback), so a user never chooses `windows/cpu` vs `windows/nvidia` by hand.
- Prod base URL by default; pass `baseUrl` to target staging or a mock. sha256 is verified when the artifact carries a hash (staging does not expose one yet, so it is verify-if-present).

## Illustration
```
  ComfyBuilderClient        list distributions -> versions -> artifacts, resolve presigned url
        |                   (Bearer via injected TokenProvider; token never crosses IPC)
        v
  selectArtifactForHost     pick the artifact for { os: hostOs(), gpu }   (os x gpu, cpu fallback)
        |
        v
  installArtifact           resolve -> download -> sha256-verify -> extract -> validate venv/+ComfyUI/
        |
        v
  buildLaunchSpec           -> { cmd: venv python, args: [-s, ComfyUI/main.py, ...], cwd, port }
```

The UI plugs in with a `TokenProvider` and these calls:
```ts
const client = new ComfyBuilderClient({ baseUrl, auth: tokenStoreAdapter })
const dists = await client.listDistributions()                    // render tiles
const { artifacts } = await client.getVersion(versionId)
const artifact = selectArtifactForHost(artifacts, { os: hostOs(), gpu })
await installArtifact({ artifact, client, installPath, cacheDir, onProgress })
const launch = buildLaunchSpec(installPath, { launchArgs })
```

## Implementation Details
New `src/main/comfybuilder/`:
- `client.ts` `ComfyBuilderClient`: `listDistributions` / `listVersions` / `getVersion` / `resolveDownloadUrl`; bearer via `TokenProvider`; typed `ComfyBuilderApiError` (unauthorized / not-found / network / server), 401 calls `onUnauthorized`.
- `targets.ts` `hostOs()` + `selectArtifactForHost()` (pure).
- `install.ts` `installArtifact()`: reuses the shared `download()` + `extractNested()`; sha-verify when present; cleanup on failure; typed `ComfyBuilderInstallError`.
- `launch.ts` `buildLaunchSpec()` + `venvPython()`.
- `types.ts` wire shapes + the `TokenProvider` / progress seams. `index.ts` public surface.

Tests: 18 unit tests (targets, launch, client with a mock fetch). Validated against real staging (list -> version -> artifacts -> select windows/cpu -> resolve presigned url), and a full Windows e2e (install a distribution -> boot 855 nodes -> run a workflow). typecheck (4 configs) + lint green.

Not here (separate, coordinated): the distribution UI (owned by the auth/tiles PRs) adopting this library, and the OAuth client wiring.

