### PR TITLE
feat(chooser): add "Deploy as Distribution" to the install context menu

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -47,6 +47,7 @@
     "menuMigrate": "Migrate to Standalone",
     "menuRestoreSnapshot": "Restore Snapshot",
     "menuRevealInFolder": "Open Folder",
+    "menuDeployDistribution": "Deploy as Distribution",
     "menuDelete": "Uninstall",
     "stoppedActionGatedReason": "Stop the running instance first.",
     "menuDismissError": "Dismiss Error",
@@ -1174,6 +1175,18 @@
         "buildFailed": "This distribution has no successful build yet.",
         "noArtifactForMachine": "The latest build has no artifact for this operating system and GPU."
       }
+    },
+    "deploy": {
+      "confirmBody": "Publishing happens in Comfy Builder, which opens in your browser. Seed the new distribution with a snapshot exported from this menu's Share action. That import is approximate, so finish tuning the distribution in Builder rather than importing again.",
+      "carriedLabel": "Carried over by a snapshot",
+      "carriedNodes": "Custom nodes and their versions",
+      "carriedPythonPins": "Python package pins",
+      "separateLabel": "Set up separately in Builder",
+      "separateModels": "Models",
+      "separateWorkflows": "Workflows",
+      "separateArgs": "Startup arguments",
+      "separateFiles": "Your input and output files",
+      "openCta": "Open Comfy Builder"
     }
   },
   "errors": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -47,7 +47,6 @@
     "menuMigrate": "Migrate to Standalone",
     "menuRestoreSnapshot": "Restore Snapshot",
     "menuRevealInFolder": "Open Folder",
-    "menuDeployDistribution": "Deploy as Distribution",
     "menuDelete": "Uninstall",
     "stoppedActionGatedReason": "Stop the running instance first.",
     "menuDismissError": "Dismiss Error",
@@ -1177,7 +1176,8 @@
       }
     },
     "deploy": {
-      "confirmBody": "Publishing happens in Comfy Builder, which opens in your browser. Seed the new distribution with a snapshot exported from this menu's Share action. That import is approximate, so finish tuning the distribution in Builder rather than importing again.",
+      "menuLabel": "Deploy as Distribution",
+      "confirmBody": "Publishing happens in Comfy Builder, which opens in your browser. To seed the new distribution, launch this instance once, then export a snapshot with this menu's Share action. That import is approximate, so finish tuning the distribution in Builder rather than importing again.",
       "carriedLabel": "Carried over by a snapshot",
       "carriedNodes": "Custom nodes and their versions",
       "carriedPythonPins": "Python package pins",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -47,7 +47,6 @@
     "menuMigrate": "迁移到独立版",
     "menuRestoreSnapshot": "恢复快照",
     "menuRevealInFolder": "打开文件夹",
-    "menuDeployDistribution": "发布为分发版本",
     "menuDelete": "卸载",
     "stoppedActionGatedReason": "请先停止正在运行的实例。",
     "menuDismissError": "忽略错误",
@@ -1177,7 +1176,8 @@
       }
     },
     "deploy": {
-      "confirmBody": "发布在 Comfy Builder 中完成，它会在浏览器中打开。请使用此菜单中“分享”操作导出的快照来创建新的分发版本。该导入并不完整，请在 Builder 中继续调整，而不是重新导入。",
+      "menuLabel": "发布为分发版本",
+      "confirmBody": "发布在 Comfy Builder 中完成，它会在浏览器中打开。若要为新的分发版本提供初始内容，请先启动一次此实例，然后用此菜单中的“分享”操作导出快照。该导入并不完整，请在 Builder 中继续调整，而不是重新导入。",
       "carriedLabel": "快照会带过去的内容",
       "carriedNodes": "自定义节点及其版本",
       "carriedPythonPins": "Python 包版本锁定",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -47,6 +47,7 @@
     "menuMigrate": "迁移到独立版",
     "menuRestoreSnapshot": "恢复快照",
     "menuRevealInFolder": "打开文件夹",
+    "menuDeployDistribution": "发布为分发版本",
     "menuDelete": "卸载",
     "stoppedActionGatedReason": "请先停止正在运行的实例。",
     "menuDismissError": "忽略错误",
@@ -1174,6 +1175,18 @@
         "buildFailed": "此分发版本尚无成功的构建。",
         "noArtifactForMachine": "最新构建没有适用于此操作系统和 GPU 的制品。"
       }
+    },
+    "deploy": {
+      "confirmBody": "发布在 Comfy Builder 中完成，它会在浏览器中打开。请使用此菜单中“分享”操作导出的快照来创建新的分发版本。该导入并不完整，请在 Builder 中继续调整，而不是重新导入。",
+      "carriedLabel": "快照会带过去的内容",
+      "carriedNodes": "自定义节点及其版本",
+      "carriedPythonPins": "Python 包版本锁定",
+      "separateLabel": "需要在 Builder 中单独设置",
+      "separateModels": "模型",
+      "separateWorkflows": "工作流",
+      "separateArgs": "启动参数",
+      "separateFiles": "你的输入和输出文件",
+      "openCta": "打开 Comfy Builder"
     }
   },
   "errors": {

--- a/src/main/lib/cloudUrl.ts
+++ b/src/main/lib/cloudUrl.ts
@@ -1,11 +1,7 @@
 import { getDeviceId } from './deviceId'
+import { DEFAULT_UTM_PARAMS } from '../../shared/utmParams'
 
 const CLOUD_DISTRIBUTION_HOST = 'cloud.comfy.org'
-
-const DEFAULT_UTM_PARAMS: Record<string, string> = {
-  utm_source: 'comfy.desktop',
-  utm_medium: 'app_feature'
-}
 
 // Query param used to forward the Desktop telemetry distinct_id into
 // the cloud webContents so cloud.comfy.org's posthog-js can call

--- a/src/renderer/src/composables/useInstallContextMenu.test.ts
+++ b/src/renderer/src/composables/useInstallContextMenu.test.ts
@@ -33,6 +33,7 @@ const apiMock = {
   getSnapshots: vi.fn().mockResolvedValue({ snapshots: [] }),
   exportSnapshot: vi.fn().mockResolvedValue({ ok: true }),
   stopComfyUI: vi.fn().mockResolvedValue(undefined),
+  openExternal: vi.fn().mockResolvedValue(undefined),
 }
 vi.stubGlobal('window', {
   ...window,
@@ -47,7 +48,23 @@ const messages = {
       menuMigrate: 'Migrate to Standalone',
       menuRestoreSnapshot: 'Restore Snapshot',
       menuRevealInFolder: 'Open Folder',
+      menuDeployDistribution: 'Deploy as Distribution',
       menuDelete: 'Uninstall',
+    },
+    devPlatform: {
+      deploy: {
+        confirmBody:
+          "Publishing happens in Comfy Builder, which opens in your browser. Seed the new distribution with a snapshot exported from this menu's Share action. That import is approximate, so finish tuning the distribution in Builder rather than importing again.",
+        carriedLabel: 'Carried over by a snapshot',
+        carriedNodes: 'Custom nodes and their versions',
+        carriedPythonPins: 'Python package pins',
+        separateLabel: 'Set up separately in Builder',
+        separateModels: 'Models',
+        separateWorkflows: 'Workflows',
+        separateArgs: 'Startup arguments',
+        separateFiles: 'Your input and output files',
+        openCta: 'Open Comfy Builder',
+      },
     },
     actions: {
       copyInstallation: 'Duplicate Instance',
@@ -486,6 +503,115 @@ describe('useInstallContextMenu — share (export latest snapshot)', () => {
     await menu.triggerAction('share', inst)
     expect(modalMock.alert).toHaveBeenCalledTimes(1)
     expect(modalMock.alert.mock.calls[0]![0].message).toBe('Disk full')
+  })
+})
+
+describe('useInstallContextMenu — deploy-distribution (hand off to Builder on the web)', () => {
+  beforeEach(() => {
+    apiMock.openExternal.mockReset()
+    apiMock.openExternal.mockResolvedValue(undefined)
+    modalMock.confirm.mockReset()
+    modalMock.alert.mockReset()
+  })
+
+  it('shows the item for an installed local install', () => {
+    const { menu } = mountHarness(makeInstall({ sourceCategory: 'local' }))
+    expect(findItem(menu.ctxMenuItems.value, 'deploy-distribution')).toBeTruthy()
+  })
+
+  it('hides the item for cloud installs (no local snapshot to seed from)', () => {
+    const { menu } = mountHarness(makeInstall({ sourceCategory: 'cloud' }))
+    expect(findItem(menu.ctxMenuItems.value, 'deploy-distribution')).toBeUndefined()
+  })
+
+  // A distribution-backed install reports `sourceCategory: 'local'`, so the
+  // local-like gate alone would let it through. Its contents already live in
+  // Builder faithfully; re-publishing would degrade them through the lossy
+  // snapshot import. Share stays — it exports rather than re-publishes.
+  it('hides the item for a distribution-backed install but keeps Share', () => {
+    const { menu } = mountHarness(
+      makeInstall({ sourceId: 'comfybuilder', distributionId: 'dist-1' } as Partial<Installation>),
+    )
+    expect(findItem(menu.ctxMenuItems.value, 'deploy-distribution')).toBeUndefined()
+    expect(findItem(menu.ctxMenuItems.value, 'share')).toBeTruthy()
+  })
+
+  it('hides the item for a record that is not installed yet', () => {
+    const { menu } = mountHarness(makeInstall({ status: 'installing' } as Partial<Installation>))
+    expect(findItem(menu.ctxMenuItems.value, 'deploy-distribution')).toBeUndefined()
+  })
+
+  // Not REQUIRES_STOPPED: it opens a browser and touches nothing on disk.
+  it('stays enabled while the install is running', () => {
+    const inst = makeInstall()
+    const { menu } = mountHarness(inst, ({ session }) => {
+      session.runningInstances.set(inst.id, {
+        installationId: inst.id,
+        installationName: inst.name,
+      } as never)
+    })
+    const item = findItem(menu.ctxMenuItems.value, 'deploy-distribution')
+    expect(item).toBeTruthy()
+    expect(item?.disabled).toBeFalsy()
+  })
+
+  it('confirms with both detail groups before opening the browser', async () => {
+    modalMock.confirm.mockResolvedValue(true)
+    const inst = makeInstall()
+    const { menu } = mountHarnessWithManage(() => {})
+
+    await menu.triggerAction('deploy-distribution', inst)
+
+    expect(modalMock.confirm).toHaveBeenCalledTimes(1)
+    const args = modalMock.confirm.mock.calls[0]![0]
+    expect(args.title).toBe('Deploy as Distribution')
+    expect(args.confirmLabel).toBe('Open Comfy Builder')
+    expect(args.confirmStyle).toBe('primary')
+    expect(args.messageDetails).toHaveLength(2)
+    expect(args.messageDetails[0].label).toBe('Carried over by a snapshot')
+    expect(args.messageDetails[0].items).toEqual([
+      'Custom nodes and their versions',
+      'Python package pins',
+    ])
+    expect(args.messageDetails[1].label).toBe('Set up separately in Builder')
+    expect(args.messageDetails[1].items).toContain('Models')
+  })
+
+  it('on confirm true, opens the Builder web URL once', async () => {
+    modalMock.confirm.mockResolvedValue(true)
+    const inst = makeInstall()
+    const { menu } = mountHarnessWithManage(() => {})
+
+    await menu.triggerAction('deploy-distribution', inst)
+
+    expect(apiMock.openExternal).toHaveBeenCalledTimes(1)
+    const url = new URL(apiMock.openExternal.mock.calls[0]![0] as string)
+    expect(url.host).toBe('platform.comfy.org')
+    expect(modalMock.alert).not.toHaveBeenCalled()
+  })
+
+  it('on confirm cancel, opens nothing', async () => {
+    modalMock.confirm.mockResolvedValue(false)
+    const inst = makeInstall()
+    const { menu } = mountHarnessWithManage(() => {})
+
+    await menu.triggerAction('deploy-distribution', inst)
+
+    expect(apiMock.openExternal).not.toHaveBeenCalled()
+    expect(modalMock.alert).not.toHaveBeenCalled()
+  })
+
+  it('surfaces an openExternal failure via an alert', async () => {
+    modalMock.confirm.mockResolvedValue(true)
+    apiMock.openExternal.mockRejectedValueOnce(new Error('no browser'))
+    const inst = makeInstall()
+    const { menu } = mountHarnessWithManage(() => {})
+
+    await menu.triggerAction('deploy-distribution', inst)
+
+    expect(modalMock.alert).toHaveBeenCalledTimes(1)
+    expect(modalMock.alert.mock.calls[0]![0].title).toBe('Deploy as Distribution')
+    expect(modalMock.alert.mock.calls[0]![0].message).toBe('no browser')
   })
 })
 

--- a/src/renderer/src/composables/useInstallContextMenu.test.ts
+++ b/src/renderer/src/composables/useInstallContextMenu.test.ts
@@ -18,6 +18,7 @@ vi.mock('./useModal', () => ({
 }))
 
 import { useInstallContextMenu } from './useInstallContextMenu'
+import { builderHandoffUrl } from '../devplatform/builderWeb'
 import { useSessionStore } from '../stores/sessionStore'
 import { useProgressStore } from '../stores/progressStore'
 import type { Installation, ShowProgressOpts } from '../types/ipc'
@@ -48,13 +49,13 @@ const messages = {
       menuMigrate: 'Migrate to Standalone',
       menuRestoreSnapshot: 'Restore Snapshot',
       menuRevealInFolder: 'Open Folder',
-      menuDeployDistribution: 'Deploy as Distribution',
       menuDelete: 'Uninstall',
     },
     devPlatform: {
       deploy: {
+        menuLabel: 'Deploy as Distribution',
         confirmBody:
-          "Publishing happens in Comfy Builder, which opens in your browser. Seed the new distribution with a snapshot exported from this menu's Share action. That import is approximate, so finish tuning the distribution in Builder rather than importing again.",
+          "Publishing happens in Comfy Builder, which opens in your browser. To seed the new distribution, launch this instance once, then export a snapshot with this menu's Share action. That import is approximate, so finish tuning the distribution in Builder rather than importing again.",
         carriedLabel: 'Carried over by a snapshot',
         carriedNodes: 'Custom nodes and their versions',
         carriedPythonPins: 'Python package pins',
@@ -524,10 +525,6 @@ describe('useInstallContextMenu — deploy-distribution (hand off to Builder on 
     expect(findItem(menu.ctxMenuItems.value, 'deploy-distribution')).toBeUndefined()
   })
 
-  // A distribution-backed install reports `sourceCategory: 'local'`, so the
-  // local-like gate alone would let it through. Its contents already live in
-  // Builder faithfully; re-publishing would degrade them through the lossy
-  // snapshot import. Share stays — it exports rather than re-publishes.
   it('hides the item for a distribution-backed install but keeps Share', () => {
     const { menu } = mountHarness(
       makeInstall({ sourceId: 'comfybuilder', distributionId: 'dist-1' } as Partial<Installation>),
@@ -585,8 +582,7 @@ describe('useInstallContextMenu — deploy-distribution (hand off to Builder on 
     await menu.triggerAction('deploy-distribution', inst)
 
     expect(apiMock.openExternal).toHaveBeenCalledTimes(1)
-    const url = new URL(apiMock.openExternal.mock.calls[0]![0] as string)
-    expect(url.host).toBe('platform.comfy.org')
+    expect(apiMock.openExternal).toHaveBeenCalledWith(builderHandoffUrl())
     expect(modalMock.alert).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/src/composables/useInstallContextMenu.ts
+++ b/src/renderer/src/composables/useInstallContextMenu.ts
@@ -7,6 +7,8 @@ import { useStopAction } from './useStopAction'
 import { revealInFolderLabel } from './usePlatform'
 import { progressOpKindForActionId, destroysInstanceForActionId } from '../lib/progressOpKind'
 import { shareLatestSnapshot } from '../lib/snapshots'
+import { isDistributionInstall } from '../devplatform/distributionState'
+import { buildDeployDistributionUrl } from '../devplatform/builderWeb'
 import type { ContextMenuItem } from '../types/context-menu'
 import type { Installation, ShowProgressOpts } from '../types/ipc'
 
@@ -26,6 +28,7 @@ export type InstallMenuActionId =
   | 'stop'
   | 'reveal-in-folder'
   | 'share'
+  | 'deploy-distribution'
   | 'copy-install'
   | 'untrack'
   | 'delete'
@@ -128,6 +131,15 @@ export function useInstallContextMenu(opts: {
     // gate on installed + local.
     if (isInstalled(inst) && hasInstallPath(inst) && isLocalLikeInstall(inst)) {
       items.push({ id: 'share', label: t('actions.share', 'Share') })
+    }
+
+    // Deploy as Distribution — hands off to Builder on the web, so it joins
+    // Share's group and stays enabled while the install runs. Hidden for
+    // distribution-backed installs: Builder already holds their contents
+    // faithfully, and re-publishing would round-trip them through a lossy
+    // snapshot import.
+    if (isInstalled(inst) && hasInstallPath(inst) && isLocalLikeInstall(inst) && !isDistributionInstall(inst)) {
+      items.push({ id: 'deploy-distribution', label: t('chooser.menuDeployDistribution') })
     }
 
     // Copy Installation — standalone source only. REQUIRES_STOPPED.
@@ -253,6 +265,41 @@ export function useInstallContextMenu(opts: {
                 : result.message ?? t('snapshots.shareFailed', 'Could not share the snapshot.'),
           })
         }
+      } catch (err) {
+        await modal.alert({ title: label, message: (err as Error)?.message || String(err) })
+      }
+    } else if (id === 'deploy-distribution') {
+      // Desktop hands off; Builder owns the publish. Spell out what a
+      // snapshot import carries before the browser takes focus, so the
+      // action can't imply a faithful clone. Cancel is a silent no-op.
+      const label = t('chooser.menuDeployDistribution')
+      const confirmed = await modal.confirm({
+        title: label,
+        message: t('devPlatform.deploy.confirmBody'),
+        messageDetails: [
+          {
+            label: t('devPlatform.deploy.carriedLabel'),
+            items: [
+              t('devPlatform.deploy.carriedNodes'),
+              t('devPlatform.deploy.carriedPythonPins'),
+            ],
+          },
+          {
+            label: t('devPlatform.deploy.separateLabel'),
+            items: [
+              t('devPlatform.deploy.separateModels'),
+              t('devPlatform.deploy.separateWorkflows'),
+              t('devPlatform.deploy.separateArgs'),
+              t('devPlatform.deploy.separateFiles'),
+            ],
+          },
+        ],
+        confirmLabel: t('devPlatform.deploy.openCta'),
+        confirmStyle: 'primary',
+      })
+      if (!confirmed) return
+      try {
+        await window.api.openExternal(buildDeployDistributionUrl())
       } catch (err) {
         await modal.alert({ title: label, message: (err as Error)?.message || String(err) })
       }

--- a/src/renderer/src/composables/useInstallContextMenu.ts
+++ b/src/renderer/src/composables/useInstallContextMenu.ts
@@ -8,7 +8,7 @@ import { revealInFolderLabel } from './usePlatform'
 import { progressOpKindForActionId, destroysInstanceForActionId } from '../lib/progressOpKind'
 import { shareLatestSnapshot } from '../lib/snapshots'
 import { isDistributionInstall } from '../devplatform/distributionState'
-import { buildDeployDistributionUrl } from '../devplatform/builderWeb'
+import { builderHandoffUrl } from '../devplatform/builderWeb'
 import type { ContextMenuItem } from '../types/context-menu'
 import type { Installation, ShowProgressOpts } from '../types/ipc'
 
@@ -88,6 +88,11 @@ export function useInstallContextMenu(opts: {
     return !!inst.installPath
   }
 
+  /** An installed local install with files on disk. */
+  function isLocalInstallOnDisk(inst: Installation): boolean {
+    return isInstalled(inst) && hasInstallPath(inst) && isLocalLikeInstall(inst)
+  }
+
   /** True when REQUIRES_STOPPED actions would no-op: install is running,
    *  stopping, or has an op in flight. Drives the `disabled` flag. */
   function isStoppedActionGated(inst: Installation): boolean {
@@ -114,7 +119,7 @@ export function useInstallContextMenu(opts: {
       if (hasMigratePrompt(inst)) {
         items.push({ id: 'migrate', label: t('chooser.menuMigrate'), disabled: stoppedActionGated, title: gatedTitle })
       }
-      if (isInstalled(inst) && hasInstallPath(inst) && isLocalLikeInstall(inst)) {
+      if (isLocalInstallOnDisk(inst)) {
         items.push({ id: 'restore-snapshot', label: t('chooser.menuRestoreSnapshot'), disabled: stoppedActionGated, title: gatedTitle })
       }
     }
@@ -129,17 +134,14 @@ export function useInstallContextMenu(opts: {
 
     // Share — export the latest snapshot. Local-only and post-boot, so
     // gate on installed + local.
-    if (isInstalled(inst) && hasInstallPath(inst) && isLocalLikeInstall(inst)) {
+    if (isLocalInstallOnDisk(inst)) {
       items.push({ id: 'share', label: t('actions.share', 'Share') })
     }
 
-    // Deploy as Distribution — hands off to Builder on the web, so it joins
-    // Share's group and stays enabled while the install runs. Hidden for
-    // distribution-backed installs: Builder already holds their contents
-    // faithfully, and re-publishing would round-trip them through a lossy
-    // snapshot import.
-    if (isInstalled(inst) && hasInstallPath(inst) && isLocalLikeInstall(inst) && !isDistributionInstall(inst)) {
-      items.push({ id: 'deploy-distribution', label: t('chooser.menuDeployDistribution') })
+    // Deploy as Distribution — outward action, joins Share's group. Hidden for
+    // distribution-backed installs (Builder already owns those).
+    if (isLocalInstallOnDisk(inst) && !isDistributionInstall(inst)) {
+      items.push({ id: 'deploy-distribution', label: t('devPlatform.deploy.menuLabel') })
     }
 
     // Copy Installation — standalone source only. REQUIRES_STOPPED.
@@ -269,10 +271,9 @@ export function useInstallContextMenu(opts: {
         await modal.alert({ title: label, message: (err as Error)?.message || String(err) })
       }
     } else if (id === 'deploy-distribution') {
-      // Desktop hands off; Builder owns the publish. Spell out what a
-      // snapshot import carries before the browser takes focus, so the
-      // action can't imply a faithful clone. Cancel is a silent no-op.
-      const label = t('chooser.menuDeployDistribution')
+      // Spell out what a snapshot import carries before the browser takes
+      // focus. Cancel is a silent no-op.
+      const label = t('devPlatform.deploy.menuLabel')
       const confirmed = await modal.confirm({
         title: label,
         message: t('devPlatform.deploy.confirmBody'),
@@ -299,7 +300,7 @@ export function useInstallContextMenu(opts: {
       })
       if (!confirmed) return
       try {
-        await window.api.openExternal(buildDeployDistributionUrl())
+        await window.api.openExternal(builderHandoffUrl())
       } catch (err) {
         await modal.alert({ title: label, message: (err as Error)?.message || String(err) })
       }

--- a/src/renderer/src/devplatform/builderWeb.test.ts
+++ b/src/renderer/src/devplatform/builderWeb.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import { buildDeployDistributionUrl } from './builderWeb'
+
+describe('buildDeployDistributionUrl', () => {
+  it('points at the Builder web root with attribution params', () => {
+    const url = new URL(buildDeployDistributionUrl())
+    expect(url.host).toBe('platform.comfy.org')
+    expect(url.protocol).toBe('https:')
+    expect(url.pathname).toBe('/')
+    expect(url.searchParams.get('utm_source')).toBe('comfy.desktop')
+    expect(url.searchParams.get('utm_medium')).toBe('app_feature')
+  })
+})

--- a/src/renderer/src/devplatform/builderWeb.test.ts
+++ b/src/renderer/src/devplatform/builderWeb.test.ts
@@ -1,13 +1,24 @@
-import { describe, expect, it } from 'vitest'
-import { buildDeployDistributionUrl } from './builderWeb'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { builderHandoffUrl } from './builderWeb'
 
-describe('buildDeployDistributionUrl', () => {
+describe('builderHandoffUrl', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
   it('points at the Builder web root with attribution params', () => {
-    const url = new URL(buildDeployDistributionUrl())
+    const url = new URL(builderHandoffUrl())
     expect(url.host).toBe('platform.comfy.org')
     expect(url.protocol).toBe('https:')
     expect(url.pathname).toBe('/')
     expect(url.searchParams.get('utm_source')).toBe('comfy.desktop')
     expect(url.searchParams.get('utm_medium')).toBe('app_feature')
+  })
+
+  it('follows VITE_COMFY_BUILDER_WEB_URL when the build sets one', () => {
+    vi.stubEnv('VITE_COMFY_BUILDER_WEB_URL', 'https://builder.example.test/')
+    const url = new URL(builderHandoffUrl())
+    expect(url.host).toBe('builder.example.test')
+    expect(url.searchParams.get('utm_source')).toBe('comfy.desktop')
   })
 })

--- a/src/renderer/src/devplatform/builderWeb.ts
+++ b/src/renderer/src/devplatform/builderWeb.ts
@@ -1,0 +1,14 @@
+/**
+ * Comfy Builder on the web — the one place Desktop links out to it, so the
+ * URL is a single edit when it needs to follow the API's staging/prod split.
+ */
+const BUILDER_WEB_URL = 'https://platform.comfy.org/'
+
+/** Hand-off target for "Deploy as Distribution". Deliberately the root: no
+ *  Builder route is attested here, and a root can't 404. */
+export function buildDeployDistributionUrl(): string {
+  const url = new URL(BUILDER_WEB_URL)
+  url.searchParams.set('utm_source', 'comfy.desktop')
+  url.searchParams.set('utm_medium', 'app_feature')
+  return url.toString()
+}

--- a/src/renderer/src/devplatform/builderWeb.ts
+++ b/src/renderer/src/devplatform/builderWeb.ts
@@ -2,13 +2,18 @@
  * Comfy Builder on the web — the one place Desktop links out to it, so the
  * URL is a single edit when it needs to follow the API's staging/prod split.
  */
-const BUILDER_WEB_URL = 'https://platform.comfy.org/'
+import { DEFAULT_UTM_PARAMS } from '../../../shared/utmParams'
 
-/** Hand-off target for "Deploy as Distribution". Deliberately the root: no
- *  Builder route is attested here, and a root can't 404. */
-export function buildDeployDistributionUrl(): string {
-  const url = new URL(BUILDER_WEB_URL)
-  url.searchParams.set('utm_source', 'comfy.desktop')
-  url.searchParams.set('utm_medium', 'app_feature')
+/** The only Builder web origin attested anywhere. */
+const DEFAULT_BUILDER_WEB_URL = 'https://platform.comfy.org/'
+
+/** Hand-off target for "Deploy as Distribution", UTM-tagged like the cloud
+ *  links. Deliberately the root: no Builder route is attested here, and a root
+ *  can't 404. `VITE_COMFY_BUILDER_WEB_URL` repoints it at build time. */
+export function builderHandoffUrl(): string {
+  const url = new URL(import.meta.env.VITE_COMFY_BUILDER_WEB_URL || DEFAULT_BUILDER_WEB_URL)
+  for (const [key, value] of Object.entries(DEFAULT_UTM_PARAMS)) {
+    url.searchParams.set(key, value)
+  }
   return url.toString()
 }

--- a/src/shared/utmParams.ts
+++ b/src/shared/utmParams.ts
@@ -1,0 +1,6 @@
+/** Attribution tags for Desktop → web hand-offs. Shared so main and the
+ *  renderer can't drift on the source token. */
+export const DEFAULT_UTM_PARAMS: Record<string, string> = {
+  utm_source: 'comfy.desktop',
+  utm_medium: 'app_feature'
+}


### PR DESCRIPTION
Closes DES-566.

## Problem

Everything built so far is one-directional — distributions come *down* from Builder onto the machine. Design partners work the other way: author locally, then publish.

## Change

A **Deploy as Distribution** action on the install context menu, alongside Manage / Update / Delete. It confirms, then opens Comfy Builder in the browser.

The confirm is doing real work, not ceremony. The snapshot import carries **custom nodes and python pins only** — models, workflows, startup args and your files are set up separately in Builder, and the import is approximate. The dialog says so before the user leaves, split into "carried over" and "set up separately" so the gap is legible rather than buried in prose.

It also names the actual path: launch the instance once, export a snapshot via Share, then import. Offered on a fresh install, the old wording would have sent the user to Share's empty state — nothing captures a snapshot until first boot.

No in-Desktop publish flow and no new auth. The hand-off is one `openExternal` to a UTM-tagged Builder URL, repointable at build time via `VITE_COMFY_BUILDER_WEB_URL`.

## Notes

- UTM params moved to `src/shared/utmParams.ts` so main and renderer can't drift apart on attribution.
- Builder web origin is asserted in exactly one place, so the URL is a single edit when staging/prod split.

## Testing

`pnpm run typecheck` (4 configs), `lint`, `test`, `test:integration` — green.