### PR TITLE
feat(telemetry): add Firebase auth consensus

### DIFF
--- a/packages/comfyui-desktop-bridge-types/comfyDesktopBridge.d.ts
+++ b/packages/comfyui-desktop-bridge-types/comfyDesktopBridge.d.ts
@@ -29,6 +29,14 @@ export interface LogsOutputMsg {
 }
 export type ComfyDesktop2TelemetryValue = string | number | boolean | null;
 export type ComfyDesktop2TelemetryProperties = Record<string, ComfyDesktop2TelemetryValue | ComfyDesktop2TelemetryValue[]>;
+export type ComfyDesktop2FirebaseAuthState = {
+    status: 'pending';
+} | {
+    status: 'signed_out';
+} | {
+    status: 'signed_in';
+    userId: string;
+};
 export interface ComfyDesktop2TerminalBridge {
     subscribe(installationId?: string): Promise<TerminalRestore>;
     unsubscribe(installationId?: string): Promise<void>;
@@ -47,6 +55,8 @@ export interface ComfyDesktop2LogsBridge {
 }
 export interface ComfyDesktop2TelemetryBridge {
     capture(event: string, properties?: ComfyDesktop2TelemetryProperties): void;
+    /** Report the hosted view's complete Firebase state for process-wide consensus. */
+    reportFirebaseAuthState?(state: ComfyDesktop2FirebaseAuthState): void;
 }
 export interface ComfyDesktop2Bridge {
     isRemote(): boolean;

--- a/packages/comfyui-desktop-bridge-types/package.json
+++ b/packages/comfyui-desktop-bridge-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comfyorg/comfyui-desktop-bridge-types",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "TypeScript definitions for the Comfy Desktop hosted frontend bridge",
   "type": "module",
   "main": "./index.js",

--- a/src/main/auth/firebaseBridge/flowShared.ts
+++ b/src/main/auth/firebaseBridge/flowShared.ts
@@ -1,5 +1,6 @@
 import type { BrowserWindow, WebContents } from 'electron'
 
+import { bindMainVerifiedFirebaseUser } from '../../lib/firebaseAuthIdentity'
 import * as mainTelemetry from '../../lib/telemetry'
 import { extractErrorClass } from '../../../shared/errorEvent'
 
@@ -59,8 +60,8 @@ export function emitSignInFailure(
   return failure
 }
 
-/** Bind the anonymous installation to the resolved Firebase user. */
-export function bindSignedInUser(user: Record<string, unknown>, _source: WebContents): void {
+/** Submit a Desktop-verified Firebase user to the process-wide identity consensus. */
+export function bindSignedInUser(user: Record<string, unknown>, source: WebContents): void {
   try {
     const uid = typeof user.uid === 'string' && user.uid.length > 0 ? user.uid : null
     if (!uid) return
@@ -73,7 +74,7 @@ export function bindSignedInUser(user: Record<string, unknown>, _source: WebCont
     }
     if (email) properties.email = email
     if (emailDomain) properties.email_domain = emailDomain
-    mainTelemetry.bindUserId(uid, properties)
+    bindMainVerifiedFirebaseUser(uid, properties, source)
   } catch {
     // Telemetry must never break the auth flow.
   }

--- a/src/main/host/attach.ts
+++ b/src/main/host/attach.ts
@@ -12,6 +12,10 @@ import { noteCloudEntered } from '../lib/cloudEntry'
 import { noteCanvasRendered } from '../lib/canvasEntry'
 import { forwardDatadogError } from '../lib/processErrorHandlers'
 import { recordInstanceSurface } from '../lib/lastSession'
+import {
+  activateFirebaseAuthReporter,
+  deactivateFirebaseAuthReporter
+} from '../lib/firebaseAuthIdentity'
 import { convertLevelToZoomPercent } from '../lib/zoom'
 import { clearPendingTemplateOpen, installationEvents, type InstallationRecord } from '../installations'
 import { buildTemplateDeeplink } from '../sources/standalone/curatedTemplates'
@@ -139,6 +143,7 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
   const comfyContents = entry.comfyView.webContents
   const comfyWindow = entry.window
   const titleBarView = entry.titleBarView
+  activateFirebaseAuthReporter(comfyContents)
 
   // Seed entry install state. The secondary index is the source of
   // truth for `getEntryByInstallationId(id)` — keep it in lockstep
@@ -626,6 +631,7 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
   entry._installCleanup = (): void => {
     if (entry._installCleanup === null) return
     entry._installCleanup = null
+    deactivateFirebaseAuthReporter(comfyContents)
     installationEvents.off('updated', onInstallationUpdated)
     cancelFailRetry()
     if (!comfyContents.isDestroyed()) {

--- a/src/main/host/createHostWindow.ts
+++ b/src/main/host/createHostWindow.ts
@@ -33,6 +33,7 @@ import {
 } from '../lib/ipc/shared'
 import * as mainTelemetry from '../lib/telemetry'
 import { getUserTier } from '../lib/userTier'
+import { trackFirebaseAuthReporter } from '../lib/firebaseAuthIdentity'
 import { forwardDatadogError } from '../lib/processErrorHandlers'
 import { recordDashboardSurface, recordInstanceSurface } from '../lib/lastSession'
 import * as settings from '../settings'
@@ -1156,6 +1157,7 @@ export function buildComfyView(
   comfyView.setBackgroundColor(COMFY_BG)
 
   const comfyContents = comfyView.webContents
+  trackFirebaseAuthReporter(comfyContents)
   // Eagerly attach the will-download handler to the comfy view's
   // session so any `session.downloadURL(...)` call below — or a server-
   // initiated `Content-Disposition: attachment` response — flows

--- a/src/main/lib/anonymousIdentity.test.ts
+++ b/src/main/lib/anonymousIdentity.test.ts
@@ -24,9 +24,12 @@ vi.mock('./safe-file', async (importOriginal) => {
 
 import {
   anonymousDistinctIdPath,
+  clearPersistedUnmergeableAnonymousEpoch,
   getOrCreateAnonymousDistinctId,
+  hasPersistedUnmergeableAnonymousEpoch,
   normalizeAnonymousDistinctId,
   persistAnonymousDistinctId,
+  persistUnmergeableAnonymousEpoch,
   readPersistedAnonymousDistinctId,
   rotatePersistedAnonymousDistinctId
 } from './anonymousIdentity'
@@ -77,6 +80,26 @@ describe('anonymousIdentity', () => {
 
     expect(rotatePersistedAnonymousDistinctId()).toBeNull()
     expect(readPersistedAnonymousDistinctId()).toBe(ANONYMOUS_ID_1)
+  })
+
+  it('persists an unmergeable epoch across restarts until a clean rotation clears it', () => {
+    expect(persistAnonymousDistinctId(ANONYMOUS_ID_1)).toBe(true)
+    expect(persistUnmergeableAnonymousEpoch()).toBe(true)
+
+    expect(hasPersistedUnmergeableAnonymousEpoch()).toBe(true)
+    expect(readPersistedAnonymousDistinctId()).toBe(ANONYMOUS_ID_1)
+    expect(rotatePersistedAnonymousDistinctId()).not.toBeNull()
+    expect(clearPersistedUnmergeableAnonymousEpoch()).toBe(true)
+    expect(hasPersistedUnmergeableAnonymousEpoch()).toBe(false)
+  })
+
+  it('deletes the reusable identity if the taint marker cannot be written', () => {
+    expect(persistAnonymousDistinctId(ANONYMOUS_ID_1)).toBe(true)
+    safeFileMock.failWrites = true
+
+    expect(persistUnmergeableAnonymousEpoch()).toBe(true)
+    expect(readPersistedAnonymousDistinctId()).toBeNull()
+    expect(hasPersistedUnmergeableAnonymousEpoch()).toBe(false)
   })
 })
 

--- a/src/main/lib/anonymousIdentity.ts
+++ b/src/main/lib/anonymousIdentity.ts
@@ -5,6 +5,7 @@ import { configDir } from './paths'
 import { writeFileSafe } from './safe-file'
 
 const ANONYMOUS_DISTINCT_ID_FILE = 'posthog-anonymous-distinct-id.txt'
+const UNMERGEABLE_EPOCH_FILE = 'posthog-anonymous-epoch-unmergeable'
 const UUID_PATTERN = /^[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/
 
 export function normalizeAnonymousDistinctId(value: unknown): string | null {
@@ -49,4 +50,40 @@ export function getOrCreateAnonymousDistinctId(): string {
 export function rotatePersistedAnonymousDistinctId(): string | null {
   const anonymousDistinctId = randomUUID()
   return persistAnonymousDistinctId(anonymousDistinctId) ? anonymousDistinctId : null
+}
+
+function unmergeableEpochPath(): string {
+  return path.join(configDir(), UNMERGEABLE_EPOCH_FILE)
+}
+
+export function hasPersistedUnmergeableAnonymousEpoch(): boolean {
+  try {
+    return fs.readFileSync(unmergeableEpochPath(), 'utf-8') === '1'
+  } catch {
+    return false
+  }
+}
+
+/** Persist taint, or delete the reusable identity as a fail-safe fallback. */
+export function persistUnmergeableAnonymousEpoch(): boolean {
+  try {
+    writeFileSafe(unmergeableEpochPath(), '1')
+    return true
+  } catch {
+    try {
+      fs.rmSync(anonymousDistinctIdPath(), { force: true })
+      return !fs.existsSync(anonymousDistinctIdPath())
+    } catch {
+      return false
+    }
+  }
+}
+
+export function clearPersistedUnmergeableAnonymousEpoch(): boolean {
+  try {
+    fs.rmSync(unmergeableEpochPath(), { force: true })
+    return true
+  } catch {
+    return false
+  }
 }

--- a/src/main/lib/firebaseAuthIdentity.test.ts
+++ b/src/main/lib/firebaseAuthIdentity.test.ts
@@ -1,0 +1,864 @@
+import { EventEmitter } from 'node:events'
+import type { WebContents } from 'electron'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const telemetry = vi.hoisted(() => ({
+  applyFirebaseAnonymousConsensus: vi.fn(),
+  applyFirebaseUserConsensus: vi.fn(),
+  bindUserId: vi.fn(),
+  registerPersonProperties: vi.fn(),
+  discardUnmergeableAnonymousEpoch: vi.fn(() => true),
+  hasUnmergeableAnonymousEpoch: vi.fn(() => false),
+  markAnonymousEpochUnmergeable: vi.fn(() => true)
+}))
+
+vi.mock('./telemetry', () => telemetry)
+
+const verifiedLocalUsers = vi.hoisted(() => new Map<string, string>())
+const verifiedLocalPersistence = vi.hoisted(() => ({ succeeds: true }))
+vi.mock('./verifiedLocalFirebaseAuth', () => ({
+  isLoopbackOrigin: (origin: string) => {
+    try {
+      const url = new URL(origin)
+      return url.hostname === 'localhost' || url.hostname.startsWith('127.')
+    } catch {
+      return false
+    }
+  },
+  readVerifiedLocalFirebaseUser: (origin: string) => verifiedLocalUsers.get(origin) ?? null,
+  persistVerifiedLocalFirebaseUser: (origin: string, userId: string) => {
+    if (!verifiedLocalPersistence.succeeds) return false
+    verifiedLocalUsers.set(origin, userId)
+    return true
+  },
+  clearVerifiedLocalFirebaseUser: (origin: string) => {
+    verifiedLocalUsers.delete(origin)
+    return true
+  }
+}))
+
+import {
+  _resetForTest,
+  activateFirebaseAuthReporter,
+  bindMainVerifiedFirebaseUser,
+  deactivateFirebaseAuthReporter,
+  reportFirebaseAuthState as recordFirebaseAuthState,
+  trackFirebaseAuthReporter
+} from './firebaseAuthIdentity'
+
+class FakeWebContents extends EventEmitter {
+  private destroyed = false
+  private loadingMainFrame = false
+  private nextRoutingId = 1
+  private currentMainFrame: {
+    processId: number
+    routingId: number
+    url: string
+  }
+
+  constructor(url: string) {
+    super()
+    this.currentMainFrame = { processId: 100, routingId: this.nextRoutingId, url }
+  }
+
+  getURL(): string {
+    return this.currentMainFrame.url
+  }
+
+  get mainFrame(): { processId: number; routingId: number; url: string } {
+    return this.currentMainFrame
+  }
+
+  isDestroyed(): boolean {
+    return this.destroyed
+  }
+
+  isLoadingMainFrame(): boolean {
+    return this.loadingMainFrame
+  }
+
+  navigate(url: string, isInPlace = false, isMainFrame = true): void {
+    this.startNavigation(url, isInPlace, isMainFrame)
+    if (!isMainFrame) return
+    if (isInPlace) {
+      this.currentMainFrame = { ...this.currentMainFrame, url }
+      return
+    }
+    this.commitNavigation(url)
+  }
+
+  startNavigation(url: string, isInPlace = false, isMainFrame = true): void {
+    if (isMainFrame && !isInPlace) this.loadingMainFrame = true
+    this.emit('did-start-navigation', {
+      url,
+      isSameDocument: isInPlace,
+      isMainFrame,
+      frame: isMainFrame ? this.currentMainFrame : null
+    })
+  }
+
+  commitNavigation(url: string, anotherNavigationIsLoading = false): void {
+    this.nextRoutingId += 1
+    this.currentMainFrame = {
+      processId: 100,
+      routingId: this.nextRoutingId,
+      url
+    }
+    this.loadingMainFrame = anotherNavigationIsLoading
+    this.emit(
+      'did-frame-navigate',
+      {},
+      url,
+      200,
+      'OK',
+      true,
+      this.currentMainFrame.processId,
+      this.currentMainFrame.routingId
+    )
+  }
+
+  failProvisionalNavigation(url: string): void {
+    this.emit(
+      'did-fail-provisional-load',
+      {},
+      -3,
+      'ERR_ABORTED',
+      url,
+      true,
+      this.currentMainFrame.processId,
+      this.currentMainFrame.routingId
+    )
+  }
+
+  failNavigation(
+    url: string,
+    errorCode: number = -105,
+    error: string = 'ERR_NAME_NOT_RESOLVED'
+  ): void {
+    this.emit(
+      'did-fail-load',
+      {},
+      errorCode,
+      error,
+      url,
+      true,
+      this.currentMainFrame.processId,
+      this.currentMainFrame.routingId
+    )
+  }
+
+  stopLoading(): void {
+    this.loadingMainFrame = false
+    this.emit('did-stop-loading')
+  }
+
+  destroy(): void {
+    this.destroyed = true
+    this.emit('destroyed')
+  }
+
+  asWebContents(): WebContents {
+    return this as unknown as WebContents
+  }
+}
+
+function reportFirebaseAuthState(
+  webContents: WebContents,
+  state: Parameters<typeof recordFirebaseAuthState>[2]
+): void {
+  const frame = webContents.mainFrame
+  recordFirebaseAuthState(
+    webContents,
+    { processId: frame.processId, routingId: frame.routingId },
+    state
+  )
+}
+
+const cloudUrl = 'https://cloud.comfy.org/workspaces/test'
+
+function activate(reporter: FakeWebContents): void {
+  trackFirebaseAuthReporter(reporter.asWebContents())
+  activateFirebaseAuthReporter(reporter.asWebContents())
+  reporter.commitNavigation(reporter.getURL())
+}
+
+describe('firebaseAuthIdentity consensus', () => {
+  beforeEach(() => {
+    _resetForTest()
+    vi.clearAllMocks()
+    telemetry.discardUnmergeableAnonymousEpoch.mockReturnValue(true)
+    telemetry.hasUnmergeableAnonymousEpoch.mockReturnValue(false)
+    telemetry.markAnonymousEpochUnmergeable.mockReturnValue(true)
+    verifiedLocalUsers.clear()
+    verifiedLocalPersistence.succeeds = true
+  })
+
+  it('waits for every live trusted reporter before binding one agreed user', () => {
+    const first = new FakeWebContents(cloudUrl)
+    const second = new FakeWebContents(cloudUrl)
+    activate(first)
+    activate(second)
+
+    reportFirebaseAuthState(first.asWebContents(), { status: 'signed_in', userId: 'F' })
+    expect(telemetry.applyFirebaseUserConsensus).not.toHaveBeenCalled()
+
+    reportFirebaseAuthState(second.asWebContents(), { status: 'signed_in', userId: 'F' })
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('F')
+    expect(telemetry.discardUnmergeableAnonymousEpoch).not.toHaveBeenCalled()
+  })
+
+  it('waits for active renderer consensus after a main-verified sign-in', () => {
+    const reporter = new FakeWebContents(cloudUrl)
+    activate(reporter)
+    vi.clearAllMocks()
+
+    bindMainVerifiedFirebaseUser(
+      'F',
+      { signed_in_via: 'desktop_2' },
+      reporter.asWebContents()
+    )
+    expect(telemetry.bindUserId).not.toHaveBeenCalled()
+    expect(telemetry.registerPersonProperties).not.toHaveBeenCalled()
+
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_out' })
+    expect(telemetry.applyFirebaseUserConsensus).not.toHaveBeenCalled()
+  })
+
+  it('applies main-verified properties only after that hosted reporter confirms the UID', () => {
+    const reporter = new FakeWebContents(cloudUrl)
+    activate(reporter)
+    vi.clearAllMocks()
+
+    bindMainVerifiedFirebaseUser(
+      'F',
+      { signed_in_via: 'desktop_2' },
+      reporter.asWebContents()
+    )
+    reporter.navigate(cloudUrl)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+
+    expect(telemetry.bindUserId).toHaveBeenCalledWith('F', {
+      signed_in_via: 'desktop_2'
+    })
+  })
+
+  it('waits for a scoped local reporter after main-verified sign-in and across reload', () => {
+    const localUrl = 'http://127.0.0.1:8188/'
+    const reporter = new FakeWebContents(localUrl)
+    activate(reporter)
+    vi.clearAllMocks()
+
+    bindMainVerifiedFirebaseUser(
+      'F',
+      { signed_in_via: 'desktop_2' },
+      reporter.asWebContents()
+    )
+    expect(telemetry.bindUserId).not.toHaveBeenCalled()
+
+    reporter.navigate(localUrl)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+    expect(telemetry.bindUserId).toHaveBeenCalledWith('F', {
+      signed_in_via: 'desktop_2'
+    })
+
+    vi.clearAllMocks()
+    reporter.navigate(localUrl)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+
+    expect(telemetry.applyFirebaseAnonymousConsensus).toHaveBeenCalledTimes(1)
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('F')
+    expect(telemetry.markAnonymousEpochUnmergeable).not.toHaveBeenCalled()
+  })
+
+  it('unbinds a scoped local user on logout and rejects an unverified replacement', () => {
+    const localUrl = 'http://127.0.0.1:8188/'
+    const reporter = new FakeWebContents(localUrl)
+    activate(reporter)
+    bindMainVerifiedFirebaseUser('F', {}, reporter.asWebContents())
+    reporter.navigate(localUrl)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+    vi.clearAllMocks()
+
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_out' })
+    expect(telemetry.applyFirebaseAnonymousConsensus).toHaveBeenCalledTimes(1)
+    expect(verifiedLocalUsers.size).toBe(0)
+
+    vi.clearAllMocks()
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'attacker' })
+    expect(telemetry.applyFirebaseUserConsensus).not.toHaveBeenCalled()
+    expect(telemetry.bindUserId).not.toHaveBeenCalled()
+  })
+
+  it('unbinds a scoped local user when the page switches directly to an unverified user', () => {
+    const localUrl = 'http://127.0.0.1:8188/'
+    const reporter = new FakeWebContents(localUrl)
+    activate(reporter)
+    bindMainVerifiedFirebaseUser('F', {}, reporter.asWebContents())
+    reporter.navigate(localUrl)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+    vi.clearAllMocks()
+
+    reportFirebaseAuthState(reporter.asWebContents(), {
+      status: 'signed_in',
+      userId: 'attacker'
+    })
+
+    expect(telemetry.applyFirebaseAnonymousConsensus).toHaveBeenCalledTimes(1)
+    expect(telemetry.applyFirebaseUserConsensus).not.toHaveBeenCalled()
+    expect(telemetry.bindUserId).not.toHaveBeenCalled()
+    expect(verifiedLocalUsers.size).toBe(0)
+
+    vi.clearAllMocks()
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+    expect(telemetry.applyFirebaseUserConsensus).not.toHaveBeenCalled()
+    expect(telemetry.bindUserId).not.toHaveBeenCalled()
+  })
+
+  it('revokes remote fallback trust on a direct account switch', () => {
+    const remoteUrl = 'http://192.168.1.2:8188/'
+    const reporter = new FakeWebContents(remoteUrl)
+    activate(reporter)
+    bindMainVerifiedFirebaseUser('F', {}, reporter.asWebContents())
+    expect(telemetry.bindUserId).toHaveBeenCalledWith('F', {})
+    vi.clearAllMocks()
+
+    reportFirebaseAuthState(reporter.asWebContents(), {
+      status: 'signed_in',
+      userId: 'attacker'
+    })
+    expect(telemetry.applyFirebaseAnonymousConsensus).toHaveBeenCalledTimes(1)
+    expect(telemetry.applyFirebaseUserConsensus).not.toHaveBeenCalled()
+
+    vi.clearAllMocks()
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+    expect(telemetry.applyFirebaseUserConsensus).not.toHaveBeenCalled()
+  })
+
+  it('revokes remote fallback trust on logout', () => {
+    const remoteUrl = 'http://192.168.1.2:8188/'
+    const reporter = new FakeWebContents(remoteUrl)
+    activate(reporter)
+    bindMainVerifiedFirebaseUser('F', {}, reporter.asWebContents())
+    vi.clearAllMocks()
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_out' })
+    expect(telemetry.applyFirebaseAnonymousConsensus).toHaveBeenCalledTimes(1)
+    expect(telemetry.applyFirebaseUserConsensus).not.toHaveBeenCalled()
+
+    vi.clearAllMocks()
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+    expect(telemetry.applyFirebaseUserConsensus).not.toHaveBeenCalled()
+  })
+
+  it('keeps a remote fallback pending through commit until its new frame confirms', () => {
+    const remoteUrl = 'http://192.168.1.2:8188/'
+    const reporter = new FakeWebContents(remoteUrl)
+    activate(reporter)
+    bindMainVerifiedFirebaseUser('F', {}, reporter.asWebContents())
+    vi.clearAllMocks()
+
+    reporter.startNavigation(remoteUrl)
+    expect(telemetry.applyFirebaseAnonymousConsensus).toHaveBeenCalledTimes(1)
+    reporter.commitNavigation(remoteUrl)
+    expect(telemetry.applyFirebaseUserConsensus).not.toHaveBeenCalled()
+
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('F')
+  })
+
+  it('retains a remote fallback logout reported while navigation is in flight', () => {
+    const remoteUrl = 'http://192.168.1.2:8188/'
+    const reporter = new FakeWebContents(remoteUrl)
+    activate(reporter)
+    bindMainVerifiedFirebaseUser('F', {}, reporter.asWebContents())
+    reporter.startNavigation(`${remoteUrl}?retry=1`)
+    vi.clearAllMocks()
+
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_out' })
+    reporter.failProvisionalNavigation(`${remoteUrl}?retry=1`)
+
+    expect(telemetry.applyFirebaseUserConsensus).not.toHaveBeenCalled()
+  })
+
+  it('rejects source-backed verification after the reporter becomes ineligible', () => {
+    const reporter = new FakeWebContents(cloudUrl)
+    activate(reporter)
+    deactivateFirebaseAuthReporter(reporter.asWebContents())
+    vi.clearAllMocks()
+
+    bindMainVerifiedFirebaseUser('F', {}, reporter.asWebContents())
+
+    expect(telemetry.bindUserId).not.toHaveBeenCalled()
+    expect(telemetry.applyFirebaseUserConsensus).not.toHaveBeenCalled()
+  })
+
+  it('does not clear a conflicted epoch when local verification cannot persist', () => {
+    const first = new FakeWebContents(cloudUrl)
+    const second = new FakeWebContents(cloudUrl)
+    activate(first)
+    activate(second)
+    reportFirebaseAuthState(first.asWebContents(), { status: 'signed_in', userId: 'F1' })
+    reportFirebaseAuthState(second.asWebContents(), { status: 'signed_in', userId: 'F2' })
+    const local = new FakeWebContents('http://127.0.0.1:8188/')
+    activate(local)
+    verifiedLocalPersistence.succeeds = false
+    vi.clearAllMocks()
+
+    bindMainVerifiedFirebaseUser('F1', {}, local.asWebContents())
+
+    expect(telemetry.discardUnmergeableAnonymousEpoch).not.toHaveBeenCalled()
+    expect(telemetry.bindUserId).not.toHaveBeenCalled()
+  })
+
+  it('restores a previously verified local session after process state resets', () => {
+    const localUrl = 'http://127.0.0.1:8188/'
+    verifiedLocalUsers.set('http://127.0.0.1:8188', 'F')
+    const reporter = new FakeWebContents(localUrl)
+    activate(reporter)
+    vi.clearAllMocks()
+
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('F')
+    expect(telemetry.bindUserId).not.toHaveBeenCalled()
+  })
+
+  it('does not apply a local account properties to an unrelated active Cloud account', () => {
+    const hosted = new FakeWebContents(cloudUrl)
+    activate(hosted)
+    reportFirebaseAuthState(hosted.asWebContents(), { status: 'signed_in', userId: 'B' })
+    const local = new FakeWebContents('http://127.0.0.1:8188/')
+    activate(local)
+    vi.clearAllMocks()
+
+    bindMainVerifiedFirebaseUser(
+      'A',
+      { email: 'a@example.com' },
+      local.asWebContents()
+    )
+    local.navigate(local.getURL())
+    reportFirebaseAuthState(local.asWebContents(), { status: 'signed_in', userId: 'A' })
+
+    expect(telemetry.bindUserId).not.toHaveBeenCalled()
+    expect(telemetry.registerPersonProperties).not.toHaveBeenCalled()
+    expect(telemetry.markAnonymousEpochUnmergeable).toHaveBeenCalled()
+  })
+
+  it('unbinds while any live reporter is pending without tainting the epoch', () => {
+    const first = new FakeWebContents(cloudUrl)
+    const second = new FakeWebContents(cloudUrl)
+    activate(first)
+    activate(second)
+    reportFirebaseAuthState(first.asWebContents(), { status: 'signed_in', userId: 'F' })
+    reportFirebaseAuthState(second.asWebContents(), { status: 'signed_in', userId: 'F' })
+    vi.clearAllMocks()
+
+    second.navigate('https://cloud.comfy.org/workspaces/other')
+    expect(telemetry.applyFirebaseAnonymousConsensus).toHaveBeenCalledTimes(1)
+
+    reportFirebaseAuthState(second.asWebContents(), { status: 'signed_in', userId: 'F' })
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('F')
+    expect(telemetry.discardUnmergeableAnonymousEpoch).not.toHaveBeenCalled()
+  })
+
+  it('ignores stale auth IPC from the unloading document until navigation commits', () => {
+    const reporter = new FakeWebContents(cloudUrl)
+    activate(reporter)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F1' })
+    vi.clearAllMocks()
+
+    reporter.startNavigation(cloudUrl)
+    expect(telemetry.applyFirebaseAnonymousConsensus).toHaveBeenCalledTimes(1)
+
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F1' })
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F2' })
+    expect(telemetry.applyFirebaseUserConsensus).not.toHaveBeenCalled()
+
+    reporter.commitNavigation(cloudUrl)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F1' })
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledTimes(1)
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('F1')
+  })
+
+  it('keeps the committed trusted reporter pending before an untrusted destination commits', () => {
+    const first = new FakeWebContents(cloudUrl)
+    const second = new FakeWebContents(cloudUrl)
+    activate(first)
+    activate(second)
+    reportFirebaseAuthState(first.asWebContents(), { status: 'signed_in', userId: 'F1' })
+    reportFirebaseAuthState(second.asWebContents(), { status: 'signed_in', userId: 'F1' })
+    vi.clearAllMocks()
+
+    first.startNavigation('https://attacker.example/')
+    expect(telemetry.applyFirebaseAnonymousConsensus).toHaveBeenCalledTimes(1)
+    vi.clearAllMocks()
+
+    reportFirebaseAuthState(second.asWebContents(), { status: 'signed_in', userId: 'F2' })
+    expect(telemetry.applyFirebaseUserConsensus).not.toHaveBeenCalled()
+    expect(telemetry.markAnonymousEpochUnmergeable).not.toHaveBeenCalled()
+  })
+
+  it('accepts the committed document while its main frame is still loading', () => {
+    const reporter = new FakeWebContents(cloudUrl)
+    activate(reporter)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+
+    reporter.startNavigation(cloudUrl)
+    reporter.commitNavigation(cloudUrl, true)
+    vi.clearAllMocks()
+
+    expect(reporter.isLoadingMainFrame()).toBe(true)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'pending' })
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledTimes(1)
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('F')
+
+    reporter.stopLoading()
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the navigation gate across detach and reattach of a retained view', () => {
+    const reporter = new FakeWebContents(cloudUrl)
+    activate(reporter)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F1' })
+    reporter.startNavigation(cloudUrl)
+    deactivateFirebaseAuthReporter(reporter.asWebContents())
+    activateFirebaseAuthReporter(reporter.asWebContents())
+    vi.clearAllMocks()
+
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F1' })
+    expect(telemetry.applyFirebaseUserConsensus).not.toHaveBeenCalled()
+
+    reporter.commitNavigation(cloudUrl)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F1' })
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('F1')
+  })
+
+  it('does not let an older navigation commit open the gate for a newer load', () => {
+    const reporter = new FakeWebContents(cloudUrl)
+    activate(reporter)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F1' })
+    reporter.startNavigation('https://cloud.comfy.org/workspaces/old')
+    deactivateFirebaseAuthReporter(reporter.asWebContents())
+    activateFirebaseAuthReporter(reporter.asWebContents())
+    reporter.startNavigation('https://cloud.comfy.org/workspaces/new')
+    vi.clearAllMocks()
+
+    reporter.commitNavigation('https://cloud.comfy.org/workspaces/old', true)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F1' })
+    expect(telemetry.applyFirebaseUserConsensus).not.toHaveBeenCalled()
+
+    reporter.commitNavigation('https://cloud.comfy.org/workspaces/new')
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F1' })
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('F1')
+  })
+
+  it('keeps a trusted committed candidate pending while a newer untrusted load is in flight', () => {
+    const first = new FakeWebContents(cloudUrl)
+    const second = new FakeWebContents(cloudUrl)
+    activate(first)
+    activate(second)
+    reportFirebaseAuthState(first.asWebContents(), { status: 'signed_in', userId: 'F1' })
+    reportFirebaseAuthState(second.asWebContents(), { status: 'signed_in', userId: 'F1' })
+
+    first.startNavigation('https://cloud.comfy.org/workspaces/commits')
+    first.startNavigation('https://attacker.example/')
+    first.commitNavigation('https://cloud.comfy.org/workspaces/commits', true)
+    vi.clearAllMocks()
+
+    reportFirebaseAuthState(second.asWebContents(), { status: 'signed_in', userId: 'F2' })
+    expect(telemetry.applyFirebaseUserConsensus).not.toHaveBeenCalled()
+    expect(telemetry.markAnonymousEpochUnmergeable).not.toHaveBeenCalled()
+  })
+
+  it('settles a canceled older navigation before the newer document commits', () => {
+    const reporter = new FakeWebContents(cloudUrl)
+    activate(reporter)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F1' })
+    reporter.startNavigation('https://cloud.comfy.org/workspaces/old')
+    reporter.startNavigation('https://cloud.comfy.org/workspaces/new')
+    vi.clearAllMocks()
+
+    reporter.failProvisionalNavigation('https://cloud.comfy.org/workspaces/old')
+    reporter.failNavigation('https://cloud.comfy.org/workspaces/old', -3, 'ERR_ABORTED')
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F1' })
+    expect(telemetry.applyFirebaseUserConsensus).not.toHaveBeenCalled()
+
+    reporter.commitNavigation('https://cloud.comfy.org/workspaces/new', true)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'pending' })
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F1' })
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledTimes(1)
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('F1')
+  })
+
+  it('ignores a canceled load ordinary-failure duplicate after a retry starts', () => {
+    const reporter = new FakeWebContents(cloudUrl)
+    activate(reporter)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+
+    const canceledUrl = 'https://cloud.comfy.org/workspaces/canceled'
+    const retryUrl = 'https://cloud.comfy.org/workspaces/retry'
+    reporter.startNavigation(canceledUrl)
+    reporter.failProvisionalNavigation(canceledUrl)
+    reporter.startNavigation(retryUrl)
+    reporter.failNavigation(canceledUrl, -3, 'ERR_ABORTED')
+    reporter.commitNavigation(retryUrl, true)
+    vi.clearAllMocks()
+
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'pending' })
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledTimes(1)
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('F')
+  })
+
+  it('settles repeated canceled loads without retaining terminal suppression state', () => {
+    const reporter = new FakeWebContents(cloudUrl)
+    activate(reporter)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+
+    const flakyUrl = 'https://cloud.comfy.org/workspaces/flaky'
+    const frame = reporter.mainFrame
+    reporter.startNavigation(flakyUrl)
+    reporter.failProvisionalNavigation(flakyUrl)
+
+    // Commit a later navigation without changing the main-frame identity, as
+    // same-process navigations do (the FakeWebContents helper always rotates
+    // routing ids, so emit the commit directly).
+    reporter.startNavigation(cloudUrl)
+    reporter.emit(
+      'did-frame-navigate',
+      {},
+      cloudUrl,
+      200,
+      'OK',
+      true,
+      frame.processId,
+      frame.routingId
+    )
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+    vi.clearAllMocks()
+
+    // A later cancellation for the same URL and frame still settles.
+    reporter.startNavigation(flakyUrl)
+    reporter.failProvisionalNavigation(flakyUrl)
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledTimes(1)
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('F')
+  })
+
+  it('settles an ordinary failed load so a successful retry can report', () => {
+    const reporter = new FakeWebContents(cloudUrl)
+    activate(reporter)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+
+    const retryUrl = 'https://cloud.comfy.org/workspaces/retry'
+    reporter.startNavigation(retryUrl)
+    reporter.failNavigation(retryUrl)
+    reporter.startNavigation(retryUrl)
+    reporter.commitNavigation(retryUrl, true)
+    vi.clearAllMocks()
+
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'pending' })
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledTimes(1)
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('F')
+  })
+
+  it('restores the retained document state, including in-flight updates, when a load is canceled', () => {
+    const reporter = new FakeWebContents(cloudUrl)
+    activate(reporter)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+
+    // Canceling with no in-flight report re-binds the retained signed-in state.
+    reporter.startNavigation('https://cloud.comfy.org/workspaces/canceled')
+    vi.clearAllMocks()
+    reporter.failProvisionalNavigation('https://cloud.comfy.org/workspaces/canceled')
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledTimes(1)
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('F')
+
+    // A report from the retained document during a later in-flight load
+    // updates its latest auth state without applying it yet…
+    reporter.startNavigation('https://cloud.comfy.org/workspaces/canceled-again')
+    vi.clearAllMocks()
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_out' })
+    expect(telemetry.applyFirebaseAnonymousConsensus).not.toHaveBeenCalled()
+    expect(telemetry.applyFirebaseUserConsensus).not.toHaveBeenCalled()
+
+    // …so this cancel settles to that latest state, not the old signed-in bind.
+    reporter.failProvisionalNavigation('https://cloud.comfy.org/workspaces/canceled-again')
+    expect(telemetry.applyFirebaseUserConsensus).not.toHaveBeenCalled()
+  })
+
+  it('promotes a committed candidate only after the newer load is canceled', () => {
+    const reporter = new FakeWebContents(cloudUrl)
+    activate(reporter)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+    reporter.startNavigation('https://cloud.comfy.org/workspaces/commits')
+    reporter.startNavigation('https://cloud.comfy.org/workspaces/canceled')
+    reporter.commitNavigation('https://cloud.comfy.org/workspaces/commits', true)
+    vi.clearAllMocks()
+
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'pending' })
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+    expect(telemetry.applyFirebaseUserConsensus).not.toHaveBeenCalled()
+
+    reporter.failProvisionalNavigation('https://cloud.comfy.org/workspaces/canceled')
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledTimes(1)
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('F')
+  })
+
+  it('taints mixed signed-in and signed-out state, then rotates before a later bind', () => {
+    const first = new FakeWebContents(cloudUrl)
+    const second = new FakeWebContents(cloudUrl)
+    activate(first)
+    activate(second)
+    reportFirebaseAuthState(first.asWebContents(), { status: 'signed_in', userId: 'F' })
+    reportFirebaseAuthState(second.asWebContents(), { status: 'signed_out' })
+
+    expect(telemetry.applyFirebaseAnonymousConsensus).toHaveBeenCalledTimes(1)
+    expect(telemetry.applyFirebaseUserConsensus).not.toHaveBeenCalled()
+
+    reportFirebaseAuthState(second.asWebContents(), { status: 'signed_in', userId: 'F' })
+    expect(telemetry.discardUnmergeableAnonymousEpoch).toHaveBeenCalledTimes(1)
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('F')
+  })
+
+  it('rotates a conflicted epoch once every reporter resolves signed out', () => {
+    const first = new FakeWebContents(cloudUrl)
+    const second = new FakeWebContents(cloudUrl)
+    activate(first)
+    activate(second)
+    reportFirebaseAuthState(first.asWebContents(), { status: 'signed_in', userId: 'F' })
+    reportFirebaseAuthState(second.asWebContents(), { status: 'signed_out' })
+
+    reportFirebaseAuthState(first.asWebContents(), { status: 'signed_out' })
+    expect(telemetry.discardUnmergeableAnonymousEpoch).toHaveBeenCalledTimes(1)
+
+    second.destroy()
+    reportFirebaseAuthState(first.asWebContents(), { status: 'signed_in', userId: 'F' })
+    expect(telemetry.discardUnmergeableAnonymousEpoch).toHaveBeenCalledTimes(1)
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('F')
+  })
+
+  it('taints conflicting Firebase users and keeps them anonymous until they agree', () => {
+    const first = new FakeWebContents(cloudUrl)
+    const second = new FakeWebContents(cloudUrl)
+    activate(first)
+    activate(second)
+    reportFirebaseAuthState(first.asWebContents(), { status: 'signed_in', userId: 'F1' })
+    reportFirebaseAuthState(second.asWebContents(), { status: 'signed_in', userId: 'F2' })
+
+    expect(telemetry.applyFirebaseAnonymousConsensus).toHaveBeenCalledTimes(1)
+    expect(telemetry.applyFirebaseUserConsensus).not.toHaveBeenCalled()
+
+    reportFirebaseAuthState(first.asWebContents(), { status: 'signed_in', userId: 'F2' })
+    expect(telemetry.discardUnmergeableAnonymousEpoch).toHaveBeenCalledTimes(1)
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('F2')
+  })
+
+  it('retries a required clean rotation and refuses to bind while persistence fails', () => {
+    const first = new FakeWebContents(cloudUrl)
+    const second = new FakeWebContents(cloudUrl)
+    activate(first)
+    activate(second)
+    reportFirebaseAuthState(first.asWebContents(), { status: 'signed_in', userId: 'F' })
+    reportFirebaseAuthState(second.asWebContents(), { status: 'signed_out' })
+    telemetry.discardUnmergeableAnonymousEpoch.mockReturnValueOnce(false).mockReturnValueOnce(true)
+
+    reportFirebaseAuthState(second.asWebContents(), { status: 'signed_in', userId: 'F' })
+    expect(telemetry.applyFirebaseUserConsensus).not.toHaveBeenCalled()
+
+    reportFirebaseAuthState(second.asWebContents(), { status: 'signed_in', userId: 'F' })
+    expect(telemetry.discardUnmergeableAnonymousEpoch).toHaveBeenCalledTimes(2)
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('F')
+  })
+
+  it('removes detached, navigated-away, and destroyed reporters from consensus', () => {
+    const first = new FakeWebContents(cloudUrl)
+    const second = new FakeWebContents(cloudUrl)
+    activate(first)
+    activate(second)
+    reportFirebaseAuthState(first.asWebContents(), { status: 'signed_in', userId: 'F' })
+    reportFirebaseAuthState(second.asWebContents(), { status: 'signed_in', userId: 'F' })
+    vi.clearAllMocks()
+
+    deactivateFirebaseAuthReporter(second.asWebContents())
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('F')
+    vi.clearAllMocks()
+    reportFirebaseAuthState(second.asWebContents(), { status: 'signed_in', userId: 'F2' })
+    expect(telemetry.applyFirebaseAnonymousConsensus).not.toHaveBeenCalled()
+    expect(telemetry.applyFirebaseUserConsensus).not.toHaveBeenCalled()
+
+    first.navigate('https://example.com/')
+    expect(telemetry.applyFirebaseAnonymousConsensus).toHaveBeenCalledTimes(1)
+
+    activateFirebaseAuthReporter(second.asWebContents())
+    reportFirebaseAuthState(second.asWebContents(), { status: 'signed_in', userId: 'F2' })
+    expect(telemetry.applyFirebaseUserConsensus).not.toHaveBeenCalled()
+    second.commitNavigation(cloudUrl)
+    reportFirebaseAuthState(second.asWebContents(), { status: 'signed_in', userId: 'F' })
+    second.destroy()
+    expect(telemetry.applyFirebaseAnonymousConsensus).toHaveBeenCalledTimes(2)
+  })
+
+  it('ignores reports while the sender is outside a trusted Cloud page', () => {
+    const reporter = new FakeWebContents('http://127.0.0.1:8188/')
+    activate(reporter)
+
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+    expect(telemetry.applyFirebaseUserConsensus).not.toHaveBeenCalled()
+
+    reporter.navigate(cloudUrl)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('F')
+  })
+
+  it('honors durable taint after restart before binding the first reporter', () => {
+    telemetry.hasUnmergeableAnonymousEpoch.mockReturnValue(true)
+    const reporter = new FakeWebContents(cloudUrl)
+    activate(reporter)
+
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+
+    expect(telemetry.discardUnmergeableAnonymousEpoch).toHaveBeenCalledTimes(1)
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('F')
+  })
+
+  it('does not bind if conflict taint cannot be made restart-safe', () => {
+    telemetry.markAnonymousEpochUnmergeable.mockReturnValue(false)
+    telemetry.discardUnmergeableAnonymousEpoch.mockReturnValue(false)
+    const first = new FakeWebContents(cloudUrl)
+    const second = new FakeWebContents(cloudUrl)
+    activate(first)
+    activate(second)
+    reportFirebaseAuthState(first.asWebContents(), { status: 'signed_in', userId: 'F' })
+    reportFirebaseAuthState(second.asWebContents(), { status: 'signed_out' })
+    expect(telemetry.discardUnmergeableAnonymousEpoch).toHaveBeenCalledTimes(1)
+
+    reportFirebaseAuthState(second.asWebContents(), { status: 'signed_in', userId: 'F' })
+    expect(telemetry.discardUnmergeableAnonymousEpoch).toHaveBeenCalledTimes(1)
+    expect(telemetry.applyFirebaseUserConsensus).not.toHaveBeenCalled()
+
+    telemetry.markAnonymousEpochUnmergeable.mockReturnValue(true)
+    telemetry.discardUnmergeableAnonymousEpoch.mockReturnValue(true)
+    reportFirebaseAuthState(second.asWebContents(), { status: 'signed_in', userId: 'F' })
+    expect(telemetry.discardUnmergeableAnonymousEpoch).toHaveBeenCalledTimes(2)
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('F')
+  })
+
+  it('replaces the epoch durably when the taint marker cannot persist', () => {
+    telemetry.markAnonymousEpochUnmergeable.mockReturnValue(false)
+    const first = new FakeWebContents(cloudUrl)
+    const second = new FakeWebContents(cloudUrl)
+    activate(first)
+    activate(second)
+    reportFirebaseAuthState(first.asWebContents(), { status: 'signed_in', userId: 'F1' })
+    reportFirebaseAuthState(second.asWebContents(), { status: 'signed_in', userId: 'F2' })
+    expect(telemetry.discardUnmergeableAnonymousEpoch).toHaveBeenCalledTimes(1)
+
+    reportFirebaseAuthState(first.asWebContents(), { status: 'signed_in', userId: 'F1' })
+    expect(telemetry.discardUnmergeableAnonymousEpoch).toHaveBeenCalledTimes(1)
+
+    reportFirebaseAuthState(first.asWebContents(), { status: 'signed_in', userId: 'F2' })
+    expect(telemetry.discardUnmergeableAnonymousEpoch).toHaveBeenCalledTimes(2)
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('F2')
+  })
+})

--- a/src/main/lib/firebaseAuthIdentity.ts
+++ b/src/main/lib/firebaseAuthIdentity.ts
@@ -1,0 +1,636 @@
+import type { WebContents } from 'electron'
+import type { ComfyDesktop2FirebaseAuthState } from '../../types/comfyDesktopBridge'
+import * as mainTelemetry from './telemetry'
+import { isIllegalPostHogDistinctId, normalizeOpaqueIdentifier } from './opaqueIdentifier'
+import { isTrustedCloudUrl } from './trustedCloudUrl'
+import {
+  clearVerifiedLocalFirebaseUser,
+  isLoopbackOrigin,
+  persistVerifiedLocalFirebaseUser,
+  readVerifiedLocalFirebaseUser
+} from './verifiedLocalFirebaseAuth'
+
+interface Reporter {
+  eligible: boolean
+  active: boolean
+  localReportingAuthorized: boolean
+  localExpectedUserId: string | null
+  awaitingCommittedFrame: boolean
+  mainFrameNavigationsInFlight: number
+  provisionalFailureTerminals: Map<string, number>
+  committedFrame: FirebaseAuthFrameIdentity | null
+  recoverableState: ReporterFrameState | null
+  committedCandidate: ReporterFrameState | null
+  state: ComfyDesktop2FirebaseAuthState
+  onDidStartNavigation: (
+    details: Electron.Event<Electron.WebContentsDidStartNavigationEventParams>
+  ) => void
+  onDidFrameNavigate: (
+    event: Electron.Event,
+    url: string,
+    httpResponseCode: number,
+    httpStatusText: string,
+    isMainFrame: boolean,
+    frameProcessId: number,
+    frameRoutingId: number
+  ) => void
+  onDidFailProvisionalLoad: (
+    event: Electron.Event,
+    errorCode: number,
+    errorDescription: string,
+    validatedURL: string,
+    isMainFrame: boolean,
+    frameProcessId: number,
+    frameRoutingId: number
+  ) => void
+  onDidFailLoad: (
+    event: Electron.Event,
+    errorCode: number,
+    errorDescription: string,
+    validatedURL: string,
+    isMainFrame: boolean,
+    frameProcessId: number,
+    frameRoutingId: number
+  ) => void
+  onDestroyed: () => void
+}
+
+export interface FirebaseAuthFrameIdentity {
+  processId: number
+  routingId: number
+}
+
+interface ReporterFrameState {
+  frame: FirebaseAuthFrameIdentity
+  active: boolean
+  state: ComfyDesktop2FirebaseAuthState
+}
+
+interface MainVerifiedAuthState {
+  userId: string
+  origin: string
+  properties: Record<string, mainTelemetry.TelemetryValue>
+  propertiesApplied: boolean
+  reportedState?: ComfyDesktop2FirebaseAuthState
+  rendererMayReaffirm: boolean
+}
+
+const reporters = new Map<WebContents, Reporter>()
+const mainVerifiedStates = new Map<WebContents, MainVerifiedAuthState>()
+let requestedUserId: string | null = null
+let anonymousEpochIsUnmergeable = false
+let persistedEpochStateLoaded = false
+let epochTaintIsDurable = true
+
+function originOf(url: string): string | null {
+  try {
+    return new URL(url).origin
+  } catch {
+    return null
+  }
+}
+
+function localExpectedUserIdForUrl(url: string): string | null {
+  const origin = originOf(url)
+  return origin && isLoopbackOrigin(origin) ? readVerifiedLocalFirebaseUser(origin) : null
+}
+
+function refreshReporterAuthScope(reporter: Reporter, url: string): boolean {
+  const expectedUserId = localExpectedUserIdForUrl(url)
+  reporter.localExpectedUserId = expectedUserId
+  reporter.localReportingAuthorized = expectedUserId !== null
+  return isTrustedCloudUrl(url) || reporter.localReportingAuthorized
+}
+
+function revokeAcceptedLocalAuthorization(
+  webContents: WebContents,
+  reporter: Reporter,
+  origin: string | null,
+  state: ComfyDesktop2FirebaseAuthState,
+  userMismatch: boolean
+): void {
+  if (
+    !origin ||
+    !isLoopbackOrigin(origin) ||
+    (state.status !== 'signed_out' && !userMismatch)
+  )
+    return
+  clearVerifiedLocalFirebaseUser(origin)
+  reporter.localReportingAuthorized = false
+  reporter.localExpectedUserId = null
+  mainVerifiedStates.delete(webContents)
+}
+
+function isSameFrame(
+  first: FirebaseAuthFrameIdentity | null,
+  second: FirebaseAuthFrameIdentity
+): boolean {
+  return first?.processId === second.processId && first.routingId === second.routingId
+}
+
+function currentMainFrame(webContents: WebContents): FirebaseAuthFrameIdentity {
+  return {
+    processId: webContents.mainFrame.processId,
+    routingId: webContents.mainFrame.routingId
+  }
+}
+
+function failureTerminalKey(
+  errorCode: number,
+  validatedURL: string,
+  frameProcessId: number,
+  frameRoutingId: number
+): string {
+  return `${errorCode}\u0000${validatedURL}\u0000${frameProcessId}\u0000${frameRoutingId}`
+}
+
+function requestAnonymousIdentity(): void {
+  if (requestedUserId === null) return
+  requestedUserId = null
+  mainTelemetry.applyFirebaseAnonymousConsensus()
+}
+
+function clearUnmergeableEpoch(): boolean {
+  if (!anonymousEpochIsUnmergeable) return true
+  requestAnonymousIdentity()
+  if (!epochTaintIsDurable) {
+    epochTaintIsDurable = mainTelemetry.markAnonymousEpochUnmergeable()
+    if (!epochTaintIsDurable) return false
+  }
+  if (!mainTelemetry.discardUnmergeableAnonymousEpoch()) return false
+  anonymousEpochIsUnmergeable = false
+  epochTaintIsDurable = true
+  return true
+}
+
+function loadPersistedEpochState(): void {
+  if (persistedEpochStateLoaded) return
+  persistedEpochStateLoaded = true
+  anonymousEpochIsUnmergeable = mainTelemetry.hasUnmergeableAnonymousEpoch()
+}
+
+/**
+ * Bind a user verified by Desktop's auth flow while keeping the declarative
+ * renderer consensus authoritative once hosted views begin reporting.
+ */
+export function bindMainVerifiedFirebaseUser(
+  userId: string,
+  properties: Record<string, mainTelemetry.TelemetryValue> = {},
+  source?: WebContents
+): void {
+  const normalizedUserId = normalizeOpaqueIdentifier(userId, 256)
+  if (!normalizedUserId || isIllegalPostHogDistinctId(normalizedUserId)) return
+  loadPersistedEpochState()
+  if (!source) {
+    if (!clearUnmergeableEpoch()) return
+    requestedUserId = normalizedUserId
+    mainTelemetry.bindUserId(normalizedUserId, properties)
+    return
+  }
+  const origin = originOf(source.getURL())
+  if (!origin) return
+  trackFirebaseAuthReporter(source)
+  const reporter = reporters.get(source)
+  if (!reporter?.eligible) return
+  if (isLoopbackOrigin(origin)) {
+    if (!persistVerifiedLocalFirebaseUser(origin, normalizedUserId)) {
+      return
+    }
+    reporter.localReportingAuthorized = true
+    reporter.localExpectedUserId = normalizedUserId
+    reporter.active = true
+    reporter.state = { status: 'pending' }
+  }
+  mainVerifiedStates.set(source, {
+    userId: normalizedUserId,
+    origin,
+    properties,
+    propertiesApplied: false,
+    rendererMayReaffirm: true
+  })
+  reconcile()
+}
+
+function reconcile(): void {
+  const activeReporterStates = [...reporters.entries()]
+    .filter(([webContents, reporter]) => !webContents.isDestroyed() && reporter.active)
+    .map(([webContents, reporter]) => ({ webContents, state: reporter.state }))
+  const mainCandidates: Array<{
+    webContents: WebContents
+    state: MainVerifiedAuthState
+    contributes: boolean
+    contributionState: ComfyDesktop2FirebaseAuthState
+  }> = []
+  for (const [webContents, state] of mainVerifiedStates) {
+    if (webContents.isDestroyed() || originOf(webContents.getURL()) !== state.origin) {
+      mainVerifiedStates.delete(webContents)
+      continue
+    }
+    const reporter = reporters.get(webContents)
+    if (
+      reporter?.active &&
+      reporter.state.status !== 'pending' &&
+      (reporter.state.status !== 'signed_in' || reporter.state.userId !== state.userId)
+    ) {
+      mainVerifiedStates.delete(webContents)
+      continue
+    }
+    const navigationPending =
+      reporter?.awaitingCommittedFrame || (reporter?.mainFrameNavigationsInFlight ?? 0) > 0
+    mainCandidates.push({
+      webContents,
+      state,
+      contributes: !reporter?.active,
+      contributionState: navigationPending
+        ? { status: 'pending' }
+        : (state.reportedState ?? { status: 'signed_in', userId: state.userId })
+    })
+  }
+  const states: ComfyDesktop2FirebaseAuthState[] = [
+    ...activeReporterStates.map(({ state }) => state),
+    ...mainCandidates
+      .filter(({ contributes }) => contributes)
+      .map(({ contributionState }) => contributionState)
+  ]
+
+  if (states.length === 0 || states.some((state) => state.status === 'pending')) {
+    requestAnonymousIdentity()
+    return
+  }
+
+  const signedIn = states.filter(
+    (state): state is Extract<ComfyDesktop2FirebaseAuthState, { status: 'signed_in' }> =>
+      state.status === 'signed_in'
+  )
+
+  if (signedIn.length === 0) {
+    requestAnonymousIdentity()
+    clearUnmergeableEpoch()
+    return
+  }
+
+  const userIds = new Set(signedIn.map((state) => state.userId))
+  const hasConflict = signedIn.length !== states.length || userIds.size !== 1
+  if (hasConflict) {
+    const wasAlreadyTainted = anonymousEpochIsUnmergeable
+    requestedUserId = null
+    mainTelemetry.applyFirebaseAnonymousConsensus()
+    anonymousEpochIsUnmergeable = true
+    if (!wasAlreadyTainted || !epochTaintIsDurable) {
+      epochTaintIsDurable = mainTelemetry.markAnonymousEpochUnmergeable()
+      if (!epochTaintIsDurable && !wasAlreadyTainted) {
+        // The taint marker could not persist, so a restart would resurrect
+        // the conflicted anonymous ID untainted. Durably replace the epoch
+        // instead; attempted once per conflict episode to avoid rotation
+        // churn while the views still disagree.
+        epochTaintIsDurable = mainTelemetry.discardUnmergeableAnonymousEpoch()
+      }
+    }
+    return
+  }
+
+  const userId = signedIn[0]!.userId
+  if (!clearUnmergeableEpoch()) return
+
+  requestedUserId = userId
+  const confirmedMainStates = mainCandidates.filter(({ webContents, state, contributes }) => {
+    if (state.userId !== userId) return false
+    if (contributes) return true
+    const reporterState = reporters.get(webContents)?.state
+    return reporterState?.status === 'signed_in' && reporterState.userId === userId
+  })
+  const unappliedMainStates = confirmedMainStates.filter(({ state }) => !state.propertiesApplied)
+  if (unappliedMainStates.length > 0) {
+    const properties = Object.assign(
+      {},
+      ...unappliedMainStates.map(({ state }) => state.properties)
+    ) as Record<string, mainTelemetry.TelemetryValue>
+    mainTelemetry.bindUserId(userId, properties)
+    for (const { webContents, state, contributes } of unappliedMainStates) {
+      state.propertiesApplied = true
+      if (!contributes) mainVerifiedStates.delete(webContents)
+    }
+  } else {
+    mainTelemetry.applyFirebaseUserConsensus(userId)
+  }
+}
+
+function settleFailedNavigation(webContents: WebContents, reporter: Reporter): void {
+  if (reporter.mainFrameNavigationsInFlight === 0) return
+  reporter.mainFrameNavigationsInFlight -= 1
+  if (reporter.mainFrameNavigationsInFlight > 0) {
+    reporter.state = { status: 'pending' }
+    reconcile()
+    return
+  }
+
+  const currentFrame = currentMainFrame(webContents)
+  const retainedState = isSameFrame(reporter.committedCandidate?.frame ?? null, currentFrame)
+    ? reporter.committedCandidate
+    : isSameFrame(reporter.recoverableState?.frame ?? null, currentFrame)
+      ? reporter.recoverableState
+      : null
+  if (retainedState) {
+    reporter.awaitingCommittedFrame = false
+    reporter.committedFrame = retainedState.frame
+    reporter.active = reporter.eligible && retainedState.active
+    reporter.state = retainedState.state
+  } else {
+    // A terminal without an attributable retained frame must not reopen stale
+    // IPC. Keep a trusted current document in consensus as pending until a
+    // later commit supplies an exact frame identity.
+    reporter.awaitingCommittedFrame = true
+    reporter.committedFrame = null
+    reporter.active =
+      reporter.eligible && refreshReporterAuthScope(reporter, webContents.getURL())
+    reporter.state = { status: 'pending' }
+  }
+  reporter.committedCandidate = null
+  reporter.recoverableState = null
+  reconcile()
+}
+
+function isAcceptedFallbackFrame(
+  webContents: WebContents,
+  reporter: Reporter,
+  frame: FirebaseAuthFrameIdentity
+): boolean {
+  if (!isSameFrame(frame, currentMainFrame(webContents))) return false
+  if (
+    !reporter.awaitingCommittedFrame &&
+    reporter.mainFrameNavigationsInFlight === 0 &&
+    isSameFrame(reporter.committedFrame, frame)
+  ) {
+    return true
+  }
+  return (
+    isSameFrame(reporter.recoverableState?.frame ?? null, frame) ||
+    isSameFrame(reporter.committedCandidate?.frame ?? null, frame)
+  )
+}
+
+/** Track a hosted view before its first navigation so unresolved views count as pending. */
+export function trackFirebaseAuthReporter(webContents: WebContents): void {
+  if (reporters.has(webContents) || webContents.isDestroyed()) return
+
+  const reporter: Reporter = {
+    eligible: false,
+    active: false,
+    localReportingAuthorized: false,
+    localExpectedUserId: null,
+    awaitingCommittedFrame: true,
+    mainFrameNavigationsInFlight: 0,
+    provisionalFailureTerminals: new Map(),
+    committedFrame: null,
+    recoverableState: null,
+    committedCandidate: null,
+    state: { status: 'pending' },
+    onDidStartNavigation: (details) => {
+      if (!details.isMainFrame || details.isSameDocument) return
+      if (
+        reporter.mainFrameNavigationsInFlight === 0 &&
+        !reporter.awaitingCommittedFrame &&
+        reporter.committedFrame
+      ) {
+        reporter.recoverableState = {
+          frame: reporter.committedFrame,
+          active: reporter.active,
+          state: reporter.state
+        }
+        reporter.committedCandidate = null
+      }
+      reporter.mainFrameNavigationsInFlight += 1
+      reporter.awaitingCommittedFrame = true
+      // The requested destination is not the current document until commit.
+      // Keep current-frame trust active, but gate consensus as pending.
+      reporter.state = { status: 'pending' }
+      reconcile()
+    },
+    onDidFrameNavigate: (
+      _event,
+      url,
+      _httpResponseCode,
+      _httpStatusText,
+      isMainFrame,
+      frameProcessId,
+      frameRoutingId
+    ) => {
+      if (!isMainFrame) return
+      // Electron emits a provisional failure's paired `did-fail-load` before
+      // the next main-frame commit (canceled loads never emit it at all), so
+      // entries still recorded here are unpairable; drop them rather than let
+      // canceled loads accumulate for the view's lifetime.
+      reporter.provisionalFailureTerminals.clear()
+      if (reporter.mainFrameNavigationsInFlight > 0) {
+        reporter.mainFrameNavigationsInFlight -= 1
+      }
+      const authScopeIsActive = refreshReporterAuthScope(reporter, url)
+      reporter.committedCandidate = {
+        frame: {
+          processId: frameProcessId,
+          routingId: frameRoutingId
+        },
+        active: reporter.eligible && authScopeIsActive,
+        state: { status: 'pending' }
+      }
+      reporter.committedFrame = reporter.committedCandidate.frame
+      reporter.active = reporter.committedCandidate.active
+      reporter.state = { status: 'pending' }
+      reporter.recoverableState = null
+      const mainVerifiedState = mainVerifiedStates.get(webContents)
+      if (mainVerifiedState) mainVerifiedState.reportedState = { status: 'pending' }
+      if (reporter.mainFrameNavigationsInFlight > 0) {
+        reconcile()
+        return
+      }
+      reporter.awaitingCommittedFrame = false
+      reporter.committedCandidate = null
+      reconcile()
+    },
+    onDidFailProvisionalLoad: (
+      _event,
+      errorCode,
+      _errorDescription,
+      validatedURL,
+      isMainFrame,
+      frameProcessId,
+      frameRoutingId
+    ) => {
+      if (!isMainFrame) return
+      if (errorCode !== -3) {
+        const key = failureTerminalKey(errorCode, validatedURL, frameProcessId, frameRoutingId)
+        const existing = reporter.provisionalFailureTerminals.get(key) ?? 0
+        reporter.provisionalFailureTerminals.set(key, existing + 1)
+      }
+      settleFailedNavigation(webContents, reporter)
+    },
+    onDidFailLoad: (
+      _event,
+      errorCode,
+      _errorDescription,
+      validatedURL,
+      isMainFrame,
+      frameProcessId,
+      frameRoutingId
+    ) => {
+      if (!isMainFrame) return
+      // Electron does not pair ERR_ABORTED provisional failures with this
+      // event; ignore a defensive duplicate without retaining unbounded keys.
+      if (errorCode === -3) return
+      const key = failureTerminalKey(errorCode, validatedURL, frameProcessId, frameRoutingId)
+      const provisional = reporter.provisionalFailureTerminals.get(key)
+      if (provisional !== undefined) {
+        if (provisional === 1) reporter.provisionalFailureTerminals.delete(key)
+        else reporter.provisionalFailureTerminals.set(key, provisional - 1)
+        return
+      }
+      settleFailedNavigation(webContents, reporter)
+    },
+    onDestroyed: () => {
+      mainVerifiedStates.delete(webContents)
+      reporters.delete(webContents)
+      reconcile()
+    }
+  }
+
+  reporters.set(webContents, reporter)
+  webContents.on('did-start-navigation', reporter.onDidStartNavigation)
+  webContents.on('did-frame-navigate', reporter.onDidFrameNavigate)
+  webContents.on('did-fail-provisional-load', reporter.onDidFailProvisionalLoad)
+  webContents.on('did-fail-load', reporter.onDidFailLoad)
+  webContents.once('destroyed', reporter.onDestroyed)
+  reconcile()
+}
+
+/** Make an attached installation's tracked view eligible to report auth. */
+export function activateFirebaseAuthReporter(webContents: WebContents): void {
+  loadPersistedEpochState()
+  trackFirebaseAuthReporter(webContents)
+  const reporter = reporters.get(webContents)
+  if (!reporter) return
+  reporter.eligible = true
+  reporter.awaitingCommittedFrame = true
+  reporter.committedFrame = null
+  reporter.recoverableState = null
+  reporter.committedCandidate = null
+  reporter.active = refreshReporterAuthScope(reporter, webContents.getURL())
+  reporter.state = { status: 'pending' }
+  reconcile()
+}
+
+/** Exclude a retained view while its host is detached from an installation. */
+export function deactivateFirebaseAuthReporter(webContents: WebContents): void {
+  const reporter = reporters.get(webContents)
+  if (!reporter) return
+  reporter.eligible = false
+  reporter.active = false
+  reporter.state = { status: 'pending' }
+  mainVerifiedStates.delete(webContents)
+  reconcile()
+}
+
+/** Record a trusted renderer's complete Firebase state and recompute consensus. */
+export function reportFirebaseAuthState(
+  webContents: WebContents,
+  frame: FirebaseAuthFrameIdentity,
+  state: ComfyDesktop2FirebaseAuthState
+): void {
+  trackFirebaseAuthReporter(webContents)
+  const reporter = reporters.get(webContents)
+  if (!reporter?.eligible) return
+  const currentOrigin = originOf(webContents.getURL())
+  const trustedCloud = isTrustedCloudUrl(webContents.getURL())
+  const trustedLocal =
+    currentOrigin !== null &&
+    isLoopbackOrigin(currentOrigin) &&
+    reporter.localReportingAuthorized
+  if (!trustedCloud && !trustedLocal) {
+    const mainVerifiedState = mainVerifiedStates.get(webContents)
+    if (
+      !mainVerifiedState ||
+      currentOrigin !== mainVerifiedState.origin ||
+      !mainVerifiedState.rendererMayReaffirm ||
+      !isAcceptedFallbackFrame(webContents, reporter, frame)
+    ) {
+      return
+    }
+    const userMismatch =
+      state.status === 'signed_in' && state.userId !== mainVerifiedState.userId
+    mainVerifiedState.reportedState = userMismatch ? { status: 'pending' } : state
+    if (userMismatch || state.status === 'signed_out') {
+      mainVerifiedState.rendererMayReaffirm = false
+    }
+    reconcile()
+    return
+  }
+  const localUserMismatch =
+    trustedLocal &&
+    state.status === 'signed_in' &&
+    state.userId !== reporter.localExpectedUserId
+  const acceptedState: ComfyDesktop2FirebaseAuthState = localUserMismatch
+    ? { status: 'pending' }
+    : state
+  const candidate = reporter.committedCandidate
+  if (candidate && isSameFrame(candidate.frame, frame)) {
+    revokeAcceptedLocalAuthorization(
+      webContents,
+      reporter,
+      currentOrigin,
+      acceptedState,
+      localUserMismatch
+    )
+    candidate.state = acceptedState
+    return
+  }
+  const recoverable = reporter.recoverableState
+  if (
+    recoverable &&
+    isSameFrame(recoverable.frame, frame) &&
+    isSameFrame(recoverable.frame, currentMainFrame(webContents))
+  ) {
+    revokeAcceptedLocalAuthorization(
+      webContents,
+      reporter,
+      currentOrigin,
+      acceptedState,
+      localUserMismatch
+    )
+    recoverable.state = acceptedState
+    return
+  }
+  if (
+    reporter.awaitingCommittedFrame ||
+    reporter.mainFrameNavigationsInFlight > 0 ||
+    !isSameFrame(reporter.committedFrame, frame)
+  )
+    return
+  revokeAcceptedLocalAuthorization(
+    webContents,
+    reporter,
+    currentOrigin,
+    acceptedState,
+    localUserMismatch
+  )
+  reporter.active = true
+  reporter.state = acceptedState
+  reconcile()
+}
+
+/** @internal Reset process-global reporter state between tests. */
+export function _resetForTest(): void {
+  for (const [webContents, reporter] of reporters) {
+    if (!webContents.isDestroyed()) {
+      webContents.off('did-start-navigation', reporter.onDidStartNavigation)
+      webContents.off('did-frame-navigate', reporter.onDidFrameNavigate)
+      webContents.off('did-fail-provisional-load', reporter.onDidFailProvisionalLoad)
+      webContents.off('did-fail-load', reporter.onDidFailLoad)
+      webContents.off('destroyed', reporter.onDestroyed)
+    }
+  }
+  reporters.clear()
+  mainVerifiedStates.clear()
+  requestedUserId = null
+  anonymousEpochIsUnmergeable = false
+  persistedEpochStateLoaded = false
+  epochTaintIsDurable = true
+}

--- a/src/main/lib/firebaseAuthIdentity.ts
+++ b/src/main/lib/firebaseAuthIdentity.ts
@@ -176,17 +176,11 @@ function loadPersistedEpochState(): void {
 export function bindMainVerifiedFirebaseUser(
   userId: string,
   properties: Record<string, mainTelemetry.TelemetryValue> = {},
-  source?: WebContents
+  source: WebContents
 ): void {
   const normalizedUserId = normalizeOpaqueIdentifier(userId, 256)
   if (!normalizedUserId || isIllegalPostHogDistinctId(normalizedUserId)) return
   loadPersistedEpochState()
-  if (!source) {
-    if (!clearUnmergeableEpoch()) return
-    requestedUserId = normalizedUserId
-    mainTelemetry.bindUserId(normalizedUserId, properties)
-    return
-  }
   const origin = originOf(source.getURL())
   if (!origin) return
   trackFirebaseAuthReporter(source)

--- a/src/main/lib/ipc/registerTelemetryHandlers.test.ts
+++ b/src/main/lib/ipc/registerTelemetryHandlers.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
-  bindUserId: vi.fn(),
   capture: vi.fn(),
   captureException: vi.fn(),
   findEntryByComfySender: vi.fn(),
@@ -9,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   handle: vi.fn(),
   on: vi.fn(),
   recordExposure: vi.fn(),
+  reportFirebaseAuthState: vi.fn(),
   registerPersonProperties: vi.fn()
 }))
 
@@ -27,10 +27,13 @@ vi.mock('../telemetry', () => ({
   // Real (pure) narrowing logic, mirrored here because importOriginal would
   // pull in telemetry.ts's electron/posthog-node imports under the stub mock.
   asDeployment: (v: unknown) => (v === 'local' || v === 'cloud' || v === 'remote' ? v : null),
-  bindUserId: mocks.bindUserId,
   capture: mocks.capture,
   captureException: mocks.captureException,
   registerPersonProperties: mocks.registerPersonProperties
+}))
+
+vi.mock('../firebaseAuthIdentity', () => ({
+  reportFirebaseAuthState: mocks.reportFirebaseAuthState
 }))
 
 vi.mock('../experiments', () => ({
@@ -46,6 +49,23 @@ function listener(channel: string): IpcListener {
   const call = mocks.on.mock.calls.find(([name]) => name === channel)
   expect(call).toBeDefined()
   return call![1] as IpcListener
+}
+
+function identityEvent(
+  url: string,
+  mainFrame: boolean = true,
+  equivalentWrapper: boolean = false
+): unknown {
+  const senderMainFrame = { url, processId: 100, routingId: 200 }
+  const sender = { mainFrame: senderMainFrame }
+  return {
+    sender,
+    senderFrame: mainFrame
+      ? equivalentWrapper
+        ? { ...senderMainFrame }
+        : senderMainFrame
+      : { url, processId: 101, routingId: 201 }
+  }
 }
 
 describe('registerTelemetryHandlers', () => {
@@ -142,51 +162,139 @@ describe('registerTelemetryHandlers', () => {
     expect(sent.key_125).toBeUndefined()
   })
 
-  it('tags relayed events with the deployment of the sender comfyView install', () => {
-    const sender = { id: 1 }
-    mocks.findEntryByComfySender.mockReturnValue({ sourceCategory: 'cloud' })
+  it('accepts declarative auth state from Cloud main frames', () => {
+    const signedInEvent = identityEvent('https://cloud.comfy.org/workspaces/abc')
+    const signedOutEvent = identityEvent('https://pr-123.testingcloud.comfy.org/workspaces/abc')
+    listener('telemetry:firebaseAuthState')(signedInEvent, {
+      status: 'signed_in',
+      userId: ' firebase-uid-123 '
+    })
+    listener('telemetry:firebaseAuthState')(signedOutEvent, { status: 'signed_out' })
 
-    listener('telemetry:capture')({ sender }, { event: 'execution_start', properties: { a: 1 } })
+    expect(mocks.reportFirebaseAuthState).toHaveBeenNthCalledWith(
+      1,
+      (signedInEvent as { sender: unknown }).sender,
+      { processId: 100, routingId: 200 },
+      { status: 'signed_in', userId: 'firebase-uid-123' }
+    )
+    expect(mocks.reportFirebaseAuthState).toHaveBeenNthCalledWith(
+      2,
+      (signedOutEvent as { sender: unknown }).sender,
+      { processId: 100, routingId: 200 },
+      { status: 'signed_out' }
+    )
+  })
+
+  it('accepts an equivalent main-frame wrapper and rejects a different frame identity', () => {
+    const equivalentMainFrame = identityEvent('https://cloud.comfy.org/workspaces/abc', true, true)
+    listener('telemetry:firebaseAuthState')(equivalentMainFrame, { status: 'signed_out' })
+    listener('telemetry:firebaseAuthState')(
+      identityEvent('https://cloud.comfy.org/workspaces/abc', false),
+      { status: 'signed_out' }
+    )
+
+    expect(mocks.reportFirebaseAuthState).toHaveBeenCalledTimes(1)
+    expect(mocks.reportFirebaseAuthState).toHaveBeenCalledWith(
+      (equivalentMainFrame as { sender: unknown }).sender,
+      { processId: 100, routingId: 200 },
+      { status: 'signed_out' }
+    )
+  })
+
+  it('rejects PostHog-illegal Firebase UIDs at the IPC boundary', () => {
+    listener('telemetry:firebaseAuthState')(
+      identityEvent('https://cloud.comfy.org/workspaces/abc'),
+      { status: 'signed_in', userId: 'anonymous' }
+    )
+
+    expect(mocks.reportFirebaseAuthState).not.toHaveBeenCalled()
+  })
+
+  it('forwards main frames for auth-scope validation and rejects subframes or malformed payloads', () => {
+    const fileEvent = identityEvent('file:///launcher/index.html')
+    const remoteEvent = identityEvent('https://attacker.example/')
+    listener('telemetry:firebaseAuthState')(fileEvent, {
+      status: 'signed_in',
+      userId: 'local-user'
+    })
+    listener('telemetry:firebaseAuthState')(remoteEvent, {
+      status: 'signed_out'
+    })
+    listener('telemetry:firebaseAuthState')(identityEvent('https://cloud.comfy.org/', false), {
+      status: 'pending'
+    })
+    listener('telemetry:firebaseAuthState')(identityEvent('https://cloud.comfy.org/'), {
+      status: 'signed_in',
+      userId: '\u0000invalid'
+    })
+    listener('telemetry:firebaseAuthState')(identityEvent('https://cloud.comfy.org/'), {
+      status: 'unknown'
+    })
+
+    expect(mocks.reportFirebaseAuthState).toHaveBeenCalledTimes(2)
+    expect(mocks.reportFirebaseAuthState).toHaveBeenNthCalledWith(
+      1,
+      (fileEvent as { sender: unknown }).sender,
+      { processId: 100, routingId: 200 },
+      { status: 'signed_in', userId: 'local-user' }
+    )
+    expect(mocks.reportFirebaseAuthState).toHaveBeenNthCalledWith(
+      2,
+      (remoteEvent as { sender: unknown }).sender,
+      { processId: 100, routingId: 200 },
+      { status: 'signed_out' }
+    )
+  })
+
+  it.each([
+    // [case, attached comfyView entry, payload properties, expected capture properties]
+    // Main's attachment lookup is the ground truth for which install actually
+    // emitted an event — a hosted frontend may forward stale posthog-js super
+    // properties (e.g. a cloud bundle's deployment=cloud).
+    [
+      'tags relayed events with the deployment of the sender comfyView install',
+      { sourceCategory: 'cloud' },
+      { a: 1 },
+      { deployment: 'cloud', a: 1 }
+    ],
+    [
+      'leaves events untagged when the sender is not an attached comfyView',
+      null,
+      { a: 1 },
+      { a: 1 }
+    ],
+    [
+      'overwrites a payload deployment with the sender-derived value',
+      { sourceCategory: 'local' },
+      { deployment: 'cloud' },
+      { deployment: 'local' }
+    ],
+    [
+      'keeps a payload deployment when the sender is not an attached comfyView',
+      null,
+      { deployment: 'local' },
+      { deployment: 'local' }
+    ],
+    [
+      'ignores unknown source categories rather than emitting a junk tag',
+      { sourceCategory: null },
+      {},
+      {}
+    ],
+    [
+      'strips an invalid payload deployment even from non-comfyView senders',
+      null,
+      { deployment: 'banana' },
+      {}
+    ]
+  ])('%s', (_case, entry, properties, expectedSent) => {
+    const sender = { id: 1 }
+    mocks.findEntryByComfySender.mockReturnValue(entry)
+
+    listener('telemetry:capture')({ sender }, { event: 'execution_start', properties })
 
     expect(mocks.findEntryByComfySender).toHaveBeenCalledWith(sender)
-    const sent = mocks.capture.mock.calls[0]![1] as Record<string, unknown>
-    expect(sent).toEqual({ deployment: 'cloud', a: 1 })
-  })
-
-  it('leaves events untagged when the sender is not an attached comfyView', () => {
-    mocks.findEntryByComfySender.mockReturnValue(null)
-
-    listener('telemetry:capture')({ sender: { id: 2 } }, { event: 'launcher.click', properties: {} })
-
-    const sent = mocks.capture.mock.calls[0]![1] as Record<string, unknown>
-    expect(sent.deployment).toBeUndefined()
-  })
-
-  it('overwrites a payload deployment with the sender-derived value', () => {
-    // A hosted frontend may forward stale posthog-js super properties (e.g. a
-    // cloud bundle's deployment=cloud) — main's attachment lookup is the
-    // ground truth for which install actually emitted the event.
-    mocks.findEntryByComfySender.mockReturnValue({ sourceCategory: 'local' })
-
-    listener('telemetry:capture')(
-      { sender: { id: 3 } },
-      { event: 'execution_start', properties: { deployment: 'cloud' } }
-    )
-
-    const sent = mocks.capture.mock.calls[0]![1] as Record<string, unknown>
-    expect(sent.deployment).toBe('local')
-  })
-
-  it('keeps a payload deployment when the sender is not an attached comfyView', () => {
-    mocks.findEntryByComfySender.mockReturnValue(null)
-
-    listener('telemetry:capture')(
-      { sender: { id: 5 } },
-      { event: 'popout.event', properties: { deployment: 'local' } }
-    )
-
-    const sent = mocks.capture.mock.calls[0]![1] as Record<string, unknown>
-    expect(sent.deployment).toBe('local')
+    expect(mocks.capture.mock.calls[0]![1]).toEqual(expectedSent)
   })
 
   it('strips a payload client so the SDK default (desktop) applies', () => {
@@ -200,27 +308,6 @@ describe('registerTelemetryHandlers', () => {
     const sent = mocks.capture.mock.calls[0]![1] as Record<string, unknown>
     expect(sent.client).toBeUndefined()
     expect(sent.a).toBe(1)
-  })
-
-  it('ignores unknown source categories rather than emitting a junk tag', () => {
-    mocks.findEntryByComfySender.mockReturnValue({ sourceCategory: null })
-
-    listener('telemetry:capture')({ sender: { id: 4 } }, { event: 'execution_start', properties: {} })
-
-    const sent = mocks.capture.mock.calls[0]![1] as Record<string, unknown>
-    expect(sent.deployment).toBeUndefined()
-  })
-
-  it('strips an invalid payload deployment even from non-comfyView senders', () => {
-    mocks.findEntryByComfySender.mockReturnValue(null)
-
-    listener('telemetry:capture')(
-      { sender: { id: 7 } },
-      { event: 'popout.event', properties: { deployment: 'banana' } }
-    )
-
-    const sent = mocks.capture.mock.calls[0]![1] as Record<string, unknown>
-    expect(sent.deployment).toBeUndefined()
   })
 
   it('applies the same platform-axes handling to relayed exceptions', () => {

--- a/src/main/lib/ipc/registerTelemetryHandlers.ts
+++ b/src/main/lib/ipc/registerTelemetryHandlers.ts
@@ -1,7 +1,7 @@
 // IPC for renderer-originated telemetry: the renderer routes through main so
 // identity, consent, and dedup live in one place. Capture messages are
 // fire-and-forget (ipcMain.on).
-import { ipcMain, type WebContents } from 'electron'
+import { ipcMain, type IpcMainEvent, type WebContents, type WebFrameMain } from 'electron'
 import { findEntryByComfySender } from '../../host/registry'
 import * as mainTelemetry from '../telemetry'
 import {
@@ -9,6 +9,9 @@ import {
   recordExposure,
   type ExperimentExposureSource
 } from '../experiments'
+import { reportFirebaseAuthState } from '../firebaseAuthIdentity'
+import type { ComfyDesktop2FirebaseAuthState } from '../../../types/comfyDesktopBridge'
+import { isIllegalPostHogDistinctId, normalizeOpaqueIdentifier } from '../opaqueIdentifier'
 
 interface CapturePayload {
   event?: unknown
@@ -23,6 +26,26 @@ interface CaptureExceptionPayload {
 
 function asString(value: unknown): string | null {
   return typeof value === 'string' && value.length > 0 ? value : null
+}
+
+function firebaseAuthReporterFrame(event: IpcMainEvent): WebFrameMain | null {
+  const frame = event.senderFrame
+  const mainFrame = event.sender.mainFrame
+  if (!frame || frame.processId !== mainFrame.processId || frame.routingId !== mainFrame.routingId)
+    return null
+  return frame
+}
+
+function asFirebaseAuthState(value: unknown): ComfyDesktop2FirebaseAuthState | null {
+  if (!value || typeof value !== 'object') return null
+  const source = value as Record<string, unknown>
+  if (source.status === 'pending' || source.status === 'signed_out') {
+    return { status: source.status }
+  }
+  if (source.status !== 'signed_in') return null
+  const userId = normalizeOpaqueIdentifier(source.userId, 256)
+  if (!userId || isIllegalPostHogDistinctId(userId)) return null
+  return { status: 'signed_in', userId }
 }
 
 function isTelemetryValue(v: unknown): v is mainTelemetry.TelemetryValue {
@@ -184,17 +207,18 @@ export function registerTelemetryHandlers(): void {
     mainTelemetry.registerPersonProperties(props)
   })
 
-  // Renderer still owns datadogRum.setUser (Datadog is browser-only).
-  ipcMain.on('telemetry:bindUserId', (_event, payload: unknown) => {
-    if (!payload || typeof payload !== 'object') return
-    const userId = asString((payload as Record<string, unknown>).userId)
-    if (!userId) return
-    const properties = asPersonProps((payload as Record<string, unknown>).properties)
-    mainTelemetry.bindUserId(userId, properties)
-  })
-
-  ipcMain.on('telemetry:unbindUserId', () => {
-    mainTelemetry.unbindUserId()
+  // Auth consensus validates trusted Cloud and scoped, main-verified loopback
+  // reporters after this handler proves the message came from the main frame.
+  ipcMain.on('telemetry:firebaseAuthState', (event, payload: unknown) => {
+    const frame = firebaseAuthReporterFrame(event)
+    if (!frame) return
+    const state = asFirebaseAuthState(payload)
+    if (!state) return
+    reportFirebaseAuthState(
+      event.sender,
+      { processId: frame.processId, routingId: frame.routingId },
+      state
+    )
   })
 
   // Flag lookup for renderer A/B branches; awaits the boot fetch so a query

--- a/src/main/lib/opaqueIdentifier.test.ts
+++ b/src/main/lib/opaqueIdentifier.test.ts
@@ -1,5 +1,49 @@
 import { describe, expect, it } from 'vitest'
-import { normalizeOpaqueIdentifier } from './opaqueIdentifier'
+import { isIllegalPostHogDistinctId, normalizeOpaqueIdentifier } from './opaqueIdentifier'
+
+describe('isIllegalPostHogDistinctId', () => {
+  it.each([
+    // Case-insensitive entries match in any casing.
+    'anonymous',
+    'ANONYMOUS',
+    'guest',
+    'distinctid',
+    'DistinctId',
+    'distinct_id',
+    'id',
+    'not_authenticated',
+    'email',
+    'undefined',
+    'true',
+    'False',
+    // Case-sensitive entries match only in their listed casing.
+    '[object Object]',
+    'NaN',
+    'None',
+    'none',
+    'null',
+    '0',
+    // Blank identities can never merge.
+    '',
+    '   '
+  ])('flags %j as illegal', (value) => {
+    expect(isIllegalPostHogDistinctId(value)).toBe(true)
+  })
+
+  it.each([
+    // Other casings of the case-sensitive entries stay legal.
+    'NONE',
+    'NULL',
+    'nan',
+    '[object object]',
+    // Near-misses of illegal values stay legal.
+    '00',
+    'anonymous-2',
+    'user-123'
+  ])('keeps %j legal', (value) => {
+    expect(isIllegalPostHogDistinctId(value)).toBe(false)
+  })
+})
 
 describe('normalizeOpaqueIdentifier', () => {
   it('trims a valid identifier', () => {

--- a/src/main/lib/opaqueIdentifier.ts
+++ b/src/main/lib/opaqueIdentifier.ts
@@ -1,3 +1,36 @@
+const CASE_INSENSITIVE_ILLEGAL_DISTINCT_IDS: ReadonlySet<string> = new Set([
+  'anonymous',
+  'guest',
+  'distinctid',
+  'distinct_id',
+  'id',
+  'not_authenticated',
+  'email',
+  'undefined',
+  'true',
+  'false'
+])
+const CASE_SENSITIVE_ILLEGAL_DISTINCT_IDS: ReadonlySet<string> = new Set([
+  '[object Object]',
+  'NaN',
+  'None',
+  'none',
+  'null',
+  '0'
+])
+
+/**
+ * PostHog ingestion refuses to merge these IDs: adopting one would pool
+ * unrelated installs and silently reject the `$anon_distinct_id` merge.
+ */
+export function isIllegalPostHogDistinctId(value: string): boolean {
+  return (
+    value.trim().length === 0 ||
+    CASE_INSENSITIVE_ILLEGAL_DISTINCT_IDS.has(value.toLowerCase()) ||
+    CASE_SENSITIVE_ILLEGAL_DISTINCT_IDS.has(value)
+  )
+}
+
 export function normalizeOpaqueIdentifier(value: unknown, maxLength: number): string | null {
   if (typeof value !== 'string') return null
   const normalized = value.trim()

--- a/src/main/lib/telemetry.test.ts
+++ b/src/main/lib/telemetry.test.ts
@@ -823,7 +823,7 @@ describe('telemetry Firebase consensus identity lifecycle', () => {
     telemetry.registerPersonProperties({ gpu_tier: 'high' })
     telemetry.registerPersonPropertiesOnce({ first_generation_at: 'first' })
 
-    telemetry.unbindUserId()
+    telemetry.applyFirebaseAnonymousConsensus()
 
     expect(anonymousIdentityMock.index).toBe(0)
     expect(captured.find((c) => c.event === 'comfy.desktop.person.set')).toBeUndefined()
@@ -968,10 +968,6 @@ describe('telemetry Firebase consensus identity lifecycle', () => {
 
     telemetry.bindUserId('bridge-user', { plan: 'pro' })
     expect(identifies).toHaveLength(1)
-
-    telemetry.unbindUserId()
-    telemetry.capture('after.unbind')
-    expect(captured.at(-1)?.distinctId).toBe('anonymous-next-1')
   })
 
   it('fails closed without identifying when the next D cannot be persisted', () => {

--- a/src/main/lib/telemetry.ts
+++ b/src/main/lib/telemetry.ts
@@ -118,8 +118,13 @@ import { isDatadogMirroredEvent } from '../../shared/datadogMirroredEvents'
 import { bucketError as sharedBucketError } from '../../shared/errorBucket'
 import { buildErrorFields } from '../../shared/errorEvent'
 import { scrubAll } from '../../shared/piiScrub'
-import { rotatePersistedAnonymousDistinctId } from './anonymousIdentity'
-import { normalizeOpaqueIdentifier } from './opaqueIdentifier'
+import {
+  clearPersistedUnmergeableAnonymousEpoch,
+  hasPersistedUnmergeableAnonymousEpoch,
+  persistUnmergeableAnonymousEpoch,
+  rotatePersistedAnonymousDistinctId
+} from './anonymousIdentity'
+import { isIllegalPostHogDistinctId, normalizeOpaqueIdentifier } from './opaqueIdentifier'
 import {
   clearPendingIdentityMerges,
   type PendingIdentityProperties,
@@ -771,7 +776,8 @@ function applyFirebaseUserBinding(
   const normalizedUserId = normalizeOpaqueIdentifier(userId, 256)
   // Reject early rather than burn an anonymous rotation on an identify that
   // can never merge.
-  if (!normalizedUserId || consentState === 'denied') return
+  if (!normalizedUserId || isIllegalPostHogDistinctId(normalizedUserId)) return
+  if (consentState === 'denied') return
 
   if (!canEmit() || !anonymousDistinctId || !installationIdProperty) {
     queuePendingUserBinding(normalizedUserId, emitLoginEvent, properties)
@@ -894,9 +900,27 @@ export function applyFirebaseAnonymousConsensus(): void {
   distinctId = safeAnonymousId
 }
 
-/** Compatibility path for legacy IPC callers. */
-export function unbindUserId(): void {
+/**
+ * Replace an anonymous epoch that observed conflicting resolved auth states.
+ * Returns false when the clean identity could not be persisted; callers must
+ * keep the process anonymous and retry before any later Firebase bind.
+ */
+export function discardUnmergeableAnonymousEpoch(): boolean {
   applyFirebaseAnonymousConsensus()
+  const cleanAnonymousId = rotatePersistedAnonymousDistinctId()
+  if (!cleanAnonymousId) return false
+  anonymousDistinctId = cleanAnonymousId
+  distinctId = cleanAnonymousId
+  nextAnonymousDistinctId = null
+  return clearPersistedUnmergeableAnonymousEpoch()
+}
+
+export function hasUnmergeableAnonymousEpoch(): boolean {
+  return hasPersistedUnmergeableAnonymousEpoch()
+}
+
+export function markAnonymousEpochUnmergeable(): boolean {
+  return persistUnmergeableAnonymousEpoch()
 }
 
 /**

--- a/src/main/lib/trustedCloudUrl.test.ts
+++ b/src/main/lib/trustedCloudUrl.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { isTrustedCloudUrl } from './trustedCloudUrl'
+
+describe('isTrustedCloudUrl', () => {
+  it.each([
+    'https://cloud.comfy.org/workspaces/abc',
+    'https://stagingcloud.comfy.org/',
+    'https://testcloud.comfy.org/',
+    'https://pr-123.testingcloud.comfy.org/workspaces/abc'
+  ])('accepts a trusted Cloud HTTPS origin: %s', (url) => {
+    expect(isTrustedCloudUrl(url)).toBe(true)
+  })
+
+  it.each([
+    'http://cloud.comfy.org/',
+    'https://cloud.comfy.org:444/',
+    'https://user:pass@cloud.comfy.org/',
+    'https://testingcloud.comfy.org/',
+    'https://eviltestingcloud.comfy.org/',
+    'https://cloud.comfy.org.attacker.example/',
+    'file:///launcher/index.html',
+    'not a url'
+  ])('rejects an untrusted or malformed URL: %s', (url) => {
+    expect(isTrustedCloudUrl(url)).toBe(false)
+  })
+})

--- a/src/main/lib/trustedCloudUrl.ts
+++ b/src/main/lib/trustedCloudUrl.ts
@@ -1,0 +1,23 @@
+const TRUSTED_CLOUD_HOSTS = new Set([
+  'cloud.comfy.org',
+  'stagingcloud.comfy.org',
+  'testcloud.comfy.org'
+])
+
+export function isTrustedCloudUrl(value: string): boolean {
+  try {
+    const url = new URL(value)
+    const hostname = url.hostname.toLowerCase()
+    const isTestingCloudPreview =
+      hostname !== 'testingcloud.comfy.org' && hostname.endsWith('.testingcloud.comfy.org')
+    return (
+      url.protocol === 'https:' &&
+      url.username === '' &&
+      url.password === '' &&
+      url.port === '' &&
+      (TRUSTED_CLOUD_HOSTS.has(hostname) || isTestingCloudPreview)
+    )
+  } catch {
+    return false
+  }
+}

--- a/src/main/lib/verifiedLocalFirebaseAuth.test.ts
+++ b/src/main/lib/verifiedLocalFirebaseAuth.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+let testUserData = ''
+
+vi.mock('./paths', () => ({
+  configDir: () => testUserData
+}))
+
+import {
+  clearVerifiedLocalFirebaseUser,
+  persistVerifiedLocalFirebaseUser,
+  readVerifiedLocalFirebaseUser
+} from './verifiedLocalFirebaseAuth'
+
+beforeEach(() => {
+  testUserData = fs.mkdtempSync(path.join(os.tmpdir(), 'verified-local-firebase-auth-test-'))
+})
+
+afterEach(() => {
+  fs.rmSync(testUserData, { recursive: true, force: true })
+})
+
+describe('verifiedLocalFirebaseAuth', () => {
+  it('persists a main-verified user only for the exact loopback origin', () => {
+    expect(persistVerifiedLocalFirebaseUser('http://127.0.0.1:8188', 'firebase-1')).toBe(true)
+    expect(readVerifiedLocalFirebaseUser('http://127.0.0.1:8188')).toBe('firebase-1')
+    expect(readVerifiedLocalFirebaseUser('http://127.0.0.1:8189')).toBeNull()
+    expect(persistVerifiedLocalFirebaseUser('https://attacker.example', 'firebase-2')).toBe(false)
+  })
+
+  it('clears the trusted local user on logout', () => {
+    expect(persistVerifiedLocalFirebaseUser('http://localhost:8188', 'firebase-1')).toBe(true)
+    expect(clearVerifiedLocalFirebaseUser('http://localhost:8188')).toBe(true)
+    expect(readVerifiedLocalFirebaseUser('http://localhost:8188')).toBeNull()
+  })
+})

--- a/src/main/lib/verifiedLocalFirebaseAuth.ts
+++ b/src/main/lib/verifiedLocalFirebaseAuth.ts
@@ -1,0 +1,94 @@
+import fs from 'fs'
+import path from 'path'
+import { isLoopbackHostname } from '../auth/desktopLoginCode/origins'
+import { configDir } from './paths'
+import { isIllegalPostHogDistinctId, normalizeOpaqueIdentifier } from './opaqueIdentifier'
+import { writeFileSafe } from './safe-file'
+
+const VERIFIED_LOCAL_FIREBASE_AUTH_FILE = 'verified-local-firebase-auth.json'
+const MAX_VERIFIED_LOCAL_ORIGINS = 32
+
+function verifiedLocalFirebaseAuthPath(): string {
+  return path.join(configDir(), VERIFIED_LOCAL_FIREBASE_AUTH_FILE)
+}
+
+function normalizeLoopbackOrigin(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  try {
+    const url = new URL(value)
+    if (
+      url.origin !== value ||
+      (url.protocol !== 'http:' && url.protocol !== 'https:') ||
+      !isLoopbackHostname(url.hostname)
+    ) {
+      return null
+    }
+    return url.origin
+  } catch {
+    return null
+  }
+}
+
+function normalizeUserId(value: unknown): string | null {
+  const normalized = normalizeOpaqueIdentifier(value, 256)
+  return normalized && !isIllegalPostHogDistinctId(normalized) ? normalized : null
+}
+
+function readBindings(): Record<string, string> {
+  try {
+    const parsed: unknown = JSON.parse(
+      fs.readFileSync(verifiedLocalFirebaseAuthPath(), 'utf-8')
+    )
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {}
+    const bindings: Record<string, string> = {}
+    for (const [rawOrigin, rawUserId] of Object.entries(parsed).slice(
+      -MAX_VERIFIED_LOCAL_ORIGINS
+    )) {
+      const origin = normalizeLoopbackOrigin(rawOrigin)
+      const userId = normalizeUserId(rawUserId)
+      if (origin && userId) bindings[origin] = userId
+    }
+    return bindings
+  } catch {
+    return {}
+  }
+}
+
+function writeBindings(bindings: Record<string, string>): boolean {
+  try {
+    if (Object.keys(bindings).length === 0) {
+      fs.rmSync(verifiedLocalFirebaseAuthPath(), { force: true })
+    } else {
+      writeFileSafe(verifiedLocalFirebaseAuthPath(), JSON.stringify(bindings))
+    }
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function readVerifiedLocalFirebaseUser(origin: string): string | null {
+  const normalizedOrigin = normalizeLoopbackOrigin(origin)
+  return normalizedOrigin ? (readBindings()[normalizedOrigin] ?? null) : null
+}
+
+export function persistVerifiedLocalFirebaseUser(origin: string, userId: string): boolean {
+  const normalizedOrigin = normalizeLoopbackOrigin(origin)
+  const normalizedUserId = normalizeUserId(userId)
+  if (!normalizedOrigin || !normalizedUserId) return false
+  const entries = Object.entries(readBindings()).filter(([candidate]) => candidate !== normalizedOrigin)
+  entries.push([normalizedOrigin, normalizedUserId])
+  return writeBindings(Object.fromEntries(entries.slice(-MAX_VERIFIED_LOCAL_ORIGINS)))
+}
+
+export function clearVerifiedLocalFirebaseUser(origin: string): boolean {
+  const normalizedOrigin = normalizeLoopbackOrigin(origin)
+  if (!normalizedOrigin) return false
+  const bindings = readBindings()
+  delete bindings[normalizedOrigin]
+  return writeBindings(bindings)
+}
+
+export function isLoopbackOrigin(origin: string): boolean {
+  return normalizeLoopbackOrigin(origin) !== null
+}

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -414,20 +414,6 @@ export function buildElectronApi(): ElectronApi {
         // ignore
       }
     },
-    telemetryBindUserId: (payload) => {
-      try {
-        ipcRenderer.send('telemetry:bindUserId', payload)
-      } catch {
-        // ignore
-      }
-    },
-    telemetryUnbindUserId: () => {
-      try {
-        ipcRenderer.send('telemetry:unbindUserId')
-      } catch {
-        // ignore
-      }
-    },
     telemetryGetExperimentFlag: (key) => ipcRenderer.invoke('telemetry:getExperimentFlag', key),
     telemetryRecordExposure: (payload) => {
       try {

--- a/src/preload/comfyPreload.ts
+++ b/src/preload/comfyPreload.ts
@@ -3,13 +3,22 @@ import type { IpcRendererEvent } from 'electron'
 import type {
   ComfyDesktop2Bridge,
   ComfyDesktop2LogsBridge,
-  ComfyDesktop2TelemetryBridge,
   ComfyDesktop2TerminalBridge,
   ComfyDownloadProgress,
   LogsOutputMsg,
   LogsRestore,
   TerminalRestore
 } from '@comfyorg/comfyui-desktop-bridge-types'
+import type { ComfyDesktop2TelemetryBridge } from '../types/comfyDesktopBridge'
+import { startLocalFirebaseAuthMonitor } from './localFirebaseAuthMonitor'
+
+function sendTelemetry(channel: string, payload: unknown): void {
+  try {
+    ipcRenderer.send(channel, payload)
+  } catch {
+    // Telemetry must never break hosted frontend code.
+  }
+}
 
 /**
  * Interactive terminal bridge for the served ComfyUI frontend.
@@ -75,18 +84,19 @@ const Logs: ComfyDesktop2LogsBridge = {
   }
 }
 
+const reportFirebaseAuthState: NonNullable<
+  ComfyDesktop2TelemetryBridge['reportFirebaseAuthState']
+> = (state): void => sendTelemetry('telemetry:firebaseAuthState', state)
+
 const Telemetry: ComfyDesktop2TelemetryBridge = {
-  capture: (event, properties): void => {
-    // Telemetry payload errors must never break hosted frontend code.
-    try {
-      ipcRenderer.send('telemetry:capture', { event, properties })
-    } catch {
-      // ignore: telemetry must never break the renderer
-    }
-  }
+  capture: (event, properties): void => sendTelemetry('telemetry:capture', { event, properties }),
+  reportFirebaseAuthState
 }
 
-type ComfyDesktop2BridgeWithModelAccess = ComfyDesktop2Bridge & {
+startLocalFirebaseAuthMonitor(reportFirebaseAuthState)
+
+type ComfyDesktop2RuntimeBridge = ComfyDesktop2Bridge & {
+  Telemetry: ComfyDesktop2TelemetryBridge
   openModelAccessPage: (url: string) => Promise<boolean>
 }
 
@@ -126,6 +136,6 @@ const bridge = {
   Terminal,
   Logs,
   Telemetry
-} satisfies ComfyDesktop2BridgeWithModelAccess
+} satisfies ComfyDesktop2RuntimeBridge
 
 contextBridge.exposeInMainWorld('__comfyDesktop2', bridge)

--- a/src/preload/localFirebaseAuthMonitor.test.ts
+++ b/src/preload/localFirebaseAuthMonitor.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { readLocalFirebaseAuthState } from './localFirebaseAuthMonitor'
+
+const originalIndexedDb = globalThis.indexedDB
+
+function successfulRequest<T>(result: T): IDBRequest<T> {
+  const request = { result } as IDBRequest<T>
+  queueMicrotask(() => request.onsuccess?.(new Event('success')))
+  return request
+}
+
+function installIndexedDb(entries: unknown[] | null): void {
+  const database = {
+    close: () => {},
+    objectStoreNames: { contains: () => entries !== null },
+    transaction: () => ({
+      objectStore: () => ({
+        getAll: () => successfulRequest(entries ?? [])
+      })
+    })
+  } as unknown as IDBDatabase
+  globalThis.indexedDB = {
+    databases: async () => (entries === null ? [] : [{ name: 'firebaseLocalStorageDb' }]),
+    open: () => successfulRequest(database)
+  } as unknown as IDBFactory
+}
+
+afterEach(() => {
+  globalThis.indexedDB = originalIndexedDb
+})
+
+describe('local Firebase auth monitor', () => {
+  it('reports the single persisted Firebase user', async () => {
+    installIndexedDb([
+      {
+        fbase_key: 'firebase:authUser:api-key:[DEFAULT]',
+        value: { uid: 'firebase-user' }
+      }
+    ])
+
+    await expect(readLocalFirebaseAuthState()).resolves.toEqual({
+      status: 'signed_in',
+      userId: 'firebase-user'
+    })
+  })
+
+  it('fails pending when multiple Firebase projects disagree', async () => {
+    installIndexedDb([
+      { fbase_key: 'firebase:authUser:a:[DEFAULT]', value: { uid: 'user-a' } },
+      { fbase_key: 'firebase:authUser:b:[DEFAULT]', value: { uid: 'user-b' } }
+    ])
+
+    await expect(readLocalFirebaseAuthState()).resolves.toEqual({ status: 'pending' })
+  })
+
+  it('reports signed out without Firebase persistence', async () => {
+    installIndexedDb(null)
+
+    await expect(readLocalFirebaseAuthState()).resolves.toEqual({ status: 'signed_out' })
+  })
+})

--- a/src/preload/localFirebaseAuthMonitor.ts
+++ b/src/preload/localFirebaseAuthMonitor.ts
@@ -1,0 +1,97 @@
+import type { ComfyDesktop2FirebaseAuthState } from '../types/comfyDesktopBridge'
+
+const FIREBASE_DB = 'firebaseLocalStorageDb'
+const FIREBASE_STORE = 'firebaseLocalStorage'
+const FIREBASE_AUTH_KEY_PREFIX = 'firebase:authUser:'
+const POLL_INTERVAL_MS = 1000
+
+function isLoopbackPage(): boolean {
+  if (typeof location === 'undefined') return false
+  const hostname = location.hostname.toLowerCase()
+  return (
+    hostname === 'localhost' ||
+    hostname === '[::1]' ||
+    hostname.startsWith('127.')
+  )
+}
+
+function requestResult<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result)
+    request.onerror = () => reject(request.error ?? new Error('IndexedDB request failed'))
+  })
+}
+
+async function openExistingFirebaseDatabase(): Promise<IDBDatabase | null> {
+  const databases = await indexedDB.databases()
+  if (!databases.some(({ name }) => name === FIREBASE_DB)) return null
+  return requestResult(indexedDB.open(FIREBASE_DB))
+}
+
+export async function readLocalFirebaseAuthState(): Promise<ComfyDesktop2FirebaseAuthState> {
+  try {
+    const database = await openExistingFirebaseDatabase()
+    if (!database) return { status: 'signed_out' }
+    try {
+      if (!database.objectStoreNames.contains(FIREBASE_STORE)) {
+        return { status: 'signed_out' }
+      }
+      const transaction = database.transaction(FIREBASE_STORE, 'readonly')
+      const entries = (await requestResult(
+        transaction.objectStore(FIREBASE_STORE).getAll()
+      )) as unknown[]
+      const userIds = new Set<string>()
+      for (const entry of entries) {
+        if (!entry || typeof entry !== 'object') continue
+        const candidate = entry as {
+          fbase_key?: unknown
+          value?: { uid?: unknown }
+        }
+        if (
+          typeof candidate.fbase_key === 'string' &&
+          candidate.fbase_key.startsWith(FIREBASE_AUTH_KEY_PREFIX) &&
+          typeof candidate.value?.uid === 'string' &&
+          candidate.value.uid.length > 0
+        ) {
+          userIds.add(candidate.value.uid)
+        }
+      }
+      if (userIds.size === 0) return { status: 'signed_out' }
+      if (userIds.size > 1) return { status: 'pending' }
+      return { status: 'signed_in', userId: [...userIds][0]! }
+    } finally {
+      database.close()
+    }
+  } catch {
+    return { status: 'pending' }
+  }
+}
+
+/** Report local Firebase persistence because the frontend's own sync is Cloud-only. */
+export function startLocalFirebaseAuthMonitor(
+  report: (state: ComfyDesktop2FirebaseAuthState) => void
+): (() => void) | null {
+  if (!isLoopbackPage() || typeof indexedDB === 'undefined') return null
+  let lastState = ''
+  let stopped = false
+  let polling = false
+  const poll = async (): Promise<void> => {
+    if (stopped || polling) return
+    polling = true
+    const state = await readLocalFirebaseAuthState()
+    polling = false
+    if (stopped) return
+    const serialized = JSON.stringify(state)
+    if (serialized === lastState) return
+    lastState = serialized
+    report(state)
+  }
+  report({ status: 'pending' })
+  lastState = JSON.stringify({ status: 'pending' })
+  void poll()
+  const interval = setInterval(() => void poll(), POLL_INTERVAL_MS)
+  return () => {
+    stopped = true
+    clearInterval(interval)
+  }
+}

--- a/src/renderer/src/lib/rendererBootstrap.ts
+++ b/src/renderer/src/lib/rendererBootstrap.ts
@@ -366,15 +366,14 @@ async function initializeProviders(): Promise<void> {
     } catch {}
   }
 
-  // PostHog Browser SDK init removed Main process owns
-  // PostHog capture via `posthog-node`; renderer forwards every event
+  // Main owns PostHog capture via `posthog-node`; renderer forwards every event
   // through `window.api.captureTelemetry` / `captureExceptionTelemetry` /
   // `registerTelemetryProperties` IPC bridges. The `comfy.desktop.session.started`
-  // event is still owned by main's `identify()` and fires on consent grant.
+  // event is owned by main and fires when consent permits it.
 
-  // Cohort context + device-id binding fire regardless of Datadog state —
-  // main's posthog-node handles the IPC capture even if Datadog is
-  // configured off.
+  // registerCohortContext always runs, but its Datadog context writes — like
+  // the setUser below — only take effect once Datadog is initialized. PostHog
+  // person properties route through main.
   void registerCohortContext({ appVersion, telemetryEnabled: consent })
   window.api
     .getDeviceId()
@@ -384,8 +383,6 @@ async function initializeProviders(): Promise<void> {
           datadogRum.setUser({ id })
         } catch {}
       }
-      // PostHog identify happens in main's boot block — no renderer call
-      // needed. Person-property upserts ride through registerTelemetryProperties.
     })
     .catch(() => {})
 

--- a/src/types/comfyDesktopBridge.ts
+++ b/src/types/comfyDesktopBridge.ts
@@ -34,6 +34,11 @@ export type ComfyDesktop2TelemetryProperties = Record<
   ComfyDesktop2TelemetryValue | ComfyDesktop2TelemetryValue[]
 >
 
+export type ComfyDesktop2FirebaseAuthState =
+  | { status: 'pending' }
+  | { status: 'signed_out' }
+  | { status: 'signed_in'; userId: string }
+
 export interface ComfyDesktop2TerminalBridge {
   subscribe(installationId?: string): Promise<TerminalRestore>
   unsubscribe(installationId?: string): Promise<void>
@@ -54,6 +59,8 @@ export interface ComfyDesktop2LogsBridge {
 
 export interface ComfyDesktop2TelemetryBridge {
   capture(event: string, properties?: ComfyDesktop2TelemetryProperties): void
+  /** Report the hosted view's complete Firebase state for process-wide consensus. */
+  reportFirebaseAuthState?(state: ComfyDesktop2FirebaseAuthState): void
 }
 
 export interface ComfyDesktop2Bridge {

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -1478,18 +1478,6 @@ export interface ElectronApi {
    */
   registerTelemetryProperties(properties: Record<string, unknown>): void
   /**
-   * Bind a user_id on the current PostHog identity after a successful login.
-   * Main identifies the user with the active anonymous ID, sets
-   * `is_authenticated: true`, and fires `app:user_logged_in`.
-   * The renderer remains responsible for Datadog `setUser` on its own SDK.
-   */
-  telemetryBindUserId(payload: { userId: string; properties?: Record<string, unknown> }): void
-  /**
-   * Unbind user_id on logout and adopt the fresh anonymous ID reserved before
-   * the binding. Renderer also clears Datadog setUser.
-   */
-  telemetryUnbindUserId(): void
-  /**
    * Look up an A/B experiment / feature-flag variant for this user.
    * Returns the cached value (string for multivariate, boolean for a
    * single-flag rollout) or `null` if the flag is not present in the


### PR DESCRIPTION
Split E of #1249.

## Summary

- Add frame-bound Firebase auth consensus across trusted Cloud, Desktop-verified loopback, and fail-closed remote fallback reporters.
- Replace renderer bind/unbind IPC with declarative auth-state reporting.
- Persist verified loopback authorization and monitor local Firebase IndexedDB from preload.
- Route the desktop login-code seam through the process-wide consensus and publish bridge types 0.1.3.
- Fail closed across identity replacement, logout, navigation/frame races, detached hosts, persistence failures, and canceled loads.

This final slice depends functionally on B and C; D is included because the GitHub stack is linear.

## Stack

| Split | PR | Base | Release gate |
|---|---|---|---|
| A | [#1302 — download-path extraction](https://github.com/Comfy-Org/Comfy-Desktop/pull/1302) | `main` | Normal |
| B | [#1303 — desktop login-code auth](https://github.com/Comfy-Org/Comfy-Desktop/pull/1303) | A | Packaged RC |
| C | [#1304 — anonymous identity core](https://github.com/Comfy-Org/Comfy-Desktop/pull/1304) | B | Normal |
| D | [#1305 — installer website-ID carrier](https://github.com/Comfy-Org/Comfy-Desktop/pull/1305) | C | Packaged Windows RC |
| E | [#1306 — Firebase auth consensus](https://github.com/Comfy-Org/Comfy-Desktop/pull/1306) | D | Packaged RC |

## Validation

- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test` — 3,078 passed, 1 skipped
- Focused identity/IPC/preload suite — 211 passed
- Independent security/lifecycle review: no remaining actionable findings

## RC gate

Validate packaged multi-window login/logout/account-switch behavior, Cloud and local/remote installs, navigation/frame replacement, and identity recovery before rollout.