### PR TITLE
proto(picker): distribution menus + Manage view in the real instance picker

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -364,6 +364,7 @@
   "channelCards": {
     "installedVersion": "Installed Version",
     "latestVersion": "Latest Version",
+    "comfyVersion": "ComfyUI Version",
     "lastChecked": "Last Checked",
     "status": "Status",
     "updateAvailable": "Update available",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -364,6 +364,7 @@
   "channelCards": {
     "installedVersion": "已安装版本",
     "latestVersion": "最新版本",
+    "comfyVersion": "ComfyUI 版本",
     "lastChecked": "上次检查",
     "status": "状态",
     "updateAvailable": "有可用更新",

--- a/src/renderer/src/comfyTitlePopup/InstancePickerView.vue
+++ b/src/renderer/src/comfyTitlePopup/InstancePickerView.vue
@@ -14,6 +14,7 @@ import ComfyUISettingsContent from '../components/settings/ComfyUISettingsConten
 import InfoTooltip from '../components/InfoTooltip.vue'
 import Tooltip from '../components/ui/Tooltip.vue'
 import InstanceRow from './instancePicker/InstanceRow.vue'
+import { isMockDistributionId, mockDistributionRows } from './instancePicker/distributionMocks'
 import { resolvePickerTab, type PickerTab } from '../lib/pickerTabs'
 import { resolveProgressRouting } from '../lib/pickerProgressRouting'
 import type {
@@ -168,7 +169,12 @@ const bridge = (window as unknown as { __comfyTitlePopup?: PickerBridge }).__com
 const installations = computed<Installation[]>(
   () => props.snapshot.installs as unknown as Installation[]
 )
-const installationsRef = toRef(() => installations.value)
+// TEMP(dist-mock): installed workspace distributions ride the list as
+// renderer-local rows; their settings data is answered by the mock api
+// layer (see distributionMocks.ts). James swaps both for the real feed.
+const distributionRows = mockDistributionRows()
+const allRows = computed<Installation[]>(() => [...installations.value, ...distributionRows])
+const installationsRef = toRef(() => allRows.value)
 const {
   searchQuery,
   activeFilter,
@@ -238,7 +244,7 @@ watch(
 const selectedInstall = computed<Installation | null>(() => {
   const id = selectedId.value
   if (id) {
-    const found = installations.value.find((i) => i.id === id)
+    const found = allRows.value.find((i) => i.id === id)
     if (found) return found
   }
   return null
@@ -324,7 +330,9 @@ function handleOpenDashboard(): void {
 watch(
   () => selectedInstall.value?.id ?? null,
   (next) => {
-    bridge?.setPickerSelectedInstall(next)
+    // TEMP(dist-mock): main must never see mock distribution ids — it would
+    // try to resolve settings for an install it doesn't track.
+    bridge?.setPickerSelectedInstall(next && isMockDistributionId(next) ? null : next)
   }
 )
 
@@ -332,6 +340,7 @@ watch(
 // via the change-only watcher above, so persist it once on mount.
 if (
   selectedId.value &&
+  !isMockDistributionId(selectedId.value) &&
   !props.snapshot.selectedInstallationId &&
   !props.snapshot.activeInstallationId
 ) {
@@ -356,6 +365,8 @@ watch(
 
 function handleSettingsShowProgress(opts: ShowProgressOpts): void {
   if (!opts.actionId) return
+  // TEMP(dist-mock): no real ops exist for mock distribution rows.
+  if (isMockDistributionId(opts.installationId)) return
   // opts.actionData may be a Vue reactive proxy, which can't cross the
   // contextBridge structured-clone boundary; deep-clone to a plain object.
   const rawActionData = opts.actionData
@@ -501,6 +512,8 @@ const instanceActions = useInstanceActions({
 async function handleExpandedNav(decision: NavDecision): Promise<void> {
   const inst = selectedInstall.value
   if (!inst) return
+  // TEMP(dist-mock): mock distribution rows can't launch or navigate.
+  if (isMockDistributionId(inst.id)) return
   await instanceActions.dispatch(decision, inst)
 }
 </script>

--- a/src/renderer/src/comfyTitlePopup/instancePicker/distributionMocks.ts
+++ b/src/renderer/src/comfyTitlePopup/instancePicker/distributionMocks.ts
@@ -79,26 +79,24 @@ function buildDistributionSections(dist: Distribution): DetailSection[] {
   const hasUpdate = dist.state === 'update-available'
   return [
     // --- Update: same channel-cards shape the standalone source emits, so
-    //     ChannelPicker renders the identical headline / facts box /
-    //     right-aligned CTAs — with distribution versions in every slot. ---
+    //     ChannelPicker renders the identical headline + facts box. A single
+    //     option = trackless mode: no track card, and the actions (Update
+    //     Now / Check for Updates) render inside the versions table. ---
     {
       tab: 'update',
       title: 'Updates',
       fields: [
         {
           id: 'updateChannel',
-          label: 'Update Track',
+          label: 'Updates',
           value: 'latest',
           editable: true,
           refreshSection: true,
           editType: 'channel-cards',
-          tooltip: 'How this install follows new versions published to the workspace.',
           options: [
             {
               value: 'latest',
               label: 'Latest published',
-              description: 'Follow every version the workspace publishes.',
-              recommended: true,
               data: {
                 installedVersion: `Dist v${installedVersion}`,
                 latestVersion: `Dist v${dist.version ?? installedVersion}`,
@@ -117,19 +115,6 @@ function buildDistributionSections(dist: Distribution): DetailSection[] {
                       }
                     ]
                   : []
-              }
-            },
-            {
-              value: 'pinned',
-              label: `Pinned — Dist v${installedVersion}`,
-              description: 'Stay on this version until an admin changes the pin.',
-              data: {
-                installedVersion: `Dist v${installedVersion}`,
-                latestVersion: `Dist v${installedVersion}`,
-                bundledComfyVersion: dist.comfyuiVersion ? `v${dist.comfyuiVersion}` : undefined,
-                lastChecked: 'Just now',
-                lastCheckedAt: Date.now() - 60_000,
-                updateAvailable: false
               }
             }
           ]

--- a/src/renderer/src/comfyTitlePopup/instancePicker/distributionMocks.ts
+++ b/src/renderer/src/comfyTitlePopup/instancePicker/distributionMocks.ts
@@ -1,0 +1,295 @@
+/**
+ * TEMP(dist-mock) — installed workspace distributions inside the REAL
+ * instance-picker popup, fed entirely by renderer-local mock data.
+ *
+ * Two pieces:
+ *   - `mockDistributionRows()`: installed mock distributions as picker rows.
+ *   - `installDistributionMockApiLayer()`: wraps the picker's `window.api`
+ *     shim so calls for `dist:*` ids are answered locally; everything else
+ *     passes through to main untouched.
+ *
+ * This is the seam the real integration replaces: James swaps the row feed
+ * for main-tracked distribution installs and the api layer for real
+ * pickerSettings handlers. The section content below is the current
+ * proposal for which fields exist per tab and which are editable — the
+ * whole point of the mock is reviewing those decisions in the real UI.
+ */
+import { MOCK_DISTRIBUTIONS } from '../../devplatform/mocks'
+import type { Distribution } from '../../devplatform/types'
+import type { DetailSection, Installation, SnapshotListData } from '../../types/ipc'
+
+export const DIST_ID_PREFIX = 'dist:'
+
+export function isMockDistributionId(id: unknown): boolean {
+  return typeof id === 'string' && id.startsWith(DIST_ID_PREFIX)
+}
+
+/** TEMP: the popup has no auth/workspace store — hardcoded to the mock
+ *  workspace the chooser presents. */
+const MOCK_WORKSPACE_NAME = 'Comfy Design Team'
+
+function isInstalledState(dist: Distribution): boolean {
+  return dist.state === 'installed' || dist.state === 'update-available'
+}
+
+function mockInstallPath(dist: Distribution): string {
+  return `~/ComfyUI-Distributions/${dist.name}`
+}
+
+function formatSize(bytes?: number): string {
+  return bytes ? `${(bytes / 1_000_000_000).toFixed(1)} GB` : ''
+}
+
+function formatDate(iso?: string): string {
+  if (!iso) return ''
+  const date = new Date(iso)
+  return Number.isNaN(date.getTime())
+    ? ''
+    : date.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+}
+
+/** Installed mock distributions as picker-list rows. The `dist:` id prefix
+ *  is the discriminator every mock code path keys off. */
+export function mockDistributionRows(): Installation[] {
+  return MOCK_DISTRIBUTIONS.filter(isInstalledState).map((dist) => ({
+    id: `${DIST_ID_PREFIX}${dist.id}`,
+    name: dist.name,
+    sourceLabel: MOCK_WORKSPACE_NAME,
+    // Unknown category → Box icon in installTypeMetaFor, and pickerTabs
+    // hides the Console tab for it.
+    sourceCategory: 'distribution',
+    version: dist.installedVersion ? `Dist v${dist.installedVersion}` : undefined,
+    status: 'installed',
+    installPath: mockInstallPath(dist),
+    statusTag:
+      dist.state === 'update-available'
+        ? { style: 'update', label: `Dist v${dist.version} available` }
+        : undefined
+  }))
+}
+
+/**
+ * The tabbed Manage content for one distribution row. Tab presence is
+ * data-driven (a tab renders iff a section carries its tag), so this list IS
+ * the tab set: Update, Startup Args (settings), Snapshots, Storage, About
+ * (status). Console is category-hidden.
+ */
+function buildDistributionSections(dist: Distribution): DetailSection[] {
+  const installedVersion = dist.installedVersion ?? dist.version ?? '?'
+  const hasUpdate = dist.state === 'update-available'
+  return [
+    // --- Update: distribution versions, not ComfyUI's. ---
+    {
+      tab: 'update',
+      title: 'Distribution Version',
+      fields: [
+        {
+          id: 'dist-installed-version',
+          label: 'Installed Version',
+          value: `Dist v${installedVersion}`,
+          editable: false
+        },
+        {
+          id: 'dist-latest-version',
+          label: 'Latest Version',
+          value: `Dist v${dist.version ?? installedVersion}`,
+          editable: false
+        },
+        {
+          id: 'dist-comfyui-version',
+          label: 'ComfyUI Version',
+          value: dist.comfyuiVersion ? `v${dist.comfyuiVersion}` : '—',
+          editable: false,
+          tooltip: 'Bundled by the distribution build — updates with the distribution.'
+        },
+        { id: 'dist-last-checked', label: 'Last Checked', value: 'Just now', editable: false }
+      ],
+      actions: [
+        { id: 'check-update', label: 'Check for Updates', style: 'accent' },
+        {
+          id: 'dist-update-now',
+          label: hasUpdate ? `Update to Dist v${dist.version}` : 'Update Now',
+          style: 'primary',
+          enabled: hasUpdate,
+          disabledMessage: "You're on the latest version."
+        }
+      ]
+    },
+    {
+      tab: 'update',
+      title: 'Update Track',
+      description: 'How this install follows new versions published to the workspace.',
+      fields: [
+        {
+          id: 'dist-update-track',
+          label: 'Track',
+          value: 'latest',
+          editable: true,
+          editType: 'select',
+          options: [
+            {
+              value: 'latest',
+              label: 'Latest published',
+              description: 'Follow every version the workspace publishes.',
+              recommended: true
+            },
+            {
+              value: 'pinned',
+              label: `Pinned — Dist v${installedVersion}`,
+              description: 'Stay on this version until an admin changes the pin.'
+            }
+          ]
+        },
+        {
+          id: 'dist-auto-update',
+          label: 'Update automatically on launch',
+          value: false,
+          editable: true,
+          editType: 'boolean'
+        }
+      ]
+    },
+    // --- Startup Args: what the distribution locks vs what the user owns. ---
+    {
+      tab: 'settings',
+      title: 'Launch',
+      fields: [
+        {
+          id: 'dist-name',
+          label: 'Name',
+          value: dist.name,
+          editable: false,
+          tooltip: 'Distribution names are set by the workspace.'
+        },
+        {
+          id: 'dist-extra-args',
+          label: 'Additional Arguments',
+          value: '',
+          editable: true,
+          editType: 'text',
+          placeholder: '--example-flag',
+          description: 'Appended after the arguments the distribution defines.'
+        }
+      ]
+    },
+    {
+      tab: 'settings',
+      title: 'Distribution Arguments',
+      description: 'Defined by the distribution and locked on this computer.',
+      fields: [
+        {
+          id: 'dist-locked-args',
+          label: 'Arguments',
+          value: '--fast --preview-method taesd',
+          editable: false
+        }
+      ]
+    },
+    // --- Snapshots: tab shown, list empty — whether distributions keep
+    //     snapshots at all is an open decision (dist versions may BE the
+    //     rollback mechanism). ---
+    { tab: 'snapshots', title: 'Snapshots' },
+    // --- Storage ---
+    {
+      tab: 'storage',
+      title: 'Storage',
+      fields: [
+        {
+          id: 'dist-install-path',
+          label: 'Install Location',
+          value: mockInstallPath(dist),
+          editable: false,
+          editType: 'path'
+        },
+        {
+          id: 'dist-size',
+          label: 'Size on Disk',
+          value: formatSize(dist.sizeBytes) || '—',
+          editable: false
+        }
+      ]
+    },
+    // --- About ---
+    {
+      tab: 'status',
+      title: 'About',
+      fields: [
+        { id: 'about-dist', label: 'Distribution', value: dist.name, editable: false },
+        { id: 'about-workspace', label: 'Workspace', value: MOCK_WORKSPACE_NAME, editable: false },
+        {
+          id: 'about-installed',
+          label: 'Installed Version',
+          value: `Dist v${installedVersion}`,
+          editable: false
+        },
+        {
+          id: 'about-comfyui',
+          label: 'ComfyUI Version',
+          value: dist.comfyuiVersion ? `v${dist.comfyuiVersion}` : '—',
+          editable: false
+        },
+        {
+          id: 'about-published',
+          label: 'Published',
+          value: formatDate(dist.finishedAt) || '—',
+          editable: false
+        }
+      ]
+    }
+  ]
+}
+
+function sectionsForMockId(mockRowId: string): DetailSection[] {
+  const dist = MOCK_DISTRIBUTIONS.find((d) => `${DIST_ID_PREFIX}${d.id}` === mockRowId)
+  return dist ? buildDistributionSections(dist) : []
+}
+
+function emptySnapshots(): SnapshotListData {
+  return {
+    snapshots: [],
+    copyEvents: [],
+    totalCount: 0,
+    context: { updateChannel: 'stable', pythonVersion: '3.12', variant: '', variantLabel: '' }
+  }
+}
+
+type AnyFn = (...args: unknown[]) => unknown
+
+/**
+ * Wrap the picker's `window.api` (installed by `installPickerSettingsApiShim`)
+ * so calls carrying a `dist:*` id resolve from the mocks above. Must run
+ * after the shim and before Vue mounts, for the same capture reason.
+ */
+export function installDistributionMockApiLayer(): void {
+  const real = (window as unknown as { api?: Record<string, AnyFn> }).api
+  if (!real) return
+
+  /** Route a call by first-arg id: mock answer for dist rows, else real. */
+  function byId(name: string, mock: (id: string, ...rest: unknown[]) => unknown): AnyFn {
+    // Every wrapped name exists on the shim; the cast just narrows the
+    // Record's `| undefined` index read.
+    const original = real![name] as AnyFn
+    return (...args: unknown[]) =>
+      isMockDistributionId(args[0])
+        ? Promise.resolve(mock(args[0] as string, ...args.slice(1)))
+        : original(...args)
+  }
+
+  const wrapped: Record<string, AnyFn> = {
+    ...real,
+    getDetailSections: byId('getDetailSections', (id) => sectionsForMockId(id)),
+    getInstallationSize: byId('getInstallationSize', (id) => {
+      const dist = MOCK_DISTRIBUTIONS.find((d) => `${DIST_ID_PREFIX}${d.id}` === id)
+      return { sizeBytes: dist?.sizeBytes ?? null }
+    }),
+    getSnapshots: byId('getSnapshots', () => emptySnapshots()),
+    getComfyArgs: byId('getComfyArgs', () => []),
+    getStableTags: byId('getStableTags', () => []),
+    getFieldOptions: byId('getFieldOptions', () => []),
+    // Writes + actions are accepted and dropped — the mock has no backend.
+    updateInstallation: byId('updateInstallation', () => ({ ok: true })),
+    runAction: byId('runAction', () => ({ ok: true }))
+  }
+
+  ;(window as unknown as { api: unknown }).api = wrapped
+}

--- a/src/renderer/src/comfyTitlePopup/instancePicker/distributionMocks.ts
+++ b/src/renderer/src/comfyTitlePopup/instancePicker/distributionMocks.ts
@@ -78,68 +78,67 @@ function buildDistributionSections(dist: Distribution): DetailSection[] {
   const installedVersion = dist.installedVersion ?? dist.version ?? '?'
   const hasUpdate = dist.state === 'update-available'
   return [
-    // --- Update: distribution versions, not ComfyUI's. ---
+    // --- Update: same channel-cards shape the standalone source emits, so
+    //     ChannelPicker renders the identical headline / facts box /
+    //     right-aligned CTAs — with distribution versions in every slot. ---
     {
       tab: 'update',
-      title: 'Distribution Version',
+      title: 'Updates',
       fields: [
         {
-          id: 'dist-installed-version',
-          label: 'Installed Version',
-          value: `Dist v${installedVersion}`,
-          editable: false
-        },
-        {
-          id: 'dist-latest-version',
-          label: 'Latest Version',
-          value: `Dist v${dist.version ?? installedVersion}`,
-          editable: false
-        },
-        {
-          id: 'dist-comfyui-version',
-          label: 'ComfyUI Version',
-          value: dist.comfyuiVersion ? `v${dist.comfyuiVersion}` : '—',
-          editable: false,
-          tooltip: 'Bundled by the distribution build — updates with the distribution.'
-        },
-        { id: 'dist-last-checked', label: 'Last Checked', value: 'Just now', editable: false }
-      ],
-      actions: [
-        { id: 'check-update', label: 'Check for Updates', style: 'accent' },
-        {
-          id: 'dist-update-now',
-          label: hasUpdate ? `Update to Dist v${dist.version}` : 'Update Now',
-          style: 'primary',
-          enabled: hasUpdate,
-          disabledMessage: "You're on the latest version."
-        }
-      ]
-    },
-    {
-      tab: 'update',
-      title: 'Update Track',
-      description: 'How this install follows new versions published to the workspace.',
-      fields: [
-        {
-          id: 'dist-update-track',
-          label: 'Track',
+          id: 'updateChannel',
+          label: 'Update Track',
           value: 'latest',
           editable: true,
-          editType: 'select',
+          refreshSection: true,
+          editType: 'channel-cards',
+          tooltip: 'How this install follows new versions published to the workspace.',
           options: [
             {
               value: 'latest',
               label: 'Latest published',
               description: 'Follow every version the workspace publishes.',
-              recommended: true
+              recommended: true,
+              data: {
+                installedVersion: `Dist v${installedVersion}`,
+                latestVersion: `Dist v${dist.version ?? installedVersion}`,
+                lastChecked: 'Just now',
+                lastCheckedAt: Date.now() - 60_000,
+                updateAvailable: hasUpdate,
+                actions: hasUpdate
+                  ? [
+                      {
+                        id: 'dist-update-now',
+                        label: 'Update Now',
+                        style: 'primary',
+                        enabled: true,
+                        tooltip: `Update to Dist v${dist.version}`
+                      }
+                    ]
+                  : []
+              }
             },
             {
               value: 'pinned',
               label: `Pinned — Dist v${installedVersion}`,
-              description: 'Stay on this version until an admin changes the pin.'
+              description: 'Stay on this version until an admin changes the pin.',
+              data: {
+                installedVersion: `Dist v${installedVersion}`,
+                latestVersion: `Dist v${installedVersion}`,
+                lastChecked: 'Just now',
+                lastCheckedAt: Date.now() - 60_000,
+                updateAvailable: false
+              }
             }
           ]
-        },
+        }
+      ],
+      actions: [{ id: 'check-update', label: 'Check for Updates' }]
+    },
+    {
+      tab: 'update',
+      title: 'Automatic Updates',
+      fields: [
         {
           id: 'dist-auto-update',
           label: 'Update automatically on launch',

--- a/src/renderer/src/comfyTitlePopup/instancePicker/distributionMocks.ts
+++ b/src/renderer/src/comfyTitlePopup/instancePicker/distributionMocks.ts
@@ -102,6 +102,7 @@ function buildDistributionSections(dist: Distribution): DetailSection[] {
               data: {
                 installedVersion: `Dist v${installedVersion}`,
                 latestVersion: `Dist v${dist.version ?? installedVersion}`,
+                bundledComfyVersion: dist.comfyuiVersion ? `v${dist.comfyuiVersion}` : undefined,
                 lastChecked: 'Just now',
                 lastCheckedAt: Date.now() - 60_000,
                 updateAvailable: hasUpdate,
@@ -125,6 +126,7 @@ function buildDistributionSections(dist: Distribution): DetailSection[] {
               data: {
                 installedVersion: `Dist v${installedVersion}`,
                 latestVersion: `Dist v${installedVersion}`,
+                bundledComfyVersion: dist.comfyuiVersion ? `v${dist.comfyuiVersion}` : undefined,
                 lastChecked: 'Just now',
                 lastCheckedAt: Date.now() - 60_000,
                 updateAvailable: false

--- a/src/renderer/src/comfyTitlePopup/main.ts
+++ b/src/renderer/src/comfyTitlePopup/main.ts
@@ -6,6 +6,7 @@ import { createPinia } from 'pinia'
 import TitlePopupApp from './TitlePopupApp.vue'
 import { createAppI18n } from '../lib/i18nFactory'
 import { installPickerSettingsApiShim } from './pickerSettingsApiShim'
+import { installDistributionMockApiLayer } from './instancePicker/distributionMocks'
 
 // Default to dark; the popup overrides bg/text inline from main's theme,
 // but data-theme still drives any non-overridden fallback CSS variables.
@@ -16,6 +17,9 @@ document.documentElement.setAttribute('data-theme', 'dark')
 // Must run BEFORE Vue mounts so modules that capture window.api at import
 // time (e.g. useComfyUISettings) see the shim populated.
 installPickerSettingsApiShim()
+// TEMP(dist-mock): answers dist:* calls locally on top of the shim — same
+// mount-order constraint.
+installDistributionMockApiLayer()
 
 const pinia = createPinia()
 

--- a/src/renderer/src/lib/pickerTabs.ts
+++ b/src/renderer/src/lib/pickerTabs.ts
@@ -28,8 +28,9 @@ export function isPickerTab(tab: string | null | undefined): tab is PickerTab {
   return tab != null && PICKER_TABS.has(tab as PickerTab)
 }
 
-/** Instance source categories (mirrors `category` in `src/main/sources/*.ts`). */
-export type InstanceCategory = 'local' | 'cloud' | 'remote'
+/** Instance source categories (mirrors `category` in `src/main/sources/*.ts`,
+ *  plus `distribution` for workspace-distribution installs). */
+export type InstanceCategory = 'local' | 'cloud' | 'remote' | 'distribution'
 
 /**
  * Tabs each instance category cannot surface, regardless of backend sections.
@@ -44,6 +45,10 @@ const HIDDEN_TABS_BY_CATEGORY: Record<InstanceCategory, ReadonlySet<PickerTab>> 
   local: new Set(),
   cloud: new Set(['console']),
   remote: new Set(['console']),
+  // Distribution installs will run locally, but the mock rows have no
+  // process to attach a PTY to — hidden until the real feed lands
+  // (whether the tab returns then is an open product decision).
+  distribution: new Set(['console']),
 }
 
 /** Whether `tab` is permitted for an instance of `category`. Unknown categories

--- a/src/renderer/src/views/ChooserView.vue
+++ b/src/renderer/src/views/ChooserView.vue
@@ -15,6 +15,7 @@ import BaseInput from '../components/ui/BaseInput.vue'
 import ComfyWordmark from '../components/icons/ComfyWordmark.vue'
 import ChooserFamilyGrid from './chooser/ChooserFamilyGrid.vue'
 import DevPlatformAccountChip from './devplatform/DevPlatformAccountChip.vue'
+import DistributionDetailOverlay from './devplatform/DistributionDetailOverlay.vue'
 import { resolvePickerTab } from '../lib/pickerTabs'
 import type { ChooserGridEntry } from './chooser/chooser-proto'
 import type { Distribution } from '../devplatform/types'
@@ -136,6 +137,28 @@ const distributionNote = computed(() => {
 
 function handleDistributionActivate(dist: Distribution): void {
   emit('install-distribution', dist)
+  // TEMP: the real install chain isn't wired yet, so flip the mock state in
+  // place — install and update both land on the latest published version.
+  // Lets the prototype demo the full install → installed → uninstall loop.
+  if (dist.state === 'installable' || dist.state === 'update-available') {
+    dist.state = 'installed'
+    dist.installedVersion = dist.version
+  }
+}
+
+/** Uninstall (mock): confirm, then return the card to its hollow available
+ *  state. The real path will run the delete pipeline once installs carry a
+ *  distribution link. */
+async function uninstallDistribution(dist: Distribution): Promise<void> {
+  const confirmed = await modal.confirm({
+    title: 'Uninstall Distribution',
+    message: `${dist.name} will be removed from this computer. It stays available from ${workspaceName.value} and can be reinstalled at any time.`,
+    confirmLabel: 'Uninstall',
+    confirmStyle: 'danger'
+  })
+  if (!confirmed) return
+  dist.state = 'installable'
+  dist.installedVersion = undefined
 }
 
 // --- PROTOTYPE: family partitions -----------------------------------------
@@ -193,6 +216,12 @@ const showWorkspaceShelf = computed(
 )
 
 // --- Distribution kebab menu ---
+//
+// Two item sets sharing one grammar with the install-tile menu:
+//   uninstalled → Install · Details… · [View on Developer Platform]
+//   installed   → [Update to Dist vN] · Manage… · [View on Developer
+//                 Platform] · Uninstall
+// The platform link is admin/owner only — members can't edit the pipeline.
 const distMenu = ref<{ open: boolean; x: number; y: number; dist: Distribution | null }>({
   open: false,
   x: 0,
@@ -200,17 +229,39 @@ const distMenu = ref<{ open: boolean; x: number; y: number; dist: Distribution |
   dist: null
 })
 
+/** TEMP: hardcoded base until main exposes the platform web URL. */
+const DEV_PLATFORM_URL_BASE = 'https://comfy-builder.fennec-typhon.ts.net'
+
+const canViewOnPlatform = computed(() => {
+  const role = authStore.selectedWorkspace?.role
+  return role === 'owner' || role === 'admin'
+})
+
 const distMenuItems = computed<ContextMenuItem[]>(() => {
   const dist = distMenu.value.dist
   if (!dist) return []
-  const installable = dist.state === 'installable' || dist.state === 'update-available'
-  return [
-    {
+  const installed = dist.state === 'installed' || dist.state === 'update-available'
+  const items: ContextMenuItem[] = []
+  if (installed) {
+    if (dist.state === 'update-available') {
+      items.push({ id: 'update', label: `Update to Dist v${dist.version}` })
+    }
+    items.push({ id: 'manage', label: 'Manage…' })
+  } else {
+    items.push({
       id: 'install',
       label: t('devPlatform.distribution.menuInstall'),
-      disabled: !installable
-    }
-  ]
+      disabled: dist.state !== 'installable'
+    })
+    items.push({ id: 'details', label: 'Details…' })
+  }
+  if (canViewOnPlatform.value) {
+    items.push({ id: 'view-platform', label: 'View on Developer Platform', separator: true })
+  }
+  if (installed) {
+    items.push({ id: 'uninstall', label: 'Uninstall', style: 'danger', separator: true })
+  }
+  return items
 })
 
 function openDistKebabMenu(event: MouseEvent, dist: Distribution): void {
@@ -229,7 +280,47 @@ function closeDistMenu(): void {
 function handleDistMenuSelect(itemId: string): void {
   const dist = distMenu.value.dist
   closeDistMenu()
-  if (itemId === 'install' && dist) handleDistributionActivate(dist)
+  if (!dist) return
+  switch (itemId) {
+    case 'install':
+    case 'update':
+      handleDistributionActivate(dist)
+      break
+    case 'details':
+      openDistOverlay(dist, 'details')
+      break
+    case 'manage':
+      openDistOverlay(dist, 'manage')
+      break
+    case 'view-platform':
+      void window.api.openExternal(`${DEV_PLATFORM_URL_BASE}/pipelines/${dist.id}`)
+      break
+    case 'uninstall':
+      void uninstallDistribution(dist)
+      break
+  }
+}
+
+// --- PROTOTYPE: distribution Details / Manage overlay ---
+//
+// Same presentation family as the install Manage view, renderer-local
+// against the mocks (the real picker popup is main-process-fed).
+const distOverlay = ref<{ open: boolean; mode: 'details' | 'manage'; dist: Distribution | null }>({
+  open: false,
+  mode: 'details',
+  dist: null
+})
+
+function openDistOverlay(dist: Distribution, mode: 'details' | 'manage'): void {
+  distOverlay.value = { open: true, mode, dist }
+}
+
+function closeDistOverlay(): void {
+  distOverlay.value = { open: false, mode: 'details', dist: null }
+}
+
+function handleOverlayInstall(): void {
+  if (distOverlay.value.dist) handleDistributionActivate(distOverlay.value.dist)
 }
 
 // --- Manage / context menu ---
@@ -429,6 +520,15 @@ const gridHandlers = {
         :items="distMenuItems"
         @close="closeDistMenu"
         @select="handleDistMenuSelect"
+      />
+
+      <DistributionDetailOverlay
+        v-if="distOverlay.open && distOverlay.dist"
+        :distribution="distOverlay.dist"
+        :mode="distOverlay.mode"
+        :workspace-name="workspaceName"
+        @close="closeDistOverlay"
+        @install="handleOverlayInstall"
       />
     </div>
   </BrandBackground>

--- a/src/renderer/src/views/ChooserView.vue
+++ b/src/renderer/src/views/ChooserView.vue
@@ -290,7 +290,9 @@ function handleDistMenuSelect(itemId: string): void {
       openDistOverlay(dist, 'details')
       break
     case 'manage':
-      openDistOverlay(dist, 'manage')
+      // Manage opens the REAL instance-picker popup: the popup's TEMP mock
+      // layer owns the dist:* row and its tab data (distributionMocks.ts).
+      window.api.openInstancePicker({ installationId: `dist:${dist.id}` })
       break
     case 'view-platform':
       void window.api.openExternal(`${DEV_PLATFORM_URL_BASE}/pipelines/${dist.id}`)

--- a/src/renderer/src/views/comfyUISettings/ChannelPicker.vue
+++ b/src/renderer/src/views/comfyUISettings/ChannelPicker.vue
@@ -119,8 +119,10 @@ const showEnrichingHint = computed(
 function formatVersionLabel(raw: string | undefined): string {
   if (!raw || raw === '—') return '—'
   const trimmed = raw.trim()
-  if (trimmed.startsWith('v') || trimmed.startsWith('V')) return trimmed
-  return `v${trimmed}`
+  // Only bare numeric versions earn the v prefix; labelled values
+  // ("Dist v12") pass through untouched.
+  if (/^\d/.test(trimmed)) return `v${trimmed}`
+  return trimmed
 }
 
 function normalizeVersion(raw: string | undefined): string {

--- a/src/renderer/src/views/comfyUISettings/ChannelPicker.vue
+++ b/src/renderer/src/views/comfyUISettings/ChannelPicker.vue
@@ -59,6 +59,9 @@ const draftIsCurrent = computed(() => state.draft === currentValue.value)
 interface PreviewData {
   installedVersion?: string
   latestVersion?: string
+  /** The ComfyUI version this build bundles — set for distribution installs,
+   *  whose own version numbers are the headline facts. */
+  bundledComfyVersion?: string
   lastChecked?: string
   lastCheckedAt?: number
   updateAvailable?: boolean
@@ -73,6 +76,7 @@ const preview = computed<PreviewData | null>(() => {
   return {
     installedVersion: data.installedVersion,
     latestVersion: data.latestVersion,
+    bundledComfyVersion: data.bundledComfyVersion,
     lastChecked: data.lastChecked,
     lastCheckedAt: data.lastCheckedAt,
     updateAvailable: data.updateAvailable,
@@ -210,6 +214,14 @@ const statRows = computed<StatRow[]>(() => {
       label: t('channelCards.latestVersion', 'Latest'),
       value: formatVersionLabel(preview.value.latestVersion),
       highlight: true
+    })
+  }
+
+  if (preview.value.bundledComfyVersion) {
+    rows.push({
+      id: 'comfy-version',
+      label: t('channelCards.comfyVersion', 'ComfyUI Version'),
+      value: formatVersionLabel(preview.value.bundledComfyVersion)
     })
   }
 

--- a/src/renderer/src/views/comfyUISettings/ChannelPicker.vue
+++ b/src/renderer/src/views/comfyUISettings/ChannelPicker.vue
@@ -264,8 +264,15 @@ const otherSecondaryActions = computed<ActionDef[]>(() =>
   )
 )
 
+/** A field with fewer than two options has no track to pick, so the whole
+ *  track card disappears and its actions move into the stats box —
+ *  distribution installs simply follow their workspace; standalone keeps
+ *  its stable/latest picker. */
+const trackless = computed(() => (props.field.options?.length ?? 0) < 2)
+
 const showCheckInHeader = computed(
   () =>
+    !trackless.value &&
     checkUpdateAction.value != null &&
     promotedPrimaryActions.value.length === 0 &&
     otherSecondaryActions.value.length === 0
@@ -370,6 +377,27 @@ const selectOptions = computed<BaseSelectOption[]>(() =>
         <dt>{{ row.label }}</dt>
         <dd :title="row.title">{{ row.value }}</dd>
       </div>
+      <!-- Trackless mode: the track card is gone, so its actions live here. -->
+      <div v-if="trackless && showFooterActions" class="channel-picker-stat-actions">
+        <button
+          v-for="{ action, variant } in footerActions"
+          :key="action.id"
+          type="button"
+          class="channel-picker-action"
+          :class="[variant, { 'is-running': isActionRunning(action.id) }]"
+          :disabled="action.enabled === false || isActionRunning(action.id)"
+          :title="action.tooltip"
+          :data-testid="TID.updateActionButton(action.id)"
+          @click="emit('action', action)"
+        >
+          <Loader2
+            v-if="isActionRunning(action.id)"
+            :size="14"
+            class="channel-picker-action-spinner"
+          />
+          {{ action.label }}
+        </button>
+      </div>
     </dl>
 
     <!-- Hint shown while `commitsAhead` is still being computed; self-hides
@@ -384,7 +412,7 @@ const selectOptions = computed<BaseSelectOption[]>(() =>
       {{ t('channelCards.computingCommitsAhead', 'Computing commits ahead…') }}
     </p>
 
-    <div class="channel-picker-card">
+    <div v-if="!trackless" class="channel-picker-card">
       <div class="channel-picker-channel-header">
         <span class="channel-picker-field-label">
           {{ field.label }}
@@ -537,6 +565,16 @@ const selectOptions = computed<BaseSelectOption[]>(() =>
 .channel-picker-stat-row.is-highlight dd {
   color: var(--accent);
   font-weight: 500;
+}
+
+/* Trackless action row — right-aligned inside the stats box, divided from
+ * the fact rows like any other row. */
+.channel-picker-stat-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 10px 0;
+  border-top: 1px solid var(--border-hover);
 }
 
 .channel-picker-card {

--- a/src/renderer/src/views/comfyUISettings/ChannelPicker.vue
+++ b/src/renderer/src/views/comfyUISettings/ChannelPicker.vue
@@ -233,7 +233,12 @@ const checkUpdateAction = computed<ActionDef | undefined>(() =>
 )
 
 const promotedPrimaryActions = computed<ActionDef[]>(() =>
-  selectedActions.value.filter((a) => a.id === 'update-comfyui' || a.id === 'copy-update')
+  // The two known standalone ids, plus any primary-styled card action —
+  // sources aren't limited to the ComfyUI update vocabulary (e.g. a
+  // distribution card's Update Now).
+  selectedActions.value.filter(
+    (a) => a.id === 'update-comfyui' || a.id === 'copy-update' || a.style === 'primary'
+  )
 )
 
 const otherSecondaryActions = computed<ActionDef[]>(() =>
@@ -295,9 +300,13 @@ const footerActions = computed<
     }
   }
 
-  const updateNow = promotedPrimaryActions.value.find((a) => a.id === 'update-comfyui')
-  if (updateNow) {
-    out.push({ action: updateNow, variant: 'accent' })
+  // The accented do-the-update action renders last (bottom-right):
+  // update-comfyui on standalone installs, any other promoted primary
+  // elsewhere.
+  for (const action of promotedPrimaryActions.value) {
+    if (action.id !== 'copy-update') {
+      out.push({ action, variant: 'accent' })
+    }
   }
 
   return out

--- a/src/renderer/src/views/devplatform/DistributionDetailOverlay.vue
+++ b/src/renderer/src/views/devplatform/DistributionDetailOverlay.vue
@@ -1,0 +1,458 @@
+<script setup lang="ts">
+/**
+ * PROTOTYPE (throwaway branch) — the distribution Details / Manage surface.
+ *
+ * Presented the same way as the install Manage view (identity header, left
+ * tab rail, tabbed body) but renderer-local against the mock distributions:
+ * the real picker popup is main-process-fed and can't host mock data. When
+ * the backend link lands this ports into `ComfyUISettingsContent`.
+ *
+ * Two modes:
+ *   - details: uninstalled distribution — read-only spec sheet (Overview
+ *     only), Install CTA when installable.
+ *   - manage:  installed distribution — Overview + Update tabs; the Update
+ *     pane is distribution-relevant (Dist versions, not ComfyUI) and can
+ *     fire the update just like the card pill.
+ *
+ * Prototype copy is hardcoded English — dies with the branch.
+ */
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { ArrowDownToLine, Info, Package, X } from 'lucide-vue-next'
+import type { Distribution, DistributionState } from '../../devplatform/types'
+
+const props = defineProps<{
+  distribution: Distribution
+  mode: 'details' | 'manage'
+  /** Shown as the owning workspace on the Overview pane. */
+  workspaceName: string
+}>()
+
+const emit = defineEmits<{
+  close: []
+  /** Install (details mode) or update (manage mode) — the same action the
+   *  card itself performs. */
+  install: []
+}>()
+
+const { t } = useI18n()
+
+const dist = computed(() => props.distribution)
+
+type TabId = 'overview' | 'update'
+const activeTab = ref<TabId>('overview')
+
+const hasUpdate = computed(() => dist.value.state === 'update-available')
+
+const tabs = computed<{ id: TabId; label: string; icon: typeof Info; badge: boolean }[]>(() => {
+  const list = [{ id: 'overview' as TabId, label: 'Overview', icon: Info, badge: false }]
+  if (props.mode === 'manage') {
+    list.push({ id: 'update', label: 'Update', icon: ArrowDownToLine, badge: hasUpdate.value })
+  }
+  return list
+})
+
+const BLOCKED_STATES: readonly DistributionState[] = [
+  'no-build',
+  'platform-mismatch',
+  'needs-desktop-update'
+]
+const BLOCKED_STATE_KEY: Record<string, string> = {
+  'no-build': 'noBuild',
+  'platform-mismatch': 'platformMismatch',
+  'needs-desktop-update': 'needsDesktopUpdate'
+}
+
+const isBlocked = computed(() => BLOCKED_STATES.includes(dist.value.state))
+
+/** Full blocked explanation — same i18n contract as the card. */
+const blockedReason = computed(() => {
+  if (!isBlocked.value) return ''
+  const suffix = dist.value.blockedReason ?? BLOCKED_STATE_KEY[dist.value.state] ?? 'noBuild'
+  return t(`devPlatform.distribution.blockedReason.${suffix}`, {
+    version: dist.value.minDesktopVersion ?? ''
+  })
+})
+
+const headerMeta = computed(() =>
+  [
+    dist.value.comfyuiVersion ? `v${dist.value.comfyuiVersion}` : '',
+    dist.value.version ? `Dist v${dist.value.version}` : ''
+  ]
+    .filter(Boolean)
+    .join(' · ')
+)
+
+function formatSize(bytes?: number): string {
+  if (!bytes) return ''
+  return `${(bytes / 1_000_000_000).toFixed(1)} GB`
+}
+
+function formatDate(iso?: string): string {
+  if (!iso) return ''
+  const date = new Date(iso)
+  return Number.isNaN(date.getTime())
+    ? ''
+    : date.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+}
+
+/** Overview facts — rendered top to bottom; empty values drop their row. */
+const overviewRows = computed<{ label: string; value: string }[]>(() =>
+  [
+    { label: 'Workspace', value: props.workspaceName },
+    {
+      label: 'Installed version',
+      value:
+        props.mode === 'manage' && dist.value.installedVersion
+          ? `Dist v${dist.value.installedVersion}`
+          : ''
+    },
+    { label: 'Latest version', value: dist.value.version ? `Dist v${dist.value.version}` : '' },
+    {
+      label: 'ComfyUI version',
+      value: dist.value.comfyuiVersion ? `v${dist.value.comfyuiVersion}` : ''
+    },
+    { label: 'Download size', value: formatSize(dist.value.sizeBytes) },
+    { label: 'Published', value: formatDate(dist.value.finishedAt) }
+  ].filter((row) => row.value)
+)
+
+/** Details-mode footer CTA: install, only when actually installable. */
+const showInstallCta = computed(
+  () => props.mode === 'details' && dist.value.state === 'installable'
+)
+
+function handlePrimary(): void {
+  emit('install')
+  emit('close')
+}
+
+function onKeydown(event: KeyboardEvent): void {
+  if (event.key === 'Escape') emit('close')
+}
+onMounted(() => window.addEventListener('keydown', onKeydown))
+onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown))
+</script>
+
+<template>
+  <div class="dist-overlay-backdrop" @click.self="emit('close')">
+    <div class="dist-overlay" role="dialog" aria-modal="true" :aria-label="dist.name">
+      <button
+        type="button"
+        class="dist-overlay-close"
+        aria-label="Close"
+        @click="emit('close')"
+      >
+        <X :size="16" />
+      </button>
+
+      <!-- Left rail — same shape as the Manage view's tab rail; details mode
+           simply has fewer tabs. -->
+      <aside class="dist-overlay-rail">
+        <button
+          v-for="tab in tabs"
+          :key="tab.id"
+          type="button"
+          class="dist-overlay-tab"
+          :class="{ 'dist-overlay-tab--active': activeTab === tab.id }"
+          @click="activeTab = tab.id"
+        >
+          <component :is="tab.icon" :size="14" aria-hidden="true" />
+          <span class="dist-overlay-tab-label">{{ tab.label }}</span>
+          <span v-if="tab.badge" class="dist-overlay-tab-badge" aria-hidden="true" />
+        </button>
+      </aside>
+
+      <section class="dist-overlay-body">
+        <header class="dist-overlay-head">
+          <span class="dist-overlay-icon"><Package :size="28" /></span>
+          <div class="dist-overlay-title">
+            <h2 class="dist-overlay-name">{{ dist.name }}</h2>
+            <p v-if="headerMeta" class="dist-overlay-meta">{{ headerMeta }}</p>
+          </div>
+        </header>
+
+        <!-- Overview: read-only spec sheet. -->
+        <div v-if="activeTab === 'overview'" class="dist-overlay-pane">
+          <p v-if="dist.description" class="dist-overlay-desc">{{ dist.description }}</p>
+
+          <div v-if="blockedReason" class="dist-overlay-blocked" role="note">
+            {{ blockedReason }}
+          </div>
+
+          <dl class="dist-overlay-facts">
+            <template v-for="row in overviewRows" :key="row.label">
+              <dt>{{ row.label }}</dt>
+              <dd>{{ row.value }}</dd>
+            </template>
+          </dl>
+        </div>
+
+        <!-- Update: distribution-relevant update pane (manage mode). -->
+        <div v-else class="dist-overlay-pane">
+          <template v-if="hasUpdate">
+            <h3 class="dist-overlay-update-headline">Dist v{{ dist.version }} is available</h3>
+            <p class="dist-overlay-update-sub">
+              You have Dist v{{ dist.installedVersion ?? '?' }}. Updates are published by
+              {{ props.workspaceName }}.
+            </p>
+            <p v-if="formatDate(dist.finishedAt) || formatSize(dist.sizeBytes)" class="dist-overlay-update-facts">
+              {{ [formatDate(dist.finishedAt), formatSize(dist.sizeBytes)].filter(Boolean).join(' · ') }}
+            </p>
+            <button type="button" class="dist-overlay-cta" @click="handlePrimary">
+              <ArrowDownToLine :size="14" aria-hidden="true" />
+              Update to Dist v{{ dist.version }}
+            </button>
+          </template>
+          <template v-else>
+            <h3 class="dist-overlay-update-headline">You're up to date</h3>
+            <p class="dist-overlay-update-sub">
+              Dist v{{ dist.installedVersion ?? dist.version }} is the latest version published by
+              {{ props.workspaceName }}.
+            </p>
+          </template>
+        </div>
+
+        <footer v-if="showInstallCta" class="dist-overlay-foot">
+          <button type="button" class="dist-overlay-cta" @click="handlePrimary">
+            <ArrowDownToLine :size="14" aria-hidden="true" />
+            {{ t('devPlatform.distribution.menuInstall') }}
+          </button>
+        </footer>
+      </section>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.dist-overlay-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+.dist-overlay {
+  position: relative;
+  display: flex;
+  width: min(640px, calc(100vw - 48px));
+  min-height: 340px;
+  max-height: min(520px, calc(100vh - 48px));
+  border-radius: 14px;
+  border: 1px solid var(--modal-surface-border, rgba(255, 255, 255, 0.08));
+  background: var(--modal-surface-bg, #17171c);
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+}
+
+.dist-overlay-close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition:
+    background-color 100ms ease,
+    color 100ms ease;
+}
+.dist-overlay-close:hover,
+.dist-overlay-close:focus-visible {
+  background: var(--bg-elev-2, rgba(127, 127, 127, 0.18));
+  color: var(--text);
+  outline: none;
+}
+
+/* --- Tab rail --- */
+
+.dist-overlay-rail {
+  flex: 0 0 148px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 14px 8px;
+  border-right: 1px solid var(--chooser-surface-border);
+}
+
+.dist-overlay-tab {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  font: inherit;
+  font-size: 12px;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition:
+    background-color 100ms ease,
+    color 100ms ease;
+}
+.dist-overlay-tab:hover {
+  background: var(--chooser-surface-bg-hover);
+  color: var(--text);
+}
+.dist-overlay-tab--active {
+  background: var(--chooser-surface-bg-hover);
+  color: var(--text);
+}
+.dist-overlay-tab-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.dist-overlay-tab-badge {
+  margin-left: auto;
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--accent, #4a90e2);
+  flex-shrink: 0;
+}
+
+/* --- Body --- */
+
+.dist-overlay-body {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  padding: 18px 20px 16px;
+  overflow-y: auto;
+}
+
+.dist-overlay-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding-right: 32px;
+  margin-bottom: 14px;
+}
+.dist-overlay-icon {
+  color: var(--neutral-100);
+  opacity: 0.85;
+  flex-shrink: 0;
+}
+.dist-overlay-title {
+  min-width: 0;
+}
+.dist-overlay-name {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.dist-overlay-meta {
+  margin: 2px 0 0;
+  font-size: 12px;
+  color: var(--text-faint);
+}
+
+.dist-overlay-pane {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.dist-overlay-desc {
+  margin: 0 0 14px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-muted);
+}
+
+.dist-overlay-blocked {
+  margin: 0 0 14px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--chooser-surface-border-hover);
+  background: var(--chooser-surface-bg);
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--neutral-200);
+}
+
+.dist-overlay-facts {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 7px 18px;
+  margin: 0;
+  font-size: 12px;
+}
+.dist-overlay-facts dt {
+  color: var(--text-faint);
+}
+.dist-overlay-facts dd {
+  margin: 0;
+  color: var(--text);
+  font-weight: 500;
+}
+
+/* --- Update pane --- */
+
+.dist-overlay-update-headline {
+  margin: 0 0 6px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+}
+.dist-overlay-update-sub {
+  margin: 0 0 4px;
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--text-muted);
+}
+.dist-overlay-update-facts {
+  margin: 0 0 16px;
+  font-size: 12px;
+  color: var(--text-faint);
+}
+
+/* --- CTA + footer --- */
+
+.dist-overlay-foot {
+  margin-top: 16px;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.dist-overlay-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 14px;
+  border-radius: 8px;
+  border: 1px solid var(--accent, #4a90e2);
+  background: var(--accent-soft, rgba(74, 144, 226, 0.12));
+  font: inherit;
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--accent, #4a90e2);
+  cursor: pointer;
+  transition:
+    background-color 120ms ease,
+    transform 120ms ease;
+}
+.dist-overlay-cta:hover,
+.dist-overlay-cta:focus-visible {
+  background: var(--accent-soft-hover, rgba(74, 144, 226, 0.22));
+  outline: none;
+}
+</style>


### PR DESCRIPTION
> [!IMPORTANT]
> **Prototype — will be reworked onto James's stack, not merged as-is.**
> All distribution data here is mocked renderer-side. The real backend lands
> in #1295 / #1296 / #1297; this exists so the interface can be reviewed and
> the active/inactive and editable/read-only decisions settled before that
> wiring happens. Stacked on #1309.

## What this is

The two remaining pieces of the distribution surface: what the kebab menu
offers, and what Manage looks like for a distribution.

### Kebab menus

Two item sets sharing the install-tile menu's grammar:

| Uninstalled | Installed |
| --- | --- |
| Install | Update to Dist vN *(when available)* |
| Details… | Manage… |
| View on Developer Platform | View on Developer Platform |
| | Uninstall *(danger)* |

"View on Developer Platform" is admin/owner only — members can't edit the
pipeline. Note the default mock workspace is *member*, so switch to Comfy
Front End in the account chip to see it.

### Manage runs in the REAL instance picker

Installed distributions appear as rows in the actual picker popup
alongside Local instance and Comfy Cloud, and selecting one renders the
genuine tabbed settings surface — not a lookalike. Update, Startup Args,
Snapshots, Storage, About; Terminal is hidden for distributions.

The **Update tab** renders through the real `ChannelPicker` with
distribution versions: headline + "Update available" pill, the versions
table (Installed / Latest / ComfyUI Version / Last Checked), and Update Now
in the table's bottom-right. Three small changes to shared components made
that work without special-casing distributions:

- `formatVersionLabel` only prefixes `v` onto bare numeric versions, so
  "Dist v12" doesn't render as "vDist v12".
- Any primary-styled card action promotes to the footer, not just the
  hardcoded `update-comfyui` / `copy-update` ids.
- **Trackless mode**: a channel-cards field with fewer than two options
  drops the track card entirely and moves its actions into the versions
  table. Distributions follow their workspace, so they have no track to
  pick. Standalone installs keep stable/latest and render unchanged.

## Where the backend plugs in

Everything mock lives in
`src/renderer/src/comfyTitlePopup/instancePicker/distributionMocks.ts`,
marked `TEMP(dist-mock)`:

- `mockDistributionRows()` — the picker rows.
- `installDistributionMockApiLayer()` — wraps the popup's `window.api` so
  any call carrying a `dist:*` id resolves locally; real installs pass
  through untouched. Writes and actions are accepted and dropped.
- `buildDistributionSections()` — **the per-tab field/action proposal**.
  This is the file to argue with: it's where each field's editable vs
  read-only decision is recorded.

Main never sees mock ids — the selection sync sends `null` for them and the
launch/progress paths no-op.

## Open decisions this surfaces

From the Jul 24 standup, two rulings the mock does **not** yet reflect:

- [ ] **Shared models off for distributions** in MVP (each carries its own
      allowed model list) — the Storage tab still shows the shared
      model-directories UI.
- [ ] **Snapshots are admin/owner only** — currently shown to everyone as
      an empty tab. Also unresolved whether distributions keep snapshots at
      all, given dist versions may be the rollback mechanism.

Also still to build, per the standup: **rename** (display name) and
**version selection** — Jacob confirmed users may pick any published
version including rollback, and that multiple versions of one distribution
can be installed side by side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)