### PR TITLE
feat(chooser): read the version delta off an updatable tile

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1161,6 +1161,7 @@
     "distribution": {
       "menuInstall": "Install",
       "distVersion": "Dist v{version}",
+      "distVersionNext": "v{version}",
       "notInstalled": "Not installed",
       "emptyTitle": "No distributions published to this workspace yet.",
       "loadError": "Couldn't load distributions. Retry",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -1161,6 +1161,7 @@
     "distribution": {
       "menuInstall": "安装",
       "distVersion": "分发版 v{version}",
+      "distVersionNext": "v{version}",
       "notInstalled": "未安装",
       "emptyTitle": "此工作区尚未发布任何分发版本。",
       "loadError": "无法加载分发版本，请重试",

--- a/src/renderer/src/devplatform/distributionState.test.ts
+++ b/src/renderer/src/devplatform/distributionState.test.ts
@@ -53,6 +53,25 @@ describe('distributionUpdateVersion', () => {
     expect(distributionUpdateVersion(makeInstall({}), [makeDist()])).toBe('')
   })
 
+  // `Number(' ')` is 0, so a blank-but-not-empty version would otherwise read
+  // as behind every published version.
+  it('treats a whitespace-only version as unknown on either side', () => {
+    expect(distributionUpdateVersion(makeInstall({ distributionVersion: '  ' }), [makeDist()])).toBe(
+      ''
+    )
+    expect(
+      distributionUpdateVersion(makeInstall({ distributionVersion: '7' }), [makeDist({ version: ' ' })])
+    ).toBe('')
+  })
+
+  it('rejects versions that are numeric but not plain integers', () => {
+    for (const version of ['-1', '1e3', '1.5', ' 7 ']) {
+      expect(
+        distributionUpdateVersion(makeInstall({ distributionVersion: version }), [makeDist()])
+      ).toBe('')
+    }
+  })
+
   it('claims nothing when either side is not an integer version', () => {
     expect(
       distributionUpdateVersion(makeInstall({ distributionVersion: 'beta' }), [makeDist()])

--- a/src/renderer/src/devplatform/distributionState.test.ts
+++ b/src/renderer/src/devplatform/distributionState.test.ts
@@ -32,12 +32,12 @@ describe('distributionUpdateVersion', () => {
     ).toBe('')
   })
 
-  // The row's state is computed against the HIGHEST installed version, so a
-  // second install stuck at v5 sits under an `installable` row and must still
-  // learn it is behind.
+  // The row's state is computed against the HIGHEST installed version, so it
+  // answers a different question: an `update-available` row says SOME install of
+  // this distribution is behind, not that this one is.
   it('compares per-install, not against the row state', () => {
-    const rows = [makeDist({ state: 'installable', version: '9' })]
-    expect(distributionUpdateVersion(makeInstall({ distributionVersion: '5' }), rows)).toBe('9')
+    const rows = [makeDist({ state: 'update-available', version: '9' })]
+    expect(distributionUpdateVersion(makeInstall({ distributionVersion: '9' }), rows)).toBe('')
   })
 
   it('never points at a build this machine cannot run', () => {
@@ -83,10 +83,10 @@ describe('distributionUpdateVersion', () => {
     ).toBe('')
   })
 
-  it('ignores an install that did not come from a distribution', () => {
+  it('ignores an install with no linked distribution id', () => {
     expect(
       distributionUpdateVersion(
-        makeInstall({ sourceId: 'standalone', distributionId: undefined, distributionVersion: '7' }),
+        makeInstall({ sourceId: 'comfybuilder', distributionId: undefined, distributionVersion: '7' }),
         [makeDist()]
       )
     ).toBe('')

--- a/src/renderer/src/devplatform/distributionState.test.ts
+++ b/src/renderer/src/devplatform/distributionState.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+
+import { distributionUpdateVersion } from './distributionState'
+import type { Distribution } from './types'
+import type { Installation } from '../types/ipc'
+
+function makeInstall(overrides: Record<string, unknown>): Installation {
+  return {
+    id: 'i1',
+    name: 'Built',
+    sourceId: 'comfybuilder',
+    sourceLabel: 'Comfy Builder',
+    sourceCategory: 'local',
+    distributionId: 'd1',
+    ...overrides,
+  } as unknown as Installation
+}
+
+function makeDist(overrides: Partial<Distribution> = {}): Distribution {
+  return { id: 'd1', name: 'Image', state: 'installable', version: '9', ...overrides }
+}
+
+describe('distributionUpdateVersion', () => {
+  it('names the newer catalog version for an install left behind', () => {
+    const target = distributionUpdateVersion(makeInstall({ distributionVersion: '7' }), [makeDist()])
+    expect(target).toBe('9')
+  })
+
+  it('says nothing when the install is already on the catalog version', () => {
+    expect(
+      distributionUpdateVersion(makeInstall({ distributionVersion: '9' }), [makeDist()])
+    ).toBe('')
+  })
+
+  // The row's state is computed against the HIGHEST installed version, so a
+  // second install stuck at v5 sits under an `installable` row and must still
+  // learn it is behind.
+  it('compares per-install, not against the row state', () => {
+    const rows = [makeDist({ state: 'installable', version: '9' })]
+    expect(distributionUpdateVersion(makeInstall({ distributionVersion: '5' }), rows)).toBe('9')
+  })
+
+  it('never points at a build this machine cannot run', () => {
+    for (const state of ['no-build', 'platform-mismatch'] as const) {
+      expect(
+        distributionUpdateVersion(makeInstall({ distributionVersion: '7' }), [makeDist({ state })])
+      ).toBe('')
+    }
+  })
+
+  it('treats an empty current version as unknown, not as zero', () => {
+    expect(distributionUpdateVersion(makeInstall({ distributionVersion: '' }), [makeDist()])).toBe('')
+    expect(distributionUpdateVersion(makeInstall({}), [makeDist()])).toBe('')
+  })
+
+  it('claims nothing when either side is not an integer version', () => {
+    expect(
+      distributionUpdateVersion(makeInstall({ distributionVersion: 'beta' }), [makeDist()])
+    ).toBe('')
+    expect(
+      distributionUpdateVersion(makeInstall({ distributionVersion: '7' }), [
+        makeDist({ version: 'nightly' }),
+      ])
+    ).toBe('')
+    expect(
+      distributionUpdateVersion(makeInstall({ distributionVersion: '7' }), [
+        makeDist({ version: undefined }),
+      ])
+    ).toBe('')
+  })
+
+  it('claims nothing while the catalog is cold or the install has no linked row', () => {
+    expect(distributionUpdateVersion(makeInstall({ distributionVersion: '7' }), [])).toBe('')
+    expect(
+      distributionUpdateVersion(makeInstall({ distributionVersion: '7', distributionId: '' }), [
+        makeDist(),
+      ])
+    ).toBe('')
+    expect(
+      distributionUpdateVersion(makeInstall({ distributionVersion: '7' }), [
+        makeDist({ id: 'other' }),
+      ])
+    ).toBe('')
+  })
+
+  it('ignores an install that did not come from a distribution', () => {
+    expect(
+      distributionUpdateVersion(
+        makeInstall({ sourceId: 'standalone', distributionId: undefined, distributionVersion: '7' }),
+        [makeDist()]
+      )
+    ).toBe('')
+  })
+})

--- a/src/renderer/src/devplatform/distributionState.ts
+++ b/src/renderer/src/devplatform/distributionState.ts
@@ -35,6 +35,15 @@ export function isBlockedDistribution(dist: Pick<Distribution, 'state'>): boolea
   return BLOCKED_DISTRIBUTION_STATES.includes(dist.state)
 }
 
+/** A version as a number, or null if it isn't one. Digits only: `Number` reads
+ *  '' and ' ' as 0, which would advertise an update over every published
+ *  version, and accepts '-1' and '1e3' as integers. */
+function versionNumber(raw: unknown): number | null {
+  if (typeof raw !== 'string' || !/^\d+$/.test(raw)) return null
+  const num = Number(raw)
+  return Number.isSafeInteger(num) ? num : null
+}
+
 /** The distribution version this install would move to, or '' when there is
  *  nothing to promise. Compares THIS install against its catalog row rather than
  *  reading the row's `state`, which is computed against the highest installed
@@ -47,15 +56,12 @@ export function distributionUpdateVersion(
   // The linked id is the whole identity check: no id, no claim.
   const id = inst.distributionId
   if (typeof id !== 'string' || !id) return ''
-  // `Number('')` is 0, which would read as "behind everything".
-  const current = typeof inst.distributionVersion === 'string' ? inst.distributionVersion : ''
-  if (!current) return ''
-  const currentNum = Number(current)
-  if (!Number.isInteger(currentNum)) return ''
+  const currentNum = versionNumber(inst.distributionVersion)
+  if (currentNum === null) return ''
 
   const row = distributions.find((dist) => dist.id === id)
   if (!row || isBlockedDistribution(row)) return ''
-  const latestNum = Number(row.version)
-  if (!row.version || !Number.isInteger(latestNum)) return ''
+  const latestNum = versionNumber(row.version)
+  if (latestNum === null) return ''
   return latestNum > currentNum ? String(latestNum) : ''
 }

--- a/src/renderer/src/devplatform/distributionState.ts
+++ b/src/renderer/src/devplatform/distributionState.ts
@@ -35,23 +35,16 @@ export function isBlockedDistribution(dist: Pick<Distribution, 'state'>): boolea
   return BLOCKED_DISTRIBUTION_STATES.includes(dist.state)
 }
 
-/**
- * The distribution version this install would move to, or '' when there is
- * nothing to promise.
- *
- * Compares THIS install against its catalog row rather than reading the row's
- * `state`: that state is computed against the highest installed version of the
- * distribution, so a second install left behind at v5 would read `installable`.
- * The blocked gate still applies — never point at a build this machine can't run.
- *
- * Matching is by `distributionId` only. The chooser's name fallback is fine for
- * hiding a duplicate card; claiming a version needs a certain link.
- */
+/** The distribution version this install would move to, or '' when there is
+ *  nothing to promise. Compares THIS install against its catalog row rather than
+ *  reading the row's `state`, which is computed against the highest installed
+ *  version. Matching is by `distributionId` only — the chooser's name fallback
+ *  is fine for hiding a duplicate card, not for claiming a version. */
 export function distributionUpdateVersion(
   inst: Installation,
   distributions: readonly Distribution[]
 ): string {
-  if (!isDistributionInstall(inst)) return ''
+  // The linked id is the whole identity check: no id, no claim.
   const id = inst.distributionId
   if (typeof id !== 'string' || !id) return ''
   // `Number('')` is 0, which would read as "behind everything".

--- a/src/renderer/src/devplatform/distributionState.ts
+++ b/src/renderer/src/devplatform/distributionState.ts
@@ -34,3 +34,35 @@ export const BLOCKED_STATE_KEY: Record<string, string> = {
 export function isBlockedDistribution(dist: Pick<Distribution, 'state'>): boolean {
   return BLOCKED_DISTRIBUTION_STATES.includes(dist.state)
 }
+
+/**
+ * The distribution version this install would move to, or '' when there is
+ * nothing to promise.
+ *
+ * Compares THIS install against its catalog row rather than reading the row's
+ * `state`: that state is computed against the highest installed version of the
+ * distribution, so a second install left behind at v5 would read `installable`.
+ * The blocked gate still applies — never point at a build this machine can't run.
+ *
+ * Matching is by `distributionId` only. The chooser's name fallback is fine for
+ * hiding a duplicate card; claiming a version needs a certain link.
+ */
+export function distributionUpdateVersion(
+  inst: Installation,
+  distributions: readonly Distribution[]
+): string {
+  if (!isDistributionInstall(inst)) return ''
+  const id = inst.distributionId
+  if (typeof id !== 'string' || !id) return ''
+  // `Number('')` is 0, which would read as "behind everything".
+  const current = typeof inst.distributionVersion === 'string' ? inst.distributionVersion : ''
+  if (!current) return ''
+  const currentNum = Number(current)
+  if (!Number.isInteger(currentNum)) return ''
+
+  const row = distributions.find((dist) => dist.id === id)
+  if (!row || isBlockedDistribution(row)) return ''
+  const latestNum = Number(row.version)
+  if (!row.version || !Number.isInteger(latestNum)) return ''
+  return latestNum > currentNum ? String(latestNum) : ''
+}

--- a/src/renderer/src/views/ChooserView.test.ts
+++ b/src/renderer/src/views/ChooserView.test.ts
@@ -65,6 +65,7 @@ const messages = {
       distribution: {
         menuInstall: 'Install',
         distVersion: 'Dist v{version}',
+        distVersionNext: 'v{version}',
         notInstalled: 'Not installed',
         states: {
           noBuild: 'No build',
@@ -418,8 +419,41 @@ describe('ChooserView', () => {
     const pill = tile.find('.chooser-tile-pill-update')
     expect(pill.exists()).toBe(true)
     expect(pill.text().trim()).toBe('Update')
-    // Current version stays visible in the quiet meta line, not on the pill.
-    expect(tile.find('.chooser-tile-meta-line').text()).toContain('v0.22.3')
+    // Both versions read off the tile — no hover needed to learn the target.
+    const meta = tile.find('.chooser-tile-meta-line')
+    expect(meta.text()).toContain('v0.22.3')
+    expect(meta.find('.chooser-tile-meta-target').text()).toBe('v0.24.1')
+    // The one emphasised element moves to the target; the current one recedes.
+    expect(meta.find('.chooser-tile-meta-version--superseded').text()).toBe('v0.22.3')
+  })
+
+  it('leaves the meta row untouched when there is no update to point at', async () => {
+    installMockApi([makeInstall({ id: 'c', name: 'Current', version: 'v0.24.1' })])
+    const wrapper = mountChooser()
+    await flushPromises()
+    const tile = wrapper.findAll('.chooser-tile').find((t) => t.text().includes('Current'))!
+    const meta = tile.find('.chooser-tile-meta-line')
+    expect(meta.find('.chooser-tile-meta-version').text()).toBe('v0.24.1')
+    expect(meta.find('.chooser-tile-meta-target').exists()).toBe(false)
+    expect(meta.find('.chooser-tile-meta-arrow').exists()).toBe(false)
+    expect(meta.find('.chooser-tile-meta-version--superseded').exists()).toBe(false)
+  })
+
+  it('says nothing about a target when the current version is unknown', async () => {
+    installMockApi([
+      makeInstall({
+        id: 'u',
+        name: 'Versionless',
+        statusTag: { style: 'update', label: 'Update v0.24.1', version: 'v0.24.1' },
+      }),
+    ])
+    const wrapper = mountChooser()
+    await flushPromises()
+    const tile = wrapper.findAll('.chooser-tile').find((t) => t.text().includes('Versionless'))!
+    // An arrow with nothing on its left is not a delta — the pill still offers
+    // the action, the facts just don't invent a comparison.
+    expect(tile.find('.chooser-tile-meta-target').exists()).toBe(false)
+    expect(tile.find('.chooser-tile-pill-update').exists()).toBe(true)
   })
 
   it('keeps the action pill present even when the name is very long', async () => {
@@ -592,6 +626,51 @@ describe('ChooserView', () => {
     expect(meta).toContain('Dist v7')
     // The install path is noise on a tile whose identity is the distribution.
     expect(meta).not.toContain('Standalone')
+  })
+
+  it('reads the distribution delta off the tile, under the one label', async () => {
+    installMockApiSignedIn(
+      [
+        makeInstall({
+          id: 'built',
+          name: 'BuiltThing',
+          sourceId: 'comfybuilder',
+          distributionId: 'd1',
+          version: 'v0.28.2',
+          distributionVersion: '7',
+        }),
+      ],
+      [makeDist({ id: 'd1', name: 'BuiltThing', state: 'installable', version: '9' })],
+    )
+    const wrapper = mountChooser()
+    await flushPromises()
+    const tile = wrapper.findAll('.chooser-tile').find((t) => t.text().includes('BuiltThing'))!
+    const meta = tile.find('.chooser-tile-meta-line')
+    // "Dist v7 → v9": one governing label, so the target can't be read as a
+    // ComfyUI version either.
+    expect(meta.find('.chooser-tile-meta-version--superseded').text()).toBe('Dist v7')
+    expect(meta.find('.chooser-tile-meta-target').text()).toBe('v9')
+    expect(meta.text()).toContain('v0.28.2')
+  })
+
+  it('claims no distribution delta while the catalog is cold', async () => {
+    installMockApi([
+      makeInstall({
+        id: 'built',
+        name: 'ColdThing',
+        sourceId: 'comfybuilder',
+        distributionId: 'd1',
+        version: 'v0.28.2',
+        distributionVersion: '7',
+      }),
+    ])
+    const wrapper = mountChooser()
+    await flushPromises()
+    const tile = wrapper.findAll('.chooser-tile').find((t) => t.text().includes('ColdThing'))!
+    // Signed out, or the fetch not back yet: never promise an update we haven't
+    // verified. The current version still shows, fully emphasised.
+    expect(tile.find('.chooser-tile-meta-target').exists()).toBe(false)
+    expect(tile.find('.chooser-tile-meta-version').text()).toBe('Dist v7')
   })
 
   it('gives every card exactly one blue action pill', async () => {

--- a/src/renderer/src/views/ChooserView.test.ts
+++ b/src/renderer/src/views/ChooserView.test.ts
@@ -420,11 +420,13 @@ describe('ChooserView', () => {
     expect(pill.exists()).toBe(true)
     expect(pill.text().trim()).toBe('Update')
     // Both versions read off the tile — no hover needed to learn the target.
-    const meta = tile.find('.chooser-tile-meta-line')
+    const meta = tile.find('.chooser-tile-meta-row')
     expect(meta.text()).toContain('v0.22.3')
     expect(meta.find('.chooser-tile-meta-target').text()).toBe('v0.24.1')
     // The one emphasised element moves to the target; the current one recedes.
     expect(meta.find('.chooser-tile-meta-version--superseded').text()).toBe('v0.22.3')
+    // The delta sits outside the ellipsised facts, so it can't be truncated away.
+    expect(meta.find('.chooser-tile-meta-line').text()).not.toContain('v0.24.1')
   })
 
   it('leaves the meta row untouched when there is no update to point at', async () => {
@@ -432,7 +434,7 @@ describe('ChooserView', () => {
     const wrapper = mountChooser()
     await flushPromises()
     const tile = wrapper.findAll('.chooser-tile').find((t) => t.text().includes('Current'))!
-    const meta = tile.find('.chooser-tile-meta-line')
+    const meta = tile.find('.chooser-tile-meta-row')
     expect(meta.find('.chooser-tile-meta-version').text()).toBe('v0.24.1')
     expect(meta.find('.chooser-tile-meta-target').exists()).toBe(false)
     expect(meta.find('.chooser-tile-meta-arrow').exists()).toBe(false)
@@ -645,7 +647,7 @@ describe('ChooserView', () => {
     const wrapper = mountChooser()
     await flushPromises()
     const tile = wrapper.findAll('.chooser-tile').find((t) => t.text().includes('BuiltThing'))!
-    const meta = tile.find('.chooser-tile-meta-line')
+    const meta = tile.find('.chooser-tile-meta-row')
     // "Dist v7 → v9": one governing label, so the target can't be read as a
     // ComfyUI version either.
     expect(meta.find('.chooser-tile-meta-version--superseded').text()).toBe('Dist v7')

--- a/src/renderer/src/views/chooser/ChooserInstallTile.vue
+++ b/src/renderer/src/views/chooser/ChooserInstallTile.vue
@@ -8,11 +8,12 @@ import {
   MoreVertical
 } from 'lucide-vue-next'
 import { useSessionStore } from '../../stores/sessionStore'
+import { useAuthStore } from '../../stores/authStore'
 import { installTypeMetaForInstall } from '../../lib/installTypeIcon'
 import Tooltip from '../../components/ui/Tooltip.vue'
 import TruncatedText from '../../components/TruncatedText.vue'
 import { TID } from '../../../../shared/testIds'
-import { isDistributionInstall } from '../../devplatform/distributionState'
+import { distributionUpdateVersion, isDistributionInstall } from '../../devplatform/distributionState'
 import type { Installation } from '../../types/ipc'
 
 interface Props {
@@ -34,6 +35,7 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 const sessionStore = useSessionStore()
+const authStore = useAuthStore()
 
 const inst = computed(() => props.installation)
 
@@ -111,9 +113,24 @@ const leadingFact = computed(() =>
   isFromDistribution.value ? inst.value.version || '' : sourceLabel.value
 )
 
-const metaLine = computed(() =>
-  [leadingFact.value, trailingFact.value].filter(Boolean).join(' · ')
-)
+/** The version you'd be getting, when an update exists. Needs a current version
+ *  to point away from — an arrow with nothing on its left is not a delta.
+ *  Distribution installs compare against the workspace catalog (empty until it
+ *  loads, and never a claim while it's cold); every other source already carries
+ *  its target in the update tag. */
+const targetFact = computed(() => {
+  if (!trailingFact.value) return ''
+  if (isFromDistribution.value) {
+    const next = distributionUpdateVersion(inst.value, authStore.distributions)
+    return next ? t('devPlatform.distribution.distVersionNext', { version: next }) : ''
+  }
+  return hasUpdate.value ? inst.value.statusTag?.version || '' : ''
+})
+
+const metaLine = computed(() => {
+  const facts = [leadingFact.value, trailingFact.value].filter(Boolean).join(' · ')
+  return targetFact.value ? `${facts} → ${targetFact.value}` : facts
+})
 
 
 /** The single update/migrate affordance, or null when the install has neither.
@@ -232,7 +249,18 @@ function triggerInstallAction(action: 'update' | 'migrate'): void {
         <TruncatedText v-if="metaLine" class="chooser-tile-meta-line" :text="metaLine">
           <span v-if="leadingFact" class="chooser-tile-meta-source">{{ leadingFact }}</span>
           <span v-if="leadingFact && trailingFact" class="chooser-tile-meta-sep">·</span>
-          <span v-if="trailingFact" class="chooser-tile-meta-version">{{ trailingFact }}</span>
+          <!-- With an update pending the roles shift down a seat: what you have
+               recedes and what you'd get takes the emphasis slot. -->
+          <span
+            v-if="trailingFact"
+            class="chooser-tile-meta-version"
+            :class="{ 'chooser-tile-meta-version--superseded': targetFact }"
+            >{{ trailingFact }}</span
+          >
+          <template v-if="targetFact">
+            <span class="chooser-tile-meta-arrow">→</span>
+            <span class="chooser-tile-meta-target">{{ targetFact }}</span>
+          </template>
         </TruncatedText>
         <!-- Action pill; pinned right by its own margin, never truncates. -->
         <Tooltip v-if="actionPill" :text="actionPill.tooltip" class="chooser-tile-pill-action">

--- a/src/renderer/src/views/chooser/ChooserInstallTile.vue
+++ b/src/renderer/src/views/chooser/ChooserInstallTile.vue
@@ -127,14 +127,13 @@ const targetFact = computed(() => {
   return hasUpdate.value ? inst.value.statusTag?.version || '' : ''
 })
 
-const metaLine = computed(() => {
-  const facts = [leadingFact.value, trailingFact.value].filter(Boolean).join(' · ')
-  return targetFact.value ? `${facts} → ${targetFact.value}` : facts
-})
+const metaLine = computed(() =>
+  [leadingFact.value, trailingFact.value].filter(Boolean).join(' · ')
+)
 
 
 /** The single update/migrate affordance, or null when the install has neither.
- *  The Update tooltip surfaces the target version the bare pill hides. */
+ *  The target version reads off the meta row, so the pill stays bare. */
 const actionPill = computed(() => {
   if (hasUpdate.value)
     return {
@@ -246,22 +245,25 @@ function triggerInstallAction(action: 'update' | 'migrate'): void {
     <div class="chooser-tile-body">
       <TruncatedText class="chooser-tile-name" :text="inst.name" />
       <div v-if="metaLine || actionPill" class="chooser-tile-footer">
-        <TruncatedText v-if="metaLine" class="chooser-tile-meta-line" :text="metaLine">
-          <span v-if="leadingFact" class="chooser-tile-meta-source">{{ leadingFact }}</span>
-          <span v-if="leadingFact && trailingFact" class="chooser-tile-meta-sep">·</span>
-          <!-- With an update pending the roles shift down a seat: what you have
-               recedes and what you'd get takes the emphasis slot. -->
-          <span
-            v-if="trailingFact"
-            class="chooser-tile-meta-version"
-            :class="{ 'chooser-tile-meta-version--superseded': targetFact }"
-            >{{ trailingFact }}</span
-          >
-          <template v-if="targetFact">
-            <span class="chooser-tile-meta-arrow">→</span>
+        <div v-if="metaLine" class="chooser-tile-meta-row">
+          <TruncatedText class="chooser-tile-meta-line" :text="metaLine">
+            <span v-if="leadingFact" class="chooser-tile-meta-source">{{ leadingFact }}</span>
+            <span v-if="leadingFact && trailingFact" class="chooser-tile-meta-sep">·</span>
+            <!-- With an update pending the roles shift down a seat: what you have
+                 recedes and what you'd get takes the emphasis slot. -->
+            <span
+              v-if="trailingFact"
+              class="chooser-tile-meta-version"
+              :class="{ 'chooser-tile-meta-version--superseded': targetFact }"
+              >{{ trailingFact }}</span
+            >
+          </TruncatedText>
+          <!-- Outside the ellipsised facts: the source label gives way first. -->
+          <span v-if="targetFact" class="chooser-tile-meta-delta">
+            <span class="chooser-tile-meta-arrow" aria-hidden="true">→</span>
             <span class="chooser-tile-meta-target">{{ targetFact }}</span>
-          </template>
-        </TruncatedText>
+          </span>
+        </div>
         <!-- Action pill; pinned right by its own margin, never truncates. -->
         <Tooltip v-if="actionPill" :text="actionPill.tooltip" class="chooser-tile-pill-action">
           <span

--- a/src/renderer/src/views/chooser/chooser-tiles.css
+++ b/src/renderer/src/views/chooser/chooser-tiles.css
@@ -121,6 +121,37 @@
   color: var(--text);
 }
 
+/* Version delta ("v0.22.3 → v0.24.1"). The row keeps exactly one emphasised
+ * element: the current version steps back a rung and the target takes the slot,
+ * so an updatable tile is no louder than a current one.
+ *
+ * Neutral ramp, not `--text-muted` / `--text-faint`: those invert between the
+ * themes while these tiles sit on the dark surface in both, which would flip the
+ * emphasis in light mode. The superseded/arrow hover rules must stay AFTER the
+ * `--text` lift above — equal specificity, source order decides. */
+.chooser-tile-meta-version--superseded {
+  color: var(--neutral-300);
+  font-weight: 400;
+}
+.chooser-tile-meta-arrow {
+  margin: 0 4px;
+  color: var(--neutral-300);
+}
+.chooser-tile-meta-target {
+  color: var(--neutral-200);
+  font-weight: 500;
+}
+.chooser-tile:hover .chooser-tile-meta-version--superseded,
+.chooser-tile:focus-visible .chooser-tile-meta-version--superseded,
+.chooser-tile:hover .chooser-tile-meta-arrow,
+.chooser-tile:focus-visible .chooser-tile-meta-arrow {
+  color: var(--neutral-200);
+}
+.chooser-tile:hover .chooser-tile-meta-target,
+.chooser-tile:focus-visible .chooser-tile-meta-target {
+  color: var(--text);
+}
+
 .chooser-tile-footer {
   display: flex;
   align-items: center;

--- a/src/renderer/src/views/chooser/chooser-tiles.css
+++ b/src/renderer/src/views/chooser/chooser-tiles.css
@@ -121,14 +121,21 @@
   color: var(--text);
 }
 
-/* Version delta ("v0.22.3 → v0.24.1"). The row keeps exactly one emphasised
- * element: the current version steps back a rung and the target takes the slot,
- * so an updatable tile is no louder than a current one.
- *
- * Neutral ramp, not `--text-muted` / `--text-faint`: those invert between the
- * themes while these tiles sit on the dark surface in both, which would flip the
- * emphasis in light mode. The superseded/arrow hover rules must stay AFTER the
- * `--text` lift above — equal specificity, source order decides. */
+/* Version delta ("v0.22.3 → v0.24.1"): one emphasised element per row — the
+ * current version steps back a rung and the target takes the slot. The
+ * superseded/arrow hover rules must stay AFTER the `--text` lift above — equal
+ * specificity, source order decides. */
+.chooser-tile-meta-row {
+  display: flex;
+  font-size: 12px;
+  max-width: 100%;
+  min-width: 0;
+  overflow: hidden;
+}
+/* Never shrinks: the facts truncate first so the delta stays readable. */
+.chooser-tile-meta-delta {
+  flex-shrink: 0;
+}
 .chooser-tile-meta-version--superseded {
   color: var(--neutral-300);
   font-weight: 400;


### PR DESCRIPTION
Closes DES-568.

## Problem

When an update exists, the tile shows a bare **Update** pill and hides the target version in a tooltip. A tooltip is not readable — it needs a hover the user has no reason to attempt. The ticket asks for "you have 11.3, 12.0 is out" to read off the tile.

## Change

The meta row now carries the delta: `Dist v9 → Dist v12`. The version you have recedes; the version you'd get takes the emphasis slot. No update, no arrow.

Version stays metadata, not a selector — the name is still the headline, and the tile keeps its two-line geometry.

Distribution installs resolve the target from the workspace catalog and stay silent while it's cold, so a loading catalog never renders a false claim. Other sources read the target from their existing update tag.

The delta sits outside the ellipsised facts, so the source label truncates before the version pair does.

## Already done in earlier PRs

The rest of DES-568 shipped in #1319 — the labelled `Dist v7` meta line, and the size removal (the platform dropped storage estimation, so Desktop stopped rendering it).

## Testing

`pnpm run typecheck` (4 configs), `lint`, `test` (3033), `test:integration` (27) — green. New tests verified to fail against the unmodified source.