### PR TITLE
feat(chooser): one footer grammar for distribution cards

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1142,8 +1142,7 @@
     "distribution": {
       "availablePill": "Available",
       "menuInstall": "Install",
-      "updatedLabel": "Updated",
-      "installTileMeta": "Not installed yet",
+      "distVersion": "Dist v{version}",
       "emptyTitle": "No distributions published to this workspace yet.",
       "installFailed": "Could not start the install. Try again.",
       "states": {

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -1142,8 +1142,7 @@
     "distribution": {
       "availablePill": "可安装",
       "menuInstall": "安装",
-      "updatedLabel": "更新于",
-      "installTileMeta": "尚未安装",
+      "distVersion": "分发版 v{version}",
       "emptyTitle": "此工作区尚未发布任何分发版本。",
       "installFailed": "无法开始安装，请重试。",
       "states": {

--- a/src/renderer/src/views/ChooserView.test.ts
+++ b/src/renderer/src/views/ChooserView.test.ts
@@ -63,8 +63,7 @@ const messages = {
       distribution: {
         availablePill: 'Available',
         menuInstall: 'Install',
-        updatedLabel: 'Updated',
-        installTileMeta: 'Not installed yet',
+        distVersion: 'Dist v{version}',
         states: {
           noBuild: 'No build',
           platformMismatch: 'Not for this machine',
@@ -73,9 +72,10 @@ const messages = {
           installed: 'Installed',
         },
         blockedReason: {
-          noBuild: 'This distribution has no completed build yet.',
-          platformMismatch: 'No build for this platform.',
-          needsDesktopUpdate: 'Requires Desktop {version}.',
+          noBuild: 'This distribution has no successful build yet.',
+          platformMismatch:
+            'The latest build has no artifact for this operating system and GPU.',
+          needsDesktopUpdate: 'This distribution needs Comfy Desktop {version} or newer.',
         },
       },
     },
@@ -560,6 +560,55 @@ describe('ChooserView', () => {
       .find((m) => m.props('open') === true)!
     const items = menu.props('items') as { id: string; disabled?: boolean }[]
     expect(items[0]!.disabled).toBe(true)
+  })
+
+  it('labels the distribution version so it cannot be read as a ComfyUI version', async () => {
+    installMockApiSignedIn([], [makeDist({ id: 'd3', name: 'Versioned', version: '2' })])
+    const wrapper = mountChooser()
+    await flushPromises()
+    const card = wrapper.find('[data-testid="chooser-dist-tile-d3"]')
+    expect(card.find('.chooser-tile-meta-line').text()).toContain('Dist v2')
+  })
+
+  it('puts a blocked reason in the footer status slot, not the kebab corner', async () => {
+    installMockApiSignedIn(
+      [],
+      [makeDist({ id: 'd4', name: 'Blocked', state: 'platform-mismatch', version: '5' })],
+    )
+    const wrapper = mountChooser()
+    await flushPromises()
+    const card = wrapper.find('[data-testid="chooser-dist-tile-d4"]')
+
+    // State reads in the footer's right slot; the facts keep the left.
+    expect(card.find('.dist-tile-state-tag').text()).toBe('Not for this machine')
+    expect(card.find('.chooser-tile-meta-line').text()).toContain('Dist v5')
+    // The corner holds the kebab and nothing else.
+    const corner = card.find('.chooser-tile-actions')
+    expect(corner.findAll('.chooser-tile-pill').length).toBe(0)
+    expect(corner.find('.chooser-tile-kebab').exists()).toBe(true)
+    // Blocked tiles recede but stay readable, and explain themselves on hover.
+    expect(card.classes()).toContain('dist-tile--blocked')
+    expect(card.attributes('title')).toContain('operating system')
+  })
+
+  it('never renders both an action pill and a state tag', async () => {
+    installMockApiSignedIn(
+      [],
+      [
+        makeDist({ id: 'a', name: 'Available', state: 'installable' }),
+        makeDist({ id: 'b', name: 'Updatable', state: 'update-available' }),
+      ],
+    )
+    const wrapper = mountChooser()
+    await flushPromises()
+    for (const id of ['a', 'b']) {
+      const card = wrapper.find(`[data-testid="chooser-dist-tile-${id}"]`)
+      expect(card.findAll('.chooser-tile-pill-action').length).toBe(1)
+    }
+    // Update is the actionable one, so it takes the blue pill.
+    const updatable = wrapper.find('[data-testid="chooser-dist-tile-b"]')
+    expect(updatable.find('.chooser-tile-pill-update').exists()).toBe(true)
+    expect(updatable.find('.dist-tile-state-tag').exists()).toBe(false)
   })
 
   it('has no Desktop entry in the filter state', async () => {

--- a/src/renderer/src/views/devplatform/DevPlatformDistributionCard.vue
+++ b/src/renderer/src/views/devplatform/DevPlatformDistributionCard.vue
@@ -1,24 +1,28 @@
 <script setup lang="ts">
 /**
  * One distribution, rendered as a chooser tile: a sibling of
- * `views/chooser/ChooserInstallTile.vue`: same box, same classes, same type
- * scale. Activating it is the same gesture as launching an existing install.
+ * `views/chooser/ChooserInstallTile.vue` — same box, same classes, same type
+ * scale, same top-right kebab. Activating it is the same gesture as launching
+ * an existing install.
  *
- * NAME is the headline; version + size drop into the single meta row. Blocked
- * states (no-build / platform-mismatch / needs-desktop-update) are shown with
- * a short reason tag: full reason on `title`: and never hidden. No security
- * chrome: these are ordinary pipeline facts, not threats.
+ * NAME is the headline. The footer row follows the grammar the install tiles
+ * use: LEFT is identity facts (labelled version · size), RIGHT is one
+ * status/action slot — a pill for what you can do, or a quiet tag for why you
+ * can't. Never both, and state never replaces the facts.
  *
- * The footer answers the installation tile's recency question honestly: a
- * distribution that isn't installed says "Not installed yet"; an installed one
- * carries the build's "updated" stamp.
+ * The version is labelled ("Dist v2") because these cards share a grid with
+ * install tiles, whose version IS the ComfyUI version. A bare "2" beside a
+ * "0.3.20" invites misreading.
+ *
+ * Blocked states (no-build / platform-mismatch / needs-desktop-update) recede
+ * but are never hidden, and keep their full reason on the tile's `title`. No
+ * security chrome: these are ordinary pipeline facts, not threats.
  */
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { AlertCircle, ArrowDownToLine, MoreVertical, Package } from 'lucide-vue-next'
+import { ArrowDownToLine, MoreVertical, Package } from 'lucide-vue-next'
 import TruncatedText from '../../components/TruncatedText.vue'
 import { formatBytesCoarse } from '../../lib/formatting'
-import { formatRelativeFromMs } from '../../lib/datetime'
 import type { Distribution, DistributionState } from '../../devplatform/types'
 
 const props = defineProps<{
@@ -51,17 +55,41 @@ const BLOCKED_STATE_KEY: Record<string, string> = {
 
 const isBlocked = computed(() => BLOCKED_STATES.includes(props.distribution.state))
 
-/** Present on this machine already: the two post-install states. */
-const isInstalledLocally = computed(
-  () => props.distribution.state === 'installed' || props.distribution.state === 'update-available'
+const sizeLabel = computed(() =>
+  props.distribution.sizeBytes ? formatBytesCoarse(props.distribution.sizeBytes) : ''
 )
 
-const showAvailablePill = computed(() => props.distribution.state === 'installable')
+/** Labelled so it can't be read as a ComfyUI version (see file header). */
+const versionLabel = computed(() =>
+  props.distribution.version
+    ? t('devPlatform.distribution.distVersion', { version: props.distribution.version })
+    : ''
+)
 
-const blockedLabel = computed(() => {
-  if (!isBlocked.value) return ''
-  const suffix = BLOCKED_STATE_KEY[props.distribution.state] ?? 'noBuild'
-  return t(`devPlatform.distribution.states.${suffix}`)
+/** Dot-separated identity facts: version · size. Both optional. */
+const factsLine = computed(() => [versionLabel.value, sizeLabel.value].filter(Boolean).join(' · '))
+
+/** Right slot, part one: the blue pill for an action the card can perform.
+ *  Empty when there's nothing to do. */
+const actionPill = computed(() => {
+  if (props.distribution.state === 'update-available')
+    return t('devPlatform.distribution.states.updateAvailable')
+  return ''
+})
+
+/** Right slot, part two: a quiet tag for a fact the user can't act on —
+ *  why it's blocked, or that it's already installed. Only consulted when
+ *  `actionPill` is empty; the two never render together. */
+const stateTag = computed(() => {
+  if (isBlocked.value) {
+    const suffix = BLOCKED_STATE_KEY[props.distribution.state] ?? 'noBuild'
+    return t(`devPlatform.distribution.states.${suffix}`)
+  }
+  if (props.distribution.state === 'installed')
+    return t('devPlatform.distribution.states.installed')
+  if (props.distribution.state === 'installable')
+    return t('devPlatform.distribution.availablePill')
+  return ''
 })
 
 /** Full-contrast explanation, carried on `title` so it eats no tile space. */
@@ -72,29 +100,6 @@ const blockedReason = computed(() => {
   return t(`devPlatform.distribution.blockedReason.${suffix}`, {
     version: props.distribution.minDesktopVersion ?? '',
   })
-})
-
-const sizeLabel = computed(() =>
-  props.distribution.sizeBytes ? formatBytesCoarse(props.distribution.sizeBytes) : ''
-)
-
-/** Dot-separated facts row: version · size. Both optional. */
-const metaLine = computed(() =>
-  [props.distribution.version, sizeLabel.value].filter(Boolean).join(' · ')
-)
-
-const updatedLabel = computed(() => {
-  const iso = props.distribution.finishedAt
-  if (!iso) return ''
-  const ms = Date.parse(iso)
-  if (Number.isNaN(ms)) return ''
-  const rel = formatRelativeFromMs(ms, t)
-  return rel ? `${t('devPlatform.distribution.updatedLabel')} ${rel}` : ''
-})
-
-const footerLabel = computed(() => {
-  if (!isInstalledLocally.value) return t('devPlatform.distribution.installTileMeta')
-  return updatedLabel.value
 })
 
 function onActivate(): void {
@@ -110,6 +115,7 @@ function onActivate(): void {
     role="button"
     tabindex="0"
     :aria-disabled="isBlocked ? true : undefined"
+    :title="blockedReason || undefined"
     :data-testid="`chooser-dist-tile-${distribution.id}`"
     @click="onActivate"
     @keydown.enter.prevent="onActivate"
@@ -120,38 +126,8 @@ function onActivate(): void {
       <Package :size="22" />
     </span>
 
+    <!-- The corner is the kebab's alone; state lives on the footer row. -->
     <div class="chooser-tile-actions">
-      <span
-        v-if="isBlocked"
-        class="chooser-tile-danger-tag dist-tile-tag--blocked"
-        :title="blockedReason"
-      >
-        <AlertCircle :size="12" aria-hidden="true" />
-        {{ blockedLabel }}
-      </span>
-      <!-- Update-available: the only state asking the user to act. -->
-      <span
-        v-else-if="distribution.state === 'update-available'"
-        class="chooser-tile-pill dist-tile-pill--update"
-      >
-        <ArrowDownToLine :size="11" aria-hidden="true" />
-        {{ t('devPlatform.distribution.states.updateAvailable') }}
-      </span>
-      <span
-        v-else-if="distribution.state === 'installed'"
-        class="chooser-tile-pill dist-tile-pill--installed"
-      >
-        {{ t('devPlatform.distribution.states.installed') }}
-      </span>
-      <!-- Says this tile is something you can ADD, which is what distinguishes
-           it from the installation tiles beside it. -->
-      <span v-else-if="showAvailablePill" class="chooser-tile-pill dist-tile-pill--available">
-        {{ t('devPlatform.distribution.availablePill') }}
-      </span>
-
-      <!-- Same corner affordance as an install tile. Always present, blocked
-           or not: a card whose kebab comes and goes reads as broken, and the
-           menu still has something honest to say while blocked. -->
       <button
         type="button"
         class="chooser-tile-kebab"
@@ -167,18 +143,27 @@ function onActivate(): void {
       </button>
     </div>
 
+    <!-- Two lines: name, then facts left / one status slot right. -->
     <div class="chooser-tile-body">
       <TruncatedText class="chooser-tile-name" :text="distribution.name" />
-      <TruncatedText v-if="metaLine" class="chooser-tile-meta-line" :text="metaLine">
-        <span v-if="distribution.version" class="chooser-tile-meta-version">
-          {{ distribution.version }}
+      <div v-if="factsLine || actionPill || stateTag" class="chooser-tile-footer">
+        <TruncatedText v-if="factsLine" class="chooser-tile-meta-line" :text="factsLine">
+          <span v-if="versionLabel" class="chooser-tile-meta-version">{{ versionLabel }}</span>
+          <span v-if="versionLabel && sizeLabel" class="chooser-tile-meta-sep">·</span>
+          <span v-if="sizeLabel" class="chooser-tile-meta-source">{{ sizeLabel }}</span>
+        </TruncatedText>
+        <span
+          v-if="actionPill"
+          class="chooser-tile-pill chooser-tile-pill-update chooser-tile-pill-action"
+        >
+          <ArrowDownToLine :size="11" aria-hidden="true" />
+          {{ actionPill }}
         </span>
-        <span v-if="distribution.version && sizeLabel" class="chooser-tile-meta-sep">·</span>
-        <span v-if="sizeLabel" class="chooser-tile-meta-source">{{ sizeLabel }}</span>
-      </TruncatedText>
-      <div class="chooser-tile-footer">
-        <span v-if="footerLabel" class="chooser-tile-recency">
-          <span class="chooser-tile-recency-text">{{ footerLabel }}</span>
+        <span
+          v-else-if="stateTag"
+          class="chooser-tile-pill chooser-tile-pill-action dist-tile-state-tag"
+        >
+          {{ stateTag }}
         </span>
       </div>
     </div>

--- a/src/renderer/src/views/devplatform/devplatform-tiles.css
+++ b/src/renderer/src/views/devplatform/devplatform-tiles.css
@@ -3,9 +3,9 @@
  *
  * A distribution renders as a chooser tile: a visual sibling of an
  * installed-instance tile, since that is the interface users already pick
- * installs from. Everything structural (box, padding, radius, name → meta →
- * footer stack, pill vocabulary) comes from chooser-tiles.css unchanged; this
- * file adds only the blocked treatment, the pill tones, and the house
+ * installs from. Everything structural (box, padding, radius, name → footer
+ * stack, pill vocabulary) comes from chooser-tiles.css unchanged; this file
+ * adds only the blocked treatment, the neutral state tag, and the house
  * focus ring.
  */
 
@@ -19,59 +19,28 @@
   outline-offset: 2px;
 }
 
-/* --- Pills ---------------------------------------------------------------- */
-
-/* "Installed" is a fact, not a call to action. */
-.dist-tile-pill--installed {
-  color: var(--neutral-200);
-  border-color: var(--brand-surface-border);
-  background: var(--brand-surface-bg-hover);
-}
-
-/* "Available" answers the one question a distribution tile raises next to the
- * installation tiles around it. Deliberately the quietest pill in the family. */
-.dist-tile-pill--available {
+/* --- State tag -------------------------------------------------------------
+ * The footer's right slot when there is nothing to DO: "Available",
+ * "Installed", or a blocking reason. Deliberately the quietest thing in the
+ * tile family — it reports, it doesn't ask. The blue action pill (borrowed
+ * wholesale from the install tiles) covers the acting case. */
+.dist-tile-state-tag {
   color: var(--neutral-200);
   border-color: color-mix(in oklab, var(--neutral-100) 14%, transparent);
   background: color-mix(in oklab, var(--neutral-100) 6%, transparent);
+  /* A label, not a button: no hover lift. */
+  cursor: inherit;
 }
-.dist-tile--chooser:hover .dist-tile-pill--available,
-.dist-tile--chooser:focus-visible .dist-tile-pill--available {
+.dist-tile--chooser:hover .dist-tile-state-tag,
+.dist-tile--chooser:focus-visible .dist-tile-state-tag {
   color: var(--neutral-100);
-}
-
-/* Update-available is the one state asking the user to act: warning tone. */
-.dist-tile-pill--update {
-  gap: 4px;
-  flex-shrink: 0;
-  opacity: 1;
-  color: var(--warning);
-  border-color: color-mix(in oklab, var(--warning) 45%, transparent);
-  background: color-mix(in oklab, var(--warning) 12%, transparent);
-}
-
-/* Blocked tag: the danger tag's shape, re-toned. Not a security signal: these
- * are ordinary pipeline facts, so no lock icon, no red banner. The label stays
- * full-contrast on a dimmed tile; the full reason rides on `title`. */
-.dist-tile-tag--blocked {
-  cursor: default;
-  color: var(--neutral-100);
-  border-color: color-mix(in oklab, var(--warning) 40%, transparent);
-  background: color-mix(in oklab, var(--warning) 10%, transparent);
-  max-width: 190px;
-  text-overflow: ellipsis;
-}
-.dist-tile-tag--blocked:hover,
-.dist-tile-tag--blocked:focus-visible {
-  /* No hover lift: the tag is a label, not a button. */
-  background: color-mix(in oklab, var(--warning) 10%, transparent);
-  transform: none;
 }
 
 /* --- Blocked tile ---------------------------------------------------------
  * De-emphasised but readable, never hidden (product contract). The dim goes on
- * the identity block, not the root: root opacity would drag the state label
- * down with it. */
+ * the identity block, not the root: root opacity would drag the state tag
+ * down with it, and the tag is the one thing worth reading here. The full
+ * reason rides on the tile's `title`. */
 .dist-tile--blocked {
   cursor: default;
 }
@@ -79,14 +48,20 @@
 .dist-tile--blocked .chooser-tile-name {
   opacity: 0.62;
 }
-/* Meta + footer step UP to --neutral-200 instead of dimming: the faint tier
+/* Facts step UP to --neutral-200 instead of dimming: the faint tier
  * multiplied by 0.62 would drop under the 3:1 contrast floor. */
 .dist-tile--blocked .chooser-tile-meta-line,
 .dist-tile--blocked .chooser-tile-meta-source,
 .dist-tile--blocked .chooser-tile-meta-sep,
-.dist-tile--blocked .chooser-tile-meta-version,
-.dist-tile--blocked .chooser-tile-recency-text {
+.dist-tile--blocked .chooser-tile-meta-version {
   color: var(--neutral-200);
+}
+/* Warning tone on the tag is the whole signal now that the corner is the
+ * kebab's — enough to find at a glance, not enough to alarm. */
+.dist-tile--blocked .dist-tile-state-tag {
+  color: var(--neutral-100);
+  border-color: color-mix(in oklab, var(--warning) 40%, transparent);
+  background: color-mix(in oklab, var(--warning) 10%, transparent);
 }
 /* Suppress the hover promise the tile cannot honour. */
 .dist-tile--blocked:hover {


### PR DESCRIPTION
Third of four small chunks porting the chooser card design work onto the builder-ux stack. **Stacked on #1315 → #1314.**

## What

Distribution cards adopt the same footer grammar as install tiles: name, then **identity facts left, one status/action slot right**.

## Why

#1314 took install tiles to two lines, which left distribution cards as the only three-line tile in the grid. This closes that gap and settles what the two families put where.

Three consequences fall out:

1. **The version is labelled** — `Dist v2` rather than `2`. These cards share a grid with install tiles whose version *is* the ComfyUI version; a bare `2` beside a `0.3.20` invites misreading.
2. **Blocked state leaves the corner.** #1315 gave the corner to the kebab, so the blocked tag moves to the footer's right slot and the full reason moves to the tile's `title` — costs no space, still available on hover.
3. **The recency row goes** (`"Not installed yet"` / `"Updated 3h ago"`), along with the two locale keys that fed it.

The rule the slot follows: pills say what you *can do*, tags say what *is so*, and the two never render together. State never displaces the facts.

## What I did not port

Our prototype showed **two** labelled versions here — the bundled ComfyUI version alongside the distribution version. That reads `distribution.comfyuiVersion`, which turned out to exist only in the renderer mocks; no backend on either stack populates it. Wiring it up means touching the distribution row mapping in `src/main/devplatform/distributions.ts`, which is #1297's territory, so I left the slot open rather than shipping a field that always renders empty. The facts line takes a second fact without changes when it lands.

## Testing

`ChooserView.test.ts` passes (24 tests). Three new: the version renders labelled, a blocked distribution puts its reason in the footer slot with an empty kebab corner and a `title` explanation, and no card ever renders both an action pill and a state tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)