### PR TITLE
feat(desktop): builder distribution interaction (session, IPC, install/launch plugin)

### DIFF
--- a/e2e/comfybuilder-launch.test.ts
+++ b/e2e/comfybuilder-launch.test.ts
@@ -1,0 +1,163 @@
+/**
+ * E2E: launching a ComfyBuilder distribution from the chooser.
+ *
+ * The renderer resolves launch ONLY from `get-list-actions`
+ * (`performChooserLaunch`), so a source plugin without `getListActions`
+ * hands it an empty array, which reads as "this install cannot launch" and
+ * bounces the tile click into the new-install wizard. This file pins the
+ * comfybuilder plugin's `getListActions` end-to-end:
+ *
+ *   1. an installed distribution tile launches (run-action `launch` plus the
+ *      progress takeover) and never mounts the wizard;
+ *   2. clicking a not-ready one explains itself instead of bouncing there.
+ *
+ * The per-status action contract itself lives in the plugin unit test, which
+ * pins it without needing a seeded record.
+ *
+ * Tagged @windows @macos only: seeding install records does not work under the
+ * linux CI project (every other seeding test in this directory is lifecycle-only,
+ * and lifecycle is not in the CI matrix), so the tiles never render there.
+ *
+ * The seeded venv python exits immediately, so the launch is attempted and
+ * then fails at the boot wait. Attempted-vs-never-attempted is the whole
+ * discriminator here; a real ComfyUI boot is not.
+ */
+
+import os from 'node:os'
+import path from 'node:path'
+import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { test, expect } from '@playwright/test'
+import en from '../locales/en.json'
+import { launchApp, type AppContext, type SeedInstallation } from './launchApp'
+import { clickInstallTile, expectChooserVisible } from './support/chooserHelpers'
+import { getIpcInvocations, resetIpcInvocations } from './support/devHooks'
+import { byTestId, TID } from './support/testIds'
+
+/** Both steps of the new-install wizard: the surface a missing launch action
+ *  used to bounce the user into. */
+const NEW_INSTALL_WIZARD = '.config-shell, .template-shell'
+
+interface DistributionCase {
+  id: string
+  name: string
+  status: string
+  installPath: string
+}
+
+const INSTALLED: DistributionCase = {
+  id: 'inst-comfybuilder-installed',
+  name: 'desktop-4target-stg-v0190',
+  status: 'installed',
+  installPath: '',
+}
+
+/** `failed` is the only not-installed status that renders a tile:
+ *  `enrichInstallationsForRenderer` filters `installing` out. The per-status
+ *  action contract is pinned deterministically by the plugin unit test; here we
+ *  only cover what a user can actually click. */
+const FAILED: DistributionCase = {
+  id: 'inst-comfybuilder-failed',
+  name: 'desktop-4target-stg-v0192',
+  status: 'failed',
+  installPath: '',
+}
+
+let ctx: AppContext
+let rootDir: string
+
+test.describe.configure({ mode: 'serial' })
+
+/** Mirrors what `installDistribution` writes for a real distribution install. */
+function distributionRecord(dist: DistributionCase): SeedInstallation {
+  return {
+    id: dist.id,
+    name: dist.name,
+    sourceId: 'comfybuilder',
+    sourceLabel: 'ComfyBuilder',
+    installPath: dist.installPath,
+    distributionId: `d-${dist.id}`,
+    distributionName: dist.name,
+    version: '1',
+    artifactId: 'a-1',
+    artifactOs: 'macos',
+    artifactGpu: 'cpu',
+    artifactAccelVariant: 'cpu',
+    launchArgs: '--enable-manager',
+    launchMode: 'window',
+    browserPartition: 'unique',
+    status: dist.status,
+    seen: true,
+  }
+}
+
+/** `buildLaunchSpec` returns null unless the venv interpreter and
+ *  `ComfyUI/main.py` both exist, and a null launch command fails the launch
+ *  before it is ever attempted. Written for every case so the disabled-action
+ *  assertions prove the gate is the record status, not the disk. */
+async function writeDistributionLayout(installPath: string): Promise<void> {
+  await mkdir(path.join(installPath, 'ComfyUI'), { recursive: true })
+  await writeFile(path.join(installPath, 'ComfyUI', 'main.py'), '')
+  if (process.platform === 'win32') {
+    await mkdir(path.join(installPath, 'venv'), { recursive: true })
+    await writeFile(path.join(installPath, 'venv', 'python.exe'), '')
+    return
+  }
+  await mkdir(path.join(installPath, 'venv', 'bin'), { recursive: true })
+  const python = path.join(installPath, 'venv', 'bin', 'python3')
+  // Exits straight away so the attempted launch dies at the boot wait rather
+  // than leaking a background process.
+  await writeFile(python, '#!/bin/sh\nexit 1\n')
+  await chmod(python, 0o755)
+}
+
+test.beforeAll(async () => {
+  rootDir = await mkdtemp(path.join(os.tmpdir(), 'comfyui-launcher-comfybuilder-e2e-'))
+  const cases = [INSTALLED, FAILED]
+  for (const dist of cases) {
+    dist.installPath = path.join(rootDir, dist.id)
+    await writeDistributionLayout(dist.installPath)
+  }
+
+  ctx = await launchApp({
+    settings: { firstUseCompleted: true, telemetryEnabled: false },
+    installations: cases.map(distributionRecord),
+  })
+  await expectChooserVisible(ctx.panel)
+})
+
+test.afterAll(async () => {
+  await ctx?.cleanup()
+  if (rootDir) await rm(rootDir, { recursive: true, force: true })
+})
+
+test('clicking an installed ComfyBuilder tile launches it instead of opening the new-install wizard @windows @macos', async () => {
+  await resetIpcInvocations(ctx.app)
+  await clickInstallTile(ctx.panel, INSTALLED.name)
+
+  // The whole chain (tile pick -> get-list-actions -> useListAction ->
+  // show-progress -> run-action) ends here; with no launch action in the
+  // list it never starts and the wizard takes over instead.
+  await expect
+    .poll(async () => {
+      const calls = (await getIpcInvocations(ctx.app, 'run-action')) as
+        { installationId?: string; actionId?: string }[]
+      return calls.some((c) => c.installationId === INSTALLED.id && c.actionId === 'launch')
+    }, { timeout: 20_000, intervals: [200, 500] })
+    .toBe(true)
+
+  await ctx.panel.waitForVisible('.brand-progress', { timeout: 10_000 })
+  expect(await ctx.panel.exists(NEW_INSTALL_WIZARD)).toBe(false)
+})
+
+test('clicking a not-ready ComfyBuilder tile explains itself instead of opening the new-install wizard @windows @macos', async () => {
+  await clickInstallTile(ctx.panel, FAILED.name)
+
+  // `useListAction` short-circuits a disabled action into an alert, so the
+  // user is told why nothing launched rather than being handed a wizard.
+  await ctx.panel.waitForVisible(byTestId(TID.baseAlertAction), { timeout: 10_000 })
+  expect(await ctx.panel.textOf('.base-alert-message-text')).toContain(en.errors.installNotReady)
+  expect(await ctx.panel.exists(NEW_INSTALL_WIZARD)).toBe(false)
+
+  await ctx.panel.click(byTestId(TID.baseAlertAction))
+  await expectChooserVisible(ctx.panel)
+})

--- a/e2e/comfybuilder-models.test.ts
+++ b/e2e/comfybuilder-models.test.ts
@@ -1,0 +1,124 @@
+/**
+ * E2E: staging a distribution's models in the real app.
+ *
+ * A distribution archive carries no model weights, so the comfybuilder install
+ * downloads the version's declared models into `<installPath>/ComfyUI/models/
+ * <type>/<filename>` before launch. This drives the REAL staging code (real
+ * Electron download, real fs, real sha256) in the real main process, decoupled
+ * from the archive/auth path via the E2E hook, and serves the model bytes from a
+ * local HTTP server so the run is hermetic and deterministic.
+ *
+ * The manifest source is the `COMFY_BUILDER_MODELS_MANIFEST` env seam (a file the
+ * test rewrites per case), which is exactly how the mocked manifest is injected
+ * until the builder endpoint is deployed.
+ */
+
+import { createHash } from 'node:crypto'
+import { createServer, type Server } from 'node:http'
+import { mkdtempSync, rmSync, mkdirSync, existsSync, readFileSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { test, expect } from '@playwright/test'
+import { launchApp, type AppContext } from './launchApp'
+
+const sha = (b: Buffer): string => createHash('sha256').update(b).digest('hex')
+
+// Two deterministic "model" payloads served locally.
+const DECODER = Buffer.from('taesd-decoder-bytes-fixture')
+const ENCODER = Buffer.from('taesd-encoder-bytes-fixture')
+
+let server: Server
+let baseUrl: string
+let manifestFile: string
+let ctx: AppContext
+const tmpDirs: string[] = []
+
+function freshInstall(): string {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'cb-models-e2e-'))
+  tmpDirs.push(dir)
+  mkdirSync(path.join(dir, 'ComfyUI'), { recursive: true })
+  return dir
+}
+
+/** Ask the app to run the real staging against installPath, reading the manifest
+ *  from the env-pointed file the test controls. */
+async function stage(installPath: string): Promise<{ staged?: string[]; error?: string; kind?: string }> {
+  return ctx.app.evaluate(async (_electron, arg) => {
+    const helpers = (globalThis as unknown as {
+      __e2e?: { stageDistributionModels: (o: unknown) => Promise<unknown> }
+    }).__e2e
+    if (!helpers) throw new Error('__e2e not registered')
+    return helpers.stageDistributionModels(arg) as Promise<{ staged?: string[]; error?: string; kind?: string }>
+  }, { installPath, distributionId: 'd-e2e', version: '1' })
+}
+
+test.describe.configure({ mode: 'serial' })
+
+test.beforeAll(async () => {
+  await new Promise<void>((resolve) => {
+    server = createServer((req, res) => {
+      if (req.url === '/decoder') return res.end(DECODER)
+      if (req.url === '/encoder') return res.end(ENCODER)
+      res.statusCode = 404
+      res.end()
+    })
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address()
+      baseUrl = typeof addr === 'object' && addr ? `http://127.0.0.1:${addr.port}` : ''
+      resolve()
+    })
+  })
+  manifestFile = path.join(mkdtempSync(path.join(os.tmpdir(), 'cb-mf-e2e-')), 'manifest.json')
+  writeFileSync(manifestFile, JSON.stringify({ models: [] }))
+  process.env.COMFY_BUILDER_MODELS_MANIFEST = manifestFile
+  ctx = await launchApp({ settings: { firstUseCompleted: true, telemetryEnabled: false } })
+})
+
+test.afterAll(async () => {
+  await ctx?.cleanup()
+  await new Promise<void>((r) => server.close(() => r()))
+  delete process.env.COMFY_BUILDER_MODELS_MANIFEST
+  for (const d of tmpDirs) rmSync(d, { recursive: true, force: true })
+  rmSync(path.dirname(manifestFile), { recursive: true, force: true })
+})
+
+test('stages verified models into ComfyUI/models/<type>/<filename> @windows @macos', async () => {
+  writeFileSync(manifestFile, JSON.stringify({
+    models: [
+      { type: 'vae_approx', filename: 'taesd_decoder.pth', sha256: sha(DECODER), downloadUrl: `${baseUrl}/decoder` },
+      { type: 'vae_approx', filename: 'taesd_encoder.pth', sha256: sha(ENCODER), downloadUrl: `${baseUrl}/encoder` },
+    ],
+  }))
+  const install = freshInstall()
+  const res = await stage(install)
+  expect(res.error, res.error).toBeUndefined()
+  expect(res.staged).toEqual(['vae_approx/taesd_decoder.pth', 'vae_approx/taesd_encoder.pth'])
+
+  const decoder = path.join(install, 'ComfyUI', 'models', 'vae_approx', 'taesd_decoder.pth')
+  const encoder = path.join(install, 'ComfyUI', 'models', 'vae_approx', 'taesd_encoder.pth')
+  expect(existsSync(decoder)).toBe(true)
+  expect(readFileSync(decoder)).toEqual(DECODER)
+  expect(existsSync(encoder)).toBe(true)
+  // No leftover partials.
+  expect(existsSync(`${decoder}.partial`)).toBe(false)
+})
+
+test('fails the stage and leaves no file when a model checksum does not match @windows @macos', async () => {
+  writeFileSync(manifestFile, JSON.stringify({
+    models: [{ type: 'checkpoints', filename: 'bad.safetensors', sha256: sha(Buffer.from('other')), downloadUrl: `${baseUrl}/decoder` }],
+  }))
+  const install = freshInstall()
+  const res = await stage(install)
+  expect(res.kind).toBe('model-checksum-mismatch')
+  const dest = path.join(install, 'ComfyUI', 'models', 'checkpoints', 'bad.safetensors')
+  expect(existsSync(dest)).toBe(false)
+  expect(existsSync(`${dest}.partial`)).toBe(false)
+})
+
+test('stages nothing for an empty manifest @windows @macos', async () => {
+  writeFileSync(manifestFile, JSON.stringify({ models: [] }))
+  const install = freshInstall()
+  const res = await stage(install)
+  expect(res.staged).toEqual([])
+  expect(existsSync(path.join(install, 'ComfyUI', 'models'))).toBe(false)
+})

--- a/src/main/comfybuilder/client.test.ts
+++ b/src/main/comfybuilder/client.test.ts
@@ -44,6 +44,16 @@ describe('ComfyBuilderClient', () => {
     expect(call[0]).toBe('https://api.test/builder/v1/distribution-versions/ver-9/manifest')
   })
 
+  it('getVersion surfaces the wire archiveSha256/archiveRef so the archive can be verified', async () => {
+    vi.stubGlobal('fetch', mockFetch(200, {
+      version: 3,
+      artifacts: [{ id: 'a1', os: 'linux', gpu: 'nvidia', accelVariant: 'cu128', status: 'ready', archiveRef: 'blob/a1', archiveSha256: 'deadbeef' }],
+    }))
+    const { version, artifacts } = await new ComfyBuilderClient({ auth: auth('t') }).getVersion('v1')
+    expect(version).toBe(3)
+    expect(artifacts[0]).toMatchObject({ id: 'a1', archiveSha256: 'deadbeef', archiveRef: 'blob/a1' })
+  })
+
   it('throws unauthorized (no network) when signed out', async () => {
     const f = mockFetch(200, {})
     vi.stubGlobal('fetch', f)

--- a/src/main/comfybuilder/install.test.ts
+++ b/src/main/comfybuilder/install.test.ts
@@ -21,16 +21,16 @@ describe('installArtifact guards', () => {
     expect(client.resolveDownloadUrl).not.toHaveBeenCalled()
   })
 
-  // TODO: flip back to fail-closed once the builder populates outputSha256.
+  // TODO: flip back to fail-closed once the builder populates archiveSha256.
   it.each([
     ['absent', undefined],
     ['blank', '   '],
     ['prefix-only', 'sha256:'],
-  ])('proceeds (unverified) when outputSha256 is %s', async (name, sha) => {
+  ])('proceeds (unverified) when archiveSha256 is %s', async (name, sha) => {
     const client = { resolveDownloadUrl: vi.fn(async () => 'https://example.test/a.tar.gz') }
     // Gets past the hash gate: the stubbed extract writes no layout, so it fails
     // on the layout check rather than on the missing hash.
-    await expect(installArtifact({ artifact: artifact({ outputSha256: sha }), client, installPath: path.join(os.tmpdir(), `cb-${name}`), cacheDir: os.tmpdir() }))
+    await expect(installArtifact({ artifact: artifact({ archiveSha256: sha }), client, installPath: path.join(os.tmpdir(), `cb-${name}`), cacheDir: os.tmpdir() }))
       .rejects.toMatchObject({ kind: 'invalid-layout' })
     expect(client.resolveDownloadUrl).toHaveBeenCalled()
   })

--- a/src/main/comfybuilder/install.ts
+++ b/src/main/comfybuilder/install.ts
@@ -7,7 +7,7 @@
  * `ComfyUI/` (a ready, relocatable env), so there is no post-extract env build;
  * launch drives that `venv/` directly (see `./launch`).
  *
- * Integrity: when the artifact carries an `outputSha256` the bytes must match or
+ * Integrity: when the artifact carries an `archiveSha256` the bytes must match or
  * nothing is extracted. A MISSING hash is currently installed unverified because
  * the builder does not populate it yet (see the TODO in `installArtifact`); that
  * becomes fail-closed once it does. The archive downloads to a per-run temp under `cacheDir`
@@ -117,11 +117,11 @@ export async function installArtifact(opts: InstallArtifactOptions): Promise<voi
 
   // A hash that IS present is always enforced (see the compare below).
   // TODO: fail closed on a missing hash too. The builder does not populate
-  // outputSha256 yet, so for the initial rollout a missing hash installs
+  // archiveSha256 yet, so for the initial rollout a missing hash installs
   // unverified rather than blocking every install.
-  const expected = normalizeSha256(artifact.outputSha256)
+  const expected = normalizeSha256(artifact.archiveSha256)
   if (!expected) {
-    console.warn('[comfybuilder] artifact has no outputSha256; installing without integrity verification')
+    console.warn('[comfybuilder] artifact has no archiveSha256; installing without integrity verification')
   }
 
   onProgress?.({ phase: 'resolve', percent: 0 })

--- a/src/main/comfybuilder/modelManifest.ts
+++ b/src/main/comfybuilder/modelManifest.ts
@@ -17,11 +17,6 @@ import type { ModelManifest } from './types'
 
 const EMPTY: ModelManifest = { models: [], modelPolicy: null, partnerNodePolicy: null }
 
-// A version whose build finished, matching the set the install artifact was
-// selected from, so the manifest is read off the same version the archive came
-// from (never a failed row that shares the number).
-const COMPLETE_VERSION_STATUSES = new Set(['complete', 'completed', 'ready', 'succeeded', 'success'])
-
 /** Parse an override that is inline JSON (`{...}`) or a path to a JSON file. */
 function loadOverride(value: string): ModelManifest {
   const raw = value.trimStart().startsWith('{') ? value : fs.readFileSync(value, 'utf8')
@@ -33,19 +28,17 @@ function loadOverride(value: string): ModelManifest {
   }
 }
 
-/** Map a version NUMBER to the id of its COMPLETE version, or null. */
+/** Map a version NUMBER to the id of its complete version, or null. `complete`
+ *  is the only terminal status in the builder's closed enum (queued | building
+ *  | complete), so the manifest is read off the same version the archive came
+ *  from (never a failed row that shares the number). */
 async function resolveVersionId(
   client: Pick<ComfyBuilderClient, 'listVersions'>,
   distributionId: string,
   versionNumber: string,
 ): Promise<string | null> {
   const versions = await client.listVersions(distributionId)
-  const match = versions.find(
-    (v) =>
-      String(v.version) === versionNumber &&
-      typeof v.status === 'string' &&
-      COMPLETE_VERSION_STATUSES.has(v.status.toLowerCase()),
-  )
+  const match = versions.find((v) => String(v.version) === versionNumber && v.status === 'complete')
   return match?.id ?? null
 }
 

--- a/src/main/comfybuilder/types.ts
+++ b/src/main/comfybuilder/types.ts
@@ -37,10 +37,11 @@ export interface Artifact {
   /** Accelerator build variant, e.g. `cu128`. Part of the target identity. */
   accelVariant: string
   status: string
-  /** Storage ref of the built archive. */
-  outputRef?: string
-  /** Hex sha256 of the archive (optionally `sha256:`-prefixed). Verified post-download. */
-  outputSha256?: string
+  /** Storage ref of the built archive (the API's `archiveRef`). Absent until the target is ready. */
+  archiveRef?: string
+  /** Hex sha256 of the archive (the API's `archiveSha256`, optionally `sha256:`-prefixed).
+   *  Absent until the signer computes it; verified post-download when present. */
+  archiveSha256?: string
 }
 
 /** The machine an install targets: which artifact to pick. */

--- a/src/main/devplatform/config.ts
+++ b/src/main/devplatform/config.ts
@@ -1,0 +1,19 @@
+/**
+ * Dev-platform glue config: points the cloud + comfy-builder libraries at
+ * staging for now.
+ *
+ * These are env DEFAULTS, not hardcodes: a real deployment can still override
+ * `COMFY_CLOUD_ISSUER` / `COMFY_BUILDER_BASE_URL` via the environment. This
+ * module is imported (for its side effect) BEFORE the cloud library's own
+ * `config` module, so the issuer default is in place by the time
+ * `CLOUD_ISSUER` is computed: do not reorder the import in `./session`.
+ */
+const STAGING_CLOUD_ISSUER = 'https://stagingcloud.comfy.org'
+const STAGING_BUILDER_BASE_URL = 'https://stagingplatformapi.comfy.org/builder'
+
+if (!process.env.COMFY_CLOUD_ISSUER) {
+  process.env.COMFY_CLOUD_ISSUER = STAGING_CLOUD_ISSUER
+}
+
+/** Builder gateway base URL the client targets. Staging default; env override. */
+export const BUILDER_BASE_URL = process.env.COMFY_BUILDER_BASE_URL || STAGING_BUILDER_BASE_URL

--- a/src/main/devplatform/distributions.test.ts
+++ b/src/main/devplatform/distributions.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from 'vitest'
+import { listDistributionRows, resolveHostArtifact } from './distributions'
+import type { Artifact, Distribution, DistributionVersion, Host } from '../comfybuilder'
+
+const HOST: Host = { os: 'linux', gpu: 'nvidia' }
+
+function artifact(overrides: Partial<Artifact> = {}): Artifact {
+  return {
+    id: 'art-1',
+    os: 'linux',
+    gpu: 'nvidia',
+    accelVariant: 'cu128',
+    status: 'ready',
+    archiveSha256: 'abc',
+    ...overrides,
+  }
+}
+
+function version(v: number, status: string): DistributionVersion {
+  return { id: `v${v}`, version: v, status, createdAt: '2026-07-20T00:00:00Z' }
+}
+
+/** A stub client whose per-distribution / per-version data is table-driven. */
+function stubClient(opts: {
+  distributions?: Distribution[]
+  versionsByDist?: Record<string, DistributionVersion[]>
+  artifactsByVersion?: Record<string, Artifact[]>
+}) {
+  return {
+    listDistributions: vi.fn(async () => opts.distributions ?? []),
+    listVersions: vi.fn(async (id: string) => opts.versionsByDist?.[id] ?? []),
+    getVersion: vi.fn(async (id: string) => ({ version: Number(id.replace('v', '')), artifacts: opts.artifactsByVersion?.[id] ?? [] })),
+  }
+}
+
+describe('listDistributionRows', () => {
+  it('marks a distribution installable when the latest complete version has a host artifact', async () => {
+    const client = stubClient({
+      distributions: [{ id: 'd1', name: 'Image', description: 'desc', numCustomNodes: 3 }],
+      versionsByDist: { d1: [version(1, 'complete'), version(2, 'complete')] },
+      artifactsByVersion: { v2: [artifact()] },
+    })
+    const rows = await listDistributionRows(client as never, HOST)
+    const row = rows[0]!
+    expect(row).toMatchObject({ id: 'd1', name: 'Image', description: 'desc', numCustomNodes: 3, version: '2', state: 'installable' })
+    // The latest complete version (2) is the one resolved, not version 1.
+    expect(client.getVersion).toHaveBeenCalledWith('v2')
+  })
+
+  it('marks no-build when no version has a completed status', async () => {
+    const client = stubClient({
+      distributions: [{ id: 'd1', name: 'Pending' }],
+      versionsByDist: { d1: [version(1, 'building'), version(2, 'failed')] },
+    })
+    const rows = await listDistributionRows(client as never, HOST)
+    const row = rows[0]!
+    expect(row).toMatchObject({ state: 'no-build', blockedReason: 'buildFailed' })
+    expect(row.version).toBeUndefined()
+  })
+
+  it('marks platform-mismatch when the latest complete version has no host artifact', async () => {
+    const client = stubClient({
+      distributions: [{ id: 'd1', name: 'WinOnly' }],
+      versionsByDist: { d1: [version(3, 'complete')] },
+      artifactsByVersion: { v3: [artifact({ os: 'windows' })] },
+    })
+    const rows = await listDistributionRows(client as never, HOST)
+    const row = rows[0]!
+    expect(row).toMatchObject({ version: '3', state: 'platform-mismatch', blockedReason: 'noArtifactForMachine' })
+  })
+
+  it('drops a distribution whose version lookup fails without failing the whole grid', async () => {
+    const client = stubClient({
+      distributions: [{ id: 'ok', name: 'Ok' }, { id: 'bad', name: 'Bad' }],
+      versionsByDist: { ok: [version(1, 'complete')] },
+      artifactsByVersion: { v1: [artifact()] },
+    })
+    client.listVersions.mockImplementation(async (id: string) => {
+      if (id === 'bad') throw new Error('boom')
+      return [version(1, 'complete')]
+    })
+    const rows = await listDistributionRows(client as never, HOST)
+    expect(rows.map((r) => r.id)).toEqual(['ok'])
+  })
+})
+
+describe('resolveHostArtifact', () => {
+  it('returns the host artifact of the latest complete version', async () => {
+    const client = stubClient({
+      versionsByDist: { d1: [version(5, 'complete'), version(4, 'complete')] },
+      artifactsByVersion: { v5: [artifact({ id: 'pick-me' })] },
+    })
+    const resolved = await resolveHostArtifact(client as never, HOST, 'd1')
+    expect(resolved).toMatchObject({ version: 5, artifact: { id: 'pick-me' } })
+  })
+
+  it('returns null when there is no complete version', async () => {
+    const client = stubClient({ versionsByDist: { d1: [version(1, 'building')] } })
+    expect(await resolveHostArtifact(client as never, HOST, 'd1')).toBeNull()
+  })
+
+  it('returns null when the complete version has no host artifact', async () => {
+    const client = stubClient({
+      versionsByDist: { d1: [version(1, 'complete')] },
+      artifactsByVersion: { v1: [artifact({ os: 'mac', gpu: 'mps' })] },
+    })
+    expect(await resolveHostArtifact(client as never, HOST, 'd1')).toBeNull()
+  })
+})

--- a/src/main/devplatform/distributions.test.ts
+++ b/src/main/devplatform/distributions.test.ts
@@ -70,6 +70,48 @@ describe('listDistributionRows', () => {
     expect(row).toMatchObject({ version: '3', state: 'platform-mismatch', blockedReason: 'noArtifactForMachine' })
   })
 
+  it('marks update-available when installed older and the newer build runs here', async () => {
+    const client = stubClient({
+      distributions: [{ id: 'd1', name: 'Image' }],
+      versionsByDist: { d1: [version(1, 'complete'), version(2, 'complete')] },
+      artifactsByVersion: { v2: [artifact()] },
+    })
+    const rows = await listDistributionRows(client as never, HOST, new Map([['d1', 1]]))
+    expect(rows[0]).toMatchObject({ version: '2', installedVersion: 1, state: 'update-available' })
+  })
+
+  it('stays installable (not update-available) when installed at the latest version', async () => {
+    const client = stubClient({
+      distributions: [{ id: 'd1', name: 'Image' }],
+      versionsByDist: { d1: [version(2, 'complete')] },
+      artifactsByVersion: { v2: [artifact()] },
+    })
+    const rows = await listDistributionRows(client as never, HOST, new Map([['d1', 2]]))
+    expect(rows[0]).toMatchObject({ version: '2', installedVersion: 2, state: 'installable' })
+  })
+
+  it('does NOT offer an update when the newer version has no host artifact', async () => {
+    const client = stubClient({
+      distributions: [{ id: 'd1', name: 'WinOnly' }],
+      versionsByDist: { d1: [version(2, 'complete')] },
+      artifactsByVersion: { v2: [artifact({ os: 'windows' })] }, // no linux/nvidia build
+    })
+    const rows = await listDistributionRows(client as never, HOST, new Map([['d1', 1]]))
+    expect(rows[0]).toMatchObject({ state: 'platform-mismatch' })
+    expect(rows[0]!.state).not.toBe('update-available')
+  })
+
+  it('leaves installedVersion unset for a distribution that is not installed', async () => {
+    const client = stubClient({
+      distributions: [{ id: 'd1', name: 'Image' }],
+      versionsByDist: { d1: [version(2, 'complete')] },
+      artifactsByVersion: { v2: [artifact()] },
+    })
+    const rows = await listDistributionRows(client as never, HOST, new Map())
+    expect(rows[0]!.installedVersion).toBeUndefined()
+    expect(rows[0]!.state).toBe('installable')
+  })
+
   it('drops a distribution whose version lookup fails without failing the whole grid', async () => {
     const client = stubClient({
       distributions: [{ id: 'ok', name: 'Ok' }, { id: 'bad', name: 'Bad' }],

--- a/src/main/devplatform/distributions.ts
+++ b/src/main/devplatform/distributions.ts
@@ -1,0 +1,131 @@
+/**
+ * Distribution display + install-state policy: the UI layer, NOT the library.
+ *
+ * The comfy-builder library gives raw distributions / versions / artifacts and a
+ * pure host-matcher (`selectArtifactForHost`). This module applies the product
+ * policy on top: for each distribution it resolves the latest COMPLETE version,
+ * asks whether an artifact exists for THIS host, and flattens that into a single
+ * renderer-safe display row (`installable` / `no-build` / `platform-mismatch`).
+ * The renderer renders the row and, on click, asks main to install by id: the
+ * chosen artifact (and its download ref) never leaves the main process.
+ *
+ * `installed` / `update-available` are LOCAL states owned by the renderer (it
+ * de-dupes against the installations store), so they are deliberately absent
+ * here.
+ */
+// Import from the library's leaf modules (not its barrel): these are pure and
+// pull no Electron/filesystem side effects, so this policy module stays cheap to
+// load and to unit-test.
+import { hostOs, selectArtifactForHost } from '../comfybuilder/targets'
+import type { Artifact, Distribution, Host } from '../comfybuilder/types'
+import type { ComfyBuilderClient } from '../comfybuilder/client'
+import { detectGPU } from '../lib/gpu'
+
+/** The pre-install states this layer can decide from the catalog alone. */
+export type DistributionRowState = 'installable' | 'no-build' | 'platform-mismatch'
+
+/** One renderer-safe distribution tile row. Field names mirror the renderer's
+ *  `devplatform/types.ts` so swapping mocks for this stays mechanical. */
+export interface DistributionRow {
+  id: string
+  name: string
+  description?: string
+  version?: string
+  finishedAt?: string
+  numCustomNodes?: number
+  state: DistributionRowState
+  /** i18n suffix explaining a blocked state (see `devPlatform.distribution.blockedReason.*`). */
+  blockedReason?: string
+}
+
+/** What `installDistribution` resolves before it hands off to the install chain. */
+export interface ResolvedHostArtifact {
+  artifact: Artifact
+  version: number
+}
+
+/** The signed-in host's build target: OS from the platform, GPU from detection. */
+export async function resolveHost(): Promise<Host> {
+  const gpu = await detectGPU().catch(() => null)
+  // The library targets nvidia/amd/cpu/mps; an Intel dGPU (or none) maps to the
+  // universal CPU build, which `selectArtifactForHost` treats as the fallback.
+  const mapped =
+    gpu?.id === 'nvidia' || gpu?.id === 'amd' || gpu?.id === 'mps' ? gpu.id : 'cpu'
+  return { os: hostOs(), gpu: mapped }
+}
+
+/** Latest complete version, or null. `complete` is the only terminal status in
+ *  the builder's closed enum (queued | building | complete). */
+function latestCompleteVersion<T extends { version: number; status: string }>(versions: T[]): T | null {
+  const complete = versions
+    .filter((v) => v.status === 'complete')
+    .sort((a, b) => b.version - a.version)
+  return complete[0] ?? null
+}
+
+/**
+ * Resolve one distribution into a display row: newest complete version, then
+ * whether it has a host-runnable artifact. Never drops the distribution: an
+ * un-installable one becomes a blocked row with a reason, not a hidden entry.
+ */
+async function buildRow(
+  client: Pick<ComfyBuilderClient, 'listVersions' | 'getVersion'>,
+  host: Host,
+  dist: Distribution,
+): Promise<DistributionRow> {
+  const base: DistributionRow = {
+    id: dist.id,
+    name: dist.name,
+    ...(dist.description ? { description: dist.description } : {}),
+    ...(typeof dist.numCustomNodes === 'number' ? { numCustomNodes: dist.numCustomNodes } : {}),
+    state: 'no-build',
+  }
+
+  const latest = latestCompleteVersion(await client.listVersions(dist.id))
+  if (!latest) return { ...base, state: 'no-build', blockedReason: 'buildFailed' }
+
+  const withVersion: DistributionRow = {
+    ...base,
+    version: String(latest.version),
+    ...(latest.createdAt ? { finishedAt: latest.createdAt } : {}),
+  }
+
+  const { artifacts } = await client.getVersion(latest.id)
+  const artifact = selectArtifactForHost(artifacts, host)
+  if (!artifact) return { ...withVersion, state: 'platform-mismatch', blockedReason: 'noArtifactForMachine' }
+  return { ...withVersion, state: 'installable' }
+}
+
+/**
+ * Every distribution the signed-in workspace can see, as display rows. A
+ * distribution whose version lookup fails is dropped for THIS list rather than
+ * failing the whole grid.
+ */
+export async function listDistributionRows(client: ComfyBuilderClient, host: Host): Promise<DistributionRow[]> {
+  const dists = await client.listDistributions()
+  const results = await Promise.allSettled(dists.map((d) => buildRow(client, host, d)))
+  return results
+    .filter((r): r is PromiseFulfilledResult<DistributionRow> => {
+      if (r.status === 'rejected') console.error('[devplatform] failed to resolve distribution row:', r.reason)
+      return r.status === 'fulfilled'
+    })
+    .map((r) => r.value)
+}
+
+/**
+ * Resolve the artifact to install for one distribution on this host: the latest
+ * complete version's host-matched artifact, or null when none is runnable here.
+ * This is the same policy `listDistributionRows` renders, re-run at install time
+ * against fresh catalog data.
+ */
+export async function resolveHostArtifact(
+  client: Pick<ComfyBuilderClient, 'listVersions' | 'getVersion'>,
+  host: Host,
+  distributionId: string,
+): Promise<ResolvedHostArtifact | null> {
+  const latest = latestCompleteVersion(await client.listVersions(distributionId))
+  if (!latest) return null
+  const { artifacts } = await client.getVersion(latest.id)
+  const artifact = selectArtifactForHost(artifacts, host)
+  return artifact ? { artifact, version: latest.version } : null
+}

--- a/src/main/devplatform/distributions.ts
+++ b/src/main/devplatform/distributions.ts
@@ -9,9 +9,10 @@
  * The renderer renders the row and, on click, asks main to install by id: the
  * chosen artifact (and its download ref) never leaves the main process.
  *
- * `installed` / `update-available` are LOCAL states owned by the renderer (it
- * de-dupes against the installations store), so they are deliberately absent
- * here.
+ * `update-available` also lives here: given the installed version (passed in by
+ * the handler from the installations store), a row whose newer complete version
+ * has a host-runnable artifact is marked updatable. Plain `installed` (up to date)
+ * stays a renderer concern: it de-dupes those tiles out of the grid.
  */
 // Import from the library's leaf modules (not its barrel): these are pure and
 // pull no Electron/filesystem side effects, so this policy module stays cheap to
@@ -21,8 +22,17 @@ import type { Artifact, Distribution, Host } from '../comfybuilder/types'
 import type { ComfyBuilderClient } from '../comfybuilder/client'
 import { detectGPU } from '../lib/gpu'
 
-/** The pre-install states this layer can decide from the catalog alone. */
-export type DistributionRowState = 'installable' | 'no-build' | 'platform-mismatch'
+/**
+ * Distribution tile states. `installable` / `no-build` / `platform-mismatch` are
+ * decided from the catalog alone; `update-available` also needs the installed
+ * version (passed in), and only fires when the newer version has a host-runnable
+ * artifact (you can never "update" to a build with nothing for this machine).
+ */
+export type DistributionRowState =
+  | 'installable'
+  | 'no-build'
+  | 'platform-mismatch'
+  | 'update-available'
 
 /** One renderer-safe distribution tile row. Field names mirror the renderer's
  *  `devplatform/types.ts` so swapping mocks for this stays mechanical. */
@@ -34,6 +44,9 @@ export interface DistributionRow {
   finishedAt?: string
   numCustomNodes?: number
   state: DistributionRowState
+  /** The installed version of this distribution, when one backs it. Set for both
+   *  an up-to-date install and an `update-available` one; absent when not installed. */
+  installedVersion?: number
   /** i18n suffix explaining a blocked state (see `devPlatform.distribution.blockedReason.*`). */
   blockedReason?: string
 }
@@ -72,6 +85,7 @@ async function buildRow(
   client: Pick<ComfyBuilderClient, 'listVersions' | 'getVersion'>,
   host: Host,
   dist: Distribution,
+  installed?: ReadonlyMap<string, number>,
 ): Promise<DistributionRow> {
   const base: DistributionRow = {
     id: dist.id,
@@ -84,15 +98,21 @@ async function buildRow(
   const latest = latestCompleteVersion(await client.listVersions(dist.id))
   if (!latest) return { ...base, state: 'no-build', blockedReason: 'buildFailed' }
 
+  const installedVersion = installed?.get(dist.id)
   const withVersion: DistributionRow = {
     ...base,
     version: String(latest.version),
     ...(latest.createdAt ? { finishedAt: latest.createdAt } : {}),
+    ...(installedVersion !== undefined ? { installedVersion } : {}),
   }
 
   const { artifacts } = await client.getVersion(latest.id)
   const artifact = selectArtifactForHost(artifacts, host)
   if (!artifact) return { ...withVersion, state: 'platform-mismatch', blockedReason: 'noArtifactForMachine' }
+  // Installed at an older version, and the newer one runs here: offer the update.
+  if (installedVersion !== undefined && latest.version > installedVersion) {
+    return { ...withVersion, state: 'update-available' }
+  }
   return { ...withVersion, state: 'installable' }
 }
 
@@ -101,9 +121,13 @@ async function buildRow(
  * distribution whose version lookup fails is dropped for THIS list rather than
  * failing the whole grid.
  */
-export async function listDistributionRows(client: ComfyBuilderClient, host: Host): Promise<DistributionRow[]> {
+export async function listDistributionRows(
+  client: ComfyBuilderClient,
+  host: Host,
+  installed?: ReadonlyMap<string, number>,
+): Promise<DistributionRow[]> {
   const dists = await client.listDistributions()
-  const results = await Promise.allSettled(dists.map((d) => buildRow(client, host, d)))
+  const results = await Promise.allSettled(dists.map((d) => buildRow(client, host, d, installed)))
   return results
     .filter((r): r is PromiseFulfilledResult<DistributionRow> => {
       if (r.status === 'rejected') console.error('[devplatform] failed to resolve distribution row:', r.reason)

--- a/src/main/devplatform/session.ts
+++ b/src/main/devplatform/session.ts
@@ -1,0 +1,45 @@
+/**
+ * The single main-process CloudSession + the ComfyBuilderClient built from it.
+ *
+ * Both the IPC handlers (auth / workspaces / distributions / install) and the
+ * comfy-builder SourcePlugin's `install()` read the SAME session here, so a
+ * sign-in, workspace switch, or sign-out is reflected everywhere without any of
+ * them owning their own token state. The client pulls a bearer token from the
+ * session's `TokenProvider` per request; the token never leaves this process.
+ *
+ * `./config` is imported first, for its side effect: it seeds the staging
+ * `COMFY_CLOUD_ISSUER` default before the cloud library's config reads it.
+ */
+import { BUILDER_BASE_URL } from './config'
+import { CloudSession } from '../cloud'
+import { ComfyBuilderClient } from '../comfybuilder'
+
+let session: CloudSession | null = null
+let client: ComfyBuilderClient | null = null
+
+/** The process-wide CloudSession (auth + workspace), created on first use. */
+export function getCloudSession(): CloudSession {
+  if (!session) session = new CloudSession()
+  return session
+}
+
+/**
+ * The catalog client, bound to the shared session's token provider and the
+ * staging builder gateway. Cached: the session is the mutable part, and the
+ * provider it hands out always reads the current tokens.
+ */
+export function getBuilderClient(): ComfyBuilderClient {
+  if (!client) {
+    client = new ComfyBuilderClient({
+      baseUrl: BUILDER_BASE_URL,
+      auth: getCloudSession().asTokenProvider(),
+    })
+  }
+  return client
+}
+
+/** @internal: reset the singletons between tests. */
+export function _resetForTest(): void {
+  session = null
+  client = null
+}

--- a/src/main/lib/e2eHooks.ts
+++ b/src/main/lib/e2eHooks.ts
@@ -15,6 +15,8 @@ import {
   _test_ageEntries as _test_ageReleaseCacheEntries,
 } from './release-cache'
 import { _test_getOpenTitlePopupBounds } from '../popups/titlePopup'
+import { stageModels, resolveModelManifest } from '../comfybuilder'
+import { getBuilderClient } from '../devplatform/session'
 import { returnToDashboard } from '../host/detach'
 import { comfyWindows, getEntryByInstallationId, isInstallHost } from '../host/registry'
 import { ensurePanelView } from '../host/panelView'
@@ -79,6 +81,14 @@ export interface E2EHelpers {
   /** Mount the install-backed panelView for `installationId` (production mounts it lazily),
    *  so tests can reach `panel.html` immediately after a launch. Returns whether the entry exists. */
   ensureInstallPanelView(installationId: string): boolean
+  /** Run the REAL comfybuilder model-staging (resolve manifest -> download ->
+   *  verify -> place) against `installPath`, isolated from the archive/auth path.
+   *  Resolves to the staged `type/filename` list, or a typed error on failure. */
+  stageDistributionModels(opts: {
+    installPath: string
+    distributionId: string
+    version: string
+  }): Promise<{ staged: string[] } | { error: string; kind?: string }>
 }
 
 export function registerE2EHooks(): void {
@@ -130,6 +140,16 @@ export function registerE2EHooks(): void {
       if (!entry || entry.window.isDestroyed()) return false
       ensurePanelView(entry.windowKey, entry, 'comfy-lifecycle')
       return true
+    },
+    async stageDistributionModels({ installPath, distributionId, version }) {
+      const manifest = await resolveModelManifest(getBuilderClient(), distributionId, version)
+      try {
+        await stageModels({ models: manifest.models, installPath })
+        return { staged: manifest.models.map((m) => `${m.type}/${m.filename}`) }
+      } catch (e) {
+        const err = e as { message?: string; kind?: string }
+        return { error: err.message ?? String(e), ...(err.kind ? { kind: err.kind } : {}) }
+      }
     },
   }
   ;(globalThis as unknown as { __e2e: E2EHelpers }).__e2e = helpers

--- a/src/main/lib/ipc/index.ts
+++ b/src/main/lib/ipc/index.ts
@@ -34,6 +34,7 @@ import { setTerminalEnvResolver } from '../terminal'
 import { registerLogsHandlers } from './registerLogsHandlers'
 import { registerCrashHandlers } from './registerCrashHandlers'
 import { registerTelemetryHandlers } from './registerTelemetryHandlers'
+import { registerDevPlatformHandlers } from './registerDevPlatformHandlers'
 import { reconcileAdoptedSettings } from '../desktopAdopt'
 
 export {
@@ -267,5 +268,6 @@ export function register(callbacks: RegisterCallbacks = {}): Promise<void> {
   registerLogsHandlers()
   registerCrashHandlers()
   registerTelemetryHandlers()
+  registerDevPlatformHandlers()
   return startupMaintenance
 }

--- a/src/main/lib/ipc/registerDevPlatformHandlers.test.ts
+++ b/src/main/lib/ipc/registerDevPlatformHandlers.test.ts
@@ -18,6 +18,8 @@ const mocks = vi.hoisted(() => ({
   resolveHostArtifact: vi.fn(),
   // installations + shared helpers
   add: vi.fn(),
+  list: vi.fn(async () => [] as Record<string, unknown>[]),
+  update: vi.fn(),
   uniqueName: vi.fn(async (n: string) => n),
   sanitizeDirName: vi.fn((n: string) => n),
   allocateUniqueDir: vi.fn((parent: string, dir: string) => `${parent}/${dir}`),
@@ -49,7 +51,7 @@ vi.mock('../../devplatform/distributions', () => ({
 }))
 
 vi.mock('./shared', () => ({
-  installations: { add: mocks.add },
+  installations: { add: mocks.add, list: mocks.list, update: mocks.update },
   uniqueName: mocks.uniqueName,
   sanitizeDirName: mocks.sanitizeDirName,
   allocateUniqueDir: mocks.allocateUniqueDir,
@@ -167,6 +169,66 @@ describe('registerDevPlatformHandlers', () => {
   it('installDistribution refuses when signed out', async () => {
     mocks.isSignedIn.mockReturnValue(false)
     const result = await handler('comfybuilder:installDistribution')({}, 'd1')
+    expect(result).toMatchObject({ ok: false })
+    expect(mocks.resolveHostArtifact).not.toHaveBeenCalled()
+  })
+
+  it('listDistributions passes the installed-version map built from comfybuilder installs', async () => {
+    mocks.isSignedIn.mockReturnValue(true)
+    mocks.list.mockResolvedValue([
+      { id: 'i1', sourceId: 'comfybuilder', distributionId: 'd1', version: '3' },
+      { id: 'i2', sourceId: 'standalone', distributionId: 'ignored', version: '9' } // non-builder: excluded
+    ])
+    mocks.listDistributionRows.mockResolvedValue([])
+    await handler('comfybuilder:listDistributions')({})
+    const installed = mocks.listDistributionRows.mock.calls[0]![2] as Map<string, number>
+    expect(installed.get('d1')).toBe(3)
+    expect(installed.has('ignored')).toBe(false)
+  })
+
+  it('updateDistribution re-points the existing install at the new version + artifact', async () => {
+    mocks.isSignedIn.mockReturnValue(true)
+    mocks.resolveHostArtifact.mockResolvedValue({
+      version: 9,
+      artifact: { id: 'art-new', os: 'linux', gpu: 'nvidia', accelVariant: 'cu128', status: 'ready', archiveSha256: 'newhash' }
+    })
+    mocks.list.mockResolvedValue([
+      { id: 'inst-1', name: 'Image', sourceId: 'comfybuilder', distributionId: 'd1', version: '7' }
+    ])
+    mocks.update.mockResolvedValue({ id: 'inst-1', name: 'Image' })
+
+    const result = await handler('comfybuilder:updateDistribution')({}, 'd1')
+    expect(result).toEqual({ ok: true, entry: { id: 'inst-1', name: 'Image' } })
+    expect(mocks.update).toHaveBeenCalledWith(
+      'inst-1',
+      expect.objectContaining({ version: '9', artifactId: 'art-new', artifactSha256: 'newhash', status: 'installing' })
+    )
+    expect(mocks.add).not.toHaveBeenCalled() // updates in place, never a new record
+  })
+
+  it('updateDistribution refuses when the distribution is not installed', async () => {
+    mocks.isSignedIn.mockReturnValue(true)
+    mocks.resolveHostArtifact.mockResolvedValue({
+      version: 9,
+      artifact: { id: 'a', os: 'linux', gpu: 'nvidia', accelVariant: 'cu128', status: 'ready' }
+    })
+    mocks.list.mockResolvedValue([]) // nothing installed
+    const result = await handler('comfybuilder:updateDistribution')({}, 'd1')
+    expect(result).toMatchObject({ ok: false })
+    expect(mocks.update).not.toHaveBeenCalled()
+  })
+
+  it('updateDistribution refuses when no host artifact resolves', async () => {
+    mocks.isSignedIn.mockReturnValue(true)
+    mocks.resolveHostArtifact.mockResolvedValue(null)
+    const result = await handler('comfybuilder:updateDistribution')({}, 'd1')
+    expect(result).toMatchObject({ ok: false })
+    expect(mocks.list).not.toHaveBeenCalled()
+  })
+
+  it('updateDistribution refuses when signed out', async () => {
+    mocks.isSignedIn.mockReturnValue(false)
+    const result = await handler('comfybuilder:updateDistribution')({}, 'd1')
     expect(result).toMatchObject({ ok: false })
     expect(mocks.resolveHostArtifact).not.toHaveBeenCalled()
   })

--- a/src/main/lib/ipc/registerDevPlatformHandlers.test.ts
+++ b/src/main/lib/ipc/registerDevPlatformHandlers.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  handle: vi.fn(),
+  getAllWindows: vi.fn(() => [] as unknown[]),
+  // session
+  login: vi.fn(),
+  logout: vi.fn(),
+  status: vi.fn(),
+  isSignedIn: vi.fn(),
+  listWorkspaces: vi.fn(),
+  switchWorkspace: vi.fn(),
+  // client + policy
+  getBuilderClient: vi.fn(() => ({ listDistributions: mocks.listDistributions })),
+  listDistributions: vi.fn(),
+  resolveHost: vi.fn(async () => ({ os: 'linux', gpu: 'nvidia' })),
+  listDistributionRows: vi.fn(),
+  resolveHostArtifact: vi.fn(),
+  // installations + shared helpers
+  add: vi.fn(),
+  uniqueName: vi.fn(async (n: string) => n),
+  sanitizeDirName: vi.fn((n: string) => n),
+  allocateUniqueDir: vi.fn((parent: string, dir: string) => `${parent}/${dir}`),
+  findDuplicatePath: vi.fn(async () => null),
+  defaultInstallDir: vi.fn(() => '/installs')
+}))
+
+vi.mock('electron', () => ({
+  BrowserWindow: { getAllWindows: mocks.getAllWindows },
+  ipcMain: { handle: mocks.handle }
+}))
+
+vi.mock('../../devplatform/session', () => ({
+  getCloudSession: () => ({
+    login: mocks.login,
+    logout: mocks.logout,
+    status: mocks.status,
+    isSignedIn: mocks.isSignedIn,
+    listWorkspaces: mocks.listWorkspaces,
+    switchWorkspace: mocks.switchWorkspace
+  }),
+  getBuilderClient: mocks.getBuilderClient
+}))
+
+vi.mock('../../devplatform/distributions', () => ({
+  resolveHost: mocks.resolveHost,
+  listDistributionRows: mocks.listDistributionRows,
+  resolveHostArtifact: mocks.resolveHostArtifact
+}))
+
+vi.mock('./shared', () => ({
+  installations: { add: mocks.add },
+  uniqueName: mocks.uniqueName,
+  sanitizeDirName: mocks.sanitizeDirName,
+  allocateUniqueDir: mocks.allocateUniqueDir,
+  findDuplicatePath: mocks.findDuplicatePath,
+  defaultInstallDir: mocks.defaultInstallDir
+}))
+
+import { registerDevPlatformHandlers } from './registerDevPlatformHandlers'
+
+type IpcHandler = (event: unknown, ...args: unknown[]) => unknown
+
+function handler(channel: string): IpcHandler {
+  const call = mocks.handle.mock.calls.find(([name]) => name === channel)
+  expect(call, `handler for ${channel} was registered`).toBeDefined()
+  return call![1] as IpcHandler
+}
+
+describe('registerDevPlatformHandlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    registerDevPlatformHandlers()
+  })
+
+  it('signIn returns and broadcasts the status', async () => {
+    const win = { webContents: { isDestroyed: () => false, send: vi.fn() } }
+    mocks.getAllWindows.mockReturnValue([win])
+    mocks.login.mockResolvedValue({ signedIn: true, email: 'a@b.c', workspaceId: 'w1' })
+
+    const status = await handler('comfybuilder:signIn')({})
+    expect(status).toMatchObject({ signedIn: true, email: 'a@b.c' })
+    expect(win.webContents.send).toHaveBeenCalledWith('comfybuilder:authChanged', status)
+  })
+
+  it('signOut clears the session and broadcasts signed-out', async () => {
+    const win = { webContents: { isDestroyed: () => false, send: vi.fn() } }
+    mocks.getAllWindows.mockReturnValue([win])
+
+    const status = handler('comfybuilder:signOut')({})
+    expect(status).toEqual({ signedIn: false })
+    expect(mocks.logout).toHaveBeenCalledOnce()
+    expect(win.webContents.send).toHaveBeenCalledWith('comfybuilder:authChanged', { signedIn: false })
+  })
+
+  it('listDistributions is empty (no network) when signed out', async () => {
+    mocks.isSignedIn.mockReturnValue(false)
+    const rows = await handler('comfybuilder:listDistributions')({})
+    expect(rows).toEqual([])
+    expect(mocks.listDistributionRows).not.toHaveBeenCalled()
+  })
+
+  it('listDistributions returns rows for the signed-in workspace', async () => {
+    mocks.isSignedIn.mockReturnValue(true)
+    mocks.listDistributionRows.mockResolvedValue([{ id: 'd1', name: 'Image', state: 'installable' }])
+    const rows = await handler('comfybuilder:listDistributions')({})
+    expect(rows).toEqual([{ id: 'd1', name: 'Image', state: 'installable' }])
+  })
+
+  it('switchWorkspace re-scopes and broadcasts the new status', async () => {
+    const win = { webContents: { isDestroyed: () => false, send: vi.fn() } }
+    mocks.getAllWindows.mockReturnValue([win])
+    mocks.switchWorkspace.mockResolvedValue({ signedIn: true, workspaceId: 'w2', workspaceType: 'team' })
+
+    const status = await handler('comfybuilder:switchWorkspace')({}, 'w2')
+    expect(mocks.switchWorkspace).toHaveBeenCalledWith('w2')
+    expect(status).toMatchObject({ workspaceId: 'w2' })
+    expect(win.webContents.send).toHaveBeenCalledWith('comfybuilder:authChanged', status)
+  })
+
+  it('installDistribution creates an installing record carrying the resolved artifact', async () => {
+    mocks.isSignedIn.mockReturnValue(true)
+    mocks.resolveHostArtifact.mockResolvedValue({
+      version: 7,
+      artifact: { id: 'art-9', os: 'linux', gpu: 'nvidia', accelVariant: 'cu128', status: 'ready', archiveSha256: 'deadbeef' }
+    })
+    mocks.listDistributions.mockResolvedValue([{ id: 'd1', name: 'Image Baseline' }])
+    mocks.add.mockResolvedValue({ id: 'inst-1', name: 'Image Baseline' })
+
+    const result = await handler('comfybuilder:installDistribution')({}, 'd1')
+    expect(result).toEqual({ ok: true, entry: { id: 'inst-1', name: 'Image Baseline' } })
+    expect(mocks.add).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceId: 'comfybuilder',
+        distributionId: 'd1',
+        distributionName: 'Image Baseline',
+        version: '7',
+        artifactId: 'art-9',
+        artifactSha256: 'deadbeef',
+        status: 'installing'
+      })
+    )
+  })
+
+  it('installDistribution omits the sha field when the artifact has none (fails closed later)', async () => {
+    mocks.isSignedIn.mockReturnValue(true)
+    mocks.resolveHostArtifact.mockResolvedValue({
+      version: 1,
+      artifact: { id: 'art-nohash', os: 'linux', gpu: 'nvidia', accelVariant: 'cu128', status: 'ready' }
+    })
+    mocks.listDistributions.mockResolvedValue([{ id: 'd1', name: 'NoHash' }])
+    mocks.add.mockResolvedValue({ id: 'inst-2', name: 'NoHash' })
+
+    const result = await handler('comfybuilder:installDistribution')({}, 'd1')
+    expect(result).toMatchObject({ ok: true })
+    expect(mocks.add.mock.calls[0]![0]).not.toHaveProperty('artifactSha256')
+  })
+
+  it('installDistribution refuses when no host artifact resolves', async () => {
+    mocks.isSignedIn.mockReturnValue(true)
+    mocks.resolveHostArtifact.mockResolvedValue(null)
+    const result = await handler('comfybuilder:installDistribution')({}, 'd1')
+    expect(result).toMatchObject({ ok: false })
+    expect(mocks.add).not.toHaveBeenCalled()
+  })
+
+  it('installDistribution refuses when signed out', async () => {
+    mocks.isSignedIn.mockReturnValue(false)
+    const result = await handler('comfybuilder:installDistribution')({}, 'd1')
+    expect(result).toMatchObject({ ok: false })
+    expect(mocks.resolveHostArtifact).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/lib/ipc/registerDevPlatformHandlers.ts
+++ b/src/main/lib/ipc/registerDevPlatformHandlers.ts
@@ -1,0 +1,186 @@
+/**
+ * Dev-platform IPC bridge: the ONE seam between the renderer and the
+ * cloud-auth + comfy-builder libraries.
+ *
+ * Auth, workspace, distribution-catalog, and install-kickoff all funnel through
+ * the single main-process `CloudSession` (see `../../devplatform/session`).
+ * Access/refresh tokens NEVER cross this boundary: handlers return and broadcast
+ * only renderer-safe shapes: `AuthStatus`, `Workspace[]`, and distribution
+ * DISPLAY rows: never a token or a download ref.
+ */
+import { BrowserWindow, ipcMain } from 'electron'
+
+import { getBuilderClient, getCloudSession } from '../../devplatform/session'
+import {
+  listDistributionRows,
+  resolveHost,
+  resolveHostArtifact,
+} from '../../devplatform/distributions'
+import type { DistributionRow } from '../../devplatform/distributions'
+import type { AuthStatus, Workspace } from '../../cloud'
+import {
+  installations,
+  uniqueName,
+  sanitizeDirName,
+  allocateUniqueDir,
+  findDuplicatePath,
+  defaultInstallDir,
+} from './shared'
+
+/** IPC channels for the dev-platform bridge. Kept together so a rename can't desync. */
+export const DEVPLATFORM_CHANNELS = {
+  signIn: 'comfybuilder:signIn',
+  signOut: 'comfybuilder:signOut',
+  getAuthStatus: 'comfybuilder:getAuthStatus',
+  authChanged: 'comfybuilder:authChanged',
+  listWorkspaces: 'comfybuilder:listWorkspaces',
+  switchWorkspace: 'comfybuilder:switchWorkspace',
+  listDistributions: 'comfybuilder:listDistributions',
+  installDistribution: 'comfybuilder:installDistribution',
+} as const
+
+const SIGNED_OUT: AuthStatus = { signedIn: false }
+
+const COMFYBUILDER_SOURCE_ID = 'comfybuilder'
+const COMFYBUILDER_SOURCE_LABEL = 'ComfyBuilder'
+const COMFYBUILDER_LAUNCH_ARGS = '--enable-manager'
+
+/** Result of an install-kickoff: mirrors the `add-installation` handler's shape
+ *  so the renderer can drive the same `installInstance` + progress UI. */
+export interface InstallDistributionResult {
+  ok: boolean
+  message?: string
+  entry?: { id: string; name: string }
+}
+
+/**
+ * Push the renderer-safe {@link AuthStatus} to every window so all surfaces
+ * update in lockstep. Only the status (never tokens) is sent. Exported so a
+ * mid-request session expiry could announce itself later.
+ */
+export function broadcastAuthChanged(status: AuthStatus): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.webContents.isDestroyed()) win.webContents.send(DEVPLATFORM_CHANNELS.authChanged, status)
+  }
+}
+
+/**
+ * Register the dev-platform IPC handlers. Call once at startup.
+ *
+ * The renderer can never pass a token in or read one out: `signIn` takes no
+ * arguments and returns only the status; every catalog call reads the bearer
+ * token main-side via the session's `TokenProvider`.
+ */
+export function registerDevPlatformHandlers(): void {
+  const session = getCloudSession()
+
+  // Bumped by signOut so a sign-in already out in the browser when the user
+  // signs out cannot resurrect the session when its flow completes.
+  let signOutGeneration = 0
+
+  // Distribution ids whose install-kickoff is mid-flight, so a double-click
+  // cannot create two records for the same distribution.
+  const installing = new Set<string>()
+
+  ipcMain.handle(DEVPLATFORM_CHANNELS.signIn, async (): Promise<AuthStatus> => {
+    const generation = signOutGeneration
+    const status = await session.login()
+    // Signed out while the browser flow was in flight: the login persisted
+    // tokens, so drop them rather than leave a session the user tried to kill.
+    if (generation !== signOutGeneration) {
+      session.logout()
+      return SIGNED_OUT
+    }
+    broadcastAuthChanged(status)
+    return status
+  })
+
+  ipcMain.handle(DEVPLATFORM_CHANNELS.signOut, (): AuthStatus => {
+    signOutGeneration += 1
+    session.logout()
+    broadcastAuthChanged(SIGNED_OUT)
+    return SIGNED_OUT
+  })
+
+  ipcMain.handle(DEVPLATFORM_CHANNELS.getAuthStatus, (): AuthStatus => session.status())
+
+  ipcMain.handle(DEVPLATFORM_CHANNELS.listWorkspaces, (): Promise<Workspace[]> => session.listWorkspaces())
+
+  // A workspace switch re-runs sign-in pre-selecting the workspace (a PKCE token
+  // is scoped at consent time), so it can open the browser and change identity:
+  // broadcast the new status so every surface re-scopes together.
+  ipcMain.handle(DEVPLATFORM_CHANNELS.switchWorkspace, async (_event, workspaceId: string): Promise<AuthStatus> => {
+    const generation = signOutGeneration
+    const status = await session.switchWorkspace(workspaceId)
+    if (generation !== signOutGeneration) {
+      session.logout()
+      return SIGNED_OUT
+    }
+    broadcastAuthChanged(status)
+    return status
+  })
+
+  // Display rows for the current workspace. Signed out → empty (no network
+  // calls); the renderer already gates the grid on sign-in.
+  ipcMain.handle(DEVPLATFORM_CHANNELS.listDistributions, async (): Promise<DistributionRow[]> => {
+    if (!session.isSignedIn()) return []
+    const host = await resolveHost()
+    return listDistributionRows(getBuilderClient(), host)
+  })
+
+  // Resolve the host artifact for one distribution and create an `installing`
+  // record, then hand the id back so the renderer runs the normal
+  // `installInstance` + progress flow. The install itself (download → verify
+  // sha → extract) runs in the comfybuilder SourcePlugin.
+  ipcMain.handle(
+    DEVPLATFORM_CHANNELS.installDistribution,
+    async (_event, distributionId: string): Promise<InstallDistributionResult> => {
+      if (!session.isSignedIn()) return { ok: false, message: 'Not signed in.' }
+      if (installing.has(distributionId)) return { ok: false, message: 'Install already starting.' }
+      installing.add(distributionId)
+      try {
+        const client = getBuilderClient()
+        const host = await resolveHost()
+        const resolved = await resolveHostArtifact(client, host, distributionId)
+        if (!resolved) return { ok: false, message: 'No installable build for this machine.' }
+
+        // Name the install after the distribution. One extra list call keeps the
+        // renderer from having to pass a (spoofable) display name back to main.
+        const dists = await client.listDistributions()
+        const dist = dists.find((d) => d.id === distributionId)
+        const displayName = await uniqueName(dist?.name ?? distributionId)
+
+        const installPath = allocateUniqueDir(defaultInstallDir(), sanitizeDirName(displayName))
+        const duplicate = await findDuplicatePath(installPath)
+        if (duplicate) return { ok: false, message: `That directory is already used by "${duplicate.name}".` }
+
+        const { artifact } = resolved
+        const entry = await installations.add({
+          name: displayName,
+          sourceId: COMFYBUILDER_SOURCE_ID,
+          sourceLabel: COMFYBUILDER_SOURCE_LABEL,
+          installPath,
+          distributionId,
+          distributionName: dist?.name ?? distributionId,
+          version: String(resolved.version),
+          artifactId: artifact.id,
+          artifactOs: artifact.os,
+          artifactGpu: artifact.gpu,
+          artifactAccelVariant: artifact.accelVariant,
+          // May be absent until the builder populates it: carried through
+          // verbatim so `installArtifact` verifies whenever a hash is present.
+          ...(artifact.archiveSha256 ? { artifactSha256: artifact.archiveSha256 } : {}),
+          launchArgs: COMFYBUILDER_LAUNCH_ARGS,
+          launchMode: 'window',
+          browserPartition: 'unique',
+          status: 'installing',
+          seen: false,
+        })
+
+        return { ok: true, entry: { id: entry.id, name: entry.name } }
+      } finally {
+        installing.delete(distributionId)
+      }
+    },
+  )
+}

--- a/src/main/lib/ipc/registerDevPlatformHandlers.ts
+++ b/src/main/lib/ipc/registerDevPlatformHandlers.ts
@@ -37,6 +37,7 @@ export const DEVPLATFORM_CHANNELS = {
   switchWorkspace: 'comfybuilder:switchWorkspace',
   listDistributions: 'comfybuilder:listDistributions',
   installDistribution: 'comfybuilder:installDistribution',
+  updateDistribution: 'comfybuilder:updateDistribution',
 } as const
 
 const SIGNED_OUT: AuthStatus = { signedIn: false }
@@ -121,11 +122,12 @@ export function registerDevPlatformHandlers(): void {
   })
 
   // Display rows for the current workspace. Signed out → empty (no network
-  // calls); the renderer already gates the grid on sign-in.
+  // calls); the renderer already gates the grid on sign-in. The installed-version
+  // map lets a row whose newer build runs here surface as `update-available`.
   ipcMain.handle(DEVPLATFORM_CHANNELS.listDistributions, async (): Promise<DistributionRow[]> => {
     if (!session.isSignedIn()) return []
     const host = await resolveHost()
-    return listDistributionRows(getBuilderClient(), host)
+    return listDistributionRows(getBuilderClient(), host, await installedDistributionVersions())
   })
 
   // Resolve the host artifact for one distribution and create an `installing`
@@ -183,4 +185,58 @@ export function registerDevPlatformHandlers(): void {
       }
     },
   )
+
+  // Update an installed distribution to its latest host-compatible version:
+  // re-point the EXISTING record at the new artifact + version and hand the id
+  // back so the renderer drives the same `installInstance` + progress flow. The
+  // plugin lays down a clean venv on re-install; staged models are preserved.
+  ipcMain.handle(
+    DEVPLATFORM_CHANNELS.updateDistribution,
+    async (_event, distributionId: string): Promise<InstallDistributionResult> => {
+      if (!session.isSignedIn()) return { ok: false, message: 'Not signed in.' }
+      if (installing.has(distributionId)) return { ok: false, message: 'Update already starting.' }
+      installing.add(distributionId)
+      try {
+        const client = getBuilderClient()
+        const host = await resolveHost()
+        const resolved = await resolveHostArtifact(client, host, distributionId)
+        if (!resolved) return { ok: false, message: 'No installable build for this machine.' }
+
+        const existing = (await installations.list()).find(
+          (i) => i.sourceId === COMFYBUILDER_SOURCE_ID && i.distributionId === distributionId,
+        )
+        if (!existing) return { ok: false, message: 'This distribution is not installed.' }
+
+        const { artifact } = resolved
+        const updated = await installations.update(existing.id, {
+          version: String(resolved.version),
+          artifactId: artifact.id,
+          artifactOs: artifact.os,
+          artifactGpu: artifact.gpu,
+          artifactAccelVariant: artifact.accelVariant,
+          ...(artifact.archiveSha256 ? { artifactSha256: artifact.archiveSha256 } : {}),
+          status: 'installing',
+        })
+        if (!updated) return { ok: false, message: 'This distribution is not installed.' }
+
+        return { ok: true, entry: { id: updated.id, name: updated.name } }
+      } finally {
+        installing.delete(distributionId)
+      }
+    },
+  )
+}
+
+/** distributionId -> highest installed version, over the comfybuilder installs,
+ *  so `listDistributionRows` can mark an outdated one `update-available`. */
+async function installedDistributionVersions(): Promise<Map<string, number>> {
+  const map = new Map<string, number>()
+  for (const inst of await installations.list()) {
+    if (inst.sourceId !== COMFYBUILDER_SOURCE_ID) continue
+    const id = inst.distributionId
+    const version = Number(inst.version)
+    if (typeof id !== 'string' || !id || !Number.isFinite(version)) continue
+    map.set(id, Math.max(version, map.get(id) ?? Number.NEGATIVE_INFINITY))
+  }
+  return map
 }

--- a/src/main/sources/comfybuilder/index.test.ts
+++ b/src/main/sources/comfybuilder/index.test.ts
@@ -1,0 +1,155 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: { getPath: () => '', isPackaged: false },
+  ipcMain: { handle: vi.fn() },
+  BrowserWindow: { fromWebContents: vi.fn() },
+  dialog: {},
+  shell: { openPath: vi.fn().mockResolvedValue('') },
+  net: { request: vi.fn() },
+}))
+
+// Stub the library so install() wiring can be asserted without real downloads.
+vi.mock('../../comfybuilder', () => ({
+  installArtifact: vi.fn(async () => {}),
+  buildLaunchSpec: vi.fn(() => null),
+  stageModels: vi.fn(async () => {}),
+  resolveModelManifest: vi.fn(async () => ({ models: [], modelPolicy: null, partnerNodePolicy: null })),
+}))
+vi.mock('../../devplatform/session', () => ({ getBuilderClient: vi.fn(() => ({})) }))
+
+import { installArtifact, stageModels, resolveModelManifest } from '../../comfybuilder'
+import { comfybuilder, withAccelArgs } from './index'
+import type { InstallationRecord } from '../../installations'
+import type { InstallTools } from '../../types/sources'
+
+const record = (overrides: Record<string, unknown> = {}): InstallationRecord =>
+  ({
+    id: 'i1',
+    name: 'desktop-4target-stg-v0190',
+    sourceId: 'comfybuilder',
+    installPath: '/installs/dist',
+    status: 'installed',
+    distributionId: 'd1',
+    distributionName: 'desktop-4target-stg-v0190',
+    version: '1',
+    ...overrides,
+  }) as unknown as InstallationRecord
+
+function fakeTools(signal?: AbortSignal): InstallTools & { sent: Array<{ phase: string; detail: unknown }> } {
+  const sent: Array<{ phase: string; detail: unknown }> = []
+  return {
+    sent,
+    sendProgress: (phase: string, detail: unknown) => sent.push({ phase, detail }),
+    download: vi.fn(),
+    cache: {} as never,
+    extract: vi.fn(),
+    ...(signal ? { signal } : {}),
+  } as never
+}
+
+describe('comfybuilder.install wiring', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('installs the archive, then resolves the manifest, then stages models', async () => {
+    const tools = fakeTools()
+    await comfybuilder.install!(record(), tools)
+
+    expect(installArtifact).toHaveBeenCalledTimes(1)
+    expect(resolveModelManifest).toHaveBeenCalledTimes(1)
+    expect(stageModels).toHaveBeenCalledTimes(1)
+    // The archive must be in place before models are staged into its tree.
+    const archiveOrder = (installArtifact as unknown as { mock: { invocationCallOrder: number[] } }).mock.invocationCallOrder[0]!
+    const stageOrder = (stageModels as unknown as { mock: { invocationCallOrder: number[] } }).mock.invocationCallOrder[0]!
+    expect(archiveOrder).toBeLessThan(stageOrder)
+
+    // The manifest is keyed by the record's distribution + version number.
+    expect(resolveModelManifest).toHaveBeenCalledWith(expect.anything(), 'd1', '1')
+    // A terminal models progress event fires so the step completes.
+    expect(tools.sent.some((s) => s.phase === 'models')).toBe(true)
+  })
+
+  it('folds the library resolve phase into the download step', async () => {
+    const tools = fakeTools()
+    await comfybuilder.install!(record(), tools)
+    const onProgress = (installArtifact as unknown as { mock: { calls: Array<[{ onProgress: (p: unknown) => void }]> } }).mock.calls[0]![0].onProgress
+    onProgress({ phase: 'resolve', percent: 0 })
+    expect(tools.sent.some((s) => s.phase === 'download')).toBe(true)
+    expect(tools.sent.some((s) => s.phase === 'resolve')).toBe(false)
+  })
+
+  it('threads the abort signal into both phases', async () => {
+    const signal = new AbortController().signal
+    await comfybuilder.install!(record(), fakeTools(signal))
+    expect((installArtifact as unknown as { mock: { calls: Array<[{ signal?: AbortSignal }]> } }).mock.calls[0]![0].signal).toBe(signal)
+    expect((stageModels as unknown as { mock: { calls: Array<[{ signal?: AbortSignal }]> } }).mock.calls[0]![0].signal).toBe(signal)
+  })
+})
+
+describe('comfybuilder.getListActions', () => {
+  // Without this the renderer gets an empty action array, reads the install as
+  // unlaunchable, and bounces a tile click into the new-install wizard.
+  it.each([
+    ['installed', 'installed', true],
+    ['installing', 'installing', false],
+    ['failed', 'failed', false],
+  ])('exposes a launch action for a %s install (enabled=%s)', (_name, status, enabled) => {
+    const actions = comfybuilder.getListActions!(record({ status }))
+    expect(actions).toHaveLength(1)
+    expect(actions[0]).toMatchObject({ id: 'launch', style: 'primary', enabled })
+  })
+
+  it('surfaces the launch progress UI so the boot wait is not silent', () => {
+    const [action] = comfybuilder.getListActions!(record())
+    expect(action).toMatchObject({ showProgress: true, cancellable: true })
+    expect(action!.progressTitle).toBeTruthy()
+  })
+
+  it('explains itself when disabled', () => {
+    const [action] = comfybuilder.getListActions!(record({ status: 'installing' }))
+    expect(action!.disabledMessage).toBeTruthy()
+  })
+})
+
+describe('comfybuilder.getListPreview', () => {
+  it('yields to the source label when it would echo the tile title', () => {
+    expect(comfybuilder.getListPreview!(record())).toBeNull()
+  })
+
+  it('surfaces the distribution once a rename has made the two differ', () => {
+    expect(comfybuilder.getListPreview!(record({ name: 'My Renamed Install' })))
+      .toBe('desktop-4target-stg-v0190')
+  })
+})
+
+describe('comfybuilder.withAccelArgs', () => {
+  // The flag tracks the INSTALLED ARTIFACT, not the host. `selectArtifactForHost`
+  // treats a cpu build as the universal fallback, so an nvidia machine lands on
+  // a cpu artifact whenever the distribution has no nvidia build: that torch is
+  // still CPU-only and ComfyUI would assert "Torch not compiled with CUDA
+  // enabled" without --cpu. nvidia/amd/mps builds bring their own accelerated
+  // torch and are auto-detected, so they take no flag.
+  it.each([
+    ['cpu build', 'cpu', 'cpu', '--enable-manager --cpu'],
+    ['cpu build on an nvidia host (no nvidia build published)', 'cpu', 'cpu', '--enable-manager --cpu'],
+    ['nvidia build', 'nvidia', 'cu128', '--enable-manager'],
+    ['amd build', 'amd', 'rocm6.2', '--enable-manager'],
+    ['mps build', 'mps', 'mps', '--enable-manager'],
+  ])('%s', (_name, artifactGpu, artifactAccelVariant, expected) => {
+    expect(withAccelArgs(record({ artifactGpu, artifactAccelVariant }), '--enable-manager')).toBe(expected)
+  })
+
+  it('falls back to accelVariant when the gpu field is absent', () => {
+    expect(withAccelArgs(record({ artifactGpu: undefined, artifactAccelVariant: 'cpu' }), '--enable-manager'))
+      .toBe('--enable-manager --cpu')
+  })
+
+  it.each(['--cpu', '--enable-manager --cpu', '--cpu --listen'])('does not double up on %s', (args) => {
+    expect(withAccelArgs(record({ artifactGpu: 'cpu' }), args)).toBe(args)
+  })
+
+  it('does not mistake --cpu-vae for the cpu flag', () => {
+    expect(withAccelArgs(record({ artifactGpu: 'cpu' }), '--cpu-vae')).toBe('--cpu-vae --cpu')
+  })
+})

--- a/src/main/sources/comfybuilder/index.test.ts
+++ b/src/main/sources/comfybuilder/index.test.ts
@@ -19,6 +19,7 @@ vi.mock('../../comfybuilder', () => ({
 }))
 vi.mock('../../devplatform/session', () => ({ getBuilderClient: vi.fn(() => ({})) }))
 
+import { promises as fsp } from 'fs'
 import { installArtifact, stageModels, resolveModelManifest } from '../../comfybuilder'
 import { comfybuilder, withAccelArgs } from './index'
 import type { InstallationRecord } from '../../installations'
@@ -51,6 +52,23 @@ function fakeTools(signal?: AbortSignal): InstallTools & { sent: Array<{ phase: 
 
 describe('comfybuilder.install wiring', () => {
   beforeEach(() => vi.clearAllMocks())
+
+  it('wipes the venv before extracting so a re-install/update lays down a clean env', async () => {
+    const rm = vi.spyOn(fsp, 'rm').mockResolvedValue(undefined)
+    try {
+      await comfybuilder.install!(record(), fakeTools())
+      expect(rm).toHaveBeenCalledWith(
+        expect.stringContaining('venv'),
+        expect.objectContaining({ recursive: true, force: true }),
+      )
+      // The venv must be gone before the archive lays down a fresh one.
+      const rmOrder = rm.mock.invocationCallOrder[0]!
+      const installOrder = (installArtifact as unknown as { mock: { invocationCallOrder: number[] } }).mock.invocationCallOrder[0]!
+      expect(rmOrder).toBeLessThan(installOrder)
+    } finally {
+      rm.mockRestore()
+    }
+  })
 
   it('installs the archive, then resolves the manifest, then stages models', async () => {
     const tools = fakeTools()

--- a/src/main/sources/comfybuilder/index.ts
+++ b/src/main/sources/comfybuilder/index.ts
@@ -1,0 +1,180 @@
+/**
+ * ComfyBuilder install source: main process only.
+ *
+ * A thin SourcePlugin over the comfy-builder functionality library. The catalog
+ * / host-matching / sign-in all happen in the dev-platform IPC layer; by the
+ * time an install record reaches here it already carries the chosen artifact's
+ * identity (id + os/gpu/accel + sha256). `install()` hands that artifact to the
+ * library's `installArtifact` (download, verify sha, extract into the install
+ * dir), and `getLaunchCommand()` drives the extracted `venv/` via
+ * `buildLaunchSpec`. There is no adopt/probe path: a ComfyBuilder install is
+ * only ever created by the dev-platform flow, never discovered on disk.
+ *
+ * Launch parity matters as much as install: the renderer discovers whether an
+ * install can run from `getListActions`, so omitting it silently downgrades a
+ * distribution to "not launchable" and bounces a tile click into the
+ * new-install wizard. That is why `getListActions` below exists even though it
+ * looks like boilerplate.
+ */
+import { installArtifact, buildLaunchSpec, stageModels, resolveModelManifest } from '../../comfybuilder'
+import type { Artifact, ArtifactGpu, ArtifactOs, InstallProgress, StageProgress } from '../../comfybuilder'
+import { getBuilderClient } from '../../devplatform/session'
+import { launchAction } from '../../lib/actions'
+import { defaultDownloadCacheDir } from '../../lib/paths'
+import { t } from '../../lib/i18n'
+import type { InstallationRecord } from '../../installations'
+import type {
+  SourcePlugin,
+  LaunchCommand,
+  ActionResult,
+  InstallTools,
+} from '../../types/sources'
+
+const DEFAULT_LAUNCH_ARGS = '--enable-manager'
+
+/** Reconstruct the library Artifact from the fields the install record carries. */
+function artifactFromRecord(inst: InstallationRecord): Artifact {
+  return {
+    id: (inst.artifactId as string) ?? '',
+    os: (inst.artifactOs as ArtifactOs) ?? 'linux',
+    gpu: (inst.artifactGpu as ArtifactGpu) ?? 'cpu',
+    accelVariant: (inst.artifactAccelVariant as string) ?? '',
+    status: 'ready',
+    ...(inst.artifactSha256 ? { archiveSha256: inst.artifactSha256 as string } : {}),
+  }
+}
+
+/**
+ * Pin the accelerator args the installed artifact implies.
+ *
+ * A CPU artifact ships a CPU-only torch, and ComfyUI defaults to probing CUDA:
+ * without `--cpu` it dies at import with "Torch not compiled with CUDA enabled".
+ * Which artifact got installed is a property of the machine, not a user
+ * preference, so it is pinned here rather than baked into the editable launch
+ * args. Skipped when the user already passed `--cpu` themselves. nvidia/amd/mps
+ * need no flag: torch and ComfyUI detect those on their own.
+ */
+export function withAccelArgs(installation: InstallationRecord, launchArgs: string): string {
+  const isCpu = installation.artifactGpu === 'cpu' || installation.artifactAccelVariant === 'cpu'
+  if (!isCpu || /(?:^|\s)--cpu(?:\s|$)/.test(launchArgs)) return launchArgs
+  return `${launchArgs} --cpu`.trim()
+}
+
+export const comfybuilder: SourcePlugin = {
+  id: 'comfybuilder',
+  label: 'ComfyBuilder',
+  description: 'Install a ComfyUI distribution built with ComfyBuilder.',
+  category: 'local',
+  // Never a "New Install" wizard source: records are created by the dev-platform
+  // distribution flow, so it must not appear in the generic source picker.
+  hidden: true,
+  fields: [],
+  defaultLaunchArgs: DEFAULT_LAUNCH_ARGS,
+
+  get installSteps() {
+    return [
+      { phase: 'download', label: t('common.download') },
+      { phase: 'extract', label: t('common.extract') },
+      { phase: 'models', label: t('comfybuilder.stageModels') },
+    ]
+  },
+
+  getDefaults() {
+    return { launchArgs: DEFAULT_LAUNCH_ARGS, launchMode: 'window', browserPartition: 'unique' }
+  },
+
+  buildInstallation(): Record<string, unknown> {
+    // Records are assembled by `installDistribution` (which already knows the
+    // resolved artifact), not the generic build-installation chain.
+    return { launchArgs: DEFAULT_LAUNCH_ARGS, launchMode: 'window', browserPartition: 'unique' }
+  },
+
+  // The tile prefers this over the source label, and the install is named after
+  // the distribution, so returning the name here would echo the tile title and
+  // hide the one label marking this as a distribution. Surface it only once a
+  // rename has made the two differ.
+  getListPreview(installation: InstallationRecord): string | null {
+    const distributionName = (installation.distributionName as string) || ''
+    return distributionName && distributionName !== installation.name ? distributionName : null
+  },
+
+  getLaunchCommand(installation: InstallationRecord): LaunchCommand | null {
+    const spec = buildLaunchSpec(installation.installPath, {
+      launchArgs: withAccelArgs(installation, (installation.launchArgs as string | undefined) ?? DEFAULT_LAUNCH_ARGS),
+    })
+    if (!spec) return null
+    return { cmd: spec.cmd, args: spec.args, cwd: spec.cwd, port: spec.port }
+  },
+
+  // Launch is discovered through this list, not through `getLaunchCommand`: a
+  // plugin without it hands the renderer an empty action array, which reads as
+  // "this install cannot launch" and bounces a tile click into the new-install
+  // wizard. Distributions launch like any other local install.
+  getListActions(installation: InstallationRecord): Record<string, unknown>[] {
+    const installed = installation.status === 'installed'
+    return [launchAction(installed, !installed ? t('errors.installNotReady') : undefined)]
+  },
+
+  getDetailSections(installation: InstallationRecord): Record<string, unknown>[] {
+    return [
+      {
+        tab: 'status',
+        title: 'Installation Info',
+        fields: [
+          { label: 'Install method', value: (installation.sourceLabel as string) || 'ComfyBuilder' },
+          { label: 'Distribution', value: (installation.distributionName as string) || '-' },
+          { label: 'Version', value: (installation.version as string) || '-' },
+        ],
+      },
+    ]
+  },
+
+  // A ComfyBuilder install is never discovered on disk: only the dev-platform
+  // flow creates one: so there is nothing to probe/adopt.
+  probeInstallation(): Record<string, unknown> | null {
+    return null
+  },
+
+  async install(installation: InstallationRecord, tools: InstallTools): Promise<void> {
+    const artifact = artifactFromRecord(installation)
+    const client = getBuilderClient()
+    // Phase 1: archive (code + environment). `installArtifact` verifies the
+    // sha256 when the artifact carries one and fails on a byte mismatch. A
+    // missing hash is skipped for the initial rollout (see the TODO there).
+    await installArtifact({
+      artifact,
+      client,
+      installPath: installation.installPath,
+      cacheDir: defaultDownloadCacheDir(),
+      onProgress: (p: InstallProgress) => {
+        // The library's `resolve` phase has no labeled step; fold it into the
+        // download step at 0% so the stepper still shows forward motion.
+        const phase = p.phase === 'resolve' ? 'download' : p.phase
+        tools.sendProgress(phase, { percent: p.percent, status: p.detail ?? '' })
+      },
+      ...(tools.signal ? { signal: tools.signal } : {}),
+    })
+
+    // Phase 2: models. The archive carries no weights, so stage the
+    // distribution's declared models into the install's ComfyUI model tree
+    // before launch, the way comfy-deploy provisions a volume before boot. An
+    // empty manifest stages nothing and the step completes immediately.
+    const manifest = await resolveModelManifest(
+      client,
+      installation.distributionId as string,
+      installation.version as string,
+    )
+    await stageModels({
+      models: manifest.models,
+      installPath: installation.installPath,
+      onProgress: (p: StageProgress) =>
+        tools.sendProgress('models', { percent: p.percent, status: `${p.filename} (${p.index}/${p.total})` }),
+      ...(tools.signal ? { signal: tools.signal } : {}),
+    })
+    tools.sendProgress('models', { percent: 100, status: '' })
+  },
+
+  async handleAction(actionId: string): Promise<ActionResult> {
+    return { ok: false, message: `Action "${actionId}" not yet implemented.` }
+  },
+}

--- a/src/main/sources/comfybuilder/index.ts
+++ b/src/main/sources/comfybuilder/index.ts
@@ -16,6 +16,8 @@
  * new-install wizard. That is why `getListActions` below exists even though it
  * looks like boilerplate.
  */
+import { promises as fs } from 'fs'
+import path from 'path'
 import { installArtifact, buildLaunchSpec, stageModels, resolveModelManifest } from '../../comfybuilder'
 import type { Artifact, ArtifactGpu, ArtifactOs, InstallProgress, StageProgress } from '../../comfybuilder'
 import { getBuilderClient } from '../../devplatform/session'
@@ -138,6 +140,11 @@ export const comfybuilder: SourcePlugin = {
   async install(installation: InstallationRecord, tools: InstallTools): Promise<void> {
     const artifact = artifactFromRecord(installation)
     const client = getBuilderClient()
+    // A venv can't be overlaid (leftover site-packages from the old version break
+    // Python), so remove it before extracting. No-op on a first install; on an
+    // update/retry it guarantees a clean environment. The archive lays down a
+    // fresh venv; staged models under ComfyUI/models are left untouched.
+    await fs.rm(path.join(installation.installPath, 'venv'), { recursive: true, force: true })
     // Phase 1: archive (code + environment). `installArtifact` verifies the
     // sha256 when the artifact carries one and fails on a byte mismatch. A
     // missing hash is skipped for the initial rollout (see the TODO there).

--- a/src/main/sources/index.ts
+++ b/src/main/sources/index.ts
@@ -4,8 +4,9 @@ import { gitSource } from './git'
 import { remote } from './remote'
 import { cloud } from './cloud'
 import { desktop } from './desktop'
+import { comfybuilder } from './comfybuilder'
 import type { SourcePlugin } from '../types/sources'
 
-const sources: SourcePlugin[] = [standalone, portable, gitSource, cloud, remote, desktop]
+const sources: SourcePlugin[] = [standalone, portable, gitSource, cloud, remote, desktop, comfybuilder]
 
 export default sources

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -200,6 +200,26 @@ export function buildElectronApi(): ElectronApi {
     getInstallsInventory: () => ipcRenderer.invoke('get-installs-inventory'),
     getDeviceId: () => ipcRenderer.invoke('get-device-id'),
 
+    // Dev platform (cloud auth + comfy-builder). Tokens never cross IPC; these
+    // only ever carry AuthStatus / Workspace / distribution display rows.
+    comfybuilder: {
+      signIn: () => ipcRenderer.invoke('comfybuilder:signIn'),
+      signOut: () => ipcRenderer.invoke('comfybuilder:signOut'),
+      getAuthStatus: () => ipcRenderer.invoke('comfybuilder:getAuthStatus'),
+      onAuthChanged: (callback) => {
+        const handler = (_event: IpcRendererEvent, status: unknown) =>
+          callback(status as Parameters<typeof callback>[0])
+        ipcRenderer.on('comfybuilder:authChanged', handler)
+        return () => ipcRenderer.removeListener('comfybuilder:authChanged', handler)
+      },
+      listWorkspaces: () => ipcRenderer.invoke('comfybuilder:listWorkspaces'),
+      switchWorkspace: (workspaceId) =>
+        ipcRenderer.invoke('comfybuilder:switchWorkspace', workspaceId),
+      listDistributions: () => ipcRenderer.invoke('comfybuilder:listDistributions'),
+      installDistribution: (distributionId) =>
+        ipcRenderer.invoke('comfybuilder:installDistribution', distributionId)
+    },
+
     // Model downloads
     listModelDownloads: () => ipcRenderer.invoke('model-download-list'),
     pauseModelDownload: (url) => ipcRenderer.invoke('model-download-pause', { url }),

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -217,7 +217,9 @@ export function buildElectronApi(): ElectronApi {
         ipcRenderer.invoke('comfybuilder:switchWorkspace', workspaceId),
       listDistributions: () => ipcRenderer.invoke('comfybuilder:listDistributions'),
       installDistribution: (distributionId) =>
-        ipcRenderer.invoke('comfybuilder:installDistribution', distributionId)
+        ipcRenderer.invoke('comfybuilder:installDistribution', distributionId),
+      updateDistribution: (distributionId) =>
+        ipcRenderer.invoke('comfybuilder:updateDistribution', distributionId)
     },
 
     // Model downloads

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -4,6 +4,49 @@
 import type { FirstUseMode } from '../shared/firstUseMode'
 export type { FirstUseMode }
 
+// Dev-platform (cloud auth + comfy-builder) renderer-safe types. Re-exported
+// from the cloud library so the renderer imports them from one place; tokens
+// are never part of these shapes.
+import type { AuthStatus, Workspace } from '../main/cloud/types'
+export type { AuthStatus, Workspace }
+
+/** Every state a distribution tile can be in. The first four are pre-install;
+ *  the last two are local (renderer-owned via de-dup against installs). */
+export type DevPlatformDistributionState =
+  | 'installable'
+  | 'no-build'
+  | 'platform-mismatch'
+  | 'needs-desktop-update'
+  | 'installed'
+  | 'update-available'
+
+/** One distribution as a renderer-safe display row. The install-decision fields
+ *  (artifact id / download ref) stay main-side; the renderer installs by id. */
+export interface DevPlatformDistribution {
+  id: string
+  name: string
+  description?: string
+  version?: string
+  /** ISO 8601 finish stamp of the latest complete build. */
+  finishedAt?: string
+  sizeBytes?: number
+  numCustomNodes?: number
+  state: DevPlatformDistributionState
+  /** i18n suffix explaining a blocking state (see `devPlatform.distribution.blockedReason.*`). */
+  blockedReason?: string
+  minDesktopVersion?: string
+  /** Local-only: present for installed / update-available. */
+  installedVersion?: string
+}
+
+/** Kickoff result of `installDistribution`: mirrors `addInstallation` so the
+ *  renderer drives the same `installInstance` + progress flow. */
+export interface InstallDistributionResult {
+  ok: boolean
+  message?: string
+  entry?: { id: string; name: string }
+}
+
 // Unsubscribe function returned by event listeners
 export type Unsubscribe = () => void
 
@@ -1299,6 +1342,20 @@ export interface ElectronApi {
    *  stay under PostHog's 1 MB per-event limit (shipped as `installs_json`). */
   getInstallsInventory(): Promise<InstallsInventory>
   getDeviceId(): Promise<string>
+
+  // Dev platform (cloud auth + comfy-builder): the only renderer<->main bridge
+  // for this flow. Access/refresh tokens never cross IPC: every method returns
+  // or observes a renderer-safe AuthStatus / Workspace / distribution row.
+  comfybuilder: {
+    signIn(): Promise<AuthStatus>
+    signOut(): Promise<AuthStatus>
+    getAuthStatus(): Promise<AuthStatus>
+    onAuthChanged(callback: (status: AuthStatus) => void): Unsubscribe
+    listWorkspaces(): Promise<Workspace[]>
+    switchWorkspace(workspaceId: string): Promise<AuthStatus>
+    listDistributions(): Promise<DevPlatformDistribution[]>
+    installDistribution(distributionId: string): Promise<InstallDistributionResult>
+  }
 
   // Updates
   checkForUpdate(): Promise<{ available: boolean; version?: string; error?: string }>

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -1355,6 +1355,7 @@ export interface ElectronApi {
     switchWorkspace(workspaceId: string): Promise<AuthStatus>
     listDistributions(): Promise<DevPlatformDistribution[]>
     installDistribution(distributionId: string): Promise<InstallDistributionResult>
+    updateDistribution(distributionId: string): Promise<InstallDistributionResult>
   }
 
   // Updates


### PR DESCRIPTION
> Scope: the main-process interaction layer for distributions - the shared cloud session, the IPC handlers (sign-in, workspace, list, install), host/artifact resolution, and the comfybuilder install/launch source plugin. Renderer-only UX (account chip, distribution tiles, ChooserView) was split into #1313 so it can iterate independently. This PR does not touch the core install/launch pipeline; it registers a new source plugin into it.

## TL;DR

Layer C: the Desktop UI that connects the two already-built libraries (`src/main/cloud` auth+workspace, `src/main/comfybuilder` distributions) into a working flow: **sign in -> choose workspace -> list distributions -> click to install and launch**. Mostly UI + IPC glue; the one library change is the sha256 policy noted at the bottom.

Stacked on `james/cloud-auth-workspace`.

## Intent / Why

The two functionality libraries exist but nothing wires them to the renderer. This PR adds the single main-process `CloudSession` both libraries hang off, the IPC bridge that exposes it renderer-safely, a `comfybuilder` install source that runs the library's installer, and the chooser UI (account chip + workspace switcher + distribution tiles) that a user actually drives. Tokens never cross the IPC boundary; the renderer only ever sees `AuthStatus`, `Workspace[]`, and distribution display rows.

## Decision

- **One session, one client, shared everywhere.** `src/main/devplatform/session.ts` holds the process-wide `CloudSession` and a `ComfyBuilderClient` built from `session.asTokenProvider()`. The IPC handlers and the install source read the same session, so a sign-in / switch / sign-out is reflected everywhere.
- **Install-state policy lives in the UI layer, not the library.** `src/main/devplatform/distributions.ts` resolves each distribution's latest complete version and runs `selectArtifactForHost(...)` to decide `installable` / `no-build` / `platform-mismatch`. This mirrors #1293's display-type + policy; the library stays pure.
- **Install reuses the existing chain.** `installDistribution` resolves the host artifact, creates an `installing` record carrying the chosen artifact (id + os/gpu/accel + sha256), and returns `{ ok, entry }` like `add-installation`. The renderer then drives the normal `installInstance` + progress UI via the `show-progress` event the chooser already forwards. A hidden `comfybuilder` SourcePlugin runs the actual download -> verify sha -> extract via the library's `installArtifact`, and launches via `buildLaunchSpec`.
- **Launch is discovered from `getListActions`, so the plugin must implement it.** Both renderer launch paths (`performChooserLaunch` / `performPickerLaunch`) resolve the launch action solely from `get-list-actions`. A SourcePlugin that omits the hook returns `[]`, which reads as "this install cannot launch": the tile click fell through to `switchPanel('new-install')` and created an unrelated vanilla standalone install, and post-install `autoLaunchOnFinish` silently no-opped at 70%. Implementing the hook restores auto-launch, tile-click launch, focus-if-already-running, and the "Starting ComfyUI" progress state during the boot wait. `getLaunchCommand` alone was never enough.
- **`getListPreview` defers to the source label.** The install is named after its distribution, so echoing `distributionName` duplicated the tile title and hid the one label identifying the tile as a distribution. It now returns the name only once a rename has made the two differ.
- **Accelerator args come from the installed artifact, not the host.** A cpu artifact ships CPU-only torch, so ComfyUI must be told `--cpu` or it probes CUDA and dies at import with "Torch not compiled with CUDA enabled". Keying off the artifact is what makes the fallback case right: `selectArtifactForHost` treats a cpu build as the universal fallback, so an nvidia machine lands on cpu-only torch whenever the distribution publishes no nvidia build, and still needs the flag. nvidia/amd/mps builds bring their own accelerated torch and take none. Pinned in `getLaunchCommand` rather than baked into the editable launch args, matching how the standalone source pins its structural args.
- **Workspace switcher is the new capability.** The account-chip dropdown lists `listWorkspaces()` and switches via `switchWorkspace()` (which re-runs the browser handoff pre-selecting the workspace, since a PKCE token is scoped at consent time).
- **Staging via env defaults.** `COMFY_CLOUD_ISSUER` defaults to `stagingcloud.comfy.org` and the builder base URL to `stagingplatformapi.comfy.org/builder`, both overridable by the environment.

## Illustration

```
Before:  cloud/ + comfybuilder/ libraries          (no renderer, no IPC)
         ChooserView: install tiles only

After:   ChooserView
           |- DevPlatformAccountChip  --(comfybuilder:signIn/listWorkspaces/switchWorkspace)-->  CloudSession
           |- DevPlatformDistributionCard[]  --(comfybuilder:listDistributions)-->  ComfyBuilderClient
                on click  --(comfybuilder:installDistribution)-->  resolve artifact + create record
                                                                    |
                          --(install-instance)-->  comfybuilder SourcePlugin.install -> installArtifact
                                                                    |
                                                    normal install-progress UI
                                                                    |
                          --(get-list-actions)-->  [launch]  --(run-action 'launch')-->  handleLaunch
                                                                    |
                                        getLaunchCommand -> buildLaunchSpec -> spawn venv/ python
                                                                    |
                                              ComfyUI serves; window attaches to the SAME record
                                              (keeps distributionId / distributionName / version)
```

## Implementation Details

**Main**
- `src/main/devplatform/config.ts` - staging env defaults (imported before the cloud config reads the issuer).
- `src/main/devplatform/session.ts` - shared `CloudSession` + `ComfyBuilderClient` singletons.
- `src/main/devplatform/distributions.ts` - display-row + install-state policy (`listDistributionRows`, `resolveHostArtifact`, host GPU detection).
- `src/main/sources/comfybuilder/index.ts` - hidden SourcePlugin; `install()` -> `installArtifact`, `getLaunchCommand()` -> `buildLaunchSpec`, `getListActions()` -> the launch action the renderer resolves against. Registered in `src/main/sources/index.ts`.
- `src/main/lib/ipc/registerDevPlatformHandlers.ts` - the 8 IPC channels + `authChanged` broadcast. Registered in `src/main/lib/ipc/index.ts`.
- `src/preload/api.ts`, `src/types/ipc.ts` - `api.comfybuilder.*` bridge + renderer-safe types.

**Renderer**
- `src/renderer/src/stores/authStore.ts` - pinia session store (status, workspaces, distributions).
- `src/renderer/src/views/devplatform/` - `DevPlatformAccountChip.vue` (with workspace switcher), `DevPlatformAvatar.vue`, `DevPlatformDistributionCard.vue`, `devplatform-tiles.css`.
- `src/renderer/src/devplatform/types.ts` - renderer type aliases.
- `src/renderer/src/views/ChooserView.vue` - account chip + distribution tiles + real install wiring.
- `locales/en.json`, `locales/zh.json` - `devPlatform.*` strings.

**Tests:** `distributions.test.ts` (policy), `registerDevPlatformHandlers.test.ts` (IPC handlers), `authStore.test.ts` (store), `sources/comfybuilder/index.test.ts` (launch action + list preview), plus updated `ChooserView.test.ts`. New e2e `e2e/comfybuilder-launch.test.ts` drives a seeded distribution tile through the real Electron app and asserts it launches instead of opening the new-install wizard. Tagged `@windows @macos` so it runs in CI, since the `lifecycle` project is not in the CI matrix. It is not tagged `@linux`: seeding install records does not work under that project (all 27 other seeding tests in `e2e/` are lifecycle-only, so this path had never run there and the tiles never render), which is a harness gap unrelated to this change. `typecheck`, `lint`, and the full `vitest run` (2923 tests) are green.

## Wired end-to-end vs. stubbed

- **End-to-end:** sign-in -> workspace list/switch -> distribution list -> install (record creation + real download/verify/extract via the library) -> launch spec. All against real staging endpoints.
- **Renderer-owned local states** (`installed` / `update-available`) are handled by the chooser's de-dup against the installations store, not the catalog.

## Archive sha256: verify-when-present

`installArtifact` originally failed closed when an artifact carried no `outputSha256`. The builder does not populate that field yet (every staging artifact returns `null`), so fail-closed blocked every install. Per product call for the initial rollout, a hash that IS present is still enforced byte-for-byte; a MISSING hash installs unverified and logs a warning, with a `TODO` to fail closed once the builder computes it (cloud #5489 adds the build-side hashing).

Note this touches `src/main/comfybuilder/install.ts`, which belongs to #1295. It is committed here deliberately: `installArtifact`'s only caller is `src/main/sources/comfybuilder/index.ts`, which is added in this PR, so the policy is unreachable library code until this PR lands. The behaviour change and its activation land together.

## Validation

- Unit: 205 files / 2923 tests green; `typecheck` (all 4 projects) and `lint` clean.
- E2E on macOS: the full `macos` project (the one CI runs) is 44/44 with it included. Proven to be a real regression test by removing `getListActions`, rebuilding, and confirming it fails; the failure screenshot shows the app sitting on the "Configure Comfy Desktop" wizard, which is exactly the reported bug.
- E2E on a Windows VM: same suite green against the real Electron app, and green in CI on Windows.
- Full manual e2e on Windows against a real 4.5 GB staging distribution (`desktop-4target-stg-v0190`): sign in -> workspace -> distribution list -> download 1.39 GB -> extract -> install record -> tile click dispatches `run-action('launch')` -> ComfyUI boots from the archive's `venv/` and serves on 8188 in roughly 60s.
- Both accelerator paths verified on real Windows GCE hosts. CPU host: the record as `installDistribution` writes it (`--enable-manager`, `artifactGpu=cpu`, no hand-seeded flag) boots and serves on 8188. NVIDIA host (Tesla T4, driver 596.36): the nvidia artifact (torch 2.8.0+cu128) launches with no `--cpu` and `/system_stats` reports `cuda:0 Tesla T4`.
- The 8 pre-existing failures in the full `lifecycle` e2e project were confirmed to fail identically on the unmodified baseline, so they are not caused by this change.






