### PR TITLE
fix: refresh PyTorch stack catalog on boot even when release cache is fresh

### DIFF
--- a/src/main/lib/release-cache-startup.test.ts
+++ b/src/main/lib/release-cache-startup.test.ts
@@ -14,7 +14,11 @@ vi.mock('../sources/standalone/torchStackCatalog', () => ({
   refreshTorchStackCatalogs: vi.fn(async () => {}),
 }))
 
-import { runStartupReleaseChecks, startPeriodicReleaseChecks } from './release-cache-startup'
+import {
+  runStartupReleaseChecks,
+  startPeriodicReleaseChecks,
+  _resetTorchCatalogFloorForTest,
+} from './release-cache-startup'
 import * as releaseCache from './release-cache'
 import { refreshTorchStackCatalogs } from '../sources/standalone/torchStackCatalog'
 
@@ -37,6 +41,7 @@ beforeEach(() => {
   vi.mocked(releaseCache.get).mockReturnValue(null)
   vi.mocked(releaseCache.getOrFetch).mockResolvedValue(null)
   vi.mocked(refreshTorchStackCatalogs).mockResolvedValue(undefined)
+  _resetTorchCatalogFloorForTest()
 })
 
 describe('runStartupReleaseChecks', () => {
@@ -48,11 +53,35 @@ describe('runStartupReleaseChecks', () => {
     expect(vi.mocked(refreshTorchStackCatalogs)).toHaveBeenCalledWith(installs)
   })
 
-  it('skips the PyTorch refresh when every channel cache is fresh', async () => {
+  it('still refreshes the PyTorch catalog when every channel cache is fresh (first boot after upgrade)', async () => {
+    // The persisted release cache survives Desktop upgrades, so on the first
+    // boot of a new version every channel can be fresh while the torch
+    // catalog was never fetched at all. The catalog refresh must not depend
+    // on release fetch tasks being scheduled.
     vi.mocked(releaseCache.get).mockReturnValue({ checkedAt: Date.now() })
-    await runStartupReleaseChecks([install()])
+    const onRefreshed = vi.fn()
+    await runStartupReleaseChecks([install()], { onRefreshed })
     expect(vi.mocked(releaseCache.getOrFetch)).not.toHaveBeenCalled()
-    expect(vi.mocked(refreshTorchStackCatalogs)).not.toHaveBeenCalled()
+    expect(vi.mocked(refreshTorchStackCatalogs)).toHaveBeenCalledTimes(1)
+    expect(onRefreshed).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips the PyTorch refresh inside the floor window within one app run (dashboard prewarm spam guard)', async () => {
+    vi.mocked(releaseCache.get).mockReturnValue({ checkedAt: Date.now() })
+    let clock = 100_000_000 // beyond the floor relative to the cold-start timestamp of 0
+    const now = () => clock
+    await runStartupReleaseChecks([install()], { now })
+    expect(vi.mocked(refreshTorchStackCatalogs)).toHaveBeenCalledTimes(1)
+
+    // Dashboard refreshes shortly after boot must not refetch the catalog...
+    clock += 5 * 60 * 1000
+    await runStartupReleaseChecks([install()], { now })
+    expect(vi.mocked(refreshTorchStackCatalogs)).toHaveBeenCalledTimes(1)
+
+    // ...but once the floor elapses it refreshes again.
+    clock += 60 * 60 * 1000
+    await runStartupReleaseChecks([install()], { now })
+    expect(vi.mocked(refreshTorchStackCatalogs)).toHaveBeenCalledTimes(2)
   })
 
   it('does not run at all without ComfyUI installs', async () => {

--- a/src/main/lib/release-cache-startup.test.ts
+++ b/src/main/lib/release-cache-startup.test.ts
@@ -54,10 +54,8 @@ describe('runStartupReleaseChecks', () => {
   })
 
   it('still refreshes the PyTorch catalog when every channel cache is fresh (first boot after upgrade)', async () => {
-    // The persisted release cache survives Desktop upgrades, so on the first
-    // boot of a new version every channel can be fresh while the torch
-    // catalog was never fetched at all. The catalog refresh must not depend
-    // on release fetch tasks being scheduled.
+    // Catalog freshness is independent of the release cache: the refresh
+    // must run even when no release fetch tasks are scheduled.
     vi.mocked(releaseCache.get).mockReturnValue({ checkedAt: Date.now() })
     const onRefreshed = vi.fn()
     await runStartupReleaseChecks([install()], { onRefreshed })

--- a/src/main/lib/release-cache-startup.test.ts
+++ b/src/main/lib/release-cache-startup.test.ts
@@ -11,7 +11,7 @@ vi.mock('./comfyui-releases', () => ({
   fetchLatestRelease: vi.fn(async () => null),
 }))
 vi.mock('../sources/standalone/torchStackCatalog', () => ({
-  refreshTorchStackCatalogs: vi.fn(async () => {}),
+  refreshTorchStackCatalogs: vi.fn(async () => true),
 }))
 
 import {
@@ -40,7 +40,7 @@ beforeEach(() => {
   // `clearAllMocks` keeps implementations, so pin the defaults each test relies on.
   vi.mocked(releaseCache.get).mockReturnValue(null)
   vi.mocked(releaseCache.getOrFetch).mockResolvedValue(null)
-  vi.mocked(refreshTorchStackCatalogs).mockResolvedValue(undefined)
+  vi.mocked(refreshTorchStackCatalogs).mockResolvedValue(true)
   _resetTorchCatalogFloorForTest()
 })
 
@@ -80,6 +80,41 @@ describe('runStartupReleaseChecks', () => {
     clock += 60 * 60 * 1000
     await runStartupReleaseChecks([install()], { now })
     expect(vi.mocked(refreshTorchStackCatalogs)).toHaveBeenCalledTimes(2)
+  })
+
+  it('retries a failed catalog refresh on the next check instead of waiting out the floor', async () => {
+    vi.mocked(releaseCache.get).mockReturnValue({ checkedAt: Date.now() })
+    let clock = 100_000_000
+    const now = () => clock
+
+    // Failure must not advance the floor...
+    vi.mocked(refreshTorchStackCatalogs).mockResolvedValueOnce(false)
+    await runStartupReleaseChecks([install()], { now })
+    expect(vi.mocked(refreshTorchStackCatalogs)).toHaveBeenCalledTimes(1)
+
+    // ...so the next check retries immediately and succeeds...
+    clock += 1000
+    await runStartupReleaseChecks([install()], { now })
+    expect(vi.mocked(refreshTorchStackCatalogs)).toHaveBeenCalledTimes(2)
+
+    // ...after which the floor applies again.
+    clock += 1000
+    await runStartupReleaseChecks([install()], { now })
+    expect(vi.mocked(refreshTorchStackCatalogs)).toHaveBeenCalledTimes(2)
+  })
+
+  it('joins an in-flight catalog refresh instead of refetching concurrently', async () => {
+    vi.mocked(releaseCache.get).mockReturnValue({ checkedAt: Date.now() })
+    let resolveRefresh!: (ok: boolean) => void
+    vi.mocked(refreshTorchStackCatalogs).mockImplementationOnce(
+      () => new Promise((resolve) => (resolveRefresh = resolve)),
+    )
+
+    const first = runStartupReleaseChecks([install()])
+    const second = runStartupReleaseChecks([install()])
+    resolveRefresh(true)
+    await Promise.all([first, second])
+    expect(vi.mocked(refreshTorchStackCatalogs)).toHaveBeenCalledTimes(1)
   })
 
   it('does not run at all without ComfyUI installs', async () => {

--- a/src/main/lib/release-cache-startup.ts
+++ b/src/main/lib/release-cache-startup.ts
@@ -14,14 +14,32 @@ const COMFYUI_REPO = 'Comfy-Org/ComfyUI'
 /** Source IDs that read from the shared ComfyUI release cache. */
 const COMFYUI_SOURCE_IDS = new Set(['standalone', 'portable'])
 
-/** Last time these checks refreshed the torch stack catalog. In-memory on
- *  purpose: catalog freshness is independent of the persisted release cache,
- *  and every app start must refresh the catalog at least once. */
+/** Last successful torch-stack-catalog refresh. In-memory on purpose:
+ *  catalog freshness is independent of the persisted release cache, and
+ *  every app start must refresh the catalog at least once. */
 let _torchCatalogCheckedAt = 0
+/** In-flight catalog refresh; concurrent checks join it instead of refetching. */
+let _torchCatalogRefresh: Promise<void> | null = null
 
 /** Test-only: reset the in-memory torch-catalog floor to cold start. */
 export function _resetTorchCatalogFloorForTest(): void {
   _torchCatalogCheckedAt = 0
+  _torchCatalogRefresh = null
+}
+
+/** Refresh the torch stack catalog, deduplicating concurrent calls. The
+ *  floor advances only on full success so a failed fetch retries on the
+ *  next check instead of being suppressed for the floor window. */
+function _refreshTorchCatalog(installations: InstallationRecord[], now: () => number): Promise<void> {
+  _torchCatalogRefresh ??= refreshTorchStackCatalogs(installations)
+    .then((ok) => {
+      if (ok) _torchCatalogCheckedAt = now()
+    })
+    .catch(() => undefined)
+    .finally(() => {
+      _torchCatalogRefresh = null
+    })
+  return _torchCatalogRefresh
 }
 
 function _isComfyUIInstall(inst: InstallationRecord): boolean {
@@ -84,8 +102,7 @@ export async function runStartupReleaseChecks(
   // independent of the persisted release cache, so the refresh must not
   // depend on release fetch tasks being scheduled.
   if (options.bypassFloor || now() - _torchCatalogCheckedAt >= STARTUP_RECHECK_MS) {
-    _torchCatalogCheckedAt = now()
-    tasks.push(refreshTorchStackCatalogs(installations).catch(() => null))
+    tasks.push(_refreshTorchCatalog(installations, now))
   }
 
   if (tasks.length === 0) return

--- a/src/main/lib/release-cache-startup.ts
+++ b/src/main/lib/release-cache-startup.ts
@@ -14,6 +14,18 @@ const COMFYUI_REPO = 'Comfy-Org/ComfyUI'
 /** Source IDs that read from the shared ComfyUI release cache. */
 const COMFYUI_SOURCE_IDS = new Set(['standalone', 'portable'])
 
+/** Last time these checks refreshed the torch stack catalog. In-memory on
+ *  purpose: the ComfyUI release cache persists across app restarts, so on the
+ *  first boot of a new Desktop version every channel can already be fresh -
+ *  the torch catalog must still refresh once per app start or the PyTorch
+ *  picker looks empty/absent until a manual "Check for Update". */
+let _torchCatalogCheckedAt = 0
+
+/** Test-only: reset the in-memory torch-catalog floor to cold start. */
+export function _resetTorchCatalogFloorForTest(): void {
+  _torchCatalogCheckedAt = 0
+}
+
 function _isComfyUIInstall(inst: InstallationRecord): boolean {
   if (inst.status !== 'installed') return false
   const sourceId = (inst as unknown as { sourceId?: string }).sourceId
@@ -67,13 +79,19 @@ export async function runStartupReleaseChecks(
       ).catch(() => null),
     )
   }
-  if (tasks.length === 0) return
-
   // Refresh the switchable-PyTorch-stack catalog alongside the release fetch
   // so the Update tab's PyTorch picker stays current without a manual
   // "Check for Update". Best-effort: a catalog failure never blocks the
-  // release check.
-  tasks.push(refreshTorchStackCatalogs(installations).catch(() => null))
+  // release check. The catalog has its own floor, independent of the
+  // release-cache floor above: catalog freshness is unrelated to the
+  // persisted release cache, which can be fresh on a boot where the catalog
+  // was never fetched at all (e.g. first run after a Desktop upgrade).
+  if (options.bypassFloor || now() - _torchCatalogCheckedAt >= STARTUP_RECHECK_MS) {
+    _torchCatalogCheckedAt = now()
+    tasks.push(refreshTorchStackCatalogs(installations).catch(() => null))
+  }
+
+  if (tasks.length === 0) return
 
   await Promise.allSettled(tasks)
   options.onRefreshed?.()

--- a/src/main/lib/release-cache-startup.ts
+++ b/src/main/lib/release-cache-startup.ts
@@ -15,10 +15,8 @@ const COMFYUI_REPO = 'Comfy-Org/ComfyUI'
 const COMFYUI_SOURCE_IDS = new Set(['standalone', 'portable'])
 
 /** Last time these checks refreshed the torch stack catalog. In-memory on
- *  purpose: the ComfyUI release cache persists across app restarts, so on the
- *  first boot of a new Desktop version every channel can already be fresh -
- *  the torch catalog must still refresh once per app start or the PyTorch
- *  picker looks empty/absent until a manual "Check for Update". */
+ *  purpose: catalog freshness is independent of the persisted release cache,
+ *  and every app start must refresh the catalog at least once. */
 let _torchCatalogCheckedAt = 0
 
 /** Test-only: reset the in-memory torch-catalog floor to cold start. */
@@ -82,10 +80,9 @@ export async function runStartupReleaseChecks(
   // Refresh the switchable-PyTorch-stack catalog alongside the release fetch
   // so the Update tab's PyTorch picker stays current without a manual
   // "Check for Update". Best-effort: a catalog failure never blocks the
-  // release check. The catalog has its own floor, independent of the
-  // release-cache floor above: catalog freshness is unrelated to the
-  // persisted release cache, which can be fresh on a boot where the catalog
-  // was never fetched at all (e.g. first run after a Desktop upgrade).
+  // release check. The catalog has its own floor: its freshness is
+  // independent of the persisted release cache, so the refresh must not
+  // depend on release fetch tasks being scheduled.
   if (options.bypassFloor || now() - _torchCatalogCheckedAt >= STARTUP_RECHECK_MS) {
     _torchCatalogCheckedAt = now()
     tasks.push(refreshTorchStackCatalogs(installations).catch(() => null))

--- a/src/main/sources/standalone/torchStackCatalog.test.ts
+++ b/src/main/sources/standalone/torchStackCatalog.test.ts
@@ -281,8 +281,12 @@ describe('refreshTorchStackCatalogs', () => {
     expect(vi.mocked(fetchR2VendorReleases)).not.toHaveBeenCalled()
   })
 
-  it('never throws when a variant refresh fails', async () => {
+  it('never throws when a variant refresh fails, and reports the failure', async () => {
     vi.mocked(fetchR2VendorReleases).mockRejectedValueOnce(new Error('offline'))
-    await expect(refreshTorchStackCatalogs([install('3.13.2')])).resolves.toBeUndefined()
+    await expect(refreshTorchStackCatalogs([install('3.13.2')])).resolves.toBe(false)
+  })
+
+  it('resolves true when every variant refresh succeeds', async () => {
+    await expect(refreshTorchStackCatalogs([install('3.13.2')])).resolves.toBe(true)
   })
 })

--- a/src/main/sources/standalone/torchStackCatalog.ts
+++ b/src/main/sources/standalone/torchStackCatalog.ts
@@ -250,9 +250,10 @@ export async function refreshTorchStackCatalog(installation: InstallationRecord)
 
 /** Refresh the catalog for every unique variant among installed standalone
  *  installs. One refresh per variant suffices: the cache is keyed by variant,
- *  so every install sharing it reads the refreshed data. Best-effort; never
- *  throws. */
-export async function refreshTorchStackCatalogs(installations: InstallationRecord[]): Promise<void> {
+ *  so every install sharing it reads the refreshed data. Never throws;
+ *  resolves `true` only when every variant refresh succeeded, so callers can
+ *  treat a partial or total failure as "still stale". */
+export async function refreshTorchStackCatalogs(installations: InstallationRecord[]): Promise<boolean> {
   const byVariant = new Map<string, InstallationRecord>()
   for (const inst of installations) {
     if (inst.status !== 'installed' || inst.sourceId !== 'standalone') continue
@@ -260,7 +261,8 @@ export async function refreshTorchStackCatalogs(installations: InstallationRecor
     if (!variant || byVariant.has(variant)) continue
     byVariant.set(variant, inst)
   }
-  await Promise.allSettled([...byVariant.values()].map((inst) => refreshTorchStackCatalog(inst)))
+  const results = await Promise.allSettled([...byVariant.values()].map((inst) => refreshTorchStackCatalog(inst)))
+  return results.every((r) => r.status === 'fulfilled')
 }
 
 /** Synchronous cached read for `getDetailSections`. Bundle entries are empty


### PR DESCRIPTION
Fixes #1334.

On the first run of a new Desktop version, the PyTorch stack catalog was often never fetched, making the stack-switching feature look absent until a manual `Check for Update` or the 15-minute periodic poll.

**Root cause**: `runStartupReleaseChecks` only pushed `refreshTorchStackCatalogs` after the `if (tasks.length === 0) return` guard. The persisted ComfyUI release cache survives restarts and upgrades, so right after upgrading Desktop every channel is typically fresh (inside the 1h floor), no release fetch tasks get scheduled, and the early return silently skips the catalog fetch too - even though the catalog cache may not exist at all on the first version shipping the feature.

**Fix**: the catalog refresh gets its own freshness floor, tracked in memory so every app start refreshes it at least once, independent of the release-cache floor. Dashboard prewarm calls inside the window still skip it (same 1h floor), and the periodic poll keeps bypassing it as before.

Tests: inverted the test that pinned the buggy behavior (fresh channel cache now still refreshes the catalog and fires `onRefreshed`), and added a spam-guard test proving repeated prewarm calls within the floor window don't refetch while a call after the floor does.