### PR TITLE
feat(chooser): surface the cloud free-runs pill on the dashboard

### DIFF
--- a/src/renderer/src/views/ChooserView.test.ts
+++ b/src/renderer/src/views/ChooserView.test.ts
@@ -472,18 +472,24 @@ describe('ChooserView', () => {
     expect((wrapper.vm as unknown as { activeFilter: FilterKey }).activeFilter).toBe('all')
   })
 
-  it('shows the free-runs pill on the New Install tile when the flag is on', async () => {
-    const api = installMockApi([])
+  it('shows the free-runs pill on cloud install tiles when the flag is on', async () => {
+    const cloudInst = makeInstall({ id: 'cloud-1', name: 'Comfy Cloud', sourceCategory: 'cloud' })
+    const api = installMockApi([cloudInst])
     ;(api as unknown as { getCloudFreeRunsEnabled: unknown }).getCloudFreeRunsEnabled = vi
       .fn()
       .mockResolvedValue(true)
     const wrapper = mountChooser()
     await flushPromises()
     expect(wrapper.find('[data-testid="chooser-cloud-runs-pill"]').exists()).toBe(true)
+    // Never on the New Install tile.
+    expect(wrapper.find('.chooser-tile-new [data-testid="chooser-cloud-runs-pill"]').exists()).toBe(
+      false
+    )
   })
 
-  it('hides the free-runs pill when the flag is unavailable', async () => {
-    installMockApi([])
+  it('keeps local tiles and the flag-off state pill-free', async () => {
+    const localInst = makeInstall({ id: 'local-1', sourceCategory: 'local' })
+    installMockApi([localInst])
     const wrapper = mountChooser()
     await flushPromises()
     expect(wrapper.find('[data-testid="chooser-cloud-runs-pill"]').exists()).toBe(false)

--- a/src/renderer/src/views/ChooserView.test.ts
+++ b/src/renderer/src/views/ChooserView.test.ts
@@ -481,7 +481,6 @@ describe('ChooserView', () => {
     const wrapper = mountChooser()
     await flushPromises()
     expect(wrapper.find('[data-testid="chooser-cloud-runs-pill"]').exists()).toBe(true)
-    // Never on the New Install tile.
     expect(wrapper.find('.chooser-tile-new [data-testid="chooser-cloud-runs-pill"]').exists()).toBe(
       false
     )

--- a/src/renderer/src/views/ChooserView.test.ts
+++ b/src/renderer/src/views/ChooserView.test.ts
@@ -471,4 +471,21 @@ describe('ChooserView', () => {
     // Confirms activeFilter is reachable from vm for the other filter tests.
     expect((wrapper.vm as unknown as { activeFilter: FilterKey }).activeFilter).toBe('all')
   })
+
+  it('shows the free-runs pill on the New Install tile when the flag is on', async () => {
+    const api = installMockApi([])
+    ;(api as unknown as { getCloudFreeRunsEnabled: unknown }).getCloudFreeRunsEnabled = vi
+      .fn()
+      .mockResolvedValue(true)
+    const wrapper = mountChooser()
+    await flushPromises()
+    expect(wrapper.find('[data-testid="chooser-cloud-runs-pill"]').exists()).toBe(true)
+  })
+
+  it('hides the free-runs pill when the flag is unavailable', async () => {
+    installMockApi([])
+    const wrapper = mountChooser()
+    await flushPromises()
+    expect(wrapper.find('[data-testid="chooser-cloud-runs-pill"]').exists()).toBe(false)
+  })
 })

--- a/src/renderer/src/views/ChooserView.vue
+++ b/src/renderer/src/views/ChooserView.vue
@@ -225,8 +225,6 @@ function viewDanger(inst: Installation): void {
 // surfaces a "Heavy usage" meta pill but the click still proceeds.
 const cloudCapacity = useCloudCapacity()
 
-/** Mirrors FirstUseTakeover's fail-closed default so the pill never
- *  flashes in and back out while the boot fetch is in flight. */
 const cloudFreeRunsEnabled = ref(false)
 const showCloudFreeRunsPill = computed(
   () => cloudFreeRunsEnabled.value && !cloudCapacity.isDisabled() && !cloudCapacity.isPaid()
@@ -235,7 +233,7 @@ onMounted(async () => {
   try {
     cloudFreeRunsEnabled.value = await window.api.getCloudFreeRunsEnabled()
   } catch {
-    // fail-closed: pill stays hidden
+   
   }
 })
 function handleNewInstallClick(): void {

--- a/src/renderer/src/views/ChooserView.vue
+++ b/src/renderer/src/views/ChooserView.vue
@@ -228,6 +228,9 @@ const cloudCapacity = useCloudCapacity()
 /** Mirrors FirstUseTakeover's fail-closed default so the pill never
  *  flashes in and back out while the boot fetch is in flight. */
 const cloudFreeRunsEnabled = ref(false)
+const showCloudFreeRunsPill = computed(
+  () => cloudFreeRunsEnabled.value && !cloudCapacity.isDisabled() && !cloudCapacity.isPaid()
+)
 onMounted(async () => {
   try {
     cloudFreeRunsEnabled.value = await window.api.getCloudFreeRunsEnabled()
@@ -279,15 +282,7 @@ function handleNewInstallClick(): void {
           @click="handleNewInstallClick"
         >
           <div class="chooser-tile-icon"><Plus :size="32" /></div>
-          <div class="chooser-tile-name">
-            {{ t('chooser.newInstall') }}
-            <span
-              v-if="cloudFreeRunsEnabled && !cloudCapacity.isDisabled() && !cloudCapacity.isPaid()"
-              class="chooser-cloud-runs-pill"
-              data-testid="chooser-cloud-runs-pill"
-              >{{ t('firstUse.cloudFreeRunsPill') }}</span
-            >
-          </div>
+          <div class="chooser-tile-name">{{ t('chooser.newInstall') }}</div>
           <div class="chooser-tile-meta">{{ t('chooser.newInstallDesc') }}</div>
         </button>
 
@@ -295,6 +290,7 @@ function handleNewInstallClick(): void {
           v-for="inst in visibleInstalls"
           :key="inst.id"
           :installation="inst"
+          :show-free-runs-pill="showCloudFreeRunsPill && inst.sourceCategory === 'cloud'"
           :is-stopped-action-gated="isStoppedActionGated(inst)"
           :last-launched-label="lastLaunchedLabel(inst)"
           @pick="pickInstall"
@@ -321,22 +317,6 @@ function handleNewInstallClick(): void {
 <style scoped>
 @import './chooser/chooser-tiles.css';
 
-/* Same treatment as FirstUseTakeover's start-cloud-runs-pill. */
-.chooser-cloud-runs-pill {
-  display: inline-flex;
-  align-items: center;
-  margin-left: 8px;
-  padding: 3px 8px;
-  border-radius: 999px;
-  background: var(--comfy-yellow);
-  color: var(--neutral-900);
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.02em;
-  line-height: normal;
-  text-transform: uppercase;
-  white-space: nowrap;
-}
 
 .chooser-bg :deep(.brand-inner-frame) {
   /* Inherit the default justify-content: center from BrandBackground;

--- a/src/renderer/src/views/ChooserView.vue
+++ b/src/renderer/src/views/ChooserView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, toRef } from 'vue'
+import { computed, onMounted, ref, toRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useInstallationStore } from '../stores/installationStore'
 import { useSessionStore } from '../stores/sessionStore'
@@ -224,6 +224,17 @@ function viewDanger(inst: Installation): void {
 // users can't enter cloud during an outage. When `degraded`, the tile
 // surfaces a "Heavy usage" meta pill but the click still proceeds.
 const cloudCapacity = useCloudCapacity()
+
+/** Mirrors FirstUseTakeover's fail-closed default so the pill never
+ *  flashes in and back out while the boot fetch is in flight. */
+const cloudFreeRunsEnabled = ref(false)
+onMounted(async () => {
+  try {
+    cloudFreeRunsEnabled.value = await window.api.getCloudFreeRunsEnabled()
+  } catch {
+    // fail-closed: pill stays hidden
+  }
+})
 function handleNewInstallClick(): void {
   emit('show-new-install')
 }
@@ -268,7 +279,15 @@ function handleNewInstallClick(): void {
           @click="handleNewInstallClick"
         >
           <div class="chooser-tile-icon"><Plus :size="32" /></div>
-          <div class="chooser-tile-name">{{ t('chooser.newInstall') }}</div>
+          <div class="chooser-tile-name">
+            {{ t('chooser.newInstall') }}
+            <span
+              v-if="cloudFreeRunsEnabled && !cloudCapacity.isDisabled() && !cloudCapacity.isPaid()"
+              class="chooser-cloud-runs-pill"
+              data-testid="chooser-cloud-runs-pill"
+              >{{ t('firstUse.cloudFreeRunsPill') }}</span
+            >
+          </div>
           <div class="chooser-tile-meta">{{ t('chooser.newInstallDesc') }}</div>
         </button>
 
@@ -301,6 +320,23 @@ function handleNewInstallClick(): void {
 
 <style scoped>
 @import './chooser/chooser-tiles.css';
+
+/* Same treatment as FirstUseTakeover's start-cloud-runs-pill. */
+.chooser-cloud-runs-pill {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 8px;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: var(--comfy-yellow);
+  color: var(--neutral-900);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  line-height: normal;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
 
 .chooser-bg :deep(.brand-inner-frame) {
   /* Inherit the default justify-content: center from BrandBackground;

--- a/src/renderer/src/views/chooser/ChooserInstallTile.vue
+++ b/src/renderer/src/views/chooser/ChooserInstallTile.vue
@@ -152,6 +152,12 @@ function triggerInstallAction(action: 'update' | 'migrate'): void {
 
     <!-- Lifecycle indicator + kebab. Status pill is click-through; error badge opens details. -->
     <div class="chooser-tile-actions">
+      <span
+        v-if="props.showFreeRunsPill && !hasError && !statusPill && !dangerTag"
+        class="chooser-cloud-runs-pill"
+        data-testid="chooser-cloud-runs-pill"
+        >{{ $t('firstUse.cloudFreeRunsPill') }}</span
+      >
       <button
         v-if="hasError"
         type="button"
@@ -201,15 +207,7 @@ function triggerInstallAction(action: 'update' | 'migrate'): void {
 
     <!-- Stacked tiers (name → meta → recency); each truncates on its own row. -->
     <div class="chooser-tile-body">
-      <div class="chooser-tile-name-row">
-        <TruncatedText class="chooser-tile-name" :text="inst.name" />
-        <span
-          v-if="props.showFreeRunsPill"
-          class="chooser-cloud-runs-pill"
-          data-testid="chooser-cloud-runs-pill"
-          >{{ $t('firstUse.cloudFreeRunsPill') }}</span
-        >
-      </div>
+      <TruncatedText class="chooser-tile-name" :text="inst.name" />
       <TruncatedText v-if="metaLine" class="chooser-tile-meta-line" :text="metaLine">
         <span v-if="sourceLabel" class="chooser-tile-meta-source">{{ sourceLabel }}</span>
         <span v-if="sourceLabel && inst.version" class="chooser-tile-meta-sep">·</span>
@@ -246,13 +244,6 @@ function triggerInstallAction(action: 'update' | 'migrate'): void {
 
 <style scoped>
 @import './chooser-tiles.css';
-
-.chooser-tile-name-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  min-width: 0;
-}
 
 /* Same treatment as FirstUseTakeover's start-cloud-runs-pill. */
 .chooser-cloud-runs-pill {

--- a/src/renderer/src/views/chooser/ChooserInstallTile.vue
+++ b/src/renderer/src/views/chooser/ChooserInstallTile.vue
@@ -11,7 +11,6 @@ import type { Installation } from '../../types/ipc'
 
 interface Props {
   installation: Installation
-  /** Cloud free-runs pill (resolved by the parent; presentational here). */
   showFreeRunsPill?: boolean
   /** True when REQUIRES_STOPPED actions (update / migrate / restore / delete) are gated. */
   isStoppedActionGated: boolean
@@ -245,7 +244,6 @@ function triggerInstallAction(action: 'update' | 'migrate'): void {
 <style scoped>
 @import './chooser-tiles.css';
 
-/* Same treatment as FirstUseTakeover's start-cloud-runs-pill. */
 .chooser-cloud-runs-pill {
   display: inline-flex;
   align-items: center;

--- a/src/renderer/src/views/chooser/ChooserInstallTile.vue
+++ b/src/renderer/src/views/chooser/ChooserInstallTile.vue
@@ -11,6 +11,8 @@ import type { Installation } from '../../types/ipc'
 
 interface Props {
   installation: Installation
+  /** Cloud free-runs pill (resolved by the parent; presentational here). */
+  showFreeRunsPill?: boolean
   /** True when REQUIRES_STOPPED actions (update / migrate / restore / delete) are gated. */
   isStoppedActionGated: boolean
   /** Pre-formatted recency label — "Launched 3h ago" / "Not launched yet". */
@@ -199,7 +201,15 @@ function triggerInstallAction(action: 'update' | 'migrate'): void {
 
     <!-- Stacked tiers (name → meta → recency); each truncates on its own row. -->
     <div class="chooser-tile-body">
-      <TruncatedText class="chooser-tile-name" :text="inst.name" />
+      <div class="chooser-tile-name-row">
+        <TruncatedText class="chooser-tile-name" :text="inst.name" />
+        <span
+          v-if="props.showFreeRunsPill"
+          class="chooser-cloud-runs-pill"
+          data-testid="chooser-cloud-runs-pill"
+          >{{ $t('firstUse.cloudFreeRunsPill') }}</span
+        >
+      </div>
       <TruncatedText v-if="metaLine" class="chooser-tile-meta-line" :text="metaLine">
         <span v-if="sourceLabel" class="chooser-tile-meta-source">{{ sourceLabel }}</span>
         <span v-if="sourceLabel && inst.version" class="chooser-tile-meta-sep">·</span>
@@ -236,4 +246,28 @@ function triggerInstallAction(action: 'update' | 'migrate'): void {
 
 <style scoped>
 @import './chooser-tiles.css';
+
+.chooser-tile-name-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+/* Same treatment as FirstUseTakeover's start-cloud-runs-pill. */
+.chooser-cloud-runs-pill {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: var(--comfy-yellow);
+  color: var(--neutral-900);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  line-height: normal;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
 </style>


### PR DESCRIPTION
## Summary
The `5 FREE RUNS` cloud pill exists only on the first-use takeover, so anyone already past install never learns the free tier exists. This adds the same pill to the dashboard's New Install tile:

- Same flag (`window.api.getCloudFreeRunsEnabled`), same fail-closed default (no flash while the boot fetch is in flight), same capacity kill-switch gate
- One deliberate difference from first-use: gated on `!isPaid()` instead of `tier === 'unknown'` — the dashboard audience includes signed-in free-tier users, who should still see it; paying users never do
- Pill styling mirrors `start-cloud-runs-pill`; reuses the existing `firstUse.cloudFreeRunsPill` string (no new locale keys)

## Screenshot
<img width="1272" height="889" alt="image" src="https://github.com/user-attachments/assets/c892e3a2-849e-42ad-b520-cde454fa134e" />

## Testing
2 new ChooserView tests (pill shown with flag on, hidden when the flag is unavailable); all 21 pass; `typecheck:web` clean.