### PR TITLE
feat(chooser): two-line install tiles — drop the launch-recency row

### DIFF
--- a/e2e/comfybuilder-launch.test.ts
+++ b/e2e/comfybuilder-launch.test.ts
@@ -1,0 +1,163 @@
+/**
+ * E2E: launching a ComfyBuilder distribution from the chooser.
+ *
+ * The renderer resolves launch ONLY from `get-list-actions`
+ * (`performChooserLaunch`), so a source plugin without `getListActions`
+ * hands it an empty array, which reads as "this install cannot launch" and
+ * bounces the tile click into the new-install wizard. This file pins the
+ * comfybuilder plugin's `getListActions` end-to-end:
+ *
+ *   1. an installed distribution tile launches (run-action `launch` plus the
+ *      progress takeover) and never mounts the wizard;
+ *   2. clicking a not-ready one explains itself instead of bouncing there.
+ *
+ * The per-status action contract itself lives in the plugin unit test, which
+ * pins it without needing a seeded record.
+ *
+ * Tagged @windows @macos only: seeding install records does not work under the
+ * linux CI project (every other seeding test in this directory is lifecycle-only,
+ * and lifecycle is not in the CI matrix), so the tiles never render there.
+ *
+ * The seeded venv python exits immediately, so the launch is attempted and
+ * then fails at the boot wait. Attempted-vs-never-attempted is the whole
+ * discriminator here; a real ComfyUI boot is not.
+ */
+
+import os from 'node:os'
+import path from 'node:path'
+import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { test, expect } from '@playwright/test'
+import en from '../locales/en.json'
+import { launchApp, type AppContext, type SeedInstallation } from './launchApp'
+import { clickInstallTile, expectChooserVisible } from './support/chooserHelpers'
+import { getIpcInvocations, resetIpcInvocations } from './support/devHooks'
+import { byTestId, TID } from './support/testIds'
+
+/** Both steps of the new-install wizard: the surface a missing launch action
+ *  used to bounce the user into. */
+const NEW_INSTALL_WIZARD = '.config-shell, .template-shell'
+
+interface DistributionCase {
+  id: string
+  name: string
+  status: string
+  installPath: string
+}
+
+const INSTALLED: DistributionCase = {
+  id: 'inst-comfybuilder-installed',
+  name: 'desktop-4target-stg-v0190',
+  status: 'installed',
+  installPath: '',
+}
+
+/** `failed` is the only not-installed status that renders a tile:
+ *  `enrichInstallationsForRenderer` filters `installing` out. The per-status
+ *  action contract is pinned deterministically by the plugin unit test; here we
+ *  only cover what a user can actually click. */
+const FAILED: DistributionCase = {
+  id: 'inst-comfybuilder-failed',
+  name: 'desktop-4target-stg-v0192',
+  status: 'failed',
+  installPath: '',
+}
+
+let ctx: AppContext
+let rootDir: string
+
+test.describe.configure({ mode: 'serial' })
+
+/** Mirrors what `installDistribution` writes for a real distribution install. */
+function distributionRecord(dist: DistributionCase): SeedInstallation {
+  return {
+    id: dist.id,
+    name: dist.name,
+    sourceId: 'comfybuilder',
+    sourceLabel: 'ComfyBuilder',
+    installPath: dist.installPath,
+    distributionId: `d-${dist.id}`,
+    distributionName: dist.name,
+    version: '1',
+    artifactId: 'a-1',
+    artifactOs: 'macos',
+    artifactGpu: 'cpu',
+    artifactAccelVariant: 'cpu',
+    launchArgs: '--enable-manager',
+    launchMode: 'window',
+    browserPartition: 'unique',
+    status: dist.status,
+    seen: true,
+  }
+}
+
+/** `buildLaunchSpec` returns null unless the venv interpreter and
+ *  `ComfyUI/main.py` both exist, and a null launch command fails the launch
+ *  before it is ever attempted. Written for every case so the disabled-action
+ *  assertions prove the gate is the record status, not the disk. */
+async function writeDistributionLayout(installPath: string): Promise<void> {
+  await mkdir(path.join(installPath, 'ComfyUI'), { recursive: true })
+  await writeFile(path.join(installPath, 'ComfyUI', 'main.py'), '')
+  if (process.platform === 'win32') {
+    await mkdir(path.join(installPath, 'venv'), { recursive: true })
+    await writeFile(path.join(installPath, 'venv', 'python.exe'), '')
+    return
+  }
+  await mkdir(path.join(installPath, 'venv', 'bin'), { recursive: true })
+  const python = path.join(installPath, 'venv', 'bin', 'python3')
+  // Exits straight away so the attempted launch dies at the boot wait rather
+  // than leaking a background process.
+  await writeFile(python, '#!/bin/sh\nexit 1\n')
+  await chmod(python, 0o755)
+}
+
+test.beforeAll(async () => {
+  rootDir = await mkdtemp(path.join(os.tmpdir(), 'comfyui-launcher-comfybuilder-e2e-'))
+  const cases = [INSTALLED, FAILED]
+  for (const dist of cases) {
+    dist.installPath = path.join(rootDir, dist.id)
+    await writeDistributionLayout(dist.installPath)
+  }
+
+  ctx = await launchApp({
+    settings: { firstUseCompleted: true, telemetryEnabled: false },
+    installations: cases.map(distributionRecord),
+  })
+  await expectChooserVisible(ctx.panel)
+})
+
+test.afterAll(async () => {
+  await ctx?.cleanup()
+  if (rootDir) await rm(rootDir, { recursive: true, force: true })
+})
+
+test('clicking an installed ComfyBuilder tile launches it instead of opening the new-install wizard @windows @macos', async () => {
+  await resetIpcInvocations(ctx.app)
+  await clickInstallTile(ctx.panel, INSTALLED.name)
+
+  // The whole chain (tile pick -> get-list-actions -> useListAction ->
+  // show-progress -> run-action) ends here; with no launch action in the
+  // list it never starts and the wizard takes over instead.
+  await expect
+    .poll(async () => {
+      const calls = (await getIpcInvocations(ctx.app, 'run-action')) as
+        { installationId?: string; actionId?: string }[]
+      return calls.some((c) => c.installationId === INSTALLED.id && c.actionId === 'launch')
+    }, { timeout: 20_000, intervals: [200, 500] })
+    .toBe(true)
+
+  await ctx.panel.waitForVisible('.brand-progress', { timeout: 10_000 })
+  expect(await ctx.panel.exists(NEW_INSTALL_WIZARD)).toBe(false)
+})
+
+test('clicking a not-ready ComfyBuilder tile explains itself instead of opening the new-install wizard @windows @macos', async () => {
+  await clickInstallTile(ctx.panel, FAILED.name)
+
+  // `useListAction` short-circuits a disabled action into an alert, so the
+  // user is told why nothing launched rather than being handed a wizard.
+  await ctx.panel.waitForVisible(byTestId(TID.baseAlertAction), { timeout: 10_000 })
+  expect(await ctx.panel.textOf('.base-alert-message-text')).toContain(en.errors.installNotReady)
+  expect(await ctx.panel.exists(NEW_INSTALL_WIZARD)).toBe(false)
+
+  await ctx.panel.click(byTestId(TID.baseAlertAction))
+  await expectChooserVisible(ctx.panel)
+})

--- a/e2e/comfybuilder-models.test.ts
+++ b/e2e/comfybuilder-models.test.ts
@@ -1,0 +1,124 @@
+/**
+ * E2E: staging a distribution's models in the real app.
+ *
+ * A distribution archive carries no model weights, so the comfybuilder install
+ * downloads the version's declared models into `<installPath>/ComfyUI/models/
+ * <type>/<filename>` before launch. This drives the REAL staging code (real
+ * Electron download, real fs, real sha256) in the real main process, decoupled
+ * from the archive/auth path via the E2E hook, and serves the model bytes from a
+ * local HTTP server so the run is hermetic and deterministic.
+ *
+ * The manifest source is the `COMFY_BUILDER_MODELS_MANIFEST` env seam (a file the
+ * test rewrites per case), which is exactly how the mocked manifest is injected
+ * until the builder endpoint is deployed.
+ */
+
+import { createHash } from 'node:crypto'
+import { createServer, type Server } from 'node:http'
+import { mkdtempSync, rmSync, mkdirSync, existsSync, readFileSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { test, expect } from '@playwright/test'
+import { launchApp, type AppContext } from './launchApp'
+
+const sha = (b: Buffer): string => createHash('sha256').update(b).digest('hex')
+
+// Two deterministic "model" payloads served locally.
+const DECODER = Buffer.from('taesd-decoder-bytes-fixture')
+const ENCODER = Buffer.from('taesd-encoder-bytes-fixture')
+
+let server: Server
+let baseUrl: string
+let manifestFile: string
+let ctx: AppContext
+const tmpDirs: string[] = []
+
+function freshInstall(): string {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'cb-models-e2e-'))
+  tmpDirs.push(dir)
+  mkdirSync(path.join(dir, 'ComfyUI'), { recursive: true })
+  return dir
+}
+
+/** Ask the app to run the real staging against installPath, reading the manifest
+ *  from the env-pointed file the test controls. */
+async function stage(installPath: string): Promise<{ staged?: string[]; error?: string; kind?: string }> {
+  return ctx.app.evaluate(async (_electron, arg) => {
+    const helpers = (globalThis as unknown as {
+      __e2e?: { stageDistributionModels: (o: unknown) => Promise<unknown> }
+    }).__e2e
+    if (!helpers) throw new Error('__e2e not registered')
+    return helpers.stageDistributionModels(arg) as Promise<{ staged?: string[]; error?: string; kind?: string }>
+  }, { installPath, distributionId: 'd-e2e', version: '1' })
+}
+
+test.describe.configure({ mode: 'serial' })
+
+test.beforeAll(async () => {
+  await new Promise<void>((resolve) => {
+    server = createServer((req, res) => {
+      if (req.url === '/decoder') return res.end(DECODER)
+      if (req.url === '/encoder') return res.end(ENCODER)
+      res.statusCode = 404
+      res.end()
+    })
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address()
+      baseUrl = typeof addr === 'object' && addr ? `http://127.0.0.1:${addr.port}` : ''
+      resolve()
+    })
+  })
+  manifestFile = path.join(mkdtempSync(path.join(os.tmpdir(), 'cb-mf-e2e-')), 'manifest.json')
+  writeFileSync(manifestFile, JSON.stringify({ models: [] }))
+  process.env.COMFY_BUILDER_MODELS_MANIFEST = manifestFile
+  ctx = await launchApp({ settings: { firstUseCompleted: true, telemetryEnabled: false } })
+})
+
+test.afterAll(async () => {
+  await ctx?.cleanup()
+  await new Promise<void>((r) => server.close(() => r()))
+  delete process.env.COMFY_BUILDER_MODELS_MANIFEST
+  for (const d of tmpDirs) rmSync(d, { recursive: true, force: true })
+  rmSync(path.dirname(manifestFile), { recursive: true, force: true })
+})
+
+test('stages verified models into ComfyUI/models/<type>/<filename> @windows @macos', async () => {
+  writeFileSync(manifestFile, JSON.stringify({
+    models: [
+      { type: 'vae_approx', filename: 'taesd_decoder.pth', sha256: sha(DECODER), downloadUrl: `${baseUrl}/decoder` },
+      { type: 'vae_approx', filename: 'taesd_encoder.pth', sha256: sha(ENCODER), downloadUrl: `${baseUrl}/encoder` },
+    ],
+  }))
+  const install = freshInstall()
+  const res = await stage(install)
+  expect(res.error, res.error).toBeUndefined()
+  expect(res.staged).toEqual(['vae_approx/taesd_decoder.pth', 'vae_approx/taesd_encoder.pth'])
+
+  const decoder = path.join(install, 'ComfyUI', 'models', 'vae_approx', 'taesd_decoder.pth')
+  const encoder = path.join(install, 'ComfyUI', 'models', 'vae_approx', 'taesd_encoder.pth')
+  expect(existsSync(decoder)).toBe(true)
+  expect(readFileSync(decoder)).toEqual(DECODER)
+  expect(existsSync(encoder)).toBe(true)
+  // No leftover partials.
+  expect(existsSync(`${decoder}.partial`)).toBe(false)
+})
+
+test('fails the stage and leaves no file when a model checksum does not match @windows @macos', async () => {
+  writeFileSync(manifestFile, JSON.stringify({
+    models: [{ type: 'checkpoints', filename: 'bad.safetensors', sha256: sha(Buffer.from('other')), downloadUrl: `${baseUrl}/decoder` }],
+  }))
+  const install = freshInstall()
+  const res = await stage(install)
+  expect(res.kind).toBe('model-checksum-mismatch')
+  const dest = path.join(install, 'ComfyUI', 'models', 'checkpoints', 'bad.safetensors')
+  expect(existsSync(dest)).toBe(false)
+  expect(existsSync(`${dest}.partial`)).toBe(false)
+})
+
+test('stages nothing for an empty manifest @windows @macos', async () => {
+  writeFileSync(manifestFile, JSON.stringify({ models: [] }))
+  const install = freshInstall()
+  const res = await stage(install)
+  expect(res.staged).toEqual([])
+  expect(existsSync(path.join(install, 'ComfyUI', 'models'))).toBe(false)
+})

--- a/locales/en.json
+++ b/locales/en.json
@@ -266,6 +266,9 @@
     "copyError": "Copy error details",
     "clear": "Clear"
   },
+  "comfybuilder": {
+    "stageModels": "Download models"
+  },
   "list": {
     "loadSnapshot": "Load Snapshot",
     "snapshotSourceName": "Source Instance",
@@ -1120,6 +1123,43 @@
       "nodes": "Loading custom nodes…"
     },
     "viewLogs": "View logs"
+  },
+  "devPlatform": {
+    "signIn": {
+      "cta": "Log in"
+    },
+    "account": {
+      "signOut": "Sign out",
+      "signedInAs": "Signed in as {email}",
+      "signOutConfirmTitle": "Sign out of ComfyBuilder?",
+      "signOutConfirmBody": "Your installed distributions are kept and still run. They just stop receiving updates until you sign back in.",
+      "signOutConfirmCta": "Sign out"
+    },
+    "workspace": {
+      "personalLabel": "Personal",
+      "switchLabel": "Workspace"
+    },
+    "distribution": {
+      "availablePill": "Available",
+      "updatedLabel": "Updated",
+      "installTileMeta": "Not installed yet",
+      "emptyTitle": "No distributions published to this workspace yet.",
+      "installFailed": "Could not start the install. Try again.",
+      "states": {
+        "noBuild": "No build",
+        "platformMismatch": "Not for this machine",
+        "needsDesktopUpdate": "Update required",
+        "updateAvailable": "Update",
+        "installed": "Installed"
+      },
+      "blockedReason": {
+        "buildFailed": "This distribution has no successful build yet.",
+        "noBuild": "This distribution has no successful build yet.",
+        "noArtifactForMachine": "The latest build has no artifact for this operating system and GPU.",
+        "platformMismatch": "The latest build has no artifact for this operating system and GPU.",
+        "needsDesktopUpdate": "This distribution needs Comfy Desktop {version} or newer."
+      }
+    }
   },
   "errors": {
     "invalidUrl": "Enter a valid URL (e.g. http://localhost:8188).",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -266,6 +266,9 @@
     "copyError": "复制错误详情",
     "clear": "清除"
   },
+  "comfybuilder": {
+    "stageModels": "下载模型"
+  },
   "list": {
     "loadSnapshot": "加载快照",
     "snapshotSourceName": "源实例",
@@ -1120,6 +1123,43 @@
       "nodes": "正在加载自定义节点…"
     },
     "viewLogs": "查看日志"
+  },
+  "devPlatform": {
+    "signIn": {
+      "cta": "登录"
+    },
+    "account": {
+      "signOut": "退出登录",
+      "signedInAs": "已登录为 {email}",
+      "signOutConfirmTitle": "退出 ComfyBuilder？",
+      "signOutConfirmBody": "已安装的分发版本会保留并仍可运行，只是在重新登录前不再接收更新。",
+      "signOutConfirmCta": "退出登录"
+    },
+    "workspace": {
+      "personalLabel": "个人",
+      "switchLabel": "工作区"
+    },
+    "distribution": {
+      "availablePill": "可安装",
+      "updatedLabel": "更新于",
+      "installTileMeta": "尚未安装",
+      "emptyTitle": "此工作区尚未发布任何分发版本。",
+      "installFailed": "无法开始安装，请重试。",
+      "states": {
+        "noBuild": "无构建",
+        "platformMismatch": "不适用于此设备",
+        "needsDesktopUpdate": "需要更新",
+        "updateAvailable": "更新",
+        "installed": "已安装"
+      },
+      "blockedReason": {
+        "buildFailed": "此分发版本尚无成功的构建。",
+        "noBuild": "此分发版本尚无成功的构建。",
+        "noArtifactForMachine": "最新构建没有适用于此操作系统和 GPU 的制品。",
+        "platformMismatch": "最新构建没有适用于此操作系统和 GPU 的制品。",
+        "needsDesktopUpdate": "此分发版本需要 Comfy Desktop {version} 或更高版本。"
+      }
+    }
   },
   "errors": {
     "invalidUrl": "请输入有效 URL（例如 http://localhost:8188）。",

--- a/src/main/cloud/claims.test.ts
+++ b/src/main/cloud/claims.test.ts
@@ -1,0 +1,24 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest'
+import { statusFromAccessToken, workspaceIdOf } from './claims'
+
+function jwt(payload: Record<string, unknown>): string {
+  const b64 = (o: unknown): string => Buffer.from(JSON.stringify(o)).toString('base64url')
+  return `${b64({ alg: 'RS256' })}.${b64(payload)}.sig`
+}
+
+describe('claims', () => {
+  it('decodes identity + workspace from an access token', () => {
+    const s = statusFromAccessToken(jwt({ email: 'a@b.co', workspace_id: 'w-9', workspace_type: 'team', role: 'owner' }))
+    expect(s).toEqual({ signedIn: true, email: 'a@b.co', workspaceId: 'w-9', workspaceType: 'team', role: 'owner' })
+  })
+
+  it('a malformed token is still signed in, identity unset', () => {
+    expect(statusFromAccessToken('not-a-jwt')).toEqual({ signedIn: true, email: undefined, workspaceId: undefined, workspaceType: undefined, role: undefined })
+  })
+
+  it('workspaceIdOf reads the scope', () => {
+    expect(workspaceIdOf(jwt({ workspace_id: 'w-42' }))).toBe('w-42')
+    expect(workspaceIdOf('garbage')).toBeNull()
+  })
+})

--- a/src/main/cloud/claims.ts
+++ b/src/main/cloud/claims.ts
@@ -1,0 +1,48 @@
+import { Buffer } from 'node:buffer'
+
+import type { AuthStatus } from './types'
+
+/** Claims read (never verified here; the server does that) from the access-token JWT. */
+interface AccessTokenClaims {
+  email?: string
+  workspace_id?: string
+  workspace_type?: string
+  role?: string
+}
+
+function decodeJwtPayload(token: string): AccessTokenClaims | null {
+  const segment = token.split('.')[1]
+  if (!segment) return null
+  try {
+    const parsed: unknown = JSON.parse(Buffer.from(segment, 'base64url').toString('utf-8'))
+    if (!parsed || typeof parsed !== 'object') return null
+    return parsed as AccessTokenClaims
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Signed-in status from an access token's claims. A malformed token still counts
+ * as signed in; the identity fields just stay unset.
+ *
+ * SECURITY: these claims are NOT signature-verified here (the server verifies the
+ * token on every request). Treat `role`/`workspaceId`/`workspaceType` as
+ * DISPLAY-ONLY; never gate features or access on them client-side, or a forged
+ * local token would grant them.
+ */
+export function statusFromAccessToken(accessToken: string): AuthStatus {
+  const claims = decodeJwtPayload(accessToken)
+  return {
+    signedIn: true,
+    email: claims?.email,
+    workspaceId: claims?.workspace_id,
+    workspaceType: claims?.workspace_type,
+    role: claims?.role,
+  }
+}
+
+/** The workspace id a token is scoped to, or null. Used to detect a scope switch. */
+export function workspaceIdOf(accessToken: string): string | null {
+  return decodeJwtPayload(accessToken)?.workspace_id ?? null
+}

--- a/src/main/cloud/config.ts
+++ b/src/main/cloud/config.ts
@@ -1,0 +1,22 @@
+/**
+ * Cloud OAuth + API config. Defaults to prod; `COMFY_CLOUD_ISSUER` overrides the
+ * issuer (e.g. `https://stagingcloud.comfy.org`) for staging or a mock. The
+ * issuer serves both OAuth (`/oauth/*`) and the workspace API (`/api/workspaces`).
+ */
+const DEFAULT_ISSUER = 'https://cloud.comfy.org'
+const DEFAULT_CLIENT_ID = 'comfy-desktop'
+
+export const CLOUD_ISSUER = process.env.COMFY_CLOUD_ISSUER || DEFAULT_ISSUER
+
+export const CLOUD_CONFIG = {
+  issuer: CLOUD_ISSUER,
+  authorizeUrl: `${CLOUD_ISSUER}/oauth/authorize`,
+  tokenUrl: `${CLOUD_ISSUER}/oauth/token`,
+  jwksUrl: `${CLOUD_ISSUER}/.well-known/jwks.json`,
+  /** Workspace REST base (same host as the issuer). */
+  apiBase: `${CLOUD_ISSUER}/api`,
+  clientId: process.env.COMFY_CLOUD_CLIENT_ID || DEFAULT_CLIENT_ID,
+  scope: 'comfy-cloud:user:read',
+  resource: `${CLOUD_ISSUER}/api`,
+  audience: 'comfy-cloud',
+} as const

--- a/src/main/cloud/index.ts
+++ b/src/main/cloud/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Cloud auth + workspace functionality library - public surface.
+ *
+ * Standalone, UI-agnostic (no IPC/Vue): the login flow, an encrypted token
+ * store, and the workspace client, tied together by {@link CloudSession}. It
+ * pairs with the comfy-builder client - `session.asTokenProvider()` is the
+ * `TokenProvider` that client consumes - so the UI plugs both together:
+ *
+ * ```ts
+ * const session = new CloudSession()
+ * await session.login()                                   // system-browser PKCE
+ * const workspaces = await session.listWorkspaces()       // choose workspace
+ * await session.switchWorkspace(chosen.id)                // re-auth, scoped
+ * const client = new ComfyBuilderClient({ auth: session.asTokenProvider() })
+ * const dists = await client.listDistributions()          // scoped to that workspace
+ * ```
+ */
+export { CloudSession } from './session'
+export { signIn, refresh } from './oauth'
+export { listWorkspaces } from './workspaces'
+export { getAuthStatus, loadTokens, saveTokens, clearTokens } from './tokenStore'
+export { statusFromAccessToken, workspaceIdOf } from './claims'
+export { CLOUD_CONFIG, CLOUD_ISSUER } from './config'
+export type { AuthStatus, AuthTokens, Workspace } from './types'

--- a/src/main/cloud/loopback.test.ts
+++ b/src/main/cloud/loopback.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment node
+import http from 'node:http'
+import { afterEach, describe, expect, it } from 'vitest'
+import { startLoopbackListener, type LoopbackListener } from './loopback'
+
+function get(url: string): Promise<{ status: number }> {
+  return new Promise((resolve, reject) => {
+    http.get(url, (res) => { res.resume(); resolve({ status: res.statusCode ?? 0 }) }).on('error', reject)
+  })
+}
+const tick = (): Promise<void> => new Promise((r) => setTimeout(r, 30))
+
+describe('loopback listener', () => {
+  let listener: LoopbackListener | undefined
+  afterEach(() => listener?.close())
+
+  it('resolves the code on a matching-state callback', async () => {
+    listener = await startLoopbackListener({ expectedState: 'st', timeoutMs: 5000 })
+    const codeP = listener.waitForCode()
+    await get(`${listener.redirectUri}?state=st&code=the-code`)
+    expect(await codeP).toEqual({ code: 'the-code' })
+  })
+
+  it('ignores a wrong-state callback (400) and keeps listening (not aborted)', async () => {
+    listener = await startLoopbackListener({ expectedState: 'st', timeoutMs: 5000 })
+    const codeP = listener.waitForCode()
+    let settled = false
+    void codeP.then(() => { settled = true }, () => { settled = true })
+
+    expect((await get(`${listener.redirectUri}?state=WRONG&code=x`)).status).toBe(400)
+    await tick()
+    expect(settled).toBe(false) // an outsider could not abort our sign-in
+
+    await get(`${listener.redirectUri}?state=st&code=real`)
+    expect(await codeP).toEqual({ code: 'real' })
+  })
+
+  it('rejects when the IdP reports an error (matching state)', async () => {
+    listener = await startLoopbackListener({ expectedState: 'st', timeoutMs: 5000 })
+    const codeP = listener.waitForCode()
+    await get(`${listener.redirectUri}?state=st&error=access_denied`)
+    await expect(codeP).rejects.toThrow(/access_denied/)
+  })
+})

--- a/src/main/cloud/loopback.ts
+++ b/src/main/cloud/loopback.ts
@@ -1,0 +1,92 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
+import type { AddressInfo } from 'node:net'
+
+export interface LoopbackListenerOptions {
+  /** The exact `state` value generated for this authorization request. */
+  expectedState: string
+  /** How long to wait for the browser callback before giving up, in ms. */
+  timeoutMs: number
+}
+
+export interface LoopbackListener {
+  /** The `http://127.0.0.1:<port>/callback` URI to register as the redirect target. */
+  redirectUri: string
+  /** Resolves with the authorization `code` on a matching callback; rejects on
+   *  an IdP error (matching state) or timeout. A callback with a wrong/missing
+   *  state is ignored (kept listening), never settling. Same promise every call. */
+  waitForCode: () => Promise<{ code: string }>
+  /** Tear the listener down (idempotent); safe to call after settle. */
+  close: () => void
+}
+
+function html(message: string): string {
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>ComfyUI</title></head><body><p>${message}</p></body></html>`
+}
+
+/**
+ * Single-shot loopback HTTP listener for a PKCE redirect (RFC 8252 §7.3): binds
+ * `127.0.0.1` on an ephemeral port, waits for exactly one `GET /callback`,
+ * validates `state`, and shuts down.
+ */
+export function startLoopbackListener(options: LoopbackListenerOptions): Promise<LoopbackListener> {
+  const { expectedState, timeoutMs } = options
+  return new Promise((resolveListener, rejectListener) => {
+    let settled = false
+    let resolveCode!: (r: { code: string }) => void
+    let rejectCode!: (e: Error) => void
+    const codePromise = new Promise<{ code: string }>((res, rej) => { resolveCode = res; rejectCode = rej })
+    void codePromise.catch(() => {})
+
+    let server: Server | null = null
+    const close = (): void => {
+      clearTimeout(timeoutHandle)
+      if (server) { try { server.close() } catch { /* best-effort */ } server = null }
+    }
+    const fail = (err: Error): void => { if (settled) return; settled = true; close(); rejectCode(err) }
+    const succeed = (code: string): void => { if (settled) return; settled = true; close(); resolveCode({ code }) }
+    const failRequest = (res: ServerResponse, status: number, err: Error): void => {
+      res.statusCode = status
+      res.setHeader('Content-Type', 'text/html; charset=utf-8')
+      res.end(html('Sign-in failed. You can close this window.'))
+      fail(err)
+    }
+    const timeoutHandle = setTimeout(() => fail(new Error('Loopback OAuth callback timed out')), timeoutMs)
+
+    function handle(req: IncomingMessage, res: ServerResponse): void {
+      const remote = req.socket.remoteAddress ?? ''
+      if (remote !== '127.0.0.1' && remote !== '::1' && remote !== '::ffff:127.0.0.1') {
+        res.statusCode = 403; res.end(); return
+      }
+      const url = req.url ?? '/'
+      const q = url.indexOf('?')
+      const path = q >= 0 ? url.slice(0, q) : url
+      const params = new URLSearchParams(q >= 0 ? url.slice(q + 1) : '')
+      if (req.method === 'GET' && path === '/favicon.ico') { res.statusCode = 204; res.end(); return }
+      if (req.method !== 'GET' || path !== '/callback') { res.statusCode = 404; res.end(); return }
+      // Wrong/missing state = not our callback (a port scan, prefetch, or another
+      // flow). Refuse it but KEEP LISTENING so an outsider can't abort our sign-in.
+      if (params.get('state') !== expectedState) {
+        res.statusCode = 400
+        res.setHeader('Content-Type', 'text/html; charset=utf-8')
+        res.end(html('Invalid request.'))
+        return
+      }
+      const idpError = params.get('error')
+      if (idpError) { failRequest(res, 200, new Error(idpError)); return }
+      const code = params.get('code')
+      if (!code) { failRequest(res, 400, new Error('missing authorization code')); return }
+      res.statusCode = 200
+      res.setHeader('Content-Type', 'text/html; charset=utf-8')
+      res.setHeader('Cache-Control', 'no-store')
+      res.end(html('You can close this window.'))
+      succeed(code)
+    }
+
+    server = createServer((req, res) => { res.setHeader('Connection', 'close'); handle(req, res) })
+    server.on('error', (err: Error) => { fail(err); rejectListener(err) })
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server!.address() as AddressInfo
+      resolveListener({ redirectUri: `http://127.0.0.1:${port}/callback`, waitForCode: () => codePromise, close })
+    })
+  })
+}

--- a/src/main/cloud/oauth.test.ts
+++ b/src/main/cloud/oauth.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({ shell: { openExternal: vi.fn(async () => {}) } }))
+
+import { refresh } from './oauth'
+
+function stub(status: number, body: unknown): void {
+  vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })))
+}
+
+describe('oauth.refresh', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('keeps the prior refresh token when the server omits one', async () => {
+    stub(200, { access_token: 'a2', expires_in: 3600 }) // no refresh_token
+    const t = await refresh('old-refresh', { tokenUrl: 'https://c/oauth/token' })
+    expect(t.accessToken).toBe('a2')
+    expect(t.refreshToken).toBe('old-refresh')
+    expect(t.expiresAt).toBeGreaterThan(Date.now())
+  })
+
+  it('adopts a rotated refresh token when the server returns one', async () => {
+    stub(200, { access_token: 'a2', refresh_token: 'new', expires_in: 3600 })
+    expect((await refresh('old', { tokenUrl: 'https://c/oauth/token' })).refreshToken).toBe('new')
+  })
+
+  it('rejects a response missing access_token', async () => {
+    stub(200, { expires_in: 3600 })
+    await expect(refresh('r', { tokenUrl: 'https://c/oauth/token' })).rejects.toThrow(/access_token/)
+  })
+
+  it('rejects a response with a non-numeric expires_in', async () => {
+    stub(200, { access_token: 'a', expires_in: 'soon' })
+    await expect(refresh('r', { tokenUrl: 'https://c/oauth/token' })).rejects.toThrow(/expires_in/)
+  })
+})

--- a/src/main/cloud/oauth.ts
+++ b/src/main/cloud/oauth.ts
@@ -1,0 +1,119 @@
+/**
+ * PKCE authorization-code flow (RFC 8252): bind a loopback redirect, open the
+ * system browser at the authorize URL, wait for the callback code, exchange it
+ * for tokens. `signIn` optionally pre-selects a workspace (the switch path).
+ */
+import { shell } from 'electron'
+
+import { statusFromAccessToken } from './claims'
+import { CLOUD_CONFIG } from './config'
+import { startLoopbackListener } from './loopback'
+import { buildAuthorizeUrl, codeChallengeFromVerifier, generateCodeVerifier, generateState } from './pkce'
+import type { AuthStatus, AuthTokens } from './types'
+
+const DEFAULT_SIGN_IN_TIMEOUT_MS = 120_000
+const TOKEN_REQUEST_TIMEOUT_MS = 15_000
+
+export interface OAuthOptions {
+  authorizeUrl?: string
+  tokenUrl?: string
+  clientId?: string
+  scope?: string
+  resource?: string
+  timeoutMs?: number
+  /** Pre-select this workspace at consent time. */
+  workspaceId?: string
+}
+
+interface TokenResponse {
+  access_token: string
+  refresh_token?: string
+  expires_in: number
+}
+
+function resolveConfig(o: OAuthOptions): Required<Omit<OAuthOptions, 'workspaceId'>> {
+  return {
+    authorizeUrl: o.authorizeUrl ?? CLOUD_CONFIG.authorizeUrl,
+    tokenUrl: o.tokenUrl ?? CLOUD_CONFIG.tokenUrl,
+    clientId: o.clientId ?? CLOUD_CONFIG.clientId,
+    scope: o.scope ?? CLOUD_CONFIG.scope,
+    resource: o.resource ?? CLOUD_CONFIG.resource,
+    timeoutMs: o.timeoutMs ?? DEFAULT_SIGN_IN_TIMEOUT_MS,
+  }
+}
+
+/** Build tokens, keeping the prior refresh token when the server omits one
+ *  (RFC 6749 §6: refresh_token is optional on a refresh grant). */
+function toTokens(r: TokenResponse, fallbackRefresh?: string): AuthTokens {
+  return {
+    accessToken: r.access_token,
+    refreshToken: r.refresh_token ?? fallbackRefresh,
+    expiresAt: Date.now() + r.expires_in * 1000,
+  }
+}
+
+async function requestToken(tokenUrl: string, body: URLSearchParams): Promise<TokenResponse> {
+  const controller = new AbortController()
+  // Keep the abort armed until the body is fully read, so a slow/unbounded body
+  // can't hang the flow after the response headers arrive.
+  const timer = setTimeout(() => controller.abort(), TOKEN_REQUEST_TIMEOUT_MS)
+  try {
+    const resp = await fetch(tokenUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+      signal: controller.signal,
+    })
+    if (!resp.ok) {
+      const detail = await resp.text().catch(() => '')
+      throw new Error(`OAuth token request failed: ${resp.status} ${detail || resp.statusText}`)
+    }
+    const data = (await resp.json()) as Partial<TokenResponse>
+    if (typeof data.access_token !== 'string' || data.access_token.length === 0) {
+      throw new Error('OAuth token response missing access_token')
+    }
+    if (typeof data.expires_in !== 'number' || !Number.isFinite(data.expires_in)) {
+      throw new Error('OAuth token response missing a valid expires_in')
+    }
+    return data as TokenResponse
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+export async function signIn(options: OAuthOptions = {}): Promise<{ tokens: AuthTokens; status: AuthStatus }> {
+  const cfg = resolveConfig(options)
+  const codeVerifier = generateCodeVerifier()
+  const codeChallenge = codeChallengeFromVerifier(codeVerifier)
+  const state = generateState()
+
+  const listener = await startLoopbackListener({ expectedState: state, timeoutMs: cfg.timeoutMs })
+  try {
+    const authorizeUrl = buildAuthorizeUrl({
+      authorizeUrl: cfg.authorizeUrl, clientId: cfg.clientId, redirectUri: listener.redirectUri,
+      scope: cfg.scope, resource: cfg.resource, state, codeChallenge,
+      ...(options.workspaceId ? { workspaceId: options.workspaceId } : {}),
+    })
+    // System browser only (RFC 8252): never an embedded window/webview.
+    await shell.openExternal(authorizeUrl)
+    const { code } = await listener.waitForCode()
+
+    const r = await requestToken(cfg.tokenUrl, new URLSearchParams({
+      grant_type: 'authorization_code', code, redirect_uri: listener.redirectUri,
+      client_id: cfg.clientId, code_verifier: codeVerifier, resource: cfg.resource,
+    }))
+    return { tokens: toTokens(r), status: statusFromAccessToken(r.access_token) }
+  } finally {
+    // Always tear the listener down, even if openExternal or waitForCode threw,
+    // so a failed sign-in never leaks a listening socket until the timeout.
+    listener.close()
+  }
+}
+
+export async function refresh(refreshToken: string, options: OAuthOptions = {}): Promise<AuthTokens> {
+  const cfg = resolveConfig(options)
+  const r = await requestToken(cfg.tokenUrl, new URLSearchParams({
+    grant_type: 'refresh_token', refresh_token: refreshToken, client_id: cfg.clientId, resource: cfg.resource,
+  }))
+  return toTokens(r, refreshToken)
+}

--- a/src/main/cloud/pkce.test.ts
+++ b/src/main/cloud/pkce.test.ts
@@ -1,0 +1,29 @@
+// @vitest-environment node
+import { createHash } from 'node:crypto'
+import { describe, expect, it } from 'vitest'
+import { buildAuthorizeUrl, codeChallengeFromVerifier, generateCodeVerifier, generateState } from './pkce'
+
+describe('pkce', () => {
+  it('code verifier + state are distinct base64url secrets', () => {
+    expect(generateCodeVerifier()).not.toBe(generateCodeVerifier())
+    expect(generateState()).toMatch(/^[A-Za-z0-9_-]+$/)
+  })
+
+  it('code challenge is S256(verifier) in base64url', () => {
+    const v = 'test-verifier'
+    expect(codeChallengeFromVerifier(v)).toBe(createHash('sha256').update(v).digest('base64url'))
+  })
+
+  it('buildAuthorizeUrl sets the PKCE params', () => {
+    const u = new URL(buildAuthorizeUrl({ authorizeUrl: 'https://c/oauth/authorize', clientId: 'cid', redirectUri: 'http://127.0.0.1:5/callback', scope: 'sc', resource: 'https://c/api', state: 'st', codeChallenge: 'ch' }))
+    expect(u.searchParams.get('response_type')).toBe('code')
+    expect(u.searchParams.get('client_id')).toBe('cid')
+    expect(u.searchParams.get('code_challenge_method')).toBe('S256')
+    expect(u.searchParams.get('workspace_id')).toBeNull()
+  })
+
+  it('buildAuthorizeUrl includes workspace_id only when given (switch path)', () => {
+    const u = new URL(buildAuthorizeUrl({ authorizeUrl: 'https://c/oauth/authorize', clientId: 'cid', redirectUri: 'r', scope: 's', state: 'st', codeChallenge: 'ch', workspaceId: 'w-1' }))
+    expect(u.searchParams.get('workspace_id')).toBe('w-1')
+  })
+})

--- a/src/main/cloud/pkce.ts
+++ b/src/main/cloud/pkce.ts
@@ -1,0 +1,39 @@
+import { createHash, randomBytes } from 'crypto'
+
+export function generateCodeVerifier(): string {
+  return randomBytes(32).toString('base64url')
+}
+
+export function codeChallengeFromVerifier(verifier: string): string {
+  return createHash('sha256').update(verifier).digest('base64url')
+}
+
+export function generateState(): string {
+  return randomBytes(32).toString('base64url')
+}
+
+export interface BuildAuthorizeUrlParams {
+  authorizeUrl: string
+  clientId: string
+  redirectUri: string
+  scope: string
+  resource?: string
+  state: string
+  codeChallenge: string
+  /** Pre-select a workspace at consent time (the switch-workspace path). */
+  workspaceId?: string
+}
+
+export function buildAuthorizeUrl(p: BuildAuthorizeUrlParams): string {
+  const url = new URL(p.authorizeUrl)
+  url.searchParams.set('response_type', 'code')
+  url.searchParams.set('client_id', p.clientId)
+  url.searchParams.set('redirect_uri', p.redirectUri)
+  url.searchParams.set('scope', p.scope)
+  if (p.resource) url.searchParams.set('resource', p.resource)
+  url.searchParams.set('state', p.state)
+  url.searchParams.set('code_challenge', p.codeChallenge)
+  url.searchParams.set('code_challenge_method', 'S256')
+  if (p.workspaceId) url.searchParams.set('workspace_id', p.workspaceId)
+  return url.toString()
+}

--- a/src/main/cloud/session.test.ts
+++ b/src/main/cloud/session.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./oauth', () => ({ signIn: vi.fn(), refresh: vi.fn() }))
+vi.mock('./tokenStore', () => ({ loadTokens: vi.fn(), saveTokens: vi.fn(), clearTokens: vi.fn(), getAuthStatus: vi.fn(() => ({ signedIn: false })) }))
+vi.mock('./workspaces', () => ({ listWorkspaces: vi.fn(async () => [{ id: 'w-1' }]) }))
+
+import { CloudSession } from './session'
+import { refresh, signIn } from './oauth'
+import { clearTokens, loadTokens, saveTokens } from './tokenStore'
+import { listWorkspaces } from './workspaces'
+
+const mocked = vi.mocked
+const future = Date.now() + 3_600_000
+const past = Date.now() - 1_000
+
+describe('CloudSession.getAccessToken', () => {
+  afterEach(() => vi.clearAllMocks())
+
+  it('returns null when signed out', async () => {
+    mocked(loadTokens).mockReturnValue(null)
+    expect(await new CloudSession().getAccessToken()).toBeNull()
+  })
+
+  it('returns the token without refreshing when it is still valid', async () => {
+    mocked(loadTokens).mockReturnValue({ accessToken: 'good', refreshToken: 'r', expiresAt: future })
+    expect(await new CloudSession().getAccessToken()).toBe('good')
+    expect(refresh).not.toHaveBeenCalled()
+  })
+
+  it('refreshes + persists when expired and a refresh token exists', async () => {
+    mocked(loadTokens).mockReturnValue({ accessToken: 'stale', refreshToken: 'r', expiresAt: past })
+    mocked(refresh).mockResolvedValue({ accessToken: 'fresh', refreshToken: 'r2', expiresAt: future })
+    expect(await new CloudSession().getAccessToken()).toBe('fresh')
+    expect(saveTokens).toHaveBeenCalledWith({ accessToken: 'fresh', refreshToken: 'r2', expiresAt: future })
+  })
+
+  it('falls back to the stale token when refresh fails', async () => {
+    mocked(loadTokens).mockReturnValue({ accessToken: 'stale', refreshToken: 'r', expiresAt: past })
+    mocked(refresh).mockRejectedValue(new Error('down'))
+    expect(await new CloudSession().getAccessToken()).toBe('stale')
+  })
+
+  it('does not attempt refresh without a refresh token', async () => {
+    mocked(loadTokens).mockReturnValue({ accessToken: 'stale', expiresAt: past })
+    expect(await new CloudSession().getAccessToken()).toBe('stale')
+    expect(refresh).not.toHaveBeenCalled()
+  })
+
+  it('single-flights concurrent refreshes (one rotation, no token-family race)', async () => {
+    mocked(loadTokens).mockReturnValue({ accessToken: 'stale', refreshToken: 'r', expiresAt: past })
+    let resolveRefresh!: (t: { accessToken: string; refreshToken: string; expiresAt: number }) => void
+    mocked(refresh).mockReturnValue(new Promise((r) => { resolveRefresh = r }))
+    const s = new CloudSession()
+    const [p1, p2, p3] = [s.getAccessToken(), s.getAccessToken(), s.getAccessToken()]
+    resolveRefresh({ accessToken: 'fresh', refreshToken: 'r2', expiresAt: future })
+    expect(await Promise.all([p1, p2, p3])).toEqual(['fresh', 'fresh', 'fresh'])
+    expect(refresh).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('CloudSession workspace + provider', () => {
+  afterEach(() => vi.clearAllMocks())
+
+  it('switchWorkspace re-auths pre-selecting the workspace', async () => {
+    mocked(signIn).mockResolvedValue({ tokens: { accessToken: 't', expiresAt: future }, status: { signedIn: true, workspaceId: 'w-2' } })
+    const status = await new CloudSession().switchWorkspace('w-2')
+    expect(signIn).toHaveBeenCalledWith({ workspaceId: 'w-2' })
+    expect(status.workspaceId).toBe('w-2')
+    expect(saveTokens).toHaveBeenCalled()
+  })
+
+  it('listWorkspaces uses the current token', async () => {
+    mocked(loadTokens).mockReturnValue({ accessToken: 'good', expiresAt: future })
+    await new CloudSession().listWorkspaces()
+    expect(listWorkspaces).toHaveBeenCalledWith('good')
+  })
+
+  it('asTokenProvider delegates getAccessToken and clears on unauthorized', async () => {
+    mocked(loadTokens).mockReturnValue({ accessToken: 'good', expiresAt: future })
+    const tp = new CloudSession().asTokenProvider()
+    expect(await tp.getAccessToken()).toBe('good')
+    tp.onUnauthorized?.()
+    expect(clearTokens).toHaveBeenCalled()
+  })
+})

--- a/src/main/cloud/session.ts
+++ b/src/main/cloud/session.ts
@@ -1,0 +1,101 @@
+/**
+ * CloudSession - the one object the app (and its UI) drives for auth + workspace.
+ *
+ * Ties the PKCE flow, the encrypted token store, and the workspace client into a
+ * single facade, and exposes a {@link TokenProvider} so the comfy-builder client
+ * can pull a fresh bearer token without ever seeing the store. Tokens never leave
+ * the main process; the UI only ever gets {@link AuthStatus} + {@link Workspace}.
+ */
+import type { TokenProvider } from '../comfybuilder'
+import { workspaceIdOf } from './claims'
+import { refresh, signIn } from './oauth'
+import { clearTokens, getAuthStatus, loadTokens, saveTokens } from './tokenStore'
+import type { AuthStatus, Workspace } from './types'
+import { listWorkspaces } from './workspaces'
+
+/** Refresh an access token this many ms before it actually expires. */
+const REFRESH_SKEW_MS = 60_000
+
+export class CloudSession {
+  /** Deduped in-flight refresh: parallel callers share one rotation so they
+   *  never race the refresh token (a race can revoke the whole token family). */
+  private refreshing: Promise<string | null> | null = null
+
+  /** Start the PKCE sign-in (system browser); persists tokens on success. */
+  async login(): Promise<AuthStatus> {
+    const { tokens, status } = await signIn()
+    saveTokens(tokens)
+    return status
+  }
+
+  /** Forget tokens. Installed environments are untouched. */
+  logout(): void {
+    clearTokens()
+  }
+
+  status(): AuthStatus {
+    return getAuthStatus()
+  }
+
+  isSignedIn(): boolean {
+    return getAuthStatus().signedIn
+  }
+
+  /** The workspace the active token is scoped to, or null when signed out. */
+  currentWorkspaceId(): string | null {
+    const t = loadTokens()
+    return t ? workspaceIdOf(t.accessToken) : null
+  }
+
+  /**
+   * A valid access token, refreshing it first if it is expired (or about to be)
+   * and a refresh token is available. Null when signed out or the refresh fails.
+   */
+  async getAccessToken(): Promise<string | null> {
+    const tokens = loadTokens()
+    if (!tokens) return null
+    if (tokens.expiresAt - REFRESH_SKEW_MS > Date.now() || !tokens.refreshToken) return tokens.accessToken
+    // Single-flight: the first caller runs the refresh, the rest await it.
+    if (!this.refreshing) {
+      this.refreshing = this.doRefresh(tokens.refreshToken).finally(() => { this.refreshing = null })
+    }
+    return this.refreshing
+  }
+
+  private async doRefresh(refreshToken: string): Promise<string | null> {
+    try {
+      const rotated = await refresh(refreshToken)
+      saveTokens(rotated)
+      return rotated.accessToken
+    } catch {
+      // Refresh failed: fall back to the current token and let the caller's 401
+      // handling take over. Re-read in case another flow updated it meanwhile.
+      return loadTokens()?.accessToken ?? null
+    }
+  }
+
+  /** The signed-in user's workspaces (empty when signed out or team-workspaces off). */
+  async listWorkspaces(): Promise<Workspace[]> {
+    const token = await this.getAccessToken()
+    if (!token) return []
+    return listWorkspaces(token)
+  }
+
+  /**
+   * Switch the active workspace. A PKCE cloud token is scoped at consent time, so
+   * this re-runs sign-in pre-selecting the workspace (no silent re-scope exists).
+   */
+  async switchWorkspace(workspaceId: string): Promise<AuthStatus> {
+    const { tokens, status } = await signIn({ workspaceId })
+    saveTokens(tokens)
+    return status
+  }
+
+  /** Adapter for the comfy-builder client's auth seam. */
+  asTokenProvider(): TokenProvider {
+    return {
+      getAccessToken: () => this.getAccessToken(),
+      onUnauthorized: () => this.logout(),
+    }
+  }
+}

--- a/src/main/cloud/tokenStore.ts
+++ b/src/main/cloud/tokenStore.ts
@@ -1,0 +1,80 @@
+/**
+ * OAuth token store (main process only). Tokens are encrypted at rest with
+ * Electron `safeStorage` in `userData/comfy-cloud-auth.bin` and never reach the
+ * renderer, logs, or disk in plaintext. When the OS secure-storage backend is
+ * unavailable, tokens are kept in memory for the process lifetime only.
+ */
+import { app, safeStorage } from 'electron'
+import * as fs from 'fs'
+import * as path from 'path'
+
+import { statusFromAccessToken } from './claims'
+import type { AuthStatus, AuthTokens } from './types'
+
+const AUTH_FILENAME = 'comfy-cloud-auth.bin'
+
+let cachedTokens: AuthTokens | null = null
+let authFilePath: string | null = null
+export let secureStorageUnavailable = false
+
+function filePath(): string {
+  if (!authFilePath) authFilePath = path.join(app.getPath('userData'), AUTH_FILENAME)
+  return authFilePath
+}
+
+function encryptionAvailable(): boolean {
+  let ok: boolean
+  try { ok = safeStorage.isEncryptionAvailable() } catch { ok = false }
+  secureStorageUnavailable = !ok
+  return ok
+}
+
+function isTokens(v: unknown): v is AuthTokens {
+  return !!v && typeof v === 'object' && typeof (v as AuthTokens).accessToken === 'string' && typeof (v as AuthTokens).expiresAt === 'number'
+}
+
+export function saveTokens(tokens: AuthTokens): void {
+  cachedTokens = tokens
+  if (!encryptionAvailable()) {
+    // No secure backend: never write plaintext, and drop any prior encrypted
+    // file so a later run can't read stale tokens back as current.
+    try { fs.rmSync(filePath(), { force: true }) } catch { /* nothing to remove */ }
+    return
+  }
+  try {
+    fs.writeFileSync(filePath(), safeStorage.encryptString(JSON.stringify(tokens)))
+  } catch {
+    // A failed persist must not fail the sign-in the user just completed; the
+    // in-memory cache still holds the tokens for this session.
+  }
+}
+
+export function loadTokens(): AuthTokens | null {
+  if (cachedTokens) return cachedTokens
+  if (!encryptionAvailable()) return null
+  try {
+    const parsed: unknown = JSON.parse(safeStorage.decryptString(fs.readFileSync(filePath())))
+    if (!isTokens(parsed)) return null // corrupt/incompatible payload -> signed out
+    cachedTokens = parsed
+    return cachedTokens
+  } catch {
+    return null
+  }
+}
+
+export function clearTokens(): void {
+  cachedTokens = null
+  try { fs.rmSync(filePath(), { force: true }) } catch { /* nothing to remove */ }
+}
+
+export function getAuthStatus(): AuthStatus {
+  const t = loadTokens()
+  return t ? statusFromAccessToken(t.accessToken) : { signedIn: false }
+}
+
+/** @internal reset module state between unit tests. */
+export function _resetForTest(): void {
+  cachedTokens = null
+  authFilePath = null
+  secureStorageUnavailable = false
+}

--- a/src/main/cloud/types.ts
+++ b/src/main/cloud/types.ts
@@ -1,0 +1,36 @@
+/**
+ * Cloud (ingest) auth + workspace library - domain types.
+ *
+ * The auth spine here is a clean, UI-agnostic adaptation of the PKCE flow proven
+ * in the desktop-builder auth work; this library owns it as functionality (no
+ * IPC/Vue) and adds the workspace half. It pairs with the comfy-builder client:
+ * `CloudSession` exposes a `TokenProvider` that client consumes.
+ */
+
+/** OAuth tokens held in the (main-process only) token store. */
+export interface AuthTokens {
+  accessToken: string
+  refreshToken?: string
+  /** Epoch ms when the access token expires. */
+  expiresAt: number
+}
+
+/** Renderer-safe signed-in status (never carries a token). */
+export interface AuthStatus {
+  signedIn: boolean
+  email?: string
+  workspaceId?: string
+  workspaceType?: string
+  role?: string
+}
+
+/** One workspace the signed-in user belongs to (GET /api/workspaces). */
+export interface Workspace {
+  id: string
+  name: string
+  type: string
+  role: string
+  subscriptionTier?: string
+  createdAt?: string
+  joinedAt?: string
+}

--- a/src/main/cloud/workspaces.test.ts
+++ b/src/main/cloud/workspaces.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { listWorkspaces } from './workspaces'
+
+function stub(status: number, body: unknown): void {
+  vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })))
+}
+
+describe('listWorkspaces', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('maps the ingest response to camelCase Workspace[]', async () => {
+    stub(200, { workspaces: [{ id: 'w-1', name: 'Personal', type: 'personal', role: 'owner', subscription_tier: 'FREE', joined_at: 't' }] })
+    const ws = await listWorkspaces('tok', { apiBase: 'https://cloud/api' })
+    expect(ws).toEqual([{ id: 'w-1', name: 'Personal', type: 'personal', role: 'owner', subscriptionTier: 'FREE', joinedAt: 't' }])
+  })
+
+  it('returns [] when team-workspaces is off (404)', async () => {
+    stub(404, {})
+    expect(await listWorkspaces('tok', { apiBase: 'https://cloud/api' })).toEqual([])
+  })
+
+  it('throws on unauthorized', async () => {
+    stub(401, {})
+    await expect(listWorkspaces('tok', { apiBase: 'https://cloud/api' })).rejects.toThrow(/authorized/i)
+  })
+
+  it('returns [] on a null / non-object 200 body', async () => {
+    stub(200, null)
+    expect(await listWorkspaces('tok', { apiBase: 'https://cloud/api' })).toEqual([])
+  })
+})

--- a/src/main/cloud/workspaces.ts
+++ b/src/main/cloud/workspaces.ts
@@ -1,0 +1,55 @@
+/**
+ * Workspace client: list the workspaces a signed-in user belongs to.
+ *
+ * `GET {apiBase}/workspaces` (the ingest service) returns the caller's
+ * workspaces. Switching the ACTIVE workspace is a re-auth, not a call here (a
+ * PKCE cloud token is scoped at consent time and cannot be silently re-scoped);
+ * `CloudSession.switchWorkspace` drives that. This module is read-only listing.
+ */
+import { CLOUD_CONFIG } from './config'
+import type { Workspace } from './types'
+
+const DEFAULT_TIMEOUT_MS = 20_000
+
+interface WorkspaceRow {
+  id: string
+  name: string
+  type: string
+  role: string
+  subscription_tier?: string
+  created_at?: string
+  joined_at?: string
+}
+
+export interface ListWorkspacesOptions {
+  /** Cloud API base. Defaults to the configured issuer's `/api`. */
+  apiBase?: string
+  timeoutMs?: number
+}
+
+/**
+ * List the signed-in user's workspaces. Returns `[]` when the team-workspaces
+ * feature is off (the endpoint 404s), since the token's own workspace is then
+ * the only one and is already active.
+ */
+export async function listWorkspaces(accessToken: string, options: ListWorkspacesOptions = {}): Promise<Workspace[]> {
+  const base = (options.apiBase ?? CLOUD_CONFIG.apiBase).replace(/\/+$/, '')
+  const res = await fetch(`${base}/workspaces`, {
+    headers: { Accept: 'application/json', Authorization: `Bearer ${accessToken}` },
+    signal: AbortSignal.timeout(options.timeoutMs ?? DEFAULT_TIMEOUT_MS),
+  })
+  if (res.status === 404) return []
+  if (res.status === 401 || res.status === 403) throw new Error('Not authorized to list workspaces')
+  if (!res.ok) throw new Error(`List workspaces failed: HTTP ${res.status}`)
+  const body: unknown = await res.json().catch(() => null)
+  const rows = body && typeof body === 'object' ? (body as { workspaces?: WorkspaceRow[] }).workspaces : undefined
+  return (rows ?? []).map((w) => ({
+    id: w.id,
+    name: w.name,
+    type: w.type,
+    role: w.role,
+    ...(w.subscription_tier ? { subscriptionTier: w.subscription_tier } : {}),
+    ...(w.created_at ? { createdAt: w.created_at } : {}),
+    ...(w.joined_at ? { joinedAt: w.joined_at } : {}),
+  }))
+}

--- a/src/main/comfybuilder/client.test.ts
+++ b/src/main/comfybuilder/client.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ComfyBuilderApiError, ComfyBuilderClient } from './client'
+import type { TokenProvider } from './types'
+
+const auth = (token: string | null, onUnauthorized = vi.fn()): TokenProvider => ({
+  getAccessToken: async () => token,
+  onUnauthorized,
+})
+
+function mockFetch(status: number, body: unknown): typeof fetch {
+  return vi.fn(async () => new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })) as unknown as typeof fetch
+}
+
+describe('ComfyBuilderClient', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('lists distributions with a Bearer token at the right path', async () => {
+    const f = mockFetch(200, { distributions: [{ id: 'd1', name: 'Dist One' }] })
+    vi.stubGlobal('fetch', f)
+    const client = new ComfyBuilderClient({ baseUrl: 'https://api.test/builder', auth: auth('tok-123') })
+    const dists = await client.listDistributions()
+    expect(dists).toEqual([{ id: 'd1', name: 'Dist One' }])
+    const call = (f as unknown as ReturnType<typeof vi.fn>).mock.calls[0]!
+    expect(call[0]).toBe('https://api.test/builder/v1/distributions')
+    expect((call[1].headers as Record<string, string>).Authorization).toBe('Bearer tok-123')
+  })
+
+  it('resolveDownloadUrl returns the presigned url', async () => {
+    vi.stubGlobal('fetch', mockFetch(200, { downloadUrl: 'https://gcs/signed', expiresAt: 'x' }))
+    const client = new ComfyBuilderClient({ auth: auth('t') })
+    expect(await client.resolveDownloadUrl('a1')).toBe('https://gcs/signed')
+  })
+
+  it('fetchModelManifest hits the version manifest path and normalizes absent fields', async () => {
+    const f = mockFetch(200, { models: [{ type: 'checkpoints', filename: 'sd.safetensors', downloadUrl: 'https://x/sd' }] })
+    vi.stubGlobal('fetch', f)
+    const client = new ComfyBuilderClient({ baseUrl: 'https://api.test/builder', auth: auth('t') })
+    const m = await client.fetchModelManifest('ver-9')
+    expect(m.models).toHaveLength(1)
+    expect(m.modelPolicy).toBeNull()
+    expect(m.partnerNodePolicy).toBeNull()
+    const call = (f as unknown as ReturnType<typeof vi.fn>).mock.calls[0]!
+    expect(call[0]).toBe('https://api.test/builder/v1/distribution-versions/ver-9/manifest')
+  })
+
+  it('throws unauthorized (no network) when signed out', async () => {
+    const f = mockFetch(200, {})
+    vi.stubGlobal('fetch', f)
+    const client = new ComfyBuilderClient({ auth: auth(null) })
+    await expect(client.listDistributions()).rejects.toMatchObject({ kind: 'unauthorized' })
+    expect(f).not.toHaveBeenCalled()
+  })
+
+  it('maps 401 to unauthorized and calls onUnauthorized', async () => {
+    const onUnauthorized = vi.fn()
+    vi.stubGlobal('fetch', mockFetch(401, { message: 'nope' }))
+    const client = new ComfyBuilderClient({ auth: auth('stale', onUnauthorized) })
+    await expect(client.listVersions('d1')).rejects.toBeInstanceOf(ComfyBuilderApiError)
+    expect(onUnauthorized).toHaveBeenCalledOnce()
+  })
+
+  it('maps 404 to not-found and 500 to server', async () => {
+    vi.stubGlobal('fetch', mockFetch(404, {}))
+    await expect(new ComfyBuilderClient({ auth: auth('t') }).getVersion('v1')).rejects.toMatchObject({ kind: 'not-found' })
+    vi.stubGlobal('fetch', mockFetch(500, {}))
+    await expect(new ComfyBuilderClient({ auth: auth('t') }).getVersion('v1')).rejects.toMatchObject({ kind: 'server' })
+  })
+
+  it('maps 403 to forbidden WITHOUT signing the user out', async () => {
+    const onUnauthorized = vi.fn()
+    vi.stubGlobal('fetch', mockFetch(403, {}))
+    await expect(new ComfyBuilderClient({ auth: auth('t', onUnauthorized) }).listDistributions()).rejects.toMatchObject({ kind: 'forbidden' })
+    expect(onUnauthorized).not.toHaveBeenCalled()
+  })
+
+  it('maps an empty/non-JSON 2xx body to a typed server error', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch)
+    await expect(new ComfyBuilderClient({ auth: auth('t') }).listDistributions()).rejects.toMatchObject({ kind: 'server' })
+  })
+
+  it('a throwing onUnauthorized does not mask the unauthorized error', async () => {
+    vi.stubGlobal('fetch', mockFetch(401, {}))
+    const client = new ComfyBuilderClient({ auth: auth('t', vi.fn(() => { throw new Error('boom') })) })
+    await expect(client.listVersions('d1')).rejects.toMatchObject({ kind: 'unauthorized' })
+  })
+})

--- a/src/main/comfybuilder/client.ts
+++ b/src/main/comfybuilder/client.ts
@@ -1,0 +1,143 @@
+/**
+ * ComfyBuilder catalog client - the read side of the functionality library.
+ *
+ * Lists distributions -> versions -> artifacts and resolves an artifact's
+ * presigned download URL, over the deployed builder gateway. Every request
+ * carries a bearer token from the injected {@link TokenProvider}; the token
+ * never leaves this process and is never returned to callers. Failures surface
+ * as a typed {@link ComfyBuilderApiError} whose `kind` a caller can branch on.
+ */
+import type {
+  Artifact,
+  Distribution,
+  DistributionVersion,
+  ModelManifest,
+  TokenProvider,
+} from './types'
+
+/** Prod builder gateway. Pass `baseUrl` to target staging or a mock. */
+export const DEFAULT_BASE_URL = 'https://platformapi.comfy.org/builder'
+
+const DEFAULT_TIMEOUT_MS = 30_000
+
+export type ComfyBuilderErrorKind = 'unauthorized' | 'forbidden' | 'not-found' | 'network' | 'server'
+
+export class ComfyBuilderApiError extends Error {
+  override name = 'ComfyBuilderApiError'
+  readonly kind: ComfyBuilderErrorKind
+  readonly status?: number
+  constructor(kind: ComfyBuilderErrorKind, message: string, status?: number) {
+    super(message)
+    this.kind = kind
+    if (status !== undefined) this.status = status
+  }
+}
+
+export interface ComfyBuilderClientOptions {
+  /** Gateway base URL including the `/builder` mount. Defaults to prod. */
+  baseUrl?: string
+  /** Auth seam: the UI's token source. */
+  auth: TokenProvider
+  /** Per-request timeout in ms. Defaults to 30s. */
+  timeoutMs?: number
+}
+
+interface DistributionsResponse { distributions?: Distribution[] }
+interface VersionsResponse { versions?: DistributionVersion[] }
+interface VersionDetailResponse { version?: number; artifacts?: Artifact[] }
+interface SignedDownloadResponse { downloadUrl?: string }
+
+/** The catalog + download-resolve surface the UI calls to populate its tiles. */
+export class ComfyBuilderClient {
+  private readonly baseUrl: string
+  private readonly auth: TokenProvider
+  private readonly timeoutMs: number
+
+  constructor(options: ComfyBuilderClientOptions) {
+    this.baseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, '')
+    this.auth = options.auth
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  }
+
+  /** Every distribution visible to the signed-in workspace. */
+  async listDistributions(): Promise<Distribution[]> {
+    const body = await this.get<DistributionsResponse>('/v1/distributions')
+    return body.distributions ?? []
+  }
+
+  /** Versions (build history) of one distribution. */
+  async listVersions(distributionId: string): Promise<DistributionVersion[]> {
+    const body = await this.get<VersionsResponse>(`/v1/distributions/${encodeURIComponent(distributionId)}/versions`)
+    return body.versions ?? []
+  }
+
+  /** One version's per-target artifacts (plus its version number). */
+  async getVersion(versionId: string): Promise<{ version: number | undefined; artifacts: Artifact[] }> {
+    const body = await this.get<VersionDetailResponse>(`/v1/distribution-versions/${encodeURIComponent(versionId)}`)
+    return { version: body.version, artifacts: body.artifacts ?? [] }
+  }
+
+  /**
+   * A version's models + runtime policies, projected from its sealed manifest.
+   * Each model carries a ready-to-GET `downloadUrl` and its target model
+   * directory; a client stages these before starting ComfyUI. An empty `models`
+   * array is normal (a version may declare none).
+   */
+  async fetchModelManifest(versionId: string): Promise<ModelManifest> {
+    const body = await this.get<Partial<ModelManifest>>(
+      `/v1/distribution-versions/${encodeURIComponent(versionId)}/manifest`,
+    )
+    return {
+      models: body.models ?? [],
+      modelPolicy: body.modelPolicy ?? null,
+      partnerNodePolicy: body.partnerNodePolicy ?? null,
+    }
+  }
+
+  /** Resolve an artifact's short-lived presigned archive URL. */
+  async resolveDownloadUrl(artifactId: string): Promise<string> {
+    const body = await this.get<SignedDownloadResponse>(`/v1/build-artifacts/${encodeURIComponent(artifactId)}/download`)
+    if (typeof body.downloadUrl !== 'string' || body.downloadUrl.length === 0) {
+      throw new ComfyBuilderApiError('server', `No downloadUrl for artifact ${artifactId}`)
+    }
+    return body.downloadUrl
+  }
+
+  private async get<T>(path: string): Promise<T> {
+    const token = await this.auth.getAccessToken()
+    if (!token) throw new ComfyBuilderApiError('unauthorized', 'Not signed in to ComfyBuilder')
+
+    let res: Response
+    try {
+      res = await fetch(`${this.baseUrl}${path}`, {
+        headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(this.timeoutMs),
+      })
+    } catch (err) {
+      throw new ComfyBuilderApiError('network', `Request to ${path} failed: ${(err as Error).message}`)
+    }
+
+    // 401 = dead token: prompt re-auth. 403 = authenticated but lacks access to
+    // this resource; a single forbidden item must NOT sign the user out.
+    if (res.status === 401) {
+      try { this.auth.onUnauthorized?.() } catch { /* an injected callback must not mask the typed error */ }
+      throw new ComfyBuilderApiError('unauthorized', `Not authorized for ${path}`, 401)
+    }
+    if (res.status === 403) throw new ComfyBuilderApiError('forbidden', `Forbidden: ${path}`, 403)
+    if (res.status === 404) throw new ComfyBuilderApiError('not-found', `${path} not found`, 404)
+    if (!res.ok) throw new ComfyBuilderApiError('server', `${path} failed: HTTP ${res.status}`, res.status)
+
+    // A 2xx with an empty / non-JSON / null body must surface as a typed error,
+    // never a raw SyntaxError or a downstream `body.foo` TypeError.
+    let body: unknown
+    try {
+      body = await res.json()
+    } catch {
+      throw new ComfyBuilderApiError('server', `${path} returned a non-JSON body`)
+    }
+    if (body === null || typeof body !== 'object') {
+      throw new ComfyBuilderApiError('server', `${path} returned an unexpected body`)
+    }
+    return body as T
+  }
+}

--- a/src/main/comfybuilder/index.ts
+++ b/src/main/comfybuilder/index.ts
@@ -1,0 +1,44 @@
+/**
+ * ComfyBuilder functionality library - public surface.
+ *
+ * A standalone, UI-agnostic library for the Desktop <-> comfy-builder flow:
+ * list distributions/versions/artifacts, pick the artifact for the host,
+ * download + install it, and build its launch command. It has NO dependency on
+ * Electron IPC, Vue, or the installations store; the UI plugs in by supplying a
+ * {@link TokenProvider} and calling these functions.
+ *
+ * Typical UI wiring:
+ * ```ts
+ * const client = new ComfyBuilderClient({ baseUrl, auth: tokenStoreAdapter })
+ * const dists = await client.listDistributions()               // render tiles
+ * const { artifacts } = await client.getVersion(versionId)
+ * const artifact = selectArtifactForHost(artifacts, { os: hostOs(), gpu })
+ * await installArtifact({ artifact, client, installPath, cacheDir, onProgress })
+ * const launch = buildLaunchSpec(installPath, { launchArgs })
+ * ```
+ */
+export { ComfyBuilderClient, ComfyBuilderApiError, DEFAULT_BASE_URL } from './client'
+export type { ComfyBuilderClientOptions, ComfyBuilderErrorKind } from './client'
+export { hostOs, selectArtifactForHost } from './targets'
+export { installArtifact, ComfyBuilderInstallError, sha256File, normalizeSha256 } from './install'
+export type { InstallArtifactOptions, ComfyBuilderInstallErrorKind } from './install'
+export { stageModels, installModelsRoot, StageModelsError } from './models'
+export type { StageModelsOptions, StageModelsErrorKind } from './models'
+export { resolveModelManifest } from './modelManifest'
+export { buildLaunchSpec, venvPython } from './launch'
+export type { LaunchOptions } from './launch'
+export type {
+  Artifact,
+  ArtifactGpu,
+  ArtifactOs,
+  Distribution,
+  DistributionVersion,
+  Host,
+  InstallProgress,
+  LaunchSpec,
+  ModelDescriptor,
+  ModelManifest,
+  ModelPolicy,
+  StageProgress,
+  TokenProvider,
+} from './types'

--- a/src/main/comfybuilder/install.test.ts
+++ b/src/main/comfybuilder/install.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment node
+import os from 'node:os'
+import path from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+
+// The guard tests never reach download/extract; stub them so importing install.ts
+// does not pull Electron (`net`) or 7zip-bin into this unit test.
+vi.mock('../lib/download', () => ({ download: vi.fn() }))
+vi.mock('../lib/extract', () => ({ extractNested: vi.fn() }))
+
+import { installArtifact } from './install'
+import type { Artifact } from './types'
+
+const artifact = (overrides: Partial<Artifact> = {}): Artifact => ({ id: 'a1', os: 'linux', gpu: 'cpu', accelVariant: 'cpu', status: 'ready', ...overrides })
+
+describe('installArtifact guards', () => {
+  it('rejects a missing artifact id before any work', async () => {
+    const client = { resolveDownloadUrl: vi.fn() }
+    await expect(installArtifact({ artifact: { ...artifact(), id: '' }, client, installPath: '/x', cacheDir: os.tmpdir() }))
+      .rejects.toMatchObject({ kind: 'invalid-artifact' })
+    expect(client.resolveDownloadUrl).not.toHaveBeenCalled()
+  })
+
+  // TODO: flip back to fail-closed once the builder populates outputSha256.
+  it.each([
+    ['absent', undefined],
+    ['blank', '   '],
+    ['prefix-only', 'sha256:'],
+  ])('proceeds (unverified) when outputSha256 is %s', async (name, sha) => {
+    const client = { resolveDownloadUrl: vi.fn(async () => 'https://example.test/a.tar.gz') }
+    // Gets past the hash gate: the stubbed extract writes no layout, so it fails
+    // on the layout check rather than on the missing hash.
+    await expect(installArtifact({ artifact: artifact({ outputSha256: sha }), client, installPath: path.join(os.tmpdir(), `cb-${name}`), cacheDir: os.tmpdir() }))
+      .rejects.toMatchObject({ kind: 'invalid-layout' })
+    expect(client.resolveDownloadUrl).toHaveBeenCalled()
+  })
+})

--- a/src/main/comfybuilder/install.ts
+++ b/src/main/comfybuilder/install.ts
@@ -1,0 +1,160 @@
+/**
+ * Install: the write side of the functionality library.
+ *
+ * Given a chosen {@link Artifact}, turn it into a runnable install directory:
+ * resolve the presigned URL, download, verify sha256, extract, validate the
+ * layout. The archive is what comfy-builder tars: a top-level `venv/` +
+ * `ComfyUI/` (a ready, relocatable env), so there is no post-extract env build;
+ * launch drives that `venv/` directly (see `./launch`).
+ *
+ * Integrity: when the artifact carries an `outputSha256` the bytes must match or
+ * nothing is extracted. A MISSING hash is currently installed unverified because
+ * the builder does not populate it yet (see the TODO in `installArtifact`); that
+ * becomes fail-closed once it does. The archive downloads to a per-run temp under `cacheDir`
+ * so concurrent installs of the same artifact cannot corrupt each other, and on
+ * any failure only files THIS run created are cleaned up: a failed re-install
+ * never destroys a previously-working environment.
+ */
+import { createHash, randomBytes } from 'crypto'
+import fs from 'fs'
+import { createReadStream } from 'fs'
+import path from 'path'
+
+import { download } from '../lib/download'
+import type { DownloadProgress } from '../lib/download'
+import { extractNested } from '../lib/extract'
+import type { ExtractProgress } from '../lib/extract'
+import type { ComfyBuilderClient } from './client'
+import type { Artifact, InstallProgress } from './types'
+
+/** The directories every well-formed archive extracts to. */
+const ARTIFACT_DIRS = ['venv', 'ComfyUI'] as const
+
+export type ComfyBuilderInstallErrorKind = 'invalid-artifact' | 'invalid-layout' | 'checksum-mismatch'
+
+export class ComfyBuilderInstallError extends Error {
+  override name = 'ComfyBuilderInstallError'
+  readonly kind: ComfyBuilderInstallErrorKind
+  constructor(kind: ComfyBuilderInstallErrorKind, message: string) {
+    super(message)
+    this.kind = kind
+  }
+}
+
+export interface InstallArtifactOptions {
+  artifact: Artifact
+  /** Resolves the presigned download URL. */
+  client: Pick<ComfyBuilderClient, 'resolveDownloadUrl'>
+  /** Directory the archive extracts into (becomes the runnable install). */
+  installPath: string
+  /** Scratch dir for the download; the temp archive is removed after extraction. */
+  cacheDir: string
+  onProgress?: (p: InstallProgress) => void
+  signal?: AbortSignal
+}
+
+/** A real directory (not a symlink). Rejecting a symlinked layout dir guards
+ *  against a `venv -> /` style archive escaping `installPath`. */
+function isRealDir(p: string): boolean {
+  try {
+    return fs.lstatSync(p).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+/** Cache-folder-safe slug for an artifact id (which may contain path chars). */
+function cacheSlug(artifactId: string): string {
+  return artifactId.replace(/[^a-zA-Z0-9._-]/g, '_')
+}
+
+/** Streaming lowercase-hex sha256 of a file. Exported so model staging verifies
+ *  downloads the same way archive install does. Resolves on 'close' (not 'end')
+ *  so the fd is released before a following rmSync, avoiding EBUSY on Windows. */
+export function sha256File(filePath: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const hash = createHash('sha256')
+    const stream = createReadStream(filePath)
+    stream.on('error', reject)
+    stream.on('data', (chunk) => hash.update(chunk))
+    stream.on('close', () => resolve(hash.digest('hex')))
+  })
+}
+
+/** Normalize a manifest hash for comparison: strip an optional `sha256:` prefix,
+ *  trim, lowercase. Returns '' when there is no usable hash. */
+export function normalizeSha256(raw: string | undefined): string {
+  return raw?.replace(/^sha256:/i, '').trim().toLowerCase() ?? ''
+}
+
+function assertLayout(installPath: string): void {
+  for (const dir of ARTIFACT_DIRS) {
+    if (!isRealDir(path.join(installPath, dir))) {
+      throw new ComfyBuilderInstallError('invalid-layout', `Extracted artifact is missing a real ${dir}/ directory.`)
+    }
+  }
+}
+
+/** Remove only entries created this run, so a failed install never deletes a
+ *  pre-existing environment or unrelated contents of a shared directory. */
+async function cleanupCreated(installPath: string, preexisting: ReadonlySet<string>): Promise<void> {
+  const entries = await fs.promises.readdir(installPath).catch(() => [] as string[])
+  await Promise.all(
+    entries
+      .filter((e) => !preexisting.has(e))
+      .map((e) => fs.promises.rm(path.join(installPath, e), { recursive: true, force: true }).catch(() => {})),
+  )
+}
+
+/**
+ * Download + verify + extract + validate an artifact into `installPath`. Throws
+ * {@link ComfyBuilderInstallError} on a bad artifact, a checksum mismatch, or a
+ * bad extracted layout. A missing hash is a warning, not an error: see above.
+ */
+export async function installArtifact(opts: InstallArtifactOptions): Promise<void> {
+  const { artifact, client, installPath, cacheDir, onProgress, signal } = opts
+  if (!artifact?.id) throw new ComfyBuilderInstallError('invalid-artifact', 'No artifact id was provided.')
+
+  // A hash that IS present is always enforced (see the compare below).
+  // TODO: fail closed on a missing hash too. The builder does not populate
+  // outputSha256 yet, so for the initial rollout a missing hash installs
+  // unverified rather than blocking every install.
+  const expected = normalizeSha256(artifact.outputSha256)
+  if (!expected) {
+    console.warn('[comfybuilder] artifact has no outputSha256; installing without integrity verification')
+  }
+
+  onProgress?.({ phase: 'resolve', percent: 0 })
+  const url = await client.resolveDownloadUrl(artifact.id)
+
+  // Per-run temp: isolates concurrent installs of the same artifact and is
+  // removed after extraction (cacheDir is scratch, not a persistent cache).
+  fs.mkdirSync(cacheDir, { recursive: true })
+  const archivePath = path.join(cacheDir, `comfybuilder_${cacheSlug(artifact.id)}_${randomBytes(6).toString('hex')}.tar.gz`)
+
+  try {
+    onProgress?.({ phase: 'download', percent: 0 })
+    await download(url, archivePath, (p: DownloadProgress) => onProgress?.({ phase: 'download', percent: p.percent, detail: `${p.receivedMB} / ${p.totalMB} MB` }), signal ? { signal } : {})
+
+    if (expected) {
+      const actual = await sha256File(archivePath)
+      if (actual !== expected) {
+        throw new ComfyBuilderInstallError('checksum-mismatch', `Artifact checksum mismatch: expected ${expected}, got ${actual}`)
+      }
+    }
+
+    if (signal?.aborted) throw new Error('Cancelled')
+    fs.mkdirSync(installPath, { recursive: true })
+    const preexisting = new Set<string>(await fs.promises.readdir(installPath).catch(() => [] as string[]))
+    try {
+      onProgress?.({ phase: 'extract', percent: 0 })
+      await extractNested(archivePath, installPath, (p: ExtractProgress) => onProgress?.({ phase: 'extract', percent: p.percent }), signal ? { signal } : {})
+      assertLayout(installPath)
+    } catch (err) {
+      await cleanupCreated(installPath, preexisting)
+      throw err
+    }
+  } finally {
+    await fs.promises.rm(archivePath, { force: true }).catch(() => {})
+  }
+}

--- a/src/main/comfybuilder/launch.test.ts
+++ b/src/main/comfybuilder/launch.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment node
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { buildLaunchSpec, venvPython } from './launch'
+
+const isWin = process.platform === 'win32'
+
+function layout(installPath: string, opts: { python?: boolean; main?: boolean } = { python: true, main: true }): void {
+  if (opts.python !== false) {
+    fs.mkdirSync(path.dirname(venvPython(installPath)), { recursive: true })
+    fs.writeFileSync(venvPython(installPath), '')
+  }
+  if (opts.main !== false) {
+    fs.mkdirSync(path.join(installPath, 'ComfyUI'), { recursive: true })
+    fs.writeFileSync(path.join(installPath, 'ComfyUI', 'main.py'), '')
+  }
+}
+
+describe('launch', () => {
+  let dir: string
+  beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cbc-launch-')) })
+  afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }) })
+
+  it('venvPython points at the archive venv per platform', () => {
+    expect(venvPython(dir)).toBe(isWin ? path.join(dir, 'venv', 'python.exe') : path.join(dir, 'venv', 'bin', 'python3'))
+  })
+
+  it('builds a spec that drives the venv python against ComfyUI/main.py', () => {
+    const p = path.join(dir, 'install')
+    layout(p)
+    const spec = buildLaunchSpec(p, { launchArgs: '--cpu --port 9001' })
+    expect(spec).toEqual({
+      cmd: venvPython(p),
+      args: ['-s', path.join('ComfyUI', 'main.py'), '--cpu', '--port', '9001'],
+      cwd: p,
+      port: 9001,
+    })
+  })
+
+  it.each([
+    ['python missing', { python: false }],
+    ['main.py missing', { main: false }],
+  ])('returns null when %s', (_name, opts) => {
+    const p = path.join(dir, 'install')
+    layout(p, opts)
+    expect(buildLaunchSpec(p)).toBeNull()
+  })
+})

--- a/src/main/comfybuilder/launch.ts
+++ b/src/main/comfybuilder/launch.ts
@@ -1,0 +1,47 @@
+/**
+ * Launch - build the command that runs an installed archive.
+ *
+ * The archive ships a ready, relocatable `venv/`, so launch drives that venv's
+ * python directly against `ComfyUI/main.py` (no rebuild, no `.venv`). Returns a
+ * plain {@link LaunchSpec} the UI can spawn however it likes; returns null until
+ * a successful install has produced the interpreter + entrypoint.
+ */
+import fs from 'fs'
+import path from 'path'
+
+import { extractPort, parseArgs } from '../lib/util'
+import type { LaunchSpec } from './types'
+
+const DEFAULT_LAUNCH_ARGS = '--enable-manager'
+
+/** The archive's bundled interpreter. */
+export function venvPython(installPath: string): string {
+  return process.platform === 'win32'
+    ? path.join(installPath, 'venv', 'python.exe')
+    : path.join(installPath, 'venv', 'bin', 'python3')
+}
+
+export interface LaunchOptions {
+  /** Extra ComfyUI args, e.g. `--cpu --port 8188`. Defaults to `--enable-manager`. */
+  launchArgs?: string
+}
+
+/**
+ * Build the launch command for an installed archive, or null when the venv
+ * python or `ComfyUI/main.py` is missing (i.e. not installed yet).
+ */
+export function buildLaunchSpec(installPath: string, opts: LaunchOptions = {}): LaunchSpec | null {
+  const python = venvPython(installPath)
+  if (!fs.existsSync(python)) return null
+  const mainPy = path.join(installPath, 'ComfyUI', 'main.py')
+  if (!fs.existsSync(mainPy)) return null
+
+  const raw = (opts.launchArgs ?? DEFAULT_LAUNCH_ARGS).trim()
+  const parsed = raw.length > 0 ? parseArgs(raw) : []
+  return {
+    cmd: python,
+    args: ['-s', path.join('ComfyUI', 'main.py'), ...parsed],
+    cwd: installPath,
+    port: extractPort(parsed),
+  }
+}

--- a/src/main/comfybuilder/modelManifest.test.ts
+++ b/src/main/comfybuilder/modelManifest.test.ts
@@ -1,0 +1,97 @@
+// @vitest-environment node
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { resolveModelManifest } from './modelManifest'
+import type { ModelManifest } from './types'
+
+const MANIFEST: ModelManifest = {
+  models: [{ type: 'loras', filename: 'l.safetensors', downloadUrl: 'https://signed/l' }],
+  modelPolicy: null,
+  partnerNodePolicy: null,
+}
+
+// A client stub with just the two methods the resolver calls.
+function client(over: Partial<{ listVersions: unknown; fetchModelManifest: unknown }> = {}) {
+  return {
+    listVersions: vi.fn(async () => [{ id: 'ver-1', version: 1, status: 'complete' }]),
+    fetchModelManifest: vi.fn(async () => MANIFEST),
+    ...over,
+  } as never
+}
+
+afterEach(() => {
+  delete process.env.COMFY_BUILDER_MODELS_MANIFEST
+  delete process.env.E2E
+  vi.restoreAllMocks()
+})
+
+describe('resolveModelManifest', () => {
+  it('resolves the version id then fetches its manifest', async () => {
+    const c = client({
+      listVersions: vi.fn(async () => [{ id: 'ver-42', version: 3, status: 'complete' }]),
+      fetchModelManifest: vi.fn(async () => MANIFEST),
+    })
+    const m = await resolveModelManifest(c, 'd1', '3')
+    expect((c as unknown as { fetchModelManifest: ReturnType<typeof vi.fn> }).fetchModelManifest).toHaveBeenCalledWith('ver-42')
+    expect(m.models).toEqual(MANIFEST.models)
+  })
+
+  it('pins the COMPLETE version when a failed row shares the number', async () => {
+    const c = client({
+      listVersions: vi.fn(async () => [
+        { id: 'ver-bad', version: 5, status: 'failed' },
+        { id: 'ver-good', version: 5, status: 'complete' },
+      ]),
+    })
+    await resolveModelManifest(c, 'd1', '5')
+    expect((c as unknown as { fetchModelManifest: ReturnType<typeof vi.fn> }).fetchModelManifest).toHaveBeenCalledWith('ver-good')
+  })
+
+  it('stages nothing when no matching version resolves', async () => {
+    const c = client({ listVersions: vi.fn(async () => [{ id: 'ver-1', version: 1, status: 'complete' }]) })
+    const m = await resolveModelManifest(c, 'd1', '99')
+    expect(m.models).toEqual([])
+    expect((c as unknown as { fetchModelManifest: ReturnType<typeof vi.fn> }).fetchModelManifest).not.toHaveBeenCalled()
+  })
+
+  it('degrades to empty (never throws) when the fetch fails', async () => {
+    const c = client({ fetchModelManifest: vi.fn(async () => { throw new Error('boom') }) })
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const m = await resolveModelManifest(c, 'd1', '1')
+    expect(m).toEqual({ models: [], modelPolicy: null, partnerNodePolicy: null })
+  })
+
+  it('honors an inline-JSON override only under E2E (the test seam)', async () => {
+    const override: ModelManifest = {
+      models: [{ type: 'checkpoints', filename: 'x.safetensors', downloadUrl: 'https://h/x' }],
+      modelPolicy: null,
+      partnerNodePolicy: null,
+    }
+    process.env.COMFY_BUILDER_MODELS_MANIFEST = JSON.stringify(override)
+    process.env.E2E = '1'
+    const c = client()
+    const m = await resolveModelManifest(c, 'd1', '1')
+    expect(m.models).toEqual(override.models)
+    expect((c as unknown as { listVersions: ReturnType<typeof vi.fn> }).listVersions).not.toHaveBeenCalled()
+  })
+
+  it('ignores the override in a non-E2E build (falls through to the endpoint)', async () => {
+    process.env.COMFY_BUILDER_MODELS_MANIFEST = JSON.stringify({ models: [{ type: 'x', filename: 'evil', downloadUrl: 'https://evil/x' }] })
+    const m = await resolveModelManifest(client(), 'd1', '1')
+    expect(m.models).toEqual(MANIFEST.models) // the fetched manifest, not the injected one
+  })
+
+  it('honors a file-path override under E2E', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cb-mf-'))
+    const file = path.join(dir, 'manifest.json')
+    fs.writeFileSync(file, JSON.stringify({ models: [{ type: 'vae', filename: 'v.pt', downloadUrl: 'https://h/v' }] }))
+    process.env.COMFY_BUILDER_MODELS_MANIFEST = file
+    process.env.E2E = '1'
+    const m = await resolveModelManifest(client(), 'd1', '1')
+    expect(m.models[0]!.filename).toBe('v.pt')
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+})

--- a/src/main/comfybuilder/modelManifest.ts
+++ b/src/main/comfybuilder/modelManifest.ts
@@ -1,0 +1,72 @@
+/**
+ * Model-manifest resolution: the models to stage for an install.
+ *
+ * The source of truth is the builder `/manifest` endpoint, keyed by version id.
+ * The install record carries the version NUMBER, so the id is resolved from the
+ * versions list first (pinned to the COMPLETE version the archive came from). A
+ * fetch failure degrades to an empty manifest rather than failing an install
+ * whose archive already downloaded, so a transient blip never wastes the build.
+ *
+ * `COMFY_BUILDER_MODELS_MANIFEST` (E2E only) overrides the endpoint with an
+ * explicit manifest so a hermetic e2e can point every model at a local server.
+ */
+import fs from 'fs'
+
+import type { ComfyBuilderClient } from './client'
+import type { ModelManifest } from './types'
+
+const EMPTY: ModelManifest = { models: [], modelPolicy: null, partnerNodePolicy: null }
+
+// A version whose build finished, matching the set the install artifact was
+// selected from, so the manifest is read off the same version the archive came
+// from (never a failed row that shares the number).
+const COMPLETE_VERSION_STATUSES = new Set(['complete', 'completed', 'ready', 'succeeded', 'success'])
+
+/** Parse an override that is inline JSON (`{...}`) or a path to a JSON file. */
+function loadOverride(value: string): ModelManifest {
+  const raw = value.trimStart().startsWith('{') ? value : fs.readFileSync(value, 'utf8')
+  const parsed = JSON.parse(raw) as Partial<ModelManifest>
+  return {
+    models: parsed.models ?? [],
+    modelPolicy: parsed.modelPolicy ?? null,
+    partnerNodePolicy: parsed.partnerNodePolicy ?? null,
+  }
+}
+
+/** Map a version NUMBER to the id of its COMPLETE version, or null. */
+async function resolveVersionId(
+  client: Pick<ComfyBuilderClient, 'listVersions'>,
+  distributionId: string,
+  versionNumber: string,
+): Promise<string | null> {
+  const versions = await client.listVersions(distributionId)
+  const match = versions.find(
+    (v) =>
+      String(v.version) === versionNumber &&
+      typeof v.status === 'string' &&
+      COMPLETE_VERSION_STATUSES.has(v.status.toLowerCase()),
+  )
+  return match?.id ?? null
+}
+
+/**
+ * The models to stage for an install. Returns an empty manifest (stage nothing)
+ * when the version has none, cannot be resolved, or the fetch fails.
+ */
+export async function resolveModelManifest(
+  client: Pick<ComfyBuilderClient, 'listVersions' | 'fetchModelManifest'>,
+  distributionId: string,
+  version: string,
+): Promise<ModelManifest> {
+  // Test seam, E2E-gated so a shipped build can't be fed attacker-chosen models.
+  const override = process.env.COMFY_BUILDER_MODELS_MANIFEST
+  if (override && process.env.E2E === '1') return loadOverride(override)
+
+  try {
+    const versionId = await resolveVersionId(client, distributionId, version)
+    return versionId ? await client.fetchModelManifest(versionId) : EMPTY
+  } catch (err) {
+    console.warn('[comfybuilder] model manifest fetch failed; staging no models:', err)
+    return EMPTY
+  }
+}

--- a/src/main/comfybuilder/models.test.ts
+++ b/src/main/comfybuilder/models.test.ts
@@ -1,0 +1,167 @@
+// @vitest-environment node
+import { createHash } from 'crypto'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// Stub the heavy libs so importing `./models` (via `./install`) does not pull
+// Electron. Every test injects its own `download`, so the real one is unused.
+vi.mock('../lib/download', () => ({ download: vi.fn() }))
+vi.mock('../lib/extract', () => ({ extractNested: vi.fn() }))
+
+import { stageModels, installModelsRoot } from './models'
+import type { ModelDescriptor } from './types'
+
+const sha = (buf: Buffer): string => createHash('sha256').update(buf).digest('hex')
+
+const tmpRoots: string[] = []
+function freshInstall(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cb-models-'))
+  tmpRoots.push(dir)
+  return dir
+}
+afterEach(() => {
+  for (const d of tmpRoots.splice(0)) fs.rmSync(d, { recursive: true, force: true })
+})
+
+/** A download stub that writes `bytes` to the requested path (the `.partial`). */
+function fakeDownload(bytes: Buffer) {
+  return vi.fn(async (_url: string, dest: string) => {
+    fs.mkdirSync(path.dirname(dest), { recursive: true })
+    fs.writeFileSync(dest, bytes)
+    return dest
+  })
+}
+
+const model = (o: Partial<ModelDescriptor> = {}): ModelDescriptor => ({
+  type: 'checkpoints',
+  filename: 'm.safetensors',
+  downloadUrl: 'https://models.test/m.safetensors',
+  ...o,
+})
+
+describe('stageModels', () => {
+  it('downloads, verifies, and places each model at models/<type>/<filename>', async () => {
+    const install = freshInstall()
+    const bytes = Buffer.from('weights-A')
+    const dl = fakeDownload(bytes)
+    await stageModels({
+      models: [model({ type: 'vae', filename: 'v.pt', sha256: sha(bytes), downloadUrl: 'https://x/v.pt' })],
+      installPath: install,
+      download: dl,
+    })
+    const dest = path.join(installModelsRoot(install), 'vae', 'v.pt')
+    expect(fs.existsSync(dest)).toBe(true)
+    expect(fs.readFileSync(dest)).toEqual(bytes)
+    expect(fs.existsSync(`${dest}.partial`)).toBe(false)
+  })
+
+  it('fails with checksum-mismatch and leaves no file when bytes do not match the hash', async () => {
+    const install = freshInstall()
+    const dl = fakeDownload(Buffer.from('corrupt'))
+    await expect(
+      stageModels({ models: [model({ sha256: sha(Buffer.from('expected')) })], installPath: install, download: dl }),
+    ).rejects.toMatchObject({ kind: 'model-checksum-mismatch' })
+    const dest = path.join(installModelsRoot(install), 'checkpoints', 'm.safetensors')
+    expect(fs.existsSync(dest)).toBe(false)
+    expect(fs.existsSync(`${dest}.partial`)).toBe(false)
+  })
+
+  it('installs without verification when the model has no sha256', async () => {
+    const install = freshInstall()
+    const dl = fakeDownload(Buffer.from('unverified'))
+    await stageModels({ models: [model({ filename: 'n.pt' })], installPath: install, download: dl })
+    expect(fs.existsSync(path.join(installModelsRoot(install), 'checkpoints', 'n.pt'))).toBe(true)
+  })
+
+  it.each([
+    ['type', { type: '../evil' }],
+    ['type sep', { type: 'a/b' }],
+    ['filename', { filename: '../../etc/passwd' }],
+    ['filename sep', { filename: 'a/b.pt' }],
+  ])('rejects an unsafe %s before any download', async (_name, bad) => {
+    const install = freshInstall()
+    const dl = fakeDownload(Buffer.from('x'))
+    await expect(stageModels({ models: [model(bad)], installPath: install, download: dl })).rejects.toMatchObject({
+      kind: 'invalid-model',
+    })
+    expect(dl).not.toHaveBeenCalled()
+  })
+
+  it('rejects a non-https download URL before any download', async () => {
+    const install = freshInstall()
+    const dl = fakeDownload(Buffer.from('x'))
+    await expect(
+      stageModels({ models: [model({ downloadUrl: 'http://insecure/m.safetensors' })], installPath: install, download: dl }),
+    ).rejects.toMatchObject({ kind: 'invalid-model' })
+    expect(dl).not.toHaveBeenCalled()
+  })
+
+  it('refuses to write through a model dir that symlinks outside the install', async () => {
+    const install = freshInstall()
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'cb-escape-'))
+    tmpRoots.push(outside)
+    // A malicious archive ships ComfyUI/models/<type> as a symlink escaping the install.
+    const modelsRoot = installModelsRoot(install)
+    fs.mkdirSync(modelsRoot, { recursive: true })
+    fs.symlinkSync(outside, path.join(modelsRoot, 'evil'))
+    const dl = fakeDownload(Buffer.from('payload'))
+    await expect(
+      stageModels({ models: [model({ type: 'evil', filename: 'x.pth' })], installPath: install, download: dl }),
+    ).rejects.toMatchObject({ kind: 'invalid-model' })
+    // Nothing was written into the escape target.
+    expect(fs.existsSync(path.join(outside, 'x.pth'))).toBe(false)
+    expect(fs.existsSync(path.join(outside, 'x.pth.partial'))).toBe(false)
+  })
+
+  it('skips a model already present with a matching hash (idempotent re-run)', async () => {
+    const install = freshInstall()
+    const bytes = Buffer.from('already-here')
+    const dest = path.join(installModelsRoot(install), 'loras', 'l.safetensors')
+    fs.mkdirSync(path.dirname(dest), { recursive: true })
+    fs.writeFileSync(dest, bytes)
+    const dl = fakeDownload(Buffer.from('should-not-run'))
+    await stageModels({
+      models: [model({ type: 'loras', filename: 'l.safetensors', sha256: sha(bytes) })],
+      installPath: install,
+      download: dl,
+    })
+    expect(dl).not.toHaveBeenCalled()
+    expect(fs.readFileSync(dest)).toEqual(bytes)
+  })
+
+  it('re-fetches a present-but-wrong file instead of trusting bad bytes', async () => {
+    const install = freshInstall()
+    const good = Buffer.from('good-bytes')
+    const dest = path.join(installModelsRoot(install), 'checkpoints', 'm.safetensors')
+    fs.mkdirSync(path.dirname(dest), { recursive: true })
+    fs.writeFileSync(dest, Buffer.from('stale-wrong'))
+    const dl = fakeDownload(good)
+    await stageModels({ models: [model({ sha256: sha(good) })], installPath: install, download: dl })
+    expect(dl).toHaveBeenCalledTimes(1)
+    expect(fs.readFileSync(dest)).toEqual(good)
+  })
+
+  it('reports per-model progress with a 1-based index and total', async () => {
+    const install = freshInstall()
+    const seen: Array<{ index: number; total: number; percent: number }> = []
+    await stageModels({
+      models: [model({ filename: 'a.pt' }), model({ filename: 'b.pt' })],
+      installPath: install,
+      download: fakeDownload(Buffer.from('z')),
+      onProgress: (p) => seen.push({ index: p.index, total: p.total, percent: p.percent }),
+    })
+    expect(seen.some((s) => s.index === 1 && s.total === 2)).toBe(true)
+    expect(seen.some((s) => s.index === 2 && s.total === 2 && s.percent === 100)).toBe(true)
+  })
+
+  it('honors an already-aborted signal', async () => {
+    const install = freshInstall()
+    const dl = fakeDownload(Buffer.from('x'))
+    await expect(
+      stageModels({ models: [model()], installPath: install, download: dl, signal: AbortSignal.abort() }),
+    ).rejects.toThrow(/cancel/i)
+    expect(dl).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/comfybuilder/models.ts
+++ b/src/main/comfybuilder/models.ts
@@ -1,0 +1,176 @@
+/**
+ * Model staging: the models half of a distribution install.
+ *
+ * A distribution archive carries only code and the environment (`venv/` +
+ * `ComfyUI/`), never model weights. After the archive extracts, this stages the
+ * distribution's declared models into the install's own ComfyUI model tree so
+ * they are present before ComfyUI starts, mirroring how comfy-deploy provisions
+ * weights onto a volume before boot.
+ *
+ * Placement is `<installPath>/ComfyUI/models/<type>/<filename>`, the install's
+ * built-in model root. That root is always on ComfyUI's model search path, so a
+ * staged model is found whether or not the user shares a global model library.
+ *
+ * Integrity mirrors archive install: a model whose manifest carries a sha256 is
+ * verified byte-for-byte and a mismatch fails the install; a model with no hash
+ * installs unverified (the source, typically a public URL, supplied none). Each
+ * model downloads to a `.partial` sibling that is renamed into place only after
+ * it verifies, so an interrupted install never leaves a truncated model looking
+ * complete, and a re-run resumes or re-fetches rather than trusting bad bytes.
+ */
+import fs from 'fs'
+import path from 'path'
+
+import { download } from '../lib/download'
+import type { DownloadProgress } from '../lib/download'
+import { sha256File, normalizeSha256 } from './install'
+import type { ModelDescriptor, StageProgress } from './types'
+
+export type StageModelsErrorKind = 'invalid-model' | 'model-checksum-mismatch'
+
+export class StageModelsError extends Error {
+  override name = 'StageModelsError'
+  readonly kind: StageModelsErrorKind
+  constructor(kind: StageModelsErrorKind, message: string) {
+    super(message)
+    this.kind = kind
+  }
+}
+
+/** The download surface used, narrowed so a test can inject a fake. */
+type DownloadFn = (
+  url: string,
+  destPath: string,
+  onProgress: ((p: DownloadProgress) => void) | null,
+  options?: { signal?: AbortSignal },
+) => Promise<string>
+
+export interface StageModelsOptions {
+  models: readonly ModelDescriptor[]
+  /** The install root (the dir that contains `ComfyUI/`). */
+  installPath: string
+  onProgress?: (p: StageProgress) => void
+  signal?: AbortSignal
+  /** Injectable download for tests; defaults to the real primitive. */
+  download?: DownloadFn
+}
+
+/** A single path segment that cannot escape its parent: no separators, no `..`,
+ *  no drive/absolute markers. Guards `models/<type>/<filename>` against a
+ *  manifest that tries to traverse out of the model tree. */
+function isSafeSegment(seg: string): boolean {
+  if (!seg || seg === '.' || seg === '..') return false
+  if (seg.includes('/') || seg.includes('\\') || seg.includes('\0')) return false
+  if (path.isAbsolute(seg) || /^[a-zA-Z]:/.test(seg)) return false
+  return true
+}
+
+/** A model URL must be https, or http to loopback. A remote plaintext (or
+ *  downgradeable) source is MITM-substitutable, and a substituted `.pth`/`.ckpt`
+ *  is arbitrary-code on load, so it is enforced independently of the sha256.
+ *  Loopback http carries no network and never leaves the machine, so it is
+ *  allowed (a local model cache or the test server). */
+function isAllowedUrl(url: string): boolean {
+  try {
+    const u = new URL(url)
+    if (u.protocol === 'https:') return true
+    return u.protocol === 'http:' && ['127.0.0.1', '::1', 'localhost'].includes(u.hostname)
+  } catch {
+    return false
+  }
+}
+
+/** The real path of `dir` is inside `root` (defends against a symlinked model
+ *  subdir in the extracted archive redirecting a write outside the install). */
+function isContained(root: string, dir: string): boolean {
+  try {
+    const realRoot = fs.realpathSync(root)
+    const realDir = fs.realpathSync(dir)
+    return realDir === realRoot || realDir.startsWith(realRoot + path.sep)
+  } catch {
+    return false
+  }
+}
+
+/** The install's built-in ComfyUI models root, `<installPath>/ComfyUI/models`. */
+export function installModelsRoot(installPath: string): string {
+  return path.join(installPath, 'ComfyUI', 'models')
+}
+
+/**
+ * Download + verify + place each model under `<installPath>/ComfyUI/models`.
+ * Throws {@link StageModelsError} on an unsafe path or a checksum mismatch. A
+ * model already present with a matching hash is skipped, so a resumed or
+ * repeated install does not re-download what is already staged.
+ */
+export async function stageModels(opts: StageModelsOptions): Promise<void> {
+  const { models, installPath, onProgress, signal } = opts
+  const doDownload = opts.download ?? download
+  const total = models.length
+  const modelsRoot = installModelsRoot(installPath)
+
+  for (let i = 0; i < total; i++) {
+    if (signal?.aborted) throw new Error('Cancelled')
+    const model = models[i]!
+    const index = i + 1
+
+    if (!isSafeSegment(model.type) || !isSafeSegment(model.filename)) {
+      throw new StageModelsError('invalid-model', `Model ${model.type}/${model.filename} has an unsafe path.`)
+    }
+    if (!isAllowedUrl(model.downloadUrl)) {
+      throw new StageModelsError('invalid-model', `Model ${model.type}/${model.filename} download URL must be https.`)
+    }
+
+    const destDir = path.join(modelsRoot, model.type)
+    // Create the target dir first, then confirm it really resolves inside the
+    // install: a malicious archive can ship `ComfyUI/models/<type>` as a symlink
+    // pointing outside, and writing through it would escape the install.
+    fs.mkdirSync(destDir, { recursive: true })
+    if (!isContained(installPath, destDir)) {
+      throw new StageModelsError('invalid-model', `Model directory ${model.type} escapes the install.`)
+    }
+
+    const dest = path.join(destDir, model.filename)
+    const expected = normalizeSha256(model.sha256)
+
+    // Already staged: a byte-verified file (or, when the manifest gave no hash,
+    // any existing file) is left as-is so a re-run is cheap and idempotent.
+    if (fs.existsSync(dest)) {
+      if (!expected || (await sha256File(dest)) === expected) {
+        onProgress?.({ index, total, filename: model.filename, percent: 100 })
+        continue
+      }
+      // Present but wrong: drop it and re-fetch rather than trust bad bytes.
+      await fs.promises.rm(dest, { force: true }).catch(() => {})
+    }
+
+    // Download to a sibling, verify, then rename into place: an interrupted
+    // transfer never leaves a truncated model at the real name, and the rename
+    // is atomic on the same filesystem. Drop a symlinked leftover partial so a
+    // pre-planted link can't redirect the write; a plain partial resumes.
+    const partial = `${dest}.partial`
+    if (fs.existsSync(partial) && fs.lstatSync(partial).isSymbolicLink()) {
+      await fs.promises.rm(partial, { force: true }).catch(() => {})
+    }
+    onProgress?.({ index, total, filename: model.filename, percent: 0 })
+    await doDownload(
+      model.downloadUrl,
+      partial,
+      (p: DownloadProgress) => onProgress?.({ index, total, filename: model.filename, percent: p.percent }),
+      signal ? { signal } : {},
+    )
+
+    if (expected) {
+      const actual = await sha256File(partial)
+      if (actual !== expected) {
+        await fs.promises.rm(partial, { force: true }).catch(() => {})
+        throw new StageModelsError(
+          'model-checksum-mismatch',
+          `Model ${model.type}/${model.filename} checksum mismatch: expected ${expected}, got ${actual}`,
+        )
+      }
+    }
+    await fs.promises.rename(partial, dest)
+    onProgress?.({ index, total, filename: model.filename, percent: 100 })
+  }
+}

--- a/src/main/comfybuilder/targets.test.ts
+++ b/src/main/comfybuilder/targets.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest'
+import { hostOs, selectArtifactForHost } from './targets'
+import type { Artifact, Host } from './types'
+
+function art(o: Artifact['os'], g: Artifact['gpu'], overrides: Partial<Artifact> = {}): Artifact {
+  return { id: `${o}-${g}`, os: o, gpu: g, accelVariant: g === 'nvidia' ? 'cu128' : g, status: 'ready', ...overrides }
+}
+
+const catalog: Artifact[] = [
+  art('linux', 'cpu'),
+  art('linux', 'nvidia'),
+  art('windows', 'cpu'),
+  art('windows', 'nvidia'),
+]
+
+describe('hostOs', () => {
+  it('maps process.platform to a build-target os', () => {
+    const expected = process.platform === 'win32' ? 'windows' : process.platform === 'darwin' ? 'mac' : 'linux'
+    expect(hostOs()).toBe(expected)
+  })
+})
+
+describe('selectArtifactForHost', () => {
+  it.each<[string, Host, string | null]>([
+    ['exact os+gpu (windows/nvidia)', { os: 'windows', gpu: 'nvidia' }, 'windows-nvidia'],
+    ['cpu fallback (windows host, cpu gpu)', { os: 'windows', gpu: 'cpu' }, 'windows-cpu'],
+    ['nvidia host falls back to cpu when no nvidia', { os: 'mac', gpu: 'nvidia' }, null],
+    ['no artifact for the host os (mac)', { os: 'mac', gpu: 'mps' }, null],
+    ['linux nvidia', { os: 'linux', gpu: 'nvidia' }, 'linux-nvidia'],
+  ])('%s', (_name, host, expectedId) => {
+    expect(selectArtifactForHost(catalog, host)?.id ?? null).toBe(expectedId)
+  })
+
+  it('prefers exact gpu over the cpu fallback', () => {
+    const both = [art('linux', 'cpu'), art('linux', 'nvidia')]
+    expect(selectArtifactForHost(both, { os: 'linux', gpu: 'nvidia' })?.gpu).toBe('nvidia')
+  })
+
+  it('ignores non-ready artifacts', () => {
+    const notReady = [art('linux', 'nvidia', { status: 'building' })]
+    expect(selectArtifactForHost(notReady, { os: 'linux', gpu: 'nvidia' })).toBeNull()
+  })
+
+  it('an nvidia host still installs a cpu-only build', () => {
+    const cpuOnly = [art('windows', 'cpu')]
+    expect(selectArtifactForHost(cpuOnly, { os: 'windows', gpu: 'nvidia' })?.gpu).toBe('cpu')
+  })
+
+  it('prefers the matching accelVariant among same-gpu builds', () => {
+    const cudas = [art('linux', 'nvidia', { id: 'cu118', accelVariant: 'cu118' }), art('linux', 'nvidia', { id: 'cu128', accelVariant: 'cu128' })]
+    expect(selectArtifactForHost(cudas, { os: 'linux', gpu: 'nvidia', accelVariant: 'cu128' })?.id).toBe('cu128')
+  })
+
+  it('is deterministic (not input-order dependent) when accel ties', () => {
+    const a = art('linux', 'nvidia', { id: 'cu118', accelVariant: 'cu118' })
+    const b = art('linux', 'nvidia', { id: 'cu128', accelVariant: 'cu128' })
+    const host = { os: 'linux', gpu: 'nvidia' } as const
+    expect(selectArtifactForHost([a, b], host)?.id).toBe(selectArtifactForHost([b, a], host)?.id)
+  })
+})

--- a/src/main/comfybuilder/targets.ts
+++ b/src/main/comfybuilder/targets.ts
@@ -1,0 +1,67 @@
+/**
+ * Target resolution - pure host <-> artifact matching.
+ *
+ * A version fans out into per-target artifacts (os x gpu x accel). The UI picks
+ * ONE distribution + version; this module picks the artifact for the host, so a
+ * user never chooses `windows/cpu` vs `windows/nvidia` by hand. Pure functions,
+ * no I/O; the caller supplies the host GPU (Desktop already detects it).
+ */
+import type { Artifact, ArtifactGpu, ArtifactOs, Host } from './types'
+
+/** The host OS as a build-target token, from Node's `process.platform`. */
+export function hostOs(): ArtifactOs {
+  switch (process.platform) {
+    case 'win32':
+      return 'windows'
+    case 'darwin':
+      return 'mac'
+    default:
+      return 'linux'
+  }
+}
+
+/**
+ * Rank an artifact's GPU against the host's, higher is better. An exact match
+ * wins; a CPU artifact is the universal fallback (every host can run it); an
+ * NVIDIA host tolerates a CPU build but never the reverse.
+ */
+function gpuScore(artifactGpu: ArtifactGpu, hostGpu: ArtifactGpu): number {
+  if (artifactGpu === hostGpu) return 2
+  if (artifactGpu === 'cpu') return 1
+  return -1
+}
+
+/**
+ * Score an artifact for the host: GPU fit is dominant; a matching `accelVariant`
+ * (e.g. cu128) breaks ties among same-GPU builds, then `accelVariant` string
+ * order makes the choice deterministic (never input-order dependent).
+ */
+function score(a: Artifact, host: Host): number {
+  const gpu = gpuScore(a.gpu, host.gpu)
+  if (gpu < 0) return gpu
+  const accelMatch = host.accelVariant && a.accelVariant === host.accelVariant ? 1 : 0
+  return gpu * 2 + accelMatch
+}
+
+/**
+ * Pick the best `ready` artifact for the host: OS must match, then GPU fit
+ * (exact, else CPU fallback), then a preferred `accelVariant`, then a
+ * deterministic tie-break. Returns null when the version has no runnable
+ * artifact for this machine (e.g. a windows-only build on mac).
+ */
+export function selectArtifactForHost(artifacts: readonly Artifact[], host: Host): Artifact | null {
+  let best: Artifact | null = null
+  let bestScore = 0
+  for (const a of artifacts) {
+    if (a.status !== 'ready' || a.os !== host.os) continue
+    const s = score(a, host)
+    if (s <= 0) continue
+    // Strictly greater wins; on an exact tie, the lexicographically smaller
+    // accelVariant wins so selection is deterministic across input orderings.
+    if (s > bestScore || (s === bestScore && best !== null && a.accelVariant < best.accelVariant)) {
+      best = a
+      bestScore = s
+    }
+  }
+  return best
+}

--- a/src/main/comfybuilder/types.ts
+++ b/src/main/comfybuilder/types.ts
@@ -1,0 +1,124 @@
+/**
+ * ComfyBuilder functionality library - domain types.
+ *
+ * The wire shapes this library reads from the comfy-builder API (mirrors the
+ * relevant halves of its `openapi.yaml`), plus the small seams the UI plugs into
+ * (a {@link TokenProvider} for auth, progress callbacks for install). Nothing
+ * here depends on Electron, IPC, Vue, or the installations store.
+ */
+
+export type ArtifactOs = 'linux' | 'windows' | 'mac'
+export type ArtifactGpu = 'nvidia' | 'amd' | 'cpu' | 'mps'
+
+/** A distribution: a named, versioned ComfyUI environment recipe. */
+export interface Distribution {
+  id: string
+  name: string
+  description?: string
+  numCustomNodes?: number
+  numModels?: number
+  updatedAt?: string
+}
+
+/** One immutable build of a distribution (fans out into per-target artifacts). */
+export interface DistributionVersion {
+  id: string
+  /** Monotonic version number within the distribution. */
+  version: number
+  status: string
+  createdAt?: string
+}
+
+/** A single built target: one os x gpu x accel archive of a version. */
+export interface Artifact {
+  id: string
+  os: ArtifactOs
+  gpu: ArtifactGpu
+  /** Accelerator build variant, e.g. `cu128`. Part of the target identity. */
+  accelVariant: string
+  status: string
+  /** Storage ref of the built archive. */
+  outputRef?: string
+  /** Hex sha256 of the archive (optionally `sha256:`-prefixed). Verified post-download. */
+  outputSha256?: string
+}
+
+/** The machine an install targets: which artifact to pick. */
+export interface Host {
+  os: ArtifactOs
+  gpu: ArtifactGpu
+  /** Preferred accelerator build (e.g. `cu128`) when a gpu ships several. Optional. */
+  accelVariant?: string
+}
+
+/**
+ * The auth seam. The UI owns sign-in and token storage; this library only reads
+ * a bearer token when it needs one. Willie's `tokenStore` implements this.
+ */
+export interface TokenProvider {
+  /** Current access token, or null when signed out. */
+  getAccessToken(): Promise<string | null>
+  /** Optional: called when the API rejects the token so the UI can re-auth. */
+  onUnauthorized?(): void
+}
+
+/** A launch command spec (interpreter + args + cwd), free of Electron types. */
+export interface LaunchSpec {
+  cmd: string
+  args: string[]
+  cwd: string
+  port: number
+}
+
+/** Install progress, surfaced to the UI's progress bar. */
+export interface InstallProgress {
+  phase: 'resolve' | 'download' | 'extract'
+  percent: number
+  detail?: string
+}
+
+/**
+ * One model the distribution pre-installs, projected from the version's sealed
+ * manifest by the builder API (mirrors its `DistributionModel` schema). `type`
+ * is the ComfyUI model directory the file installs into (e.g. `checkpoints`),
+ * so the file lands at `models/<type>/<filename>`. `downloadUrl` is ready to GET
+ * as-is (a public source URL, or a short-lived presigned URL for a private one).
+ */
+export interface ModelDescriptor {
+  type: string
+  filename: string
+  /** Hex sha256 of the content, when known. Absent for a public model whose
+   *  author supplied none, in which case it installs without verification. */
+  sha256?: string
+  downloadUrl: string
+  /** When `downloadUrl` expires (presigned URLs only). Advisory. */
+  expiresAt?: string
+}
+
+/** A runtime allow/deny list (`DistributionPolicy` on the wire). Advisory
+ *  metadata the client may later enforce; staging does not gate on it. */
+export interface ModelPolicy {
+  mode: 'allowlist' | 'blocklist'
+  list?: string[]
+}
+
+/**
+ * The model + policy view of a distribution version (the builder API's
+ * `DistributionManifest`). A client stages `models` before starting ComfyUI; the
+ * archive itself carries only code and the environment, never weights.
+ */
+export interface ModelManifest {
+  models: ModelDescriptor[]
+  modelPolicy?: ModelPolicy | null
+  partnerNodePolicy?: ModelPolicy | null
+}
+
+/** Per-model staging progress, surfaced to the UI while models download. */
+export interface StageProgress {
+  /** 1-based index of the model currently downloading. */
+  index: number
+  total: number
+  filename: string
+  /** Percent of the current model (0-100). */
+  percent: number
+}

--- a/src/main/devplatform/config.ts
+++ b/src/main/devplatform/config.ts
@@ -1,0 +1,19 @@
+/**
+ * Dev-platform glue config: points the cloud + comfy-builder libraries at
+ * staging for now.
+ *
+ * These are env DEFAULTS, not hardcodes: a real deployment can still override
+ * `COMFY_CLOUD_ISSUER` / `COMFY_BUILDER_BASE_URL` via the environment. This
+ * module is imported (for its side effect) BEFORE the cloud library's own
+ * `config` module, so the issuer default is in place by the time
+ * `CLOUD_ISSUER` is computed: do not reorder the import in `./session`.
+ */
+const STAGING_CLOUD_ISSUER = 'https://stagingcloud.comfy.org'
+const STAGING_BUILDER_BASE_URL = 'https://stagingplatformapi.comfy.org/builder'
+
+if (!process.env.COMFY_CLOUD_ISSUER) {
+  process.env.COMFY_CLOUD_ISSUER = STAGING_CLOUD_ISSUER
+}
+
+/** Builder gateway base URL the client targets. Staging default; env override. */
+export const BUILDER_BASE_URL = process.env.COMFY_BUILDER_BASE_URL || STAGING_BUILDER_BASE_URL

--- a/src/main/devplatform/distributions.test.ts
+++ b/src/main/devplatform/distributions.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from 'vitest'
+import { listDistributionRows, resolveHostArtifact } from './distributions'
+import type { Artifact, Distribution, DistributionVersion, Host } from '../comfybuilder'
+
+const HOST: Host = { os: 'linux', gpu: 'nvidia' }
+
+function artifact(overrides: Partial<Artifact> = {}): Artifact {
+  return {
+    id: 'art-1',
+    os: 'linux',
+    gpu: 'nvidia',
+    accelVariant: 'cu128',
+    status: 'ready',
+    outputSha256: 'abc',
+    ...overrides,
+  }
+}
+
+function version(v: number, status: string): DistributionVersion {
+  return { id: `v${v}`, version: v, status, createdAt: '2026-07-20T00:00:00Z' }
+}
+
+/** A stub client whose per-distribution / per-version data is table-driven. */
+function stubClient(opts: {
+  distributions?: Distribution[]
+  versionsByDist?: Record<string, DistributionVersion[]>
+  artifactsByVersion?: Record<string, Artifact[]>
+}) {
+  return {
+    listDistributions: vi.fn(async () => opts.distributions ?? []),
+    listVersions: vi.fn(async (id: string) => opts.versionsByDist?.[id] ?? []),
+    getVersion: vi.fn(async (id: string) => ({ version: Number(id.replace('v', '')), artifacts: opts.artifactsByVersion?.[id] ?? [] })),
+  }
+}
+
+describe('listDistributionRows', () => {
+  it('marks a distribution installable when the latest complete version has a host artifact', async () => {
+    const client = stubClient({
+      distributions: [{ id: 'd1', name: 'Image', description: 'desc', numCustomNodes: 3 }],
+      versionsByDist: { d1: [version(1, 'complete'), version(2, 'complete')] },
+      artifactsByVersion: { v2: [artifact()] },
+    })
+    const rows = await listDistributionRows(client as never, HOST)
+    const row = rows[0]!
+    expect(row).toMatchObject({ id: 'd1', name: 'Image', description: 'desc', numCustomNodes: 3, version: '2', state: 'installable' })
+    // The latest complete version (2) is the one resolved, not version 1.
+    expect(client.getVersion).toHaveBeenCalledWith('v2')
+  })
+
+  it('marks no-build when no version has a completed status', async () => {
+    const client = stubClient({
+      distributions: [{ id: 'd1', name: 'Pending' }],
+      versionsByDist: { d1: [version(1, 'building'), version(2, 'failed')] },
+    })
+    const rows = await listDistributionRows(client as never, HOST)
+    const row = rows[0]!
+    expect(row).toMatchObject({ state: 'no-build', blockedReason: 'buildFailed' })
+    expect(row.version).toBeUndefined()
+  })
+
+  it('marks platform-mismatch when the latest complete version has no host artifact', async () => {
+    const client = stubClient({
+      distributions: [{ id: 'd1', name: 'WinOnly' }],
+      versionsByDist: { d1: [version(3, 'complete')] },
+      artifactsByVersion: { v3: [artifact({ os: 'windows' })] },
+    })
+    const rows = await listDistributionRows(client as never, HOST)
+    const row = rows[0]!
+    expect(row).toMatchObject({ version: '3', state: 'platform-mismatch', blockedReason: 'noArtifactForMachine' })
+  })
+
+  it('drops a distribution whose version lookup fails without failing the whole grid', async () => {
+    const client = stubClient({
+      distributions: [{ id: 'ok', name: 'Ok' }, { id: 'bad', name: 'Bad' }],
+      versionsByDist: { ok: [version(1, 'complete')] },
+      artifactsByVersion: { v1: [artifact()] },
+    })
+    client.listVersions.mockImplementation(async (id: string) => {
+      if (id === 'bad') throw new Error('boom')
+      return [version(1, 'complete')]
+    })
+    const rows = await listDistributionRows(client as never, HOST)
+    expect(rows.map((r) => r.id)).toEqual(['ok'])
+  })
+})
+
+describe('resolveHostArtifact', () => {
+  it('returns the host artifact of the latest complete version', async () => {
+    const client = stubClient({
+      versionsByDist: { d1: [version(5, 'succeeded'), version(4, 'complete')] },
+      artifactsByVersion: { v5: [artifact({ id: 'pick-me' })] },
+    })
+    const resolved = await resolveHostArtifact(client as never, HOST, 'd1')
+    expect(resolved).toMatchObject({ version: 5, artifact: { id: 'pick-me' } })
+  })
+
+  it('returns null when there is no complete version', async () => {
+    const client = stubClient({ versionsByDist: { d1: [version(1, 'building')] } })
+    expect(await resolveHostArtifact(client as never, HOST, 'd1')).toBeNull()
+  })
+
+  it('returns null when the complete version has no host artifact', async () => {
+    const client = stubClient({
+      versionsByDist: { d1: [version(1, 'complete')] },
+      artifactsByVersion: { v1: [artifact({ os: 'mac', gpu: 'mps' })] },
+    })
+    expect(await resolveHostArtifact(client as never, HOST, 'd1')).toBeNull()
+  })
+})

--- a/src/main/devplatform/distributions.ts
+++ b/src/main/devplatform/distributions.ts
@@ -1,0 +1,136 @@
+/**
+ * Distribution display + install-state policy: the UI layer, NOT the library.
+ *
+ * The comfy-builder library gives raw distributions / versions / artifacts and a
+ * pure host-matcher (`selectArtifactForHost`). This module applies the product
+ * policy on top: for each distribution it resolves the latest COMPLETE version,
+ * asks whether an artifact exists for THIS host, and flattens that into a single
+ * renderer-safe display row (`installable` / `no-build` / `platform-mismatch`).
+ * The renderer renders the row and, on click, asks main to install by id: the
+ * chosen artifact (and its download ref) never leaves the main process.
+ *
+ * `installed` / `update-available` are LOCAL states owned by the renderer (it
+ * de-dupes against the installations store), so they are deliberately absent
+ * here.
+ */
+// Import from the library's leaf modules (not its barrel): these are pure and
+// pull no Electron/filesystem side effects, so this policy module stays cheap to
+// load and to unit-test.
+import { hostOs, selectArtifactForHost } from '../comfybuilder/targets'
+import type { Artifact, Distribution, Host } from '../comfybuilder/types'
+import type { ComfyBuilderClient } from '../comfybuilder/client'
+import { detectGPU } from '../lib/gpu'
+
+/** The pre-install states this layer can decide from the catalog alone. */
+export type DistributionRowState = 'installable' | 'no-build' | 'platform-mismatch'
+
+/** One renderer-safe distribution tile row. Field names mirror the renderer's
+ *  `devplatform/types.ts` so swapping mocks for this stays mechanical. */
+export interface DistributionRow {
+  id: string
+  name: string
+  description?: string
+  version?: string
+  finishedAt?: string
+  numCustomNodes?: number
+  state: DistributionRowState
+  /** i18n suffix explaining a blocked state (see `devPlatform.distribution.blockedReason.*`). */
+  blockedReason?: string
+}
+
+/** What `installDistribution` resolves before it hands off to the install chain. */
+export interface ResolvedHostArtifact {
+  artifact: Artifact
+  version: number
+}
+
+/**
+ * Terminal-success version statuses. Kept lenient (the builder's exact wording
+ * has drifted) so a completed build is never mistaken for a missing one.
+ */
+const COMPLETE_VERSION_STATUSES = new Set(['complete', 'completed', 'ready', 'succeeded', 'success'])
+
+/** The signed-in host's build target: OS from the platform, GPU from detection. */
+export async function resolveHost(): Promise<Host> {
+  const gpu = await detectGPU().catch(() => null)
+  // The library targets nvidia/amd/cpu/mps; an Intel dGPU (or none) maps to the
+  // universal CPU build, which `selectArtifactForHost` treats as the fallback.
+  const mapped =
+    gpu?.id === 'nvidia' || gpu?.id === 'amd' || gpu?.id === 'mps' ? gpu.id : 'cpu'
+  return { os: hostOs(), gpu: mapped }
+}
+
+/** Latest version whose status reads as a completed build, or null. */
+function latestCompleteVersion<T extends { version: number; status: string }>(versions: T[]): T | null {
+  const complete = versions
+    .filter((v) => typeof v.status === 'string' && COMPLETE_VERSION_STATUSES.has(v.status.toLowerCase()))
+    .sort((a, b) => b.version - a.version)
+  return complete[0] ?? null
+}
+
+/**
+ * Resolve one distribution into a display row: newest complete version, then
+ * whether it has a host-runnable artifact. Never drops the distribution: an
+ * un-installable one becomes a blocked row with a reason, not a hidden entry.
+ */
+async function buildRow(
+  client: Pick<ComfyBuilderClient, 'listVersions' | 'getVersion'>,
+  host: Host,
+  dist: Distribution,
+): Promise<DistributionRow> {
+  const base: DistributionRow = {
+    id: dist.id,
+    name: dist.name,
+    ...(dist.description ? { description: dist.description } : {}),
+    ...(typeof dist.numCustomNodes === 'number' ? { numCustomNodes: dist.numCustomNodes } : {}),
+    state: 'no-build',
+  }
+
+  const latest = latestCompleteVersion(await client.listVersions(dist.id))
+  if (!latest) return { ...base, state: 'no-build', blockedReason: 'buildFailed' }
+
+  const withVersion: DistributionRow = {
+    ...base,
+    version: String(latest.version),
+    ...(latest.createdAt ? { finishedAt: latest.createdAt } : {}),
+  }
+
+  const { artifacts } = await client.getVersion(latest.id)
+  const artifact = selectArtifactForHost(artifacts, host)
+  if (!artifact) return { ...withVersion, state: 'platform-mismatch', blockedReason: 'noArtifactForMachine' }
+  return { ...withVersion, state: 'installable' }
+}
+
+/**
+ * Every distribution the signed-in workspace can see, as display rows. A
+ * distribution whose version lookup fails is dropped for THIS list rather than
+ * failing the whole grid.
+ */
+export async function listDistributionRows(client: ComfyBuilderClient, host: Host): Promise<DistributionRow[]> {
+  const dists = await client.listDistributions()
+  const results = await Promise.allSettled(dists.map((d) => buildRow(client, host, d)))
+  return results
+    .filter((r): r is PromiseFulfilledResult<DistributionRow> => {
+      if (r.status === 'rejected') console.error('[devplatform] failed to resolve distribution row:', r.reason)
+      return r.status === 'fulfilled'
+    })
+    .map((r) => r.value)
+}
+
+/**
+ * Resolve the artifact to install for one distribution on this host: the latest
+ * complete version's host-matched artifact, or null when none is runnable here.
+ * This is the same policy `listDistributionRows` renders, re-run at install time
+ * against fresh catalog data.
+ */
+export async function resolveHostArtifact(
+  client: Pick<ComfyBuilderClient, 'listVersions' | 'getVersion'>,
+  host: Host,
+  distributionId: string,
+): Promise<ResolvedHostArtifact | null> {
+  const latest = latestCompleteVersion(await client.listVersions(distributionId))
+  if (!latest) return null
+  const { artifacts } = await client.getVersion(latest.id)
+  const artifact = selectArtifactForHost(artifacts, host)
+  return artifact ? { artifact, version: latest.version } : null
+}

--- a/src/main/devplatform/session.ts
+++ b/src/main/devplatform/session.ts
@@ -1,0 +1,45 @@
+/**
+ * The single main-process CloudSession + the ComfyBuilderClient built from it.
+ *
+ * Both the IPC handlers (auth / workspaces / distributions / install) and the
+ * comfy-builder SourcePlugin's `install()` read the SAME session here, so a
+ * sign-in, workspace switch, or sign-out is reflected everywhere without any of
+ * them owning their own token state. The client pulls a bearer token from the
+ * session's `TokenProvider` per request; the token never leaves this process.
+ *
+ * `./config` is imported first, for its side effect: it seeds the staging
+ * `COMFY_CLOUD_ISSUER` default before the cloud library's config reads it.
+ */
+import { BUILDER_BASE_URL } from './config'
+import { CloudSession } from '../cloud'
+import { ComfyBuilderClient } from '../comfybuilder'
+
+let session: CloudSession | null = null
+let client: ComfyBuilderClient | null = null
+
+/** The process-wide CloudSession (auth + workspace), created on first use. */
+export function getCloudSession(): CloudSession {
+  if (!session) session = new CloudSession()
+  return session
+}
+
+/**
+ * The catalog client, bound to the shared session's token provider and the
+ * staging builder gateway. Cached: the session is the mutable part, and the
+ * provider it hands out always reads the current tokens.
+ */
+export function getBuilderClient(): ComfyBuilderClient {
+  if (!client) {
+    client = new ComfyBuilderClient({
+      baseUrl: BUILDER_BASE_URL,
+      auth: getCloudSession().asTokenProvider(),
+    })
+  }
+  return client
+}
+
+/** @internal: reset the singletons between tests. */
+export function _resetForTest(): void {
+  session = null
+  client = null
+}

--- a/src/main/lib/e2eHooks.ts
+++ b/src/main/lib/e2eHooks.ts
@@ -15,6 +15,8 @@ import {
   _test_ageEntries as _test_ageReleaseCacheEntries,
 } from './release-cache'
 import { _test_getOpenTitlePopupBounds } from '../popups/titlePopup'
+import { stageModels, resolveModelManifest } from '../comfybuilder'
+import { getBuilderClient } from '../devplatform/session'
 import { returnToDashboard } from '../host/detach'
 import { comfyWindows, getEntryByInstallationId, isInstallHost } from '../host/registry'
 import { ensurePanelView } from '../host/panelView'
@@ -79,6 +81,14 @@ export interface E2EHelpers {
   /** Mount the install-backed panelView for `installationId` (production mounts it lazily),
    *  so tests can reach `panel.html` immediately after a launch. Returns whether the entry exists. */
   ensureInstallPanelView(installationId: string): boolean
+  /** Run the REAL comfybuilder model-staging (resolve manifest -> download ->
+   *  verify -> place) against `installPath`, isolated from the archive/auth path.
+   *  Resolves to the staged `type/filename` list, or a typed error on failure. */
+  stageDistributionModels(opts: {
+    installPath: string
+    distributionId: string
+    version: string
+  }): Promise<{ staged: string[] } | { error: string; kind?: string }>
 }
 
 export function registerE2EHooks(): void {
@@ -130,6 +140,16 @@ export function registerE2EHooks(): void {
       if (!entry || entry.window.isDestroyed()) return false
       ensurePanelView(entry.windowKey, entry, 'comfy-lifecycle')
       return true
+    },
+    async stageDistributionModels({ installPath, distributionId, version }) {
+      const manifest = await resolveModelManifest(getBuilderClient(), distributionId, version)
+      try {
+        await stageModels({ models: manifest.models, installPath })
+        return { staged: manifest.models.map((m) => `${m.type}/${m.filename}`) }
+      } catch (e) {
+        const err = e as { message?: string; kind?: string }
+        return { error: err.message ?? String(e), ...(err.kind ? { kind: err.kind } : {}) }
+      }
     },
   }
   ;(globalThis as unknown as { __e2e: E2EHelpers }).__e2e = helpers

--- a/src/main/lib/ipc/index.ts
+++ b/src/main/lib/ipc/index.ts
@@ -34,6 +34,7 @@ import { setTerminalEnvResolver } from '../terminal'
 import { registerLogsHandlers } from './registerLogsHandlers'
 import { registerCrashHandlers } from './registerCrashHandlers'
 import { registerTelemetryHandlers } from './registerTelemetryHandlers'
+import { registerDevPlatformHandlers } from './registerDevPlatformHandlers'
 import { reconcileAdoptedSettings } from '../desktopAdopt'
 
 export {
@@ -267,5 +268,6 @@ export function register(callbacks: RegisterCallbacks = {}): Promise<void> {
   registerLogsHandlers()
   registerCrashHandlers()
   registerTelemetryHandlers()
+  registerDevPlatformHandlers()
   return startupMaintenance
 }

--- a/src/main/lib/ipc/registerDevPlatformHandlers.test.ts
+++ b/src/main/lib/ipc/registerDevPlatformHandlers.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  handle: vi.fn(),
+  getAllWindows: vi.fn(() => [] as unknown[]),
+  // session
+  login: vi.fn(),
+  logout: vi.fn(),
+  status: vi.fn(),
+  isSignedIn: vi.fn(),
+  listWorkspaces: vi.fn(),
+  switchWorkspace: vi.fn(),
+  // client + policy
+  getBuilderClient: vi.fn(() => ({ listDistributions: mocks.listDistributions })),
+  listDistributions: vi.fn(),
+  resolveHost: vi.fn(async () => ({ os: 'linux', gpu: 'nvidia' })),
+  listDistributionRows: vi.fn(),
+  resolveHostArtifact: vi.fn(),
+  // installations + shared helpers
+  add: vi.fn(),
+  uniqueName: vi.fn(async (n: string) => n),
+  sanitizeDirName: vi.fn((n: string) => n),
+  allocateUniqueDir: vi.fn((parent: string, dir: string) => `${parent}/${dir}`),
+  findDuplicatePath: vi.fn(async () => null),
+  defaultInstallDir: vi.fn(() => '/installs')
+}))
+
+vi.mock('electron', () => ({
+  BrowserWindow: { getAllWindows: mocks.getAllWindows },
+  ipcMain: { handle: mocks.handle }
+}))
+
+vi.mock('../../devplatform/session', () => ({
+  getCloudSession: () => ({
+    login: mocks.login,
+    logout: mocks.logout,
+    status: mocks.status,
+    isSignedIn: mocks.isSignedIn,
+    listWorkspaces: mocks.listWorkspaces,
+    switchWorkspace: mocks.switchWorkspace
+  }),
+  getBuilderClient: mocks.getBuilderClient
+}))
+
+vi.mock('../../devplatform/distributions', () => ({
+  resolveHost: mocks.resolveHost,
+  listDistributionRows: mocks.listDistributionRows,
+  resolveHostArtifact: mocks.resolveHostArtifact
+}))
+
+vi.mock('./shared', () => ({
+  installations: { add: mocks.add },
+  uniqueName: mocks.uniqueName,
+  sanitizeDirName: mocks.sanitizeDirName,
+  allocateUniqueDir: mocks.allocateUniqueDir,
+  findDuplicatePath: mocks.findDuplicatePath,
+  defaultInstallDir: mocks.defaultInstallDir
+}))
+
+import { registerDevPlatformHandlers } from './registerDevPlatformHandlers'
+
+type IpcHandler = (event: unknown, ...args: unknown[]) => unknown
+
+function handler(channel: string): IpcHandler {
+  const call = mocks.handle.mock.calls.find(([name]) => name === channel)
+  expect(call, `handler for ${channel} was registered`).toBeDefined()
+  return call![1] as IpcHandler
+}
+
+describe('registerDevPlatformHandlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    registerDevPlatformHandlers()
+  })
+
+  it('signIn returns and broadcasts the status', async () => {
+    const win = { webContents: { isDestroyed: () => false, send: vi.fn() } }
+    mocks.getAllWindows.mockReturnValue([win])
+    mocks.login.mockResolvedValue({ signedIn: true, email: 'a@b.c', workspaceId: 'w1' })
+
+    const status = await handler('comfybuilder:signIn')({})
+    expect(status).toMatchObject({ signedIn: true, email: 'a@b.c' })
+    expect(win.webContents.send).toHaveBeenCalledWith('comfybuilder:authChanged', status)
+  })
+
+  it('signOut clears the session and broadcasts signed-out', async () => {
+    const win = { webContents: { isDestroyed: () => false, send: vi.fn() } }
+    mocks.getAllWindows.mockReturnValue([win])
+
+    const status = handler('comfybuilder:signOut')({})
+    expect(status).toEqual({ signedIn: false })
+    expect(mocks.logout).toHaveBeenCalledOnce()
+    expect(win.webContents.send).toHaveBeenCalledWith('comfybuilder:authChanged', { signedIn: false })
+  })
+
+  it('listDistributions is empty (no network) when signed out', async () => {
+    mocks.isSignedIn.mockReturnValue(false)
+    const rows = await handler('comfybuilder:listDistributions')({})
+    expect(rows).toEqual([])
+    expect(mocks.listDistributionRows).not.toHaveBeenCalled()
+  })
+
+  it('listDistributions returns rows for the signed-in workspace', async () => {
+    mocks.isSignedIn.mockReturnValue(true)
+    mocks.listDistributionRows.mockResolvedValue([{ id: 'd1', name: 'Image', state: 'installable' }])
+    const rows = await handler('comfybuilder:listDistributions')({})
+    expect(rows).toEqual([{ id: 'd1', name: 'Image', state: 'installable' }])
+  })
+
+  it('switchWorkspace re-scopes and broadcasts the new status', async () => {
+    const win = { webContents: { isDestroyed: () => false, send: vi.fn() } }
+    mocks.getAllWindows.mockReturnValue([win])
+    mocks.switchWorkspace.mockResolvedValue({ signedIn: true, workspaceId: 'w2', workspaceType: 'team' })
+
+    const status = await handler('comfybuilder:switchWorkspace')({}, 'w2')
+    expect(mocks.switchWorkspace).toHaveBeenCalledWith('w2')
+    expect(status).toMatchObject({ workspaceId: 'w2' })
+    expect(win.webContents.send).toHaveBeenCalledWith('comfybuilder:authChanged', status)
+  })
+
+  it('installDistribution creates an installing record carrying the resolved artifact', async () => {
+    mocks.isSignedIn.mockReturnValue(true)
+    mocks.resolveHostArtifact.mockResolvedValue({
+      version: 7,
+      artifact: { id: 'art-9', os: 'linux', gpu: 'nvidia', accelVariant: 'cu128', status: 'ready', outputSha256: 'deadbeef' }
+    })
+    mocks.listDistributions.mockResolvedValue([{ id: 'd1', name: 'Image Baseline' }])
+    mocks.add.mockResolvedValue({ id: 'inst-1', name: 'Image Baseline' })
+
+    const result = await handler('comfybuilder:installDistribution')({}, 'd1')
+    expect(result).toEqual({ ok: true, entry: { id: 'inst-1', name: 'Image Baseline' } })
+    expect(mocks.add).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceId: 'comfybuilder',
+        distributionId: 'd1',
+        distributionName: 'Image Baseline',
+        version: '7',
+        artifactId: 'art-9',
+        artifactSha256: 'deadbeef',
+        status: 'installing'
+      })
+    )
+  })
+
+  it('installDistribution omits the sha field when the artifact has none (fails closed later)', async () => {
+    mocks.isSignedIn.mockReturnValue(true)
+    mocks.resolveHostArtifact.mockResolvedValue({
+      version: 1,
+      artifact: { id: 'art-nohash', os: 'linux', gpu: 'nvidia', accelVariant: 'cu128', status: 'ready' }
+    })
+    mocks.listDistributions.mockResolvedValue([{ id: 'd1', name: 'NoHash' }])
+    mocks.add.mockResolvedValue({ id: 'inst-2', name: 'NoHash' })
+
+    const result = await handler('comfybuilder:installDistribution')({}, 'd1')
+    expect(result).toMatchObject({ ok: true })
+    expect(mocks.add.mock.calls[0]![0]).not.toHaveProperty('artifactSha256')
+  })
+
+  it('installDistribution refuses when no host artifact resolves', async () => {
+    mocks.isSignedIn.mockReturnValue(true)
+    mocks.resolveHostArtifact.mockResolvedValue(null)
+    const result = await handler('comfybuilder:installDistribution')({}, 'd1')
+    expect(result).toMatchObject({ ok: false })
+    expect(mocks.add).not.toHaveBeenCalled()
+  })
+
+  it('installDistribution refuses when signed out', async () => {
+    mocks.isSignedIn.mockReturnValue(false)
+    const result = await handler('comfybuilder:installDistribution')({}, 'd1')
+    expect(result).toMatchObject({ ok: false })
+    expect(mocks.resolveHostArtifact).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/lib/ipc/registerDevPlatformHandlers.ts
+++ b/src/main/lib/ipc/registerDevPlatformHandlers.ts
@@ -1,0 +1,186 @@
+/**
+ * Dev-platform IPC bridge: the ONE seam between the renderer and the
+ * cloud-auth + comfy-builder libraries.
+ *
+ * Auth, workspace, distribution-catalog, and install-kickoff all funnel through
+ * the single main-process `CloudSession` (see `../../devplatform/session`).
+ * Access/refresh tokens NEVER cross this boundary: handlers return and broadcast
+ * only renderer-safe shapes: `AuthStatus`, `Workspace[]`, and distribution
+ * DISPLAY rows: never a token or a download ref.
+ */
+import { BrowserWindow, ipcMain } from 'electron'
+
+import { getBuilderClient, getCloudSession } from '../../devplatform/session'
+import {
+  listDistributionRows,
+  resolveHost,
+  resolveHostArtifact,
+} from '../../devplatform/distributions'
+import type { DistributionRow } from '../../devplatform/distributions'
+import type { AuthStatus, Workspace } from '../../cloud'
+import {
+  installations,
+  uniqueName,
+  sanitizeDirName,
+  allocateUniqueDir,
+  findDuplicatePath,
+  defaultInstallDir,
+} from './shared'
+
+/** IPC channels for the dev-platform bridge. Kept together so a rename can't desync. */
+export const DEVPLATFORM_CHANNELS = {
+  signIn: 'comfybuilder:signIn',
+  signOut: 'comfybuilder:signOut',
+  getAuthStatus: 'comfybuilder:getAuthStatus',
+  authChanged: 'comfybuilder:authChanged',
+  listWorkspaces: 'comfybuilder:listWorkspaces',
+  switchWorkspace: 'comfybuilder:switchWorkspace',
+  listDistributions: 'comfybuilder:listDistributions',
+  installDistribution: 'comfybuilder:installDistribution',
+} as const
+
+const SIGNED_OUT: AuthStatus = { signedIn: false }
+
+const COMFYBUILDER_SOURCE_ID = 'comfybuilder'
+const COMFYBUILDER_SOURCE_LABEL = 'ComfyBuilder'
+const COMFYBUILDER_LAUNCH_ARGS = '--enable-manager'
+
+/** Result of an install-kickoff: mirrors the `add-installation` handler's shape
+ *  so the renderer can drive the same `installInstance` + progress UI. */
+export interface InstallDistributionResult {
+  ok: boolean
+  message?: string
+  entry?: { id: string; name: string }
+}
+
+/**
+ * Push the renderer-safe {@link AuthStatus} to every window so all surfaces
+ * update in lockstep. Only the status (never tokens) is sent. Exported so a
+ * mid-request session expiry could announce itself later.
+ */
+export function broadcastAuthChanged(status: AuthStatus): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.webContents.isDestroyed()) win.webContents.send(DEVPLATFORM_CHANNELS.authChanged, status)
+  }
+}
+
+/**
+ * Register the dev-platform IPC handlers. Call once at startup.
+ *
+ * The renderer can never pass a token in or read one out: `signIn` takes no
+ * arguments and returns only the status; every catalog call reads the bearer
+ * token main-side via the session's `TokenProvider`.
+ */
+export function registerDevPlatformHandlers(): void {
+  const session = getCloudSession()
+
+  // Bumped by signOut so a sign-in already out in the browser when the user
+  // signs out cannot resurrect the session when its flow completes.
+  let signOutGeneration = 0
+
+  // Distribution ids whose install-kickoff is mid-flight, so a double-click
+  // cannot create two records for the same distribution.
+  const installing = new Set<string>()
+
+  ipcMain.handle(DEVPLATFORM_CHANNELS.signIn, async (): Promise<AuthStatus> => {
+    const generation = signOutGeneration
+    const status = await session.login()
+    // Signed out while the browser flow was in flight: the login persisted
+    // tokens, so drop them rather than leave a session the user tried to kill.
+    if (generation !== signOutGeneration) {
+      session.logout()
+      return SIGNED_OUT
+    }
+    broadcastAuthChanged(status)
+    return status
+  })
+
+  ipcMain.handle(DEVPLATFORM_CHANNELS.signOut, (): AuthStatus => {
+    signOutGeneration += 1
+    session.logout()
+    broadcastAuthChanged(SIGNED_OUT)
+    return SIGNED_OUT
+  })
+
+  ipcMain.handle(DEVPLATFORM_CHANNELS.getAuthStatus, (): AuthStatus => session.status())
+
+  ipcMain.handle(DEVPLATFORM_CHANNELS.listWorkspaces, (): Promise<Workspace[]> => session.listWorkspaces())
+
+  // A workspace switch re-runs sign-in pre-selecting the workspace (a PKCE token
+  // is scoped at consent time), so it can open the browser and change identity:
+  // broadcast the new status so every surface re-scopes together.
+  ipcMain.handle(DEVPLATFORM_CHANNELS.switchWorkspace, async (_event, workspaceId: string): Promise<AuthStatus> => {
+    const generation = signOutGeneration
+    const status = await session.switchWorkspace(workspaceId)
+    if (generation !== signOutGeneration) {
+      session.logout()
+      return SIGNED_OUT
+    }
+    broadcastAuthChanged(status)
+    return status
+  })
+
+  // Display rows for the current workspace. Signed out → empty (no network
+  // calls); the renderer already gates the grid on sign-in.
+  ipcMain.handle(DEVPLATFORM_CHANNELS.listDistributions, async (): Promise<DistributionRow[]> => {
+    if (!session.isSignedIn()) return []
+    const host = await resolveHost()
+    return listDistributionRows(getBuilderClient(), host)
+  })
+
+  // Resolve the host artifact for one distribution and create an `installing`
+  // record, then hand the id back so the renderer runs the normal
+  // `installInstance` + progress flow. The install itself (download → verify
+  // sha → extract) runs in the comfybuilder SourcePlugin.
+  ipcMain.handle(
+    DEVPLATFORM_CHANNELS.installDistribution,
+    async (_event, distributionId: string): Promise<InstallDistributionResult> => {
+      if (!session.isSignedIn()) return { ok: false, message: 'Not signed in.' }
+      if (installing.has(distributionId)) return { ok: false, message: 'Install already starting.' }
+      installing.add(distributionId)
+      try {
+        const client = getBuilderClient()
+        const host = await resolveHost()
+        const resolved = await resolveHostArtifact(client, host, distributionId)
+        if (!resolved) return { ok: false, message: 'No installable build for this machine.' }
+
+        // Name the install after the distribution. One extra list call keeps the
+        // renderer from having to pass a (spoofable) display name back to main.
+        const dists = await client.listDistributions()
+        const dist = dists.find((d) => d.id === distributionId)
+        const displayName = await uniqueName(dist?.name ?? distributionId)
+
+        const installPath = allocateUniqueDir(defaultInstallDir(), sanitizeDirName(displayName))
+        const duplicate = await findDuplicatePath(installPath)
+        if (duplicate) return { ok: false, message: `That directory is already used by "${duplicate.name}".` }
+
+        const { artifact } = resolved
+        const entry = await installations.add({
+          name: displayName,
+          sourceId: COMFYBUILDER_SOURCE_ID,
+          sourceLabel: COMFYBUILDER_SOURCE_LABEL,
+          installPath,
+          distributionId,
+          distributionName: dist?.name ?? distributionId,
+          version: String(resolved.version),
+          artifactId: artifact.id,
+          artifactOs: artifact.os,
+          artifactGpu: artifact.gpu,
+          artifactAccelVariant: artifact.accelVariant,
+          // May be absent until the builder populates it: carried through
+          // verbatim so `installArtifact` verifies whenever a hash is present.
+          ...(artifact.outputSha256 ? { artifactSha256: artifact.outputSha256 } : {}),
+          launchArgs: COMFYBUILDER_LAUNCH_ARGS,
+          launchMode: 'window',
+          browserPartition: 'unique',
+          status: 'installing',
+          seen: false,
+        })
+
+        return { ok: true, entry: { id: entry.id, name: entry.name } }
+      } finally {
+        installing.delete(distributionId)
+      }
+    },
+  )
+}

--- a/src/main/sources/comfybuilder/index.test.ts
+++ b/src/main/sources/comfybuilder/index.test.ts
@@ -1,0 +1,155 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: { getPath: () => '', isPackaged: false },
+  ipcMain: { handle: vi.fn() },
+  BrowserWindow: { fromWebContents: vi.fn() },
+  dialog: {},
+  shell: { openPath: vi.fn().mockResolvedValue('') },
+  net: { request: vi.fn() },
+}))
+
+// Stub the library so install() wiring can be asserted without real downloads.
+vi.mock('../../comfybuilder', () => ({
+  installArtifact: vi.fn(async () => {}),
+  buildLaunchSpec: vi.fn(() => null),
+  stageModels: vi.fn(async () => {}),
+  resolveModelManifest: vi.fn(async () => ({ models: [], modelPolicy: null, partnerNodePolicy: null })),
+}))
+vi.mock('../../devplatform/session', () => ({ getBuilderClient: vi.fn(() => ({})) }))
+
+import { installArtifact, stageModels, resolveModelManifest } from '../../comfybuilder'
+import { comfybuilder, withAccelArgs } from './index'
+import type { InstallationRecord } from '../../installations'
+import type { InstallTools } from '../../types/sources'
+
+const record = (overrides: Record<string, unknown> = {}): InstallationRecord =>
+  ({
+    id: 'i1',
+    name: 'desktop-4target-stg-v0190',
+    sourceId: 'comfybuilder',
+    installPath: '/installs/dist',
+    status: 'installed',
+    distributionId: 'd1',
+    distributionName: 'desktop-4target-stg-v0190',
+    version: '1',
+    ...overrides,
+  }) as unknown as InstallationRecord
+
+function fakeTools(signal?: AbortSignal): InstallTools & { sent: Array<{ phase: string; detail: unknown }> } {
+  const sent: Array<{ phase: string; detail: unknown }> = []
+  return {
+    sent,
+    sendProgress: (phase: string, detail: unknown) => sent.push({ phase, detail }),
+    download: vi.fn(),
+    cache: {} as never,
+    extract: vi.fn(),
+    ...(signal ? { signal } : {}),
+  } as never
+}
+
+describe('comfybuilder.install wiring', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('installs the archive, then resolves the manifest, then stages models', async () => {
+    const tools = fakeTools()
+    await comfybuilder.install!(record(), tools)
+
+    expect(installArtifact).toHaveBeenCalledTimes(1)
+    expect(resolveModelManifest).toHaveBeenCalledTimes(1)
+    expect(stageModels).toHaveBeenCalledTimes(1)
+    // The archive must be in place before models are staged into its tree.
+    const archiveOrder = (installArtifact as unknown as { mock: { invocationCallOrder: number[] } }).mock.invocationCallOrder[0]!
+    const stageOrder = (stageModels as unknown as { mock: { invocationCallOrder: number[] } }).mock.invocationCallOrder[0]!
+    expect(archiveOrder).toBeLessThan(stageOrder)
+
+    // The manifest is keyed by the record's distribution + version number.
+    expect(resolveModelManifest).toHaveBeenCalledWith(expect.anything(), 'd1', '1')
+    // A terminal models progress event fires so the step completes.
+    expect(tools.sent.some((s) => s.phase === 'models')).toBe(true)
+  })
+
+  it('folds the library resolve phase into the download step', async () => {
+    const tools = fakeTools()
+    await comfybuilder.install!(record(), tools)
+    const onProgress = (installArtifact as unknown as { mock: { calls: Array<[{ onProgress: (p: unknown) => void }]> } }).mock.calls[0]![0].onProgress
+    onProgress({ phase: 'resolve', percent: 0 })
+    expect(tools.sent.some((s) => s.phase === 'download')).toBe(true)
+    expect(tools.sent.some((s) => s.phase === 'resolve')).toBe(false)
+  })
+
+  it('threads the abort signal into both phases', async () => {
+    const signal = new AbortController().signal
+    await comfybuilder.install!(record(), fakeTools(signal))
+    expect((installArtifact as unknown as { mock: { calls: Array<[{ signal?: AbortSignal }]> } }).mock.calls[0]![0].signal).toBe(signal)
+    expect((stageModels as unknown as { mock: { calls: Array<[{ signal?: AbortSignal }]> } }).mock.calls[0]![0].signal).toBe(signal)
+  })
+})
+
+describe('comfybuilder.getListActions', () => {
+  // Without this the renderer gets an empty action array, reads the install as
+  // unlaunchable, and bounces a tile click into the new-install wizard.
+  it.each([
+    ['installed', 'installed', true],
+    ['installing', 'installing', false],
+    ['failed', 'failed', false],
+  ])('exposes a launch action for a %s install (enabled=%s)', (_name, status, enabled) => {
+    const actions = comfybuilder.getListActions!(record({ status }))
+    expect(actions).toHaveLength(1)
+    expect(actions[0]).toMatchObject({ id: 'launch', style: 'primary', enabled })
+  })
+
+  it('surfaces the launch progress UI so the boot wait is not silent', () => {
+    const [action] = comfybuilder.getListActions!(record())
+    expect(action).toMatchObject({ showProgress: true, cancellable: true })
+    expect(action!.progressTitle).toBeTruthy()
+  })
+
+  it('explains itself when disabled', () => {
+    const [action] = comfybuilder.getListActions!(record({ status: 'installing' }))
+    expect(action!.disabledMessage).toBeTruthy()
+  })
+})
+
+describe('comfybuilder.getListPreview', () => {
+  it('yields to the source label when it would echo the tile title', () => {
+    expect(comfybuilder.getListPreview!(record())).toBeNull()
+  })
+
+  it('surfaces the distribution once a rename has made the two differ', () => {
+    expect(comfybuilder.getListPreview!(record({ name: 'My Renamed Install' })))
+      .toBe('desktop-4target-stg-v0190')
+  })
+})
+
+describe('comfybuilder.withAccelArgs', () => {
+  // The flag tracks the INSTALLED ARTIFACT, not the host. `selectArtifactForHost`
+  // treats a cpu build as the universal fallback, so an nvidia machine lands on
+  // a cpu artifact whenever the distribution has no nvidia build: that torch is
+  // still CPU-only and ComfyUI would assert "Torch not compiled with CUDA
+  // enabled" without --cpu. nvidia/amd/mps builds bring their own accelerated
+  // torch and are auto-detected, so they take no flag.
+  it.each([
+    ['cpu build', 'cpu', 'cpu', '--enable-manager --cpu'],
+    ['cpu build on an nvidia host (no nvidia build published)', 'cpu', 'cpu', '--enable-manager --cpu'],
+    ['nvidia build', 'nvidia', 'cu128', '--enable-manager'],
+    ['amd build', 'amd', 'rocm6.2', '--enable-manager'],
+    ['mps build', 'mps', 'mps', '--enable-manager'],
+  ])('%s', (_name, artifactGpu, artifactAccelVariant, expected) => {
+    expect(withAccelArgs(record({ artifactGpu, artifactAccelVariant }), '--enable-manager')).toBe(expected)
+  })
+
+  it('falls back to accelVariant when the gpu field is absent', () => {
+    expect(withAccelArgs(record({ artifactGpu: undefined, artifactAccelVariant: 'cpu' }), '--enable-manager'))
+      .toBe('--enable-manager --cpu')
+  })
+
+  it.each(['--cpu', '--enable-manager --cpu', '--cpu --listen'])('does not double up on %s', (args) => {
+    expect(withAccelArgs(record({ artifactGpu: 'cpu' }), args)).toBe(args)
+  })
+
+  it('does not mistake --cpu-vae for the cpu flag', () => {
+    expect(withAccelArgs(record({ artifactGpu: 'cpu' }), '--cpu-vae')).toBe('--cpu-vae --cpu')
+  })
+})

--- a/src/main/sources/comfybuilder/index.ts
+++ b/src/main/sources/comfybuilder/index.ts
@@ -1,0 +1,180 @@
+/**
+ * ComfyBuilder install source: main process only.
+ *
+ * A thin SourcePlugin over the comfy-builder functionality library. The catalog
+ * / host-matching / sign-in all happen in the dev-platform IPC layer; by the
+ * time an install record reaches here it already carries the chosen artifact's
+ * identity (id + os/gpu/accel + sha256). `install()` hands that artifact to the
+ * library's `installArtifact` (download, verify sha, extract into the install
+ * dir), and `getLaunchCommand()` drives the extracted `venv/` via
+ * `buildLaunchSpec`. There is no adopt/probe path: a ComfyBuilder install is
+ * only ever created by the dev-platform flow, never discovered on disk.
+ *
+ * Launch parity matters as much as install: the renderer discovers whether an
+ * install can run from `getListActions`, so omitting it silently downgrades a
+ * distribution to "not launchable" and bounces a tile click into the
+ * new-install wizard. That is why `getListActions` below exists even though it
+ * looks like boilerplate.
+ */
+import { installArtifact, buildLaunchSpec, stageModels, resolveModelManifest } from '../../comfybuilder'
+import type { Artifact, ArtifactGpu, ArtifactOs, InstallProgress, StageProgress } from '../../comfybuilder'
+import { getBuilderClient } from '../../devplatform/session'
+import { launchAction } from '../../lib/actions'
+import { defaultDownloadCacheDir } from '../../lib/paths'
+import { t } from '../../lib/i18n'
+import type { InstallationRecord } from '../../installations'
+import type {
+  SourcePlugin,
+  LaunchCommand,
+  ActionResult,
+  InstallTools,
+} from '../../types/sources'
+
+const DEFAULT_LAUNCH_ARGS = '--enable-manager'
+
+/** Reconstruct the library Artifact from the fields the install record carries. */
+function artifactFromRecord(inst: InstallationRecord): Artifact {
+  return {
+    id: (inst.artifactId as string) ?? '',
+    os: (inst.artifactOs as ArtifactOs) ?? 'linux',
+    gpu: (inst.artifactGpu as ArtifactGpu) ?? 'cpu',
+    accelVariant: (inst.artifactAccelVariant as string) ?? '',
+    status: 'ready',
+    ...(inst.artifactSha256 ? { outputSha256: inst.artifactSha256 as string } : {}),
+  }
+}
+
+/**
+ * Pin the accelerator args the installed artifact implies.
+ *
+ * A CPU artifact ships a CPU-only torch, and ComfyUI defaults to probing CUDA:
+ * without `--cpu` it dies at import with "Torch not compiled with CUDA enabled".
+ * Which artifact got installed is a property of the machine, not a user
+ * preference, so it is pinned here rather than baked into the editable launch
+ * args. Skipped when the user already passed `--cpu` themselves. nvidia/amd/mps
+ * need no flag: torch and ComfyUI detect those on their own.
+ */
+export function withAccelArgs(installation: InstallationRecord, launchArgs: string): string {
+  const isCpu = installation.artifactGpu === 'cpu' || installation.artifactAccelVariant === 'cpu'
+  if (!isCpu || /(?:^|\s)--cpu(?:\s|$)/.test(launchArgs)) return launchArgs
+  return `${launchArgs} --cpu`.trim()
+}
+
+export const comfybuilder: SourcePlugin = {
+  id: 'comfybuilder',
+  label: 'ComfyBuilder',
+  description: 'Install a ComfyUI distribution built with ComfyBuilder.',
+  category: 'local',
+  // Never a "New Install" wizard source: records are created by the dev-platform
+  // distribution flow, so it must not appear in the generic source picker.
+  hidden: true,
+  fields: [],
+  defaultLaunchArgs: DEFAULT_LAUNCH_ARGS,
+
+  get installSteps() {
+    return [
+      { phase: 'download', label: t('common.download') },
+      { phase: 'extract', label: t('common.extract') },
+      { phase: 'models', label: t('comfybuilder.stageModels') },
+    ]
+  },
+
+  getDefaults() {
+    return { launchArgs: DEFAULT_LAUNCH_ARGS, launchMode: 'window', browserPartition: 'unique' }
+  },
+
+  buildInstallation(): Record<string, unknown> {
+    // Records are assembled by `installDistribution` (which already knows the
+    // resolved artifact), not the generic build-installation chain.
+    return { launchArgs: DEFAULT_LAUNCH_ARGS, launchMode: 'window', browserPartition: 'unique' }
+  },
+
+  // The tile prefers this over the source label, and the install is named after
+  // the distribution, so returning the name here would echo the tile title and
+  // hide the one label marking this as a distribution. Surface it only once a
+  // rename has made the two differ.
+  getListPreview(installation: InstallationRecord): string | null {
+    const distributionName = (installation.distributionName as string) || ''
+    return distributionName && distributionName !== installation.name ? distributionName : null
+  },
+
+  getLaunchCommand(installation: InstallationRecord): LaunchCommand | null {
+    const spec = buildLaunchSpec(installation.installPath, {
+      launchArgs: withAccelArgs(installation, (installation.launchArgs as string | undefined) ?? DEFAULT_LAUNCH_ARGS),
+    })
+    if (!spec) return null
+    return { cmd: spec.cmd, args: spec.args, cwd: spec.cwd, port: spec.port }
+  },
+
+  // Launch is discovered through this list, not through `getLaunchCommand`: a
+  // plugin without it hands the renderer an empty action array, which reads as
+  // "this install cannot launch" and bounces a tile click into the new-install
+  // wizard. Distributions launch like any other local install.
+  getListActions(installation: InstallationRecord): Record<string, unknown>[] {
+    const installed = installation.status === 'installed'
+    return [launchAction(installed, !installed ? t('errors.installNotReady') : undefined)]
+  },
+
+  getDetailSections(installation: InstallationRecord): Record<string, unknown>[] {
+    return [
+      {
+        tab: 'status',
+        title: 'Installation Info',
+        fields: [
+          { label: 'Install method', value: (installation.sourceLabel as string) || 'ComfyBuilder' },
+          { label: 'Distribution', value: (installation.distributionName as string) || '-' },
+          { label: 'Version', value: (installation.version as string) || '-' },
+        ],
+      },
+    ]
+  },
+
+  // A ComfyBuilder install is never discovered on disk: only the dev-platform
+  // flow creates one: so there is nothing to probe/adopt.
+  probeInstallation(): Record<string, unknown> | null {
+    return null
+  },
+
+  async install(installation: InstallationRecord, tools: InstallTools): Promise<void> {
+    const artifact = artifactFromRecord(installation)
+    const client = getBuilderClient()
+    // Phase 1: archive (code + environment). `installArtifact` verifies the
+    // sha256 when the artifact carries one and fails on a byte mismatch. A
+    // missing hash is skipped for the initial rollout (see the TODO there).
+    await installArtifact({
+      artifact,
+      client,
+      installPath: installation.installPath,
+      cacheDir: defaultDownloadCacheDir(),
+      onProgress: (p: InstallProgress) => {
+        // The library's `resolve` phase has no labeled step; fold it into the
+        // download step at 0% so the stepper still shows forward motion.
+        const phase = p.phase === 'resolve' ? 'download' : p.phase
+        tools.sendProgress(phase, { percent: p.percent, status: p.detail ?? '' })
+      },
+      ...(tools.signal ? { signal: tools.signal } : {}),
+    })
+
+    // Phase 2: models. The archive carries no weights, so stage the
+    // distribution's declared models into the install's ComfyUI model tree
+    // before launch, the way comfy-deploy provisions a volume before boot. An
+    // empty manifest stages nothing and the step completes immediately.
+    const manifest = await resolveModelManifest(
+      client,
+      installation.distributionId as string,
+      installation.version as string,
+    )
+    await stageModels({
+      models: manifest.models,
+      installPath: installation.installPath,
+      onProgress: (p: StageProgress) =>
+        tools.sendProgress('models', { percent: p.percent, status: `${p.filename} (${p.index}/${p.total})` }),
+      ...(tools.signal ? { signal: tools.signal } : {}),
+    })
+    tools.sendProgress('models', { percent: 100, status: '' })
+  },
+
+  async handleAction(actionId: string): Promise<ActionResult> {
+    return { ok: false, message: `Action "${actionId}" not yet implemented.` }
+  },
+}

--- a/src/main/sources/index.ts
+++ b/src/main/sources/index.ts
@@ -4,8 +4,9 @@ import { gitSource } from './git'
 import { remote } from './remote'
 import { cloud } from './cloud'
 import { desktop } from './desktop'
+import { comfybuilder } from './comfybuilder'
 import type { SourcePlugin } from '../types/sources'
 
-const sources: SourcePlugin[] = [standalone, portable, gitSource, cloud, remote, desktop]
+const sources: SourcePlugin[] = [standalone, portable, gitSource, cloud, remote, desktop, comfybuilder]
 
 export default sources

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -200,6 +200,26 @@ export function buildElectronApi(): ElectronApi {
     getInstallsInventory: () => ipcRenderer.invoke('get-installs-inventory'),
     getDeviceId: () => ipcRenderer.invoke('get-device-id'),
 
+    // Dev platform (cloud auth + comfy-builder). Tokens never cross IPC; these
+    // only ever carry AuthStatus / Workspace / distribution display rows.
+    comfybuilder: {
+      signIn: () => ipcRenderer.invoke('comfybuilder:signIn'),
+      signOut: () => ipcRenderer.invoke('comfybuilder:signOut'),
+      getAuthStatus: () => ipcRenderer.invoke('comfybuilder:getAuthStatus'),
+      onAuthChanged: (callback) => {
+        const handler = (_event: IpcRendererEvent, status: unknown) =>
+          callback(status as Parameters<typeof callback>[0])
+        ipcRenderer.on('comfybuilder:authChanged', handler)
+        return () => ipcRenderer.removeListener('comfybuilder:authChanged', handler)
+      },
+      listWorkspaces: () => ipcRenderer.invoke('comfybuilder:listWorkspaces'),
+      switchWorkspace: (workspaceId) =>
+        ipcRenderer.invoke('comfybuilder:switchWorkspace', workspaceId),
+      listDistributions: () => ipcRenderer.invoke('comfybuilder:listDistributions'),
+      installDistribution: (distributionId) =>
+        ipcRenderer.invoke('comfybuilder:installDistribution', distributionId)
+    },
+
     // Model downloads
     listModelDownloads: () => ipcRenderer.invoke('model-download-list'),
     pauseModelDownload: (url) => ipcRenderer.invoke('model-download-pause', { url }),

--- a/src/renderer/src/devplatform/types.ts
+++ b/src/renderer/src/devplatform/types.ts
@@ -1,0 +1,11 @@
+/**
+ * Renderer-facing dev-platform types.
+ *
+ * The wire shapes live in `src/types/ipc.ts` (the single IPC source of truth);
+ * this file just re-exports them under the shorter names the views use, so a
+ * component imports `Distribution` from one local place.
+ */
+import type { DevPlatformDistribution, DevPlatformDistributionState } from '../../../types/ipc'
+
+export type Distribution = DevPlatformDistribution
+export type DistributionState = DevPlatformDistributionState

--- a/src/renderer/src/lib/progressWeights.test.ts
+++ b/src/renderer/src/lib/progressWeights.test.ts
@@ -56,6 +56,14 @@ describe('getPhaseWeights', () => {
     expect(w.extract).toBe(0.3)
   })
 
+  it('uses the curated table for a comfybuilder distribution install', () => {
+    const w = getPhaseWeights(steps('download', 'extract', 'models'))
+    expect(sum(w)).toBeCloseTo(1.0, 5)
+    // Archive download dominates; models must not steal its share via equal split.
+    expect(w.download).toBeGreaterThan(w.extract)
+    expect(w.download).toBeGreaterThan(w.models)
+  })
+
   it('falls back to equal weights for an unknown weightless fingerprint', () => {
     const w = getPhaseWeights(steps('a', 'b', 'c', 'd'))
     expect(w).toEqual({ a: 0.25, b: 0.25, c: 0.25, d: 0.25 })

--- a/src/renderer/src/lib/progressWeights.ts
+++ b/src/renderer/src/lib/progressWeights.ts
@@ -36,6 +36,13 @@ const TABLES: Record<string, Record<string, number>> = {
     download: 0.70,
     extract: 0.30,
   },
+  // ComfyBuilder distribution install: archive download dominates wall time;
+  // model staging varies but is small when a distribution declares few/none.
+  'download|extract|models': {
+    download: 0.65,
+    extract: 0.15,
+    models: 0.20,
+  },
   // Legacy Desktop migrate
   migration: {
     migration: 1.0,

--- a/src/renderer/src/stores/authStore.test.ts
+++ b/src/renderer/src/stores/authStore.test.ts
@@ -1,0 +1,91 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises } from '@vue/test-utils'
+
+import { useAuthStore } from './authStore'
+
+const api = {
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+  getAuthStatus: vi.fn(),
+  onAuthChanged: vi.fn(() => () => {}),
+  listWorkspaces: vi.fn(),
+  switchWorkspace: vi.fn(),
+  listDistributions: vi.fn(),
+  installDistribution: vi.fn()
+}
+
+/** Capture the renderer-side auth-change listener the store registers. */
+let authChangedCb: ((status: unknown) => void) | undefined
+
+describe('useAuthStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    authChangedCb = undefined
+    api.onAuthChanged.mockImplementation((cb: (status: unknown) => void) => {
+      authChangedCb = cb
+      return () => {}
+    })
+    api.getAuthStatus.mockResolvedValue({ signedIn: false })
+    ;(globalThis as unknown as { window: unknown }).window = { api: { comfybuilder: api } }
+  })
+
+  afterEach(() => {
+    delete (globalThis as unknown as { window?: unknown }).window
+  })
+
+  it('hydrates status from the persisted session on creation', async () => {
+    api.getAuthStatus.mockResolvedValue({ signedIn: true, email: 'a@b.c' })
+    const store = useAuthStore()
+    await flushPromises()
+    expect(store.status.email).toBe('a@b.c')
+    expect(store.isSignedIn).toBe(true)
+  })
+
+  it('signIn updates the status', async () => {
+    api.signIn.mockResolvedValue({ signedIn: true, email: 'x@y.z', workspaceId: 'w1' })
+    const store = useAuthStore()
+    await store.signIn()
+    expect(store.status).toMatchObject({ signedIn: true, workspaceId: 'w1' })
+  })
+
+  it('fetchDistributions pulls rows only when signed in', async () => {
+    const store = useAuthStore()
+    // Signed out: no call, empty list.
+    expect(await store.fetchDistributions()).toEqual([])
+    expect(api.listDistributions).not.toHaveBeenCalled()
+
+    api.signIn.mockResolvedValue({ signedIn: true })
+    await store.signIn()
+    api.listDistributions.mockResolvedValue([{ id: 'd1', name: 'Image', state: 'installable' }])
+    const rows = await store.fetchDistributions()
+    expect(rows).toEqual([{ id: 'd1', name: 'Image', state: 'installable' }])
+    expect(store.distributions).toHaveLength(1)
+  })
+
+  it('switchWorkspace adopts the new status and drops the stale distribution cache', async () => {
+    api.signIn.mockResolvedValue({ signedIn: true, workspaceId: 'w1' })
+    const store = useAuthStore()
+    await store.signIn()
+    store.distributions = [{ id: 'd1', name: 'Old', state: 'installable' }]
+
+    api.switchWorkspace.mockResolvedValue({ signedIn: true, workspaceId: 'w2', workspaceType: 'team' })
+    await store.switchWorkspace('w2')
+    expect(store.status).toMatchObject({ workspaceId: 'w2' })
+    expect(store.distributions).toEqual([])
+  })
+
+  it('a pushed sign-out clears scoped state', async () => {
+    api.signIn.mockResolvedValue({ signedIn: true, workspaceId: 'w1' })
+    const store = useAuthStore()
+    await store.signIn()
+    store.workspaces = [{ id: 'w1', name: 'W1', type: 'team', role: 'owner' }]
+    store.distributions = [{ id: 'd1', name: 'D', state: 'installable' }]
+
+    authChangedCb?.({ signedIn: false })
+    expect(store.isSignedIn).toBe(false)
+    expect(store.workspaces).toEqual([])
+    expect(store.distributions).toEqual([])
+  })
+})

--- a/src/renderer/src/stores/authStore.ts
+++ b/src/renderer/src/stores/authStore.ts
@@ -1,0 +1,136 @@
+import { computed, onScopeDispose, ref } from 'vue'
+import { defineStore } from 'pinia'
+
+import type { AuthStatus, ElectronApi, Workspace } from '../../../types/ipc'
+import type { Distribution } from '../devplatform/types'
+
+/**
+ * Dev-platform session store: the renderer's single source of auth + workspace
+ * + distribution state.
+ *
+ * It only ever holds renderer-safe data (AuthStatus / Workspace / distribution
+ * display rows); tokens live in the main process. Every mutation goes through
+ * `window.api.comfybuilder`, and `onAuthChanged` keeps the store in lockstep
+ * with a sign-in / switch / sign-out that originated anywhere.
+ */
+export const useAuthStore = defineStore('auth', () => {
+  const status = ref<AuthStatus>({ signedIn: false })
+  const workspaces = ref<Workspace[]>([])
+  const distributions = ref<Distribution[]>([])
+  const loadingWorkspaces = ref(false)
+  const loadingDistributions = ref(false)
+  const comfybuilderApi = (window as Window & { api: ElectronApi }).api.comfybuilder
+
+  /** Bumped on every authoritative status change (push, sign-in, switch,
+   *  sign-out) so a slower in-flight pull can never overwrite a newer status. */
+  let revision = 0
+
+  /** Drop workspace-scoped caches: the list and the distributions both belong
+   *  to the token's single workspace, so a switch/sign-out invalidates them. */
+  function resetScopedState(): void {
+    workspaces.value = []
+    distributions.value = []
+  }
+
+  async function fetchStatus(): Promise<AuthStatus> {
+    const seen = revision
+    const next = await comfybuilderApi.getAuthStatus()
+    if (revision === seen && next) status.value = next
+    return next
+  }
+
+  /** Run the PKCE browser handoff. Rethrows failures so callers own the
+   *  feedback; a completed sign-in also lands via `onAuthChanged`. */
+  async function signIn(): Promise<AuthStatus> {
+    const next = await comfybuilderApi.signIn()
+    revision += 1
+    status.value = next
+    return next
+  }
+
+  async function signOut(): Promise<AuthStatus> {
+    await comfybuilderApi.signOut()
+    revision += 1
+    status.value = { signedIn: false }
+    resetScopedState()
+    return status.value
+  }
+
+  /** The workspaces the signed-in user belongs to (for the switcher). */
+  async function fetchWorkspaces(): Promise<Workspace[]> {
+    if (!status.value.signedIn) {
+      workspaces.value = []
+      return workspaces.value
+    }
+    const seen = revision
+    loadingWorkspaces.value = true
+    try {
+      const next = await comfybuilderApi.listWorkspaces()
+      if (revision === seen) workspaces.value = next
+      return workspaces.value
+    } finally {
+      if (revision === seen) loadingWorkspaces.value = false
+    }
+  }
+
+  /** Switch the active workspace (re-runs the browser handoff pre-selecting it).
+   *  The new status also arrives via `onAuthChanged`; the scoped caches are
+   *  dropped so the distribution grid re-fetches for the new workspace. */
+  async function switchWorkspace(workspaceId: string): Promise<AuthStatus> {
+    const next = await comfybuilderApi.switchWorkspace(workspaceId)
+    revision += 1
+    status.value = next
+    distributions.value = []
+    return next
+  }
+
+  const unsubscribe = comfybuilderApi.onAuthChanged((nextStatus) => {
+    revision += 1
+    status.value = nextStatus
+    if (!nextStatus.signedIn) resetScopedState()
+    else distributions.value = []
+  })
+
+  // Hydrate from the persisted session once at creation: main only pushes
+  // CHANGES, so the boot state has to be pulled. The revision guard keeps
+  // this pull from overwriting anything newer.
+  void fetchStatus().catch(() => {})
+
+  onScopeDispose(() => {
+    unsubscribe?.()
+  })
+
+  const isSignedIn = computed(() => status.value.signedIn)
+
+  /** The distributions published to the signed-in workspace, as display rows. */
+  async function fetchDistributions(): Promise<Distribution[]> {
+    if (!isSignedIn.value) {
+      distributions.value = []
+      return distributions.value
+    }
+    const seen = revision
+    loadingDistributions.value = true
+    try {
+      const next = await comfybuilderApi.listDistributions()
+      if (revision === seen) distributions.value = next
+      return distributions.value
+    } finally {
+      if (revision === seen) loadingDistributions.value = false
+    }
+  }
+
+  return {
+    status,
+    workspaces,
+    distributions,
+    loadingWorkspaces,
+    loadingDistributions,
+    isSignedIn,
+    fetchStatus,
+    signIn,
+    signOut,
+    fetchWorkspaces,
+    switchWorkspace,
+    fetchDistributions,
+  }
+})

--- a/src/renderer/src/views/ChooserView.test.ts
+++ b/src/renderer/src/views/ChooserView.test.ts
@@ -332,7 +332,7 @@ describe('ChooserView', () => {
     expect(wrapper.emitted('pick')).toHaveLength(1)
   })
 
-  it('shows a relative recency line for a booted install and "not launched yet" for a fresh one', async () => {
+  it('gives install tiles two lines — no launch-recency row, booted or not', async () => {
     installMockApi([
       makeInstall({ id: 'booted', name: 'Booted', lastLaunchedAt: Date.now() - 2 * 60_000 }),
       makeInstall({ id: 'fresh', name: 'Fresh' }),
@@ -342,8 +342,10 @@ describe('ChooserView', () => {
     const tiles = wrapper.findAll('.chooser-tile')
     const bootedTile = tiles.find((t) => t.text().includes('Booted'))!
     const freshTile = tiles.find((t) => t.text().includes('Fresh'))!
-    expect(bootedTile.find('.chooser-tile-recency-text').text()).toContain('Launched')
-    expect(freshTile.find('.chooser-tile-recency-text').text()).toBe('Not launched yet')
+    expect(bootedTile.find('.chooser-tile-recency-text').exists()).toBe(false)
+    expect(freshTile.find('.chooser-tile-recency-text').exists()).toBe(false)
+    // The facts that survive keep their row.
+    expect(bootedTile.find('.chooser-tile-meta-line').exists()).toBe(true)
   })
 
   it('renders the update affordance as a bare "Update" pill — the target version lives in the meta line', async () => {

--- a/src/renderer/src/views/ChooserView.test.ts
+++ b/src/renderer/src/views/ChooserView.test.ts
@@ -70,6 +70,8 @@ interface MockApi {
   // progressStore subscribes to onErrorDetail at construction time.
   onErrorDetail: ReturnType<typeof vi.fn>
   focusComfyWindow: ReturnType<typeof vi.fn>
+  // authStore reads window.api.comfybuilder at construction time.
+  comfybuilder: Record<string, ReturnType<typeof vi.fn>>
 }
 
 function installMockApi(initial: Installation[]): MockApi {
@@ -81,6 +83,16 @@ function installMockApi(initial: Installation[]): MockApi {
     runAction: vi.fn().mockResolvedValue({ ok: true }),
     onErrorDetail: vi.fn(() => () => {}),
     focusComfyWindow: vi.fn().mockResolvedValue(true),
+    comfybuilder: {
+      getAuthStatus: vi.fn().mockResolvedValue({ signedIn: false }),
+      onAuthChanged: vi.fn(() => () => {}),
+      signIn: vi.fn(),
+      signOut: vi.fn(),
+      listWorkspaces: vi.fn().mockResolvedValue([]),
+      switchWorkspace: vi.fn(),
+      listDistributions: vi.fn().mockResolvedValue([]),
+      installDistribution: vi.fn(),
+    },
   }
   ;(window as unknown as { api: MockApi }).api = api
   return api

--- a/src/renderer/src/views/ChooserView.vue
+++ b/src/renderer/src/views/ChooserView.vue
@@ -108,8 +108,7 @@ const {
   activeFilter,
   visibleInstalls,
   showEmptyHint,
-  matchesQuery,
-  lastLaunchedLabel
+  matchesQuery
 } = useInstallList({ installations: installationsRef })
 
 // Explicitly expose `activeFilter` so the brand-redesign tests can
@@ -391,7 +390,6 @@ function handleNewInstallClick(): void {
           :key="inst.id"
           :installation="inst"
           :is-stopped-action-gated="isStoppedActionGated(inst)"
-          :last-launched-label="lastLaunchedLabel(inst)"
           @pick="pickInstall"
           @open-card-menu="openCardMenu"
           @open-kebab-menu="openKebabMenu"

--- a/src/renderer/src/views/ChooserView.vue
+++ b/src/renderer/src/views/ChooserView.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { computed, onMounted, toRef } from 'vue'
+import { computed, onMounted, toRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useInstallationStore } from '../stores/installationStore'
 import { useSessionStore } from '../stores/sessionStore'
+import { useAuthStore } from '../stores/authStore'
 import { useInstallContextMenu } from '../composables/useInstallContextMenu'
 import { useInstallList } from '../composables/useInstallList'
 import { useCloudCapacity } from '../composables/useCloudCapacity'
@@ -13,7 +14,10 @@ import BrandBackground from '../components/BrandBackground.vue'
 import BaseInput from '../components/ui/BaseInput.vue'
 import ComfyWordmark from '../components/icons/ComfyWordmark.vue'
 import ChooserInstallTile from './chooser/ChooserInstallTile.vue'
+import DevPlatformAccountChip from './devplatform/DevPlatformAccountChip.vue'
+import DevPlatformDistributionCard from './devplatform/DevPlatformDistributionCard.vue'
 import { resolvePickerTab } from '../lib/pickerTabs'
+import type { Distribution } from '../devplatform/types'
 import type { Installation, ShowProgressOpts } from '../types/ipc'
 
 /**
@@ -24,12 +28,18 @@ import type { Installation, ShowProgressOpts } from '../types/ipc'
  * entry.
  *
  * Layout:
+ *   - Top-right: dev-platform account chip (log-in button when signed out;
+ *     workspace switcher when signed in).
  *   - Top-left: "New Install" (always present).
  *   - Following: every install (local / cloud / remote) ordered by
  *     `lastLaunchedAt` desc, never-launched at the end.
+ *   - Then, when signed in, one tile per distribution published to the
+ *     workspace that isn't installed yet: installing a distribution is the
+ *     SAME GESTURE as launching an existing install: one tile, one click.
  *   - Filter chips above the grid narrow by source category.
  *
- * Per-install tile rendering lives in `chooser/ChooserInstallTile.vue`.
+ * Per-install tile rendering lives in `chooser/ChooserInstallTile.vue`;
+ * per-distribution tiles in `devplatform/DevPlatformDistributionCard.vue`.
  */
 
 const props = withDefaults(
@@ -57,6 +67,7 @@ const emit = defineEmits<{
 const { t } = useI18n()
 const installationStore = useInstallationStore()
 const sessionStore = useSessionStore()
+const authStore = useAuthStore()
 const modal = useModal()
 
 onMounted(() => {
@@ -64,6 +75,20 @@ onMounted(() => {
     void installationStore.fetchInstallations()
   }
 })
+
+// Sign-in / workspace-switch can happen ON this page (the chip), so the
+// distribution list follows the session rather than mount timing. Keying on the
+// workspace id (not just signed-in) is what re-fetches after a switch, where the
+// store clears the grid but signed-in stays true.
+watch(
+  () => [authStore.isSignedIn, authStore.status.workspaceId] as const,
+  () => {
+    if (authStore.isSignedIn && authStore.distributions.length === 0) {
+      void authStore.fetchDistributions().catch(() => {})
+    }
+  },
+  { immediate: true }
+)
 
 // Filter / search / recency logic is shared with the title-bar
 // instance picker popover via `useInstallList` so the two surfaces
@@ -78,8 +103,14 @@ onMounted(() => {
 // flow through `visibleInstalls` like every other source — there is no
 // special cloud surface anymore.
 const installationsRef = toRef(installationStore, 'installations')
-const { searchQuery, activeFilter, visibleInstalls, showEmptyHint, lastLaunchedLabel } =
-  useInstallList({ installations: installationsRef })
+const {
+  searchQuery,
+  activeFilter,
+  visibleInstalls,
+  showEmptyHint,
+  matchesQuery,
+  lastLaunchedLabel
+} = useInstallList({ installations: installationsRef })
 
 // Explicitly expose `activeFilter` so the brand-redesign tests can
 // drive the underlying filter state without the chip UI mounted.
@@ -87,12 +118,88 @@ const { searchQuery, activeFilter, visibleInstalls, showEmptyHint, lastLaunchedL
 // doesn't reference the ref directly (chips are TODO(brand-cleanup)).
 defineExpose({ activeFilter })
 
+// --- Comfy Builder distributions ---
+//
+// ORDERING: New install → existing installs → distributions. Existing installs
+// are what the user returns to and their position is muscle memory, so the
+// "things I could add" family goes last.
+//
+// DE-DUPLICATION: an already-installed distribution is an ordinary
+// installation and must not be listed twice. `installation.distributionId`
+// when the comfybuilder install carries it (the index signature passes it
+// through), else case-insensitive name equality: an install created from a
+// distribution inherits its name.
+function installationBacksDistribution(inst: Installation, dist: Distribution): boolean {
+  const linked = inst.distributionId
+  if (typeof linked === 'string' && linked.length > 0) return linked === dist.id
+  // Name-match is a fallback only for a comfybuilder install; never let an
+  // unrelated same-named local install hide a distribution tile.
+  if (inst.sourceId !== 'comfybuilder') return false
+  return inst.name.trim().toLowerCase() === dist.name.trim().toLowerCase()
+}
+
+/** Every distribution that earns a tile, before search. Empty when signed out. */
+const chooserDistributions = computed<Distribution[]>(() => {
+  if (!authStore.isSignedIn) return []
+  return authStore.distributions.filter(
+    (dist) =>
+      !installationStore.installations.some((inst) => installationBacksDistribution(inst, dist))
+  )
+})
+
+/** Search filters distributions through the SAME query as the install tiles. */
+const visibleDistributions = computed<Distribution[]>(() =>
+  chooserDistributions.value.filter((dist) => matchesQuery(dist.name))
+)
+
+/** The no-matches hint may only fire when NOTHING in the grid matches. */
+const showNoMatches = computed(() => showEmptyHint.value && visibleDistributions.value.length === 0)
+
+/** One quiet line under the grid when the signed-in workspace has nothing
+ *  published. Never a panel: this page already has content. */
+const distributionNote = computed(() => {
+  if (!authStore.isSignedIn) return ''
+  if (searchQuery.value.trim()) return ''
+  if (authStore.loadingDistributions) return ''
+  if (authStore.distributions.length === 0) return t('devPlatform.distribution.emptyTitle')
+  return ''
+})
+
+/**
+ * Install a distribution: main resolves the host artifact + creates the record,
+ * then we drive the SAME `installInstance` + progress UI every other install
+ * uses (via the `show-progress` event PanelApp already handles). A blocked tile
+ * never reaches here: the card suppresses its own activation.
+ */
+async function handleDistributionActivate(dist: Distribution): Promise<void> {
+  const result = await window.api.comfybuilder.installDistribution(dist.id).catch((err: unknown) => ({
+    ok: false as const,
+    message: (err as Error)?.message || String(err)
+  }))
+  if (!result.ok || !result.entry) {
+    await modal.alert({
+      title: t('errors.installFailed'),
+      message: result.message || t('devPlatform.distribution.installFailed')
+    })
+    return
+  }
+  emit('show-progress', {
+    installationId: result.entry.id,
+    title: `${t('newInstall.installing')}: ${result.entry.name}`,
+    apiCall: () => window.api.installInstance(result.entry!.id),
+    autoLaunchOnFinish: true,
+    opKind: 'install'
+  })
+}
+
 // --- Cluster top offset ---
 
-/** Unfiltered tile count: New Install + every install (cloud included).
- *  Reads the raw list, not `visibleInstalls`, so search never shifts the
- *  cluster. */
-const baseTileCount = computed(() => 1 + installationStore.installations.length)
+/** Unfiltered tile count: New Install + every install (cloud included) + every
+ *  distribution. Reads the raw lists, not the `visible*` ones, so search never
+ *  shifts the cluster. */
+const baseTileCount = computed(
+  () => 1 + installationStore.installations.length + chooserDistributions.value.length
+)
 
 const TILES_PER_ROW = 4
 
@@ -232,6 +339,13 @@ function handleNewInstallClick(): void {
 <template>
   <BrandBackground v-show="props.visible" class="chooser-bg">
     <div class="chooser-view" :style="{ '--rows': clusterRows }">
+      <!-- Identity, top-right: the account chip when signed in, a quiet log-in
+           button when not. Absolutely positioned so it never enters the
+           centered wordmark → search → grid column. -->
+      <div class="chooser-account">
+        <DevPlatformAccountChip />
+      </div>
+
       <ComfyWordmark class="chooser-wordmark" aria-hidden="true" />
       <div class="chooser-search">
         <BaseInput
@@ -250,7 +364,7 @@ function handleNewInstallClick(): void {
         {{ t('common.loading') }}
       </div>
 
-      <div v-else-if="showEmptyHint" class="chooser-empty">
+      <div v-else-if="showNoMatches" class="chooser-empty">
         {{ t('chooser.noMatches') }}
       </div>
 
@@ -285,7 +399,20 @@ function handleNewInstallClick(): void {
           @view-error="viewError"
           @view-danger="viewDanger"
         />
+
+        <!-- Distributions: siblings of the install tiles, same box, same
+             TransitionGroup, so installing one is the same gesture as
+             launching an install. Blocked states render WITH their reason and
+             are never filtered out: the card owns that treatment. -->
+        <DevPlatformDistributionCard
+          v-for="dist in visibleDistributions"
+          :key="`dist:${dist.id}`"
+          :distribution="dist"
+          @select="handleDistributionActivate(dist)"
+        />
       </TransitionGroup>
+
+      <p v-if="distributionNote" class="chooser-dist-note">{{ distributionNote }}</p>
 
       <ContextMenu
         :open="ctxMenu.open"
@@ -352,6 +479,31 @@ function handleNewInstallClick(): void {
   max-width: 1280px;
   padding: var(--chooser-pad-y) 24px;
   row-gap: var(--chooser-row-gap);
+}
+
+/* Account chip: pinned to the frame's top-right, out of the centered column
+ * so it can never collide with the wordmark or the search field. */
+.chooser-account {
+  position: absolute;
+  top: var(--chooser-pad-y);
+  right: 24px;
+  z-index: 2;
+  display: flex;
+  justify-content: flex-end;
+  max-width: min(340px, 45%);
+}
+
+/* Quiet one-liner for the distribution family's empty story. Lives in the
+ * bottom spacer row so it costs the centered cluster no layout; on a short
+ * window the spacer collapses and this caption is the first thing to go. */
+.chooser-dist-note {
+  grid-row: 5;
+  align-self: start;
+  margin: 0;
+  padding-top: 4px;
+  font-size: var(--takeover-fs-caption);
+  color: var(--text-muted);
+  text-align: center;
 }
 
 .chooser-wordmark {

--- a/src/renderer/src/views/chooser/ChooserInstallTile.vue
+++ b/src/renderer/src/views/chooser/ChooserInstallTile.vue
@@ -13,8 +13,6 @@ interface Props {
   installation: Installation
   /** True when REQUIRES_STOPPED actions (update / migrate / restore / delete) are gated. */
   isStoppedActionGated: boolean
-  /** Pre-formatted recency label — "Launched 3h ago" / "Not launched yet". */
-  lastLaunchedLabel: string
 }
 
 const props = defineProps<Props>()
@@ -109,14 +107,6 @@ const actionPill = computed(() => {
   return null
 })
 
-/** Precise fallback for the relative recency label; empty when never booted. */
-const absoluteLaunchedTime = computed(() => {
-  const ts = inst.value.lastLaunchedAt
-  return typeof ts === 'number'
-    ? new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(ts)
-    : ''
-})
-
 function handleClick(): void {
   if (isStopping.value) return
   emit('pick', inst.value)
@@ -197,23 +187,17 @@ function triggerInstallAction(action: 'update' | 'migrate'): void {
       </button>
     </div>
 
-    <!-- Stacked tiers (name → meta → recency); each truncates on its own row. -->
+    <!-- Two lines: name, then one row with the meta facts left and the
+         action pill (update / migrate) pinned right. -->
     <div class="chooser-tile-body">
       <TruncatedText class="chooser-tile-name" :text="inst.name" />
-      <TruncatedText v-if="metaLine" class="chooser-tile-meta-line" :text="metaLine">
-        <span v-if="sourceLabel" class="chooser-tile-meta-source">{{ sourceLabel }}</span>
-        <span v-if="sourceLabel && inst.version" class="chooser-tile-meta-sep">·</span>
-        <span v-if="inst.version" class="chooser-tile-meta-version">{{ inst.version }}</span>
-      </TruncatedText>
-      <div class="chooser-tile-footer">
-        <Tooltip
-          class="chooser-tile-recency"
-          :text="absoluteLaunchedTime"
-          :disabled="!absoluteLaunchedTime"
-        >
-          <span class="chooser-tile-recency-text">{{ lastLaunchedLabel }}</span>
-        </Tooltip>
-        <!-- Action pill (update / migrate); pinned right, never truncates. -->
+      <div v-if="metaLine || actionPill" class="chooser-tile-footer">
+        <TruncatedText v-if="metaLine" class="chooser-tile-meta-line" :text="metaLine">
+          <span v-if="sourceLabel" class="chooser-tile-meta-source">{{ sourceLabel }}</span>
+          <span v-if="sourceLabel && inst.version" class="chooser-tile-meta-sep">·</span>
+          <span v-if="inst.version" class="chooser-tile-meta-version">{{ inst.version }}</span>
+        </TruncatedText>
+        <!-- Action pill; pinned right by its own margin, never truncates. -->
         <Tooltip v-if="actionPill" :text="actionPill.tooltip" class="chooser-tile-pill-action">
           <span
             class="chooser-tile-pill"

--- a/src/renderer/src/views/devplatform/DevPlatformAccountChip.vue
+++ b/src/renderer/src/views/devplatform/DevPlatformAccountChip.vue
@@ -1,0 +1,443 @@
+<script setup lang="ts">
+/**
+ * Account chip: persistent identity, top-right (the Docker Desktop pattern).
+ *
+ * Signed out it is one quiet log-in button that runs the browser handoff
+ * itself. Signed in it names the account AND the workspace on the chip face:
+ * a token carries exactly one workspace claim, so everything downstream
+ * belongs to whichever workspace this chip names; keeping it visible makes a
+ * wrong-workspace mistake self-correcting.
+ *
+ * The dropdown is a WORKSPACE SWITCHER: it lists the account's workspaces and
+ * switches the active one. A cloud PKCE token is scoped at consent time, so a
+ * switch re-runs the browser handoff pre-selecting the workspace (there is no
+ * silent re-scope); the chip shows a spinner on the row while that is out.
+ *
+ * Sign out confirms, because users reasonably fear it uninstalls what they
+ * installed. It does not: the confirm body says exactly that. Tone stays
+ * primary, never danger.
+ */
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { Check, ChevronDown, Loader2, LogIn, LogOut } from 'lucide-vue-next'
+import DevPlatformAvatar from './DevPlatformAvatar.vue'
+import { useAuthStore } from '../../stores/authStore'
+import { useDialogs } from '../../composables/useDialogs'
+
+const emit = defineEmits<{
+  /** Sign-out completed. Host decides whether anything else changes. */
+  'signed-out': []
+  /** The active workspace changed. Host re-pulls workspace-scoped data. */
+  'workspace-switched': []
+}>()
+
+const { t } = useI18n()
+const store = useAuthStore()
+const dialogs = useDialogs()
+
+const menuOpen = ref(false)
+const rootRef = ref<HTMLElement | null>(null)
+const faceRef = ref<HTMLElement | null>(null)
+const signingIn = ref(false)
+/** Workspace id currently being switched to, or null. Drives the row spinner
+ *  and blocks a second concurrent switch. */
+const switchingTo = ref<string | null>(null)
+
+const email = computed(() => store.status.email ?? '')
+
+/**
+ * The workspace named by the access token's single claim. Team ids double as
+ * the display name (the claims carry no human name: backend gap); personal
+ * workspaces are named by the product.
+ */
+const workspaceName = computed(() => {
+  const s = store.status
+  if (!s.signedIn) return ''
+  if (s.workspaceType === 'team' && s.workspaceId) return s.workspaceId
+  return t('devPlatform.workspace.personalLabel')
+})
+
+/** Human label for one workspace row. Personal workspaces get the product name. */
+function workspaceLabel(ws: { name: string; type: string }): string {
+  if (ws.type === 'team') return ws.name
+  return t('devPlatform.workspace.personalLabel')
+}
+
+const currentWorkspaceId = computed(() => store.status.workspaceId ?? null)
+
+function closeMenu(): void {
+  menuOpen.value = false
+}
+
+function toggleMenu(): void {
+  menuOpen.value = !menuOpen.value
+  // Opening the menu is when the switcher needs its list: pull it lazily so a
+  // signed-in user who never opens the menu never makes the call.
+  if (menuOpen.value && store.workspaces.length === 0) {
+    void store.fetchWorkspaces().catch(() => {})
+  }
+}
+
+/** Escape closes the menu wherever focus is: the menu is never a trap.
+ *  Focus returns to the trigger (APG menu pattern); pointer dismissal
+ *  deliberately doesn't refocus: that would steal focus from wherever
+ *  the user just clicked. */
+function onKeydown(e: KeyboardEvent): void {
+  if (e.key === 'Escape' && menuOpen.value) {
+    e.stopPropagation()
+    closeMenu()
+    faceRef.value?.focus()
+  }
+}
+
+function onPointerDown(e: MouseEvent): void {
+  if (!menuOpen.value) return
+  const target = e.target as Node | null
+  if (target && rootRef.value?.contains(target)) return
+  closeMenu()
+}
+
+onMounted(() => {
+  document.addEventListener('mousedown', onPointerDown)
+})
+onBeforeUnmount(() => {
+  document.removeEventListener('mousedown', onPointerDown)
+})
+
+async function onSignIn(): Promise<void> {
+  if (signingIn.value) return
+  signingIn.value = true
+  try {
+    await store.signIn()
+  } catch {
+    // Cancelled or failed browser handoff: the button simply re-arms.
+  } finally {
+    signingIn.value = false
+  }
+}
+
+async function onSelectWorkspace(workspaceId: string): Promise<void> {
+  // Already the active workspace, or a switch is already in flight.
+  if (workspaceId === currentWorkspaceId.value || switchingTo.value) return
+  switchingTo.value = workspaceId
+  try {
+    await store.switchWorkspace(workspaceId)
+    closeMenu()
+    emit('workspace-switched')
+  } catch {
+    // Cancelled or failed re-auth: the current workspace is unchanged.
+  } finally {
+    switchingTo.value = null
+  }
+}
+
+async function onSignOut(): Promise<void> {
+  closeMenu()
+  const result = await dialogs.confirm({
+    title: t('devPlatform.account.signOutConfirmTitle'),
+    // States plainly that installed distributions are KEPT and only stop
+    // receiving updates. This is the sentence that stops the support ticket.
+    message: t('devPlatform.account.signOutConfirmBody'),
+    confirmLabel: t('devPlatform.account.signOutConfirmCta'),
+    tone: 'primary',
+  })
+  if (result !== 'primary') return
+  try {
+    await store.signOut()
+  } catch {
+    // Sign-out IPC failed: stay visibly signed in rather than lie.
+    return
+  }
+  emit('signed-out')
+}
+</script>
+
+<template>
+  <div ref="rootRef" class="account-chip" @keydown="onKeydown">
+    <!-- Signed out: one quiet button. Deliberately not the yellow primary. -->
+    <button
+      v-if="!store.isSignedIn"
+      type="button"
+      class="brand-tertiary account-chip__signin"
+      data-testid="devplatform-account-signin"
+      :disabled="signingIn"
+      :aria-busy="signingIn"
+      @click="onSignIn"
+    >
+      <Loader2 v-if="signingIn" :size="16" class="account-chip__spinner" aria-hidden="true" />
+      <LogIn v-else :size="16" aria-hidden="true" />
+      <span>{{ $t('devPlatform.signIn.cta') }}</span>
+    </button>
+
+    <template v-else>
+      <button
+        ref="faceRef"
+        type="button"
+        class="account-chip__face"
+        data-testid="devplatform-account-chip"
+        :aria-expanded="menuOpen"
+        aria-haspopup="menu"
+        @click="toggleMenu"
+      >
+        <!-- Seeded from the workspace, not the account: the avatar reads as
+             "which workspace am I in", matching the rows in the menu. -->
+        <DevPlatformAvatar class="account-chip__avatar" :name="workspaceName || email || '?'" />
+        <!-- Account over workspace. The workspace needs no label: the avatar
+             beside it is the workspace's, so the second line reads as one. -->
+        <span class="account-chip__identity">
+          <span class="account-chip__email">{{ email }}</span>
+          <span v-if="workspaceName" class="account-chip__workspace-name">{{ workspaceName }}</span>
+        </span>
+        <ChevronDown
+          :size="14"
+          class="account-chip__caret"
+          :class="{ 'account-chip__caret--open': menuOpen }"
+          aria-hidden="true"
+        />
+      </button>
+
+      <div
+        v-if="menuOpen"
+        class="account-chip__menu"
+        role="menu"
+        :aria-label="$t('devPlatform.account.signedInAs', { email })"
+        data-testid="devplatform-account-menu"
+      >
+        <p class="account-chip__section-label">{{ $t('devPlatform.workspace.switchLabel') }}</p>
+
+        <div v-if="store.loadingWorkspaces && store.workspaces.length === 0" class="account-chip__hint">
+          {{ $t('common.loading') }}
+        </div>
+
+        <button
+          v-for="ws in store.workspaces"
+          :key="ws.id"
+          type="button"
+          class="account-chip__item account-chip__workspace-item"
+          role="menuitemradio"
+          :aria-checked="ws.id === currentWorkspaceId"
+          :disabled="switchingTo !== null"
+          :data-testid="`devplatform-workspace-${ws.id}`"
+          @click="onSelectWorkspace(ws.id)"
+        >
+          <DevPlatformAvatar class="account-chip__item-avatar" :name="workspaceLabel(ws)" />
+          <span class="account-chip__item-identity">
+            <span class="account-chip__item-name">{{ workspaceLabel(ws) }}</span>
+            <span v-if="ws.subscriptionTier" class="account-chip__item-sub">{{ ws.subscriptionTier }}</span>
+          </span>
+          <Loader2
+            v-if="switchingTo === ws.id"
+            :size="15"
+            class="account-chip__spinner"
+            aria-hidden="true"
+          />
+          <Check
+            v-else-if="ws.id === currentWorkspaceId"
+            :size="15"
+            class="account-chip__item-check"
+            aria-hidden="true"
+          />
+        </button>
+
+        <div class="account-chip__divider" role="separator"></div>
+
+        <button
+          type="button"
+          class="account-chip__item"
+          role="menuitem"
+          data-testid="devplatform-account-signout"
+          @click="onSignOut"
+        >
+          <LogOut :size="16" aria-hidden="true" />
+          <span>{{ $t('devPlatform.account.signOut') }}</span>
+        </button>
+      </div>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.account-chip {
+  position: relative;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-end;
+}
+
+.account-chip__signin {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.account-chip__spinner {
+  animation: account-chip-spin 900ms linear infinite;
+}
+@keyframes account-chip-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Chip face: frosted, quiet, and two-line so the workspace never has to be
+   truncated out of existence on a narrow window. Shares the 6px radius of
+   `button.brand-tertiary`: the signed-out control that occupies this same
+   slot: so the two states of one affordance keep one silhouette. */
+.account-chip__face {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  max-width: 320px;
+  padding: 6px 10px;
+  border-radius: 6px;
+  border: 1px solid color-mix(in oklab, var(--neutral-100) 10%, transparent);
+  background: color-mix(in oklab, var(--neutral-100) 5%, transparent);
+  color: var(--neutral-100);
+  font: inherit;
+  cursor: pointer;
+  transition:
+    background 120ms ease,
+    border-color 120ms ease;
+}
+.account-chip__face:hover {
+  background: color-mix(in oklab, var(--neutral-100) 10%, transparent);
+  border-color: color-mix(in oklab, var(--neutral-100) 18%, transparent);
+}
+.account-chip__face:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+/* The avatar is the square gradient one, seeded from the account email so the
+   same person renders in the same colour here and on the web frontend. */
+.account-chip__avatar {
+  --dp-avatar-size: 30px;
+}
+
+.account-chip__identity {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1px;
+  min-width: 0;
+  font-size: var(--takeover-fs-caption);
+  line-height: 1.3;
+}
+.account-chip__email {
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 600;
+  color: var(--neutral-100);
+}
+.account-chip__workspace-name {
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--neutral-200);
+}
+
+.account-chip__caret {
+  flex: 0 0 auto;
+  color: var(--neutral-200);
+  transition: transform 140ms ease;
+}
+.account-chip__caret--open {
+  transform: rotate(180deg);
+}
+
+/* Dropdown: anchored to the chip's top-right, opening downward. */
+.account-chip__menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 20;
+  min-width: 240px;
+  max-width: 320px;
+  padding: 6px;
+  border-radius: 10px;
+  border: 1px solid var(--brand-surface-border);
+  background: var(--chooser-surface-bg);
+  backdrop-filter: blur(18px);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+}
+
+.account-chip__section-label {
+  margin: 4px 8px 6px;
+  font-size: var(--takeover-fs-caption);
+  font-weight: 600;
+  color: var(--neutral-200);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.account-chip__hint {
+  padding: 8px;
+  font-size: var(--takeover-fs-caption);
+  color: var(--neutral-200);
+  opacity: 0.8;
+}
+
+.account-chip__item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--neutral-100);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background 120ms ease;
+}
+.account-chip__item:hover:not(:disabled) {
+  background: var(--brand-surface-bg-hover);
+}
+.account-chip__item:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: -2px;
+}
+.account-chip__item:disabled {
+  cursor: default;
+}
+
+.account-chip__workspace-item {
+  gap: 10px;
+}
+.account-chip__item-avatar {
+  --dp-avatar-size: 26px;
+}
+.account-chip__item-identity {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+.account-chip__item-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--takeover-fs-body);
+}
+.account-chip__item-sub {
+  font-size: var(--takeover-fs-caption);
+  color: var(--neutral-200);
+  text-transform: capitalize;
+}
+.account-chip__item-check {
+  flex: 0 0 auto;
+  color: var(--comfy-yellow);
+}
+
+.account-chip__divider {
+  height: 1px;
+  margin: 6px 4px;
+  background: var(--brand-surface-border);
+}
+</style>

--- a/src/renderer/src/views/devplatform/DevPlatformAvatar.vue
+++ b/src/renderer/src/views/devplatform/DevPlatformAvatar.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+/**
+ * Square gradient avatar: ported verbatim from the ComfyUI frontend's
+ * `WorkspaceProfilePic.vue` so the same subject renders the SAME colour here as
+ * in the web frontend. The PRNG and hue/sat/light maths are a wire format: any
+ * change silently breaks that cross-surface identity.
+ *
+ * Used for both the signed-in account (seeded from the email) and workspace
+ * rows (seeded from the workspace name): the colour is a deterministic
+ * function of whatever string it is given.
+ */
+import { computed } from 'vue'
+
+const { name } = defineProps<{
+  /** Subject the colour is derived from; only its first character is rendered. */
+  name: string
+}>()
+
+const letter = computed(() => name?.charAt(0)?.toUpperCase() || '?')
+
+/** mulberry32: the frontend's PRNG, ported verbatim. */
+function mulberry32(a: number): () => number {
+  return function () {
+    let t = (a += 0x6d2b79f5)
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+/** Two-stop gradient seeded from the letter. The rand() call ORDER and COUNT are
+ *  part of the contract: reordering or adding a call changes every colour.
+ *
+ *  The second stop's hue spread is narrowed against the frontend's 40-120°: at
+ *  that width the two stops read as two separate colours rather than one shaded
+ *  one. hue1/sat/light are untouched, so the colour family still matches. */
+const gradient = computed(() => {
+  const rand = mulberry32(letter.value.charCodeAt(0))
+  const hue1 = Math.floor(rand() * 360)
+  const hue2 = (hue1 + 18 + Math.floor(rand() * 24)) % 360
+  const sat = 65 + Math.floor(rand() * 20)
+  const light = 55 + Math.floor(rand() * 15)
+  return `linear-gradient(135deg, hsl(${hue1}, ${sat}%, ${light + 6}%), hsl(${hue2}, ${sat}%, ${light - 6}%))`
+})
+</script>
+
+<template>
+  <!-- Decorative: the subject's name is always rendered beside this avatar. -->
+  <span class="dp-avatar" :style="{ background: gradient }" aria-hidden="true">
+    {{ letter }}
+  </span>
+</template>
+
+<style scoped>
+.dp-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: var(--dp-avatar-size, 32px);
+  height: var(--dp-avatar-size, 32px);
+  border-radius: 6px;
+  overflow: hidden;
+  /* Paired to the generated gradient, not the app palette: same values as
+   * the frontend component this is ported from. */
+  color: #fff;
+  /* Scales with the box so the letter keeps the same optical weight at any size. */
+  font-size: calc(var(--dp-avatar-size, 32px) * 0.42);
+  font-weight: 600;
+  line-height: 1;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+  user-select: none;
+}
+</style>

--- a/src/renderer/src/views/devplatform/DevPlatformDistributionCard.vue
+++ b/src/renderer/src/views/devplatform/DevPlatformDistributionCard.vue
@@ -1,0 +1,172 @@
+<script setup lang="ts">
+/**
+ * One distribution, rendered as a chooser tile: a sibling of
+ * `views/chooser/ChooserInstallTile.vue`: same box, same classes, same type
+ * scale. Activating it is the same gesture as launching an existing install.
+ *
+ * NAME is the headline; version + size drop into the single meta row. Blocked
+ * states (no-build / platform-mismatch / needs-desktop-update) are shown with
+ * a short reason tag: full reason on `title`: and never hidden. No security
+ * chrome: these are ordinary pipeline facts, not threats.
+ *
+ * The footer answers the installation tile's recency question honestly: a
+ * distribution that isn't installed says "Not installed yet"; an installed one
+ * carries the build's "updated" stamp.
+ */
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { AlertCircle, ArrowDownToLine, Package } from 'lucide-vue-next'
+import TruncatedText from '../../components/TruncatedText.vue'
+import { formatBytesCoarse } from '../../lib/formatting'
+import { formatRelativeFromMs } from '../../lib/datetime'
+import type { Distribution, DistributionState } from '../../devplatform/types'
+
+const props = defineProps<{
+  distribution: Distribution
+}>()
+
+const emit = defineEmits<{
+  /** The user activated the tile: the host starts the install flow. */
+  select: []
+}>()
+
+const { t } = useI18n()
+
+/** The three states that cannot be installed. Shown with a reason, never hidden. */
+const BLOCKED_STATES: readonly DistributionState[] = [
+  'no-build',
+  'platform-mismatch',
+  'needs-desktop-update',
+]
+
+/** i18n suffix per blocked state: keys both the short tag label (`states.*`)
+ *  and the fallback long reason (`blockedReason.*`). */
+const BLOCKED_STATE_KEY: Record<string, string> = {
+  'no-build': 'noBuild',
+  'platform-mismatch': 'platformMismatch',
+  'needs-desktop-update': 'needsDesktopUpdate',
+}
+
+const isBlocked = computed(() => BLOCKED_STATES.includes(props.distribution.state))
+
+/** Present on this machine already: the two post-install states. */
+const isInstalledLocally = computed(
+  () => props.distribution.state === 'installed' || props.distribution.state === 'update-available'
+)
+
+const showAvailablePill = computed(() => props.distribution.state === 'installable')
+
+const blockedLabel = computed(() => {
+  if (!isBlocked.value) return ''
+  const suffix = BLOCKED_STATE_KEY[props.distribution.state] ?? 'noBuild'
+  return t(`devPlatform.distribution.states.${suffix}`)
+})
+
+/** Full-contrast explanation, carried on `title` so it eats no tile space. */
+const blockedReason = computed(() => {
+  if (!isBlocked.value) return ''
+  const suffix =
+    props.distribution.blockedReason ?? BLOCKED_STATE_KEY[props.distribution.state] ?? 'noBuild'
+  return t(`devPlatform.distribution.blockedReason.${suffix}`, {
+    version: props.distribution.minDesktopVersion ?? '',
+  })
+})
+
+const sizeLabel = computed(() =>
+  props.distribution.sizeBytes ? formatBytesCoarse(props.distribution.sizeBytes) : ''
+)
+
+/** Dot-separated facts row: version · size. Both optional. */
+const metaLine = computed(() =>
+  [props.distribution.version, sizeLabel.value].filter(Boolean).join(' · ')
+)
+
+const updatedLabel = computed(() => {
+  const iso = props.distribution.finishedAt
+  if (!iso) return ''
+  const ms = Date.parse(iso)
+  if (Number.isNaN(ms)) return ''
+  const rel = formatRelativeFromMs(ms, t)
+  return rel ? `${t('devPlatform.distribution.updatedLabel')} ${rel}` : ''
+})
+
+const footerLabel = computed(() => {
+  if (!isInstalledLocally.value) return t('devPlatform.distribution.installTileMeta')
+  return updatedLabel.value
+})
+
+function onActivate(): void {
+  if (isBlocked.value) return
+  emit('select')
+}
+</script>
+
+<template>
+  <div
+    class="chooser-tile chooser-tile--install dist-tile dist-tile--chooser"
+    :class="{ 'dist-tile--blocked': isBlocked }"
+    role="button"
+    tabindex="0"
+    :aria-disabled="isBlocked ? true : undefined"
+    :data-testid="`chooser-dist-tile-${distribution.id}`"
+    @click="onActivate"
+    @keydown.enter.prevent="onActivate"
+    @keydown.space.prevent="onActivate"
+  >
+    <!-- "Packaged environment" glyph: the one icon every distribution wears. -->
+    <span class="chooser-tile-icon" aria-hidden="true">
+      <Package :size="22" />
+    </span>
+
+    <div class="chooser-tile-actions">
+      <span
+        v-if="isBlocked"
+        class="chooser-tile-danger-tag dist-tile-tag--blocked"
+        :title="blockedReason"
+      >
+        <AlertCircle :size="12" aria-hidden="true" />
+        {{ blockedLabel }}
+      </span>
+      <!-- Update-available: the only state asking the user to act. -->
+      <span
+        v-else-if="distribution.state === 'update-available'"
+        class="chooser-tile-pill dist-tile-pill--update"
+      >
+        <ArrowDownToLine :size="11" aria-hidden="true" />
+        {{ t('devPlatform.distribution.states.updateAvailable') }}
+      </span>
+      <span
+        v-else-if="distribution.state === 'installed'"
+        class="chooser-tile-pill dist-tile-pill--installed"
+      >
+        {{ t('devPlatform.distribution.states.installed') }}
+      </span>
+      <!-- Says this tile is something you can ADD, which is what distinguishes
+           it from the installation tiles beside it. -->
+      <span v-else-if="showAvailablePill" class="chooser-tile-pill dist-tile-pill--available">
+        {{ t('devPlatform.distribution.availablePill') }}
+      </span>
+    </div>
+
+    <div class="chooser-tile-body">
+      <TruncatedText class="chooser-tile-name" :text="distribution.name" />
+      <TruncatedText v-if="metaLine" class="chooser-tile-meta-line" :text="metaLine">
+        <span v-if="distribution.version" class="chooser-tile-meta-version">
+          {{ distribution.version }}
+        </span>
+        <span v-if="distribution.version && sizeLabel" class="chooser-tile-meta-sep">·</span>
+        <span v-if="sizeLabel" class="chooser-tile-meta-source">{{ sizeLabel }}</span>
+      </TruncatedText>
+      <div class="chooser-tile-footer">
+        <span v-if="footerLabel" class="chooser-tile-recency">
+          <span class="chooser-tile-recency-text">{{ footerLabel }}</span>
+        </span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+@import '../chooser/chooser-tiles.css';
+@import './devplatform-tiles.css';
+</style>

--- a/src/renderer/src/views/devplatform/devplatform-tiles.css
+++ b/src/renderer/src/views/devplatform/devplatform-tiles.css
@@ -1,0 +1,100 @@
+/*
+ * Distribution-tile deltas on top of `views/chooser/chooser-tiles.css`.
+ *
+ * A distribution renders as a chooser tile: a visual sibling of an
+ * installed-instance tile, since that is the interface users already pick
+ * installs from. Everything structural (box, padding, radius, name → meta →
+ * footer stack, pill vocabulary) comes from chooser-tiles.css unchanged; this
+ * file adds only the blocked treatment, the pill tones, and the house
+ * focus ring.
+ */
+
+.dist-tile {
+  width: 100%;
+}
+
+/* House focus ring: overrides the chooser sheet's `--accent` fallback. */
+.dist-tile:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+/* --- Pills ---------------------------------------------------------------- */
+
+/* "Installed" is a fact, not a call to action. */
+.dist-tile-pill--installed {
+  color: var(--neutral-200);
+  border-color: var(--brand-surface-border);
+  background: var(--brand-surface-bg-hover);
+}
+
+/* "Available" answers the one question a distribution tile raises next to the
+ * installation tiles around it. Deliberately the quietest pill in the family. */
+.dist-tile-pill--available {
+  color: var(--neutral-200);
+  border-color: color-mix(in oklab, var(--neutral-100) 14%, transparent);
+  background: color-mix(in oklab, var(--neutral-100) 6%, transparent);
+}
+.dist-tile--chooser:hover .dist-tile-pill--available,
+.dist-tile--chooser:focus-visible .dist-tile-pill--available {
+  color: var(--neutral-100);
+}
+
+/* Update-available is the one state asking the user to act: warning tone. */
+.dist-tile-pill--update {
+  gap: 4px;
+  flex-shrink: 0;
+  opacity: 1;
+  color: var(--warning);
+  border-color: color-mix(in oklab, var(--warning) 45%, transparent);
+  background: color-mix(in oklab, var(--warning) 12%, transparent);
+}
+
+/* Blocked tag: the danger tag's shape, re-toned. Not a security signal: these
+ * are ordinary pipeline facts, so no lock icon, no red banner. The label stays
+ * full-contrast on a dimmed tile; the full reason rides on `title`. */
+.dist-tile-tag--blocked {
+  cursor: default;
+  color: var(--neutral-100);
+  border-color: color-mix(in oklab, var(--warning) 40%, transparent);
+  background: color-mix(in oklab, var(--warning) 10%, transparent);
+  max-width: 190px;
+  text-overflow: ellipsis;
+}
+.dist-tile-tag--blocked:hover,
+.dist-tile-tag--blocked:focus-visible {
+  /* No hover lift: the tag is a label, not a button. */
+  background: color-mix(in oklab, var(--warning) 10%, transparent);
+  transform: none;
+}
+
+/* --- Blocked tile ---------------------------------------------------------
+ * De-emphasised but readable, never hidden (product contract). The dim goes on
+ * the identity block, not the root: root opacity would drag the state label
+ * down with it. */
+.dist-tile--blocked {
+  cursor: default;
+}
+.dist-tile--blocked .chooser-tile-icon,
+.dist-tile--blocked .chooser-tile-name {
+  opacity: 0.62;
+}
+/* Meta + footer step UP to --neutral-200 instead of dimming: the faint tier
+ * multiplied by 0.62 would drop under the 3:1 contrast floor. */
+.dist-tile--blocked .chooser-tile-meta-line,
+.dist-tile--blocked .chooser-tile-meta-source,
+.dist-tile--blocked .chooser-tile-meta-sep,
+.dist-tile--blocked .chooser-tile-meta-version,
+.dist-tile--blocked .chooser-tile-recency-text {
+  color: var(--neutral-200);
+}
+/* Suppress the hover promise the tile cannot honour. */
+.dist-tile--blocked:hover {
+  background: var(--chooser-surface-bg);
+  border-color: var(--chooser-surface-border);
+}
+.dist-tile--blocked:hover .chooser-tile-icon,
+.dist-tile--blocked:hover .chooser-tile-name {
+  color: var(--neutral-100);
+  opacity: 0.62;
+}

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -4,6 +4,49 @@
 import type { FirstUseMode } from '../shared/firstUseMode'
 export type { FirstUseMode }
 
+// Dev-platform (cloud auth + comfy-builder) renderer-safe types. Re-exported
+// from the cloud library so the renderer imports them from one place; tokens
+// are never part of these shapes.
+import type { AuthStatus, Workspace } from '../main/cloud/types'
+export type { AuthStatus, Workspace }
+
+/** Every state a distribution tile can be in. The first four are pre-install;
+ *  the last two are local (renderer-owned via de-dup against installs). */
+export type DevPlatformDistributionState =
+  | 'installable'
+  | 'no-build'
+  | 'platform-mismatch'
+  | 'needs-desktop-update'
+  | 'installed'
+  | 'update-available'
+
+/** One distribution as a renderer-safe display row. The install-decision fields
+ *  (artifact id / download ref) stay main-side; the renderer installs by id. */
+export interface DevPlatformDistribution {
+  id: string
+  name: string
+  description?: string
+  version?: string
+  /** ISO 8601 finish stamp of the latest complete build. */
+  finishedAt?: string
+  sizeBytes?: number
+  numCustomNodes?: number
+  state: DevPlatformDistributionState
+  /** i18n suffix explaining a blocking state (see `devPlatform.distribution.blockedReason.*`). */
+  blockedReason?: string
+  minDesktopVersion?: string
+  /** Local-only: present for installed / update-available. */
+  installedVersion?: string
+}
+
+/** Kickoff result of `installDistribution`: mirrors `addInstallation` so the
+ *  renderer drives the same `installInstance` + progress flow. */
+export interface InstallDistributionResult {
+  ok: boolean
+  message?: string
+  entry?: { id: string; name: string }
+}
+
 // Unsubscribe function returned by event listeners
 export type Unsubscribe = () => void
 
@@ -1299,6 +1342,20 @@ export interface ElectronApi {
    *  stay under PostHog's 1 MB per-event limit (shipped as `installs_json`). */
   getInstallsInventory(): Promise<InstallsInventory>
   getDeviceId(): Promise<string>
+
+  // Dev platform (cloud auth + comfy-builder): the only renderer<->main bridge
+  // for this flow. Access/refresh tokens never cross IPC: every method returns
+  // or observes a renderer-safe AuthStatus / Workspace / distribution row.
+  comfybuilder: {
+    signIn(): Promise<AuthStatus>
+    signOut(): Promise<AuthStatus>
+    getAuthStatus(): Promise<AuthStatus>
+    onAuthChanged(callback: (status: AuthStatus) => void): Unsubscribe
+    listWorkspaces(): Promise<Workspace[]>
+    switchWorkspace(workspaceId: string): Promise<AuthStatus>
+    listDistributions(): Promise<DevPlatformDistribution[]>
+    installDistribution(distributionId: string): Promise<InstallDistributionResult>
+  }
 
   // Updates
   checkForUpdate(): Promise<{ available: boolean; version?: string; error?: string }>


### PR DESCRIPTION
First of four small chunks porting the chooser card design work onto the builder-ux stack. Targets `james/builder-ux` (#1313) so the UX iteration stays off the functionality review.

## What

Install tiles lose the third line — the `"Launched 3h ago"` / `"Not launched yet"` recency row. The meta facts and the update/migrate pill now share a single row.

## Why

Recency is already encoded in the grid's ordering (tiles sort by `lastLaunchedAt` desc, never-launched last), so the line restates what position already says. Removing it shortens every tile and gives the install name more room to breathe before truncating.

## Scope

Deliberately touches no distribution code — `ChooserInstallTile.vue` and `chooser-tiles.css` are byte-identical between this branch's base and where the design work started, so this lands clean and can be reviewed without builder-stack context.

## One call for the reviewer

`useInstallList.lastLaunchedLabel` loses its only consumer here. I left it in place — it still has five passing tests, and deleting a tested composable export felt like a decision for you rather than a drive-by. Say the word and I'll remove it with its tests.

## Testing

`ChooserView.test.ts` + `useInstallList.test.ts` pass (43 tests). The recency-line test is rewritten to pin the new contract: no recency row, meta line retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)