### PR TITLE
feat(desktop): builder distribution UI

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -266,6 +266,9 @@
     "copyError": "Copy error details",
     "clear": "Clear"
   },
+  "comfybuilder": {
+    "stageModels": "Download models"
+  },
   "list": {
     "loadSnapshot": "Load Snapshot",
     "snapshotSourceName": "Source Instance",
@@ -1120,6 +1123,39 @@
       "nodes": "Loading custom nodes…"
     },
     "viewLogs": "View logs"
+  },
+  "devPlatform": {
+    "signIn": {
+      "cta": "Log in"
+    },
+    "account": {
+      "signOut": "Sign out",
+      "signedInAs": "Signed in as {email}",
+      "signOutConfirmTitle": "Sign out of ComfyBuilder?",
+      "signOutConfirmBody": "Your installed distributions are kept and still run. They just stop receiving updates until you sign back in.",
+      "signOutConfirmCta": "Sign out"
+    },
+    "workspace": {
+      "personalLabel": "Personal",
+      "switchLabel": "Workspace",
+      "loadError": "Couldn't load workspaces. Retry"
+    },
+    "distribution": {
+      "menuInstall": "Install",
+      "distVersion": "Dist v{version}",
+      "emptyTitle": "No distributions published to this workspace yet.",
+      "loadError": "Couldn't load distributions. Retry",
+      "installFailed": "Could not start the install. Try again.",
+      "states": {
+        "noBuild": "No build",
+        "platformMismatch": "Not for this machine",
+        "updateAvailable": "Update"
+      },
+      "blockedReason": {
+        "buildFailed": "This distribution has no successful build yet.",
+        "noArtifactForMachine": "The latest build has no artifact for this operating system and GPU."
+      }
+    }
   },
   "errors": {
     "invalidUrl": "Enter a valid URL (e.g. http://localhost:8188).",

--- a/locales/en.json
+++ b/locales/en.json
@@ -38,6 +38,7 @@
     "filterRemote": "Remote",
     "updatePill": "Update",
     "migratePill": "Migrate",
+    "workspaceShelf": "Workspace",
     "openInstall": "Open",
     "manageInstall": "Manage",
     "moreActions": "More actions",
@@ -1143,6 +1144,7 @@
     "distribution": {
       "menuInstall": "Install",
       "distVersion": "Dist v{version}",
+      "notInstalled": "Not installed",
       "emptyTitle": "No distributions published to this workspace yet.",
       "loadError": "Couldn't load distributions. Retry",
       "installFailed": "Could not start the install. Try again.",

--- a/locales/en.json
+++ b/locales/en.json
@@ -20,7 +20,8 @@
     "cloud": "Cloud",
     "legacyDesktop": "Legacy Desktop",
     "remote": "Remote",
-    "unknown": "Unknown"
+    "unknown": "Unknown",
+    "distribution": "Distribution"
   },
   "chooser": {
     "title": "Choose an instance",
@@ -268,7 +269,23 @@
     "clear": "Clear"
   },
   "comfybuilder": {
-    "stageModels": "Download models"
+    "stageModels": "Download models",
+    "distribution": "Distribution",
+    "distributionVersion": "Distribution Version",
+    "comfyuiVersion": "ComfyUI Version",
+    "distributionVersionTitle": "Distribution Version",
+    "installedVersion": "Installed",
+    "latestVersion": "Latest Published",
+    "errorNoDistribution": "This install is not linked to a distribution.",
+    "updateAvailable": "Update available",
+    "upToDate": "Up to date",
+    "lastChecked": "Last Checked",
+    "updateToVersion": "Update to v{version}",
+    "updatingTo": "Updating to v{version}",
+    "updateConfirmTitle": "Update distribution",
+    "updateConfirmMessage": "Update this instance from {from} to {to}?\n\nThe environment is replaced in place. Your workflows and staged models are kept.",
+    "errorNoVersion": "No target version was given.",
+    "errorVersionUnavailable": "Version v{version} has no build for this machine."
   },
   "list": {
     "loadSnapshot": "Load Snapshot",
@@ -660,7 +677,7 @@
     "connect": "Connect",
     "connecting": "Connecting",
     "openDirectory": "Open Directory",
-    "checkForUpdate": "Check for Update",
+    "checkForUpdate": "Check for updates",
     "featureNotImplemented": "This feature is not yet implemented.",
     "updateAvailable": "Update Available",
     "copyInstallation": "Duplicate Instance",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -266,6 +266,9 @@
     "copyError": "复制错误详情",
     "clear": "清除"
   },
+  "comfybuilder": {
+    "stageModels": "下载模型"
+  },
   "list": {
     "loadSnapshot": "加载快照",
     "snapshotSourceName": "源实例",
@@ -1120,6 +1123,39 @@
       "nodes": "正在加载自定义节点…"
     },
     "viewLogs": "查看日志"
+  },
+  "devPlatform": {
+    "signIn": {
+      "cta": "登录"
+    },
+    "account": {
+      "signOut": "退出登录",
+      "signedInAs": "已登录为 {email}",
+      "signOutConfirmTitle": "退出 ComfyBuilder？",
+      "signOutConfirmBody": "已安装的分发版本会保留并仍可运行，只是在重新登录前不再接收更新。",
+      "signOutConfirmCta": "退出登录"
+    },
+    "workspace": {
+      "personalLabel": "个人",
+      "switchLabel": "工作区",
+      "loadError": "无法加载工作区，请重试"
+    },
+    "distribution": {
+      "menuInstall": "安装",
+      "distVersion": "分发版 v{version}",
+      "emptyTitle": "此工作区尚未发布任何分发版本。",
+      "loadError": "无法加载分发版本，请重试",
+      "installFailed": "无法开始安装，请重试。",
+      "states": {
+        "noBuild": "无构建",
+        "platformMismatch": "不适用于此设备",
+        "updateAvailable": "更新"
+      },
+      "blockedReason": {
+        "buildFailed": "此分发版本尚无成功的构建。",
+        "noArtifactForMachine": "最新构建没有适用于此操作系统和 GPU 的制品。"
+      }
+    }
   },
   "errors": {
     "invalidUrl": "请输入有效 URL（例如 http://localhost:8188）。",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -20,7 +20,8 @@
     "cloud": "云端",
     "legacyDesktop": "旧版桌面端",
     "remote": "远程",
-    "unknown": "未知"
+    "unknown": "未知",
+    "distribution": "分发版"
   },
   "chooser": {
     "title": "选择一个实例",
@@ -268,7 +269,23 @@
     "clear": "清除"
   },
   "comfybuilder": {
-    "stageModels": "下载模型"
+    "stageModels": "下载模型",
+    "distribution": "分发版",
+    "distributionVersion": "分发版版本",
+    "comfyuiVersion": "ComfyUI 版本",
+    "distributionVersionTitle": "分发版版本",
+    "installedVersion": "已安装",
+    "latestVersion": "最新发布",
+    "errorNoDistribution": "此安装未关联到分发版。",
+    "updateAvailable": "有可用更新",
+    "upToDate": "已是最新",
+    "lastChecked": "上次检查",
+    "updateToVersion": "更新到 v{version}",
+    "updatingTo": "正在更新到 v{version}",
+    "updateConfirmTitle": "更新分发版",
+    "updateConfirmMessage": "将此实例从 {from} 更新到 {to}？\n\n环境将就地替换，工作流与已暂存的模型会保留。",
+    "errorNoVersion": "未指定目标版本。",
+    "errorVersionUnavailable": "版本 v{version} 没有适用于此设备的构建。"
   },
   "list": {
     "loadSnapshot": "加载快照",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -38,6 +38,7 @@
     "filterRemote": "远程",
     "updatePill": "更新",
     "migratePill": "迁移",
+    "workspaceShelf": "工作区",
     "openInstall": "打开",
     "manageInstall": "管理",
     "moreActions": "更多操作",
@@ -1143,6 +1144,7 @@
     "distribution": {
       "menuInstall": "安装",
       "distVersion": "分发版 v{version}",
+      "notInstalled": "未安装",
       "emptyTitle": "此工作区尚未发布任何分发版本。",
       "loadError": "无法加载分发版本，请重试",
       "installFailed": "无法开始安装，请重试。",

--- a/src/main/devplatform/distributions.test.ts
+++ b/src/main/devplatform/distributions.test.ts
@@ -68,6 +68,26 @@ describe('listDistributionRows', () => {
     const rows = await listDistributionRows(client as never, HOST)
     const row = rows[0]!
     expect(row).toMatchObject({ version: '3', state: 'platform-mismatch', blockedReason: 'noArtifactForMachine' })
+    expect(row.targetOs).toEqual(['windows'])
+  })
+
+  it('reports every OS a mismatched build targets, deduped and sorted', async () => {
+    const client = stubClient({
+      distributions: [{ id: 'd1', name: 'NotForLinux' }],
+      versionsByDist: { d1: [version(3, 'complete')] },
+      artifactsByVersion: {
+        v3: [
+          artifact({ os: 'windows', gpu: 'nvidia' }),
+          artifact({ os: 'mac' }),
+          // Same OS twice must not double up, and a half-built target isn't
+          // somewhere you could actually run it.
+          artifact({ os: 'windows', gpu: 'cpu' }),
+          artifact({ os: 'linux', status: 'building' }),
+        ],
+      },
+    })
+    const rows = await listDistributionRows(client as never, HOST)
+    expect(rows[0]!.targetOs).toEqual(['mac', 'windows'])
   })
 
   it('marks update-available when installed older and the newer build runs here', async () => {

--- a/src/main/devplatform/distributions.test.ts
+++ b/src/main/devplatform/distributions.test.ts
@@ -1,6 +1,11 @@
 // @vitest-environment node
 import { describe, expect, it, vi } from 'vitest'
-import { listCompleteVersions, listDistributionRows, resolveHostArtifact } from './distributions'
+import {
+  listCompleteVersions,
+  listDistributionRows,
+  resolveHostArtifact,
+  resolveHostArtifactForVersion,
+} from './distributions'
 import { clearVersionCache, getCachedVersions } from './versionCache'
 import type { Artifact, Distribution, DistributionVersion, Host } from '../comfybuilder'
 
@@ -195,5 +200,37 @@ describe('resolveHostArtifact', () => {
       artifactsByVersion: { v1: [artifact({ os: 'mac', gpu: 'mps' })] },
     })
     expect(await resolveHostArtifact(client as never, HOST, 'd1')).toBeNull()
+  })
+})
+
+describe('resolveHostArtifactForVersion', () => {
+  it('resolves the named version, not just the latest', async () => {
+    const client = stubClient({
+      versionsByDist: { d1: [version(9, 'complete'), version(5, 'complete')] },
+      artifactsByVersion: { v5: [artifact({ id: 'older-pick' })], v9: [artifact({ id: 'newer' })] },
+    })
+    const resolved = await resolveHostArtifactForVersion(client as never, HOST, 'd1', 5)
+    expect(resolved).toMatchObject({ version: 5, artifact: { id: 'older-pick' } })
+  })
+
+  it('returns null when the named version is not published', async () => {
+    const client = stubClient({ versionsByDist: { d1: [version(9, 'complete')] } })
+    expect(await resolveHostArtifactForVersion(client as never, HOST, 'd1', 5)).toBeNull()
+  })
+
+  it('returns null when the named version is not complete', async () => {
+    const client = stubClient({
+      versionsByDist: { d1: [version(5, 'building')] },
+      artifactsByVersion: { v5: [artifact()] },
+    })
+    expect(await resolveHostArtifactForVersion(client as never, HOST, 'd1', 5)).toBeNull()
+  })
+
+  it('returns null when the named version has no artifact for this host', async () => {
+    const client = stubClient({
+      versionsByDist: { d1: [version(5, 'complete')] },
+      artifactsByVersion: { v5: [artifact({ os: 'mac', gpu: 'mps' })] },
+    })
+    expect(await resolveHostArtifactForVersion(client as never, HOST, 'd1', 5)).toBeNull()
   })
 })

--- a/src/main/devplatform/distributions.test.ts
+++ b/src/main/devplatform/distributions.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 import { describe, expect, it, vi } from 'vitest'
-import { listDistributionRows, resolveHostArtifact } from './distributions'
+import { listCompleteVersions, listDistributionRows, resolveHostArtifact } from './distributions'
+import { clearVersionCache, getCachedVersions } from './versionCache'
 import type { Artifact, Distribution, DistributionVersion, Host } from '../comfybuilder'
 
 const HOST: Host = { os: 'linux', gpu: 'nvidia' }
@@ -144,6 +145,32 @@ describe('listDistributionRows', () => {
     })
     const rows = await listDistributionRows(client as never, HOST)
     expect(rows.map((r) => r.id)).toEqual(['ok'])
+  })
+})
+
+describe('listCompleteVersions', () => {
+  it('returns complete versions newest first, dropping unbuilt ones', async () => {
+    const client = stubClient({
+      versionsByDist: {
+        d1: [version(2, 'complete'), version(5, 'complete'), version(6, 'building'), version(1, 'failed')],
+      },
+    })
+    expect(await listCompleteVersions(client as never, 'd1')).toEqual([5, 2])
+  })
+})
+
+describe('version cache warming', () => {
+  it('caches a distribution\'s complete versions as a side effect of listing rows', async () => {
+    // The manage view builds its Update tab synchronously and cannot fetch, so
+    // the catalog read the chooser already does is what fills it.
+    clearVersionCache()
+    const client = stubClient({
+      distributions: [{ id: 'd1', name: 'Image' }],
+      versionsByDist: { d1: [version(1, 'complete'), version(3, 'complete'), version(4, 'building')] },
+      artifactsByVersion: { v3: [artifact()] },
+    })
+    await listDistributionRows(client as never, HOST)
+    expect(getCachedVersions('d1')?.versions).toEqual([3, 1])
   })
 })
 

--- a/src/main/devplatform/distributions.ts
+++ b/src/main/devplatform/distributions.ts
@@ -21,6 +21,7 @@ import { hostOs, selectArtifactForHost } from '../comfybuilder/targets'
 import type { Artifact, Distribution, Host } from '../comfybuilder/types'
 import type { ComfyBuilderClient } from '../comfybuilder/client'
 import { detectGPU } from '../lib/gpu'
+import { setCachedVersions } from './versionCache'
 
 /**
  * Distribution tile states. `installable` / `no-build` / `platform-mismatch` are
@@ -101,7 +102,15 @@ async function buildRow(
     state: 'no-build',
   }
 
-  const latest = latestCompleteVersion(await client.listVersions(dist.id))
+  const allVersions = await client.listVersions(dist.id)
+  // The manage view's version picker is built synchronously and can't fetch, so
+  // hand it what this read already saw.
+  setCachedVersions(
+    dist.id,
+    allVersions.filter((v) => v.status === 'complete').map((v) => v.version),
+  )
+
+  const latest = latestCompleteVersion(allVersions)
   if (!latest) return { ...base, state: 'no-build', blockedReason: 'buildFailed' }
 
   const installedVersion = installed?.get(dist.id)
@@ -167,4 +176,40 @@ export async function resolveHostArtifact(
   const { artifacts } = await client.getVersion(latest.id)
   const artifact = selectArtifactForHost(artifacts, host)
   return artifact ? { artifact, version: latest.version } : null
+}
+
+/**
+ * The same resolution against ONE named version — what the manage view's update
+ * action installs. Rollback and roll-forward are the same operation.
+ *
+ * Null when the version isn't published, isn't complete, or has no artifact this
+ * machine can run, so the caller reports that instead of installing something
+ * the host can't launch.
+ */
+export async function resolveHostArtifactForVersion(
+  client: Pick<ComfyBuilderClient, 'listVersions' | 'getVersion'>,
+  host: Host,
+  distributionId: string,
+  version: number,
+): Promise<ResolvedHostArtifact | null> {
+  const target = (await client.listVersions(distributionId)).find(
+    (v) => v.version === version && v.status === 'complete',
+  )
+  if (!target) return null
+  const { artifacts } = await client.getVersion(target.id)
+  const artifact = selectArtifactForHost(artifacts, host)
+  return artifact ? { artifact, version: target.version } : null
+}
+
+/** Every complete version, newest first — what the manage view reports as
+ *  published, and the basis for a future version picker. */
+export async function listCompleteVersions(
+  client: Pick<ComfyBuilderClient, 'listVersions'>,
+  distributionId: string,
+): Promise<number[]> {
+  const versions = await client.listVersions(distributionId)
+  return versions
+    .filter((v) => v.status === 'complete')
+    .map((v) => v.version)
+    .sort((a, b) => b - a)
 }

--- a/src/main/devplatform/distributions.ts
+++ b/src/main/devplatform/distributions.ts
@@ -41,6 +41,9 @@ export interface DistributionRow {
   name: string
   description?: string
   version?: string
+  /** ComfyUI version bundled by this distribution. TODO(builder-backend): the
+   *  build metadata doesn't carry it yet, so this is currently never set. */
+  comfyuiVersion?: string
   finishedAt?: string
   numCustomNodes?: number
   state: DistributionRowState
@@ -49,6 +52,9 @@ export interface DistributionRow {
   installedVersion?: number
   /** i18n suffix explaining a blocked state (see `devPlatform.distribution.blockedReason.*`). */
   blockedReason?: string
+  /** On `platform-mismatch`, the OSes this build DOES target (`windows` / `mac`
+   *  / `linux`), so the card can name a machine that would run it. */
+  targetOs?: string[]
 }
 
 /** What `installDistribution` resolves before it hands off to the install chain. */
@@ -108,7 +114,16 @@ async function buildRow(
 
   const { artifacts } = await client.getVersion(latest.id)
   const artifact = selectArtifactForHost(artifacts, host)
-  if (!artifact) return { ...withVersion, state: 'platform-mismatch', blockedReason: 'noArtifactForMachine' }
+  if (!artifact) {
+    // Sorted so the label is stable across artifact orderings.
+    const targetOs = [...new Set(artifacts.filter((a) => a.status === 'ready').map((a) => a.os))].sort()
+    return {
+      ...withVersion,
+      state: 'platform-mismatch',
+      blockedReason: 'noArtifactForMachine',
+      ...(targetOs.length ? { targetOs } : {}),
+    }
+  }
   // Installed at an older version, and the newer one runs here: offer the update.
   if (installedVersion !== undefined && latest.version > installedVersion) {
     return { ...withVersion, state: 'update-available' }

--- a/src/main/devplatform/versionCache.ts
+++ b/src/main/devplatform/versionCache.ts
@@ -1,0 +1,36 @@
+/**
+ * Published-version cache, keyed by distribution id.
+ *
+ * `SourcePlugin.getDetailSections` is synchronous, so the manage view can't
+ * fetch a distribution's version list while building the Update tab. This holds
+ * what the last catalog read saw, the way `lib/release-cache` does for
+ * standalone channels.
+ *
+ * Deliberately in-memory and never persisted: it is catalog data, not install
+ * state. Persisting it on the record would go stale silently and follow an
+ * install through a duplicate.
+ */
+
+export interface CachedVersions {
+  /** Complete versions, newest first. */
+  versions: number[]
+  fetchedAt: number
+}
+
+const cache = new Map<string, CachedVersions>()
+
+export function setCachedVersions(distributionId: string, versions: number[]): void {
+  const sorted = [...new Set(versions)].sort((a, b) => b - a)
+  cache.set(distributionId, { versions: sorted, fetchedAt: Date.now() })
+}
+
+/** Cached versions, or null when nothing has read the catalog yet. Callers
+ *  render a "check for updates" affordance rather than an empty picker. */
+export function getCachedVersions(distributionId: string): CachedVersions | null {
+  return cache.get(distributionId) ?? null
+}
+
+/** Test seam. */
+export function clearVersionCache(): void {
+  cache.clear()
+}

--- a/src/main/lib/ipc/registerInstallationHandlers.ts
+++ b/src/main/lib/ipc/registerInstallationHandlers.ts
@@ -124,8 +124,19 @@ export function enrichInstallationsForRenderer(allInstalls: InstallationRecord[]
             : source.getStatusTag
               ? source.getStatusTag(inst)
               : undefined
+    // A comfybuilder install's raw `version` is its DISTRIBUTION version, not a
+    // ComfyUI one (see `installedDistributionVersions`), so it gets its own
+    // field — otherwise a bare "7" lands where every other tile shows "v0.28.2".
+    const isFromDistribution = inst.sourceId === 'comfybuilder'
+    const distributionVersion = isFromDistribution
+      ? (inst.version as string | undefined)
+      : undefined
     const cv = inst.comfyVersion as ComfyVersion | undefined
-    const rawVersion = cv ? formatComfyVersion(cv, 'short') : (inst.version as string | undefined)
+    const rawVersion = cv
+      ? formatComfyVersion(cv, 'short')
+      : isFromDistribution
+        ? undefined
+        : (inst.version as string | undefined)
     const version = rawVersion === inst.sourceId ? undefined : rawVersion
     return {
       ...inst,
@@ -133,6 +144,7 @@ export function enrichInstallationsForRenderer(allInstalls: InstallationRecord[]
       sourceLabel: source.label,
       sourceCategory: source.category,
       hasConsole: source.hasConsole !== false,
+      ...(distributionVersion ? { distributionVersion } : {}),
       ...(listPreview != null ? { listPreview } : {}),
       ...(statusTag ? { statusTag } : {})
     }
@@ -163,7 +175,6 @@ export function registerInstallationHandlers(): void {
     // indicator appears/clears as drives go offline/online. Single-flight +
     // broadcasts only on change, so a dashboard refresh can't loop.
     void refreshInstallDirStates()
-
     return enriched
   })
 

--- a/src/main/sources/comfybuilder/constants.ts
+++ b/src/main/sources/comfybuilder/constants.ts
@@ -1,0 +1,3 @@
+/** Shared by the plugin and its detail sections; separate module so the two
+ *  don't import each other in a cycle. */
+export const DEFAULT_LAUNCH_ARGS = '--enable-manager'

--- a/src/main/sources/comfybuilder/detailSections.test.ts
+++ b/src/main/sources/comfybuilder/detailSections.test.ts
@@ -1,0 +1,210 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: { getPath: () => '', isPackaged: false },
+  ipcMain: { handle: vi.fn() },
+  BrowserWindow: { fromWebContents: vi.fn() },
+  dialog: {},
+  shell: { openPath: vi.fn() },
+  net: { request: vi.fn() },
+}))
+
+import { getDetailSections } from './detailSections'
+import {
+  clearVersionCache,
+  getCachedVersions,
+  setCachedVersions,
+} from '../../devplatform/versionCache'
+import type { InstallationRecord } from '../../installations'
+
+const record = (overrides: Record<string, unknown> = {}): InstallationRecord =>
+  ({
+    id: 'i1',
+    name: 'Studio Render Pipeline',
+    sourceId: 'comfybuilder',
+    sourceLabel: 'Comfy Builder',
+    installPath: '/installs/studio',
+    status: 'installed',
+    distributionId: 'd1',
+    distributionName: 'Studio Render Pipeline',
+    version: '7',
+    ...overrides,
+  }) as unknown as InstallationRecord
+
+type Section = {
+  tab?: string
+  title?: string
+  pinBottom?: boolean
+  fields?: Record<string, unknown>[]
+  actions?: Record<string, unknown>[]
+}
+
+const sectionsFor = (inst: InstallationRecord): Section[] =>
+  getDetailSections(inst) as unknown as Section[]
+
+const tabsOf = (s: Section[]): string[] => s.map((x) => x.tab).filter(Boolean) as string[]
+
+const fieldIds = (s: Section | undefined): string[] =>
+  (s?.fields ?? []).map((f) => (f.id ?? f.key) as string).filter(Boolean)
+
+type StatRow = { id: string; label: string; value: string; highlight?: boolean }
+type StatsValue = { headline: string; headlineHighlight: boolean; badge: string | null; rows: StatRow[] }
+
+const statsField = (inst: InstallationRecord): Record<string, unknown> | undefined =>
+  (sectionsFor(inst).find((s) => s.tab === 'update')?.fields ?? []).find(
+    (f) => f.editType === 'version-stats',
+  )
+
+const statsValue = (inst: InstallationRecord): StatsValue =>
+  (statsField(inst)?.value ?? { rows: [] }) as StatsValue
+
+const rowIds = (inst: InstallationRecord): string[] => statsValue(inst).rows.map((r) => r.id)
+
+const updateActions = (inst: InstallationRecord): Record<string, unknown>[] =>
+  (sectionsFor(inst).find((s) => s.tab === 'update')?.actions ?? []) as Record<string, unknown>[]
+
+
+beforeEach(() => clearVersionCache())
+
+describe('comfybuilder.getDetailSections', () => {
+  it('surfaces the tabs a distribution install should have', () => {
+    const tabs = tabsOf(sectionsFor(record()))
+    expect(tabs).toContain('status')
+    expect(tabs).toContain('settings')
+    expect(tabs).toContain('update')
+  })
+
+  it('declares NO snapshots section, which is what hides the tab', () => {
+    // Snapshots are admin/owner only (Jul 24 dev-platform standup). A tab
+    // appears iff a section declares it, so this absence IS the policy gate —
+    // copying another source's sections wholesale would silently re-open it.
+    expect(tabsOf(sectionsFor(record()))).not.toContain('snapshots')
+  })
+
+  it('declares NO storage section, because a reduced one shows shared models', () => {
+    // Shared models are off for distributions at MVP — each carries its own
+    // allowed list. Declaring a storage section with the toggles omitted does
+    // NOT achieve that: StoragePane reads an absent `useSharedModels` as
+    // enabled (`f ? f.value !== false : true`) and renders the global
+    // shared-models directory list. Declaring it `false` is no better, since
+    // BooleanToggle ignores `editable` and would render a live switch.
+    expect(tabsOf(sectionsFor(record()))).not.toContain('storage')
+  })
+
+  it('keeps startup arguments editable', () => {
+    const settings = sectionsFor(record()).find((s) => s.tab === 'settings')
+    const args = (settings?.fields ?? []).find((f) => f.id === 'launchArgs')
+    expect(args).toBeDefined()
+    expect(args?.editable).toBe(true)
+  })
+
+  it('labels the distribution version apart from the ComfyUI version', () => {
+    // A bare "7" in a slot every other install fills with "v0.28.2" reads as a
+    // ComfyUI version and is not one.
+    const status = sectionsFor(record()).find((s) => s.tab === 'status')
+    const ids = fieldIds(status)
+    expect(ids).toContain('distribution-version')
+    expect(ids).toContain('comfyui-version')
+    const distField = (status?.fields ?? []).find((f) => f.key === 'distribution-version')
+    expect(distField?.value).toBe('v7')
+  })
+
+  it('pins launch/rename/open-folder/remove/delete, all session-dispatched ids', () => {
+    const pinned = sectionsFor(record()).find((s) => s.pinBottom === true)
+    const ids = (pinned?.actions ?? []).map((a) => a.id)
+    expect(ids).toEqual(
+      expect.arrayContaining(['launch', 'rename', 'open-folder', 'remove', 'delete']),
+    )
+  })
+
+  it('renders the update tab as a version-stats table, like a local install', () => {
+    // Same component the local-install Update tab uses, so the two read as one
+    // surface rather than merely saying the same words.
+    setCachedVersions('d1', [3, 7, 9])
+    const field = statsField(record({ version: '7' }))
+    expect(field?.editType).toBe('version-stats')
+    expect(field?.editable).toBe(false)
+  })
+
+  it('omits the published-version list until the catalog has been read', () => {
+    // "No versions found" is a different claim from "not looked yet".
+    const update = sectionsFor(record()).find((s) => s.tab === 'update')
+    expect(rowIds(record())).not.toContain('latest')
+    expect(rowIds(record())).not.toContain('published')
+    expect((update?.actions ?? []).map((a) => a.id)).toContain('check-update')
+  })
+
+  it('states installed and latest as bare versions once the cache is warm', () => {
+    // Newest wins whatever order the catalog returned.
+    setCachedVersions('d1', [3, 7, 9])
+    const rows = statsValue(record({ version: '7' })).rows
+    expect(rows.find((r) => r.id === 'installed')?.value).toBe('v7')
+    expect(rows.find((r) => r.id === 'latest')?.value).toBe('v9')
+  })
+
+  it('offers the update action only when a newer version exists', () => {
+    // An always-present Update that no-ops on the newest version teaches the
+    // user to distrust it.
+    setCachedVersions('d1', [3, 7, 9])
+    const behind = updateActions(record({ version: '7' }))
+    const update = behind.find((a) => a.id === 'update-distribution')
+    expect(update).toBeDefined()
+    expect(update?.data).toEqual({ version: 9 })
+    expect(update?.showProgress).toBe(true)
+    expect(update?.confirm).toBeDefined()
+
+    setCachedVersions('d1', [7, 3])
+    expect(
+      updateActions(record({ version: '7' })).find((a) => a.id === 'update-distribution'),
+    ).toBeUndefined()
+  })
+
+  it('offers no update when the installed version is unknown', () => {
+    // `Number('')` is 0, which would read as "behind everything" and offer an
+    // update from a blank version.
+    setCachedVersions('d1', [9, 7])
+    const blank = record({ version: '' })
+    expect(updateActions(blank).find((a) => a.id === 'update-distribution')).toBeUndefined()
+    expect(statsValue(blank).headlineHighlight).toBe(false)
+  })
+
+  it('disables the update action while the install is not ready', () => {
+    setCachedVersions('d1', [9, 7])
+    const update = updateActions(record({ version: '7', status: 'failed' })).find(
+      (a) => a.id === 'update-distribution',
+    )
+    expect(update?.enabled).toBe(false)
+  })
+
+  it('accents the latest row and the headline only when an update is waiting', () => {
+    setCachedVersions('d1', [3, 7, 9])
+    const behind = statsValue(record({ version: '7' }))
+    expect(behind.headlineHighlight).toBe(true)
+    expect(behind.rows.find((r) => r.id === 'latest')?.highlight).toBe(true)
+
+    setCachedVersions('d1', [7, 3])
+    const current = statsValue(record({ version: '7' }))
+    expect(current.headlineHighlight).toBe(false)
+    expect(current.rows.find((r) => r.id === 'latest')?.highlight).toBe(false)
+  })
+
+  it('shows installed and latest as equal when already on the newest version', () => {
+    setCachedVersions('d1', [7, 3])
+    const rows = statsValue(record({ version: '7' })).rows
+    expect(rows.find((r) => r.id === 'installed')?.value).toBe('v7')
+    expect(rows.find((r) => r.id === 'latest')?.value).toBe('v7')
+  })
+
+  it('dedupes repeated versions from the catalog', () => {
+    setCachedVersions('d1', [5, 5, 2, 5])
+    expect(getCachedVersions('d1')?.versions).toEqual([5, 2])
+  })
+
+  it('drops the update tab for a record with no distribution link', () => {
+    const tabs = tabsOf(sectionsFor(record({ distributionId: undefined })))
+    expect(tabs).not.toContain('update')
+    // The rest of the manage view still stands.
+    expect(tabs).toContain('settings')
+  })
+})

--- a/src/main/sources/comfybuilder/detailSections.test.ts
+++ b/src/main/sources/comfybuilder/detailSections.test.ts
@@ -131,7 +131,7 @@ describe('comfybuilder.getDetailSections', () => {
     // "No versions found" is a different claim from "not looked yet".
     const update = sectionsFor(record()).find((s) => s.tab === 'update')
     expect(rowIds(record())).not.toContain('latest')
-    expect(rowIds(record())).not.toContain('published')
+    expect(rowIds(record())).not.toContain('last-checked')
     expect((update?.actions ?? []).map((a) => a.id)).toContain('check-update')
   })
 

--- a/src/main/sources/comfybuilder/detailSections.ts
+++ b/src/main/sources/comfybuilder/detailSections.ts
@@ -1,0 +1,210 @@
+/**
+ * Manage-view sections for a distribution install.
+ *
+ * Deliberately NOT built on `standalone/updateSections.ts`. That model updates
+ * along a ComfyUI release *channel*; a distribution pins its ComfyUI build, and
+ * what the user moves between is distribution versions. Offering a channel
+ * switch here would either do nothing or break the pin the distribution exists
+ * to provide.
+ *
+ * Tabs a distribution deliberately does NOT get. A tab exists iff a section
+ * declares it, so leaving one out IS the gate — don't reinstate either by
+ * copying another source's sections wholesale:
+ *
+ *   - Snapshots — admin/owner only (Jul 24 dev-platform standup).
+ *   - Storage — each distribution carries its own allowed model list, and
+ *     shared models are off for distributions at MVP. Note a REDUCED storage
+ *     section does not achieve that: `StoragePane` treats an ABSENT
+ *     `useSharedModels` field as enabled (`f ? f.value !== false : true`) and
+ *     renders the global shared-models directory list, and declaring the field
+ *     `false` is no better because `BooleanToggle` ignores `editable` and would
+ *     hand the user a live switch. Showing a distribution's staged models needs
+ *     its own pane, not a subset of this one.
+ */
+import { t } from '../../lib/i18n'
+import { deleteAction, launchAction, openFolderAction, renameAction, untrackAction } from '../../lib/actions'
+import { buildLaunchSettingsFields } from '../common/launchSettingsFields'
+import { getCachedVersions } from '../../devplatform/versionCache'
+import { formatComfyVersion } from '../../lib/version'
+import type { ComfyVersion } from '../../lib/version'
+import type { InstallationRecord } from '../../installations'
+import { DEFAULT_LAUNCH_ARGS } from './constants'
+
+/** The distribution's own release. Stored in `version` because that IS what the
+ *  builder versions; the ComfyUI build it pins is a separate fact. */
+function distributionVersion(installation: InstallationRecord): string {
+  return (installation.version as string | undefined) || ''
+}
+
+/** The ComfyUI version the distribution pins, when the record carries one.
+ *  Probed post-install like any other local install. */
+function comfyVersionLabel(installation: InstallationRecord): string {
+  const cv = installation.comfyVersion as ComfyVersion | undefined
+  return cv ? formatComfyVersion(cv, 'detail') : ''
+}
+
+function buildStatusFields(installation: InstallationRecord): Record<string, unknown>[] {
+  const dist = distributionVersion(installation)
+  const comfy = comfyVersionLabel(installation)
+  return [
+    { label: t('common.installMethod'), value: (installation.sourceLabel as string) || 'ComfyBuilder' },
+    {
+      label: t('comfybuilder.distribution'),
+      value: (installation.distributionName as string) || '—',
+    },
+    // Labelled as the DISTRIBUTION's version. A bare "7" next to a "v0.28.2"
+    // reads as a ComfyUI version and isn't one.
+    {
+      key: 'distribution-version',
+      label: t('comfybuilder.distributionVersion'),
+      value: dist ? `v${dist}` : '—',
+    },
+    { key: 'comfyui-version', label: t('comfybuilder.comfyuiVersion'), value: comfy || '—' },
+    { label: t('common.location'), value: (installation.installPath as string) || '—' },
+  ]
+}
+
+/**
+ * The Update tab: which distribution version this install is on, and where it
+ * can go.
+ *
+ * Versions come from the catalog cache, which the chooser's distribution read
+ * warms. Cold (nothing read yet, or signed out) the latest row is omitted
+ * rather than shown empty — "no versions found" is a different claim from "not
+ * looked yet".
+ */
+function buildUpdateSection(installation: InstallationRecord): Record<string, unknown> | null {
+  const distributionId = installation.distributionId as string | undefined
+  if (!distributionId) return null
+
+  const current = distributionVersion(installation)
+  const cached = getCachedVersions(distributionId)
+  const versions = cached?.versions ?? []
+  const latest = versions[0]
+  const currentNum = Number(current)
+  // An empty version is unknown, not zero — `Number('')` is 0, which would
+  // otherwise read as "behind every published version" and offer an update
+  // from a blank.
+  const updateAvailable =
+    latest !== undefined && current !== '' && Number.isFinite(currentNum) && latest > currentNum
+
+  // The same version table the local-install Update tab uses, so the two read
+  // as one surface. Rows are stated as bare versions and left to compare
+  // themselves — a "v9 available" sentence says the same thing while burying
+  // the number it is about.
+  const rows: Record<string, unknown>[] = [
+    {
+      id: 'installed',
+      label: t('comfybuilder.installedVersion'),
+      value: current ? `v${current}` : '—',
+    },
+  ]
+  if (latest !== undefined) {
+    rows.push({
+      id: 'latest',
+      label: t('comfybuilder.latestVersion'),
+      value: `v${latest}`,
+      highlight: updateAvailable,
+    })
+  }
+  if (cached?.fetchedAt) {
+    rows.push({
+      id: 'last-checked',
+      label: t('comfybuilder.lastChecked'),
+      value: new Date(cached.fetchedAt).toLocaleString(),
+    })
+  }
+
+  return {
+    tab: 'update',
+    title: t('comfybuilder.distributionVersionTitle'),
+    fields: [
+      {
+        id: 'distributionVersionStats',
+        label: t('comfybuilder.distributionVersionTitle'),
+        editType: 'version-stats',
+        editable: false,
+        value: {
+          headline: current ? `v${current}` : '—',
+          headlineHighlight: updateAvailable,
+          badge: updateAvailable
+            ? t('comfybuilder.updateAvailable')
+            : latest !== undefined
+              ? t('comfybuilder.upToDate')
+              : null,
+          badgeTone: updateAvailable ? 'update' : 'current',
+          rows,
+        },
+      },
+    ],
+    actions: [
+      { id: 'check-update', label: t('actions.checkForUpdate'), style: 'default', enabled: true },
+      // Only when there is somewhere to go. An always-present Update that no-ops
+      // on the newest version teaches the user to distrust it.
+      ...(updateAvailable
+        ? [
+            {
+              id: 'update-distribution',
+              label: t('comfybuilder.updateToVersion', { version: latest }),
+              style: 'primary',
+              enabled: installation.status === 'installed',
+              showProgress: true,
+              cancellable: true,
+              progressTitle: t('comfybuilder.updatingTo', { version: latest }),
+              data: { version: latest },
+              confirm: {
+                title: t('comfybuilder.updateConfirmTitle'),
+                message: t('comfybuilder.updateConfirmMessage', {
+                  from: `**v${current}**`,
+                  to: `**v${latest}**`,
+                }),
+              },
+            },
+          ]
+        : []),
+    ],
+  }
+}
+
+export function getDetailSections(installation: InstallationRecord): Record<string, unknown>[] {
+  const installed = installation.status === 'installed'
+
+  const sections: Record<string, unknown>[] = [
+    {
+      tab: 'status',
+      title: t('common.installInfo'),
+      fields: buildStatusFields(installation),
+    },
+  ]
+
+  const update = buildUpdateSection(installation)
+  if (update) sections.push(update)
+
+  sections.push(
+    {
+      tab: 'settings',
+      title: t('common.launchSettings'),
+      // Args stay open even where a distribution may ignore some of them —
+      // the Jul 24 standup kept the field editable rather than second-guessing
+      // which flags a given build honours.
+      fields: buildLaunchSettingsFields(installation, { defaultLaunchArgs: DEFAULT_LAUNCH_ARGS }),
+    },
+    {
+      // No title: only `.actions` is read off a pinBottom section (the footer
+      // renders the buttons), so a title here would be an untranslated string
+      // nothing displays.
+      pinBottom: true,
+      // Every id here is handled by the generic session-action dispatch
+      // (`sessionActions/index.ts`), not by this plugin's `handleAction`.
+      actions: [
+        launchAction(installed, !installed ? t('errors.installNotReady') : undefined),
+        renameAction(installation.name),
+        openFolderAction(installation.installPath),
+        untrackAction(),
+        deleteAction(installation),
+      ],
+    },
+  )
+
+  return sections
+}

--- a/src/main/sources/comfybuilder/index.test.ts
+++ b/src/main/sources/comfybuilder/index.test.ts
@@ -18,9 +18,15 @@ vi.mock('../../comfybuilder', () => ({
   resolveModelManifest: vi.fn(async () => ({ models: [], modelPolicy: null, partnerNodePolicy: null })),
 }))
 vi.mock('../../devplatform/session', () => ({ getBuilderClient: vi.fn(() => ({})) }))
+vi.mock('../../devplatform/distributions', () => ({
+  resolveHost: vi.fn(async () => ({ os: 'linux', gpu: 'nvidia' })),
+  resolveHostArtifactForVersion: vi.fn(),
+  listCompleteVersions: vi.fn(async () => []),
+}))
 
 import { promises as fsp } from 'fs'
 import { installArtifact, stageModels, resolveModelManifest } from '../../comfybuilder'
+import { resolveHostArtifactForVersion } from '../../devplatform/distributions'
 import { comfybuilder, withAccelArgs } from './index'
 import type { InstallationRecord } from '../../installations'
 import type { InstallTools } from '../../types/sources'
@@ -53,19 +59,40 @@ function fakeTools(signal?: AbortSignal): InstallTools & { sent: Array<{ phase: 
 describe('comfybuilder.install wiring', () => {
   beforeEach(() => vi.clearAllMocks())
 
-  it('wipes the venv before extracting so a re-install/update lays down a clean env', async () => {
+  it('moves the venv aside before extracting so a re-install lays down a clean env', async () => {
+    const rename = vi.spyOn(fsp, 'rename').mockResolvedValue(undefined)
     const rm = vi.spyOn(fsp, 'rm').mockResolvedValue(undefined)
     try {
       await comfybuilder.install!(record(), fakeTools())
-      expect(rm).toHaveBeenCalledWith(
+      // Aside, NOT deleted: `installArtifact` only touches installPath after the
+      // download and checksum pass, so the old env has to survive until then.
+      expect(rename).toHaveBeenCalledWith(
         expect.stringContaining('venv'),
-        expect.objectContaining({ recursive: true, force: true }),
+        expect.stringContaining('venv.previous'),
       )
-      // The venv must be gone before the archive lays down a fresh one.
-      const rmOrder = rm.mock.invocationCallOrder[0]!
+      const renameOrder = rename.mock.invocationCallOrder[0]!
       const installOrder = (installArtifact as unknown as { mock: { invocationCallOrder: number[] } }).mock.invocationCallOrder[0]!
-      expect(rmOrder).toBeLessThan(installOrder)
+      expect(renameOrder).toBeLessThan(installOrder)
     } finally {
+      rename.mockRestore()
+      rm.mockRestore()
+    }
+  })
+
+  it('puts the previous venv back when the install fails', async () => {
+    // Otherwise a failed update leaves the record on a version whose
+    // environment is gone — an install that reports fine and cannot launch.
+    const rename = vi.spyOn(fsp, 'rename').mockResolvedValue(undefined)
+    const rm = vi.spyOn(fsp, 'rm').mockResolvedValue(undefined)
+    vi.mocked(installArtifact).mockRejectedValueOnce(new Error('disk full'))
+    try {
+      await expect(comfybuilder.install!(record(), fakeTools())).rejects.toThrow('disk full')
+      expect(rename).toHaveBeenCalledTimes(2)
+      const [from, to] = rename.mock.calls[1]!
+      expect(String(from)).toContain('venv.previous')
+      expect(String(to)).toMatch(/venv$/)
+    } finally {
+      rename.mockRestore()
       rm.mockRestore()
     }
   })
@@ -169,5 +196,136 @@ describe('comfybuilder.withAccelArgs', () => {
 
   it('does not mistake --cpu-vae for the cpu flag', () => {
     expect(withAccelArgs(record({ artifactGpu: 'cpu' }), '--cpu-vae')).toBe('--cpu-vae --cpu')
+  })
+})
+
+describe('comfybuilder update-distribution', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  const artifact = {
+    id: 'art-9',
+    os: 'linux',
+    gpu: 'nvidia',
+    accelVariant: 'cu128',
+    status: 'ready',
+    archiveSha256: 'sha-9',
+  }
+
+  function actionTools() {
+    const updates: Record<string, unknown>[] = []
+    return {
+      updates,
+      update: vi.fn(async (d: Record<string, unknown>) => {
+        updates.push(d)
+      }),
+      sendProgress: vi.fn(),
+      sendOutput: vi.fn(),
+    }
+  }
+
+  it('re-points the record, re-installs, then marks it installed', async () => {
+    vi.mocked(resolveHostArtifactForVersion).mockResolvedValue({ artifact, version: 9 } as never)
+    const tools = actionTools()
+
+    const result = await comfybuilder.handleAction(
+      'update-distribution',
+      record(),
+      { version: 9 },
+      tools as never,
+    )
+
+    expect(result.ok).toBe(true)
+    expect(installArtifact).toHaveBeenCalledTimes(1)
+    // Installing first, installed last — never left mid-flight.
+    expect(tools.updates[0]).toMatchObject({ version: '9', artifactId: 'art-9', status: 'installing' })
+    expect(tools.updates.at(-1)).toMatchObject({ status: 'installed' })
+    // The environment is laid down for the NEW artifact, not the old one.
+    const passed = vi.mocked(installArtifact).mock.calls[0]![0] as { artifact: { id: string } }
+    expect(passed.artifact.id).toBe('art-9')
+  })
+
+  it('restores the previous version when the install fails', async () => {
+    // Otherwise the record advertises a version whose environment never landed.
+    vi.mocked(resolveHostArtifactForVersion).mockResolvedValue({ artifact, version: 9 } as never)
+    vi.mocked(installArtifact).mockRejectedValueOnce(new Error('disk full'))
+    // The venv survived — `installEnvironment` put it back.
+    const stat = vi.spyOn(fsp, 'stat').mockResolvedValue({} as never)
+    const tools = actionTools()
+
+    try {
+      const result = await comfybuilder.handleAction(
+        'update-distribution',
+        record({ artifactId: 'art-1' }),
+        { version: 9 },
+        tools as never,
+      )
+
+      expect(result.ok).toBe(false)
+      expect(result.message).toContain('disk full')
+      expect(tools.updates.at(-1)).toMatchObject({ version: '1', artifactId: 'art-1', status: 'installed' })
+    } finally {
+      stat.mockRestore()
+    }
+  })
+
+  it('reports failed when the environment did not survive the attempt', async () => {
+    // Restoring the record but still claiming `installed` would advertise a
+    // working install that cannot launch.
+    vi.mocked(resolveHostArtifactForVersion).mockResolvedValue({ artifact, version: 9 } as never)
+    vi.mocked(installArtifact).mockRejectedValueOnce(new Error('disk full'))
+    const stat = vi.spyOn(fsp, 'stat').mockRejectedValue(new Error('ENOENT'))
+    const tools = actionTools()
+
+    try {
+      const result = await comfybuilder.handleAction(
+        'update-distribution',
+        record({ artifactId: 'art-1' }),
+        { version: 9 },
+        tools as never,
+      )
+
+      expect(result.ok).toBe(false)
+      expect(tools.updates.at(-1)).toMatchObject({ version: '1', status: 'failed' })
+    } finally {
+      stat.mockRestore()
+    }
+  })
+
+  it('refuses to update an install that is not ready', async () => {
+    // The section disables the button, but an action id is reachable alone.
+    const tools = actionTools()
+    const result = await comfybuilder.handleAction(
+      'update-distribution',
+      record({ status: 'failed' }),
+      { version: 9 },
+      tools as never,
+    )
+
+    expect(result.ok).toBe(false)
+    expect(resolveHostArtifactForVersion).not.toHaveBeenCalled()
+    expect(tools.update).not.toHaveBeenCalled()
+  })
+
+  it('refuses a version with no build for this machine, without touching the record', async () => {
+    vi.mocked(resolveHostArtifactForVersion).mockResolvedValue(null)
+    const tools = actionTools()
+
+    const result = await comfybuilder.handleAction(
+      'update-distribution',
+      record(),
+      { version: 4 },
+      tools as never,
+    )
+
+    expect(result.ok).toBe(false)
+    expect(installArtifact).not.toHaveBeenCalled()
+    expect(tools.update).not.toHaveBeenCalled()
+  })
+
+  it('rejects a missing target version', async () => {
+    const tools = actionTools()
+    const result = await comfybuilder.handleAction('update-distribution', record(), {}, tools as never)
+    expect(result.ok).toBe(false)
+    expect(tools.update).not.toHaveBeenCalled()
   })
 })

--- a/src/main/sources/comfybuilder/index.test.ts
+++ b/src/main/sources/comfybuilder/index.test.ts
@@ -26,7 +26,8 @@ vi.mock('../../devplatform/distributions', () => ({
 
 import { promises as fsp } from 'fs'
 import { installArtifact, stageModels, resolveModelManifest } from '../../comfybuilder'
-import { resolveHostArtifactForVersion } from '../../devplatform/distributions'
+import { listCompleteVersions, resolveHostArtifactForVersion } from '../../devplatform/distributions'
+import { clearVersionCache, getCachedVersions } from '../../devplatform/versionCache'
 import { comfybuilder, withAccelArgs } from './index'
 import type { InstallationRecord } from '../../installations'
 import type { InstallTools } from '../../types/sources'
@@ -327,5 +328,27 @@ describe('comfybuilder update-distribution', () => {
     const result = await comfybuilder.handleAction('update-distribution', record(), {}, tools as never)
     expect(result.ok).toBe(false)
     expect(tools.update).not.toHaveBeenCalled()
+  })
+})
+
+describe('comfybuilder check-update', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    clearVersionCache()
+  })
+
+  it('warms the version cache from the catalog', async () => {
+    vi.mocked(listCompleteVersions).mockResolvedValue([7, 3])
+    const result = await comfybuilder.handleAction('check-update', record(), undefined, fakeTools() as never)
+    expect(result.ok).toBe(true)
+    expect(getCachedVersions('d1')?.versions).toEqual([7, 3])
+  })
+
+  it('reports failure and leaves the cache untouched when the catalog read throws', async () => {
+    vi.mocked(listCompleteVersions).mockRejectedValueOnce(new Error('offline'))
+    const result = await comfybuilder.handleAction('check-update', record(), undefined, fakeTools() as never)
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('offline')
+    expect(getCachedVersions('d1')).toBeNull()
   })
 })

--- a/src/main/sources/comfybuilder/index.ts
+++ b/src/main/sources/comfybuilder/index.ts
@@ -21,6 +21,8 @@ import path from 'path'
 import { installArtifact, buildLaunchSpec, stageModels, resolveModelManifest } from '../../comfybuilder'
 import type { Artifact, ArtifactGpu, ArtifactOs, InstallProgress, StageProgress } from '../../comfybuilder'
 import { getBuilderClient } from '../../devplatform/session'
+import { listCompleteVersions, resolveHost, resolveHostArtifactForVersion } from '../../devplatform/distributions'
+import { setCachedVersions } from '../../devplatform/versionCache'
 import { launchAction } from '../../lib/actions'
 import { defaultDownloadCacheDir } from '../../lib/paths'
 import { t } from '../../lib/i18n'
@@ -29,10 +31,12 @@ import type {
   SourcePlugin,
   LaunchCommand,
   ActionResult,
+  ActionTools,
   InstallTools,
 } from '../../types/sources'
 
-const DEFAULT_LAUNCH_ARGS = '--enable-manager'
+import { DEFAULT_LAUNCH_ARGS } from './constants'
+import { getDetailSections } from './detailSections'
 
 /** Reconstruct the library Artifact from the fields the install record carries. */
 function artifactFromRecord(inst: InstallationRecord): Artifact {
@@ -60,6 +64,86 @@ export function withAccelArgs(installation: InstallationRecord, launchArgs: stri
   const isCpu = installation.artifactGpu === 'cpu' || installation.artifactAccelVariant === 'cpu'
   if (!isCpu || /(?:^|\s)--cpu(?:\s|$)/.test(launchArgs)) return launchArgs
   return `${launchArgs} --cpu`.trim()
+}
+
+/**
+ * Lay down the environment for whatever artifact the record currently points
+ * at. Shared by the first install and by an in-place version change, so the two
+ * can't diverge on venv handling or model staging.
+ *
+ * Takes only what both callers have: progress + an abort signal.
+ */
+async function installEnvironment(
+  installation: InstallationRecord,
+  // Narrower than `ActionTools.sendProgress` on purpose: a handler that accepts
+  // `Record<string, unknown>` satisfies this, but not the reverse.
+  tools: {
+    sendProgress: (step: string, data: { percent: number; status: string }) => void
+    signal?: AbortSignal
+  },
+): Promise<void> {
+  const artifact = artifactFromRecord(installation)
+  const client = getBuilderClient()
+  const venvPath = path.join(installation.installPath, 'venv')
+  const previousVenvPath = `${venvPath}.previous`
+
+  // A venv can't be overlaid (leftover site-packages from the old version break
+  // Python), so the old one moves aside before extracting. MOVED, not deleted:
+  // `installArtifact` downloads to a temp and verifies the checksum before it
+  // touches `installPath`, precisely so a failed run never destroys a working
+  // environment. Deleting up front would throw that guarantee away and leave a
+  // failed update on a version it can no longer launch.
+  await fs.rm(previousVenvPath, { recursive: true, force: true }).catch(() => {})
+  const hadPreviousVenv = await fs
+    .rename(venvPath, previousVenvPath)
+    .then(() => true)
+    .catch(() => false)
+
+  try {
+    // Phase 1: archive (code + environment). `installArtifact` verifies the
+    // sha256 when the artifact carries one and fails on a byte mismatch. A
+    // missing hash is skipped for the initial rollout (see the TODO there).
+    await installArtifact({
+      artifact,
+      client,
+      installPath: installation.installPath,
+      cacheDir: defaultDownloadCacheDir(),
+      onProgress: (p: InstallProgress) => {
+        // The library's `resolve` phase has no labeled step; fold it into the
+        // download step at 0% so the stepper still shows forward motion.
+        const phase = p.phase === 'resolve' ? 'download' : p.phase
+        tools.sendProgress(phase, { percent: p.percent, status: p.detail ?? '' })
+      },
+      ...(tools.signal ? { signal: tools.signal } : {}),
+    })
+
+    // Phase 2: models. The archive carries no weights, so stage the
+    // distribution's declared models into the install's ComfyUI model tree
+    // before launch, the way comfy-deploy provisions a volume before boot. An
+    // empty manifest stages nothing and the step completes immediately.
+    const manifest = await resolveModelManifest(
+      client,
+      installation.distributionId as string,
+      installation.version as string,
+    )
+    await stageModels({
+      models: manifest.models,
+      installPath: installation.installPath,
+      onProgress: (p: StageProgress) =>
+        tools.sendProgress('models', { percent: p.percent, status: `${p.filename} (${p.index}/${p.total})` }),
+      ...(tools.signal ? { signal: tools.signal } : {}),
+    })
+    tools.sendProgress('models', { percent: 100, status: '' })
+  } catch (err) {
+    // Put the working environment back before surfacing the failure.
+    if (hadPreviousVenv) {
+      await fs.rm(venvPath, { recursive: true, force: true }).catch(() => {})
+      await fs.rename(previousVenvPath, venvPath).catch(() => {})
+    }
+    throw err
+  }
+
+  await fs.rm(previousVenvPath, { recursive: true, force: true }).catch(() => {})
 }
 
 export const comfybuilder: SourcePlugin = {
@@ -117,19 +201,7 @@ export const comfybuilder: SourcePlugin = {
     return [launchAction(installed, !installed ? t('errors.installNotReady') : undefined)]
   },
 
-  getDetailSections(installation: InstallationRecord): Record<string, unknown>[] {
-    return [
-      {
-        tab: 'status',
-        title: 'Installation Info',
-        fields: [
-          { label: 'Install method', value: (installation.sourceLabel as string) || 'ComfyBuilder' },
-          { label: 'Distribution', value: (installation.distributionName as string) || '-' },
-          { label: 'Version', value: (installation.version as string) || '-' },
-        ],
-      },
-    ]
-  },
+  getDetailSections,
 
   // A ComfyBuilder install is never discovered on disk: only the dev-platform
   // flow creates one: so there is nothing to probe/adopt.
@@ -138,50 +210,117 @@ export const comfybuilder: SourcePlugin = {
   },
 
   async install(installation: InstallationRecord, tools: InstallTools): Promise<void> {
-    const artifact = artifactFromRecord(installation)
-    const client = getBuilderClient()
-    // A venv can't be overlaid (leftover site-packages from the old version break
-    // Python), so remove it before extracting. No-op on a first install; on an
-    // update/retry it guarantees a clean environment. The archive lays down a
-    // fresh venv; staged models under ComfyUI/models are left untouched.
-    await fs.rm(path.join(installation.installPath, 'venv'), { recursive: true, force: true })
-    // Phase 1: archive (code + environment). `installArtifact` verifies the
-    // sha256 when the artifact carries one and fails on a byte mismatch. A
-    // missing hash is skipped for the initial rollout (see the TODO there).
-    await installArtifact({
-      artifact,
-      client,
-      installPath: installation.installPath,
-      cacheDir: defaultDownloadCacheDir(),
-      onProgress: (p: InstallProgress) => {
-        // The library's `resolve` phase has no labeled step; fold it into the
-        // download step at 0% so the stepper still shows forward motion.
-        const phase = p.phase === 'resolve' ? 'download' : p.phase
-        tools.sendProgress(phase, { percent: p.percent, status: p.detail ?? '' })
-      },
-      ...(tools.signal ? { signal: tools.signal } : {}),
-    })
-
-    // Phase 2: models. The archive carries no weights, so stage the
-    // distribution's declared models into the install's ComfyUI model tree
-    // before launch, the way comfy-deploy provisions a volume before boot. An
-    // empty manifest stages nothing and the step completes immediately.
-    const manifest = await resolveModelManifest(
-      client,
-      installation.distributionId as string,
-      installation.version as string,
-    )
-    await stageModels({
-      models: manifest.models,
-      installPath: installation.installPath,
-      onProgress: (p: StageProgress) =>
-        tools.sendProgress('models', { percent: p.percent, status: `${p.filename} (${p.index}/${p.total})` }),
-      ...(tools.signal ? { signal: tools.signal } : {}),
-    })
-    tools.sendProgress('models', { percent: 100, status: '' })
+    await installEnvironment(installation, tools)
   },
 
-  async handleAction(actionId: string): Promise<ActionResult> {
+  // Launch / rename / open-folder / remove / delete never reach here — the
+  // generic session-action dispatch (`sessionActions/index.ts`) handles those
+  // before a plugin is consulted.
+  async handleAction(
+    actionId: string,
+    installation: InstallationRecord,
+    actionData: Record<string, unknown> | undefined,
+    tools: ActionTools,
+  ): Promise<ActionResult> {
+    const distributionId = installation.distributionId as string | undefined
+    if (!distributionId) return { ok: false, message: t('comfybuilder.errorNoDistribution') }
+
+    if (actionId === 'check-update') {
+      try {
+        setCachedVersions(
+          distributionId,
+          await listCompleteVersions(getBuilderClient(), distributionId),
+        )
+        return { ok: true }
+      } catch (err) {
+        return { ok: false, message: err instanceof Error ? err.message : String(err) }
+      }
+    }
+
+    if (actionId === 'update-distribution') {
+      return updateDistributionVersion(installation, distributionId, actionData, tools)
+    }
+
     return { ok: false, message: `Action "${actionId}" not yet implemented.` }
   },
+}
+
+/**
+ * Move this install to another published version of its own distribution.
+ *
+ * Re-installs in place: the record is re-pointed at the target artifact, then
+ * the same `installEnvironment` a first install runs lays the new environment
+ * down over it. Done here rather than through the `install-instance` chain
+ * because that chain is bound to its IPC sender — but the pieces it owns are
+ * only needed for a FRESH install. The directory and the record already exist,
+ * so what remains is the status arc, which is handled explicitly below.
+ *
+ * Targets the INSTALLATION, never the distribution id: several installs of one
+ * distribution are allowed, so distribution-keyed lookup would pick arbitrarily.
+ */
+async function updateDistributionVersion(
+  installation: InstallationRecord,
+  distributionId: string,
+  actionData: Record<string, unknown> | undefined,
+  tools: ActionTools,
+): Promise<ActionResult> {
+  const target = Number(actionData?.version)
+  if (!Number.isFinite(target)) return { ok: false, message: t('comfybuilder.errorNoVersion') }
+
+  // The section only offers this on a ready install, but an action id is
+  // reachable on its own — re-check rather than trust the caller, since the
+  // rollback below can only restore a state that was coherent to begin with.
+  const previousStatus = installation.status as string | undefined
+  if (previousStatus !== 'installed') return { ok: false, message: t('errors.installNotReady') }
+
+  const previous = {
+    version: installation.version as string | undefined,
+    artifactId: installation.artifactId as string | undefined,
+    artifactOs: installation.artifactOs as string | undefined,
+    artifactGpu: installation.artifactGpu as string | undefined,
+    artifactAccelVariant: installation.artifactAccelVariant as string | undefined,
+    artifactSha256: installation.artifactSha256 as string | undefined,
+  }
+
+  try {
+    const resolved = await resolveHostArtifactForVersion(
+      getBuilderClient(),
+      await resolveHost(),
+      distributionId,
+      target,
+    )
+    if (!resolved) {
+      return { ok: false, message: t('comfybuilder.errorVersionUnavailable', { version: target }) }
+    }
+
+    const { artifact } = resolved
+    const next: Record<string, unknown> = {
+      version: String(resolved.version),
+      artifactId: artifact.id,
+      artifactOs: artifact.os,
+      artifactGpu: artifact.gpu,
+      artifactAccelVariant: artifact.accelVariant,
+      ...(artifact.archiveSha256 ? { artifactSha256: artifact.archiveSha256 } : {}),
+    }
+    await tools.update({ ...next, status: 'installing' })
+
+    await installEnvironment({ ...installation, ...next } as InstallationRecord, tools)
+
+    await tools.update({ status: 'installed' })
+    return { ok: true, navigate: 'detail' }
+  } catch (err) {
+    // Put the record back where it was. Leaving it pointed at a version whose
+    // environment never landed would report a version the install doesn't have.
+    //
+    // `installEnvironment` restores the previous venv on failure, but if that
+    // did not survive the install can no longer launch: report it failed rather
+    // than advertise a working install that isn't one.
+    const runnable = await fs
+      .stat(path.join(installation.installPath, 'venv'))
+      .then(() => true)
+      .catch(() => false)
+    await tools.update({ ...previous, status: runnable ? previousStatus : 'failed' }).catch(() => {})
+    if (tools.signal?.aborted) return { ok: false, cancelled: true }
+    return { ok: false, message: err instanceof Error ? err.message : String(err) }
+  }
 }

--- a/src/renderer/src/composables/useInstallList.test.ts
+++ b/src/renderer/src/composables/useInstallList.test.ts
@@ -247,56 +247,6 @@ describe('useInstallList', () => {
     })
   })
 
-  describe('lastLaunchedLabel', () => {
-    it('returns the neverLaunched string when lastLaunchedAt is undefined', () => {
-      const installations = ref<Installation[]>([])
-      const list = withI18nScope(i18n, () => useInstallList({ installations }))
-
-      const inst = makeInstall({ id: 'a' })
-      expect(list.lastLaunchedLabel(inst)).toBe('Not launched yet')
-    })
-
-    it('formats sub-minute timestamps as "just now"', () => {
-      vi.useFakeTimers()
-      vi.setSystemTime(new Date('2026-05-18T12:00:00Z'))
-      const installations = ref<Installation[]>([])
-      const list = withI18nScope(i18n, () => useInstallList({ installations }))
-
-      const inst = makeInstall({ id: 'a', lastLaunchedAt: Date.now() - 30_000 })
-      expect(list.lastLaunchedLabel(inst)).toBe('Launched Just now')
-    })
-
-    it('formats sub-hour timestamps as "Nm ago"', () => {
-      vi.useFakeTimers()
-      vi.setSystemTime(new Date('2026-05-18T12:00:00Z'))
-      const installations = ref<Installation[]>([])
-      const list = withI18nScope(i18n, () => useInstallList({ installations }))
-
-      const inst = makeInstall({ id: 'a', lastLaunchedAt: Date.now() - 17 * 60_000 })
-      expect(list.lastLaunchedLabel(inst)).toBe('Launched 17m ago')
-    })
-
-    it('formats sub-day timestamps as "Nh ago"', () => {
-      vi.useFakeTimers()
-      vi.setSystemTime(new Date('2026-05-18T12:00:00Z'))
-      const installations = ref<Installation[]>([])
-      const list = withI18nScope(i18n, () => useInstallList({ installations }))
-
-      const inst = makeInstall({ id: 'a', lastLaunchedAt: Date.now() - 3 * 3_600_000 })
-      expect(list.lastLaunchedLabel(inst)).toBe('Launched 3h ago')
-    })
-
-    it('formats older timestamps as "Nd ago"', () => {
-      vi.useFakeTimers()
-      vi.setSystemTime(new Date('2026-05-18T12:00:00Z'))
-      const installations = ref<Installation[]>([])
-      const list = withI18nScope(i18n, () => useInstallList({ installations }))
-
-      const inst = makeInstall({ id: 'a', lastLaunchedAt: Date.now() - 5 * 86_400_000 })
-      expect(list.lastLaunchedLabel(inst)).toBe('Launched 5d ago')
-    })
-  })
-
   describe('lastLaunchedShortLabel', () => {
     it('returns an empty string when lastLaunchedAt is undefined', () => {
       const installations = ref<Installation[]>([])

--- a/src/renderer/src/composables/useInstallList.ts
+++ b/src/renderer/src/composables/useInstallList.ts
@@ -6,7 +6,6 @@ import {
   type ComputedRef,
   type Ref,
 } from 'vue'
-import { useI18n } from 'vue-i18n'
 import { scoreName } from '../utils/fuzzyMatch'
 import type { Installation } from '../types/ipc'
 
@@ -38,7 +37,6 @@ export interface UseInstallListApi {
   visibleInstalls: ComputedRef<Installation[]>
   showEmptyHint: ComputedRef<boolean>
   matchesQuery: (name: string) => boolean
-  lastLaunchedLabel: (inst: Installation) => string
   /** Compact recency for tight picker rows — `3h ago`, not `Launched 3h ago`. */
   lastLaunchedShortLabel: (inst: Installation) => string
 }
@@ -52,7 +50,6 @@ export interface UseInstallListApi {
 // any settings broadcast — toggling Global Settings filters cloud out
 // without requiring a window reopen.
 export function useInstallList(opts: UseInstallListOpts): UseInstallListApi {
-  const { t } = useI18n()
   const { installations } = opts
 
   const searchQuery = ref('')
@@ -157,12 +154,6 @@ export function useInstallList(opts: UseInstallListOpts): UseInstallListApi {
     return `${days}d ago`
   }
 
-  function lastLaunchedLabel(inst: Installation): string {
-    return typeof inst.lastLaunchedAt === 'number'
-      ? t('dashboard.launchedAgo', { time: timeAgo(inst.lastLaunchedAt) })
-      : t('dashboard.neverLaunched')
-  }
-
   function lastLaunchedShortLabel(inst: Installation): string {
     return typeof inst.lastLaunchedAt === 'number'
       ? timeAgo(inst.lastLaunchedAt)
@@ -175,7 +166,6 @@ export function useInstallList(opts: UseInstallListOpts): UseInstallListApi {
     visibleInstalls,
     showEmptyHint,
     matchesQuery,
-    lastLaunchedLabel,
     lastLaunchedShortLabel,
   }
 }

--- a/src/renderer/src/devplatform/distributionState.ts
+++ b/src/renderer/src/devplatform/distributionState.ts
@@ -1,0 +1,29 @@
+/**
+ * One definition of "can't install this", so the tile's receded treatment, its
+ * reason tag and its disabled activation can't disagree.
+ */
+import type { Distribution, DistributionState } from './types'
+import type { Installation } from '../types/ipc'
+
+/** An install that came from a distribution. One definition, so the shelf it
+ *  sorts into and the glyph it wears can't disagree. `distributionId` arrives
+ *  through an index signature, hence the emptiness check. */
+export function isDistributionInstall(inst: Installation): boolean {
+  return inst.sourceId === 'comfybuilder' || Boolean(inst.distributionId)
+}
+
+export const BLOCKED_DISTRIBUTION_STATES: readonly DistributionState[] = [
+  'no-build',
+  'platform-mismatch',
+]
+
+/** i18n suffix per blocked state: keys both the short tag label (`states.*`)
+ *  and the fallback long reason (`blockedReason.*`). */
+export const BLOCKED_STATE_KEY: Record<string, string> = {
+  'no-build': 'noBuild',
+  'platform-mismatch': 'platformMismatch',
+}
+
+export function isBlockedDistribution(dist: Pick<Distribution, 'state'>): boolean {
+  return BLOCKED_DISTRIBUTION_STATES.includes(dist.state)
+}

--- a/src/renderer/src/devplatform/distributionState.ts
+++ b/src/renderer/src/devplatform/distributionState.ts
@@ -5,11 +5,18 @@
 import type { Distribution, DistributionState } from './types'
 import type { Installation } from '../types/ipc'
 
+/** The rule itself, over the two raw fields — so callers holding only a subset
+ *  of the record (the picker row, the title bar) can ask without a cast.
+ *  `distributionId` arrives through an index signature, hence the emptiness
+ *  check rather than a `typeof`. */
+export function isDistributionSource(sourceId: unknown, distributionId: unknown): boolean {
+  return sourceId === 'comfybuilder' || Boolean(distributionId)
+}
+
 /** An install that came from a distribution. One definition, so the shelf it
- *  sorts into and the glyph it wears can't disagree. `distributionId` arrives
- *  through an index signature, hence the emptiness check. */
+ *  sorts into and the glyph it wears can't disagree. */
 export function isDistributionInstall(inst: Installation): boolean {
-  return inst.sourceId === 'comfybuilder' || Boolean(inst.distributionId)
+  return isDistributionSource(inst.sourceId, inst.distributionId)
 }
 
 export const BLOCKED_DISTRIBUTION_STATES: readonly DistributionState[] = [

--- a/src/renderer/src/devplatform/types.ts
+++ b/src/renderer/src/devplatform/types.ts
@@ -1,0 +1,11 @@
+/**
+ * Renderer-facing dev-platform types.
+ *
+ * The wire shapes live in `src/types/ipc.ts` (the single IPC source of truth);
+ * this file just re-exports them under the shorter names the views use, so a
+ * component imports `Distribution` from one local place.
+ */
+import type { DevPlatformDistribution, DevPlatformDistributionState } from '../../../types/ipc'
+
+export type Distribution = DevPlatformDistribution
+export type DistributionState = DevPlatformDistributionState

--- a/src/renderer/src/lib/installTypeIcon.test.ts
+++ b/src/renderer/src/lib/installTypeIcon.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { Cloud, Computer, LaptopMinimal, Globe, Box } from 'lucide-vue-next'
+import { Cloud, Computer, LaptopMinimal, Globe, Box, Package } from 'lucide-vue-next'
 
 import { installTypeMetaFor, installTypeMetaForInstall } from './installTypeIcon'
 
@@ -62,6 +62,7 @@ describe('installTypeMetaForInstall', () => {
       sourceCategory: 'local',
     })
     expect(bySource.key).toBe('distribution')
+    expect(bySource.icon).toBe(Package)
     expect(bySource.labelKey).toBe('installType.distribution')
 
     const byLink = installTypeMetaForInstall({

--- a/src/renderer/src/lib/installTypeIcon.test.ts
+++ b/src/renderer/src/lib/installTypeIcon.test.ts
@@ -53,6 +53,35 @@ describe('installTypeMetaForInstall', () => {
     expect(meta.labelKey).toBe('installType.legacyDesktop')
   })
 
+  it('gives a distribution install the distribution glyph, not the local one', () => {
+    // It reports `local` like any standalone install, but what it IS matters
+    // more than where it runs — and the tile, the picker row and the title bar
+    // all read this, so they can't drift apart.
+    const bySource = installTypeMetaForInstall({
+      sourceId: 'comfybuilder',
+      sourceCategory: 'local',
+    })
+    expect(bySource.key).toBe('distribution')
+    expect(bySource.labelKey).toBe('installType.distribution')
+
+    const byLink = installTypeMetaForInstall({
+      sourceId: 'standalone',
+      sourceCategory: 'local',
+      distributionId: 'd1',
+    })
+    expect(byLink.key).toBe('distribution')
+  })
+
+  it('does not treat an empty distributionId as a link', () => {
+    expect(
+      installTypeMetaForInstall({
+        sourceId: 'standalone',
+        sourceCategory: 'local',
+        distributionId: '',
+      }).key,
+    ).toBe('standalone')
+  })
+
   it('falls through to the category for non-desktop installs', () => {
     expect(installTypeMetaForInstall({ sourceId: 'standalone', sourceCategory: 'local' }).key).toBe(
       'standalone',

--- a/src/renderer/src/lib/installTypeIcon.ts
+++ b/src/renderer/src/lib/installTypeIcon.ts
@@ -1,5 +1,6 @@
-import { Cloud, Computer, LaptopMinimal, Globe, Box } from 'lucide-vue-next'
+import { Cloud, Computer, LaptopMinimal, Globe, Box, Package } from 'lucide-vue-next'
 import type { LucideIcon } from 'lucide-vue-next'
+import { isDistributionSource } from '../devplatform/distributionState'
 
 /** Stable UX-side install-type key. Callers switch on this for styling /
  *  analytics rather than the raw `sourceCategory` from the source plugins. */
@@ -8,6 +9,7 @@ export type InstallTypeKey =
   | 'cloud'
   | 'legacyDesktop'
   | 'remote'
+  | 'distribution'
   | 'unknown'
 
 export interface InstallTypeIconMeta {
@@ -30,6 +32,8 @@ export function installTypeMetaFor(
       return { key: 'remote', icon: Globe, labelKey: 'installType.remote' }
     case 'local':
       return { key: 'standalone', icon: LaptopMinimal, labelKey: 'installType.standalone' }
+    case 'distribution':
+      return { key: 'distribution', icon: Package, labelKey: 'installType.distribution' }
     default:
       return { key: 'unknown', icon: Box, labelKey: 'installType.unknown' }
   }
@@ -37,11 +41,19 @@ export function installTypeMetaFor(
 
 /** Resolve install-type metadata for a concrete installation. Legacy Desktop
  *  installs report `sourceCategory === 'local'`, so the distinct
- *  `legacyDesktop` identity is keyed off the `desktop` sourceId instead. */
+ *  `legacyDesktop` identity is keyed off the `desktop` sourceId instead.
+ *
+ *  A distribution install also reports `local`, but wears the distribution
+ *  glyph everywhere — what it IS matters more than where it runs, and it keeps
+ *  one identity whether it's an install tile, a picker row or a card. */
 export function installTypeMetaForInstall(inst: {
   sourceId?: unknown
   sourceCategory: string | null | undefined
+  distributionId?: unknown
 }): InstallTypeIconMeta {
+  if (isDistributionSource(inst.sourceId, inst.distributionId)) {
+    return installTypeMetaFor('distribution')
+  }
   if (inst.sourceId === 'desktop') return installTypeMetaFor('desktop')
   return installTypeMetaFor(inst.sourceCategory)
 }

--- a/src/renderer/src/lib/progressWeights.test.ts
+++ b/src/renderer/src/lib/progressWeights.test.ts
@@ -56,6 +56,14 @@ describe('getPhaseWeights', () => {
     expect(w.extract).toBe(0.3)
   })
 
+  it('uses the curated table for a comfybuilder distribution install', () => {
+    const w = getPhaseWeights(steps('download', 'extract', 'models'))
+    expect(sum(w)).toBeCloseTo(1.0, 5)
+    // Archive download dominates; models must not steal its share via equal split.
+    expect(w.download).toBeGreaterThan(w.extract)
+    expect(w.download).toBeGreaterThan(w.models)
+  })
+
   it('falls back to equal weights for an unknown weightless fingerprint', () => {
     const w = getPhaseWeights(steps('a', 'b', 'c', 'd'))
     expect(w).toEqual({ a: 0.25, b: 0.25, c: 0.25, d: 0.25 })

--- a/src/renderer/src/lib/progressWeights.ts
+++ b/src/renderer/src/lib/progressWeights.ts
@@ -36,6 +36,13 @@ const TABLES: Record<string, Record<string, number>> = {
     download: 0.70,
     extract: 0.30,
   },
+  // ComfyBuilder distribution install: archive download dominates wall time;
+  // model staging varies but is small when a distribution declares few/none.
+  'download|extract|models': {
+    download: 0.65,
+    extract: 0.15,
+    models: 0.20,
+  },
   // Legacy Desktop migrate
   migration: {
     migration: 1.0,

--- a/src/renderer/src/stores/authStore.test.ts
+++ b/src/renderer/src/stores/authStore.test.ts
@@ -1,0 +1,118 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises } from '@vue/test-utils'
+
+import { useAuthStore } from './authStore'
+
+const api = {
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+  getAuthStatus: vi.fn(),
+  onAuthChanged: vi.fn(() => () => {}),
+  listWorkspaces: vi.fn(),
+  switchWorkspace: vi.fn(),
+  listDistributions: vi.fn(),
+  installDistribution: vi.fn()
+}
+
+/** Capture the renderer-side auth-change listener the store registers. */
+let authChangedCb: ((status: unknown) => void) | undefined
+
+describe('useAuthStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    authChangedCb = undefined
+    api.onAuthChanged.mockImplementation((cb: (status: unknown) => void) => {
+      authChangedCb = cb
+      return () => {}
+    })
+    api.getAuthStatus.mockResolvedValue({ signedIn: false })
+    ;(globalThis as unknown as { window: unknown }).window = { api: { comfybuilder: api } }
+  })
+
+  afterEach(() => {
+    delete (globalThis as unknown as { window?: unknown }).window
+  })
+
+  it('hydrates status from the persisted session on creation', async () => {
+    api.getAuthStatus.mockResolvedValue({ signedIn: true, email: 'a@b.c' })
+    const store = useAuthStore()
+    await flushPromises()
+    expect(store.status.email).toBe('a@b.c')
+    expect(store.isSignedIn).toBe(true)
+  })
+
+  it('signIn updates the status', async () => {
+    api.signIn.mockResolvedValue({ signedIn: true, email: 'x@y.z', workspaceId: 'w1' })
+    const store = useAuthStore()
+    await store.signIn()
+    expect(store.status).toMatchObject({ signedIn: true, workspaceId: 'w1' })
+  })
+
+  it('fetchDistributions pulls rows only when signed in', async () => {
+    const store = useAuthStore()
+    // Signed out: no call, empty list.
+    expect(await store.fetchDistributions()).toEqual([])
+    expect(api.listDistributions).not.toHaveBeenCalled()
+
+    api.signIn.mockResolvedValue({ signedIn: true })
+    await store.signIn()
+    api.listDistributions.mockResolvedValue([{ id: 'd1', name: 'Image', state: 'installable' }])
+    const rows = await store.fetchDistributions()
+    expect(rows).toEqual([{ id: 'd1', name: 'Image', state: 'installable' }])
+    expect(store.distributions).toHaveLength(1)
+  })
+
+  it('flags a failed distribution fetch, and a successful retry clears it', async () => {
+    api.signIn.mockResolvedValue({ signedIn: true })
+    const store = useAuthStore()
+    await store.signIn()
+
+    api.listDistributions.mockRejectedValueOnce(new Error('network'))
+    await store.fetchDistributions()
+    expect(store.distributionsError).toBe(true)
+    expect(store.distributions).toEqual([]) // stays empty, but flagged as an error not an empty workspace
+
+    api.listDistributions.mockResolvedValue([{ id: 'd1', name: 'Image', state: 'installable' }])
+    await store.fetchDistributions()
+    expect(store.distributionsError).toBe(false)
+    expect(store.distributions).toHaveLength(1)
+  })
+
+  it('flags a failed workspace fetch without throwing', async () => {
+    api.signIn.mockResolvedValue({ signedIn: true })
+    const store = useAuthStore()
+    await store.signIn()
+
+    api.listWorkspaces.mockRejectedValueOnce(new Error('network'))
+    await expect(store.fetchWorkspaces()).resolves.toEqual([])
+    expect(store.workspacesError).toBe(true)
+    expect(store.loadingWorkspaces).toBe(false)
+  })
+
+  it('switchWorkspace adopts the new status and drops the stale distribution cache', async () => {
+    api.signIn.mockResolvedValue({ signedIn: true, workspaceId: 'w1' })
+    const store = useAuthStore()
+    await store.signIn()
+    store.distributions = [{ id: 'd1', name: 'Old', state: 'installable' }]
+
+    api.switchWorkspace.mockResolvedValue({ signedIn: true, workspaceId: 'w2', workspaceType: 'team' })
+    await store.switchWorkspace('w2')
+    expect(store.status).toMatchObject({ workspaceId: 'w2' })
+    expect(store.distributions).toEqual([])
+  })
+
+  it('a pushed sign-out clears scoped state', async () => {
+    api.signIn.mockResolvedValue({ signedIn: true, workspaceId: 'w1' })
+    const store = useAuthStore()
+    await store.signIn()
+    store.workspaces = [{ id: 'w1', name: 'W1', type: 'team', role: 'owner' }]
+    store.distributions = [{ id: 'd1', name: 'D', state: 'installable' }]
+
+    authChangedCb?.({ signedIn: false })
+    expect(store.isSignedIn).toBe(false)
+    expect(store.workspaces).toEqual([])
+    expect(store.distributions).toEqual([])
+  })
+})

--- a/src/renderer/src/stores/authStore.ts
+++ b/src/renderer/src/stores/authStore.ts
@@ -1,0 +1,152 @@
+import { computed, onScopeDispose, ref } from 'vue'
+import { defineStore } from 'pinia'
+
+import type { AuthStatus, ElectronApi, Workspace } from '../../../types/ipc'
+import type { Distribution } from '../devplatform/types'
+
+/**
+ * Dev-platform session store: the renderer's single source of auth + workspace
+ * + distribution state.
+ *
+ * It only ever holds renderer-safe data (AuthStatus / Workspace / distribution
+ * display rows); tokens live in the main process. Every mutation goes through
+ * `window.api.comfybuilder`, and `onAuthChanged` keeps the store in lockstep
+ * with a sign-in / switch / sign-out that originated anywhere.
+ */
+export const useAuthStore = defineStore('auth', () => {
+  const status = ref<AuthStatus>({ signedIn: false })
+  const workspaces = ref<Workspace[]>([])
+  const distributions = ref<Distribution[]>([])
+  const loadingWorkspaces = ref(false)
+  const loadingDistributions = ref(false)
+  // Load-failure flags so the UI can tell a transient error apart from an empty
+  // workspace (both otherwise leave the arrays empty).
+  const workspacesError = ref(false)
+  const distributionsError = ref(false)
+  const comfybuilderApi = (window as Window & { api: ElectronApi }).api.comfybuilder
+
+  /** Bumped on every authoritative status change (push, sign-in, switch,
+   *  sign-out) so a slower in-flight pull can never overwrite a newer status. */
+  let revision = 0
+
+  /** Drop workspace-scoped caches: the list and the distributions both belong
+   *  to the token's single workspace, so a switch/sign-out invalidates them. */
+  function resetScopedState(): void {
+    workspaces.value = []
+    distributions.value = []
+  }
+
+  async function fetchStatus(): Promise<AuthStatus> {
+    const seen = revision
+    const next = await comfybuilderApi.getAuthStatus()
+    if (revision === seen && next) status.value = next
+    return next
+  }
+
+  /** Run the PKCE browser handoff. Rethrows failures so callers own the
+   *  feedback; a completed sign-in also lands via `onAuthChanged`. */
+  async function signIn(): Promise<AuthStatus> {
+    const next = await comfybuilderApi.signIn()
+    revision += 1
+    status.value = next
+    return next
+  }
+
+  async function signOut(): Promise<AuthStatus> {
+    await comfybuilderApi.signOut()
+    revision += 1
+    status.value = { signedIn: false }
+    resetScopedState()
+    return status.value
+  }
+
+  /** The workspaces the signed-in user belongs to (for the switcher). */
+  async function fetchWorkspaces(): Promise<Workspace[]> {
+    if (!status.value.signedIn) {
+      workspaces.value = []
+      return workspaces.value
+    }
+    const seen = revision
+    loadingWorkspaces.value = true
+    if (revision === seen) workspacesError.value = false
+    try {
+      const next = await comfybuilderApi.listWorkspaces()
+      if (revision === seen) workspaces.value = next
+      return workspaces.value
+    } catch {
+      if (revision === seen) workspacesError.value = true
+      return workspaces.value
+    } finally {
+      // A fetch always clears the flag it set — an auth-revision bump mid-flight
+      // must not leave the spinner stuck on.
+      loadingWorkspaces.value = false
+    }
+  }
+
+  /** Switch the active workspace (re-runs the browser handoff pre-selecting it).
+   *  The new status also arrives via `onAuthChanged`; the scoped caches are
+   *  dropped so the distribution grid re-fetches for the new workspace. */
+  async function switchWorkspace(workspaceId: string): Promise<AuthStatus> {
+    const next = await comfybuilderApi.switchWorkspace(workspaceId)
+    revision += 1
+    status.value = next
+    distributions.value = []
+    return next
+  }
+
+  const unsubscribe = comfybuilderApi.onAuthChanged((nextStatus) => {
+    revision += 1
+    status.value = nextStatus
+    if (!nextStatus.signedIn) resetScopedState()
+    else distributions.value = []
+  })
+
+  // Hydrate from the persisted session once at creation: main only pushes
+  // CHANGES, so the boot state has to be pulled. The revision guard keeps
+  // this pull from overwriting anything newer.
+  void fetchStatus().catch(() => {})
+
+  onScopeDispose(() => {
+    unsubscribe?.()
+  })
+
+  const isSignedIn = computed(() => status.value.signedIn)
+
+  /** The distributions published to the signed-in workspace, as display rows. */
+  async function fetchDistributions(): Promise<Distribution[]> {
+    if (!isSignedIn.value) {
+      distributions.value = []
+      return distributions.value
+    }
+    const seen = revision
+    loadingDistributions.value = true
+    if (revision === seen) distributionsError.value = false
+    try {
+      const next = await comfybuilderApi.listDistributions()
+      if (revision === seen) distributions.value = next
+      return distributions.value
+    } catch {
+      if (revision === seen) distributionsError.value = true
+      return distributions.value
+    } finally {
+      loadingDistributions.value = false
+    }
+  }
+
+  return {
+    status,
+    workspaces,
+    distributions,
+    loadingWorkspaces,
+    loadingDistributions,
+    workspacesError,
+    distributionsError,
+    isSignedIn,
+    fetchStatus,
+    signIn,
+    signOut,
+    fetchWorkspaces,
+    switchWorkspace,
+    fetchDistributions,
+  }
+})

--- a/src/renderer/src/types/ipc.ts
+++ b/src/renderer/src/types/ipc.ts
@@ -10,6 +10,8 @@ export type {
   DetailItem,
   DetailField,
   DetailFieldOption,
+  VersionStatRow,
+  VersionStatsValue,
   ActionDef,
   ConfirmDef,
   ConfirmOption,

--- a/src/renderer/src/views/ChooserView.test.ts
+++ b/src/renderer/src/views/ChooserView.test.ts
@@ -58,11 +58,14 @@ const messages = {
       errorTitle: 'Error',
       updatePill: 'Update',
       migratePill: 'Migrate',
+      workspaceShelf: 'Workspace',
     },
     devPlatform: {
+      workspace: { personalLabel: 'Personal' },
       distribution: {
         menuInstall: 'Install',
         distVersion: 'Dist v{version}',
+        notInstalled: 'Not installed',
         states: {
           noBuild: 'No build',
           platformMismatch: 'Not for this machine',
@@ -138,14 +141,25 @@ function makeDist(overrides: Partial<DevPlatformDistribution>): DevPlatformDistr
   }
 }
 
-/** Sign in and publish `dists` to the workspace, so distribution cards render. */
+/** Sign in and publish `dists` to the workspace, so distribution cards render.
+ *  `workspace` names the team the shelf header should show. */
 function installMockApiSignedIn(
   installs: Installation[],
   dists: DevPlatformDistribution[],
+  workspace?: { id: string; name: string },
 ): MockApi {
   const api = installMockApi(installs)
-  api.comfybuilder.getAuthStatus.mockResolvedValue({ signedIn: true })
+  api.comfybuilder.getAuthStatus.mockResolvedValue(
+    workspace
+      ? { signedIn: true, workspaceType: 'team', workspaceId: workspace.id }
+      : { signedIn: true },
+  )
   api.comfybuilder.listDistributions.mockResolvedValue(dists)
+  if (workspace) {
+    api.comfybuilder.listWorkspaces.mockResolvedValue([
+      { id: workspace.id, name: workspace.name, type: 'team', role: 'admin' },
+    ])
+  }
   return api
 }
 
@@ -542,52 +556,45 @@ describe('ChooserView', () => {
     expect(api.comfybuilder.installDistribution).toHaveBeenCalledWith('d1')
   })
 
-  it('keeps the kebab on a blocked distribution but disables Install', async () => {
-    installMockApiSignedIn([], [makeDist({ id: 'd2', name: 'Blocked Dist', state: 'no-build' })])
-    const wrapper = mountChooser()
-    await flushPromises()
-
-    const kebab = wrapper.find('[data-testid="chooser-dist-tile-kebab-d2"]')
-    expect(kebab.exists()).toBe(true)
-    await kebab.trigger('click')
-
-    const menu = wrapper
-      .findAllComponents({ name: 'ContextMenu' })
-      .find((m) => m.props('open') === true)!
-    const items = menu.props('items') as { id: string; disabled?: boolean }[]
-    expect(items[0]!.disabled).toBe(true)
-  })
-
-  it('labels the distribution version so it cannot be read as a ComfyUI version', async () => {
-    installMockApiSignedIn([], [makeDist({ id: 'd3', name: 'Versioned', version: '2' })])
-    const wrapper = mountChooser()
-    await flushPromises()
-    const card = wrapper.find('[data-testid="chooser-dist-tile-d3"]')
-    expect(card.find('.chooser-tile-meta-line').text()).toContain('Dist v2')
-  })
-
-  it('puts a blocked reason in the footer status slot, not the kebab corner', async () => {
+  it('states the bundled ComfyUI version and that you do not have it yet', async () => {
     installMockApiSignedIn(
       [],
-      [makeDist({ id: 'd4', name: 'Blocked', state: 'platform-mismatch', version: '5', blockedReason: 'noArtifactForMachine' })],
+      [makeDist({ id: 'd3', name: 'Versioned', version: '2', comfyuiVersion: 'v0.28.2' })],
     )
     const wrapper = mountChooser()
     await flushPromises()
-    const card = wrapper.find('[data-testid="chooser-dist-tile-d4"]')
-
-    // State reads in the footer's right slot; the facts keep the left.
-    expect(card.find('.dist-tile-state-tag').text()).toBe('Not for this machine')
-    expect(card.find('.chooser-tile-meta-line').text()).toContain('Dist v5')
-    // The corner holds the kebab and nothing else.
-    const corner = card.find('.chooser-tile-actions')
-    expect(corner.findAll('.chooser-tile-pill').length).toBe(0)
-    expect(corner.find('.chooser-tile-kebab').exists()).toBe(true)
-    // Blocked tiles recede but stay readable, and explain themselves on hover.
-    expect(card.classes()).toContain('dist-tile--blocked')
-    expect(card.attributes('title')).toContain('operating system')
+    const meta = wrapper.find('[data-testid="chooser-dist-tile-d3"]').find('.chooser-tile-meta-line')
+    expect(meta.text()).toContain('v0.28.2')
+    expect(meta.text()).toContain('Not installed')
+    // The distribution's own release belongs on the INSTALL tile, once you
+    // have one — a card never shows a version you don't have.
+    expect(meta.text()).not.toContain('Dist v2')
   })
 
-  it('never renders both an action pill and a state tag', async () => {
+  it('labels a distribution install so its release cannot be read as a ComfyUI version', async () => {
+    installMockApiSignedIn(
+      [
+        makeInstall({
+          id: 'built',
+          name: 'BuiltThing',
+          sourceId: 'comfybuilder',
+          version: 'v0.28.2',
+          distributionVersion: '7',
+        }),
+      ],
+      [],
+    )
+    const wrapper = mountChooser()
+    await flushPromises()
+    const tile = wrapper.findAll('.chooser-tile').find((t) => t.text().includes('BuiltThing'))!
+    const meta = tile.find('.chooser-tile-meta-line').text()
+    expect(meta).toContain('v0.28.2')
+    expect(meta).toContain('Dist v7')
+    // The install path is noise on a tile whose identity is the distribution.
+    expect(meta).not.toContain('Standalone')
+  })
+
+  it('gives every card exactly one blue action pill', async () => {
     installMockApiSignedIn(
       [],
       [
@@ -600,13 +607,65 @@ describe('ChooserView', () => {
     for (const id of ['a', 'b']) {
       const card = wrapper.find(`[data-testid="chooser-dist-tile-${id}"]`)
       expect(card.findAll('.chooser-tile-pill-action').length).toBe(1)
-    }
-    // Both are actionable, so both take the blue pill, not a state tag.
-    for (const id of ['a', 'b']) {
-      const card = wrapper.find(`[data-testid="chooser-dist-tile-${id}"]`)
       expect(card.find('.chooser-tile-pill-update').exists()).toBe(true)
-      expect(card.find('.dist-tile-state-tag').exists()).toBe(false)
     }
+  })
+
+  it('shows builds this machine cannot install, receded and inert', async () => {
+    installMockApiSignedIn(
+      [],
+      [
+        makeDist({ id: 'ok', name: 'InstallableThing', state: 'installable' }),
+        makeDist({
+          id: 'pm',
+          name: 'WrongPlatformThing',
+          state: 'platform-mismatch',
+          blockedReason: 'noArtifactForMachine',
+          targetOs: ['linux'],
+        }),
+      ],
+      { id: 'w1', name: 'Comfy Design Team' },
+    )
+    const wrapper = mountChooser()
+    await flushPromises()
+
+    // Nothing is hidden, and the count says so.
+    expect(wrapper.text()).toContain('InstallableThing')
+    expect(wrapper.text()).toContain('WrongPlatformThing')
+    expect(wrapper.find('.chooser-shelf-count').text()).toBe('2')
+
+    // The blocked one reads as blocked: receded, reason in the status slot,
+    // full explanation on hover, and no blue pill promising an install.
+    const blocked = wrapper.find('[data-testid="chooser-dist-tile-pm"]')
+    expect(blocked.classes()).toContain('dist-tile--blocked')
+    // Names the machine the build IS for, not the one it isn't.
+    expect(blocked.find('.dist-tile-state-tag').text()).toBe('Linux')
+    expect(blocked.find('.chooser-tile-pill-update').exists()).toBe(false)
+    expect(blocked.attributes('title')).toContain('operating system')
+    expect(blocked.attributes('aria-disabled')).toBe('true')
+  })
+
+  it('falls back to the generic label when the build targets are unknown', async () => {
+    installMockApiSignedIn(
+      [],
+      [makeDist({ id: 'pm2', name: 'UnknownTargets', state: 'platform-mismatch' })],
+    )
+    const wrapper = mountChooser()
+    await flushPromises()
+    const card = wrapper.find('[data-testid="chooser-dist-tile-pm2"]')
+    expect(card.find('.dist-tile-state-tag').text()).toBe('Not for this machine')
+  })
+
+  it('does not start an install when a blocked card is activated', async () => {
+    const api = installMockApiSignedIn(
+      [],
+      [makeDist({ id: 'nb', name: 'NoBuildThing', state: 'no-build' })],
+    )
+    const wrapper = mountChooser()
+    await flushPromises()
+    await wrapper.find('[data-testid="chooser-dist-tile-nb"]').trigger('click')
+    await flushPromises()
+    expect(api.comfybuilder.installDistribution).not.toHaveBeenCalled()
   })
 
   it('de-dups an installed distribution out of the grid (distributionId link)', async () => {
@@ -660,6 +719,101 @@ describe('ChooserView', () => {
     await flushPromises()
     const pill = wrapper.find('[data-testid="chooser-dist-tile-d5"]').find('.chooser-tile-pill-action')
     expect(pill.text()).toBe('Install')
+  })
+
+  it('stays a single centered grid when the workspace has nothing to shelve', async () => {
+    // The common case — signed out, or signed in with nothing published. A lone
+    // left-aligned cluster under no header reads as broken, so we keep the
+    // shipped centered look rather than shelving one family on its own.
+    installMockApi([makeInstall({ id: 'a', name: 'Alpha' })])
+    const wrapper = mountChooser()
+    await flushPromises()
+    expect(wrapper.find('.chooser-shelf-head').exists()).toBe(false)
+    const grids = wrapper.findAll('.chooser-family-grid')
+    expect(grids.length).toBe(1)
+    expect(grids[0]!.classes()).toContain('chooser-family-grid--centered')
+  })
+
+  it('shelves the workspace family under a generic "Workspace" header', async () => {
+    // Deliberately NOT the workspace's name: a personal workspace is called
+    // "Personal", which collides with the unheaded your-installs group above it.
+    installMockApiSignedIn([], [makeDist({ id: 'd1', name: 'Alpha Dist' })], {
+      id: 'w1',
+      name: 'Comfy Design Team',
+    })
+    const wrapper = mountChooser()
+    await flushPromises()
+
+    expect(wrapper.find('.chooser-shelf-title').text()).toBe('Workspace')
+    expect(wrapper.find('.chooser-shelf-count').text()).toBe('1')
+    // Your-installs leads and gives up centering once a shelf sits beneath it.
+    const grids = wrapper.findAll('.chooser-family-grid')
+    expect(grids[0]!.classes()).not.toContain('chooser-family-grid--centered')
+    expect(grids[grids.length - 1]!.text()).toContain('Alpha Dist')
+  })
+
+  it('sorts builder-backed installs into the workspace shelf, not your installs', async () => {
+    installMockApiSignedIn(
+      [
+        makeInstall({ id: 'local', name: 'LocalThing' }),
+        makeInstall({ id: 'built', name: 'BuiltThing', sourceId: 'comfybuilder' }),
+      ],
+      [makeDist({ id: 'd1', name: 'AvailableThing' })],
+      { id: 'w1', name: 'Comfy Design Team' },
+    )
+    const wrapper = mountChooser()
+    await flushPromises()
+
+    const grids = wrapper.findAll('.chooser-family-grid')
+    // [0] your installs, [1] workspace-installed, [2] workspace-available.
+    expect(grids.length).toBe(3)
+    expect(grids[0]!.text()).toContain('LocalThing')
+    expect(grids[0]!.text()).not.toContain('BuiltThing')
+    expect(grids[1]!.text()).toContain('BuiltThing')
+    expect(grids[2]!.text()).toContain('AvailableThing')
+  })
+
+  it('leaves a local install with an empty distributionId in your installs', async () => {
+    installMockApiSignedIn(
+      [
+        makeInstall({
+          id: 'local',
+          name: 'LocalThing',
+          distributionId: '',
+        } as unknown as Partial<Installation>),
+      ],
+      [makeDist({ id: 'd1', name: 'AvailableThing' })],
+      { id: 'w1', name: 'Comfy Design Team' },
+    )
+    const wrapper = mountChooser()
+    await flushPromises()
+
+    // An empty id is no link at all — shelving it would file a plain local
+    // install under the workspace and give it the distribution glyph.
+    const grids = wrapper.findAll('.chooser-family-grid')
+    expect(grids[0]!.text()).toContain('LocalThing')
+    expect(grids.slice(1).some((g) => g.text().includes('LocalThing'))).toBe(false)
+  })
+
+  it('does not flip arrangement while the user types in search', async () => {
+    // The shelf is judged on the PRE-SEARCH lists — filtering every tile out of
+    // a family must not re-center the page mid-keystroke.
+    installMockApiSignedIn([], [makeDist({ id: 'd1', name: 'Alpha Dist' })], {
+      id: 'w1',
+      name: 'Comfy Design Team',
+    })
+    const wrapper = mountChooser()
+    await flushPromises()
+    expect(wrapper.find('.chooser-shelf-head').exists()).toBe(true)
+
+    await wrapper.find('input').setValue('zzz-matches-nothing')
+    await flushPromises()
+    // Either the no-matches hint took over, or the shelf is still a shelf —
+    // what must never happen is a silent fall back to the centered grid.
+    const stillShelved = wrapper.find('.chooser-shelf-head').exists()
+    const noMatches = wrapper.find('.chooser-empty').exists()
+    expect(stillShelved || noMatches).toBe(true)
+    expect(wrapper.find('.chooser-family-grid--centered').exists()).toBe(false)
   })
 
   it('has no Desktop entry in the filter state', async () => {

--- a/src/renderer/src/views/ChooserView.test.ts
+++ b/src/renderer/src/views/ChooserView.test.ts
@@ -5,11 +5,16 @@ import { createPinia, setActivePinia } from 'pinia'
 
 import ChooserView from './ChooserView.vue'
 import { useSessionStore } from '../stores/sessionStore'
-import type { Installation } from '../types/ipc'
+import type { DevPlatformDistribution, Installation } from '../types/ipc'
 
-// Stub the heavy ContextMenu child — we don't exercise menu interactions here.
+// Stub the heavy ContextMenu child. Props are declared so tests can assert what
+// the view HANDED the menu without rendering (or clicking through) the real one.
 vi.mock('../components/ContextMenu.vue', () => ({
-  default: { name: 'ContextMenu', template: '<div data-testid="context-menu" />' },
+  default: {
+    name: 'ContextMenu',
+    props: ['open', 'x', 'y', 'items'],
+    template: '<div data-testid="context-menu" />',
+  },
 }))
 
 // Test-controllable `useModal` mock — `viewError` routes its readable
@@ -54,6 +59,22 @@ const messages = {
       updatePill: 'Update',
       migratePill: 'Migrate',
     },
+    devPlatform: {
+      distribution: {
+        menuInstall: 'Install',
+        distVersion: 'Dist v{version}',
+        states: {
+          noBuild: 'No build',
+          platformMismatch: 'Not for this machine',
+          updateAvailable: 'Update',
+        },
+        blockedReason: {
+          buildFailed: 'This distribution has no successful build yet.',
+          noArtifactForMachine:
+            'The latest build has no artifact for this operating system and GPU.',
+        },
+      },
+    },
   },
 }
 
@@ -70,6 +91,8 @@ interface MockApi {
   // progressStore subscribes to onErrorDetail at construction time.
   onErrorDetail: ReturnType<typeof vi.fn>
   focusComfyWindow: ReturnType<typeof vi.fn>
+  // authStore reads window.api.comfybuilder at construction time.
+  comfybuilder: Record<string, ReturnType<typeof vi.fn>>
 }
 
 function installMockApi(initial: Installation[]): MockApi {
@@ -81,6 +104,16 @@ function installMockApi(initial: Installation[]): MockApi {
     runAction: vi.fn().mockResolvedValue({ ok: true }),
     onErrorDetail: vi.fn(() => () => {}),
     focusComfyWindow: vi.fn().mockResolvedValue(true),
+    comfybuilder: {
+      getAuthStatus: vi.fn().mockResolvedValue({ signedIn: false }),
+      onAuthChanged: vi.fn(() => () => {}),
+      signIn: vi.fn(),
+      signOut: vi.fn(),
+      listWorkspaces: vi.fn().mockResolvedValue([]),
+      switchWorkspace: vi.fn(),
+      listDistributions: vi.fn().mockResolvedValue([]),
+      installDistribution: vi.fn(),
+    },
   }
   ;(window as unknown as { api: MockApi }).api = api
   return api
@@ -94,6 +127,26 @@ function makeInstall(overrides: Partial<Installation>): Installation {
     sourceCategory: 'local',
     ...overrides,
   } as unknown as Installation
+}
+
+function makeDist(overrides: Partial<DevPlatformDistribution>): DevPlatformDistribution {
+  return {
+    id: 'dist-x',
+    name: 'Dist X',
+    state: 'installable',
+    ...overrides,
+  }
+}
+
+/** Sign in and publish `dists` to the workspace, so distribution cards render. */
+function installMockApiSignedIn(
+  installs: Installation[],
+  dists: DevPlatformDistribution[],
+): MockApi {
+  const api = installMockApi(installs)
+  api.comfybuilder.getAuthStatus.mockResolvedValue({ signedIn: true })
+  api.comfybuilder.listDistributions.mockResolvedValue(dists)
+  return api
 }
 
 function mountChooser() {
@@ -320,7 +373,7 @@ describe('ChooserView', () => {
     expect(wrapper.emitted('pick')).toHaveLength(1)
   })
 
-  it('shows a relative recency line for a booted install and "not launched yet" for a fresh one', async () => {
+  it('gives install tiles two lines — no launch-recency row, booted or not', async () => {
     installMockApi([
       makeInstall({ id: 'booted', name: 'Booted', lastLaunchedAt: Date.now() - 2 * 60_000 }),
       makeInstall({ id: 'fresh', name: 'Fresh' }),
@@ -330,8 +383,10 @@ describe('ChooserView', () => {
     const tiles = wrapper.findAll('.chooser-tile')
     const bootedTile = tiles.find((t) => t.text().includes('Booted'))!
     const freshTile = tiles.find((t) => t.text().includes('Fresh'))!
-    expect(bootedTile.find('.chooser-tile-recency-text').text()).toContain('Launched')
-    expect(freshTile.find('.chooser-tile-recency-text').text()).toBe('Not launched yet')
+    expect(bootedTile.find('.chooser-tile-recency-text').exists()).toBe(false)
+    expect(freshTile.find('.chooser-tile-recency-text').exists()).toBe(false)
+    // The facts that survive keep their row.
+    expect(bootedTile.find('.chooser-tile-meta-line').exists()).toBe(true)
   })
 
   it('renders the update affordance as a bare "Update" pill — the target version lives in the meta line', async () => {
@@ -458,6 +513,153 @@ describe('ChooserView', () => {
     expect(labels.some((l) => l.includes('LocalThing'))).toBe(true)
     expect(labels.some((l) => l.includes('LegacyDesktopThing'))).toBe(true)
     expect(labels.some((l) => l.includes('RemoteThing'))).toBe(false)
+  })
+
+  it('gives distribution cards the same kebab as install tiles, opening an Install menu', async () => {
+    const api = installMockApiSignedIn([], [makeDist({ id: 'd1', name: 'Alpha Dist' })])
+    api.comfybuilder.installDistribution.mockResolvedValue({
+      ok: true,
+      entry: { id: 'new-inst', name: 'Alpha Dist' },
+    })
+    const wrapper = mountChooser()
+    await flushPromises()
+
+    const kebab = wrapper.find('[data-testid="chooser-dist-tile-kebab-d1"]')
+    expect(kebab.exists()).toBe(true)
+    await kebab.trigger('click')
+
+    const menu = wrapper
+      .findAllComponents({ name: 'ContextMenu' })
+      .find((m) => m.props('open') === true)!
+    expect(menu).toBeTruthy()
+    const items = menu.props('items') as { id: string; label: string; disabled?: boolean }[]
+    expect(items.map((i) => i.id)).toEqual(['install'])
+    expect(items[0]!.disabled).toBe(false)
+
+    // Selecting Install runs the same flow the card's own activation does.
+    menu.vm.$emit('select', 'install')
+    await flushPromises()
+    expect(api.comfybuilder.installDistribution).toHaveBeenCalledWith('d1')
+  })
+
+  it('keeps the kebab on a blocked distribution but disables Install', async () => {
+    installMockApiSignedIn([], [makeDist({ id: 'd2', name: 'Blocked Dist', state: 'no-build' })])
+    const wrapper = mountChooser()
+    await flushPromises()
+
+    const kebab = wrapper.find('[data-testid="chooser-dist-tile-kebab-d2"]')
+    expect(kebab.exists()).toBe(true)
+    await kebab.trigger('click')
+
+    const menu = wrapper
+      .findAllComponents({ name: 'ContextMenu' })
+      .find((m) => m.props('open') === true)!
+    const items = menu.props('items') as { id: string; disabled?: boolean }[]
+    expect(items[0]!.disabled).toBe(true)
+  })
+
+  it('labels the distribution version so it cannot be read as a ComfyUI version', async () => {
+    installMockApiSignedIn([], [makeDist({ id: 'd3', name: 'Versioned', version: '2' })])
+    const wrapper = mountChooser()
+    await flushPromises()
+    const card = wrapper.find('[data-testid="chooser-dist-tile-d3"]')
+    expect(card.find('.chooser-tile-meta-line').text()).toContain('Dist v2')
+  })
+
+  it('puts a blocked reason in the footer status slot, not the kebab corner', async () => {
+    installMockApiSignedIn(
+      [],
+      [makeDist({ id: 'd4', name: 'Blocked', state: 'platform-mismatch', version: '5', blockedReason: 'noArtifactForMachine' })],
+    )
+    const wrapper = mountChooser()
+    await flushPromises()
+    const card = wrapper.find('[data-testid="chooser-dist-tile-d4"]')
+
+    // State reads in the footer's right slot; the facts keep the left.
+    expect(card.find('.dist-tile-state-tag').text()).toBe('Not for this machine')
+    expect(card.find('.chooser-tile-meta-line').text()).toContain('Dist v5')
+    // The corner holds the kebab and nothing else.
+    const corner = card.find('.chooser-tile-actions')
+    expect(corner.findAll('.chooser-tile-pill').length).toBe(0)
+    expect(corner.find('.chooser-tile-kebab').exists()).toBe(true)
+    // Blocked tiles recede but stay readable, and explain themselves on hover.
+    expect(card.classes()).toContain('dist-tile--blocked')
+    expect(card.attributes('title')).toContain('operating system')
+  })
+
+  it('never renders both an action pill and a state tag', async () => {
+    installMockApiSignedIn(
+      [],
+      [
+        makeDist({ id: 'a', name: 'Available', state: 'installable' }),
+        makeDist({ id: 'b', name: 'Updatable', state: 'update-available' }),
+      ],
+    )
+    const wrapper = mountChooser()
+    await flushPromises()
+    for (const id of ['a', 'b']) {
+      const card = wrapper.find(`[data-testid="chooser-dist-tile-${id}"]`)
+      expect(card.findAll('.chooser-tile-pill-action').length).toBe(1)
+    }
+    // Both are actionable, so both take the blue pill, not a state tag.
+    for (const id of ['a', 'b']) {
+      const card = wrapper.find(`[data-testid="chooser-dist-tile-${id}"]`)
+      expect(card.find('.chooser-tile-pill-update').exists()).toBe(true)
+      expect(card.find('.dist-tile-state-tag').exists()).toBe(false)
+    }
+  })
+
+  it('de-dups an installed distribution out of the grid (distributionId link)', async () => {
+    installMockApiSignedIn(
+      [makeInstall({ id: 'i1', sourceId: 'comfybuilder', distributionId: 'd1' } as unknown as Partial<Installation>)],
+      [makeDist({ id: 'd1', name: 'Image' }), makeDist({ id: 'd2', name: 'Video' })],
+    )
+    const wrapper = mountChooser()
+    await flushPromises()
+    // d1 is backed by an install -> hidden; d2 has no install -> shown.
+    expect(wrapper.find('[data-testid="chooser-dist-tile-d1"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="chooser-dist-tile-d2"]').exists()).toBe(true)
+  })
+
+  it('de-dups via case-insensitive name when a comfybuilder install lacks distributionId', async () => {
+    installMockApiSignedIn(
+      [makeInstall({ id: 'i1', name: 'Image', sourceId: 'comfybuilder' } as unknown as Partial<Installation>)],
+      [makeDist({ id: 'd1', name: 'image' })],
+    )
+    const wrapper = mountChooser()
+    await flushPromises()
+    expect(wrapper.find('[data-testid="chooser-dist-tile-d1"]').exists()).toBe(false)
+  })
+
+  it('does NOT de-dup a same-named non-comfybuilder install (the name fallback is comfybuilder-only)', async () => {
+    installMockApiSignedIn(
+      [makeInstall({ id: 'i1', name: 'Image', sourceId: 'standalone' } as unknown as Partial<Installation>)],
+      [makeDist({ id: 'd1', name: 'Image' })],
+    )
+    const wrapper = mountChooser()
+    await flushPromises()
+    expect(wrapper.find('[data-testid="chooser-dist-tile-d1"]').exists()).toBe(true)
+  })
+
+  it('de-dups an update-available distribution out until the update-wiring lands', async () => {
+    // An update-available row is by definition backed by an install, so the grid
+    // hides it today (the update pill is wired in a follow-up). This guards that
+    // the update-available render path is not yet reachable in the grid.
+    installMockApiSignedIn(
+      [makeInstall({ id: 'i1', sourceId: 'comfybuilder', distributionId: 'd1' } as unknown as Partial<Installation>)],
+      [makeDist({ id: 'd1', name: 'Image', state: 'update-available', version: '2' })],
+    )
+    const wrapper = mountChooser()
+    await flushPromises()
+    expect(wrapper.find('[data-testid="chooser-dist-tile-d1"]').exists()).toBe(false)
+  })
+
+  it('names the action on an installable distribution rather than its state', async () => {
+    installMockApiSignedIn([], [makeDist({ id: 'd5', name: 'Fresh', state: 'installable' })])
+    const wrapper = mountChooser()
+    await flushPromises()
+    const pill = wrapper.find('[data-testid="chooser-dist-tile-d5"]').find('.chooser-tile-pill-action')
+    expect(pill.text()).toBe('Install')
   })
 
   it('has no Desktop entry in the filter state', async () => {

--- a/src/renderer/src/views/ChooserView.test.ts
+++ b/src/renderer/src/views/ChooserView.test.ts
@@ -731,6 +731,10 @@ describe('ChooserView', () => {
     await flushPromises()
     const names = wrapper.findAll('.chooser-tile-name').map((w) => w.text())
     expect(names).toContain('Flux Studio')
+    // The shelf carries only the installed tile; nothing available leaks in
+    // without a workspace session, so the count is 1 and no cards render.
+    expect(wrapper.find('.chooser-shelf-count').text()).toBe('1')
+    expect(wrapper.findAll('[data-testid^="chooser-dist-tile-"]').length).toBe(0)
   })
 
   it('names the action on an installable distribution rather than its state', async () => {

--- a/src/renderer/src/views/ChooserView.test.ts
+++ b/src/renderer/src/views/ChooserView.test.ts
@@ -713,6 +713,26 @@ describe('ChooserView', () => {
     expect(wrapper.find('[data-testid="chooser-dist-tile-d1"]').exists()).toBe(false)
   })
 
+  it('keeps a distribution-backed install visible when signed out', async () => {
+    // A distribution install is a local install the user must be able to launch
+    // signed in or not. Its identity excludes it from Your installs, so if the
+    // workspace shelf stayed sign-in-gated it would vanish entirely while signed
+    // out. The shelf shows for the installs even before a workspace session.
+    installMockApi([
+      makeInstall({
+        id: 'builder-1',
+        name: 'Flux Studio',
+        sourceId: 'comfybuilder',
+        distributionId: 'd-flux',
+        status: 'installed',
+      } as unknown as Partial<Installation>),
+    ])
+    const wrapper = mountChooser()
+    await flushPromises()
+    const names = wrapper.findAll('.chooser-tile-name').map((w) => w.text())
+    expect(names).toContain('Flux Studio')
+  })
+
   it('names the action on an installable distribution rather than its state', async () => {
     installMockApiSignedIn([], [makeDist({ id: 'd5', name: 'Fresh', state: 'installable' })])
     const wrapper = mountChooser()

--- a/src/renderer/src/views/ChooserView.vue
+++ b/src/renderer/src/views/ChooserView.vue
@@ -205,11 +205,14 @@ const workspaceAvailableEntries = computed<ChooserGridEntry[]>(() =>
   visibleDistributions.value.map(distEntry)
 )
 
-/** Pre-search lists, so typing can't flip the page between arrangements. */
+/** Pre-search lists, so typing can't flip the page between arrangements.
+ *  A distribution-backed install is a local install the user must always be
+ *  able to launch, so it shows whether or not they are signed in; only the
+ *  still-available distributions to add need a workspace session. */
 const showWorkspaceShelf = computed(
   () =>
-    authStore.isSignedIn &&
-    (chooserDistributions.value.length > 0 || allBuilderInstalls.value.length > 0)
+    allBuilderInstalls.value.length > 0 ||
+    (authStore.isSignedIn && chooserDistributions.value.length > 0)
 )
 
 /**

--- a/src/renderer/src/views/ChooserView.vue
+++ b/src/renderer/src/views/ChooserView.vue
@@ -8,14 +8,15 @@ import { useInstallContextMenu } from '../composables/useInstallContextMenu'
 import { useInstallList } from '../composables/useInstallList'
 import { useCloudCapacity } from '../composables/useCloudCapacity'
 import { useModal } from '../composables/useModal'
-import { Plus, Search } from 'lucide-vue-next'
+import { Search } from 'lucide-vue-next'
 import ContextMenu from '../components/ContextMenu.vue'
 import BrandBackground from '../components/BrandBackground.vue'
 import BaseInput from '../components/ui/BaseInput.vue'
 import ComfyWordmark from '../components/icons/ComfyWordmark.vue'
-import ChooserInstallTile from './chooser/ChooserInstallTile.vue'
+import ChooserFamilyGrid from './chooser/ChooserFamilyGrid.vue'
 import DevPlatformAccountChip from './devplatform/DevPlatformAccountChip.vue'
-import DevPlatformDistributionCard from './devplatform/DevPlatformDistributionCard.vue'
+import { distEntry, installEntry, type ChooserGridEntry } from './chooser/chooserGridEntry'
+import { isDistributionInstall } from '../devplatform/distributionState'
 import { resolvePickerTab } from '../lib/pickerTabs'
 import type { ContextMenuItem } from '../types/context-menu'
 import type { Distribution } from '../devplatform/types'
@@ -138,7 +139,9 @@ function installationBacksDistribution(inst: Installation, dist: Distribution): 
   return inst.name.trim().toLowerCase() === dist.name.trim().toLowerCase()
 }
 
-/** Every distribution that earns a tile, before search. Empty when signed out. */
+/** Every distribution that earns a tile, before search. Blocked builds are kept
+ *  and receded by the card, not filtered out — a hidden one is indistinguishable
+ *  from one that was never published. */
 const chooserDistributions = computed<Distribution[]>(() => {
   if (!authStore.isSignedIn) return []
   return authStore.distributions.filter(
@@ -174,6 +177,40 @@ const distributionNote = computed(() => {
   if (authStore.distributions.length === 0) return t('devPlatform.distribution.emptyTitle')
   return ''
 })
+
+// --- Shelves ---
+//
+// Your installs lead, unheaded; the workspace's own installs and available
+// distributions sit under one header beneath. With nothing to shelve the page
+// falls back to the shipped centered grid — a lone left-aligned cluster under
+// no header reads as broken.
+
+// `isDistributionInstall` judges the install's own identity, not the fetched
+// distribution list, so the split holds when a distribution is unpublished or
+// the list hasn't loaded.
+const allPlainInstalls = computed(() =>
+  installationStore.installations.filter((i) => !isDistributionInstall(i))
+)
+const allBuilderInstalls = computed(() =>
+  installationStore.installations.filter(isDistributionInstall)
+)
+
+const ownEntries = computed<ChooserGridEntry[]>(() =>
+  visibleInstalls.value.filter((i) => !isDistributionInstall(i)).map(installEntry)
+)
+const workspaceInstalledEntries = computed<ChooserGridEntry[]>(() =>
+  visibleInstalls.value.filter(isDistributionInstall).map(installEntry)
+)
+const workspaceAvailableEntries = computed<ChooserGridEntry[]>(() =>
+  visibleDistributions.value.map(distEntry)
+)
+
+/** Pre-search lists, so typing can't flip the page between arrangements. */
+const showWorkspaceShelf = computed(
+  () =>
+    authStore.isSignedIn &&
+    (chooserDistributions.value.length > 0 || allBuilderInstalls.value.length > 0)
+)
 
 /**
  * Install a distribution: main resolves the host artifact + creates the record,
@@ -259,33 +296,17 @@ function handleDistMenuSelect(itemId: string): void {
 
 // --- Cluster top offset ---
 
-/** Unfiltered tile count: New Install + every install (cloud included) + every
- *  distribution. Reads the raw lists, not the `visible*` ones, so search never
- *  shifts the cluster. */
-const baseTileCount = computed(
-  () => 1 + installationStore.installations.length + chooserDistributions.value.length
-)
-
 const TILES_PER_ROW = 4
 
-/** Unfiltered tile rows. Drives the grid's reserved `min-height` so the box
- *  doesn't shrink while filtering — that's what keeps the centered cluster
- *  from shifting when the user types in search. */
-const clusterRows = computed(() => Math.ceil(baseTileCount.value / TILES_PER_ROW))
-
-/** Freeze a leaving tile's box so it doesn't collapse under `position:
- *  absolute`, letting survivors FLIP into the gap immediately. */
-function lockLeavingTileSize(el: Element): void {
-  const node = el as HTMLElement
-  const grid = node.parentElement
-  if (!grid) return
-  const rect = node.getBoundingClientRect()
-  const gridRect = grid.getBoundingClientRect()
-  node.style.width = `${rect.width}px`
-  node.style.height = `${rect.height}px`
-  node.style.left = `${rect.left - gridRect.left + grid.scrollLeft}px`
-  node.style.top = `${rect.top - gridRect.top + grid.scrollTop}px`
-}
+/** Unfiltered row count across both shelves, reserving `min-height` so the
+ *  cluster doesn't shift while typing in search. Raw lists, not `visible*`. */
+const clusterRows = computed(() => {
+  // +1: the New Install tile rides with the your-installs family.
+  const ownRows = Math.ceil((1 + allPlainInstalls.value.length) / TILES_PER_ROW)
+  if (!showWorkspaceShelf.value) return ownRows
+  const shelfTiles = allBuilderInstalls.value.length + chooserDistributions.value.length
+  return ownRows + Math.ceil(shelfTiles / TILES_PER_ROW)
+})
 
 // --- Manage / context menu ---
 // All Manage routes go through `window.api.openInstancePicker` (the
@@ -399,6 +420,21 @@ const cloudCapacity = useCloudCapacity()
 function handleNewInstallClick(): void {
   emit('show-new-install')
 }
+
+/** Shared by every `ChooserFamilyGrid`, so a tile behaves the same whichever
+ *  shelf it landed in. */
+const gridHandlers = {
+  'new-install': handleNewInstallClick,
+  pick: pickInstall,
+  'open-card-menu': openCardMenu,
+  'open-kebab-menu': openKebabMenu,
+  'trigger-action': (action: 'update' | 'migrate', inst: Installation) =>
+    triggerAction(action, inst),
+  'view-error': viewError,
+  'view-danger': viewDanger,
+  'dist-select': handleDistributionActivate,
+  'dist-kebab': openDistKebabMenu
+}
 </script>
 
 <template>
@@ -433,49 +469,48 @@ function handleNewInstallClick(): void {
         {{ t('chooser.noMatches') }}
       </div>
 
-      <TransitionGroup
-        v-else
-        tag="div"
-        name="tile"
-        class="chooser-grid"
-        @before-leave="lockLeavingTileSize"
-      >
-        <button
-          key="__new"
-          type="button"
-          class="chooser-tile chooser-tile-new"
-          @click="handleNewInstallClick"
+      <div v-else class="chooser-shelves">
+        <!-- Your installs: bare tiles, no header, centered until a shelf
+             appears beneath them. -->
+        <section class="chooser-shelf">
+          <ChooserFamilyGrid
+            show-new
+            :centered="!showWorkspaceShelf"
+            :entries="ownEntries"
+            :is-stopped-action-gated="isStoppedActionGated"
+            v-on="gridHandlers"
+          />
+        </section>
+
+        <!-- The workspace shelf: what it already put on this machine, then what
+             it still offers on a fresh row. -->
+        <section
+          v-if="
+            showWorkspaceShelf &&
+            (workspaceInstalledEntries.length || workspaceAvailableEntries.length)
+          "
+          class="chooser-shelf"
         >
-          <div class="chooser-tile-icon"><Plus :size="32" /></div>
-          <div class="chooser-tile-name">{{ t('chooser.newInstall') }}</div>
-          <div class="chooser-tile-meta">{{ t('chooser.newInstallDesc') }}</div>
-        </button>
-
-        <ChooserInstallTile
-          v-for="inst in visibleInstalls"
-          :key="inst.id"
-          :installation="inst"
-          :is-stopped-action-gated="isStoppedActionGated(inst)"
-          @pick="pickInstall"
-          @open-card-menu="openCardMenu"
-          @open-kebab-menu="openKebabMenu"
-          @trigger-action="(action, installation) => triggerAction(action, installation)"
-          @view-error="viewError"
-          @view-danger="viewDanger"
-        />
-
-        <!-- Distributions: siblings of the install tiles, same box, same
-             TransitionGroup, so installing one is the same gesture as
-             launching an install. Blocked states render WITH their reason and
-             are never filtered out: the card owns that treatment. -->
-        <DevPlatformDistributionCard
-          v-for="dist in visibleDistributions"
-          :key="`dist:${dist.id}`"
-          :distribution="dist"
-          @select="handleDistributionActivate(dist)"
-          @open-kebab-menu="(event) => openDistKebabMenu(event, dist)"
-        />
-      </TransitionGroup>
+          <header class="chooser-shelf-head">
+            <span class="chooser-shelf-title">{{ t('chooser.workspaceShelf') }}</span>
+            <span class="chooser-shelf-count">{{
+              workspaceInstalledEntries.length + workspaceAvailableEntries.length
+            }}</span>
+          </header>
+          <ChooserFamilyGrid
+            v-if="workspaceInstalledEntries.length"
+            :entries="workspaceInstalledEntries"
+            :is-stopped-action-gated="isStoppedActionGated"
+            v-on="gridHandlers"
+          />
+          <ChooserFamilyGrid
+            v-if="workspaceAvailableEntries.length"
+            :entries="workspaceAvailableEntries"
+            :is-stopped-action-gated="isStoppedActionGated"
+            v-on="gridHandlers"
+          />
+        </section>
+      </div>
 
       <button
         v-if="distributionLoadFailed"
@@ -648,21 +683,18 @@ function handleNewInstallClick(): void {
   padding: 24px;
 }
 
-.chooser-grid {
+/* The scroll viewport both shelves live in — column, scroll and fade only;
+ * tile layout and the FLIP belong to `ChooserFamilyGrid`. */
+.chooser-shelves {
   grid-row: 4;
-  /* Containing block for absolutely-positioned leaving tiles (`.tile-leave-active`). */
-  position: relative;
   width: 100%;
-  /* 4 fixed tracks @ 280px + 3 × 16px gaps = 1168px. Keeps the 280px
-   * fixed-track contract from the comment below intact while letting
-   * wide viewports surface a 4-up row instead of capping at 3. */
-  max-width: 1168px;
-  /* Reserve height for the UNFILTERED row count so the grid box doesn't
-   * shrink while typing in search — that's what keeps the centered cluster
-   * from jumping (replaces the old top-anchor no-shift trick). One tile is
-   * 280px × 280·156.678/246 ≈ 178px tall; rows are 178px + a 16px gap each.
-   * `max-height: 100%` still caps it on short viewports, where the grid
-   * scrolls internally and the 1fr spacers collapse to 0. */
+  /* Content box must hold exactly 4 tracks (4 × 280 + 3 × 16 = 1168px), so the
+   * side padding sits OUTSIDE the cap — inside it, `auto-fit` drops to 3
+   * columns on a wide viewport. */
+  --shelf-pad-x: 4px;
+  max-width: calc(1168px + 2 * var(--shelf-pad-x));
+  /* Reserve the unfiltered row height so the cluster doesn't jump while typing
+   * in search. Tile is 178px tall (280px at the golden-ratio aspect). */
   --tile-h: 178px;
   min-height: min(
     100%,
@@ -670,28 +702,19 @@ function handleNewInstallClick(): void {
   );
   max-height: 100%;
   overflow-y: auto;
-  display: grid;
-  /* Fixed-width tracks instead of `auto-fill` `minmax(...)`: with
-   * `auto-fill` the grid reserves blank tracks across the full
-   * width, leaving 1-3 cards stuck at the left edge. Fixed-width
-   * tracks + `justify-content: center` center the whole row as a
-   * group while still wrapping to a new row when room runs out. */
-  grid-template-columns: repeat(auto-fit, 280px);
-  justify-content: center;
-  gap: 16px;
-  align-content: start;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
   /* Vertical padding pushes the first/last rows into the mask fade so they
    * glide under it rather than clip abruptly. Fluid on height (`--chooser-fade`)
    * so short viewports reclaim the band for an extra tile row. */
   --chooser-fade: clamp(12px, 2.5vh, 24px);
-  padding: var(--chooser-fade) 0;
+  padding: var(--chooser-fade) var(--shelf-pad-x);
 }
 
-/* Soft top + bottom fade on the scroll viewport so the edge of the
- * grid feels like a smooth dissolve instead of a hard cut. Fade distance
- * tracks the grid's vertical padding so the first/last rows still tuck under. */
+/* Soft scroll edges, matched to the vertical padding so rows tuck under. */
 @supports (mask-image: linear-gradient(black, black)) {
-  .chooser-grid {
+  .chooser-shelves {
     mask-image: linear-gradient(
       to bottom,
       transparent 0,
@@ -702,45 +725,35 @@ function handleNewInstallClick(): void {
   }
 }
 
-/* Tile FLIP: enter rises in (ease-out), leave fades out of flow so survivors
- * slide into the gap, move uses the app's iOS-derived curve. Transform/opacity
- * only — GPU-friendly. */
-.tile-enter-active {
-  transition:
-    opacity 200ms ease,
-    transform 200ms cubic-bezier(0.2, 0.8, 0.2, 1);
-}
-.tile-enter-from {
-  opacity: 0;
-  transform: translateY(8px) scale(0.98);
+.chooser-shelf {
+  display: flex;
+  flex-direction: column;
+  /* The grid's own row gap, so two stacked grids read as continuous rows. */
+  gap: 16px;
 }
 
-.tile-leave-active {
-  transition:
-    opacity 140ms ease,
-    transform 140ms cubic-bezier(0.32, 0.72, 0, 1);
-  position: absolute;
+/* Caption weight: the shelf organises, it isn't a section you act on. */
+.chooser-shelf-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
-.tile-leave-to {
-  opacity: 0;
-  transform: scale(0.98);
+.chooser-shelf-head::after {
+  content: '';
+  flex: 1 1 auto;
+  height: 1px;
+  background: var(--chooser-surface-border-hover);
+}
+.chooser-shelf-title {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.chooser-shelf-count {
+  font-size: 11px;
+  color: var(--text-faint);
 }
 
-.tile-move {
-  transition: transform 220ms cubic-bezier(0.32, 0.72, 0, 1);
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .tile-enter-active,
-  .tile-leave-active,
-  .tile-move {
-    /* Non-zero so Vue's transitionend-driven cleanup still fires and leaving
-     * nodes are removed. */
-    transition-duration: 1ms;
-  }
-  .tile-enter-from,
-  .tile-leave-to {
-    transform: none;
-  }
-}
 </style>

--- a/src/renderer/src/views/ChooserView.vue
+++ b/src/renderer/src/views/ChooserView.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { computed, onMounted, toRef } from 'vue'
+import { computed, onMounted, ref, toRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useInstallationStore } from '../stores/installationStore'
 import { useSessionStore } from '../stores/sessionStore'
+import { useAuthStore } from '../stores/authStore'
 import { useInstallContextMenu } from '../composables/useInstallContextMenu'
 import { useInstallList } from '../composables/useInstallList'
 import { useCloudCapacity } from '../composables/useCloudCapacity'
@@ -13,7 +14,11 @@ import BrandBackground from '../components/BrandBackground.vue'
 import BaseInput from '../components/ui/BaseInput.vue'
 import ComfyWordmark from '../components/icons/ComfyWordmark.vue'
 import ChooserInstallTile from './chooser/ChooserInstallTile.vue'
+import DevPlatformAccountChip from './devplatform/DevPlatformAccountChip.vue'
+import DevPlatformDistributionCard from './devplatform/DevPlatformDistributionCard.vue'
 import { resolvePickerTab } from '../lib/pickerTabs'
+import type { ContextMenuItem } from '../types/context-menu'
+import type { Distribution } from '../devplatform/types'
 import type { Installation, ShowProgressOpts } from '../types/ipc'
 
 /**
@@ -24,12 +29,18 @@ import type { Installation, ShowProgressOpts } from '../types/ipc'
  * entry.
  *
  * Layout:
+ *   - Top-right: dev-platform account chip (log-in button when signed out;
+ *     workspace switcher when signed in).
  *   - Top-left: "New Install" (always present).
  *   - Following: every install (local / cloud / remote) ordered by
  *     `lastLaunchedAt` desc, never-launched at the end.
+ *   - Then, when signed in, one tile per distribution published to the
+ *     workspace that isn't installed yet: installing a distribution is the
+ *     SAME GESTURE as launching an existing install: one tile, one click.
  *   - Filter chips above the grid narrow by source category.
  *
- * Per-install tile rendering lives in `chooser/ChooserInstallTile.vue`.
+ * Per-install tile rendering lives in `chooser/ChooserInstallTile.vue`;
+ * per-distribution tiles in `devplatform/DevPlatformDistributionCard.vue`.
  */
 
 const props = withDefaults(
@@ -57,6 +68,7 @@ const emit = defineEmits<{
 const { t } = useI18n()
 const installationStore = useInstallationStore()
 const sessionStore = useSessionStore()
+const authStore = useAuthStore()
 const modal = useModal()
 
 onMounted(() => {
@@ -64,6 +76,20 @@ onMounted(() => {
     void installationStore.fetchInstallations()
   }
 })
+
+// Sign-in / workspace-switch can happen ON this page (the chip), so the
+// distribution list follows the session rather than mount timing. Keying on the
+// workspace id (not just signed-in) is what re-fetches after a switch, where the
+// store clears the grid but signed-in stays true.
+watch(
+  () => [authStore.isSignedIn, authStore.status.workspaceId] as const,
+  () => {
+    if (authStore.isSignedIn && authStore.distributions.length === 0) {
+      void authStore.fetchDistributions().catch(() => {})
+    }
+  },
+  { immediate: true }
+)
 
 // Filter / search / recency logic is shared with the title-bar
 // instance picker popover via `useInstallList` so the two surfaces
@@ -78,8 +104,13 @@ onMounted(() => {
 // flow through `visibleInstalls` like every other source — there is no
 // special cloud surface anymore.
 const installationsRef = toRef(installationStore, 'installations')
-const { searchQuery, activeFilter, visibleInstalls, showEmptyHint, lastLaunchedLabel } =
-  useInstallList({ installations: installationsRef })
+const {
+  searchQuery,
+  activeFilter,
+  visibleInstalls,
+  showEmptyHint,
+  matchesQuery
+} = useInstallList({ installations: installationsRef })
 
 // Explicitly expose `activeFilter` so the brand-redesign tests can
 // drive the underlying filter state without the chip UI mounted.
@@ -87,12 +118,153 @@ const { searchQuery, activeFilter, visibleInstalls, showEmptyHint, lastLaunchedL
 // doesn't reference the ref directly (chips are TODO(brand-cleanup)).
 defineExpose({ activeFilter })
 
+// --- Comfy Builder distributions ---
+//
+// ORDERING: New install → existing installs → distributions. Existing installs
+// are what the user returns to and their position is muscle memory, so the
+// "things I could add" family goes last.
+//
+// DE-DUPLICATION: an already-installed distribution is an ordinary
+// installation and must not be listed twice. `installation.distributionId`
+// when the comfybuilder install carries it (the index signature passes it
+// through), else case-insensitive name equality: an install created from a
+// distribution inherits its name.
+function installationBacksDistribution(inst: Installation, dist: Distribution): boolean {
+  const linked = inst.distributionId
+  if (typeof linked === 'string' && linked.length > 0) return linked === dist.id
+  // Name-match is a fallback only for a comfybuilder install; never let an
+  // unrelated same-named local install hide a distribution tile.
+  if (inst.sourceId !== 'comfybuilder') return false
+  return inst.name.trim().toLowerCase() === dist.name.trim().toLowerCase()
+}
+
+/** Every distribution that earns a tile, before search. Empty when signed out. */
+const chooserDistributions = computed<Distribution[]>(() => {
+  if (!authStore.isSignedIn) return []
+  return authStore.distributions.filter(
+    (dist) =>
+      !installationStore.installations.some((inst) => installationBacksDistribution(inst, dist))
+  )
+})
+
+/** Search filters distributions through the SAME query as the install tiles. */
+const visibleDistributions = computed<Distribution[]>(() =>
+  chooserDistributions.value.filter((dist) => matchesQuery(dist.name))
+)
+
+/** A failed distribution fetch, distinct from an empty workspace: the watch
+ *  keys on session identity so it won't re-fetch on its own, hence the retry. */
+const distributionLoadFailed = computed(
+  () => authStore.isSignedIn && authStore.distributionsError && authStore.distributions.length === 0
+)
+
+/** The no-matches hint may only fire when NOTHING in the grid matches. A failed
+ *  fetch shows its own retry line instead, so the two never co-render. */
+const showNoMatches = computed(
+  () => showEmptyHint.value && visibleDistributions.value.length === 0 && !distributionLoadFailed.value
+)
+
+/** One quiet line under the grid when the signed-in workspace has nothing
+ *  published (or the fetch failed). Never a panel: this page already has content. */
+const distributionNote = computed(() => {
+  if (!authStore.isSignedIn) return ''
+  if (searchQuery.value.trim()) return ''
+  if (authStore.loadingDistributions) return ''
+  if (distributionLoadFailed.value) return t('devPlatform.distribution.loadError')
+  if (authStore.distributions.length === 0) return t('devPlatform.distribution.emptyTitle')
+  return ''
+})
+
+/**
+ * Install a distribution: main resolves the host artifact + creates the record,
+ * then we drive the SAME `installInstance` + progress UI every other install
+ * uses (via the `show-progress` event PanelApp already handles). A blocked tile
+ * never reaches here: the card suppresses its own activation.
+ */
+/** Distribution id whose install-kickoff is in flight, so a fast second click
+ *  (tile then kebab, or a double-click) can't start two installs before the
+ *  progress modal takes over. Main also guards this, belt-and-suspenders. */
+const activatingDist = ref<string | null>(null)
+
+async function handleDistributionActivate(dist: Distribution): Promise<void> {
+  if (activatingDist.value) return
+  activatingDist.value = dist.id
+  try {
+    const result = await window.api.comfybuilder.installDistribution(dist.id).catch((err: unknown) => ({
+      ok: false as const,
+      message: (err as Error)?.message || String(err)
+    }))
+    if (!result || !result.ok || !result.entry) {
+      await modal.alert({
+        title: t('errors.installFailed'),
+        message: result.message || t('devPlatform.distribution.installFailed')
+      })
+      return
+    }
+    emit('show-progress', {
+      installationId: result.entry.id,
+      title: `${t('newInstall.installing')}: ${result.entry.name}`,
+      apiCall: () => window.api.installInstance(result.entry!.id),
+      autoLaunchOnFinish: true,
+      opKind: 'install'
+    })
+  } finally {
+    activatingDist.value = null
+  }
+}
+
+// --- Distribution kebab menu ---
+//
+// Distribution cards carry the same top-right kebab as install tiles, so the
+// corner means one thing across the grid. Install is the only action a
+// distribution supports today; blocked states keep the item visible but
+// disabled rather than presenting an empty menu, which reads as a bug.
+const distMenu = ref<{ open: boolean; x: number; y: number; dist: Distribution | null }>({
+  open: false,
+  x: 0,
+  y: 0,
+  dist: null
+})
+
+const distMenuItems = computed<ContextMenuItem[]>(() => {
+  const dist = distMenu.value.dist
+  if (!dist) return []
+  return [
+    {
+      id: 'install',
+      label: t('devPlatform.distribution.menuInstall'),
+      disabled: dist.state !== 'installable' && dist.state !== 'update-available'
+    }
+  ]
+})
+
+function openDistKebabMenu(event: MouseEvent, dist: Distribution): void {
+  const rect = (event.currentTarget as HTMLElement | null)?.getBoundingClientRect?.()
+  // Right-aligned drop, matching the install-tile kebab. ContextMenu clamps to
+  // the viewport, so a negative x is safe.
+  const x = rect ? rect.right - 180 : event.clientX
+  const y = (rect?.bottom ?? event.clientY) + 4
+  distMenu.value = { open: true, x, y, dist }
+}
+
+function closeDistMenu(): void {
+  distMenu.value = { open: false, x: 0, y: 0, dist: null }
+}
+
+function handleDistMenuSelect(itemId: string): void {
+  const dist = distMenu.value.dist
+  closeDistMenu()
+  if (itemId === 'install' && dist) void handleDistributionActivate(dist)
+}
+
 // --- Cluster top offset ---
 
-/** Unfiltered tile count: New Install + every install (cloud included).
- *  Reads the raw list, not `visibleInstalls`, so search never shifts the
- *  cluster. */
-const baseTileCount = computed(() => 1 + installationStore.installations.length)
+/** Unfiltered tile count: New Install + every install (cloud included) + every
+ *  distribution. Reads the raw lists, not the `visible*` ones, so search never
+ *  shifts the cluster. */
+const baseTileCount = computed(
+  () => 1 + installationStore.installations.length + chooserDistributions.value.length
+)
 
 const TILES_PER_ROW = 4
 
@@ -232,6 +404,13 @@ function handleNewInstallClick(): void {
 <template>
   <BrandBackground v-show="props.visible" class="chooser-bg">
     <div class="chooser-view" :style="{ '--rows': clusterRows }">
+      <!-- Identity, top-right: the account chip when signed in, a quiet log-in
+           button when not. Absolutely positioned so it never enters the
+           centered wordmark → search → grid column. -->
+      <div class="chooser-account">
+        <DevPlatformAccountChip />
+      </div>
+
       <ComfyWordmark class="chooser-wordmark" aria-hidden="true" />
       <div class="chooser-search">
         <BaseInput
@@ -250,7 +429,7 @@ function handleNewInstallClick(): void {
         {{ t('common.loading') }}
       </div>
 
-      <div v-else-if="showEmptyHint" class="chooser-empty">
+      <div v-else-if="showNoMatches" class="chooser-empty">
         {{ t('chooser.noMatches') }}
       </div>
 
@@ -277,7 +456,6 @@ function handleNewInstallClick(): void {
           :key="inst.id"
           :installation="inst"
           :is-stopped-action-gated="isStoppedActionGated(inst)"
-          :last-launched-label="lastLaunchedLabel(inst)"
           @pick="pickInstall"
           @open-card-menu="openCardMenu"
           @open-kebab-menu="openKebabMenu"
@@ -285,7 +463,29 @@ function handleNewInstallClick(): void {
           @view-error="viewError"
           @view-danger="viewDanger"
         />
+
+        <!-- Distributions: siblings of the install tiles, same box, same
+             TransitionGroup, so installing one is the same gesture as
+             launching an install. Blocked states render WITH their reason and
+             are never filtered out: the card owns that treatment. -->
+        <DevPlatformDistributionCard
+          v-for="dist in visibleDistributions"
+          :key="`dist:${dist.id}`"
+          :distribution="dist"
+          @select="handleDistributionActivate(dist)"
+          @open-kebab-menu="(event) => openDistKebabMenu(event, dist)"
+        />
       </TransitionGroup>
+
+      <button
+        v-if="distributionLoadFailed"
+        type="button"
+        class="chooser-dist-note chooser-dist-note--retry"
+        @click="authStore.fetchDistributions()"
+      >
+        {{ $t('devPlatform.distribution.loadError') }}
+      </button>
+      <p v-else-if="distributionNote" class="chooser-dist-note">{{ distributionNote }}</p>
 
       <ContextMenu
         :open="ctxMenu.open"
@@ -294,6 +494,15 @@ function handleNewInstallClick(): void {
         :items="ctxMenuItems"
         @close="closeMenu"
         @select="handleCtxMenuSelect"
+      />
+
+      <ContextMenu
+        :open="distMenu.open"
+        :x="distMenu.x"
+        :y="distMenu.y"
+        :items="distMenuItems"
+        @close="closeDistMenu"
+        @select="handleDistMenuSelect"
       />
     </div>
   </BrandBackground>
@@ -352,6 +561,46 @@ function handleNewInstallClick(): void {
   max-width: 1280px;
   padding: var(--chooser-pad-y) 24px;
   row-gap: var(--chooser-row-gap);
+}
+
+/* Account chip: pinned to the frame's top-right, out of the centered column
+ * so it can never collide with the wordmark or the search field. */
+.chooser-account {
+  position: absolute;
+  top: var(--chooser-pad-y);
+  right: 24px;
+  z-index: 2;
+  display: flex;
+  justify-content: flex-end;
+  max-width: min(340px, 45%);
+}
+
+/* Quiet one-liner for the distribution family's empty story. Lives in the
+ * bottom spacer row so it costs the centered cluster no layout; on a short
+ * window the spacer collapses and this caption is the first thing to go. */
+.chooser-dist-note {
+  grid-row: 5;
+  align-self: start;
+  margin: 0;
+  padding-top: 4px;
+  font-size: var(--takeover-fs-caption);
+  color: var(--text-muted);
+  text-align: center;
+}
+.chooser-dist-note--retry {
+  border: none;
+  background: none;
+  font: inherit;
+  cursor: pointer;
+}
+.chooser-dist-note--retry:hover {
+  color: var(--neutral-100);
+  text-decoration: underline;
+}
+.chooser-dist-note--retry:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+  border-radius: 4px;
 }
 
 .chooser-wordmark {

--- a/src/renderer/src/views/chooser/ChooserFamilyGrid.vue
+++ b/src/renderer/src/views/chooser/ChooserFamilyGrid.vue
@@ -1,0 +1,152 @@
+<script setup lang="ts">
+/**
+ * One grid of chooser tiles — the shared body of every shelf. Renders a mixed
+ * list of install tiles and distribution cards and re-emits every tile event
+ * verbatim; `ChooserView` owns the handlers, so the two families can't drift.
+ */
+import { useI18n } from 'vue-i18n'
+import { Plus } from 'lucide-vue-next'
+import ChooserInstallTile from './ChooserInstallTile.vue'
+import DevPlatformDistributionCard from '../devplatform/DevPlatformDistributionCard.vue'
+import { entryKey, type ChooserGridEntry } from './chooserGridEntry'
+import type { Distribution } from '../../devplatform/types'
+import type { Installation } from '../../types/ipc'
+
+const props = withDefaults(
+  defineProps<{
+    entries: ChooserGridEntry[]
+    /** Lead with the New Install tile (the your-installs family owns it). */
+    showNew?: boolean
+    /** Center the rows instead of left-aligning them under a shelf header. */
+    centered?: boolean
+    isStoppedActionGated: (inst: Installation) => boolean
+  }>(),
+  { showNew: false, centered: false }
+)
+
+const emit = defineEmits<{
+  'new-install': []
+  pick: [installation: Installation]
+  'open-card-menu': [event: MouseEvent, installation: Installation]
+  'open-kebab-menu': [event: MouseEvent, installation: Installation]
+  'trigger-action': [action: 'update' | 'migrate', installation: Installation]
+  'view-error': [installation: Installation]
+  'view-danger': [installation: Installation]
+  'dist-select': [distribution: Distribution]
+  'dist-kebab': [event: MouseEvent, distribution: Distribution]
+}>()
+
+const { t } = useI18n()
+
+/** Freeze a leaving tile's box so it doesn't collapse under `position:
+ *  absolute`, letting survivors FLIP into the gap immediately. */
+function lockLeavingTileSize(el: Element): void {
+  const node = el as HTMLElement
+  const grid = node.parentElement
+  if (!grid) return
+  const rect = node.getBoundingClientRect()
+  const gridRect = grid.getBoundingClientRect()
+  node.style.width = `${rect.width}px`
+  node.style.height = `${rect.height}px`
+  node.style.left = `${rect.left - gridRect.left + grid.scrollLeft}px`
+  node.style.top = `${rect.top - gridRect.top + grid.scrollTop}px`
+}
+</script>
+
+<template>
+  <TransitionGroup
+    tag="div"
+    name="tile"
+    class="chooser-family-grid"
+    :class="{ 'chooser-family-grid--centered': props.centered }"
+    @before-leave="lockLeavingTileSize"
+  >
+    <button
+      v-if="props.showNew"
+      key="__new"
+      type="button"
+      class="chooser-tile chooser-tile-new"
+      @click="emit('new-install')"
+    >
+      <div class="chooser-tile-icon"><Plus :size="32" /></div>
+      <div class="chooser-tile-name">{{ t('chooser.newInstall') }}</div>
+      <div class="chooser-tile-meta">{{ t('chooser.newInstallDesc') }}</div>
+    </button>
+
+    <template v-for="entry in props.entries" :key="entryKey(entry)">
+      <ChooserInstallTile
+        v-if="entry.kind === 'install'"
+        :installation="entry.inst"
+        :is-stopped-action-gated="props.isStoppedActionGated(entry.inst)"
+        @pick="emit('pick', $event)"
+        @open-card-menu="(event, inst) => emit('open-card-menu', event, inst)"
+        @open-kebab-menu="(event, inst) => emit('open-kebab-menu', event, inst)"
+        @trigger-action="(action, inst) => emit('trigger-action', action, inst)"
+        @view-error="emit('view-error', $event)"
+        @view-danger="emit('view-danger', $event)"
+      />
+      <DevPlatformDistributionCard
+        v-else
+        :distribution="entry.dist"
+        @select="emit('dist-select', entry.dist)"
+        @open-kebab-menu="(event) => emit('dist-kebab', event, entry.dist)"
+      />
+    </template>
+  </TransitionGroup>
+</template>
+
+<style scoped>
+@import './chooser-tiles.css';
+
+.chooser-family-grid {
+  /* Containing block for absolutely-positioned leaving tiles. */
+  position: relative;
+  width: 100%;
+  display: grid;
+  /* Fixed-width tracks instead of `auto-fill` `minmax(...)`: with `auto-fill`
+   * the grid reserves blank tracks across the full width, leaving 1-3 cards
+   * stuck at the left edge. Fixed tracks wrap honestly. */
+  grid-template-columns: repeat(auto-fit, 280px);
+  justify-content: start;
+  gap: 16px;
+  align-content: start;
+}
+.chooser-family-grid--centered {
+  justify-content: center;
+}
+
+/* Tile FLIP. */
+.tile-enter-active {
+  transition:
+    opacity 200ms ease,
+    transform 200ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.tile-enter-from {
+  opacity: 0;
+  transform: translateY(8px) scale(0.98);
+}
+.tile-leave-active {
+  transition:
+    opacity 140ms ease,
+    transform 140ms cubic-bezier(0.32, 0.72, 0, 1);
+  position: absolute;
+}
+.tile-leave-to {
+  opacity: 0;
+  transform: scale(0.98);
+}
+.tile-move {
+  transition: transform 220ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+@media (prefers-reduced-motion: reduce) {
+  .tile-enter-active,
+  .tile-leave-active,
+  .tile-move {
+    transition-duration: 1ms;
+  }
+  .tile-enter-from,
+  .tile-leave-to {
+    transform: none;
+  }
+}
+</style>

--- a/src/renderer/src/views/chooser/ChooserInstallTile.vue
+++ b/src/renderer/src/views/chooser/ChooserInstallTile.vue
@@ -5,8 +5,7 @@ import {
   AlertCircle,
   ArrowDownToLine,
   ArrowRightLeft,
-  MoreVertical,
-  Package
+  MoreVertical
 } from 'lucide-vue-next'
 import { useSessionStore } from '../../stores/sessionStore'
 import { installTypeMetaForInstall } from '../../lib/installTypeIcon'
@@ -169,10 +168,11 @@ function triggerInstallAction(action: 'update' | 'migrate'): void {
          distribution install wears the distribution glyph instead. -->
     <span
       class="chooser-tile-icon"
-      :title="isFromDistribution ? undefined : t(typeMeta.labelKey)"
+      :title="t(typeMeta.labelKey)"
     >
-      <Package v-if="isFromDistribution" :size="22" />
-      <component :is="typeMeta.icon" v-else :size="22" />
+      <!-- `typeMeta` resolves the distribution glyph itself, so the tile, the
+           picker row and the title bar can't drift apart. -->
+      <component :is="typeMeta.icon" :size="22" />
     </span>
 
     <!-- Lifecycle indicator + kebab. Status pill is click-through; error badge opens details. -->

--- a/src/renderer/src/views/chooser/ChooserInstallTile.vue
+++ b/src/renderer/src/views/chooser/ChooserInstallTile.vue
@@ -1,12 +1,19 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { AlertCircle, ArrowDownToLine, ArrowRightLeft, MoreVertical } from 'lucide-vue-next'
+import {
+  AlertCircle,
+  ArrowDownToLine,
+  ArrowRightLeft,
+  MoreVertical,
+  Package
+} from 'lucide-vue-next'
 import { useSessionStore } from '../../stores/sessionStore'
 import { installTypeMetaForInstall } from '../../lib/installTypeIcon'
 import Tooltip from '../../components/ui/Tooltip.vue'
 import TruncatedText from '../../components/TruncatedText.vue'
 import { TID } from '../../../../shared/testIds'
+import { isDistributionInstall } from '../../devplatform/distributionState'
 import type { Installation } from '../../types/ipc'
 
 interface Props {
@@ -70,9 +77,19 @@ const hasMigratePrompt = computed(() => inst.value.statusTag?.style === 'migrate
 
 const typeMeta = computed(() => installTypeMetaForInstall(inst.value))
 
+/** Wears the distribution glyph rather than its install-type icon, so a
+ *  distribution keeps one identity whether it's installed or still a card. */
+const isFromDistribution = computed(() => isDistributionInstall(inst.value))
+
+const distributionVersion = computed(() =>
+  typeof inst.value.distributionVersion === 'string' ? inst.value.distributionVersion : ''
+)
+
 /** Desktop's listPreview is the bare installPath (useless as a label), so fall
  *  back to sourceLabel. Cloud/remote values are URLs — strip the protocol. */
 const sourceLabel = computed(() => {
+  // The path is noise on a tile whose identity is the distribution.
+  if (isFromDistribution.value) return ''
   const raw =
     inst.value.sourceId === 'desktop'
       ? inst.value.sourceLabel
@@ -80,8 +97,23 @@ const sourceLabel = computed(() => {
   return raw ? raw.replace(/^https?:\/\//, '') : raw
 })
 
+/** Labelled ("Dist v7") so it can't be read as the ComfyUI version beside it. */
+const trailingFact = computed(() =>
+  isFromDistribution.value
+    ? distributionVersion.value
+      ? t('devPlatform.distribution.distVersion', { version: distributionVersion.value })
+      : ''
+    : inst.value.version || ''
+)
+
+/** Distribution installs read "<ComfyUI version> · Dist v7"; everything else
+ *  keeps "<source> · <version>". */
+const leadingFact = computed(() =>
+  isFromDistribution.value ? inst.value.version || '' : sourceLabel.value
+)
+
 const metaLine = computed(() =>
-  [sourceLabel.value, inst.value.version].filter(Boolean).join(' · ')
+  [leadingFact.value, trailingFact.value].filter(Boolean).join(' · ')
 )
 
 
@@ -133,9 +165,14 @@ function triggerInstallAction(action: 'update' | 'migrate'): void {
     @keydown.space.prevent="handleClick"
     @contextmenu.prevent="emit('open-card-menu', $event, inst)"
   >
-    <!-- Type icon only; source/channel lives in the meta line below. -->
-    <span class="chooser-tile-icon" :title="t(typeMeta.labelKey)">
-      <component :is="typeMeta.icon" :size="22" />
+    <!-- Type icon only; source/channel lives in the meta line below. A
+         distribution install wears the distribution glyph instead. -->
+    <span
+      class="chooser-tile-icon"
+      :title="isFromDistribution ? undefined : t(typeMeta.labelKey)"
+    >
+      <Package v-if="isFromDistribution" :size="22" />
+      <component :is="typeMeta.icon" v-else :size="22" />
     </span>
 
     <!-- Lifecycle indicator + kebab. Status pill is click-through; error badge opens details. -->
@@ -193,9 +230,9 @@ function triggerInstallAction(action: 'update' | 'migrate'): void {
       <TruncatedText class="chooser-tile-name" :text="inst.name" />
       <div v-if="metaLine || actionPill" class="chooser-tile-footer">
         <TruncatedText v-if="metaLine" class="chooser-tile-meta-line" :text="metaLine">
-          <span v-if="sourceLabel" class="chooser-tile-meta-source">{{ sourceLabel }}</span>
-          <span v-if="sourceLabel && inst.version" class="chooser-tile-meta-sep">·</span>
-          <span v-if="inst.version" class="chooser-tile-meta-version">{{ inst.version }}</span>
+          <span v-if="leadingFact" class="chooser-tile-meta-source">{{ leadingFact }}</span>
+          <span v-if="leadingFact && trailingFact" class="chooser-tile-meta-sep">·</span>
+          <span v-if="trailingFact" class="chooser-tile-meta-version">{{ trailingFact }}</span>
         </TruncatedText>
         <!-- Action pill; pinned right by its own margin, never truncates. -->
         <Tooltip v-if="actionPill" :text="actionPill.tooltip" class="chooser-tile-pill-action">

--- a/src/renderer/src/views/chooser/ChooserInstallTile.vue
+++ b/src/renderer/src/views/chooser/ChooserInstallTile.vue
@@ -13,8 +13,6 @@ interface Props {
   installation: Installation
   /** True when REQUIRES_STOPPED actions (update / migrate / restore / delete) are gated. */
   isStoppedActionGated: boolean
-  /** Pre-formatted recency label — "Launched 3h ago" / "Not launched yet". */
-  lastLaunchedLabel: string
 }
 
 const props = defineProps<Props>()
@@ -109,14 +107,6 @@ const actionPill = computed(() => {
   return null
 })
 
-/** Precise fallback for the relative recency label; empty when never booted. */
-const absoluteLaunchedTime = computed(() => {
-  const ts = inst.value.lastLaunchedAt
-  return typeof ts === 'number'
-    ? new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(ts)
-    : ''
-})
-
 function handleClick(): void {
   if (isStopping.value) return
   emit('pick', inst.value)
@@ -197,23 +187,17 @@ function triggerInstallAction(action: 'update' | 'migrate'): void {
       </button>
     </div>
 
-    <!-- Stacked tiers (name → meta → recency); each truncates on its own row. -->
+    <!-- Two lines: name, then one row with the meta facts left and the
+         action pill (update / migrate) pinned right. -->
     <div class="chooser-tile-body">
       <TruncatedText class="chooser-tile-name" :text="inst.name" />
-      <TruncatedText v-if="metaLine" class="chooser-tile-meta-line" :text="metaLine">
-        <span v-if="sourceLabel" class="chooser-tile-meta-source">{{ sourceLabel }}</span>
-        <span v-if="sourceLabel && inst.version" class="chooser-tile-meta-sep">·</span>
-        <span v-if="inst.version" class="chooser-tile-meta-version">{{ inst.version }}</span>
-      </TruncatedText>
-      <div class="chooser-tile-footer">
-        <Tooltip
-          class="chooser-tile-recency"
-          :text="absoluteLaunchedTime"
-          :disabled="!absoluteLaunchedTime"
-        >
-          <span class="chooser-tile-recency-text">{{ lastLaunchedLabel }}</span>
-        </Tooltip>
-        <!-- Action pill (update / migrate); pinned right, never truncates. -->
+      <div v-if="metaLine || actionPill" class="chooser-tile-footer">
+        <TruncatedText v-if="metaLine" class="chooser-tile-meta-line" :text="metaLine">
+          <span v-if="sourceLabel" class="chooser-tile-meta-source">{{ sourceLabel }}</span>
+          <span v-if="sourceLabel && inst.version" class="chooser-tile-meta-sep">·</span>
+          <span v-if="inst.version" class="chooser-tile-meta-version">{{ inst.version }}</span>
+        </TruncatedText>
+        <!-- Action pill; pinned right by its own margin, never truncates. -->
         <Tooltip v-if="actionPill" :text="actionPill.tooltip" class="chooser-tile-pill-action">
           <span
             class="chooser-tile-pill"

--- a/src/renderer/src/views/chooser/chooserGridEntry.ts
+++ b/src/renderer/src/views/chooser/chooserGridEntry.ts
@@ -1,0 +1,24 @@
+/**
+ * One tile in a chooser grid. Installs and distributions render through the
+ * same grid component, so it takes a mixed list rather than two props.
+ */
+import type { Distribution } from '../../devplatform/types'
+import type { Installation } from '../../types/ipc'
+
+export type ChooserGridEntry =
+  | { kind: 'install'; inst: Installation }
+  | { kind: 'dist'; dist: Distribution }
+
+/** Stable `v-for` key. Both sides are namespaced so an installation and a
+ *  distribution that share an id — or the reserved `__new` tile — can't collide. */
+export function entryKey(entry: ChooserGridEntry): string {
+  return entry.kind === 'install' ? `install:${entry.inst.id}` : `dist:${entry.dist.id}`
+}
+
+export function installEntry(inst: Installation): ChooserGridEntry {
+  return { kind: 'install', inst }
+}
+
+export function distEntry(dist: Distribution): ChooserGridEntry {
+  return { kind: 'dist', dist }
+}

--- a/src/renderer/src/views/chooser/chooserGridEntry.ts
+++ b/src/renderer/src/views/chooser/chooserGridEntry.ts
@@ -1,6 +1,7 @@
 /**
- * One tile in a chooser grid. Installs and distributions render through the
- * same grid component, so it takes a mixed list rather than two props.
+ * The entry type a chooser grid renders, plus its constructors and key. Installs
+ * and distributions flow through one grid as a single mixed list rather than two
+ * props, so each entry is tagged and keyed by a namespaced id to avoid collision.
  */
 import type { Distribution } from '../../devplatform/types'
 import type { Installation } from '../../types/ipc'

--- a/src/renderer/src/views/comfyUISettings/ChannelPicker.vue
+++ b/src/renderer/src/views/comfyUISettings/ChannelPicker.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n'
 import { Loader2 } from 'lucide-vue-next'
 import BaseSelect, { type BaseSelectOption } from '../../components/ui/BaseSelect.vue'
 import InfoTooltip from '../../components/InfoTooltip.vue'
+import VersionStatPanel, { type VersionStatRow } from './VersionStatPanel.vue'
 import { formatRelativeFromMs } from '../../lib/datetime'
 import type { ActionDef, DetailField, DetailFieldOption } from '../../types/ipc'
 import { TID } from '../../../../shared/testIds'
@@ -164,13 +165,7 @@ const statusBadgeTone = computed<'current' | 'update'>(() =>
   preview.value?.updateAvailable ? 'update' : 'current'
 )
 
-interface StatRow {
-  id: string
-  label: string
-  value: string
-  title?: string
-  highlight?: boolean
-}
+type StatRow = VersionStatRow
 
 const lastCheckedDisplay = computed<{ value: string; title?: string } | null>(() => {
   if (!preview.value) return null
@@ -322,32 +317,13 @@ const selectOptions = computed<BaseSelectOption[]>(() =>
 
 <template>
   <div class="channel-picker">
-    <div class="channel-picker-status">
-      <div class="channel-picker-headline-row">
-        <p
-          class="channel-picker-headline"
-          :class="{ 'is-update-available': preview?.updateAvailable }"
-        >
-          {{ headline }}
-        </p>
-        <span v-if="statusBadge && preview" class="channel-picker-badge" :class="statusBadgeTone">
-          {{ statusBadge }}
-        </span>
-      </div>
-
-    </div>
-
-    <dl v-if="statRows.length > 0" class="channel-picker-stats">
-      <div
-        v-for="row in statRows"
-        :key="row.id"
-        class="channel-picker-stat-row"
-        :class="{ 'is-highlight': row.highlight }"
-      >
-        <dt>{{ row.label }}</dt>
-        <dd :title="row.title">{{ row.value }}</dd>
-      </div>
-    </dl>
+    <VersionStatPanel
+      :headline="headline"
+      :headline-highlight="preview?.updateAvailable === true"
+      :badge="preview ? statusBadge : null"
+      :badge-tone="statusBadgeTone"
+      :rows="statRows"
+    />
 
     <!-- Hint shown while `commitsAhead` is still being computed; self-hides
          after the max window if enrichment never completes. -->
@@ -435,86 +411,17 @@ const selectOptions = computed<BaseSelectOption[]>(() =>
   gap: 12px;
 }
 
-.channel-picker-headline-row {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 8px;
-}
 
-.channel-picker-headline {
-  margin: 0;
-  font-size: 18px;
-  font-weight: 600;
-  line-height: 24px;
-  color: var(--text);
-}
 
-.channel-picker-headline.is-update-available {
-  color: var(--accent);
-}
 
-.channel-picker-badge {
-  flex-shrink: 0;
-  padding: 2px 8px;
-  font-size: 11px;
-  font-weight: 500;
-  line-height: 16px;
-  border-radius: 999px;
-}
 
-.channel-picker-badge.current {
-  color: var(--success, #4ade80);
-  background: color-mix(in srgb, var(--success, #4ade80) 12%, transparent);
-}
 
-.channel-picker-badge.update {
-  color: var(--accent);
-  background: color-mix(in srgb, var(--accent) 12%, transparent);
-}
 
-.channel-picker-stats {
-  margin: 0;
-  display: flex;
-  flex-direction: column;
-  border: 1px solid var(--chooser-surface-border);
-  border-radius: 8px;
-  padding: 4px 12px;
-  background: var(--brand-surface-bg);
-}
 
-.channel-picker-stat-row {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-  align-items: center;
-  gap: 12px;
-  padding: 8px 0;
-  border-top: 1px solid var(--border-hover);
-}
 
-.channel-picker-stat-row:first-child {
-  border-top: none;
-}
 
-.channel-picker-stat-row dt {
-  margin: 0;
-  font-size: 12px;
-  line-height: 16px;
-  color: var(--text-muted);
-}
 
-.channel-picker-stat-row dd {
-  margin: 0;
-  font-size: 13px;
-  line-height: 19px;
-  color: var(--neutral-100);
-  text-align: right;
-}
 
-.channel-picker-stat-row.is-highlight dd {
-  color: var(--accent);
-  font-weight: 500;
-}
 
 .channel-picker-card {
   display: flex;

--- a/src/renderer/src/views/comfyUISettings/ChannelPicker.vue
+++ b/src/renderer/src/views/comfyUISettings/ChannelPicker.vue
@@ -411,18 +411,6 @@ const selectOptions = computed<BaseSelectOption[]>(() =>
   gap: 12px;
 }
 
-
-
-
-
-
-
-
-
-
-
-
-
 .channel-picker-card {
   display: flex;
   flex-direction: column;

--- a/src/renderer/src/views/comfyUISettings/SettingsSectionList.test.ts
+++ b/src/renderer/src/views/comfyUISettings/SettingsSectionList.test.ts
@@ -4,7 +4,7 @@ import { createI18n } from 'vue-i18n'
 
 import { en } from '../../lib/i18nMessages.ts'
 import SettingsSectionList from './SettingsSectionList.vue'
-import type { DetailField } from '../../types/ipc'
+import type { DetailField, DetailSection } from '../../types/ipc'
 
 function makeI18n() {
   return createI18n({ legacy: false, locale: 'en', messages: { en } })
@@ -127,6 +127,48 @@ describe('SettingsSectionList', () => {
         { id: 'updated', label: 'Last updated', value: '2024/01/02' },
       ])
       expect(wrapper.find('button.settings-v2-field-readonly-open').exists()).toBe(false)
+    })
+  })
+
+  // The Update tab's version table renders the section's actions itself, so the
+  // generic footer must stand down (or the button appears twice), and the button
+  // is the only place the update action can be fired.
+  describe('version-stats section', () => {
+    const vsSection = (enabled: boolean): DetailSection => ({
+      fields: [
+        {
+          id: 'vs',
+          label: 'Distribution version',
+          editType: 'version-stats',
+          editable: false,
+          value: { headline: 'v1', rows: [{ id: 'installed', label: 'Installed', value: 'v1' }] },
+        },
+      ],
+      actions: [{ id: 'update-distribution', label: 'Update', enabled }],
+    })
+
+    function mountSection(enabled: boolean) {
+      return mount(SettingsSectionList, {
+        props: { sections: [vsSection(enabled)] },
+        global: { plugins: [makeI18n()] },
+      })
+    }
+
+    it('docks the action inside the panel and suppresses the generic footer', () => {
+      const wrapper = mountSection(true)
+      expect(wrapper.findAll('.version-stat-action')).toHaveLength(1)
+      expect(wrapper.find('.settings-v2-actions').exists()).toBe(false)
+    })
+
+    it('emits run-action from an enabled update button', async () => {
+      const wrapper = mountSection(true)
+      await wrapper.find('.version-stat-action').trigger('click')
+      expect(wrapper.emitted('run-action')).toBeTruthy()
+    })
+
+    it('disables the update button when the action is not ready', () => {
+      const wrapper = mountSection(false)
+      expect(wrapper.find('.version-stat-action').attributes('disabled')).toBeDefined()
     })
   })
 })

--- a/src/renderer/src/views/comfyUISettings/SettingsSectionList.vue
+++ b/src/renderer/src/views/comfyUISettings/SettingsSectionList.vue
@@ -8,12 +8,13 @@ import BooleanToggle from './BooleanToggle.vue'
 import PathField from './PathField.vue'
 import EnvVarsField from './EnvVarsField.vue'
 import ChannelPicker from './ChannelPicker.vue'
+import VersionStatPanel from './VersionStatPanel.vue'
 import ArgsBuilderField from './ArgsBuilderField.vue'
 import InfoTooltip from '../../components/InfoTooltip.vue'
 import BaseCopyButton from '../../components/ui/BaseCopyButton.vue'
 import TooltipWrap from '../../components/TooltipWrap.vue'
 import { isOpenablePathString } from '../../lib/openablePath'
-import type { ActionDef, DetailField, DetailSection } from '../../types/ipc'
+import type { ActionDef, DetailField, DetailSection, VersionStatsValue } from '../../types/ipc'
 
 /**
  * Shared section + field renderer for both the Settings drawer and the instance-picker's Settings accordion.
@@ -73,6 +74,19 @@ function asString(v: DetailField['value']): string {
   return typeof v === 'string' ? v : v == null ? '' : String(v)
 }
 
+/** Unpack a `version-stats` field. The backend owns the wording — it knows what
+ *  the versions mean — so this only supplies defaults for a malformed payload. */
+function versionStats(field: DetailField): Required<VersionStatsValue> {
+  const v = (field.value ?? {}) as Partial<VersionStatsValue>
+  return {
+    headline: typeof v.headline === 'string' ? v.headline : '',
+    headlineHighlight: v.headlineHighlight === true,
+    badge: typeof v.badge === 'string' ? v.badge : null,
+    badgeTone: v.badgeTone === 'update' ? 'update' : 'current',
+    rows: Array.isArray(v.rows) ? v.rows : []
+  }
+}
+
 // Per-title collapse state; only titled sections (with a `section.collapsed` seed) are collapsible.
 const collapsedTitles = ref(new Set<string>())
 
@@ -111,8 +125,14 @@ function isNestedField(field: DetailField): boolean {
   return field.nested === true
 }
 
-function hasChannelPicker(section: DetailSection): boolean {
-  return (section.fields ?? []).some((f) => f.editType === 'channel-cards')
+/** Field types that render the section's actions themselves, so the generic
+ *  full-width footer must stand down or the buttons appear twice. */
+const ACTION_OWNING_EDIT_TYPES = new Set(['channel-cards', 'version-stats'])
+
+function fieldOwnsSectionActions(section: DetailSection): boolean {
+  return (section.fields ?? []).some(
+    (f) => f.editType && ACTION_OWNING_EDIT_TYPES.has(f.editType),
+  )
 }
 
 function isPathLikeValue(value: unknown): boolean {
@@ -137,7 +157,13 @@ function readonlyDisplayValue(field: DetailField): string {
 }
 
 function fieldOwnsLabel(field: DetailField): boolean {
-  return field.editType === 'env-vars' || field.editType === 'channel-cards'
+  return (
+    field.editType === 'env-vars' ||
+    field.editType === 'channel-cards' ||
+    // The panel leads with its own headline; a label above it would echo the
+    // section title.
+    field.editType === 'version-stats'
+  )
 }
 </script>
 
@@ -324,6 +350,17 @@ function fieldOwnsLabel(field: DetailField): boolean {
             @action="(a) => emit('run-action', a)"
           />
 
+          <!-- The same version table ChannelPicker shows, for a source that has
+               versions but no release channel. The backend supplies the rows,
+               and the section's actions dock inside the table's footer. -->
+          <VersionStatPanel
+            v-else-if="field.editType === 'version-stats'"
+            v-bind="versionStats(field)"
+            :actions="section.actions ?? []"
+            :running-action-ids="runningIdsSet"
+            @action="(a) => emit('run-action', a)"
+          />
+
           <BaseInput
             v-else-if="field.editType === 'text'"
             :model-value="asString(field.value)"
@@ -352,7 +389,7 @@ function fieldOwnsLabel(field: DetailField): boolean {
       </div>
 
       <div
-        v-if="section.actions && section.actions.length && !hasChannelPicker(section)"
+        v-if="section.actions && section.actions.length && !fieldOwnsSectionActions(section)"
         class="settings-v2-actions"
       >
         <TooltipWrap

--- a/src/renderer/src/views/comfyUISettings/VersionStatPanel.vue
+++ b/src/renderer/src/views/comfyUISettings/VersionStatPanel.vue
@@ -1,0 +1,244 @@
+<script setup lang="ts">
+/**
+ * The Update tab's version summary: a headline with a status badge, over a
+ * bordered table of version facts.
+ *
+ * Extracted from `ChannelPicker` so a distribution install — which has versions
+ * but no release channel — gets the SAME table rather than a stacked list that
+ * merely says the same words. Purely presentational: callers decide what the
+ * rows mean.
+ */
+import { Loader2 } from 'lucide-vue-next'
+import type { ActionDef, VersionStatRow } from '../../types/ipc'
+
+export type { VersionStatRow }
+
+const props = withDefaults(
+  defineProps<{
+    headline: string
+    /** Accent the headline (an update is waiting). */
+    headlineHighlight?: boolean
+    badge?: string | null
+    badgeTone?: 'current' | 'update'
+    rows?: VersionStatRow[]
+    /** Rendered inside the table's bottom edge, right-aligned — they act on
+     *  what the table states, so they belong to it rather than the page. */
+    actions?: ActionDef[]
+    runningActionIds?: Set<string>
+  }>(),
+  {
+    headlineHighlight: false,
+    badge: null,
+    badgeTone: 'current',
+    rows: () => [],
+    actions: () => [],
+    runningActionIds: () => new Set<string>()
+  }
+)
+
+const emit = defineEmits<{ action: [action: ActionDef] }>()
+
+function isRunning(id: string): boolean {
+  return props.runningActionIds.has(id)
+}
+</script>
+
+<template>
+  <div class="version-stat-panel">
+    <div class="version-stat-headline-row">
+      <p class="version-stat-headline" :class="{ 'is-update-available': headlineHighlight }">
+        {{ headline }}
+      </p>
+      <span v-if="badge" class="version-stat-badge" :class="badgeTone">{{ badge }}</span>
+    </div>
+
+    <dl v-if="rows.length > 0 || actions.length > 0" class="version-stat-rows">
+      <div
+        v-for="row in rows"
+        :key="row.id"
+        class="version-stat-row"
+        :class="{ 'is-highlight': row.highlight }"
+      >
+        <dt>{{ row.label }}</dt>
+        <dd :title="row.title">{{ row.value }}</dd>
+      </div>
+
+      <div v-if="actions.length > 0" class="version-stat-actions">
+        <button
+          v-for="action in actions"
+          :key="action.id"
+          type="button"
+          class="version-stat-action"
+          :class="[action.style, { 'is-running': isRunning(action.id) }]"
+          :title="action.enabled === false ? action.disabledMessage : action.tooltip"
+          :disabled="action.enabled === false || isRunning(action.id)"
+          @click="emit('action', action)"
+        >
+          <Loader2 v-if="isRunning(action.id)" :size="14" class="version-stat-action-spinner" />
+          {{ action.label }}
+        </button>
+      </div>
+    </dl>
+  </div>
+</template>
+
+<style scoped>
+.version-stat-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.version-stat-headline-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.version-stat-headline {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 24px;
+  color: var(--text);
+}
+
+.version-stat-headline.is-update-available {
+  color: var(--accent);
+}
+
+.version-stat-badge {
+  flex-shrink: 0;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 16px;
+  border-radius: 999px;
+}
+
+.version-stat-badge.current {
+  color: var(--success, #4ade80);
+  background: color-mix(in srgb, var(--success, #4ade80) 12%, transparent);
+}
+
+.version-stat-badge.update {
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
+.version-stat-rows {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--chooser-surface-border);
+  border-radius: 8px;
+  padding: 4px 12px;
+  background: var(--brand-surface-bg);
+}
+
+.version-stat-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  align-items: center;
+  gap: 12px;
+  padding: 8px 0;
+  border-top: 1px solid var(--border-hover);
+}
+
+.version-stat-row:first-child {
+  border-top: none;
+}
+
+.version-stat-row dt {
+  margin: 0;
+  font-size: 12px;
+  line-height: 16px;
+  color: var(--text-muted);
+}
+
+.version-stat-row dd {
+  margin: 0;
+  font-size: 13px;
+  line-height: 19px;
+  color: var(--neutral-100);
+  text-align: right;
+}
+
+.version-stat-row.is-highlight dd {
+  color: var(--accent);
+  font-weight: 500;
+}
+
+/* Inside the table's bottom edge, sharing the row divider so the buttons read
+ * as the table's own footer rather than a detached block. */
+.version-stat-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 0;
+  border-top: 1px solid var(--border-hover);
+}
+
+.version-stat-rows > .version-stat-actions:first-child {
+  border-top: none;
+}
+
+.version-stat-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  flex: 0 0 auto;
+  height: 30px;
+  padding: 0 14px;
+  border-radius: 8px;
+  border: 1px solid var(--chooser-surface-border);
+  background: var(--brand-surface-bg);
+  color: var(--neutral-100);
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+  cursor: pointer;
+  box-sizing: border-box;
+  transition:
+    background-color 100ms ease,
+    filter 100ms ease;
+}
+
+.version-stat-action:hover:not(:disabled),
+.version-stat-action:focus-visible:not(:disabled) {
+  background: var(--brand-surface-bg-hover);
+  outline: none;
+}
+
+.version-stat-action.primary {
+  border-color: var(--accent);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.version-stat-action:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.version-stat-action.is-running {
+  cursor: progress;
+  opacity: 0.85;
+}
+
+.version-stat-action-spinner {
+  flex: 0 0 auto;
+  animation: version-stat-action-spin 0.9s linear infinite;
+}
+
+@keyframes version-stat-action-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+</style>

--- a/src/renderer/src/views/devplatform/DevPlatformAccountChip.vue
+++ b/src/renderer/src/views/devplatform/DevPlatformAccountChip.vue
@@ -1,0 +1,467 @@
+<script setup lang="ts">
+/**
+ * Account chip: persistent identity, top-right (the Docker Desktop pattern).
+ *
+ * Signed out it is one quiet log-in button that runs the browser handoff
+ * itself. Signed in it names the account AND the workspace on the chip face:
+ * a token carries exactly one workspace claim, so everything downstream
+ * belongs to whichever workspace this chip names; keeping it visible makes a
+ * wrong-workspace mistake self-correcting.
+ *
+ * The dropdown is a WORKSPACE SWITCHER: it lists the account's workspaces and
+ * switches the active one. A cloud PKCE token is scoped at consent time, so a
+ * switch re-runs the browser handoff pre-selecting the workspace (there is no
+ * silent re-scope); the chip shows a spinner on the row while that is out.
+ *
+ * Sign out confirms, because users reasonably fear it uninstalls what they
+ * installed. It does not: the confirm body says exactly that. Tone stays
+ * primary, never danger.
+ */
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { Check, ChevronDown, Loader2, LogIn, LogOut } from 'lucide-vue-next'
+import DevPlatformAvatar from './DevPlatformAvatar.vue'
+import { useAuthStore } from '../../stores/authStore'
+import { useDialogs } from '../../composables/useDialogs'
+
+const emit = defineEmits<{
+  /** Sign-out completed. Host decides whether anything else changes. */
+  'signed-out': []
+  /** The active workspace changed. Host re-pulls workspace-scoped data. */
+  'workspace-switched': []
+}>()
+
+const { t } = useI18n()
+const store = useAuthStore()
+const dialogs = useDialogs()
+
+const menuOpen = ref(false)
+const rootRef = ref<HTMLElement | null>(null)
+const faceRef = ref<HTMLElement | null>(null)
+const signingIn = ref(false)
+/** Workspace id currently being switched to, or null. Drives the row spinner
+ *  and blocks a second concurrent switch. */
+const switchingTo = ref<string | null>(null)
+
+const email = computed(() => store.status.email ?? '')
+
+/**
+ * The workspace named by the access token's single claim. For a team we prefer
+ * the human name from the loaded workspace list so the chip face matches the
+ * switcher row (same label AND same seeded avatar colour); the raw id is only a
+ * fallback until the list loads (the claims carry no human name: backend gap).
+ * Personal workspaces are named by the product.
+ */
+const workspaceName = computed(() => {
+  const s = store.status
+  if (!s.signedIn) return ''
+  if (s.workspaceType === 'team' && s.workspaceId) {
+    return store.workspaces.find((w) => w.id === s.workspaceId)?.name ?? s.workspaceId
+  }
+  return t('devPlatform.workspace.personalLabel')
+})
+
+/** Human label for one workspace row. Personal workspaces get the product name. */
+function workspaceLabel(ws: { name: string; type: string }): string {
+  if (ws.type === 'team') return ws.name
+  return t('devPlatform.workspace.personalLabel')
+}
+
+const currentWorkspaceId = computed(() => store.status.workspaceId ?? null)
+
+function closeMenu(): void {
+  menuOpen.value = false
+}
+
+function toggleMenu(): void {
+  menuOpen.value = !menuOpen.value
+  // Opening the menu is when the switcher needs its list: pull it lazily so a
+  // signed-in user who never opens the menu never makes the call.
+  if (menuOpen.value && store.workspaces.length === 0) {
+    void store.fetchWorkspaces().catch(() => {})
+  }
+}
+
+/** Escape closes the menu wherever focus is: the menu is never a trap.
+ *  Focus returns to the trigger (APG menu pattern); pointer dismissal
+ *  deliberately doesn't refocus: that would steal focus from wherever
+ *  the user just clicked. */
+function onKeydown(e: KeyboardEvent): void {
+  if (e.key === 'Escape' && menuOpen.value) {
+    e.stopPropagation()
+    closeMenu()
+    faceRef.value?.focus()
+  }
+}
+
+function onPointerDown(e: MouseEvent): void {
+  if (!menuOpen.value) return
+  const target = e.target as Node | null
+  if (target && rootRef.value?.contains(target)) return
+  closeMenu()
+}
+
+onMounted(() => {
+  document.addEventListener('mousedown', onPointerDown)
+})
+onBeforeUnmount(() => {
+  document.removeEventListener('mousedown', onPointerDown)
+})
+
+async function onSignIn(): Promise<void> {
+  if (signingIn.value) return
+  signingIn.value = true
+  try {
+    await store.signIn()
+  } catch {
+    // Cancelled or failed browser handoff: the button simply re-arms.
+  } finally {
+    signingIn.value = false
+  }
+}
+
+async function onSelectWorkspace(workspaceId: string): Promise<void> {
+  // Already the active workspace, or a switch is already in flight.
+  if (workspaceId === currentWorkspaceId.value || switchingTo.value) return
+  switchingTo.value = workspaceId
+  try {
+    await store.switchWorkspace(workspaceId)
+    closeMenu()
+    emit('workspace-switched')
+  } catch {
+    // Cancelled or failed re-auth: the current workspace is unchanged.
+  } finally {
+    switchingTo.value = null
+  }
+}
+
+async function onSignOut(): Promise<void> {
+  closeMenu()
+  const result = await dialogs.confirm({
+    title: t('devPlatform.account.signOutConfirmTitle'),
+    // States plainly that installed distributions are KEPT and only stop
+    // receiving updates. This is the sentence that stops the support ticket.
+    message: t('devPlatform.account.signOutConfirmBody'),
+    confirmLabel: t('devPlatform.account.signOutConfirmCta'),
+    tone: 'primary',
+  })
+  if (result !== 'primary') return
+  try {
+    await store.signOut()
+  } catch {
+    // Sign-out IPC failed: stay visibly signed in rather than lie.
+    return
+  }
+  emit('signed-out')
+}
+</script>
+
+<template>
+  <div ref="rootRef" class="account-chip" @keydown="onKeydown">
+    <!-- Signed out: one quiet button. Deliberately not the yellow primary. -->
+    <button
+      v-if="!store.isSignedIn"
+      type="button"
+      class="brand-tertiary account-chip__signin"
+      data-testid="devplatform-account-signin"
+      :disabled="signingIn"
+      :aria-busy="signingIn"
+      @click="onSignIn"
+    >
+      <Loader2 v-if="signingIn" :size="16" class="account-chip__spinner" aria-hidden="true" />
+      <LogIn v-else :size="16" aria-hidden="true" />
+      <span>{{ $t('devPlatform.signIn.cta') }}</span>
+    </button>
+
+    <template v-else>
+      <button
+        ref="faceRef"
+        type="button"
+        class="account-chip__face"
+        data-testid="devplatform-account-chip"
+        :aria-expanded="menuOpen"
+        aria-haspopup="menu"
+        @click="toggleMenu"
+      >
+        <!-- Seeded from the workspace, not the account: the avatar reads as
+             "which workspace am I in", matching the rows in the menu. -->
+        <DevPlatformAvatar class="account-chip__avatar" :name="workspaceName || email || '?'" />
+        <!-- Account over workspace. The workspace needs no label: the avatar
+             beside it is the workspace's, so the second line reads as one. -->
+        <span class="account-chip__identity">
+          <span class="account-chip__email">{{ email }}</span>
+          <span v-if="workspaceName" class="account-chip__workspace-name">{{ workspaceName }}</span>
+        </span>
+        <ChevronDown
+          :size="14"
+          class="account-chip__caret"
+          :class="{ 'account-chip__caret--open': menuOpen }"
+          aria-hidden="true"
+        />
+      </button>
+
+      <div
+        v-if="menuOpen"
+        class="account-chip__menu"
+        role="menu"
+        :aria-label="$t('devPlatform.account.signedInAs', { email })"
+        data-testid="devplatform-account-menu"
+      >
+        <p class="account-chip__section-label">{{ $t('devPlatform.workspace.switchLabel') }}</p>
+
+        <div v-if="store.loadingWorkspaces && store.workspaces.length === 0" class="account-chip__hint">
+          {{ $t('common.loading') }}
+        </div>
+        <!-- Failed load (not just empty): offer a retry rather than a blank switcher. -->
+        <button
+          v-else-if="store.workspacesError && store.workspaces.length === 0"
+          type="button"
+          class="account-chip__item account-chip__retry"
+          role="menuitem"
+          data-testid="devplatform-workspace-retry"
+          @click="store.fetchWorkspaces()"
+        >
+          {{ $t('devPlatform.workspace.loadError') }}
+        </button>
+
+        <button
+          v-for="ws in store.workspaces"
+          :key="ws.id"
+          type="button"
+          class="account-chip__item account-chip__workspace-item"
+          role="menuitemradio"
+          :aria-checked="ws.id === currentWorkspaceId"
+          :disabled="switchingTo !== null"
+          :data-testid="`devplatform-workspace-${ws.id}`"
+          @click="onSelectWorkspace(ws.id)"
+        >
+          <DevPlatformAvatar class="account-chip__item-avatar" :name="workspaceLabel(ws)" />
+          <span class="account-chip__item-identity">
+            <span class="account-chip__item-name">{{ workspaceLabel(ws) }}</span>
+            <span v-if="ws.subscriptionTier" class="account-chip__item-sub">{{ ws.subscriptionTier }}</span>
+          </span>
+          <Loader2
+            v-if="switchingTo === ws.id"
+            :size="15"
+            class="account-chip__spinner"
+            aria-hidden="true"
+          />
+          <Check
+            v-else-if="ws.id === currentWorkspaceId"
+            :size="15"
+            class="account-chip__item-check"
+            aria-hidden="true"
+          />
+        </button>
+
+        <div class="account-chip__divider" role="separator"></div>
+
+        <button
+          type="button"
+          class="account-chip__item"
+          role="menuitem"
+          data-testid="devplatform-account-signout"
+          @click="onSignOut"
+        >
+          <LogOut :size="16" aria-hidden="true" />
+          <span>{{ $t('devPlatform.account.signOut') }}</span>
+        </button>
+      </div>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.account-chip {
+  position: relative;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-end;
+}
+
+.account-chip__signin {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.account-chip__spinner {
+  animation: account-chip-spin 900ms linear infinite;
+}
+@keyframes account-chip-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Chip face: frosted, quiet, and two-line so the workspace never has to be
+   truncated out of existence on a narrow window. Shares the 6px radius of
+   `button.brand-tertiary`: the signed-out control that occupies this same
+   slot: so the two states of one affordance keep one silhouette. */
+.account-chip__face {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  max-width: 320px;
+  padding: 6px 10px;
+  border-radius: 6px;
+  border: 1px solid color-mix(in oklab, var(--neutral-100) 10%, transparent);
+  background: color-mix(in oklab, var(--neutral-100) 5%, transparent);
+  color: var(--neutral-100);
+  font: inherit;
+  cursor: pointer;
+  transition:
+    background 120ms ease,
+    border-color 120ms ease;
+}
+.account-chip__face:hover {
+  background: color-mix(in oklab, var(--neutral-100) 10%, transparent);
+  border-color: color-mix(in oklab, var(--neutral-100) 18%, transparent);
+}
+.account-chip__face:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+/* The avatar is the square gradient one, seeded from the workspace name (the
+   account email only as a fallback), so it reads as "which workspace am I in"
+   and matches the seeded colour of the active row in the switcher. */
+.account-chip__avatar {
+  --dp-avatar-size: 30px;
+}
+
+.account-chip__identity {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1px;
+  min-width: 0;
+  font-size: var(--takeover-fs-caption);
+  line-height: 1.3;
+}
+.account-chip__email {
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 600;
+  color: var(--neutral-100);
+}
+.account-chip__workspace-name {
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--neutral-200);
+}
+
+.account-chip__caret {
+  flex: 0 0 auto;
+  color: var(--neutral-200);
+  transition: transform 140ms ease;
+}
+.account-chip__caret--open {
+  transform: rotate(180deg);
+}
+
+/* Dropdown: anchored to the chip's top-right, opening downward. */
+.account-chip__menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 20;
+  min-width: 240px;
+  max-width: 320px;
+  /* Cap the height so a user in many workspaces can always reach Sign out. */
+  max-height: min(70vh, 480px);
+  overflow-y: auto;
+  padding: 6px;
+  border-radius: 10px;
+  border: 1px solid var(--brand-surface-border);
+  background: var(--chooser-surface-bg);
+  backdrop-filter: blur(18px);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+}
+
+.account-chip__section-label {
+  margin: 4px 8px 6px;
+  font-size: var(--takeover-fs-caption);
+  font-weight: 600;
+  color: var(--neutral-200);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.account-chip__hint {
+  padding: 8px;
+  font-size: var(--takeover-fs-caption);
+  color: var(--neutral-200);
+  opacity: 0.8;
+}
+
+.account-chip__retry {
+  font-size: var(--takeover-fs-caption);
+  color: var(--neutral-200);
+}
+
+.account-chip__item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--neutral-100);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background 120ms ease;
+}
+.account-chip__item:hover:not(:disabled) {
+  background: var(--brand-surface-bg-hover);
+}
+.account-chip__item:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: -2px;
+}
+.account-chip__item:disabled {
+  cursor: default;
+}
+
+.account-chip__workspace-item {
+  gap: 10px;
+}
+.account-chip__item-avatar {
+  --dp-avatar-size: 26px;
+}
+.account-chip__item-identity {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+.account-chip__item-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--takeover-fs-body);
+}
+.account-chip__item-sub {
+  font-size: var(--takeover-fs-caption);
+  color: var(--neutral-200);
+  text-transform: capitalize;
+}
+.account-chip__item-check {
+  flex: 0 0 auto;
+  color: var(--comfy-yellow);
+}
+
+.account-chip__divider {
+  height: 1px;
+  margin: 6px 4px;
+  background: var(--brand-surface-border);
+}
+</style>

--- a/src/renderer/src/views/devplatform/DevPlatformAvatar.vue
+++ b/src/renderer/src/views/devplatform/DevPlatformAvatar.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+/**
+ * Square gradient avatar: ported verbatim from the ComfyUI frontend's
+ * `WorkspaceProfilePic.vue` so the same subject renders the SAME colour here as
+ * in the web frontend. The PRNG and hue/sat/light maths are a wire format: any
+ * change silently breaks that cross-surface identity.
+ *
+ * Used for both the account-chip face (seeded from the active workspace name,
+ * falling back to the email) and the switcher rows (seeded from each workspace
+ * name): the colour is a deterministic function of whatever string it is given.
+ */
+import { computed } from 'vue'
+
+const { name } = defineProps<{
+  /** Subject the colour is derived from; only its first character is rendered. */
+  name: string
+}>()
+
+const letter = computed(() => name?.charAt(0)?.toUpperCase() || '?')
+
+/** mulberry32: the frontend's PRNG, ported verbatim. */
+function mulberry32(a: number): () => number {
+  return function () {
+    let t = (a += 0x6d2b79f5)
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+/** Two-stop gradient seeded from the letter. The rand() call ORDER and COUNT are
+ *  part of the contract: reordering or adding a call changes every colour.
+ *
+ *  The second stop's hue spread is narrowed against the frontend's 40-120°: at
+ *  that width the two stops read as two separate colours rather than one shaded
+ *  one. hue1/sat/light are untouched, so the colour family still matches. */
+const gradient = computed(() => {
+  const rand = mulberry32(letter.value.charCodeAt(0))
+  const hue1 = Math.floor(rand() * 360)
+  const hue2 = (hue1 + 18 + Math.floor(rand() * 24)) % 360
+  const sat = 65 + Math.floor(rand() * 20)
+  const light = 55 + Math.floor(rand() * 15)
+  return `linear-gradient(135deg, hsl(${hue1}, ${sat}%, ${light + 6}%), hsl(${hue2}, ${sat}%, ${light - 6}%))`
+})
+</script>
+
+<template>
+  <!-- Decorative: the subject's name is always rendered beside this avatar. -->
+  <span class="dp-avatar" :style="{ background: gradient }" aria-hidden="true">
+    {{ letter }}
+  </span>
+</template>
+
+<style scoped>
+.dp-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: var(--dp-avatar-size, 32px);
+  height: var(--dp-avatar-size, 32px);
+  border-radius: 6px;
+  overflow: hidden;
+  /* Paired to the generated gradient, not the app palette: same values as
+   * the frontend component this is ported from. */
+  color: #fff;
+  /* Scales with the box so the letter keeps the same optical weight at any size. */
+  font-size: calc(var(--dp-avatar-size, 32px) * 0.42);
+  font-weight: 600;
+  line-height: 1;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+  user-select: none;
+}
+</style>

--- a/src/renderer/src/views/devplatform/DevPlatformDistributionCard.vue
+++ b/src/renderer/src/views/devplatform/DevPlatformDistributionCard.vue
@@ -1,0 +1,154 @@
+<script setup lang="ts">
+/**
+ * One distribution, rendered as a chooser tile: a sibling of
+ * `views/chooser/ChooserInstallTile.vue` — same box, same classes, same type
+ * scale, same top-right kebab. Activating it is the same gesture as launching
+ * an existing install.
+ *
+ * NAME is the headline. The footer row follows the grammar the install tiles
+ * use: LEFT is the labelled version, RIGHT is one status/action slot — a pill
+ * for what you can do (Install / Update), or a quiet tag for why it's blocked.
+ * Never both, and state never replaces the facts.
+ *
+ * The version is labelled ("Dist v2") because these cards share a grid with
+ * install tiles, whose version IS the ComfyUI version. A bare "2" beside a
+ * "0.3.20" invites misreading.
+ *
+ * Blocked states (no-build / platform-mismatch) recede but are never hidden,
+ * and keep their full reason on the tile's `title`. No security chrome: these
+ * are ordinary pipeline facts, not threats.
+ */
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { ArrowDownToLine, MoreVertical, Package } from 'lucide-vue-next'
+import TruncatedText from '../../components/TruncatedText.vue'
+import type { Distribution, DistributionState } from '../../devplatform/types'
+
+const props = defineProps<{
+  distribution: Distribution
+}>()
+
+const emit = defineEmits<{
+  /** The user activated the tile: the host starts the install flow. */
+  select: []
+  /** Kebab pressed: the host opens the distribution menu at this anchor. */
+  'open-kebab-menu': [event: MouseEvent]
+}>()
+
+const { t } = useI18n()
+
+/** The states that cannot be installed. Shown with a reason, never hidden. */
+const BLOCKED_STATES: readonly DistributionState[] = ['no-build', 'platform-mismatch']
+
+/** i18n suffix per blocked state, keying the short tag label (`states.*`). */
+const BLOCKED_STATE_KEY: Record<string, string> = {
+  'no-build': 'noBuild',
+  'platform-mismatch': 'platformMismatch',
+}
+
+const isBlocked = computed(() => BLOCKED_STATES.includes(props.distribution.state))
+
+/** Labelled so it can't be read as a ComfyUI version (see file header). */
+const versionLabel = computed(() =>
+  props.distribution.version
+    ? t('devPlatform.distribution.distVersion', { version: props.distribution.version })
+    : ''
+)
+
+/** Right slot, part one: the blue pill for an action the card performs.
+ *  Install and Update are the same gesture — activate the card — so they
+ *  wear the same pill. Empty when there's nothing to do. */
+const actionPill = computed(() => {
+  if (props.distribution.state === 'update-available')
+    return t('devPlatform.distribution.states.updateAvailable')
+  if (props.distribution.state === 'installable')
+    return t('devPlatform.distribution.menuInstall')
+  return ''
+})
+
+/** Right slot, part two: a quiet tag for why the tile is blocked. Only consulted
+ *  when `actionPill` is empty; the two never render together. */
+const stateTag = computed(() => {
+  if (!isBlocked.value) return ''
+  const suffix = BLOCKED_STATE_KEY[props.distribution.state] ?? 'noBuild'
+  return t(`devPlatform.distribution.states.${suffix}`)
+})
+
+/** Full-contrast explanation, carried on `title` so it eats no tile space. */
+const blockedReason = computed(() => {
+  if (!isBlocked.value) return ''
+  const suffix = props.distribution.blockedReason ?? 'buildFailed'
+  return t(`devPlatform.distribution.blockedReason.${suffix}`)
+})
+
+function onActivate(): void {
+  if (isBlocked.value) return
+  emit('select')
+}
+</script>
+
+<template>
+  <div
+    class="chooser-tile chooser-tile--install dist-tile dist-tile--chooser"
+    :class="{ 'dist-tile--blocked': isBlocked }"
+    role="button"
+    tabindex="0"
+    :aria-disabled="isBlocked ? true : undefined"
+    :title="blockedReason || undefined"
+    :data-testid="`chooser-dist-tile-${distribution.id}`"
+    @click="onActivate"
+    @keydown.enter.prevent="onActivate"
+    @keydown.space.prevent="onActivate"
+    @contextmenu.prevent="emit('open-kebab-menu', $event)"
+  >
+    <!-- "Packaged environment" glyph: the one icon every distribution wears. -->
+    <span class="chooser-tile-icon" aria-hidden="true">
+      <Package :size="22" />
+    </span>
+
+    <!-- The corner is the kebab's alone; state lives on the footer row. -->
+    <div class="chooser-tile-actions">
+      <button
+        type="button"
+        class="chooser-tile-kebab"
+        :title="t('chooser.moreActions')"
+        :aria-label="t('chooser.moreActions')"
+        :data-testid="`chooser-dist-tile-kebab-${distribution.id}`"
+        @click.stop="emit('open-kebab-menu', $event)"
+        @contextmenu.stop.prevent="emit('open-kebab-menu', $event)"
+        @keydown.enter.stop
+        @keydown.space.stop
+      >
+        <MoreVertical :size="16" />
+      </button>
+    </div>
+
+    <!-- Two lines: name, then facts left / one status slot right. -->
+    <div class="chooser-tile-body">
+      <TruncatedText class="chooser-tile-name" :text="distribution.name" />
+      <div v-if="versionLabel || actionPill || stateTag" class="chooser-tile-footer">
+        <TruncatedText v-if="versionLabel" class="chooser-tile-meta-line" :text="versionLabel">
+          <span class="chooser-tile-meta-version">{{ versionLabel }}</span>
+        </TruncatedText>
+        <span
+          v-if="actionPill"
+          class="chooser-tile-pill chooser-tile-pill-update chooser-tile-pill-action"
+        >
+          <ArrowDownToLine :size="11" aria-hidden="true" />
+          {{ actionPill }}
+        </span>
+        <span
+          v-else-if="stateTag"
+          class="chooser-tile-pill chooser-tile-pill-action dist-tile-state-tag"
+        >
+          {{ stateTag }}
+        </span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+@import '../chooser/chooser-tiles.css';
+@import './devplatform-tiles.css';
+</style>

--- a/src/renderer/src/views/devplatform/DevPlatformDistributionCard.vue
+++ b/src/renderer/src/views/devplatform/DevPlatformDistributionCard.vue
@@ -1,28 +1,18 @@
 <script setup lang="ts">
 /**
- * One distribution, rendered as a chooser tile: a sibling of
- * `views/chooser/ChooserInstallTile.vue` — same box, same classes, same type
- * scale, same top-right kebab. Activating it is the same gesture as launching
- * an existing install.
+ * One distribution as a chooser tile — a sibling of `ChooserInstallTile.vue`,
+ * sharing its box, classes and footer grammar: facts on the left, ONE status
+ * slot on the right (an action pill or a blocked tag, never both).
  *
- * NAME is the headline. The footer row follows the grammar the install tiles
- * use: LEFT is the labelled version, RIGHT is one status/action slot — a pill
- * for what you can do (Install / Update), or a quiet tag for why it's blocked.
- * Never both, and state never replaces the facts.
- *
- * The version is labelled ("Dist v2") because these cards share a grid with
- * install tiles, whose version IS the ComfyUI version. A bare "2" beside a
- * "0.3.20" invites misreading.
- *
- * Blocked states (no-build / platform-mismatch) recede but are never hidden,
- * and keep their full reason on the tile's `title`. No security chrome: these
- * are ordinary pipeline facts, not threats.
+ * Blocked states recede but are never hidden, keeping the full reason on
+ * `title`.
  */
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { ArrowDownToLine, MoreVertical, Package } from 'lucide-vue-next'
 import TruncatedText from '../../components/TruncatedText.vue'
-import type { Distribution, DistributionState } from '../../devplatform/types'
+import { BLOCKED_STATE_KEY, isBlockedDistribution } from '../../devplatform/distributionState'
+import type { Distribution } from '../../devplatform/types'
 
 const props = defineProps<{
   distribution: Distribution
@@ -37,27 +27,20 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 
-/** The states that cannot be installed. Shown with a reason, never hidden. */
-const BLOCKED_STATES: readonly DistributionState[] = ['no-build', 'platform-mismatch']
+const isBlocked = computed(() => isBlockedDistribution(props.distribution))
 
-/** i18n suffix per blocked state, keying the short tag label (`states.*`). */
-const BLOCKED_STATE_KEY: Record<string, string> = {
-  'no-build': 'noBuild',
-  'platform-mismatch': 'platformMismatch',
-}
+/** A card is only ever an UNinstalled distribution — once installed it
+ *  de-duplicates into an install tile, which fills this slot differently. */
+const comfyVersionLabel = computed(() => props.distribution.comfyuiVersion ?? '')
 
-const isBlocked = computed(() => BLOCKED_STATES.includes(props.distribution.state))
-
-/** Labelled so it can't be read as a ComfyUI version (see file header). */
-const versionLabel = computed(() =>
-  props.distribution.version
-    ? t('devPlatform.distribution.distVersion', { version: props.distribution.version })
-    : ''
+const factsLine = computed(() =>
+  [comfyVersionLabel.value, t('devPlatform.distribution.notInstalled')]
+    .filter(Boolean)
+    .join(' · ')
 )
 
-/** Right slot, part one: the blue pill for an action the card performs.
- *  Install and Update are the same gesture — activate the card — so they
- *  wear the same pill. Empty when there's nothing to do. */
+/** Install and Update are the same gesture (activate the card), so one pill
+ *  covers both. Empty when there's nothing to do. */
 const actionPill = computed(() => {
   if (props.distribution.state === 'update-available')
     return t('devPlatform.distribution.states.updateAvailable')
@@ -66,15 +49,27 @@ const actionPill = computed(() => {
   return ''
 })
 
-/** Right slot, part two: a quiet tag for why the tile is blocked. Only consulted
- *  when `actionPill` is empty; the two never render together. */
+/** Build targets as product names. Proper nouns, so not translated. */
+const OS_LABELS: Record<string, string> = {
+  windows: 'Windows',
+  mac: 'macOS',
+  linux: 'Linux',
+}
+
+/** Why the tile is blocked. A platform mismatch names the machines the build IS
+ *  for ("Linux") rather than the one it isn't, falling back to the generic
+ *  label when the targets aren't known. */
 const stateTag = computed(() => {
   if (!isBlocked.value) return ''
+  const targets = props.distribution.targetOs
+  if (props.distribution.state === 'platform-mismatch' && targets?.length) {
+    return targets.map((os) => OS_LABELS[os] ?? os).join(' · ')
+  }
   const suffix = BLOCKED_STATE_KEY[props.distribution.state] ?? 'noBuild'
   return t(`devPlatform.distribution.states.${suffix}`)
 })
 
-/** Full-contrast explanation, carried on `title` so it eats no tile space. */
+/** The long explanation, on `title` so it eats no tile space. */
 const blockedReason = computed(() => {
   if (!isBlocked.value) return ''
   const suffix = props.distribution.blockedReason ?? 'buildFailed'
@@ -90,7 +85,7 @@ function onActivate(): void {
 <template>
   <div
     class="chooser-tile chooser-tile--install dist-tile dist-tile--chooser"
-    :class="{ 'dist-tile--blocked': isBlocked }"
+    :class="{ 'dist-tile--blocked': isBlocked, 'dist-tile--available': !isBlocked }"
     role="button"
     tabindex="0"
     :aria-disabled="isBlocked ? true : undefined"
@@ -101,12 +96,11 @@ function onActivate(): void {
     @keydown.space.prevent="onActivate"
     @contextmenu.prevent="emit('open-kebab-menu', $event)"
   >
-    <!-- "Packaged environment" glyph: the one icon every distribution wears. -->
+    <!-- The one glyph every distribution wears, installed or not. -->
     <span class="chooser-tile-icon" aria-hidden="true">
       <Package :size="22" />
     </span>
 
-    <!-- The corner is the kebab's alone; state lives on the footer row. -->
     <div class="chooser-tile-actions">
       <button
         type="button"
@@ -126,9 +120,15 @@ function onActivate(): void {
     <!-- Two lines: name, then facts left / one status slot right. -->
     <div class="chooser-tile-body">
       <TruncatedText class="chooser-tile-name" :text="distribution.name" />
-      <div v-if="versionLabel || actionPill || stateTag" class="chooser-tile-footer">
-        <TruncatedText v-if="versionLabel" class="chooser-tile-meta-line" :text="versionLabel">
-          <span class="chooser-tile-meta-version">{{ versionLabel }}</span>
+      <div v-if="factsLine || actionPill || stateTag" class="chooser-tile-footer">
+        <TruncatedText v-if="factsLine" class="chooser-tile-meta-line" :text="factsLine">
+          <span v-if="comfyVersionLabel" class="chooser-tile-meta-source">{{
+            comfyVersionLabel
+          }}</span>
+          <span v-if="comfyVersionLabel" class="chooser-tile-meta-sep">·</span>
+          <span class="chooser-tile-meta-version">{{
+            t('devPlatform.distribution.notInstalled')
+          }}</span>
         </TruncatedText>
         <span
           v-if="actionPill"

--- a/src/renderer/src/views/devplatform/devplatform-tiles.css
+++ b/src/renderer/src/views/devplatform/devplatform-tiles.css
@@ -1,0 +1,75 @@
+/*
+ * Distribution-tile deltas on top of `views/chooser/chooser-tiles.css`.
+ *
+ * A distribution renders as a chooser tile: a visual sibling of an
+ * installed-instance tile, since that is the interface users already pick
+ * installs from. Everything structural (box, padding, radius, name → footer
+ * stack, pill vocabulary) comes from chooser-tiles.css unchanged; this file
+ * adds only the blocked treatment, the neutral state tag, and the house
+ * focus ring.
+ */
+
+.dist-tile {
+  width: 100%;
+}
+
+/* House focus ring: overrides the chooser sheet's `--accent` fallback. */
+.dist-tile:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+/* --- State tag -------------------------------------------------------------
+ * The footer's right slot when there is nothing to DO: "Available",
+ * "Installed", or a blocking reason. Deliberately the quietest thing in the
+ * tile family — it reports, it doesn't ask. The blue action pill (borrowed
+ * wholesale from the install tiles) covers the acting case. */
+.dist-tile-state-tag {
+  color: var(--neutral-200);
+  border-color: color-mix(in oklab, var(--neutral-100) 14%, transparent);
+  background: color-mix(in oklab, var(--neutral-100) 6%, transparent);
+  /* A label, not a button: no hover lift. */
+  cursor: inherit;
+}
+.dist-tile--chooser:hover .dist-tile-state-tag,
+.dist-tile--chooser:focus-visible .dist-tile-state-tag {
+  color: var(--neutral-100);
+}
+
+/* --- Blocked tile ---------------------------------------------------------
+ * De-emphasised but readable, never hidden (product contract). The dim goes on
+ * the identity block, not the root: root opacity would drag the state tag
+ * down with it, and the tag is the one thing worth reading here. The full
+ * reason rides on the tile's `title`. */
+.dist-tile--blocked {
+  cursor: default;
+}
+.dist-tile--blocked .chooser-tile-icon,
+.dist-tile--blocked .chooser-tile-name {
+  opacity: 0.62;
+}
+/* Facts step UP to --neutral-200 instead of dimming: the faint tier
+ * multiplied by 0.62 would drop under the 3:1 contrast floor. */
+.dist-tile--blocked .chooser-tile-meta-line,
+.dist-tile--blocked .chooser-tile-meta-source,
+.dist-tile--blocked .chooser-tile-meta-sep,
+.dist-tile--blocked .chooser-tile-meta-version {
+  color: var(--neutral-200);
+}
+/* Warning tone on the tag is the whole signal now that the corner is the
+ * kebab's — enough to find at a glance, not enough to alarm. */
+.dist-tile--blocked .dist-tile-state-tag {
+  color: var(--neutral-100);
+  border-color: color-mix(in oklab, var(--warning) 40%, transparent);
+  background: color-mix(in oklab, var(--warning) 10%, transparent);
+}
+/* Suppress the hover promise the tile cannot honour. */
+.dist-tile--blocked:hover {
+  background: var(--chooser-surface-bg);
+  border-color: var(--chooser-surface-border);
+}
+.dist-tile--blocked:hover .chooser-tile-icon,
+.dist-tile--blocked:hover .chooser-tile-name {
+  color: var(--neutral-100);
+  opacity: 0.62;
+}

--- a/src/renderer/src/views/devplatform/devplatform-tiles.css
+++ b/src/renderer/src/views/devplatform/devplatform-tiles.css
@@ -1,12 +1,7 @@
 /*
- * Distribution-tile deltas on top of `views/chooser/chooser-tiles.css`.
- *
- * A distribution renders as a chooser tile: a visual sibling of an
- * installed-instance tile, since that is the interface users already pick
- * installs from. Everything structural (box, padding, radius, name → footer
- * stack, pill vocabulary) comes from chooser-tiles.css unchanged; this file
- * adds only the blocked treatment, the neutral state tag, and the house
- * focus ring.
+ * Distribution-tile deltas on top of `views/chooser/chooser-tiles.css`, which
+ * owns everything structural. This file adds only the receded treatment, the
+ * state tag and the house focus ring.
  */
 
 .dist-tile {
@@ -20,10 +15,8 @@
 }
 
 /* --- State tag -------------------------------------------------------------
- * The footer's right slot when there is nothing to DO: "Available",
- * "Installed", or a blocking reason. Deliberately the quietest thing in the
- * tile family — it reports, it doesn't ask. The blue action pill (borrowed
- * wholesale from the install tiles) covers the acting case. */
+ * The footer's right slot when there is nothing to DO. The quietest thing in
+ * the tile family: it reports, it doesn't ask. */
 .dist-tile-state-tag {
   color: var(--neutral-200);
   border-color: color-mix(in oklab, var(--neutral-100) 14%, transparent);
@@ -36,40 +29,83 @@
   color: var(--neutral-100);
 }
 
-/* --- Blocked tile ---------------------------------------------------------
- * De-emphasised but readable, never hidden (product contract). The dim goes on
- * the identity block, not the root: root opacity would drag the state tag
- * down with it, and the tag is the one thing worth reading here. The full
- * reason rides on the tile's `title`. */
-.dist-tile--blocked {
-  cursor: default;
+/* --- Not on this machine --------------------------------------------------
+ * Available and blocked recede by the SAME amount — neither is installed here.
+ * What separates them is what hover promises, below.
+ *
+ * The dim goes on the identity block, never the root: root opacity would drag
+ * the pill and the tag down with it.
+ *
+ * Doubled class throughout (`.dist-tile.dist-tile--x`) — the shared
+ * `.chooser-tile` hover rules are single-class, so a single-class resting rule
+ * loses to them and the tile lights up under the cursor. */
+.dist-tile.dist-tile--available,
+.dist-tile.dist-tile--blocked {
+  background: color-mix(in oklab, var(--chooser-surface-bg) 25%, transparent);
+  border-color: color-mix(in oklab, var(--chooser-surface-border) 50%, transparent);
 }
+.dist-tile--available .chooser-tile-icon,
+.dist-tile--available .chooser-tile-name,
 .dist-tile--blocked .chooser-tile-icon,
 .dist-tile--blocked .chooser-tile-name {
-  opacity: 0.62;
+  opacity: 0.38;
 }
-/* Facts step UP to --neutral-200 instead of dimming: the faint tier
- * multiplied by 0.62 would drop under the 3:1 contrast floor. */
+/* Blocked dims its kebab too; an available tile's stays lit, because there is
+ * something to do with it right now. */
+.dist-tile--blocked .chooser-tile-kebab {
+  opacity: 0.38;
+}
+/* Facts step UP to --neutral-200 rather than dimming: the faint tier at 0.38
+ * would fall under the 3:1 contrast floor. */
+.dist-tile--available .chooser-tile-meta-line,
+.dist-tile--available .chooser-tile-meta-source,
+.dist-tile--available .chooser-tile-meta-sep,
+.dist-tile--available .chooser-tile-meta-version,
 .dist-tile--blocked .chooser-tile-meta-line,
 .dist-tile--blocked .chooser-tile-meta-source,
 .dist-tile--blocked .chooser-tile-meta-sep,
 .dist-tile--blocked .chooser-tile-meta-version {
   color: var(--neutral-200);
 }
-/* Warning tone on the tag is the whole signal now that the corner is the
- * kebab's — enough to find at a glance, not enough to alarm. */
+
+/* --- Available: hover pays out -------------------------------------------
+ * Full strength, because this card CAN be installed. The whole behavioural
+ * difference from blocked. */
+.dist-tile.dist-tile--available:hover,
+.dist-tile.dist-tile--available:focus-visible {
+  background: var(--chooser-surface-bg-hover);
+  border-color: var(--chooser-surface-border-hover);
+}
+.dist-tile--available:hover .chooser-tile-icon,
+.dist-tile--available:focus-visible .chooser-tile-icon,
+.dist-tile--available:hover .chooser-tile-name,
+.dist-tile--available:focus-visible .chooser-tile-name {
+  opacity: 1;
+}
+
+/* --- Blocked: hover stays put --------------------------------------------- */
+.dist-tile.dist-tile--blocked {
+  cursor: default;
+}
+/* Warning tone carries the whole signal now the corner belongs to the kebab —
+ * enough to find at a glance, not enough to alarm. */
 .dist-tile--blocked .dist-tile-state-tag {
   color: var(--neutral-100);
   border-color: color-mix(in oklab, var(--warning) 40%, transparent);
   background: color-mix(in oklab, var(--warning) 10%, transparent);
 }
-/* Suppress the hover promise the tile cannot honour. */
-.dist-tile--blocked:hover {
-  background: var(--chooser-surface-bg);
-  border-color: var(--chooser-surface-border);
+/* Suppress the hover promise the tile can't honour. The kebab alone wakes —
+ * its menu still has something to offer. */
+.dist-tile.dist-tile--blocked:hover {
+  background: color-mix(in oklab, var(--chooser-surface-bg) 25%, transparent);
+  border-color: color-mix(in oklab, var(--chooser-surface-border) 50%, transparent);
 }
 .dist-tile--blocked:hover .chooser-tile-icon,
 .dist-tile--blocked:hover .chooser-tile-name {
   color: var(--neutral-100);
-  opacity: 0.62;
+  opacity: 0.38;
+}
+.dist-tile--blocked .chooser-tile-kebab:hover,
+.dist-tile--blocked .chooser-tile-kebab:focus-visible {
+  opacity: 1;
 }

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -66,6 +66,24 @@ export type ResolvedTheme = Exclude<Theme, 'system'>
  *  `degraded` = show heavy-usage warning; `disabled` = block entry. */
 export type CloudCapacityStatus = 'normal' | 'degraded' | 'disabled'
 
+/** One row of a `version-stats` field's table. */
+export interface VersionStatRow {
+  id: string
+  label: string
+  value: string
+  title?: string
+  highlight?: boolean
+}
+
+/** Payload of a `version-stats` field: the Update tab's version summary. */
+export interface VersionStatsValue {
+  headline: string
+  headlineHighlight?: boolean
+  badge?: string | null
+  badgeTone?: 'current' | 'update'
+  rows: VersionStatRow[]
+}
+
 /** Signed-in user's Comfy Cloud subscription tier, normalized to the
  *  two values the capacity gate cares about. `'unknown'` = signed out
  *  or no fetch has succeeded yet this lifetime; treated as `'free'`
@@ -185,7 +203,14 @@ export interface ComfyArgDef {
 export interface DetailField {
   id: string
   label: string
-  value: string | boolean | number | string[] | Record<string, string> | null
+  value:
+    | string
+    | boolean
+    | number
+    | string[]
+    | Record<string, string>
+    | VersionStatsValue
+    | null
   editable?: boolean
   editType?:
   | 'select'
@@ -194,6 +219,9 @@ export interface DetailField {
   | 'number'
   | 'path'
   | 'channel-cards'
+  /** Read-only version summary: headline + badge over a table of facts. The
+   *  source supplies the wording; the renderer only lays it out. */
+  | 'version-stats'
   | 'args-builder'
   | 'env-vars'
   | 'model-dirs'
@@ -1633,7 +1661,10 @@ export const REQUIRES_STOPPED = new Set([
   'migrate-to-standalone',
   'snapshot-restore',
   'update-comfyui',
-  'migrate-from'
+  'migrate-from',
+  // Re-installs the distribution's environment in place — the venv can't be
+  // rewritten under a running process.
+  'update-distribution'
 ])
 
 /** Title-popup kind tags — the discriminant for popup config/opts across main,

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -27,6 +27,10 @@ export interface DevPlatformDistribution {
   name: string
   description?: string
   version?: string
+  /** The ComfyUI version this distribution bundles, for the card's facts line.
+   *  TODO(builder-backend): not yet populated by `listDistributionRows` — the
+   *  build metadata needs to carry it through. Absent renders as unknown. */
+  comfyuiVersion?: string
   /** ISO 8601 finish stamp of the latest complete build. */
   finishedAt?: string
   sizeBytes?: number
@@ -34,6 +38,9 @@ export interface DevPlatformDistribution {
   state: DevPlatformDistributionState
   /** i18n suffix explaining a blocking state (see `devPlatform.distribution.blockedReason.*`). */
   blockedReason?: string
+  /** On `platform-mismatch`, the OSes this build DOES target (`windows` / `mac`
+   *  / `linux`). The card names them instead of saying "not for this machine". */
+  targetOs?: string[]
   minDesktopVersion?: string
   /** Local-only: present for installed / update-available. */
   installedVersion?: string

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -42,8 +42,9 @@ export interface DevPlatformDistribution {
    *  / `linux`). The card names them instead of saying "not for this machine". */
   targetOs?: string[]
   minDesktopVersion?: string
-  /** Local-only: present for installed / update-available. */
-  installedVersion?: string
+  /** Local-only: present for installed / update-available. A distribution
+   *  version is an integer, matching how the row builder sets it. */
+  installedVersion?: number
 }
 
 /** Kickoff result of `installDistribution`: mirrors `addInstallation` so the


### PR DESCRIPTION
## TL;DR

The **distribution UI/UX**, as a single clean commit on the merged `comfy-builder` functionality. This is the renderer half of the feature (the main-process side shipped via #1295/#1296/#1297). Supersedes #1313 + Willie's #1314-1317 (all folded in here). Green: typecheck, lint, tests, build.

## What's in it (16 renderer/locale files)

- **Account chip + workspace switcher** wired to the real `listWorkspaces` / `switchWorkspace` IPC, with an avatar.
- **Distribution tiles**: two-line install tiles, kebab menu on cards (also right-click), one footer grammar, install **action pill**, blocked-state treatments.
- **ChooserView integration** — distributions render as siblings of the install tiles.
- **Quality pass** (Willie is a UX designer; these are engineering fixes):
  - error/retry states for the distribution grid **and** the workspace switcher (both previously went permanently blank on a transient fetch error)
  - account-chip workspace name/avatar-colour fix (team workspaces showed a raw id + a mismatched gradient)
  - account-menu scroll cap so Sign out stays reachable
  - double-install guard, right-click parity on cards, dead-code cleanup
  - adversarial-review round: unconditional loading-flag clear, retry label during search, zero-byte size label, null-result guard

## Not in it (deliberate)

- **Update-button wiring.** #1297 now ships `update-available` detection + the `updateDistribution` handler, but the renderer doesn't consume it yet: the ChooserView still de-dups installed distributions out of the grid (so an `update-available` tile can't show), and the update pill isn't wired to call `updateDistribution`. That's the next renderer task.
- **Remaining functionality gaps** (main-process, tracked): emit `sizeBytes`, `needs-desktop-update` / `minDesktopVersion`, a human workspace name on `AuthStatus`. The card already renders these when present.
- **Prototypes** (#1298/#1309/#1310 shelf layout / Manage view) — explored, not folded; need backend.

## Verification

- typecheck (4 projects), lint, **~2972 tests**, build — all pass locally on the merged `comfy-builder` base.
- All automated review threads resolved (4 fixed, 5 resolved with rationale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
