### PR TITLE
ci: run required checks for merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   pull_request:
+  merge_group:
+    types: [checks_requested]
   push:
     branches:
       - main

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -3,6 +3,8 @@ name: CLA Assistant
 on:
   issue_comment:
     types: [created]
+  merge_group:
+    types: [checks_requested]
   pull_request_target:
     types: [opened, synchronize, closed]
 
@@ -16,6 +18,10 @@ jobs:
   cla-assistant:
     runs-on: ubuntu-latest
     steps:
+      - name: Preserve the PR CLA admission gate for merge groups
+        if: github.event_name == 'merge_group'
+        run: echo "CLA was required before each pull request entered the merge queue."
+
       # The CLA action normally requires every commit author in a PR to sign.
       # We only want the PR author to sign, so we allowlist all other committers
       # by computing them from the PR's commits and excluding the PR author.


### PR DESCRIPTION
## Summary

- run the CI workflow for merge-queue `checks_requested` events
- report the existing required `cla-assistant` check on merge-group commits
- keep PR author/signature processing limited to pull-request and comment events

## Why

GitHub merge queues validate a synthetic merge-group commit. The repository's CI and required CLA workflows only listened for pull-request events, so queued changes would either receive no CI coverage or wait indefinitely for the required `cla-assistant` context.

The merge-group CLA step is an admission bridge: each pull request must pass CLA before entering the queue, while the queue commit reports the same required check name without rerunning PR-specific comment or signature logic.

## Validation

- `git diff --check`
- parsed both modified workflow files as YAML
- independent review found no merge-queue correctness issues
- local typecheck, lint, build, and test suites were skipped at user direction; CI is expected to provide those results

Repository rules and merge-queue settings are intentionally unchanged by this PR.