### PR TITLE
feat(chooser): kebab menu on distribution cards

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1141,6 +1141,7 @@
     },
     "distribution": {
       "availablePill": "Available",
+      "menuInstall": "Install",
       "updatedLabel": "Updated",
       "installTileMeta": "Not installed yet",
       "emptyTitle": "No distributions published to this workspace yet.",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -1141,6 +1141,7 @@
     },
     "distribution": {
       "availablePill": "可安装",
+      "menuInstall": "安装",
       "updatedLabel": "更新于",
       "installTileMeta": "尚未安装",
       "emptyTitle": "此工作区尚未发布任何分发版本。",

--- a/src/renderer/src/views/ChooserView.test.ts
+++ b/src/renderer/src/views/ChooserView.test.ts
@@ -5,11 +5,16 @@ import { createPinia, setActivePinia } from 'pinia'
 
 import ChooserView from './ChooserView.vue'
 import { useSessionStore } from '../stores/sessionStore'
-import type { Installation } from '../types/ipc'
+import type { DevPlatformDistribution, Installation } from '../types/ipc'
 
-// Stub the heavy ContextMenu child — we don't exercise menu interactions here.
+// Stub the heavy ContextMenu child. Props are declared so tests can assert what
+// the view HANDED the menu without rendering (or clicking through) the real one.
 vi.mock('../components/ContextMenu.vue', () => ({
-  default: { name: 'ContextMenu', template: '<div data-testid="context-menu" />' },
+  default: {
+    name: 'ContextMenu',
+    props: ['open', 'x', 'y', 'items'],
+    template: '<div data-testid="context-menu" />',
+  },
 }))
 
 // Test-controllable `useModal` mock — `viewError` routes its readable
@@ -53,6 +58,26 @@ const messages = {
       errorTitle: 'Error',
       updatePill: 'Update',
       migratePill: 'Migrate',
+    },
+    devPlatform: {
+      distribution: {
+        availablePill: 'Available',
+        menuInstall: 'Install',
+        updatedLabel: 'Updated',
+        installTileMeta: 'Not installed yet',
+        states: {
+          noBuild: 'No build',
+          platformMismatch: 'Not for this machine',
+          needsDesktopUpdate: 'Update required',
+          updateAvailable: 'Update',
+          installed: 'Installed',
+        },
+        blockedReason: {
+          noBuild: 'This distribution has no completed build yet.',
+          platformMismatch: 'No build for this platform.',
+          needsDesktopUpdate: 'Requires Desktop {version}.',
+        },
+      },
     },
   },
 }
@@ -106,6 +131,26 @@ function makeInstall(overrides: Partial<Installation>): Installation {
     sourceCategory: 'local',
     ...overrides,
   } as unknown as Installation
+}
+
+function makeDist(overrides: Partial<DevPlatformDistribution>): DevPlatformDistribution {
+  return {
+    id: 'dist-x',
+    name: 'Dist X',
+    state: 'installable',
+    ...overrides,
+  }
+}
+
+/** Sign in and publish `dists` to the workspace, so distribution cards render. */
+function installMockApiSignedIn(
+  installs: Installation[],
+  dists: DevPlatformDistribution[],
+): MockApi {
+  const api = installMockApi(installs)
+  api.comfybuilder.getAuthStatus.mockResolvedValue({ signedIn: true })
+  api.comfybuilder.listDistributions.mockResolvedValue(dists)
+  return api
 }
 
 function mountChooser() {
@@ -472,6 +517,49 @@ describe('ChooserView', () => {
     expect(labels.some((l) => l.includes('LocalThing'))).toBe(true)
     expect(labels.some((l) => l.includes('LegacyDesktopThing'))).toBe(true)
     expect(labels.some((l) => l.includes('RemoteThing'))).toBe(false)
+  })
+
+  it('gives distribution cards the same kebab as install tiles, opening an Install menu', async () => {
+    const api = installMockApiSignedIn([], [makeDist({ id: 'd1', name: 'Alpha Dist' })])
+    api.comfybuilder.installDistribution.mockResolvedValue({
+      ok: true,
+      entry: { id: 'new-inst', name: 'Alpha Dist' },
+    })
+    const wrapper = mountChooser()
+    await flushPromises()
+
+    const kebab = wrapper.find('[data-testid="chooser-dist-tile-kebab-d1"]')
+    expect(kebab.exists()).toBe(true)
+    await kebab.trigger('click')
+
+    const menu = wrapper
+      .findAllComponents({ name: 'ContextMenu' })
+      .find((m) => m.props('open') === true)!
+    expect(menu).toBeTruthy()
+    const items = menu.props('items') as { id: string; label: string; disabled?: boolean }[]
+    expect(items.map((i) => i.id)).toEqual(['install'])
+    expect(items[0]!.disabled).toBe(false)
+
+    // Selecting Install runs the same flow the card's own activation does.
+    menu.vm.$emit('select', 'install')
+    await flushPromises()
+    expect(api.comfybuilder.installDistribution).toHaveBeenCalledWith('d1')
+  })
+
+  it('keeps the kebab on a blocked distribution but disables Install', async () => {
+    installMockApiSignedIn([], [makeDist({ id: 'd2', name: 'Blocked Dist', state: 'no-build' })])
+    const wrapper = mountChooser()
+    await flushPromises()
+
+    const kebab = wrapper.find('[data-testid="chooser-dist-tile-kebab-d2"]')
+    expect(kebab.exists()).toBe(true)
+    await kebab.trigger('click')
+
+    const menu = wrapper
+      .findAllComponents({ name: 'ContextMenu' })
+      .find((m) => m.props('open') === true)!
+    const items = menu.props('items') as { id: string; disabled?: boolean }[]
+    expect(items[0]!.disabled).toBe(true)
   })
 
   it('has no Desktop entry in the filter state', async () => {

--- a/src/renderer/src/views/ChooserView.vue
+++ b/src/renderer/src/views/ChooserView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, toRef, watch } from 'vue'
+import { computed, onMounted, ref, toRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useInstallationStore } from '../stores/installationStore'
 import { useSessionStore } from '../stores/sessionStore'
@@ -17,6 +17,7 @@ import ChooserInstallTile from './chooser/ChooserInstallTile.vue'
 import DevPlatformAccountChip from './devplatform/DevPlatformAccountChip.vue'
 import DevPlatformDistributionCard from './devplatform/DevPlatformDistributionCard.vue'
 import { resolvePickerTab } from '../lib/pickerTabs'
+import type { ContextMenuItem } from '../types/context-menu'
 import type { Distribution } from '../devplatform/types'
 import type { Installation, ShowProgressOpts } from '../types/ipc'
 
@@ -189,6 +190,50 @@ async function handleDistributionActivate(dist: Distribution): Promise<void> {
     autoLaunchOnFinish: true,
     opKind: 'install'
   })
+}
+
+// --- Distribution kebab menu ---
+//
+// Distribution cards carry the same top-right kebab as install tiles, so the
+// corner means one thing across the grid. Install is the only action a
+// distribution supports today; blocked states keep the item visible but
+// disabled rather than presenting an empty menu, which reads as a bug.
+const distMenu = ref<{ open: boolean; x: number; y: number; dist: Distribution | null }>({
+  open: false,
+  x: 0,
+  y: 0,
+  dist: null
+})
+
+const distMenuItems = computed<ContextMenuItem[]>(() => {
+  const dist = distMenu.value.dist
+  if (!dist) return []
+  return [
+    {
+      id: 'install',
+      label: t('devPlatform.distribution.menuInstall'),
+      disabled: dist.state !== 'installable' && dist.state !== 'update-available'
+    }
+  ]
+})
+
+function openDistKebabMenu(event: MouseEvent, dist: Distribution): void {
+  const rect = (event.currentTarget as HTMLElement | null)?.getBoundingClientRect?.()
+  // Right-aligned drop, matching the install-tile kebab. ContextMenu clamps to
+  // the viewport, so a negative x is safe.
+  const x = rect ? rect.right - 180 : event.clientX
+  const y = (rect?.bottom ?? event.clientY) + 4
+  distMenu.value = { open: true, x, y, dist }
+}
+
+function closeDistMenu(): void {
+  distMenu.value = { open: false, x: 0, y: 0, dist: null }
+}
+
+function handleDistMenuSelect(itemId: string): void {
+  const dist = distMenu.value.dist
+  closeDistMenu()
+  if (itemId === 'install' && dist) void handleDistributionActivate(dist)
 }
 
 // --- Cluster top offset ---
@@ -407,6 +452,7 @@ function handleNewInstallClick(): void {
           :key="`dist:${dist.id}`"
           :distribution="dist"
           @select="handleDistributionActivate(dist)"
+          @open-kebab-menu="(event) => openDistKebabMenu(event, dist)"
         />
       </TransitionGroup>
 
@@ -419,6 +465,15 @@ function handleNewInstallClick(): void {
         :items="ctxMenuItems"
         @close="closeMenu"
         @select="handleCtxMenuSelect"
+      />
+
+      <ContextMenu
+        :open="distMenu.open"
+        :x="distMenu.x"
+        :y="distMenu.y"
+        :items="distMenuItems"
+        @close="closeDistMenu"
+        @select="handleDistMenuSelect"
       />
     </div>
   </BrandBackground>

--- a/src/renderer/src/views/devplatform/DevPlatformDistributionCard.vue
+++ b/src/renderer/src/views/devplatform/DevPlatformDistributionCard.vue
@@ -15,7 +15,7 @@
  */
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { AlertCircle, ArrowDownToLine, Package } from 'lucide-vue-next'
+import { AlertCircle, ArrowDownToLine, MoreVertical, Package } from 'lucide-vue-next'
 import TruncatedText from '../../components/TruncatedText.vue'
 import { formatBytesCoarse } from '../../lib/formatting'
 import { formatRelativeFromMs } from '../../lib/datetime'
@@ -28,6 +28,8 @@ const props = defineProps<{
 const emit = defineEmits<{
   /** The user activated the tile: the host starts the install flow. */
   select: []
+  /** Kebab pressed: the host opens the distribution menu at this anchor. */
+  'open-kebab-menu': [event: MouseEvent]
 }>()
 
 const { t } = useI18n()
@@ -146,6 +148,23 @@ function onActivate(): void {
       <span v-else-if="showAvailablePill" class="chooser-tile-pill dist-tile-pill--available">
         {{ t('devPlatform.distribution.availablePill') }}
       </span>
+
+      <!-- Same corner affordance as an install tile. Always present, blocked
+           or not: a card whose kebab comes and goes reads as broken, and the
+           menu still has something honest to say while blocked. -->
+      <button
+        type="button"
+        class="chooser-tile-kebab"
+        :title="t('chooser.moreActions')"
+        :aria-label="t('chooser.moreActions')"
+        :data-testid="`chooser-dist-tile-kebab-${distribution.id}`"
+        @click.stop="emit('open-kebab-menu', $event)"
+        @contextmenu.stop.prevent="emit('open-kebab-menu', $event)"
+        @keydown.enter.stop
+        @keydown.space.stop
+      >
+        <MoreVertical :size="16" />
+      </button>
     </div>
 
     <div class="chooser-tile-body">


### PR DESCRIPTION
Second of four small chunks porting the chooser card design work onto the builder-ux stack. **Stacked on #1314** — review that one first; this PR's diff is against it.

## What

Distribution cards get the same always-present top-right kebab as install tiles, with an Install item wired through the existing `ContextMenu`.

## Why

The cards already share the grid, the box, the type scale and the `TransitionGroup` with install tiles. The corner was the one place they diverged: install tiles put a kebab there, distributions put a state pill and nothing else. Same position, different meaning, one grid.

Install is the only action a distribution supports today, so that's the only item. Blocked distributions keep the kebab and show Install **disabled** rather than opening an empty menu — an empty menu reads as a bug, and the blocking reason is already on the card's own tag.

## Notes

- Adds `devPlatform.distribution.menuInstall` to `en.json` / `zh.json`.
- The existing pills stay where they are. Reshuffling the card's top-right vocabulary is the next chunk's job, kept separate so this one is easy to revert.
- The `ContextMenu` test stub now declares its props, so tests can assert what the view handed the menu without rendering the real one.

## Testing

`ChooserView.test.ts` passes (21 tests). Two new: the kebab opens a menu whose Install item runs the same `installDistribution` flow as activating the card, and a blocked distribution keeps its kebab with Install disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)