### PR TITLE
feat(devplatform): a real manage view for distribution installs

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -276,8 +276,6 @@
     "installedVersion": "Installed",
     "latestVersion": "Latest Published",
     "publishedVersions": "All Published Versions",
-    "stagedModels": "Models",
-    "stagedModelsHint": "Staged from the distribution's model list.",
     "errorNoDistribution": "This install is not linked to a distribution."
   },
   "list": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -277,7 +277,10 @@
     "installedVersion": "Installed",
     "latestVersion": "Latest Published",
     "publishedVersions": "All Published Versions",
-    "errorNoDistribution": "This install is not linked to a distribution."
+    "errorNoDistribution": "This install is not linked to a distribution.",
+    "updateAvailable": "Update available",
+    "upToDate": "Up to date",
+    "lastChecked": "Last Checked"
   },
   "list": {
     "loadSnapshot": "Load Snapshot",

--- a/locales/en.json
+++ b/locales/en.json
@@ -672,7 +672,7 @@
     "connect": "Connect",
     "connecting": "Connecting",
     "openDirectory": "Open Directory",
-    "checkForUpdate": "Check for Update",
+    "checkForUpdate": "Check for updates",
     "featureNotImplemented": "This feature is not yet implemented.",
     "updateAvailable": "Update Available",
     "copyInstallation": "Duplicate Instance",

--- a/locales/en.json
+++ b/locales/en.json
@@ -268,7 +268,17 @@
     "clear": "Clear"
   },
   "comfybuilder": {
-    "stageModels": "Download models"
+    "stageModels": "Download models",
+    "distribution": "Distribution",
+    "distributionVersion": "Distribution Version",
+    "comfyuiVersion": "ComfyUI Version",
+    "distributionVersionTitle": "Distribution Version",
+    "installedVersion": "Installed",
+    "latestVersion": "Latest Published",
+    "publishedVersions": "All Published Versions",
+    "stagedModels": "Models",
+    "stagedModelsHint": "Staged from the distribution's model list.",
+    "errorNoDistribution": "This install is not linked to a distribution."
   },
   "list": {
     "loadSnapshot": "Load Snapshot",

--- a/locales/en.json
+++ b/locales/en.json
@@ -20,7 +20,8 @@
     "cloud": "Cloud",
     "legacyDesktop": "Legacy Desktop",
     "remote": "Remote",
-    "unknown": "Unknown"
+    "unknown": "Unknown",
+    "distribution": "Distribution"
   },
   "chooser": {
     "title": "Choose an instance",

--- a/locales/en.json
+++ b/locales/en.json
@@ -276,11 +276,16 @@
     "distributionVersionTitle": "Distribution Version",
     "installedVersion": "Installed",
     "latestVersion": "Latest Published",
-    "publishedVersions": "All Published Versions",
     "errorNoDistribution": "This install is not linked to a distribution.",
     "updateAvailable": "Update available",
     "upToDate": "Up to date",
-    "lastChecked": "Last Checked"
+    "lastChecked": "Last Checked",
+    "updateToVersion": "Update to v{version}",
+    "updatingTo": "Updating to v{version}",
+    "updateConfirmTitle": "Update distribution",
+    "updateConfirmMessage": "Update this instance from {from} to {to}?\n\nThe environment is replaced in place. Your workflows and staged models are kept.",
+    "errorNoVersion": "No target version was given.",
+    "errorVersionUnavailable": "Version v{version} has no build for this machine."
   },
   "list": {
     "loadSnapshot": "Load Snapshot",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -277,7 +277,10 @@
     "installedVersion": "已安装",
     "latestVersion": "最新发布",
     "publishedVersions": "所有已发布版本",
-    "errorNoDistribution": "此安装未关联到分发版。"
+    "errorNoDistribution": "此安装未关联到分发版。",
+    "updateAvailable": "有可用更新",
+    "upToDate": "已是最新",
+    "lastChecked": "上次检查"
   },
   "list": {
     "loadSnapshot": "加载快照",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -268,7 +268,17 @@
     "clear": "清除"
   },
   "comfybuilder": {
-    "stageModels": "下载模型"
+    "stageModels": "下载模型",
+    "distribution": "分发版",
+    "distributionVersion": "分发版版本",
+    "comfyuiVersion": "ComfyUI 版本",
+    "distributionVersionTitle": "分发版版本",
+    "installedVersion": "已安装",
+    "latestVersion": "最新发布",
+    "publishedVersions": "所有已发布版本",
+    "stagedModels": "模型",
+    "stagedModelsHint": "根据分发版的模型清单暂存。",
+    "errorNoDistribution": "此安装未关联到分发版。"
   },
   "list": {
     "loadSnapshot": "加载快照",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -276,11 +276,16 @@
     "distributionVersionTitle": "分发版版本",
     "installedVersion": "已安装",
     "latestVersion": "最新发布",
-    "publishedVersions": "所有已发布版本",
     "errorNoDistribution": "此安装未关联到分发版。",
     "updateAvailable": "有可用更新",
     "upToDate": "已是最新",
-    "lastChecked": "上次检查"
+    "lastChecked": "上次检查",
+    "updateToVersion": "更新到 v{version}",
+    "updatingTo": "正在更新到 v{version}",
+    "updateConfirmTitle": "更新分发版",
+    "updateConfirmMessage": "将此实例从 {from} 更新到 {to}？\n\n环境将就地替换，工作流与已暂存的模型会保留。",
+    "errorNoVersion": "未指定目标版本。",
+    "errorVersionUnavailable": "版本 v{version} 没有适用于此设备的构建。"
   },
   "list": {
     "loadSnapshot": "加载快照",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -20,7 +20,8 @@
     "cloud": "云端",
     "legacyDesktop": "旧版桌面端",
     "remote": "远程",
-    "unknown": "未知"
+    "unknown": "未知",
+    "distribution": "分发版"
   },
   "chooser": {
     "title": "选择一个实例",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -276,8 +276,6 @@
     "installedVersion": "已安装",
     "latestVersion": "最新发布",
     "publishedVersions": "所有已发布版本",
-    "stagedModels": "模型",
-    "stagedModelsHint": "根据分发版的模型清单暂存。",
     "errorNoDistribution": "此安装未关联到分发版。"
   },
   "list": {

--- a/src/main/devplatform/distributions.test.ts
+++ b/src/main/devplatform/distributions.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 import { describe, expect, it, vi } from 'vitest'
-import { listDistributionRows, resolveHostArtifact } from './distributions'
+import { listCompleteVersions, listDistributionRows, resolveHostArtifact } from './distributions'
+import { clearVersionCache, getCachedVersions } from './versionCache'
 import type { Artifact, Distribution, DistributionVersion, Host } from '../comfybuilder'
 
 const HOST: Host = { os: 'linux', gpu: 'nvidia' }
@@ -144,6 +145,32 @@ describe('listDistributionRows', () => {
     })
     const rows = await listDistributionRows(client as never, HOST)
     expect(rows.map((r) => r.id)).toEqual(['ok'])
+  })
+})
+
+describe('listCompleteVersions', () => {
+  it('returns complete versions newest first, dropping unbuilt ones', async () => {
+    const client = stubClient({
+      versionsByDist: {
+        d1: [version(2, 'complete'), version(5, 'complete'), version(6, 'building'), version(1, 'failed')],
+      },
+    })
+    expect(await listCompleteVersions(client as never, 'd1')).toEqual([5, 2])
+  })
+})
+
+describe('version cache warming', () => {
+  it('caches a distribution\'s complete versions as a side effect of listing rows', async () => {
+    // The manage view builds its Update tab synchronously and cannot fetch, so
+    // the catalog read the chooser already does is what fills it.
+    clearVersionCache()
+    const client = stubClient({
+      distributions: [{ id: 'd1', name: 'Image' }],
+      versionsByDist: { d1: [version(1, 'complete'), version(3, 'complete'), version(4, 'building')] },
+      artifactsByVersion: { v3: [artifact()] },
+    })
+    await listDistributionRows(client as never, HOST)
+    expect(getCachedVersions('d1')?.versions).toEqual([3, 1])
   })
 })
 

--- a/src/main/devplatform/distributions.ts
+++ b/src/main/devplatform/distributions.ts
@@ -178,6 +178,29 @@ export async function resolveHostArtifact(
   return artifact ? { artifact, version: latest.version } : null
 }
 
+/**
+ * The same resolution against ONE named version — what the manage view's update
+ * action installs. Rollback and roll-forward are the same operation.
+ *
+ * Null when the version isn't published, isn't complete, or has no artifact this
+ * machine can run, so the caller reports that instead of installing something
+ * the host can't launch.
+ */
+export async function resolveHostArtifactForVersion(
+  client: Pick<ComfyBuilderClient, 'listVersions' | 'getVersion'>,
+  host: Host,
+  distributionId: string,
+  version: number,
+): Promise<ResolvedHostArtifact | null> {
+  const target = (await client.listVersions(distributionId)).find(
+    (v) => v.version === version && v.status === 'complete',
+  )
+  if (!target) return null
+  const { artifacts } = await client.getVersion(target.id)
+  const artifact = selectArtifactForHost(artifacts, host)
+  return artifact ? { artifact, version: target.version } : null
+}
+
 /** Every complete version, newest first — what the manage view reports as
  *  published, and the basis for a future version picker. */
 export async function listCompleteVersions(

--- a/src/main/devplatform/distributions.ts
+++ b/src/main/devplatform/distributions.ts
@@ -21,6 +21,7 @@ import { hostOs, selectArtifactForHost } from '../comfybuilder/targets'
 import type { Artifact, Distribution, Host } from '../comfybuilder/types'
 import type { ComfyBuilderClient } from '../comfybuilder/client'
 import { detectGPU } from '../lib/gpu'
+import { setCachedVersions } from './versionCache'
 
 /**
  * Distribution tile states. `installable` / `no-build` / `platform-mismatch` are
@@ -101,7 +102,15 @@ async function buildRow(
     state: 'no-build',
   }
 
-  const latest = latestCompleteVersion(await client.listVersions(dist.id))
+  const allVersions = await client.listVersions(dist.id)
+  // The manage view's version picker is built synchronously and can't fetch, so
+  // hand it what this read already saw.
+  setCachedVersions(
+    dist.id,
+    allVersions.filter((v) => v.status === 'complete').map((v) => v.version),
+  )
+
+  const latest = latestCompleteVersion(allVersions)
   if (!latest) return { ...base, state: 'no-build', blockedReason: 'buildFailed' }
 
   const installedVersion = installed?.get(dist.id)
@@ -167,4 +176,17 @@ export async function resolveHostArtifact(
   const { artifacts } = await client.getVersion(latest.id)
   const artifact = selectArtifactForHost(artifacts, host)
   return artifact ? { artifact, version: latest.version } : null
+}
+
+/** Every complete version, newest first — what the manage view reports as
+ *  published, and the basis for a future version picker. */
+export async function listCompleteVersions(
+  client: Pick<ComfyBuilderClient, 'listVersions'>,
+  distributionId: string,
+): Promise<number[]> {
+  const versions = await client.listVersions(distributionId)
+  return versions
+    .filter((v) => v.status === 'complete')
+    .map((v) => v.version)
+    .sort((a, b) => b - a)
 }

--- a/src/main/devplatform/versionCache.ts
+++ b/src/main/devplatform/versionCache.ts
@@ -1,0 +1,36 @@
+/**
+ * Published-version cache, keyed by distribution id.
+ *
+ * `SourcePlugin.getDetailSections` is synchronous, so the manage view can't
+ * fetch a distribution's version list while building the Update tab. This holds
+ * what the last catalog read saw, the way `lib/release-cache` does for
+ * standalone channels.
+ *
+ * Deliberately in-memory and never persisted: it is catalog data, not install
+ * state. Persisting it on the record would go stale silently and follow an
+ * install through a duplicate.
+ */
+
+export interface CachedVersions {
+  /** Complete versions, newest first. */
+  versions: number[]
+  fetchedAt: number
+}
+
+const cache = new Map<string, CachedVersions>()
+
+export function setCachedVersions(distributionId: string, versions: number[]): void {
+  const sorted = [...new Set(versions)].sort((a, b) => b - a)
+  cache.set(distributionId, { versions: sorted, fetchedAt: Date.now() })
+}
+
+/** Cached versions, or null when nothing has read the catalog yet. Callers
+ *  render a "check for updates" affordance rather than an empty picker. */
+export function getCachedVersions(distributionId: string): CachedVersions | null {
+  return cache.get(distributionId) ?? null
+}
+
+/** Test seam. */
+export function clearVersionCache(): void {
+  cache.clear()
+}

--- a/src/main/sources/comfybuilder/constants.ts
+++ b/src/main/sources/comfybuilder/constants.ts
@@ -1,0 +1,3 @@
+/** Shared by the plugin and its detail sections; separate module so the two
+ *  don't import each other in a cycle. */
+export const DEFAULT_LAUNCH_ARGS = '--enable-manager'

--- a/src/main/sources/comfybuilder/detailSections.test.ts
+++ b/src/main/sources/comfybuilder/detailSections.test.ts
@@ -1,0 +1,141 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: { getPath: () => '', isPackaged: false },
+  ipcMain: { handle: vi.fn() },
+  BrowserWindow: { fromWebContents: vi.fn() },
+  dialog: {},
+  shell: { openPath: vi.fn() },
+  net: { request: vi.fn() },
+}))
+
+import { getDetailSections } from './detailSections'
+import { clearVersionCache, setCachedVersions } from '../../devplatform/versionCache'
+import type { InstallationRecord } from '../../installations'
+
+const record = (overrides: Record<string, unknown> = {}): InstallationRecord =>
+  ({
+    id: 'i1',
+    name: 'Studio Render Pipeline',
+    sourceId: 'comfybuilder',
+    sourceLabel: 'Comfy Builder',
+    installPath: '/installs/studio',
+    status: 'installed',
+    distributionId: 'd1',
+    distributionName: 'Studio Render Pipeline',
+    version: '7',
+    ...overrides,
+  }) as unknown as InstallationRecord
+
+type Section = {
+  tab?: string
+  title?: string
+  pinBottom?: boolean
+  fields?: Record<string, unknown>[]
+  actions?: Record<string, unknown>[]
+}
+
+const sectionsFor = (inst: InstallationRecord): Section[] =>
+  getDetailSections(inst) as unknown as Section[]
+
+const tabsOf = (s: Section[]): string[] => s.map((x) => x.tab).filter(Boolean) as string[]
+
+const fieldIds = (s: Section | undefined): string[] =>
+  (s?.fields ?? []).map((f) => (f.id ?? f.key) as string).filter(Boolean)
+
+beforeEach(() => clearVersionCache())
+
+describe('comfybuilder.getDetailSections', () => {
+  it('surfaces the tabs a distribution install should have', () => {
+    const tabs = tabsOf(sectionsFor(record()))
+    expect(tabs).toContain('status')
+    expect(tabs).toContain('settings')
+    expect(tabs).toContain('storage')
+    expect(tabs).toContain('update')
+  })
+
+  it('declares NO snapshots section, which is what hides the tab', () => {
+    // Snapshots are admin/owner only (Jul 24 dev-platform standup). A tab
+    // appears iff a section declares it, so this absence IS the policy gate —
+    // copying another source's sections wholesale would silently re-open it.
+    expect(tabsOf(sectionsFor(record()))).not.toContain('snapshots')
+  })
+
+  it('offers no shared-model storage toggles', () => {
+    // Each distribution carries its own allowed model list; shared models are
+    // off for distributions in MVP.
+    const storage = sectionsFor(record()).find((s) => s.tab === 'storage')
+    expect(storage).toBeDefined()
+    expect(fieldIds(storage)).not.toContain('useSharedModels')
+    expect(fieldIds(storage)).not.toContain('useSharedInputOutput')
+  })
+
+  it('keeps startup arguments editable', () => {
+    const settings = sectionsFor(record()).find((s) => s.tab === 'settings')
+    const args = (settings?.fields ?? []).find((f) => f.id === 'launchArgs')
+    expect(args).toBeDefined()
+    expect(args?.editable).toBe(true)
+  })
+
+  it('labels the distribution version apart from the ComfyUI version', () => {
+    // A bare "7" in a slot every other install fills with "v0.28.2" reads as a
+    // ComfyUI version and is not one.
+    const status = sectionsFor(record()).find((s) => s.tab === 'status')
+    const ids = fieldIds(status)
+    expect(ids).toContain('distribution-version')
+    expect(ids).toContain('comfyui-version')
+    const distField = (status?.fields ?? []).find((f) => f.key === 'distribution-version')
+    expect(distField?.value).toBe('v7')
+  })
+
+  it('pins launch/rename/open-folder/remove/delete, all session-dispatched ids', () => {
+    const pinned = sectionsFor(record()).find((s) => s.pinBottom === true)
+    const ids = (pinned?.actions ?? []).map((a) => a.id)
+    expect(ids).toEqual(
+      expect.arrayContaining(['launch', 'rename', 'open-folder', 'remove', 'delete']),
+    )
+  })
+
+  it('omits the published-version list until the catalog has been read', () => {
+    // "No versions found" is a different claim from "not looked yet".
+    const update = sectionsFor(record()).find((s) => s.tab === 'update')
+    expect(fieldIds(update)).not.toContain('latest-distribution-version')
+    expect(fieldIds(update)).not.toContain('published-distribution-versions')
+    expect((update?.actions ?? []).map((a) => a.id)).toContain('check-update')
+  })
+
+  it('states installed and latest as bare versions once the cache is warm', () => {
+    setCachedVersions('d1', [3, 7, 9])
+    const update = sectionsFor(record({ version: '7' })).find((s) => s.tab === 'update')
+    const fields = update?.fields ?? []
+    expect(fields.find((f) => f.key === 'current-distribution-version')?.value).toBe('v7')
+    expect(fields.find((f) => f.key === 'latest-distribution-version')?.value).toBe('v9')
+    // Newest first, whatever order the catalog returned.
+    expect(fields.find((f) => f.key === 'published-distribution-versions')?.value).toBe(
+      'v9 · v7 · v3',
+    )
+  })
+
+  it('shows installed and latest as equal when already on the newest version', () => {
+    setCachedVersions('d1', [7, 3])
+    const fields =
+      sectionsFor(record({ version: '7' })).find((s) => s.tab === 'update')?.fields ?? []
+    expect(fields.find((f) => f.key === 'current-distribution-version')?.value).toBe('v7')
+    expect(fields.find((f) => f.key === 'latest-distribution-version')?.value).toBe('v7')
+  })
+
+  it('dedupes repeated versions from the catalog', () => {
+    setCachedVersions('d1', [5, 5, 2])
+    const fields =
+      sectionsFor(record({ version: '5' })).find((s) => s.tab === 'update')?.fields ?? []
+    expect(fields.find((f) => f.key === 'published-distribution-versions')?.value).toBe('v5 · v2')
+  })
+
+  it('drops the update tab for a record with no distribution link', () => {
+    const tabs = tabsOf(sectionsFor(record({ distributionId: undefined })))
+    expect(tabs).not.toContain('update')
+    // The rest of the manage view still stands.
+    expect(tabs).toContain('settings')
+  })
+})

--- a/src/main/sources/comfybuilder/detailSections.test.ts
+++ b/src/main/sources/comfybuilder/detailSections.test.ts
@@ -160,6 +160,15 @@ describe('comfybuilder.getDetailSections', () => {
     ).toBeUndefined()
   })
 
+  it('offers no update when the installed version is unknown', () => {
+    // `Number('')` is 0, which would read as "behind everything" and offer an
+    // update from a blank version.
+    setCachedVersions('d1', [9, 7])
+    const blank = record({ version: '' })
+    expect(updateActions(blank).find((a) => a.id === 'update-distribution')).toBeUndefined()
+    expect(statsValue(blank).headlineHighlight).toBe(false)
+  })
+
   it('disables the update action while the install is not ready', () => {
     setCachedVersions('d1', [9, 7])
     const update = updateActions(record({ version: '7', status: 'failed' })).find(

--- a/src/main/sources/comfybuilder/detailSections.test.ts
+++ b/src/main/sources/comfybuilder/detailSections.test.ts
@@ -44,6 +44,19 @@ const tabsOf = (s: Section[]): string[] => s.map((x) => x.tab).filter(Boolean) a
 const fieldIds = (s: Section | undefined): string[] =>
   (s?.fields ?? []).map((f) => (f.id ?? f.key) as string).filter(Boolean)
 
+type StatRow = { id: string; label: string; value: string; highlight?: boolean }
+type StatsValue = { headline: string; headlineHighlight: boolean; badge: string | null; rows: StatRow[] }
+
+const statsField = (inst: InstallationRecord): Record<string, unknown> | undefined =>
+  (sectionsFor(inst).find((s) => s.tab === 'update')?.fields ?? []).find(
+    (f) => f.editType === 'version-stats',
+  )
+
+const statsValue = (inst: InstallationRecord): StatsValue =>
+  (statsField(inst)?.value ?? { rows: [] }) as StatsValue
+
+const rowIds = (inst: InstallationRecord): string[] => statsValue(inst).rows.map((r) => r.id)
+
 beforeEach(() => clearVersionCache())
 
 describe('comfybuilder.getDetailSections', () => {
@@ -97,39 +110,56 @@ describe('comfybuilder.getDetailSections', () => {
     )
   })
 
+  it('renders the update tab as a version-stats table, like a local install', () => {
+    // Same component the local-install Update tab uses, so the two read as one
+    // surface rather than merely saying the same words.
+    setCachedVersions('d1', [3, 7, 9])
+    const field = statsField(record({ version: '7' }))
+    expect(field?.editType).toBe('version-stats')
+    expect(field?.editable).toBe(false)
+  })
+
   it('omits the published-version list until the catalog has been read', () => {
     // "No versions found" is a different claim from "not looked yet".
     const update = sectionsFor(record()).find((s) => s.tab === 'update')
-    expect(fieldIds(update)).not.toContain('latest-distribution-version')
-    expect(fieldIds(update)).not.toContain('published-distribution-versions')
+    expect(rowIds(record())).not.toContain('latest')
+    expect(rowIds(record())).not.toContain('published')
     expect((update?.actions ?? []).map((a) => a.id)).toContain('check-update')
   })
 
   it('states installed and latest as bare versions once the cache is warm', () => {
     setCachedVersions('d1', [3, 7, 9])
-    const update = sectionsFor(record({ version: '7' })).find((s) => s.tab === 'update')
-    const fields = update?.fields ?? []
-    expect(fields.find((f) => f.key === 'current-distribution-version')?.value).toBe('v7')
-    expect(fields.find((f) => f.key === 'latest-distribution-version')?.value).toBe('v9')
+    const rows = statsValue(record({ version: '7' })).rows
+    expect(rows.find((r) => r.id === 'installed')?.value).toBe('v7')
+    expect(rows.find((r) => r.id === 'latest')?.value).toBe('v9')
     // Newest first, whatever order the catalog returned.
-    expect(fields.find((f) => f.key === 'published-distribution-versions')?.value).toBe(
-      'v9 · v7 · v3',
-    )
+    expect(rows.find((r) => r.id === 'published')?.value).toBe('v9 · v7 · v3')
+  })
+
+  it('accents the latest row and the headline only when an update is waiting', () => {
+    setCachedVersions('d1', [3, 7, 9])
+    const behind = statsValue(record({ version: '7' }))
+    expect(behind.headlineHighlight).toBe(true)
+    expect(behind.rows.find((r) => r.id === 'latest')?.highlight).toBe(true)
+
+    setCachedVersions('d1', [7, 3])
+    const current = statsValue(record({ version: '7' }))
+    expect(current.headlineHighlight).toBe(false)
+    expect(current.rows.find((r) => r.id === 'latest')?.highlight).toBe(false)
   })
 
   it('shows installed and latest as equal when already on the newest version', () => {
     setCachedVersions('d1', [7, 3])
-    const fields =
-      sectionsFor(record({ version: '7' })).find((s) => s.tab === 'update')?.fields ?? []
-    expect(fields.find((f) => f.key === 'current-distribution-version')?.value).toBe('v7')
-    expect(fields.find((f) => f.key === 'latest-distribution-version')?.value).toBe('v7')
+    const rows = statsValue(record({ version: '7' })).rows
+    expect(rows.find((r) => r.id === 'installed')?.value).toBe('v7')
+    expect(rows.find((r) => r.id === 'latest')?.value).toBe('v7')
   })
 
   it('dedupes repeated versions from the catalog', () => {
     setCachedVersions('d1', [5, 5, 2])
-    const fields =
-      sectionsFor(record({ version: '5' })).find((s) => s.tab === 'update')?.fields ?? []
-    expect(fields.find((f) => f.key === 'published-distribution-versions')?.value).toBe('v5 · v2')
+    expect(statsValue(record({ version: '5' })).rows.find((r) => r.id === 'published')?.value).toBe(
+      'v5 · v2',
+    )
   })
 
   it('drops the update tab for a record with no distribution link', () => {

--- a/src/main/sources/comfybuilder/detailSections.test.ts
+++ b/src/main/sources/comfybuilder/detailSections.test.ts
@@ -51,7 +51,6 @@ describe('comfybuilder.getDetailSections', () => {
     const tabs = tabsOf(sectionsFor(record()))
     expect(tabs).toContain('status')
     expect(tabs).toContain('settings')
-    expect(tabs).toContain('storage')
     expect(tabs).toContain('update')
   })
 
@@ -62,13 +61,14 @@ describe('comfybuilder.getDetailSections', () => {
     expect(tabsOf(sectionsFor(record()))).not.toContain('snapshots')
   })
 
-  it('offers no shared-model storage toggles', () => {
-    // Each distribution carries its own allowed model list; shared models are
-    // off for distributions in MVP.
-    const storage = sectionsFor(record()).find((s) => s.tab === 'storage')
-    expect(storage).toBeDefined()
-    expect(fieldIds(storage)).not.toContain('useSharedModels')
-    expect(fieldIds(storage)).not.toContain('useSharedInputOutput')
+  it('declares NO storage section, because a reduced one shows shared models', () => {
+    // Shared models are off for distributions at MVP — each carries its own
+    // allowed list. Declaring a storage section with the toggles omitted does
+    // NOT achieve that: StoragePane reads an absent `useSharedModels` as
+    // enabled (`f ? f.value !== false : true`) and renders the global
+    // shared-models directory list. Declaring it `false` is no better, since
+    // BooleanToggle ignores `editable` and would render a live switch.
+    expect(tabsOf(sectionsFor(record()))).not.toContain('storage')
   })
 
   it('keeps startup arguments editable', () => {

--- a/src/main/sources/comfybuilder/detailSections.test.ts
+++ b/src/main/sources/comfybuilder/detailSections.test.ts
@@ -11,7 +11,11 @@ vi.mock('electron', () => ({
 }))
 
 import { getDetailSections } from './detailSections'
-import { clearVersionCache, setCachedVersions } from '../../devplatform/versionCache'
+import {
+  clearVersionCache,
+  getCachedVersions,
+  setCachedVersions,
+} from '../../devplatform/versionCache'
 import type { InstallationRecord } from '../../installations'
 
 const record = (overrides: Record<string, unknown> = {}): InstallationRecord =>
@@ -56,6 +60,10 @@ const statsValue = (inst: InstallationRecord): StatsValue =>
   (statsField(inst)?.value ?? { rows: [] }) as StatsValue
 
 const rowIds = (inst: InstallationRecord): string[] => statsValue(inst).rows.map((r) => r.id)
+
+const updateActions = (inst: InstallationRecord): Record<string, unknown>[] =>
+  (sectionsFor(inst).find((s) => s.tab === 'update')?.actions ?? []) as Record<string, unknown>[]
+
 
 beforeEach(() => clearVersionCache())
 
@@ -128,12 +136,36 @@ describe('comfybuilder.getDetailSections', () => {
   })
 
   it('states installed and latest as bare versions once the cache is warm', () => {
+    // Newest wins whatever order the catalog returned.
     setCachedVersions('d1', [3, 7, 9])
     const rows = statsValue(record({ version: '7' })).rows
     expect(rows.find((r) => r.id === 'installed')?.value).toBe('v7')
     expect(rows.find((r) => r.id === 'latest')?.value).toBe('v9')
-    // Newest first, whatever order the catalog returned.
-    expect(rows.find((r) => r.id === 'published')?.value).toBe('v9 · v7 · v3')
+  })
+
+  it('offers the update action only when a newer version exists', () => {
+    // An always-present Update that no-ops on the newest version teaches the
+    // user to distrust it.
+    setCachedVersions('d1', [3, 7, 9])
+    const behind = updateActions(record({ version: '7' }))
+    const update = behind.find((a) => a.id === 'update-distribution')
+    expect(update).toBeDefined()
+    expect(update?.data).toEqual({ version: 9 })
+    expect(update?.showProgress).toBe(true)
+    expect(update?.confirm).toBeDefined()
+
+    setCachedVersions('d1', [7, 3])
+    expect(
+      updateActions(record({ version: '7' })).find((a) => a.id === 'update-distribution'),
+    ).toBeUndefined()
+  })
+
+  it('disables the update action while the install is not ready', () => {
+    setCachedVersions('d1', [9, 7])
+    const update = updateActions(record({ version: '7', status: 'failed' })).find(
+      (a) => a.id === 'update-distribution',
+    )
+    expect(update?.enabled).toBe(false)
   })
 
   it('accents the latest row and the headline only when an update is waiting', () => {
@@ -156,10 +188,8 @@ describe('comfybuilder.getDetailSections', () => {
   })
 
   it('dedupes repeated versions from the catalog', () => {
-    setCachedVersions('d1', [5, 5, 2])
-    expect(statsValue(record({ version: '5' })).rows.find((r) => r.id === 'published')?.value).toBe(
-      'v5 · v2',
-    )
+    setCachedVersions('d1', [5, 5, 2, 5])
+    expect(getCachedVersions('d1')?.versions).toEqual([5, 2])
   })
 
   it('drops the update tab for a record with no distribution link', () => {

--- a/src/main/sources/comfybuilder/detailSections.ts
+++ b/src/main/sources/comfybuilder/detailSections.ts
@@ -7,12 +7,19 @@
  * switch here would either do nothing or break the pin the distribution exists
  * to provide.
  *
- * Tabs a distribution deliberately does NOT get:
- *   - Snapshots — admin/owner only (Jul 24 dev-platform standup). Declaring a
- *     `snapshots` section is what makes the tab appear, so leaving it out IS
- *     the gate. Don't add one by copying another source wholesale.
- *   - Shared models — each distribution carries its own allowed model list, so
- *     `buildStorageFields`' shared-storage toggles don't apply in MVP.
+ * Tabs a distribution deliberately does NOT get. A tab exists iff a section
+ * declares it, so leaving one out IS the gate — don't reinstate either by
+ * copying another source's sections wholesale:
+ *
+ *   - Snapshots — admin/owner only (Jul 24 dev-platform standup).
+ *   - Storage — each distribution carries its own allowed model list, and
+ *     shared models are off for distributions at MVP. Note a REDUCED storage
+ *     section does not achieve that: `StoragePane` treats an ABSENT
+ *     `useSharedModels` field as enabled (`f ? f.value !== false : true`) and
+ *     renders the global shared-models directory list, and declaring the field
+ *     `false` is no better because `BooleanToggle` ignores `editable` and would
+ *     hand the user a live switch. Showing a distribution's staged models needs
+ *     its own pane, not a subset of this one.
  */
 import { t } from '../../lib/i18n'
 import { deleteAction, launchAction, openFolderAction, renameAction, untrackAction } from '../../lib/actions'
@@ -54,29 +61,6 @@ function buildStatusFields(installation: InstallationRecord): Record<string, unk
     },
     { key: 'comfyui-version', label: t('comfybuilder.comfyuiVersion'), value: comfy || '—' },
     { label: t('common.location'), value: (installation.installPath as string) || '—' },
-  ]
-}
-
-/**
- * Storage for a distribution: where it lives and what it staged, read-only.
- *
- * No shared-model toggles — see the header. `StoragePane` resolves fields by id
- * and guards on absence, so a reduced set renders cleanly rather than erroring.
- */
-function buildStorageFields(installation: InstallationRecord): Record<string, unknown>[] {
-  return [
-    {
-      id: 'installPath',
-      label: t('common.location'),
-      value: (installation.installPath as string) || '',
-      editable: false,
-    },
-    {
-      id: 'distributionModels',
-      label: t('comfybuilder.stagedModels'),
-      value: t('comfybuilder.stagedModelsHint'),
-      editable: false,
-    },
   ]
 }
 
@@ -163,10 +147,6 @@ export function getDetailSections(installation: InstallationRecord): Record<stri
       // the Jul 24 standup kept the field editable rather than second-guessing
       // which flags a given build honours.
       fields: buildLaunchSettingsFields(installation, { defaultLaunchArgs: DEFAULT_LAUNCH_ARGS }),
-    },
-    {
-      tab: 'storage',
-      fields: buildStorageFields(installation),
     },
     {
       // No title: only `.actions` is read off a pinBottom section (the footer

--- a/src/main/sources/comfybuilder/detailSections.ts
+++ b/src/main/sources/comfybuilder/detailSections.ts
@@ -82,8 +82,11 @@ function buildUpdateSection(installation: InstallationRecord): Record<string, un
   const versions = cached?.versions ?? []
   const latest = versions[0]
   const currentNum = Number(current)
+  // An empty version is unknown, not zero — `Number('')` is 0, which would
+  // otherwise read as "behind every published version" and offer an update
+  // from a blank.
   const updateAvailable =
-    latest !== undefined && Number.isFinite(currentNum) && latest > currentNum
+    latest !== undefined && current !== '' && Number.isFinite(currentNum) && latest > currentNum
 
   // The same version table the local-install Update tab uses, so the two read
   // as one surface. Rows are stated as bare versions and left to compare

--- a/src/main/sources/comfybuilder/detailSections.ts
+++ b/src/main/sources/comfybuilder/detailSections.ts
@@ -87,38 +87,69 @@ function buildUpdateSection(installation: InstallationRecord): Record<string, un
   if (!distributionId) return null
 
   const current = distributionVersion(installation)
-  const versions = getCachedVersions(distributionId)?.versions ?? []
+  const cached = getCachedVersions(distributionId)
+  const versions = cached?.versions ?? []
   const latest = versions[0]
+  const currentNum = Number(current)
+  const updateAvailable =
+    latest !== undefined && Number.isFinite(currentNum) && latest > currentNum
 
-  // Installed and latest are stated as bare versions and left to compare
-  // themselves. A translated "up to date" / "v9 available" sentence would say
-  // the same thing while hiding the number it is about.
-  const fields: Record<string, unknown>[] = [
+  // The same version table the local-install Update tab uses, so the two read
+  // as one surface. Rows are stated as bare versions and left to compare
+  // themselves — a "v9 available" sentence says the same thing while burying
+  // the number it is about.
+  const rows: Record<string, unknown>[] = [
     {
-      key: 'current-distribution-version',
+      id: 'installed',
       label: t('comfybuilder.installedVersion'),
       value: current ? `v${current}` : '—',
     },
   ]
   if (latest !== undefined) {
-    fields.push({
-      key: 'latest-distribution-version',
+    rows.push({
+      id: 'latest',
       label: t('comfybuilder.latestVersion'),
       value: `v${latest}`,
+      highlight: updateAvailable,
     })
   }
   if (versions.length > 1) {
-    fields.push({
-      key: 'published-distribution-versions',
+    rows.push({
+      id: 'published',
       label: t('comfybuilder.publishedVersions'),
       value: versions.map((v) => `v${v}`).join(' · '),
+    })
+  }
+  if (cached?.fetchedAt) {
+    rows.push({
+      id: 'last-checked',
+      label: t('comfybuilder.lastChecked'),
+      value: new Date(cached.fetchedAt).toLocaleString(),
     })
   }
 
   return {
     tab: 'update',
     title: t('comfybuilder.distributionVersionTitle'),
-    fields,
+    fields: [
+      {
+        id: 'distributionVersionStats',
+        label: t('comfybuilder.distributionVersionTitle'),
+        editType: 'version-stats',
+        editable: false,
+        value: {
+          headline: current ? `v${current}` : '—',
+          headlineHighlight: updateAvailable,
+          badge: updateAvailable
+            ? t('comfybuilder.updateAvailable')
+            : latest !== undefined
+              ? t('comfybuilder.upToDate')
+              : null,
+          badgeTone: updateAvailable ? 'update' : 'current',
+          rows,
+        },
+      },
+    ],
     actions: [
       { id: 'check-update', label: t('actions.checkForUpdate'), style: 'default', enabled: true },
     ],

--- a/src/main/sources/comfybuilder/detailSections.ts
+++ b/src/main/sources/comfybuilder/detailSections.ts
@@ -65,22 +65,13 @@ function buildStatusFields(installation: InstallationRecord): Record<string, unk
 }
 
 /**
- * The Update tab: which distribution version this install is on, and what else
- * is published.
+ * The Update tab: which distribution version this install is on, and where it
+ * can go.
  *
- * Read-only for now. Switching versions is a re-install, and the install chain
- * that owns the status transitions (`installing` → `installed` / `failed`),
- * progress streaming and abort registration lives inline in the
- * `install-instance` IPC handler — it can't be driven from a source plugin.
- * Re-pointing the record here without it would strand the install at
- * `installing`, so the action waits on that plumbing rather than shipping a
- * button that half-works. Today the chooser tile's Update pill is the working
- * path to the latest version.
- *
- * The version list comes from the catalog cache, which the chooser's
- * distribution read warms. Cold (nothing read yet, or signed out) the list is
- * omitted rather than shown empty — "no versions found" is a different claim
- * from "not looked yet".
+ * Versions come from the catalog cache, which the chooser's distribution read
+ * warms. Cold (nothing read yet, or signed out) the latest row is omitted
+ * rather than shown empty — "no versions found" is a different claim from "not
+ * looked yet".
  */
 function buildUpdateSection(installation: InstallationRecord): Record<string, unknown> | null {
   const distributionId = installation.distributionId as string | undefined
@@ -111,13 +102,6 @@ function buildUpdateSection(installation: InstallationRecord): Record<string, un
       label: t('comfybuilder.latestVersion'),
       value: `v${latest}`,
       highlight: updateAvailable,
-    })
-  }
-  if (versions.length > 1) {
-    rows.push({
-      id: 'published',
-      label: t('comfybuilder.publishedVersions'),
-      value: versions.map((v) => `v${v}`).join(' · '),
     })
   }
   if (cached?.fetchedAt) {
@@ -152,6 +136,29 @@ function buildUpdateSection(installation: InstallationRecord): Record<string, un
     ],
     actions: [
       { id: 'check-update', label: t('actions.checkForUpdate'), style: 'default', enabled: true },
+      // Only when there is somewhere to go. An always-present Update that no-ops
+      // on the newest version teaches the user to distrust it.
+      ...(updateAvailable
+        ? [
+            {
+              id: 'update-distribution',
+              label: t('comfybuilder.updateToVersion', { version: latest }),
+              style: 'primary',
+              enabled: installation.status === 'installed',
+              showProgress: true,
+              cancellable: true,
+              progressTitle: t('comfybuilder.updatingTo', { version: latest }),
+              data: { version: latest },
+              confirm: {
+                title: t('comfybuilder.updateConfirmTitle'),
+                message: t('comfybuilder.updateConfirmMessage', {
+                  from: `**v${current}**`,
+                  to: `**v${latest}**`,
+                }),
+              },
+            },
+          ]
+        : []),
     ],
   }
 }

--- a/src/main/sources/comfybuilder/detailSections.ts
+++ b/src/main/sources/comfybuilder/detailSections.ts
@@ -1,0 +1,189 @@
+/**
+ * Manage-view sections for a distribution install.
+ *
+ * Deliberately NOT built on `standalone/updateSections.ts`. That model updates
+ * along a ComfyUI release *channel*; a distribution pins its ComfyUI build, and
+ * what the user moves between is distribution versions. Offering a channel
+ * switch here would either do nothing or break the pin the distribution exists
+ * to provide.
+ *
+ * Tabs a distribution deliberately does NOT get:
+ *   - Snapshots — admin/owner only (Jul 24 dev-platform standup). Declaring a
+ *     `snapshots` section is what makes the tab appear, so leaving it out IS
+ *     the gate. Don't add one by copying another source wholesale.
+ *   - Shared models — each distribution carries its own allowed model list, so
+ *     `buildStorageFields`' shared-storage toggles don't apply in MVP.
+ */
+import { t } from '../../lib/i18n'
+import { deleteAction, launchAction, openFolderAction, renameAction, untrackAction } from '../../lib/actions'
+import { buildLaunchSettingsFields } from '../common/launchSettingsFields'
+import { getCachedVersions } from '../../devplatform/versionCache'
+import { formatComfyVersion } from '../../lib/version'
+import type { ComfyVersion } from '../../lib/version'
+import type { InstallationRecord } from '../../installations'
+import { DEFAULT_LAUNCH_ARGS } from './constants'
+
+/** The distribution's own release. Stored in `version` because that IS what the
+ *  builder versions; the ComfyUI build it pins is a separate fact. */
+function distributionVersion(installation: InstallationRecord): string {
+  return (installation.version as string | undefined) || ''
+}
+
+/** The ComfyUI version the distribution pins, when the record carries one.
+ *  Probed post-install like any other local install. */
+function comfyVersionLabel(installation: InstallationRecord): string {
+  const cv = installation.comfyVersion as ComfyVersion | undefined
+  return cv ? formatComfyVersion(cv, 'detail') : ''
+}
+
+function buildStatusFields(installation: InstallationRecord): Record<string, unknown>[] {
+  const dist = distributionVersion(installation)
+  const comfy = comfyVersionLabel(installation)
+  return [
+    { label: t('common.installMethod'), value: (installation.sourceLabel as string) || 'ComfyBuilder' },
+    {
+      label: t('comfybuilder.distribution'),
+      value: (installation.distributionName as string) || '—',
+    },
+    // Labelled as the DISTRIBUTION's version. A bare "7" next to a "v0.28.2"
+    // reads as a ComfyUI version and isn't one.
+    {
+      key: 'distribution-version',
+      label: t('comfybuilder.distributionVersion'),
+      value: dist ? `v${dist}` : '—',
+    },
+    { key: 'comfyui-version', label: t('comfybuilder.comfyuiVersion'), value: comfy || '—' },
+    { label: t('common.location'), value: (installation.installPath as string) || '—' },
+  ]
+}
+
+/**
+ * Storage for a distribution: where it lives and what it staged, read-only.
+ *
+ * No shared-model toggles — see the header. `StoragePane` resolves fields by id
+ * and guards on absence, so a reduced set renders cleanly rather than erroring.
+ */
+function buildStorageFields(installation: InstallationRecord): Record<string, unknown>[] {
+  return [
+    {
+      id: 'installPath',
+      label: t('common.location'),
+      value: (installation.installPath as string) || '',
+      editable: false,
+    },
+    {
+      id: 'distributionModels',
+      label: t('comfybuilder.stagedModels'),
+      value: t('comfybuilder.stagedModelsHint'),
+      editable: false,
+    },
+  ]
+}
+
+/**
+ * The Update tab: which distribution version this install is on, and what else
+ * is published.
+ *
+ * Read-only for now. Switching versions is a re-install, and the install chain
+ * that owns the status transitions (`installing` → `installed` / `failed`),
+ * progress streaming and abort registration lives inline in the
+ * `install-instance` IPC handler — it can't be driven from a source plugin.
+ * Re-pointing the record here without it would strand the install at
+ * `installing`, so the action waits on that plumbing rather than shipping a
+ * button that half-works. Today the chooser tile's Update pill is the working
+ * path to the latest version.
+ *
+ * The version list comes from the catalog cache, which the chooser's
+ * distribution read warms. Cold (nothing read yet, or signed out) the list is
+ * omitted rather than shown empty — "no versions found" is a different claim
+ * from "not looked yet".
+ */
+function buildUpdateSection(installation: InstallationRecord): Record<string, unknown> | null {
+  const distributionId = installation.distributionId as string | undefined
+  if (!distributionId) return null
+
+  const current = distributionVersion(installation)
+  const versions = getCachedVersions(distributionId)?.versions ?? []
+  const latest = versions[0]
+
+  // Installed and latest are stated as bare versions and left to compare
+  // themselves. A translated "up to date" / "v9 available" sentence would say
+  // the same thing while hiding the number it is about.
+  const fields: Record<string, unknown>[] = [
+    {
+      key: 'current-distribution-version',
+      label: t('comfybuilder.installedVersion'),
+      value: current ? `v${current}` : '—',
+    },
+  ]
+  if (latest !== undefined) {
+    fields.push({
+      key: 'latest-distribution-version',
+      label: t('comfybuilder.latestVersion'),
+      value: `v${latest}`,
+    })
+  }
+  if (versions.length > 1) {
+    fields.push({
+      key: 'published-distribution-versions',
+      label: t('comfybuilder.publishedVersions'),
+      value: versions.map((v) => `v${v}`).join(' · '),
+    })
+  }
+
+  return {
+    tab: 'update',
+    title: t('comfybuilder.distributionVersionTitle'),
+    fields,
+    actions: [
+      { id: 'check-update', label: t('actions.checkForUpdate'), style: 'default', enabled: true },
+    ],
+  }
+}
+
+export function getDetailSections(installation: InstallationRecord): Record<string, unknown>[] {
+  const installed = installation.status === 'installed'
+
+  const sections: Record<string, unknown>[] = [
+    {
+      tab: 'status',
+      title: t('common.installInfo'),
+      fields: buildStatusFields(installation),
+    },
+  ]
+
+  const update = buildUpdateSection(installation)
+  if (update) sections.push(update)
+
+  sections.push(
+    {
+      tab: 'settings',
+      title: t('common.launchSettings'),
+      // Args stay open even where a distribution may ignore some of them —
+      // the Jul 24 standup kept the field editable rather than second-guessing
+      // which flags a given build honours.
+      fields: buildLaunchSettingsFields(installation, { defaultLaunchArgs: DEFAULT_LAUNCH_ARGS }),
+    },
+    {
+      tab: 'storage',
+      fields: buildStorageFields(installation),
+    },
+    {
+      // No title: only `.actions` is read off a pinBottom section (the footer
+      // renders the buttons), so a title here would be an untranslated string
+      // nothing displays.
+      pinBottom: true,
+      // Every id here is handled by the generic session-action dispatch
+      // (`sessionActions/index.ts`), not by this plugin's `handleAction`.
+      actions: [
+        launchAction(installed, !installed ? t('errors.installNotReady') : undefined),
+        renameAction(installation.name),
+        openFolderAction(installation.installPath),
+        untrackAction(),
+        deleteAction(installation),
+      ],
+    },
+  )
+
+  return sections
+}

--- a/src/main/sources/comfybuilder/index.test.ts
+++ b/src/main/sources/comfybuilder/index.test.ts
@@ -59,19 +59,40 @@ function fakeTools(signal?: AbortSignal): InstallTools & { sent: Array<{ phase: 
 describe('comfybuilder.install wiring', () => {
   beforeEach(() => vi.clearAllMocks())
 
-  it('wipes the venv before extracting so a re-install/update lays down a clean env', async () => {
+  it('moves the venv aside before extracting so a re-install lays down a clean env', async () => {
+    const rename = vi.spyOn(fsp, 'rename').mockResolvedValue(undefined)
     const rm = vi.spyOn(fsp, 'rm').mockResolvedValue(undefined)
     try {
       await comfybuilder.install!(record(), fakeTools())
-      expect(rm).toHaveBeenCalledWith(
+      // Aside, NOT deleted: `installArtifact` only touches installPath after the
+      // download and checksum pass, so the old env has to survive until then.
+      expect(rename).toHaveBeenCalledWith(
         expect.stringContaining('venv'),
-        expect.objectContaining({ recursive: true, force: true }),
+        expect.stringContaining('venv.previous'),
       )
-      // The venv must be gone before the archive lays down a fresh one.
-      const rmOrder = rm.mock.invocationCallOrder[0]!
+      const renameOrder = rename.mock.invocationCallOrder[0]!
       const installOrder = (installArtifact as unknown as { mock: { invocationCallOrder: number[] } }).mock.invocationCallOrder[0]!
-      expect(rmOrder).toBeLessThan(installOrder)
+      expect(renameOrder).toBeLessThan(installOrder)
     } finally {
+      rename.mockRestore()
+      rm.mockRestore()
+    }
+  })
+
+  it('puts the previous venv back when the install fails', async () => {
+    // Otherwise a failed update leaves the record on a version whose
+    // environment is gone — an install that reports fine and cannot launch.
+    const rename = vi.spyOn(fsp, 'rename').mockResolvedValue(undefined)
+    const rm = vi.spyOn(fsp, 'rm').mockResolvedValue(undefined)
+    vi.mocked(installArtifact).mockRejectedValueOnce(new Error('disk full'))
+    try {
+      await expect(comfybuilder.install!(record(), fakeTools())).rejects.toThrow('disk full')
+      expect(rename).toHaveBeenCalledTimes(2)
+      const [from, to] = rename.mock.calls[1]!
+      expect(String(from)).toContain('venv.previous')
+      expect(String(to)).toMatch(/venv$/)
+    } finally {
+      rename.mockRestore()
       rm.mockRestore()
     }
   })
@@ -227,18 +248,62 @@ describe('comfybuilder update-distribution', () => {
     // Otherwise the record advertises a version whose environment never landed.
     vi.mocked(resolveHostArtifactForVersion).mockResolvedValue({ artifact, version: 9 } as never)
     vi.mocked(installArtifact).mockRejectedValueOnce(new Error('disk full'))
+    // The venv survived — `installEnvironment` put it back.
+    const stat = vi.spyOn(fsp, 'stat').mockResolvedValue({} as never)
     const tools = actionTools()
 
+    try {
+      const result = await comfybuilder.handleAction(
+        'update-distribution',
+        record({ artifactId: 'art-1' }),
+        { version: 9 },
+        tools as never,
+      )
+
+      expect(result.ok).toBe(false)
+      expect(result.message).toContain('disk full')
+      expect(tools.updates.at(-1)).toMatchObject({ version: '1', artifactId: 'art-1', status: 'installed' })
+    } finally {
+      stat.mockRestore()
+    }
+  })
+
+  it('reports failed when the environment did not survive the attempt', async () => {
+    // Restoring the record but still claiming `installed` would advertise a
+    // working install that cannot launch.
+    vi.mocked(resolveHostArtifactForVersion).mockResolvedValue({ artifact, version: 9 } as never)
+    vi.mocked(installArtifact).mockRejectedValueOnce(new Error('disk full'))
+    const stat = vi.spyOn(fsp, 'stat').mockRejectedValue(new Error('ENOENT'))
+    const tools = actionTools()
+
+    try {
+      const result = await comfybuilder.handleAction(
+        'update-distribution',
+        record({ artifactId: 'art-1' }),
+        { version: 9 },
+        tools as never,
+      )
+
+      expect(result.ok).toBe(false)
+      expect(tools.updates.at(-1)).toMatchObject({ version: '1', status: 'failed' })
+    } finally {
+      stat.mockRestore()
+    }
+  })
+
+  it('refuses to update an install that is not ready', async () => {
+    // The section disables the button, but an action id is reachable alone.
+    const tools = actionTools()
     const result = await comfybuilder.handleAction(
       'update-distribution',
-      record({ artifactId: 'art-1' }),
+      record({ status: 'failed' }),
       { version: 9 },
       tools as never,
     )
 
     expect(result.ok).toBe(false)
-    expect(result.message).toContain('disk full')
-    expect(tools.updates.at(-1)).toMatchObject({ version: '1', artifactId: 'art-1', status: 'installed' })
+    expect(resolveHostArtifactForVersion).not.toHaveBeenCalled()
+    expect(tools.update).not.toHaveBeenCalled()
   })
 
   it('refuses a version with no build for this machine, without touching the record', async () => {

--- a/src/main/sources/comfybuilder/index.test.ts
+++ b/src/main/sources/comfybuilder/index.test.ts
@@ -18,9 +18,15 @@ vi.mock('../../comfybuilder', () => ({
   resolveModelManifest: vi.fn(async () => ({ models: [], modelPolicy: null, partnerNodePolicy: null })),
 }))
 vi.mock('../../devplatform/session', () => ({ getBuilderClient: vi.fn(() => ({})) }))
+vi.mock('../../devplatform/distributions', () => ({
+  resolveHost: vi.fn(async () => ({ os: 'linux', gpu: 'nvidia' })),
+  resolveHostArtifactForVersion: vi.fn(),
+  listCompleteVersions: vi.fn(async () => []),
+}))
 
 import { promises as fsp } from 'fs'
 import { installArtifact, stageModels, resolveModelManifest } from '../../comfybuilder'
+import { resolveHostArtifactForVersion } from '../../devplatform/distributions'
 import { comfybuilder, withAccelArgs } from './index'
 import type { InstallationRecord } from '../../installations'
 import type { InstallTools } from '../../types/sources'
@@ -169,5 +175,92 @@ describe('comfybuilder.withAccelArgs', () => {
 
   it('does not mistake --cpu-vae for the cpu flag', () => {
     expect(withAccelArgs(record({ artifactGpu: 'cpu' }), '--cpu-vae')).toBe('--cpu-vae --cpu')
+  })
+})
+
+describe('comfybuilder update-distribution', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  const artifact = {
+    id: 'art-9',
+    os: 'linux',
+    gpu: 'nvidia',
+    accelVariant: 'cu128',
+    status: 'ready',
+    archiveSha256: 'sha-9',
+  }
+
+  function actionTools() {
+    const updates: Record<string, unknown>[] = []
+    return {
+      updates,
+      update: vi.fn(async (d: Record<string, unknown>) => {
+        updates.push(d)
+      }),
+      sendProgress: vi.fn(),
+      sendOutput: vi.fn(),
+    }
+  }
+
+  it('re-points the record, re-installs, then marks it installed', async () => {
+    vi.mocked(resolveHostArtifactForVersion).mockResolvedValue({ artifact, version: 9 } as never)
+    const tools = actionTools()
+
+    const result = await comfybuilder.handleAction(
+      'update-distribution',
+      record(),
+      { version: 9 },
+      tools as never,
+    )
+
+    expect(result.ok).toBe(true)
+    expect(installArtifact).toHaveBeenCalledTimes(1)
+    // Installing first, installed last — never left mid-flight.
+    expect(tools.updates[0]).toMatchObject({ version: '9', artifactId: 'art-9', status: 'installing' })
+    expect(tools.updates.at(-1)).toMatchObject({ status: 'installed' })
+    // The environment is laid down for the NEW artifact, not the old one.
+    const passed = vi.mocked(installArtifact).mock.calls[0]![0] as { artifact: { id: string } }
+    expect(passed.artifact.id).toBe('art-9')
+  })
+
+  it('restores the previous version when the install fails', async () => {
+    // Otherwise the record advertises a version whose environment never landed.
+    vi.mocked(resolveHostArtifactForVersion).mockResolvedValue({ artifact, version: 9 } as never)
+    vi.mocked(installArtifact).mockRejectedValueOnce(new Error('disk full'))
+    const tools = actionTools()
+
+    const result = await comfybuilder.handleAction(
+      'update-distribution',
+      record({ artifactId: 'art-1' }),
+      { version: 9 },
+      tools as never,
+    )
+
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('disk full')
+    expect(tools.updates.at(-1)).toMatchObject({ version: '1', artifactId: 'art-1', status: 'installed' })
+  })
+
+  it('refuses a version with no build for this machine, without touching the record', async () => {
+    vi.mocked(resolveHostArtifactForVersion).mockResolvedValue(null)
+    const tools = actionTools()
+
+    const result = await comfybuilder.handleAction(
+      'update-distribution',
+      record(),
+      { version: 4 },
+      tools as never,
+    )
+
+    expect(result.ok).toBe(false)
+    expect(installArtifact).not.toHaveBeenCalled()
+    expect(tools.update).not.toHaveBeenCalled()
+  })
+
+  it('rejects a missing target version', async () => {
+    const tools = actionTools()
+    const result = await comfybuilder.handleAction('update-distribution', record(), {}, tools as never)
+    expect(result.ok).toBe(false)
+    expect(tools.update).not.toHaveBeenCalled()
   })
 })

--- a/src/main/sources/comfybuilder/index.ts
+++ b/src/main/sources/comfybuilder/index.ts
@@ -21,7 +21,7 @@ import path from 'path'
 import { installArtifact, buildLaunchSpec, stageModels, resolveModelManifest } from '../../comfybuilder'
 import type { Artifact, ArtifactGpu, ArtifactOs, InstallProgress, StageProgress } from '../../comfybuilder'
 import { getBuilderClient } from '../../devplatform/session'
-import { listCompleteVersions } from '../../devplatform/distributions'
+import { listCompleteVersions, resolveHost, resolveHostArtifactForVersion } from '../../devplatform/distributions'
 import { setCachedVersions } from '../../devplatform/versionCache'
 import { launchAction } from '../../lib/actions'
 import { defaultDownloadCacheDir } from '../../lib/paths'
@@ -31,6 +31,7 @@ import type {
   SourcePlugin,
   LaunchCommand,
   ActionResult,
+  ActionTools,
   InstallTools,
 } from '../../types/sources'
 
@@ -63,6 +64,67 @@ export function withAccelArgs(installation: InstallationRecord, launchArgs: stri
   const isCpu = installation.artifactGpu === 'cpu' || installation.artifactAccelVariant === 'cpu'
   if (!isCpu || /(?:^|\s)--cpu(?:\s|$)/.test(launchArgs)) return launchArgs
   return `${launchArgs} --cpu`.trim()
+}
+
+/**
+ * Lay down the environment for whatever artifact the record currently points
+ * at. Shared by the first install and by an in-place version change, so the two
+ * can't diverge on venv handling or model staging.
+ *
+ * Takes only what both callers have: progress + an abort signal.
+ */
+async function installEnvironment(
+  installation: InstallationRecord,
+  // Narrower than `ActionTools.sendProgress` on purpose: a handler that accepts
+  // `Record<string, unknown>` satisfies this, but not the reverse.
+  tools: {
+    sendProgress: (step: string, data: { percent: number; status: string }) => void
+    signal?: AbortSignal
+  },
+): Promise<void> {
+  const artifact = artifactFromRecord(installation)
+  const client = getBuilderClient()
+
+  // A venv can't be overlaid (leftover site-packages from the old version break
+  // Python), so remove it before extracting. No-op on a first install; on an
+  // update/retry it guarantees a clean environment. The archive lays down a
+  // fresh venv; staged models under ComfyUI/models are left untouched.
+  await fs.rm(path.join(installation.installPath, 'venv'), { recursive: true, force: true })
+
+  // Phase 1: archive (code + environment). `installArtifact` verifies the
+  // sha256 when the artifact carries one and fails on a byte mismatch. A
+  // missing hash is skipped for the initial rollout (see the TODO there).
+  await installArtifact({
+    artifact,
+    client,
+    installPath: installation.installPath,
+    cacheDir: defaultDownloadCacheDir(),
+    onProgress: (p: InstallProgress) => {
+      // The library's `resolve` phase has no labeled step; fold it into the
+      // download step at 0% so the stepper still shows forward motion.
+      const phase = p.phase === 'resolve' ? 'download' : p.phase
+      tools.sendProgress(phase, { percent: p.percent, status: p.detail ?? '' })
+    },
+    ...(tools.signal ? { signal: tools.signal } : {}),
+  })
+
+  // Phase 2: models. The archive carries no weights, so stage the
+  // distribution's declared models into the install's ComfyUI model tree
+  // before launch, the way comfy-deploy provisions a volume before boot. An
+  // empty manifest stages nothing and the step completes immediately.
+  const manifest = await resolveModelManifest(
+    client,
+    installation.distributionId as string,
+    installation.version as string,
+  )
+  await stageModels({
+    models: manifest.models,
+    installPath: installation.installPath,
+    onProgress: (p: StageProgress) =>
+      tools.sendProgress('models', { percent: p.percent, status: `${p.filename} (${p.index}/${p.total})` }),
+    ...(tools.signal ? { signal: tools.signal } : {}),
+  })
+  tools.sendProgress('models', { percent: 100, status: '' })
 }
 
 export const comfybuilder: SourcePlugin = {
@@ -129,56 +191,22 @@ export const comfybuilder: SourcePlugin = {
   },
 
   async install(installation: InstallationRecord, tools: InstallTools): Promise<void> {
-    const artifact = artifactFromRecord(installation)
-    const client = getBuilderClient()
-    // A venv can't be overlaid (leftover site-packages from the old version break
-    // Python), so remove it before extracting. No-op on a first install; on an
-    // update/retry it guarantees a clean environment. The archive lays down a
-    // fresh venv; staged models under ComfyUI/models are left untouched.
-    await fs.rm(path.join(installation.installPath, 'venv'), { recursive: true, force: true })
-    // Phase 1: archive (code + environment). `installArtifact` verifies the
-    // sha256 when the artifact carries one and fails on a byte mismatch. A
-    // missing hash is skipped for the initial rollout (see the TODO there).
-    await installArtifact({
-      artifact,
-      client,
-      installPath: installation.installPath,
-      cacheDir: defaultDownloadCacheDir(),
-      onProgress: (p: InstallProgress) => {
-        // The library's `resolve` phase has no labeled step; fold it into the
-        // download step at 0% so the stepper still shows forward motion.
-        const phase = p.phase === 'resolve' ? 'download' : p.phase
-        tools.sendProgress(phase, { percent: p.percent, status: p.detail ?? '' })
-      },
-      ...(tools.signal ? { signal: tools.signal } : {}),
-    })
-
-    // Phase 2: models. The archive carries no weights, so stage the
-    // distribution's declared models into the install's ComfyUI model tree
-    // before launch, the way comfy-deploy provisions a volume before boot. An
-    // empty manifest stages nothing and the step completes immediately.
-    const manifest = await resolveModelManifest(
-      client,
-      installation.distributionId as string,
-      installation.version as string,
-    )
-    await stageModels({
-      models: manifest.models,
-      installPath: installation.installPath,
-      onProgress: (p: StageProgress) =>
-        tools.sendProgress('models', { percent: p.percent, status: `${p.filename} (${p.index}/${p.total})` }),
-      ...(tools.signal ? { signal: tools.signal } : {}),
-    })
-    tools.sendProgress('models', { percent: 100, status: '' })
+    await installEnvironment(installation, tools)
   },
 
   // Launch / rename / open-folder / remove / delete never reach here — the
   // generic session-action dispatch (`sessionActions/index.ts`) handles those
   // before a plugin is consulted.
-  async handleAction(actionId: string, installation: InstallationRecord): Promise<ActionResult> {
+  async handleAction(
+    actionId: string,
+    installation: InstallationRecord,
+    actionData: Record<string, unknown> | undefined,
+    tools: ActionTools,
+  ): Promise<ActionResult> {
+    const distributionId = installation.distributionId as string | undefined
+    if (!distributionId) return { ok: false, message: t('comfybuilder.errorNoDistribution') }
+
     if (actionId === 'check-update') {
-      const distributionId = installation.distributionId as string | undefined
-      if (!distributionId) return { ok: false, message: t('comfybuilder.errorNoDistribution') }
       try {
         setCachedVersions(
           distributionId,
@@ -189,6 +217,77 @@ export const comfybuilder: SourcePlugin = {
         return { ok: false, message: err instanceof Error ? err.message : String(err) }
       }
     }
+
+    if (actionId === 'update-distribution') {
+      return updateDistributionVersion(installation, distributionId, actionData, tools)
+    }
+
     return { ok: false, message: `Action "${actionId}" not yet implemented.` }
   },
+}
+
+/**
+ * Move this install to another published version of its own distribution.
+ *
+ * Re-installs in place: the record is re-pointed at the target artifact, then
+ * the same `installEnvironment` a first install runs lays the new environment
+ * down over it. Done here rather than through the `install-instance` chain
+ * because that chain is bound to its IPC sender — but the pieces it owns are
+ * only needed for a FRESH install. The directory and the record already exist,
+ * so what remains is the status arc, which is handled explicitly below.
+ *
+ * Targets the INSTALLATION, never the distribution id: several installs of one
+ * distribution are allowed, so distribution-keyed lookup would pick arbitrarily.
+ */
+async function updateDistributionVersion(
+  installation: InstallationRecord,
+  distributionId: string,
+  actionData: Record<string, unknown> | undefined,
+  tools: ActionTools,
+): Promise<ActionResult> {
+  const target = Number(actionData?.version)
+  if (!Number.isFinite(target)) return { ok: false, message: t('comfybuilder.errorNoVersion') }
+
+  const previous = {
+    version: installation.version as string | undefined,
+    artifactId: installation.artifactId as string | undefined,
+    artifactOs: installation.artifactOs as string | undefined,
+    artifactGpu: installation.artifactGpu as string | undefined,
+    artifactAccelVariant: installation.artifactAccelVariant as string | undefined,
+    artifactSha256: installation.artifactSha256 as string | undefined,
+  }
+
+  try {
+    const resolved = await resolveHostArtifactForVersion(
+      getBuilderClient(),
+      await resolveHost(),
+      distributionId,
+      target,
+    )
+    if (!resolved) {
+      return { ok: false, message: t('comfybuilder.errorVersionUnavailable', { version: target }) }
+    }
+
+    const { artifact } = resolved
+    const next: Record<string, unknown> = {
+      version: String(resolved.version),
+      artifactId: artifact.id,
+      artifactOs: artifact.os,
+      artifactGpu: artifact.gpu,
+      artifactAccelVariant: artifact.accelVariant,
+      ...(artifact.archiveSha256 ? { artifactSha256: artifact.archiveSha256 } : {}),
+    }
+    await tools.update({ ...next, status: 'installing' })
+
+    await installEnvironment({ ...installation, ...next } as InstallationRecord, tools)
+
+    await tools.update({ status: 'installed' })
+    return { ok: true, navigate: 'detail' }
+  } catch (err) {
+    // Put the record back where it was. Leaving it pointed at a version whose
+    // environment never landed would report a version the install doesn't have.
+    await tools.update({ ...previous, status: 'installed' }).catch(() => {})
+    if (tools.signal?.aborted) return { ok: false, cancelled: true }
+    return { ok: false, message: err instanceof Error ? err.message : String(err) }
+  }
 }

--- a/src/main/sources/comfybuilder/index.ts
+++ b/src/main/sources/comfybuilder/index.ts
@@ -84,47 +84,66 @@ async function installEnvironment(
 ): Promise<void> {
   const artifact = artifactFromRecord(installation)
   const client = getBuilderClient()
+  const venvPath = path.join(installation.installPath, 'venv')
+  const previousVenvPath = `${venvPath}.previous`
 
   // A venv can't be overlaid (leftover site-packages from the old version break
-  // Python), so remove it before extracting. No-op on a first install; on an
-  // update/retry it guarantees a clean environment. The archive lays down a
-  // fresh venv; staged models under ComfyUI/models are left untouched.
-  await fs.rm(path.join(installation.installPath, 'venv'), { recursive: true, force: true })
+  // Python), so the old one moves aside before extracting. MOVED, not deleted:
+  // `installArtifact` downloads to a temp and verifies the checksum before it
+  // touches `installPath`, precisely so a failed run never destroys a working
+  // environment. Deleting up front would throw that guarantee away and leave a
+  // failed update on a version it can no longer launch.
+  await fs.rm(previousVenvPath, { recursive: true, force: true }).catch(() => {})
+  const hadPreviousVenv = await fs
+    .rename(venvPath, previousVenvPath)
+    .then(() => true)
+    .catch(() => false)
 
-  // Phase 1: archive (code + environment). `installArtifact` verifies the
-  // sha256 when the artifact carries one and fails on a byte mismatch. A
-  // missing hash is skipped for the initial rollout (see the TODO there).
-  await installArtifact({
-    artifact,
-    client,
-    installPath: installation.installPath,
-    cacheDir: defaultDownloadCacheDir(),
-    onProgress: (p: InstallProgress) => {
-      // The library's `resolve` phase has no labeled step; fold it into the
-      // download step at 0% so the stepper still shows forward motion.
-      const phase = p.phase === 'resolve' ? 'download' : p.phase
-      tools.sendProgress(phase, { percent: p.percent, status: p.detail ?? '' })
-    },
-    ...(tools.signal ? { signal: tools.signal } : {}),
-  })
+  try {
+    // Phase 1: archive (code + environment). `installArtifact` verifies the
+    // sha256 when the artifact carries one and fails on a byte mismatch. A
+    // missing hash is skipped for the initial rollout (see the TODO there).
+    await installArtifact({
+      artifact,
+      client,
+      installPath: installation.installPath,
+      cacheDir: defaultDownloadCacheDir(),
+      onProgress: (p: InstallProgress) => {
+        // The library's `resolve` phase has no labeled step; fold it into the
+        // download step at 0% so the stepper still shows forward motion.
+        const phase = p.phase === 'resolve' ? 'download' : p.phase
+        tools.sendProgress(phase, { percent: p.percent, status: p.detail ?? '' })
+      },
+      ...(tools.signal ? { signal: tools.signal } : {}),
+    })
 
-  // Phase 2: models. The archive carries no weights, so stage the
-  // distribution's declared models into the install's ComfyUI model tree
-  // before launch, the way comfy-deploy provisions a volume before boot. An
-  // empty manifest stages nothing and the step completes immediately.
-  const manifest = await resolveModelManifest(
-    client,
-    installation.distributionId as string,
-    installation.version as string,
-  )
-  await stageModels({
-    models: manifest.models,
-    installPath: installation.installPath,
-    onProgress: (p: StageProgress) =>
-      tools.sendProgress('models', { percent: p.percent, status: `${p.filename} (${p.index}/${p.total})` }),
-    ...(tools.signal ? { signal: tools.signal } : {}),
-  })
-  tools.sendProgress('models', { percent: 100, status: '' })
+    // Phase 2: models. The archive carries no weights, so stage the
+    // distribution's declared models into the install's ComfyUI model tree
+    // before launch, the way comfy-deploy provisions a volume before boot. An
+    // empty manifest stages nothing and the step completes immediately.
+    const manifest = await resolveModelManifest(
+      client,
+      installation.distributionId as string,
+      installation.version as string,
+    )
+    await stageModels({
+      models: manifest.models,
+      installPath: installation.installPath,
+      onProgress: (p: StageProgress) =>
+        tools.sendProgress('models', { percent: p.percent, status: `${p.filename} (${p.index}/${p.total})` }),
+      ...(tools.signal ? { signal: tools.signal } : {}),
+    })
+    tools.sendProgress('models', { percent: 100, status: '' })
+  } catch (err) {
+    // Put the working environment back before surfacing the failure.
+    if (hadPreviousVenv) {
+      await fs.rm(venvPath, { recursive: true, force: true }).catch(() => {})
+      await fs.rename(previousVenvPath, venvPath).catch(() => {})
+    }
+    throw err
+  }
+
+  await fs.rm(previousVenvPath, { recursive: true, force: true }).catch(() => {})
 }
 
 export const comfybuilder: SourcePlugin = {
@@ -248,6 +267,12 @@ async function updateDistributionVersion(
   const target = Number(actionData?.version)
   if (!Number.isFinite(target)) return { ok: false, message: t('comfybuilder.errorNoVersion') }
 
+  // The section only offers this on a ready install, but an action id is
+  // reachable on its own — re-check rather than trust the caller, since the
+  // rollback below can only restore a state that was coherent to begin with.
+  const previousStatus = installation.status as string | undefined
+  if (previousStatus !== 'installed') return { ok: false, message: t('errors.installNotReady') }
+
   const previous = {
     version: installation.version as string | undefined,
     artifactId: installation.artifactId as string | undefined,
@@ -286,7 +311,15 @@ async function updateDistributionVersion(
   } catch (err) {
     // Put the record back where it was. Leaving it pointed at a version whose
     // environment never landed would report a version the install doesn't have.
-    await tools.update({ ...previous, status: 'installed' }).catch(() => {})
+    //
+    // `installEnvironment` restores the previous venv on failure, but if that
+    // did not survive the install can no longer launch: report it failed rather
+    // than advertise a working install that isn't one.
+    const runnable = await fs
+      .stat(path.join(installation.installPath, 'venv'))
+      .then(() => true)
+      .catch(() => false)
+    await tools.update({ ...previous, status: runnable ? previousStatus : 'failed' }).catch(() => {})
     if (tools.signal?.aborted) return { ok: false, cancelled: true }
     return { ok: false, message: err instanceof Error ? err.message : String(err) }
   }

--- a/src/main/sources/comfybuilder/index.ts
+++ b/src/main/sources/comfybuilder/index.ts
@@ -21,6 +21,8 @@ import path from 'path'
 import { installArtifact, buildLaunchSpec, stageModels, resolveModelManifest } from '../../comfybuilder'
 import type { Artifact, ArtifactGpu, ArtifactOs, InstallProgress, StageProgress } from '../../comfybuilder'
 import { getBuilderClient } from '../../devplatform/session'
+import { listCompleteVersions } from '../../devplatform/distributions'
+import { setCachedVersions } from '../../devplatform/versionCache'
 import { launchAction } from '../../lib/actions'
 import { defaultDownloadCacheDir } from '../../lib/paths'
 import { t } from '../../lib/i18n'
@@ -32,7 +34,8 @@ import type {
   InstallTools,
 } from '../../types/sources'
 
-const DEFAULT_LAUNCH_ARGS = '--enable-manager'
+import { DEFAULT_LAUNCH_ARGS } from './constants'
+import { getDetailSections } from './detailSections'
 
 /** Reconstruct the library Artifact from the fields the install record carries. */
 function artifactFromRecord(inst: InstallationRecord): Artifact {
@@ -117,19 +120,7 @@ export const comfybuilder: SourcePlugin = {
     return [launchAction(installed, !installed ? t('errors.installNotReady') : undefined)]
   },
 
-  getDetailSections(installation: InstallationRecord): Record<string, unknown>[] {
-    return [
-      {
-        tab: 'status',
-        title: 'Installation Info',
-        fields: [
-          { label: 'Install method', value: (installation.sourceLabel as string) || 'ComfyBuilder' },
-          { label: 'Distribution', value: (installation.distributionName as string) || '-' },
-          { label: 'Version', value: (installation.version as string) || '-' },
-        ],
-      },
-    ]
-  },
+  getDetailSections,
 
   // A ComfyBuilder install is never discovered on disk: only the dev-platform
   // flow creates one: so there is nothing to probe/adopt.
@@ -181,7 +172,23 @@ export const comfybuilder: SourcePlugin = {
     tools.sendProgress('models', { percent: 100, status: '' })
   },
 
-  async handleAction(actionId: string): Promise<ActionResult> {
+  // Launch / rename / open-folder / remove / delete never reach here — the
+  // generic session-action dispatch (`sessionActions/index.ts`) handles those
+  // before a plugin is consulted.
+  async handleAction(actionId: string, installation: InstallationRecord): Promise<ActionResult> {
+    if (actionId === 'check-update') {
+      const distributionId = installation.distributionId as string | undefined
+      if (!distributionId) return { ok: false, message: t('comfybuilder.errorNoDistribution') }
+      try {
+        setCachedVersions(
+          distributionId,
+          await listCompleteVersions(getBuilderClient(), distributionId),
+        )
+        return { ok: true }
+      } catch (err) {
+        return { ok: false, message: err instanceof Error ? err.message : String(err) }
+      }
+    }
     return { ok: false, message: `Action "${actionId}" not yet implemented.` }
   },
 }

--- a/src/renderer/src/devplatform/distributionState.ts
+++ b/src/renderer/src/devplatform/distributionState.ts
@@ -5,11 +5,18 @@
 import type { Distribution, DistributionState } from './types'
 import type { Installation } from '../types/ipc'
 
+/** The rule itself, over the two raw fields — so callers holding only a subset
+ *  of the record (the picker row, the title bar) can ask without a cast.
+ *  `distributionId` arrives through an index signature, hence the emptiness
+ *  check rather than a `typeof`. */
+export function isDistributionSource(sourceId: unknown, distributionId: unknown): boolean {
+  return sourceId === 'comfybuilder' || Boolean(distributionId)
+}
+
 /** An install that came from a distribution. One definition, so the shelf it
- *  sorts into and the glyph it wears can't disagree. `distributionId` arrives
- *  through an index signature, hence the emptiness check. */
+ *  sorts into and the glyph it wears can't disagree. */
 export function isDistributionInstall(inst: Installation): boolean {
-  return inst.sourceId === 'comfybuilder' || Boolean(inst.distributionId)
+  return isDistributionSource(inst.sourceId, inst.distributionId)
 }
 
 export const BLOCKED_DISTRIBUTION_STATES: readonly DistributionState[] = [

--- a/src/renderer/src/lib/installTypeIcon.test.ts
+++ b/src/renderer/src/lib/installTypeIcon.test.ts
@@ -53,6 +53,35 @@ describe('installTypeMetaForInstall', () => {
     expect(meta.labelKey).toBe('installType.legacyDesktop')
   })
 
+  it('gives a distribution install the distribution glyph, not the local one', () => {
+    // It reports `local` like any standalone install, but what it IS matters
+    // more than where it runs — and the tile, the picker row and the title bar
+    // all read this, so they can't drift apart.
+    const bySource = installTypeMetaForInstall({
+      sourceId: 'comfybuilder',
+      sourceCategory: 'local',
+    })
+    expect(bySource.key).toBe('distribution')
+    expect(bySource.labelKey).toBe('installType.distribution')
+
+    const byLink = installTypeMetaForInstall({
+      sourceId: 'standalone',
+      sourceCategory: 'local',
+      distributionId: 'd1',
+    })
+    expect(byLink.key).toBe('distribution')
+  })
+
+  it('does not treat an empty distributionId as a link', () => {
+    expect(
+      installTypeMetaForInstall({
+        sourceId: 'standalone',
+        sourceCategory: 'local',
+        distributionId: '',
+      }).key,
+    ).toBe('standalone')
+  })
+
   it('falls through to the category for non-desktop installs', () => {
     expect(installTypeMetaForInstall({ sourceId: 'standalone', sourceCategory: 'local' }).key).toBe(
       'standalone',

--- a/src/renderer/src/lib/installTypeIcon.ts
+++ b/src/renderer/src/lib/installTypeIcon.ts
@@ -1,5 +1,6 @@
-import { Cloud, Computer, LaptopMinimal, Globe, Box } from 'lucide-vue-next'
+import { Cloud, Computer, LaptopMinimal, Globe, Box, Package } from 'lucide-vue-next'
 import type { LucideIcon } from 'lucide-vue-next'
+import { isDistributionSource } from '../devplatform/distributionState'
 
 /** Stable UX-side install-type key. Callers switch on this for styling /
  *  analytics rather than the raw `sourceCategory` from the source plugins. */
@@ -8,6 +9,7 @@ export type InstallTypeKey =
   | 'cloud'
   | 'legacyDesktop'
   | 'remote'
+  | 'distribution'
   | 'unknown'
 
 export interface InstallTypeIconMeta {
@@ -30,6 +32,8 @@ export function installTypeMetaFor(
       return { key: 'remote', icon: Globe, labelKey: 'installType.remote' }
     case 'local':
       return { key: 'standalone', icon: LaptopMinimal, labelKey: 'installType.standalone' }
+    case 'distribution':
+      return { key: 'distribution', icon: Package, labelKey: 'installType.distribution' }
     default:
       return { key: 'unknown', icon: Box, labelKey: 'installType.unknown' }
   }
@@ -37,11 +41,19 @@ export function installTypeMetaFor(
 
 /** Resolve install-type metadata for a concrete installation. Legacy Desktop
  *  installs report `sourceCategory === 'local'`, so the distinct
- *  `legacyDesktop` identity is keyed off the `desktop` sourceId instead. */
+ *  `legacyDesktop` identity is keyed off the `desktop` sourceId instead.
+ *
+ *  A distribution install also reports `local`, but wears the distribution
+ *  glyph everywhere — what it IS matters more than where it runs, and it keeps
+ *  one identity whether it's an install tile, a picker row or a card. */
 export function installTypeMetaForInstall(inst: {
   sourceId?: unknown
   sourceCategory: string | null | undefined
+  distributionId?: unknown
 }): InstallTypeIconMeta {
+  if (isDistributionSource(inst.sourceId, inst.distributionId)) {
+    return installTypeMetaFor('distribution')
+  }
   if (inst.sourceId === 'desktop') return installTypeMetaFor('desktop')
   return installTypeMetaFor(inst.sourceCategory)
 }

--- a/src/renderer/src/types/ipc.ts
+++ b/src/renderer/src/types/ipc.ts
@@ -10,6 +10,8 @@ export type {
   DetailItem,
   DetailField,
   DetailFieldOption,
+  VersionStatRow,
+  VersionStatsValue,
   ActionDef,
   ConfirmDef,
   ConfirmOption,

--- a/src/renderer/src/views/chooser/ChooserInstallTile.vue
+++ b/src/renderer/src/views/chooser/ChooserInstallTile.vue
@@ -5,8 +5,7 @@ import {
   AlertCircle,
   ArrowDownToLine,
   ArrowRightLeft,
-  MoreVertical,
-  Package
+  MoreVertical
 } from 'lucide-vue-next'
 import { useSessionStore } from '../../stores/sessionStore'
 import { installTypeMetaForInstall } from '../../lib/installTypeIcon'
@@ -169,10 +168,11 @@ function triggerInstallAction(action: 'update' | 'migrate'): void {
          distribution install wears the distribution glyph instead. -->
     <span
       class="chooser-tile-icon"
-      :title="isFromDistribution ? undefined : t(typeMeta.labelKey)"
+      :title="t(typeMeta.labelKey)"
     >
-      <Package v-if="isFromDistribution" :size="22" />
-      <component :is="typeMeta.icon" v-else :size="22" />
+      <!-- `typeMeta` resolves the distribution glyph itself, so the tile, the
+           picker row and the title bar can't drift apart. -->
+      <component :is="typeMeta.icon" :size="22" />
     </span>
 
     <!-- Lifecycle indicator + kebab. Status pill is click-through; error badge opens details. -->

--- a/src/renderer/src/views/comfyUISettings/ChannelPicker.vue
+++ b/src/renderer/src/views/comfyUISettings/ChannelPicker.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n'
 import { Loader2 } from 'lucide-vue-next'
 import BaseSelect, { type BaseSelectOption } from '../../components/ui/BaseSelect.vue'
 import InfoTooltip from '../../components/InfoTooltip.vue'
+import VersionStatPanel, { type VersionStatRow } from './VersionStatPanel.vue'
 import { formatRelativeFromMs } from '../../lib/datetime'
 import type { ActionDef, DetailField, DetailFieldOption } from '../../types/ipc'
 import { TID } from '../../../../shared/testIds'
@@ -164,13 +165,7 @@ const statusBadgeTone = computed<'current' | 'update'>(() =>
   preview.value?.updateAvailable ? 'update' : 'current'
 )
 
-interface StatRow {
-  id: string
-  label: string
-  value: string
-  title?: string
-  highlight?: boolean
-}
+type StatRow = VersionStatRow
 
 const lastCheckedDisplay = computed<{ value: string; title?: string } | null>(() => {
   if (!preview.value) return null
@@ -322,32 +317,13 @@ const selectOptions = computed<BaseSelectOption[]>(() =>
 
 <template>
   <div class="channel-picker">
-    <div class="channel-picker-status">
-      <div class="channel-picker-headline-row">
-        <p
-          class="channel-picker-headline"
-          :class="{ 'is-update-available': preview?.updateAvailable }"
-        >
-          {{ headline }}
-        </p>
-        <span v-if="statusBadge && preview" class="channel-picker-badge" :class="statusBadgeTone">
-          {{ statusBadge }}
-        </span>
-      </div>
-
-    </div>
-
-    <dl v-if="statRows.length > 0" class="channel-picker-stats">
-      <div
-        v-for="row in statRows"
-        :key="row.id"
-        class="channel-picker-stat-row"
-        :class="{ 'is-highlight': row.highlight }"
-      >
-        <dt>{{ row.label }}</dt>
-        <dd :title="row.title">{{ row.value }}</dd>
-      </div>
-    </dl>
+    <VersionStatPanel
+      :headline="headline"
+      :headline-highlight="preview?.updateAvailable === true"
+      :badge="preview ? statusBadge : null"
+      :badge-tone="statusBadgeTone"
+      :rows="statRows"
+    />
 
     <!-- Hint shown while `commitsAhead` is still being computed; self-hides
          after the max window if enrichment never completes. -->
@@ -435,86 +411,17 @@ const selectOptions = computed<BaseSelectOption[]>(() =>
   gap: 12px;
 }
 
-.channel-picker-headline-row {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 8px;
-}
 
-.channel-picker-headline {
-  margin: 0;
-  font-size: 18px;
-  font-weight: 600;
-  line-height: 24px;
-  color: var(--text);
-}
 
-.channel-picker-headline.is-update-available {
-  color: var(--accent);
-}
 
-.channel-picker-badge {
-  flex-shrink: 0;
-  padding: 2px 8px;
-  font-size: 11px;
-  font-weight: 500;
-  line-height: 16px;
-  border-radius: 999px;
-}
 
-.channel-picker-badge.current {
-  color: var(--success, #4ade80);
-  background: color-mix(in srgb, var(--success, #4ade80) 12%, transparent);
-}
 
-.channel-picker-badge.update {
-  color: var(--accent);
-  background: color-mix(in srgb, var(--accent) 12%, transparent);
-}
 
-.channel-picker-stats {
-  margin: 0;
-  display: flex;
-  flex-direction: column;
-  border: 1px solid var(--chooser-surface-border);
-  border-radius: 8px;
-  padding: 4px 12px;
-  background: var(--brand-surface-bg);
-}
 
-.channel-picker-stat-row {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-  align-items: center;
-  gap: 12px;
-  padding: 8px 0;
-  border-top: 1px solid var(--border-hover);
-}
 
-.channel-picker-stat-row:first-child {
-  border-top: none;
-}
 
-.channel-picker-stat-row dt {
-  margin: 0;
-  font-size: 12px;
-  line-height: 16px;
-  color: var(--text-muted);
-}
 
-.channel-picker-stat-row dd {
-  margin: 0;
-  font-size: 13px;
-  line-height: 19px;
-  color: var(--neutral-100);
-  text-align: right;
-}
 
-.channel-picker-stat-row.is-highlight dd {
-  color: var(--accent);
-  font-weight: 500;
-}
 
 .channel-picker-card {
   display: flex;

--- a/src/renderer/src/views/comfyUISettings/SettingsSectionList.vue
+++ b/src/renderer/src/views/comfyUISettings/SettingsSectionList.vue
@@ -8,13 +8,13 @@ import BooleanToggle from './BooleanToggle.vue'
 import PathField from './PathField.vue'
 import EnvVarsField from './EnvVarsField.vue'
 import ChannelPicker from './ChannelPicker.vue'
-import VersionStatPanel, { type VersionStatRow } from './VersionStatPanel.vue'
+import VersionStatPanel from './VersionStatPanel.vue'
 import ArgsBuilderField from './ArgsBuilderField.vue'
 import InfoTooltip from '../../components/InfoTooltip.vue'
 import BaseCopyButton from '../../components/ui/BaseCopyButton.vue'
 import TooltipWrap from '../../components/TooltipWrap.vue'
 import { isOpenablePathString } from '../../lib/openablePath'
-import type { ActionDef, DetailField, DetailSection } from '../../types/ipc'
+import type { ActionDef, DetailField, DetailSection, VersionStatsValue } from '../../types/ipc'
 
 /**
  * Shared section + field renderer for both the Settings drawer and the instance-picker's Settings accordion.
@@ -74,17 +74,9 @@ function asString(v: DetailField['value']): string {
   return typeof v === 'string' ? v : v == null ? '' : String(v)
 }
 
-interface VersionStatsValue {
-  headline: string
-  headlineHighlight: boolean
-  badge: string | null
-  badgeTone: 'current' | 'update'
-  rows: VersionStatRow[]
-}
-
 /** Unpack a `version-stats` field. The backend owns the wording — it knows what
  *  the versions mean — so this only supplies defaults for a malformed payload. */
-function versionStats(field: DetailField): VersionStatsValue {
+function versionStats(field: DetailField): Required<VersionStatsValue> {
   const v = (field.value ?? {}) as Partial<VersionStatsValue>
   return {
     headline: typeof v.headline === 'string' ? v.headline : '',
@@ -133,8 +125,14 @@ function isNestedField(field: DetailField): boolean {
   return field.nested === true
 }
 
-function hasChannelPicker(section: DetailSection): boolean {
-  return (section.fields ?? []).some((f) => f.editType === 'channel-cards')
+/** Field types that render the section's actions themselves, so the generic
+ *  full-width footer must stand down or the buttons appear twice. */
+const ACTION_OWNING_EDIT_TYPES = new Set(['channel-cards', 'version-stats'])
+
+function fieldOwnsSectionActions(section: DetailSection): boolean {
+  return (section.fields ?? []).some(
+    (f) => f.editType && ACTION_OWNING_EDIT_TYPES.has(f.editType),
+  )
 }
 
 function isPathLikeValue(value: unknown): boolean {
@@ -159,7 +157,13 @@ function readonlyDisplayValue(field: DetailField): string {
 }
 
 function fieldOwnsLabel(field: DetailField): boolean {
-  return field.editType === 'env-vars' || field.editType === 'channel-cards'
+  return (
+    field.editType === 'env-vars' ||
+    field.editType === 'channel-cards' ||
+    // The panel leads with its own headline; a label above it would echo the
+    // section title.
+    field.editType === 'version-stats'
+  )
 }
 </script>
 
@@ -347,14 +351,14 @@ function fieldOwnsLabel(field: DetailField): boolean {
           />
 
           <!-- The same version table ChannelPicker shows, for a source that has
-               versions but no release channel. The backend supplies the rows. -->
+               versions but no release channel. The backend supplies the rows,
+               and the section's actions dock inside the table's footer. -->
           <VersionStatPanel
             v-else-if="field.editType === 'version-stats'"
-            :headline="versionStats(field).headline"
-            :headline-highlight="versionStats(field).headlineHighlight"
-            :badge="versionStats(field).badge"
-            :badge-tone="versionStats(field).badgeTone"
-            :rows="versionStats(field).rows"
+            v-bind="versionStats(field)"
+            :actions="section.actions ?? []"
+            :running-action-ids="runningIdsSet"
+            @action="(a) => emit('run-action', a)"
           />
 
           <BaseInput
@@ -385,7 +389,7 @@ function fieldOwnsLabel(field: DetailField): boolean {
       </div>
 
       <div
-        v-if="section.actions && section.actions.length && !hasChannelPicker(section)"
+        v-if="section.actions && section.actions.length && !fieldOwnsSectionActions(section)"
         class="settings-v2-actions"
       >
         <TooltipWrap

--- a/src/renderer/src/views/comfyUISettings/SettingsSectionList.vue
+++ b/src/renderer/src/views/comfyUISettings/SettingsSectionList.vue
@@ -8,6 +8,7 @@ import BooleanToggle from './BooleanToggle.vue'
 import PathField from './PathField.vue'
 import EnvVarsField from './EnvVarsField.vue'
 import ChannelPicker from './ChannelPicker.vue'
+import VersionStatPanel, { type VersionStatRow } from './VersionStatPanel.vue'
 import ArgsBuilderField from './ArgsBuilderField.vue'
 import InfoTooltip from '../../components/InfoTooltip.vue'
 import BaseCopyButton from '../../components/ui/BaseCopyButton.vue'
@@ -71,6 +72,27 @@ const { t } = useI18n()
 
 function asString(v: DetailField['value']): string {
   return typeof v === 'string' ? v : v == null ? '' : String(v)
+}
+
+interface VersionStatsValue {
+  headline: string
+  headlineHighlight: boolean
+  badge: string | null
+  badgeTone: 'current' | 'update'
+  rows: VersionStatRow[]
+}
+
+/** Unpack a `version-stats` field. The backend owns the wording — it knows what
+ *  the versions mean — so this only supplies defaults for a malformed payload. */
+function versionStats(field: DetailField): VersionStatsValue {
+  const v = (field.value ?? {}) as Partial<VersionStatsValue>
+  return {
+    headline: typeof v.headline === 'string' ? v.headline : '',
+    headlineHighlight: v.headlineHighlight === true,
+    badge: typeof v.badge === 'string' ? v.badge : null,
+    badgeTone: v.badgeTone === 'update' ? 'update' : 'current',
+    rows: Array.isArray(v.rows) ? v.rows : []
+  }
 }
 
 // Per-title collapse state; only titled sections (with a `section.collapsed` seed) are collapsible.
@@ -322,6 +344,17 @@ function fieldOwnsLabel(field: DetailField): boolean {
             :section-actions="section.actions ?? []"
             :running-action-ids="runningIdsSet"
             @action="(a) => emit('run-action', a)"
+          />
+
+          <!-- The same version table ChannelPicker shows, for a source that has
+               versions but no release channel. The backend supplies the rows. -->
+          <VersionStatPanel
+            v-else-if="field.editType === 'version-stats'"
+            :headline="versionStats(field).headline"
+            :headline-highlight="versionStats(field).headlineHighlight"
+            :badge="versionStats(field).badge"
+            :badge-tone="versionStats(field).badgeTone"
+            :rows="versionStats(field).rows"
           />
 
           <BaseInput

--- a/src/renderer/src/views/comfyUISettings/VersionStatPanel.vue
+++ b/src/renderer/src/views/comfyUISettings/VersionStatPanel.vue
@@ -1,0 +1,138 @@
+<script setup lang="ts">
+/**
+ * The Update tab's version summary: a headline with a status badge, over a
+ * bordered table of version facts.
+ *
+ * Extracted from `ChannelPicker` so a distribution install — which has versions
+ * but no release channel — gets the SAME table rather than a stacked list that
+ * merely says the same words. Purely presentational: callers decide what the
+ * rows mean.
+ */
+import type { VersionStatRow } from '../../types/ipc'
+
+export type { VersionStatRow }
+
+withDefaults(
+  defineProps<{
+    headline: string
+    /** Accent the headline (an update is waiting). */
+    headlineHighlight?: boolean
+    badge?: string | null
+    badgeTone?: 'current' | 'update'
+    rows?: VersionStatRow[]
+  }>(),
+  { headlineHighlight: false, badge: null, badgeTone: 'current', rows: () => [] }
+)
+</script>
+
+<template>
+  <div class="version-stat-panel">
+    <div class="version-stat-headline-row">
+      <p class="version-stat-headline" :class="{ 'is-update-available': headlineHighlight }">
+        {{ headline }}
+      </p>
+      <span v-if="badge" class="version-stat-badge" :class="badgeTone">{{ badge }}</span>
+    </div>
+
+    <dl v-if="rows.length > 0" class="version-stat-rows">
+      <div
+        v-for="row in rows"
+        :key="row.id"
+        class="version-stat-row"
+        :class="{ 'is-highlight': row.highlight }"
+      >
+        <dt>{{ row.label }}</dt>
+        <dd :title="row.title">{{ row.value }}</dd>
+      </div>
+    </dl>
+  </div>
+</template>
+
+<style scoped>
+.version-stat-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.version-stat-headline-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.version-stat-headline {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 24px;
+  color: var(--text);
+}
+
+.version-stat-headline.is-update-available {
+  color: var(--accent);
+}
+
+.version-stat-badge {
+  flex-shrink: 0;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 16px;
+  border-radius: 999px;
+}
+
+.version-stat-badge.current {
+  color: var(--success, #4ade80);
+  background: color-mix(in srgb, var(--success, #4ade80) 12%, transparent);
+}
+
+.version-stat-badge.update {
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
+.version-stat-rows {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--chooser-surface-border);
+  border-radius: 8px;
+  padding: 4px 12px;
+  background: var(--brand-surface-bg);
+}
+
+.version-stat-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  align-items: center;
+  gap: 12px;
+  padding: 8px 0;
+  border-top: 1px solid var(--border-hover);
+}
+
+.version-stat-row:first-child {
+  border-top: none;
+}
+
+.version-stat-row dt {
+  margin: 0;
+  font-size: 12px;
+  line-height: 16px;
+  color: var(--text-muted);
+}
+
+.version-stat-row dd {
+  margin: 0;
+  font-size: 13px;
+  line-height: 19px;
+  color: var(--neutral-100);
+  text-align: right;
+}
+
+.version-stat-row.is-highlight dd {
+  color: var(--accent);
+  font-weight: 500;
+}
+</style>

--- a/src/renderer/src/views/comfyUISettings/VersionStatPanel.vue
+++ b/src/renderer/src/views/comfyUISettings/VersionStatPanel.vue
@@ -8,11 +8,12 @@
  * merely says the same words. Purely presentational: callers decide what the
  * rows mean.
  */
-import type { VersionStatRow } from '../../types/ipc'
+import { Loader2 } from 'lucide-vue-next'
+import type { ActionDef, VersionStatRow } from '../../types/ipc'
 
 export type { VersionStatRow }
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     headline: string
     /** Accent the headline (an update is waiting). */
@@ -20,9 +21,26 @@ withDefaults(
     badge?: string | null
     badgeTone?: 'current' | 'update'
     rows?: VersionStatRow[]
+    /** Rendered inside the table's bottom edge, right-aligned — they act on
+     *  what the table states, so they belong to it rather than the page. */
+    actions?: ActionDef[]
+    runningActionIds?: Set<string>
   }>(),
-  { headlineHighlight: false, badge: null, badgeTone: 'current', rows: () => [] }
+  {
+    headlineHighlight: false,
+    badge: null,
+    badgeTone: 'current',
+    rows: () => [],
+    actions: () => [],
+    runningActionIds: () => new Set<string>()
+  }
 )
+
+const emit = defineEmits<{ action: [action: ActionDef] }>()
+
+function isRunning(id: string): boolean {
+  return props.runningActionIds.has(id)
+}
 </script>
 
 <template>
@@ -34,7 +52,7 @@ withDefaults(
       <span v-if="badge" class="version-stat-badge" :class="badgeTone">{{ badge }}</span>
     </div>
 
-    <dl v-if="rows.length > 0" class="version-stat-rows">
+    <dl v-if="rows.length > 0 || actions.length > 0" class="version-stat-rows">
       <div
         v-for="row in rows"
         :key="row.id"
@@ -43,6 +61,22 @@ withDefaults(
       >
         <dt>{{ row.label }}</dt>
         <dd :title="row.title">{{ row.value }}</dd>
+      </div>
+
+      <div v-if="actions.length > 0" class="version-stat-actions">
+        <button
+          v-for="action in actions"
+          :key="action.id"
+          type="button"
+          class="version-stat-action"
+          :class="[action.style, { 'is-running': isRunning(action.id) }]"
+          :title="action.enabled === false ? action.disabledMessage : action.tooltip"
+          :disabled="action.enabled === false || isRunning(action.id)"
+          @click="emit('action', action)"
+        >
+          <Loader2 v-if="isRunning(action.id)" :size="14" class="version-stat-action-spinner" />
+          {{ action.label }}
+        </button>
       </div>
     </dl>
   </div>
@@ -134,5 +168,77 @@ withDefaults(
 .version-stat-row.is-highlight dd {
   color: var(--accent);
   font-weight: 500;
+}
+
+/* Inside the table's bottom edge, sharing the row divider so the buttons read
+ * as the table's own footer rather than a detached block. */
+.version-stat-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 0;
+  border-top: 1px solid var(--border-hover);
+}
+
+.version-stat-rows > .version-stat-actions:first-child {
+  border-top: none;
+}
+
+.version-stat-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  flex: 0 0 auto;
+  height: 30px;
+  padding: 0 14px;
+  border-radius: 8px;
+  border: 1px solid var(--chooser-surface-border);
+  background: var(--brand-surface-bg);
+  color: var(--neutral-100);
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+  cursor: pointer;
+  box-sizing: border-box;
+  transition:
+    background-color 100ms ease,
+    filter 100ms ease;
+}
+
+.version-stat-action:hover:not(:disabled),
+.version-stat-action:focus-visible:not(:disabled) {
+  background: var(--brand-surface-bg-hover);
+  outline: none;
+}
+
+.version-stat-action.primary {
+  border-color: var(--accent);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.version-stat-action:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.version-stat-action.is-running {
+  cursor: progress;
+  opacity: 0.85;
+}
+
+.version-stat-action-spinner {
+  flex: 0 0 auto;
+  animation: version-stat-action-spin 0.9s linear infinite;
+}
+
+@keyframes version-stat-action-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 </style>

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -1661,7 +1661,10 @@ export const REQUIRES_STOPPED = new Set([
   'migrate-to-standalone',
   'snapshot-restore',
   'update-comfyui',
-  'migrate-from'
+  'migrate-from',
+  // Re-installs the distribution's environment in place — the venv can't be
+  // rewritten under a running process.
+  'update-distribution'
 ])
 
 /** Title-popup kind tags — the discriminant for popup config/opts across main,

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -66,6 +66,24 @@ export type ResolvedTheme = Exclude<Theme, 'system'>
  *  `degraded` = show heavy-usage warning; `disabled` = block entry. */
 export type CloudCapacityStatus = 'normal' | 'degraded' | 'disabled'
 
+/** One row of a `version-stats` field's table. */
+export interface VersionStatRow {
+  id: string
+  label: string
+  value: string
+  title?: string
+  highlight?: boolean
+}
+
+/** Payload of a `version-stats` field: the Update tab's version summary. */
+export interface VersionStatsValue {
+  headline: string
+  headlineHighlight?: boolean
+  badge?: string | null
+  badgeTone?: 'current' | 'update'
+  rows: VersionStatRow[]
+}
+
 /** Signed-in user's Comfy Cloud subscription tier, normalized to the
  *  two values the capacity gate cares about. `'unknown'` = signed out
  *  or no fetch has succeeded yet this lifetime; treated as `'free'`
@@ -185,7 +203,14 @@ export interface ComfyArgDef {
 export interface DetailField {
   id: string
   label: string
-  value: string | boolean | number | string[] | Record<string, string> | null
+  value:
+    | string
+    | boolean
+    | number
+    | string[]
+    | Record<string, string>
+    | VersionStatsValue
+    | null
   editable?: boolean
   editType?:
   | 'select'
@@ -194,6 +219,9 @@ export interface DetailField {
   | 'number'
   | 'path'
   | 'channel-cards'
+  /** Read-only version summary: headline + badge over a table of facts. The
+   *  source supplies the wording; the renderer only lays it out. */
+  | 'version-stats'
   | 'args-builder'
   | 'env-vars'
   | 'model-dirs'


### PR DESCRIPTION
> **Stacked on #1323.** Base is `willie/chooser-workspace-shelf`; review that one first. This PR is only the manage view.

A distribution install had two tabs — About and Terminal — by accident rather than by design: `comfybuilder` never implemented `getDetailSections`, so the manage view fell back to almost nothing. This gives it a real one.

## What a distribution gets

**Status** — install method, distribution name, distribution version, ComfyUI version, location. The distribution's own release is labelled as such: a bare `7` sitting in the slot every other install fills with `v0.28.2` reads as a ComfyUI version and isn't one.

**Update** — the same version table a local install shows (`VersionStatPanel`, extracted from `ChannelPicker` so the two are one component rather than two that agree). Installed vs. latest, a badge, and the actions docked inside the table's bottom edge — they act on what the table states, so they belong to it.

**Settings** — launch args, editable. The Jul 24 standup kept the field open rather than second-guessing which flags a given build honours.

## What it deliberately does not get

A tab exists **iff** a section declares it, so leaving one out *is* the gate. Both absences are load-bearing and there are tests asserting they stay absent:

- **Snapshots** — admin/owner only, per the Jul 24 standup.
- **Storage** — each distribution carries its own allowed model list. A *reduced* storage section does the opposite of what it looks like: `StoragePane` reads an absent `useSharedModels` as enabled (`f ? f.value !== false : true`) and renders the global shared-models directory list. Declaring it `false` is no better — `BooleanToggle` ignores `editable` and would hand the user a live switch. Showing a distribution's staged models needs its own pane, not a subset of this one.

## Moving between versions

`update-distribution` re-points the record at the target artifact and re-runs the same `installEnvironment` a first install uses — extracted and shared so the two can't drift on venv handling or model staging.

It targets the **installation**, never the distribution id. Multiple installs of one distribution are allowed, so distribution-keyed lookup picks arbitrarily. It's in `REQUIRES_STOPPED`: the venv can't be rewritten under a running process.

**On failure the record rolls back** to its previous artifact fields. Without that, a failed install leaves the record advertising a version whose environment never landed.

This is done inside `handleAction` rather than through the `install-instance` chain. That chain owns the marker file, the mkdir, the abort registry and the status arc — but all of those exist for a *fresh* install. On an update the directory and the record already exist, so only the status arc is left, and standalone's `update-comfyui` already sets that precedent.

## The venv fix (last commit)

`installArtifact` is built so a failed run never destroys a working environment — temp download, checksum verified before `installPath` is touched, and on extract failure it removes only what that run created. `installEnvironment` threw that away by deleting `venv/` up front.

On a fresh install that costs nothing. On an in-place update it's the difference between a retryable failure and a broken install: the record rolls back to the previous version while the environment that version needs is already gone, so it reports `installed` and cannot launch.

The old venv now moves aside to `venv.previous`, is restored if any phase fails, and is deleted only once the new one is staged. The update path also confirms the venv is present before claiming `installed`, and reports `failed` when it isn't — a record shouldn't advertise an install that can't run. This hardens the pre-existing retry-a-failed-install path too.


https://github.com/user-attachments/assets/aed5bb63-b8b1-4163-880c-a63b8e7175c7



## Review notes

- `installTypeMetaForInstall` now decides the distribution glyph, instead of the chooser tile special-casing it — so an install keeps one identity across tile, picker row and title bar.
- `versionCache` is deliberately in-memory and never persisted: it's catalog data, not install state. Persisting it on the record would go stale silently and follow an install through a duplicate.
- Cold cache omits the latest row rather than showing it empty — "no versions found" is a different claim from "not looked yet".

## Testing

3011 unit tests across 208 files, typecheck (4 tsconfigs) and lint clean. Every test added for the venv/status fixes was verified to **fail** against the previous implementation.

Not exercisable locally without a live builder backend: clicking Update performs a real download. The rollback path, the no-build-for-this-machine refusal, and the not-ready refusal are covered by tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
