### PR TITLE
feat: require explicit first-use choice on poor hardware

### DIFF
--- a/src/renderer/src/views/FirstUseTakeover.test.ts
+++ b/src/renderer/src/views/FirstUseTakeover.test.ts
@@ -34,8 +34,13 @@ vi.mock('../components/ModalShell.vue', () => ({
 }))
 vi.mock('../components/ChoiceCard.vue', () => ({
   default: {
+    props: {
+      selectable: { type: Boolean, default: false },
+      selected: { type: Boolean, default: false },
+    },
+    emits: ['click'],
     template:
-      '<div data-testid="stub-choice-card"><slot name="label-trailing" /><slot /></div>',
+      '<button data-testid="stub-choice-card" :role="selectable ? \'radio\' : undefined" :aria-checked="selectable ? selected : undefined" :tabindex="selectable ? (selected ? 0 : -1) : undefined" @click="$emit(\'click\')"><slot name="label-trailing" /><slot /></button>',
   },
 }))
 vi.mock('../components/WhyTryCloudModal.vue', () => ({
@@ -62,6 +67,7 @@ vi.mock('../components/BrandTakeoverLayout.vue', () => ({
 }))
 
 import FirstUseTakeover from './FirstUseTakeover.vue'
+import { emitTelemetryAction } from '../lib/telemetry'
 
 const i18n = createI18n({
   legacy: false,
@@ -72,6 +78,7 @@ const i18n = createI18n({
 })
 
 beforeEach(() => {
+  vi.mocked(emitTelemetryAction).mockClear()
   capacityMock.status = 'normal'
   capacityMock.tier = 'unknown'
   window.api = {
@@ -98,6 +105,24 @@ function mountTakeover() {
   })
 }
 
+type SystemInfoResult = Awaited<ReturnType<typeof window.api.getSystemInfo>>
+
+function deferSystemInfo() {
+  let resolvePromise!: (info: SystemInfoResult) => void
+  let rejectPromise!: (error: Error) => void
+  ;(window.api.getSystemInfo as ReturnType<typeof vi.fn>).mockReturnValue(
+    new Promise<SystemInfoResult>((resolve, reject) => {
+      resolvePromise = resolve
+      rejectPromise = reject
+    }),
+  )
+  return {
+    resolve: (info: Pick<SystemInfoResult, 'gpu_label' | 'gpu_tier'>) =>
+      resolvePromise(info as SystemInfoResult),
+    reject: rejectPromise,
+  }
+}
+
 describe('FirstUseTakeover start step', () => {
   it.each(['sub_low', 'cpu_only'] as const)(
     'requires an explicit choice for %s hardware',
@@ -114,6 +139,8 @@ describe('FirstUseTakeover start step', () => {
 
       const btn = wrapper.find('[data-testid="first-use-continue"]')
       expect(btn.attributes('disabled')).toBeDefined()
+      expect(wrapper.find('[data-testid="first-use-pick-cloud"]').attributes('tabindex')).toBe('-1')
+      expect(wrapper.find('[data-testid="first-use-pick-local"]').attributes('tabindex')).toBe('0')
       await btn.trigger('click')
       expect(wrapper.emitted('chain-local')).toBeFalsy()
       expect(wrapper.emitted('complete-cloud')).toBeFalsy()
@@ -145,21 +172,14 @@ describe('FirstUseTakeover start step', () => {
   )
 
   it('does not replace a choice made before hardware detection resolves', async () => {
-    let resolveSystemInfo:
-      | ((info: Awaited<ReturnType<typeof window.api.getSystemInfo>>) => void)
-      | undefined
-    ;(window.api.getSystemInfo as ReturnType<typeof vi.fn>).mockReturnValue(
-      new Promise((resolve) => {
-        resolveSystemInfo = resolve
-      }),
-    )
+    const systemInfo = deferSystemInfo()
     const wrapper = mountTakeover()
     await wrapper.find('[data-testid="first-use-pick-cloud"]').trigger('click')
 
-    resolveSystemInfo?.({
+    systemInfo.resolve({
       gpu_label: 'NVIDIA',
       gpu_tier: 'sub_low',
-    } as Awaited<ReturnType<typeof window.api.getSystemInfo>>)
+    })
     await flushPromises()
     await wrapper
       .find('[data-testid="first-use-consent-tos"] input[type="checkbox"]')
@@ -171,15 +191,30 @@ describe('FirstUseTakeover start step', () => {
     expect(wrapper.emitted('complete-cloud')).toBeTruthy()
   })
 
+  it('preserves an explicit Cloud choice for a legacy install when hardware resolves late', async () => {
+    const systemInfo = deferSystemInfo()
+    const wrapper = mountTakeover()
+    await (
+      wrapper.vm as unknown as { open: (opts: { hasLegacyDesktop: boolean }) => Promise<void> }
+    ).open({ hasLegacyDesktop: true })
+    await wrapper.find('[data-testid="first-use-pick-cloud"]').trigger('click')
+
+    systemInfo.resolve({
+      gpu_label: 'NVIDIA',
+      gpu_tier: 'sub_low',
+    })
+    await flushPromises()
+    await wrapper
+      .find('[data-testid="first-use-consent-tos"] input[type="checkbox"]')
+      .setValue(true)
+
+    await wrapper.find('[data-testid="first-use-continue"]').trigger('click')
+    expect(wrapper.emitted('complete-cloud')).toHaveLength(1)
+    expect(wrapper.emitted('chain-migrate')).toBeFalsy()
+  })
+
   it('waits for hardware detection before committing an untouched default', async () => {
-    let resolveSystemInfo:
-      | ((info: Awaited<ReturnType<typeof window.api.getSystemInfo>>) => void)
-      | undefined
-    ;(window.api.getSystemInfo as ReturnType<typeof vi.fn>).mockReturnValue(
-      new Promise((resolve) => {
-        resolveSystemInfo = resolve
-      }),
-    )
+    const systemInfo = deferSystemInfo()
     const wrapper = mountTakeover()
     await wrapper
       .find('[data-testid="first-use-consent-tos"] input[type="checkbox"]')
@@ -187,16 +222,69 @@ describe('FirstUseTakeover start step', () => {
 
     const btn = wrapper.find('[data-testid="first-use-continue"]')
     const clickPromise = btn.trigger('click')
-    resolveSystemInfo?.({
+    await wrapper.vm.$nextTick()
+    expect(btn.text()).toBe('firstUse.startContinueBusy')
+    expect(btn.attributes('aria-busy')).toBe('true')
+
+    systemInfo.resolve({
       gpu_label: 'NVIDIA',
       gpu_tier: 'sub_low',
-    } as Awaited<ReturnType<typeof window.api.getSystemInfo>>)
+    })
     await clickPromise
     await flushPromises()
 
     expect(btn.attributes('disabled')).toBeDefined()
+    expect(btn.text()).toBe('firstUse.startContinue')
+    expect(btn.attributes('aria-busy')).toBe('false')
     expect(wrapper.emitted('chain-local')).toBeFalsy()
     expect(wrapper.emitted('complete-cloud')).toBeFalsy()
+  })
+
+  it('continues once with the existing default when system-info rejects', async () => {
+    const systemInfo = deferSystemInfo()
+    const wrapper = mountTakeover()
+    await wrapper
+      .find('[data-testid="first-use-consent-tos"] input[type="checkbox"]')
+      .setValue(true)
+
+    const clickPromise = wrapper.find('[data-testid="first-use-continue"]').trigger('click')
+    systemInfo.reject(new Error('system-info unavailable'))
+    await clickPromise
+    await flushPromises()
+
+    expect(wrapper.emitted('chain-local')).toHaveLength(1)
+    expect(window.api.setSetting).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores Continue re-entry while system-info is pending', async () => {
+    const systemInfo = deferSystemInfo()
+    const wrapper = mountTakeover()
+    await wrapper
+      .find('[data-testid="first-use-consent-tos"] input[type="checkbox"]')
+      .setValue(true)
+
+    const btn = wrapper.find('[data-testid="first-use-continue"]')
+    const firstClick = btn.trigger('click')
+    const secondClick = btn.trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(btn.text()).toBe('firstUse.startContinueBusy')
+    expect(btn.attributes('disabled')).toBeDefined()
+
+    systemInfo.resolve({
+      gpu_label: 'NVIDIA',
+      gpu_tier: 'mid',
+    })
+    await Promise.all([firstClick, secondClick])
+    await flushPromises()
+
+    expect(wrapper.emitted('chain-local')).toHaveLength(1)
+    expect(window.api.setSetting).toHaveBeenCalledTimes(1)
+    expect(
+      vi
+        .mocked(emitTelemetryAction)
+        .mock.calls.filter(([event]) => event === 'comfy.desktop.first_use.fork_chosen'),
+    ).toHaveLength(1)
   })
 
   it('keeps the legacy-desktop Local default on poor hardware', async () => {
@@ -230,6 +318,25 @@ describe('FirstUseTakeover start step', () => {
       .setValue(true)
 
     expect(wrapper.find('[data-testid="first-use-continue"]').attributes('disabled')).toBeUndefined()
+  })
+
+  it('keeps keyboard navigation on Local when Cloud capacity is disabled', async () => {
+    capacityMock.status = 'disabled'
+    const wrapper = mountTakeover()
+    await flushPromises()
+
+    const cloud = wrapper.find('[data-testid="first-use-pick-cloud"]')
+    const local = wrapper.find('[data-testid="first-use-pick-local"]')
+    const focusLocal = vi.spyOn(local.element as HTMLElement, 'focus')
+    expect(cloud.attributes('aria-checked')).toBe('false')
+    expect(local.attributes('aria-checked')).toBe('true')
+
+    await local.trigger('keydown', { key: 'ArrowRight' })
+    await wrapper.vm.$nextTick()
+
+    expect(cloud.attributes('aria-checked')).toBe('false')
+    expect(local.attributes('aria-checked')).toBe('true')
+    expect(focusLocal).toHaveBeenCalledOnce()
   })
 
   it('Continue triggers a nudge shake on the ToS row when terms are not accepted', async () => {

--- a/src/renderer/src/views/FirstUseTakeover.test.ts
+++ b/src/renderer/src/views/FirstUseTakeover.test.ts
@@ -7,6 +7,25 @@ vi.mock('../lib/telemetry', () => ({
   emitTelemetryAction: vi.fn(),
 }))
 
+const capacityMock = vi.hoisted(() => ({
+  status: 'normal' as 'normal' | 'degraded' | 'disabled',
+  tier: 'unknown' as 'free' | 'paid' | 'unknown',
+}))
+
+vi.mock('../composables/useCloudCapacity', async () => {
+  const { computed } = await import('vue')
+  return {
+    useCloudCapacity: () => ({
+      status: computed(() => capacityMock.status),
+      tier: computed(() => capacityMock.tier),
+      whenReady: vi.fn().mockResolvedValue(undefined),
+      isDisabled: () => capacityMock.status === 'disabled',
+      isDegraded: () => capacityMock.status === 'degraded',
+      confirmEntry: vi.fn().mockResolvedValue(true),
+    }),
+  }
+})
+
 vi.mock('../components/TakeoverHeader.vue', () => ({
   default: { template: '<div data-testid="stub-takeover-header"><slot /></div>' },
 }))
@@ -53,11 +72,16 @@ const i18n = createI18n({
 })
 
 beforeEach(() => {
+  capacityMock.status = 'normal'
+  capacityMock.tier = 'unknown'
   window.api = {
     setSetting: vi.fn().mockResolvedValue(undefined),
     getSetting: vi.fn().mockResolvedValue(true),
     getLocale: vi.fn().mockResolvedValue('en'),
-    detectGPU: vi.fn().mockResolvedValue(null),
+    getSystemInfo: vi.fn().mockResolvedValue({
+      gpu_label: 'NVIDIA',
+      gpu_tier: 'mid',
+    }),
     setFirstUseMode: vi.fn(),
     closeHostWindow: vi.fn().mockResolvedValue(undefined),
     // Default to undefined so the existing tests exercise the control
@@ -75,6 +99,139 @@ function mountTakeover() {
 }
 
 describe('FirstUseTakeover start step', () => {
+  it.each(['sub_low', 'cpu_only'] as const)(
+    'requires an explicit choice for %s hardware',
+    async (gpuTier) => {
+      ;(window.api.getSystemInfo as ReturnType<typeof vi.fn>).mockResolvedValue({
+        gpu_label: gpuTier === 'cpu_only' ? null : 'NVIDIA',
+        gpu_tier: gpuTier,
+      })
+      const wrapper = mountTakeover()
+      await flushPromises()
+      await wrapper
+        .find('[data-testid="first-use-consent-tos"] input[type="checkbox"]')
+        .setValue(true)
+
+      const btn = wrapper.find('[data-testid="first-use-continue"]')
+      expect(btn.attributes('disabled')).toBeDefined()
+      await btn.trigger('click')
+      expect(wrapper.emitted('chain-local')).toBeFalsy()
+      expect(wrapper.emitted('complete-cloud')).toBeFalsy()
+
+      await wrapper.find('[data-testid="first-use-pick-local"]').trigger('click')
+      expect(btn.attributes('disabled')).toBeUndefined()
+    },
+  )
+
+  it.each(['low', 'mid', 'high', 'apple'] as const)(
+    'preserves the Local default for %s hardware',
+    async (gpuTier) => {
+      ;(window.api.getSystemInfo as ReturnType<typeof vi.fn>).mockResolvedValue({
+        gpu_label: gpuTier === 'apple' ? 'Apple Silicon' : 'NVIDIA',
+        gpu_tier: gpuTier,
+      })
+      const wrapper = mountTakeover()
+      await flushPromises()
+      await wrapper
+        .find('[data-testid="first-use-consent-tos"] input[type="checkbox"]')
+        .setValue(true)
+
+      const btn = wrapper.find('[data-testid="first-use-continue"]')
+      expect(btn.attributes('disabled')).toBeUndefined()
+      await btn.trigger('click')
+      expect(wrapper.emitted('chain-local')).toBeTruthy()
+      expect(wrapper.emitted('complete-cloud')).toBeFalsy()
+    },
+  )
+
+  it('does not replace a choice made before hardware detection resolves', async () => {
+    let resolveSystemInfo:
+      | ((info: Awaited<ReturnType<typeof window.api.getSystemInfo>>) => void)
+      | undefined
+    ;(window.api.getSystemInfo as ReturnType<typeof vi.fn>).mockReturnValue(
+      new Promise((resolve) => {
+        resolveSystemInfo = resolve
+      }),
+    )
+    const wrapper = mountTakeover()
+    await wrapper.find('[data-testid="first-use-pick-cloud"]').trigger('click')
+
+    resolveSystemInfo?.({
+      gpu_label: 'NVIDIA',
+      gpu_tier: 'sub_low',
+    } as Awaited<ReturnType<typeof window.api.getSystemInfo>>)
+    await flushPromises()
+    await wrapper
+      .find('[data-testid="first-use-consent-tos"] input[type="checkbox"]')
+      .setValue(true)
+
+    const btn = wrapper.find('[data-testid="first-use-continue"]')
+    expect(btn.attributes('disabled')).toBeUndefined()
+    await btn.trigger('click')
+    expect(wrapper.emitted('complete-cloud')).toBeTruthy()
+  })
+
+  it('waits for hardware detection before committing an untouched default', async () => {
+    let resolveSystemInfo:
+      | ((info: Awaited<ReturnType<typeof window.api.getSystemInfo>>) => void)
+      | undefined
+    ;(window.api.getSystemInfo as ReturnType<typeof vi.fn>).mockReturnValue(
+      new Promise((resolve) => {
+        resolveSystemInfo = resolve
+      }),
+    )
+    const wrapper = mountTakeover()
+    await wrapper
+      .find('[data-testid="first-use-consent-tos"] input[type="checkbox"]')
+      .setValue(true)
+
+    const btn = wrapper.find('[data-testid="first-use-continue"]')
+    const clickPromise = btn.trigger('click')
+    resolveSystemInfo?.({
+      gpu_label: 'NVIDIA',
+      gpu_tier: 'sub_low',
+    } as Awaited<ReturnType<typeof window.api.getSystemInfo>>)
+    await clickPromise
+    await flushPromises()
+
+    expect(btn.attributes('disabled')).toBeDefined()
+    expect(wrapper.emitted('chain-local')).toBeFalsy()
+    expect(wrapper.emitted('complete-cloud')).toBeFalsy()
+  })
+
+  it('keeps the legacy-desktop Local default on poor hardware', async () => {
+    ;(window.api.getSystemInfo as ReturnType<typeof vi.fn>).mockResolvedValue({
+      gpu_label: 'NVIDIA',
+      gpu_tier: 'sub_low',
+    })
+    const wrapper = mountTakeover()
+    await (
+      wrapper.vm as unknown as { open: (opts: { hasLegacyDesktop: boolean }) => Promise<void> }
+    ).open({ hasLegacyDesktop: true })
+    await flushPromises()
+    await wrapper
+      .find('[data-testid="first-use-consent-tos"] input[type="checkbox"]')
+      .setValue(true)
+
+    expect(wrapper.find('[data-testid="first-use-continue"]').attributes('disabled')).toBeUndefined()
+    expect(wrapper.find('[data-testid="first-use-migrate-existing"]').exists()).toBe(true)
+  })
+
+  it('keeps the capacity-disabled Local default on poor hardware', async () => {
+    capacityMock.status = 'disabled'
+    ;(window.api.getSystemInfo as ReturnType<typeof vi.fn>).mockResolvedValue({
+      gpu_label: 'NVIDIA',
+      gpu_tier: 'sub_low',
+    })
+    const wrapper = mountTakeover()
+    await flushPromises()
+    await wrapper
+      .find('[data-testid="first-use-consent-tos"] input[type="checkbox"]')
+      .setValue(true)
+
+    expect(wrapper.find('[data-testid="first-use-continue"]').attributes('disabled')).toBeUndefined()
+  })
+
   it('Continue triggers a nudge shake on the ToS row when terms are not accepted', async () => {
     const wrapper = mountTakeover()
     const tosRow = wrapper.find('[data-testid="first-use-consent-tos"]')
@@ -402,6 +559,21 @@ describe('FirstUseTakeover desktop-first-use-fork-default experiment', () => {
       variant: 'cloud-default',
       source: 'cache'
     })
+  })
+
+  it('overrides the cloud-default experiment for poor hardware', async () => {
+    ;(window.api.telemetryGetExperimentFlag as ReturnType<typeof vi.fn>).mockResolvedValue('cloud')
+    ;(window.api.getSystemInfo as ReturnType<typeof vi.fn>).mockResolvedValue({
+      gpu_label: 'NVIDIA',
+      gpu_tier: 'sub_low',
+    })
+    const wrapper = mountTakeover()
+    await flushPromises()
+    await wrapper
+      .find('[data-testid="first-use-consent-tos"] input[type="checkbox"]')
+      .setValue(true)
+
+    expect(wrapper.find('[data-testid="first-use-continue"]').attributes('disabled')).toBeDefined()
   })
 
   it("pre-selects nothing when the flag returns 'none' (no-default arm) and disables Continue until a card is picked", async () => {

--- a/src/renderer/src/views/FirstUseTakeover.vue
+++ b/src/renderer/src/views/FirstUseTakeover.vue
@@ -58,6 +58,8 @@ import BrandTakeoverLayout from '../components/BrandTakeoverLayout.vue'
 import InlineRichText from '../components/InlineRichText.vue'
 import { emitTelemetryAction } from '../lib/telemetry'
 import { useCloudCapacity } from '../composables/useCloudCapacity'
+import type { GpuTier } from '../../../shared/gpuTier'
+import type { SystemInfo } from '../../../types/ipc'
 
 type Step = 'start' | 'mirrors' | 'localBranch'
 
@@ -120,9 +122,17 @@ const forkExperimentVariant = ref<ForkVariant | null>(null)
  *  "Download Local" upstream, so honor that intent unless the
  *  experiment overrides it: `'cloud-default'` pre-selects Cloud,
  *  `'no-default'` pre-selects neither (user must click a card before
- *  Continue activates). Cloud is rendered as an equal-weight peer
- *  card regardless; users can flip between cards before Continue. */
+ *  Continue activates). Poor hardware also starts without a default.
+ *  Cloud is rendered as an equal-weight peer card regardless; users
+ *  can flip between cards before Continue. */
 const pickedChoice = ref<'cloud' | 'local' | null>('local')
+const forkChoiceInteracted = ref(false)
+const detectedGpuTier = ref<GpuTier | null>(null)
+
+function selectForkChoice(choice: 'cloud' | 'local'): void {
+  forkChoiceInteracted.value = true
+  pickedChoice.value = choice
+}
 
 // Capacity-protection switch for Cloud (PostHog flag
 // `desktop-cloud-capacity`). At first-use, we follow the flag
@@ -137,7 +147,8 @@ const capacityReady = ref(false)
  *  used to split `fork_chosen` conversion by signal-vs-defaulting: a
  *  user keeping the default pick is different from a user actively
  *  flipping the card. `null` for the `'no-default'` variant, where
- *  Continue is gated on an explicit pick so every commit is signal. */
+ *  Continue is gated on an explicit pick so every commit is signal,
+ *  and for poor hardware where the same explicit choice is required. */
 const initialDefaultChoice = ref<'cloud' | 'local' | null>('local')
 
 /** Read the experiment variant (boot-time cache, sync once main is
@@ -173,11 +184,10 @@ async function loadForkExperimentVariant(): Promise<ForkVariant> {
   return variant
 }
 
-/** Apply the resolved variant to the picker state, respecting the
- *  hard precedence rules (legacy-desktop > capacity-disabled >
- *  experiment). Idempotent — safe to call from `onMounted` and from
- *  `open()` on takeover replay. Always lands on a terminal state for
- *  both refs so the caller doesn't need to seed defaults first. */
+/** Apply the resolved default to the picker state, respecting hard
+ *  gates, explicit interaction, poor hardware, and then the experiment.
+ *  Idempotent — safe to call as each async input resolves and from
+ *  `open()` on takeover replay. */
 function applyForkExperimentDefault(variant: ForkVariant): void {
   // Migration flow always wins. Returning Desktop-1 users land on
   // Local with the migrate-existing checkbox pre-ticked — that's the
@@ -193,6 +203,15 @@ function applyForkExperimentDefault(variant: ForkVariant): void {
   if (cloudCapacity.isDisabled()) {
     pickedChoice.value = 'local'
     initialDefaultChoice.value = 'local'
+    return
+  }
+  if (forkChoiceInteracted.value) return
+  if (
+    !skipPick.value &&
+    (detectedGpuTier.value === 'sub_low' || detectedGpuTier.value === 'cpu_only')
+  ) {
+    pickedChoice.value = null
+    initialDefaultChoice.value = null
     return
   }
   if (variant === 'cloud-default') {
@@ -248,7 +267,7 @@ const migrateExisting = ref(true)
 const showMigrateExisting = computed(
   () => pickedChoice.value === 'local' && hasLegacyDesktop.value
 )
-/** Detected GPU vendor — populated by `window.api.detectGPU()` on
+/** Detected GPU vendor — populated from the shared system-info IPC on
  *  `open()`. Surfaces as an inline confirmation line under the Express
  *  checkbox so users on the wrong hardware can untick Express before
  *  the install kicks off. `null` when detection fails or returns no
@@ -258,6 +277,21 @@ const detectedGpuLabel = ref<string | null>(null)
 const showGpuHint = computed(
   () => pickedChoice.value === 'local' && expressInstall.value && detectedGpuLabel.value !== null
 )
+let systemInfoPromise: Promise<SystemInfo> | null = null
+
+function loadSystemInfo(): Promise<SystemInfo> {
+  systemInfoPromise ??= window.api.getSystemInfo().catch((error) => {
+    systemInfoPromise = null
+    throw error
+  })
+  return systemInfoPromise
+}
+
+function applySystemInfo(info: SystemInfo): void {
+  detectedGpuLabel.value = info.gpu_label
+  detectedGpuTier.value = info.gpu_tier
+  applyForkExperimentDefault(forkExperimentVariant.value ?? 'control')
+}
 /** Funnel-completion bookkeeping for `comfy.desktop.first_use.completed`.
  *  `mountedAt` is reset in `open()` so a takeover replay measures
  *  duration from the replay, not from the original mount.
@@ -368,10 +402,22 @@ async function onContinue(): Promise<void> {
     nudgeTos()
     return
   }
-  // No-default experiment arm: until the user clicks a card, there's
-  // no pick to commit. The button is already :disabled in this state,
-  // but guard defensively so a programmatic click can't bypass.
+  // Until an experiment cohort clicks a card, there is no pick to
+  // commit. The button is already :disabled in this state, but guard
+  // defensively so a programmatic click can't bypass.
   if (pickedChoice.value === null) return
+  // Hardware normally resolves before the user reaches Continue. If it
+  // has not, wait before committing an untouched default so poor
+  // hardware cannot slip through without the required explicit choice.
+  if (!forkChoiceInteracted.value && detectedGpuTier.value === null) {
+    try {
+      applySystemInfo(await loadSystemInfo())
+    } catch {
+      // Preserve the existing default when hardware detection fails.
+    }
+    if (pickedChoice.value === null) return
+  }
+  forkChoiceInteracted.value = true
   // Keep `isContinuing` true past `routePostStart()` because the chain
   // handlers (express prep, cloud auto-launch, new-install swap) all
   // either unmount this takeover or swap to a sub-step within ms. The
@@ -511,7 +557,7 @@ function onWhyCloudTryCloud(): void {
   // selection to Cloud but leaves the user on the screen so they can
   // accept T&C and press Continue. The legal gate is non-negotiable —
   // we can't auto-commit on the user's behalf.
-  pickedChoice.value = 'cloud'
+  selectForkChoice('cloud')
 }
 
 function chooseMigrate(): void {
@@ -525,10 +571,10 @@ function chooseMigrate(): void {
 
 /** Radiogroup arrow-key handler for the Cloud / Local cards.
  *  WAI-ARIA APG §3.15: arrow keys cycle the checked radio and move DOM
- *  focus along with it. When `pickedChoice` is `null` (the no-default
- *  experiment arm before the user has touched the picker), arrow-down
- *  enters at Cloud and arrow-up enters at Local so keyboard users can
- *  make a pick without reaching for the mouse. */
+ *  focus along with it. When `pickedChoice` is `null` before the user
+ *  has touched the picker, arrow-down enters at Cloud and arrow-up
+ *  enters at Local so keyboard users can make a pick without reaching
+ *  for the mouse. */
 function onStartCardsKeydown(e: KeyboardEvent): void {
   const target = e.target as HTMLElement | null
   if (!target?.closest('[role="radio"]')) return
@@ -545,7 +591,7 @@ function onStartCardsKeydown(e: KeyboardEvent): void {
   const nextChoice = order[next]
   if (!nextChoice) return
   e.preventDefault()
-  pickedChoice.value = nextChoice
+  selectForkChoice(nextChoice)
   void nextTick(() => {
     const radios = (e.currentTarget as HTMLElement | null)?.querySelectorAll<HTMLElement>(
       '[role="radio"]'
@@ -584,12 +630,12 @@ async function open(opts: OpenOpts = {}): Promise<void> {
   whyCloudOpen.value = false
   termsDoc.value = null
   acceptedTos.value = false
+  forkChoiceInteracted.value = false
   // Safe baseline: Local pre-selected. The variant-aware apply call
   // below overrides to Cloud (`'cloud-default'` arm) or null
-  // (`'no-default'` arm) when neither hard gate (legacy-desktop,
-  // capacity-disabled) applies. Reset unconditionally first so the
-  // takeover-replay path lands on a clean slate even if the variant
-  // hasn't resolved yet on first mount.
+  // (`'no-default'` or poor-hardware cohort) when neither hard gate
+  // (legacy-desktop, capacity-disabled) applies. Reset unconditionally
+  // first so the takeover-replay path lands on a clean slate.
   pickedChoice.value = 'local'
   initialDefaultChoice.value = 'local'
   // Re-apply the experiment variant on every replay so a user who
@@ -598,9 +644,7 @@ async function open(opts: OpenOpts = {}): Promise<void> {
   // first mount it may still be null if `loadForkExperimentVariant`
   // hasn't resolved yet, which is fine: onMounted applies it once it
   // does.
-  if (forkExperimentVariant.value) {
-    applyForkExperimentDefault(forkExperimentVariant.value)
-  }
+  applyForkExperimentDefault(forkExperimentVariant.value ?? 'control')
   expressInstall.value = false
   migrateExisting.value = true
   // `onContinue` keeps `isContinuing` true past `routePostStart()`
@@ -626,7 +670,7 @@ async function open(opts: OpenOpts = {}): Promise<void> {
   // a destructive default).
   const existing = (await window.api.getSetting('telemetryEnabled')) as boolean | undefined
   telemetryEnabled.value = existing !== false
-  // Locale + GPU detection run non-blocking so the start hero paints on
+  // Locale + hardware detection run non-blocking so the start hero paints on
   // the first frame even if main is slow to resolve (e.g. cold IPC, no
   // GPU on CI). Sensible defaults (`'en'`, `null`) are already in place;
   // the reactive updates surface the real values when they arrive.
@@ -636,11 +680,8 @@ async function open(opts: OpenOpts = {}): Promise<void> {
       locale.value = next
     })
     .catch(() => {})
-  void window.api
-    .detectGPU()
-    .then((g) => {
-      detectedGpuLabel.value = g?.label ?? null
-    })
+  void loadSystemInfo()
+    .then(applySystemInfo)
     .catch(() => {})
 }
 
@@ -765,7 +806,7 @@ defineExpose({ open, resetContinue })
             "
             :description="$t(cloudDescriptionKey)"
             data-testid="first-use-pick-cloud"
-            @click="cloudCapacity.isDisabled() ? null : (pickedChoice = 'cloud')"
+            @click="cloudCapacity.isDisabled() ? null : selectForkChoice('cloud')"
           >
             <template #label-trailing>
               <Tooltip :text="$t('firstUse.whyTryCloud')">
@@ -788,7 +829,7 @@ defineExpose({ open, resetContinue })
             :tagline="$t('firstUse.localTagline')"
             :description="$t('firstUse.localDesc')"
             data-testid="first-use-pick-local"
-            @click="pickedChoice = 'local'"
+            @click="selectForkChoice('local')"
           />
         </div>
         <!-- Modifier checkboxes (Migrate + Express). Wrapped in a

--- a/src/renderer/src/views/FirstUseTakeover.vue
+++ b/src/renderer/src/views/FirstUseTakeover.vue
@@ -130,8 +130,15 @@ const forkChoiceInteracted = ref(false)
 const detectedGpuTier = ref<GpuTier | null>(null)
 
 function selectForkChoice(choice: 'cloud' | 'local'): void {
+  if (choice === 'cloud' && cloudCapacity.isDisabled()) return
   forkChoiceInteracted.value = true
   pickedChoice.value = choice
+}
+
+function forkChoiceTabIndex(choice: 'cloud' | 'local'): number {
+  return pickedChoice.value === choice || (pickedChoice.value === null && choice === 'local')
+    ? 0
+    : -1
 }
 
 // Capacity-protection switch for Cloud (PostHog flag
@@ -184,20 +191,10 @@ async function loadForkExperimentVariant(): Promise<ForkVariant> {
   return variant
 }
 
-/** Apply the resolved default to the picker state, respecting hard
- *  gates, explicit interaction, poor hardware, and then the experiment.
- *  Idempotent — safe to call as each async input resolves and from
- *  `open()` on takeover replay. */
+/** Apply the resolved default to the picker state, respecting capacity,
+ *  explicit interaction, legacy installs, poor hardware, and then the
+ *  experiment. Idempotent across async resolution and takeover replay. */
 function applyForkExperimentDefault(variant: ForkVariant): void {
-  // Migration flow always wins. Returning Desktop-1 users land on
-  // Local with the migrate-existing checkbox pre-ticked — that's the
-  // whole point of the legacy-detection branch. The experiment never
-  // overrides it.
-  if (hasLegacyDesktop.value) {
-    pickedChoice.value = 'local'
-    initialDefaultChoice.value = 'local'
-    return
-  }
   // Capacity kill-switch also forces Local: cloud can't be booked, so
   // there's no point pre-selecting it.
   if (cloudCapacity.isDisabled()) {
@@ -206,6 +203,13 @@ function applyForkExperimentDefault(variant: ForkVariant): void {
     return
   }
   if (forkChoiceInteracted.value) return
+  // Returning Desktop-1 users initially land on Local with migration
+  // pre-ticked, but an explicit Cloud choice must remain authoritative.
+  if (hasLegacyDesktop.value) {
+    pickedChoice.value = 'local'
+    initialDefaultChoice.value = 'local'
+    return
+  }
   if (
     !skipPick.value &&
     (detectedGpuTier.value === 'sub_low' || detectedGpuTier.value === 'cpu_only')
@@ -406,6 +410,9 @@ async function onContinue(): Promise<void> {
   // commit. The button is already :disabled in this state, but guard
   // defensively so a programmatic click can't bypass.
   if (pickedChoice.value === null) return
+  // Lock before hardware detection so repeated activation cannot start
+  // duplicate telemetry or routing work while the IPC is pending.
+  isContinuing.value = true
   // Hardware normally resolves before the user reaches Continue. If it
   // has not, wait before committing an untouched default so poor
   // hardware cannot slip through without the required explicit choice.
@@ -415,7 +422,10 @@ async function onContinue(): Promise<void> {
     } catch {
       // Preserve the existing default when hardware detection fails.
     }
-    if (pickedChoice.value === null) return
+    if (pickedChoice.value === null) {
+      isContinuing.value = false
+      return
+    }
   }
   forkChoiceInteracted.value = true
   // Keep `isContinuing` true past `routePostStart()` because the chain
@@ -423,8 +433,6 @@ async function onContinue(): Promise<void> {
   // either unmount this takeover or swap to a sub-step within ms. The
   // China-mirrors branch is the only path that lingers on this component
   // post-Continue, so it explicitly clears the flag on its return.
-  isContinuing.value = true
-
   await window.api.setSetting('telemetryEnabled', telemetryEnabled.value)
 
   emitTelemetryAction('comfy.desktop.first_use.consent_decision', {
@@ -578,7 +586,10 @@ function chooseMigrate(): void {
 function onStartCardsKeydown(e: KeyboardEvent): void {
   const target = e.target as HTMLElement | null
   if (!target?.closest('[role="radio"]')) return
-  const order = ['cloud', 'local'] as const
+  const group = e.currentTarget as HTMLElement | null
+  const order: Array<'cloud' | 'local'> = cloudCapacity.isDisabled()
+    ? ['local']
+    : ['cloud', 'local']
   const currentIndex = pickedChoice.value === null ? -1 : order.indexOf(pickedChoice.value)
   let next: number
   if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
@@ -593,10 +604,10 @@ function onStartCardsKeydown(e: KeyboardEvent): void {
   e.preventDefault()
   selectForkChoice(nextChoice)
   void nextTick(() => {
-    const radios = (e.currentTarget as HTMLElement | null)?.querySelectorAll<HTMLElement>(
-      '[role="radio"]'
+    const radio = group?.querySelector<HTMLElement>(
+      `[data-testid="first-use-pick-${nextChoice}"]`
     )
-    radios?.[next]?.focus()
+    radio?.focus()
   })
 }
 
@@ -794,6 +805,7 @@ defineExpose({ open, resetContinue })
             :class="{ 'start-card-cloud--capacity-disabled': cloudCapacity.isDisabled() }"
             selectable
             :selected="pickedChoice === 'cloud'"
+            :tabindex="forkChoiceTabIndex('cloud')"
             :aria-disabled="cloudCapacity.isDisabled() ? true : undefined"
             glow
             :label="$t('cloud.label')"
@@ -806,7 +818,7 @@ defineExpose({ open, resetContinue })
             "
             :description="$t(cloudDescriptionKey)"
             data-testid="first-use-pick-cloud"
-            @click="cloudCapacity.isDisabled() ? null : selectForkChoice('cloud')"
+            @click="selectForkChoice('cloud')"
           >
             <template #label-trailing>
               <Tooltip :text="$t('firstUse.whyTryCloud')">
@@ -825,6 +837,7 @@ defineExpose({ open, resetContinue })
           <ChoiceCard
             selectable
             :selected="pickedChoice === 'local'"
+            :tabindex="forkChoiceTabIndex('local')"
             :label="$t('firstUse.localLabel')"
             :tagline="$t('firstUse.localTagline')"
             :description="$t('firstUse.localDesc')"


### PR DESCRIPTION
## Summary

- use the shared `getSystemInfo().gpu_tier` result on the first-use Local/Cloud choice
- leave both choices unselected for `sub_low` and `cpu_only` hardware until the user explicitly selects one
- preserve explicit choices across late experiment and system-info resolution while retaining the capacity-disabled Local safeguard and initial legacy Desktop Local default
- lock Continue before awaiting system info so late poor-tier resolution safely returns to an unselected picker and repeated activation cannot duplicate telemetry or routing
- keep a no-default picker keyboard-accessible and prevent keyboard navigation from selecting Cloud while capacity is disabled

This is intentionally behavior-only. It does not add the pending Cloud recommendation design, recommendation copy, new telemetry, or any Why Cloud changes.

## Base

Rebased onto `main` at `25d77cb3` after #1289 merged.

## Validation

- `mise exec -- pnpm exec vitest run src/renderer/src/views/FirstUseTakeover.test.ts` — 39 passed