### PR TITLE
feat(chooser): name the action on installable distributions

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1140,7 +1140,6 @@
       "switchLabel": "Workspace"
     },
     "distribution": {
-      "availablePill": "Available",
       "menuInstall": "Install",
       "distVersion": "Dist v{version}",
       "emptyTitle": "No distributions published to this workspace yet.",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -1140,7 +1140,6 @@
       "switchLabel": "工作区"
     },
     "distribution": {
-      "availablePill": "可安装",
       "menuInstall": "安装",
       "distVersion": "分发版 v{version}",
       "emptyTitle": "此工作区尚未发布任何分发版本。",

--- a/src/renderer/src/views/ChooserView.test.ts
+++ b/src/renderer/src/views/ChooserView.test.ts
@@ -61,7 +61,6 @@ const messages = {
     },
     devPlatform: {
       distribution: {
-        availablePill: 'Available',
         menuInstall: 'Install',
         distVersion: 'Dist v{version}',
         states: {
@@ -605,10 +604,20 @@ describe('ChooserView', () => {
       const card = wrapper.find(`[data-testid="chooser-dist-tile-${id}"]`)
       expect(card.findAll('.chooser-tile-pill-action').length).toBe(1)
     }
-    // Update is the actionable one, so it takes the blue pill.
-    const updatable = wrapper.find('[data-testid="chooser-dist-tile-b"]')
-    expect(updatable.find('.chooser-tile-pill-update').exists()).toBe(true)
-    expect(updatable.find('.dist-tile-state-tag').exists()).toBe(false)
+    // Both are actionable, so both take the blue pill, not a state tag.
+    for (const id of ['a', 'b']) {
+      const card = wrapper.find(`[data-testid="chooser-dist-tile-${id}"]`)
+      expect(card.find('.chooser-tile-pill-update').exists()).toBe(true)
+      expect(card.find('.dist-tile-state-tag').exists()).toBe(false)
+    }
+  })
+
+  it('names the action on an installable distribution rather than its state', async () => {
+    installMockApiSignedIn([], [makeDist({ id: 'd5', name: 'Fresh', state: 'installable' })])
+    const wrapper = mountChooser()
+    await flushPromises()
+    const pill = wrapper.find('[data-testid="chooser-dist-tile-d5"]').find('.chooser-tile-pill-action')
+    expect(pill.text()).toBe('Install')
   })
 
   it('has no Desktop entry in the filter state', async () => {

--- a/src/renderer/src/views/devplatform/DevPlatformDistributionCard.vue
+++ b/src/renderer/src/views/devplatform/DevPlatformDistributionCard.vue
@@ -7,8 +7,9 @@
  *
  * NAME is the headline. The footer row follows the grammar the install tiles
  * use: LEFT is identity facts (labelled version · size), RIGHT is one
- * status/action slot — a pill for what you can do, or a quiet tag for why you
- * can't. Never both, and state never replaces the facts.
+ * status/action slot — a pill for what you can do (Install / Update), or a
+ * quiet tag for what simply is (Installed, or why it's blocked). Never both,
+ * and state never replaces the facts.
  *
  * The version is labelled ("Dist v2") because these cards share a grid with
  * install tiles, whose version IS the ComfyUI version. A bare "2" beside a
@@ -69,11 +70,14 @@ const versionLabel = computed(() =>
 /** Dot-separated identity facts: version · size. Both optional. */
 const factsLine = computed(() => [versionLabel.value, sizeLabel.value].filter(Boolean).join(' · '))
 
-/** Right slot, part one: the blue pill for an action the card can perform.
- *  Empty when there's nothing to do. */
+/** Right slot, part one: the blue pill for an action the card performs.
+ *  Install and Update are the same gesture — activate the card — so they
+ *  wear the same pill. Empty when there's nothing to do. */
 const actionPill = computed(() => {
   if (props.distribution.state === 'update-available')
     return t('devPlatform.distribution.states.updateAvailable')
+  if (props.distribution.state === 'installable')
+    return t('devPlatform.distribution.menuInstall')
   return ''
 })
 
@@ -87,8 +91,6 @@ const stateTag = computed(() => {
   }
   if (props.distribution.state === 'installed')
     return t('devPlatform.distribution.states.installed')
-  if (props.distribution.state === 'installable')
-    return t('devPlatform.distribution.availablePill')
   return ''
 })
 


### PR DESCRIPTION
Last of four small chunks porting the chooser card design work onto the builder-ux stack. **Stacked on #1316 → #1315 → #1314.**

## What

An installable distribution's right slot changes from a quiet `Available` tag to the blue `Install` pill — the same pill Update already wears.

## Why

`Available` names a state on a card whose entire purpose is an action. Clicking anywhere on the card installs it, and Update uses a blue pill for precisely that gesture, so Install should look the same. Under #1316's grammar, pills say what you can do and tags say what is so — `Available` was sitting on the wrong side of that line.

The quiet tag stays for the cases you genuinely can't act on: `Installed`, and the three blocked reasons.

## The call this PR is really asking you to make

This is deliberately its own PR because it's a judgement call and I don't think it's clear-cut.

**Worth knowing:** `ChooserView.vue:141` filters out any distribution backed by an installation, so today *every* distribution card is `installable`. This PR therefore turns every one of them blue. The design it came from assumed installed and uninstalled distributions sat side by side, where the pill distinguished within the family — that's not the current model.

**The case against merging:** when a whole family shares one state, a high-contrast pill on all of them carries no information. Blue is otherwise reserved for "something needs your attention" (Update, Migrate) on install tiles, and being installable isn't that.

**The case for:** the pill isn't distinguishing distributions from each other, it's distinguishing "things you can add" from "things you have" in a mixed grid — which is the question a user actually has while scanning it.

I lean toward merging, but closing this PR is a perfectly good answer and costs nothing: #1316 stands on its own with `Available` intact.

## Also held back

The prototype rendered uninstalled distributions as **hollow** tiles (transparent, dashed border). That was a contrast device against installed siblings, so it depends on the same question — under the current dedupe every card would be hollow, which makes it decoration. Worth revisiting alongside whether an installed distribution keeps its distribution identity on the chooser.

## Testing

`ChooserView.test.ts` passes (25 tests). One new: an installable distribution's slot reads `Install`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)