### PR TITLE
feat(e2e): screen-capture harness for the comfy builder flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ out/
 result
 test-results/
 playwright-report/
+# Screenshot set written by `pnpm run test:e2e:capture` (regenerate, don't commit)
+captures/
 resources/vc_redist.x64.exe
 resources/vc_redist.x64.exe.tmp
 resources/vc_redist_version.nsh

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ On Windows/macOS, set up a fresh clone and start the app in one command with `pn
 | `pnpm test`                      | Unit tests ([Vitest](https://vitest.dev/))                            |
 | `pnpm run test:integration`      | Integration suite                                                     |
 | `pnpm run test:e2e`              | End-to-end tests ([Playwright](https://playwright.dev/))              |
+| `pnpm run test:e2e:capture`      | Screenshot the Comfy Builder flow into `captures/` (opt-in; not run in CI) |
 | `pnpm run typecheck`             | Type-check (node + web + e2e + integration)                           |
 | `pnpm run lint` / `lint:fix`     | Lint (ESLint)                                                         |
 | `pnpm run format`                | Format (Prettier)                                                     |

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ On Windows/macOS, set up a fresh clone and start the app in one command with `pn
 | `pnpm test`                      | Unit tests ([Vitest](https://vitest.dev/))                            |
 | `pnpm run test:integration`      | Integration suite                                                     |
 | `pnpm run test:e2e`              | End-to-end tests ([Playwright](https://playwright.dev/))              |
-| `pnpm run test:e2e:capture`      | Screenshot the Comfy Builder flow into `captures/` (opt-in; not run in CI) |
+| `pnpm run test:e2e:capture`      | Screenshot the Comfy Builder flow into `captures/` (opt-in; not run in CI; on macOS it resets the app's real `settings.json`, as every e2e run does) |
 | `pnpm run typecheck`             | Type-check (node + web + e2e + integration)                           |
 | `pnpm run lint` / `lint:fix`     | Lint (ESLint)                                                         |
 | `pnpm run format`                | Format (Prettier)                                                     |

--- a/e2e/comfybuilder-capture.test.ts
+++ b/e2e/comfybuilder-capture.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Screen-capture harness for the Comfy Builder flow.
+ *
+ *   pnpm run build && pnpm run test:e2e:capture
+ *
+ * Writes one PNG per screen plus `manifest.json` into `captures/` (gitignored;
+ * override with `COMFY_CAPTURE_DIR`). The directory is wiped per run, so the set
+ * is REGENERATED rather than accumulated — a screen deleted from `SCREENS`
+ * disappears instead of going stale. Filenames carry their index from
+ * declaration order, so the set sorts the way the flow reads.
+ *
+ * NOT RUN IN CI. It is the only member of the `capture` Playwright project
+ * (`grep: /@capture/`); the CI matrix runs `--project={macos,windows,linux}`,
+ * whose greps a `@capture`-only test matches none of. Same mechanism the
+ * `lifecycle` project uses.
+ *
+ * COVERAGE. Signed out, the harness reaches the log-in chooser, the host title
+ * bar, and — from two seeded `comfybuilder` records — the workspace shelf tile,
+ * its kebab, the Manage popup, the not-ready alert, and an install's progress
+ * and failure states. It does NOT implement or fake auth. It asks
+ * `getAuthStatus()` after launch: with a real session it also captures the
+ * signed-in chip, the workspace switcher and the distribution cards; without
+ * one those land in `manifest.skipped` with a reason. A signed-in profile
+ * conversely cannot show the log-in chip, so `chooser-signed-out` is skipped
+ * there — the chooser's identity corner is one screen or the other, never both.
+ * On macOS `app.getPath('userData')` ignores the harness HOME override, so an
+ * operator already signed in to the dev app is signed in here too; on
+ * Windows/Linux the isolated HOME means those screens are always skipped.
+ *
+ * SAFETY. It drives the real app, so it never clicks Log in (opens a browser),
+ * Sign out, a workspace row (a switch re-runs the browser handoff), or a
+ * distribution card / its "Install" item (would start a real multi-GB
+ * download). Menus are opened and dismissed, never selected.
+ *
+ * macOS PROFILE. `dataDir()` resolves to `app.getPath('userData')`
+ * (`src/main/lib/paths.ts`), which ignores the harness HOME override on macOS,
+ * so seeding rewrites the operator's REAL `installations.json`. It is snapshot
+ * before launch and restored in `afterAll`. The same path lets `E2E_SETTINGS_SEED`
+ * replace the operator's `settings.json` wholesale — that is pre-existing
+ * behaviour of every e2e run here and is deliberately not addressed by this file.
+ */
+
+import os from 'node:os'
+import path from 'node:path'
+import { createHash } from 'node:crypto'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { test, expect } from '@playwright/test'
+import en from '../locales/en.json'
+import { launchApp, type AppContext, type SeedInstallation } from './launchApp'
+import { clickInstallTile, dismissOverlay, expectChooserVisible } from './support/chooserHelpers'
+import { closeTitlePopupIfOpen, isPopupVisible, waitForWebContents } from './support/cdpPages'
+import {
+  captureDir,
+  resetCaptureDir,
+  ScreenCapturer,
+  type CaptureTarget,
+} from './support/screenCapture'
+import { byTestId, TID } from './support/testIds'
+
+const PANEL = 'panel.html'
+const TITLE_BAR = 'comfyTitleBar.html'
+const TITLE_POPUP = 'comfyTitlePopup.html'
+
+const INSTALLED_ID = 'inst-capture-builder-installed'
+const INSTALLED_NAME = 'desktop-4target-stg-v0190'
+const FAILED_ID = 'inst-capture-builder-failed'
+const FAILED_NAME = 'desktop-4target-stg-v0192'
+
+/** Statuses the seeded records put on screen, echoed into the manifest. */
+const DISTRIBUTION_STATES = ['installed', 'failed']
+
+const SIGNED_IN_ONLY = 'requires a signed-in dev-platform session'
+
+/** Declaration order IS file order. */
+const SCREENS: readonly CaptureTarget[] = [
+  { id: 'chooser-signed-out', surface: PANEL, anchor: '.chooser-view .account-chip__signin' },
+  { id: 'chooser-signed-in', surface: PANEL, anchor: '.chooser-view .account-chip__face' },
+  { id: 'workspace-switcher', surface: PANEL, anchor: '.account-chip__menu' },
+  // Cropped for the same reason as the shelf below: the row of not-yet-installed
+  // distributions, not another shot of the whole chooser.
+  {
+    id: 'distribution-cards',
+    surface: PANEL,
+    anchor: '.dist-tile--chooser',
+    crop: '.chooser-family-grid:has(.dist-tile--chooser)',
+  },
+  { id: 'title-bar', surface: TITLE_BAR, anchor: '.title-bar' },
+  // Cropped: uncropped this is the same viewport as the chooser above, and two
+  // identical PNGs in the set would be a lie about coverage. `:has()` picks the
+  // workspace shelf — the only one carrying a header.
+  {
+    id: 'builder-install-tile',
+    surface: PANEL,
+    anchor: byTestId(TID.dashboardTile(INSTALLED_ID)),
+    crop: '.chooser-shelf:has(.chooser-shelf-head)',
+  },
+  { id: 'builder-install-tile-kebab', surface: PANEL, anchor: '.context-menu' },
+  { id: 'builder-install-manage', surface: TITLE_POPUP, anchor: byTestId(TID.pickerRow(INSTALLED_ID)) },
+  { id: 'builder-install-not-ready', surface: PANEL, anchor: byTestId(TID.baseAlertAction) },
+  { id: 'builder-install-progress', surface: PANEL, anchor: '.brand-progress__bar' },
+  { id: 'builder-install-failed', surface: PANEL, anchor: byTestId(TID.progressErrorMessage) },
+]
+
+/** macOS only — see the header. Null everywhere else, where the harness HOME
+ *  override does isolate `userData`. */
+const realInstallationsFile = process.platform === 'darwin'
+  ? path.join(os.homedir(), 'Library', 'Application Support', 'comfyui-desktop-2', 'installations.json')
+  : null
+
+let ctx: AppContext
+let rootDir: string
+let outDir: string
+let capturer: ScreenCapturer
+let realInstallationsBackup: string | null = null
+
+test.describe.configure({ mode: 'serial' })
+
+/** Mirrors what `installDistribution` writes for a real distribution install. */
+function distributionRecord(id: string, name: string, status: string): SeedInstallation {
+  return {
+    id,
+    name,
+    sourceId: 'comfybuilder',
+    sourceLabel: 'ComfyBuilder',
+    installPath: path.join(rootDir, id),
+    distributionId: `d-${id}`,
+    distributionName: name,
+    version: '1',
+    artifactId: 'a-1',
+    artifactOs: process.platform === 'win32' ? 'windows' : process.platform === 'darwin' ? 'macos' : 'linux',
+    artifactGpu: 'cpu',
+    artifactAccelVariant: 'cpu',
+    launchArgs: '--enable-manager',
+    launchMode: 'window',
+    browserPartition: 'unique',
+    status,
+    seen: true,
+  }
+}
+
+test.beforeAll(async () => {
+  if (realInstallationsFile) {
+    realInstallationsBackup = await readFile(realInstallationsFile, 'utf8').catch(() => null)
+  }
+
+  rootDir = await mkdtemp(path.join(os.tmpdir(), 'comfyui-launcher-capture-e2e-'))
+  // A missing folder earns the tile a "Folder Not Found" danger pill
+  // (`enrichInstallationsForRenderer`), which would be a lie in the screenshot.
+  for (const id of [INSTALLED_ID, FAILED_ID]) {
+    await mkdir(path.join(rootDir, id, 'ComfyUI'), { recursive: true })
+    await writeFile(path.join(rootDir, id, 'ComfyUI', 'main.py'), '')
+  }
+
+  outDir = captureDir()
+  await resetCaptureDir(outDir)
+  console.log(`[capture] writing to ${outDir}`)
+
+  ctx = await launchApp({
+    settings: { firstUseCompleted: true, telemetryEnabled: false },
+    installations: [
+      distributionRecord(INSTALLED_ID, INSTALLED_NAME, 'installed'),
+      distributionRecord(FAILED_ID, FAILED_NAME, 'failed'),
+    ],
+  })
+  await expectChooserVisible(ctx.panel)
+  await waitForSeededTiles()
+  capturer = new ScreenCapturer(ctx.app, outDir, SCREENS)
+})
+
+test.afterAll(async () => {
+  await ctx?.cleanup()
+  if (rootDir) await rm(rootDir, { recursive: true, force: true })
+  if (realInstallationsFile) {
+    if (realInstallationsBackup !== null) await writeFile(realInstallationsFile, realInstallationsBackup)
+    else await rm(realInstallationsFile, { force: true })
+  }
+})
+
+test('chooser identity corner @capture', async () => {
+  const status = await ctx.panel.evaluate<{ signedIn?: boolean }>(
+    'window.api.comfybuilder.getAuthStatus()',
+  )
+
+  if (!status?.signedIn) {
+    await capturer.capture('chooser-signed-out')
+    capturer.skip('chooser-signed-in', SIGNED_IN_ONLY)
+    capturer.skip('workspace-switcher', SIGNED_IN_ONLY)
+    capturer.skip('distribution-cards', SIGNED_IN_ONLY)
+    return
+  }
+
+  capturer.skip(
+    'chooser-signed-out',
+    'a dev-platform session is active in this profile, so the log-in chip is not on screen',
+  )
+  await capturer.capture('chooser-signed-in')
+
+  // An empty or unreachable catalog is a real product state, not a harness
+  // failure — record it as a gap rather than failing the run.
+  const hasCards = await ctx.panel
+    .waitForVisible('.dist-tile--chooser', { timeout: 10_000 })
+    .then(() => true, () => false)
+  if (hasCards) await capturer.capture('distribution-cards')
+  else capturer.skip('distribution-cards', 'the signed-in workspace publishes no installable distribution')
+
+  // The menu only. Selecting a row re-runs the browser handoff and Sign out is
+  // real, so neither is ever clicked.
+  expect(await ctx.panel.click('.account-chip__face'), 'account chip click dispatched').toBe(true)
+  await capturer.capture('workspace-switcher')
+  await closeAccountMenu()
+})
+
+test('host title bar @capture', async () => {
+  await capturer.capture('title-bar')
+})
+
+test('workspace shelf tile and its kebab @capture', async () => {
+  await capturer.capture('builder-install-tile')
+
+  expect(
+    await ctx.panel.click(byTestId(TID.dashboardTileKebab(INSTALLED_ID))),
+    'install tile kebab click dispatched',
+  ).toBe(true)
+  await capturer.capture('builder-install-tile-kebab')
+
+  await dismissOverlay(ctx.panel)
+  await ctx.panel.waitFor(async () => !(await ctx.panel.exists('.context-menu')), {
+    message: 'kebab menu never closed',
+  })
+})
+
+test('manage popup for a distribution install @capture', async () => {
+  await ctx.panel.evaluate<boolean>(
+    `(() => { window.api.openInstancePicker({ installationId: ${JSON.stringify(INSTALLED_ID)} }); return true })()`,
+  )
+  await waitForWebContents(ctx.app, TITLE_POPUP)
+  await expect
+    .poll(() => isPopupVisible(ctx.app, TITLE_POPUP), { timeout: 10_000, intervals: [100, 200] })
+    .toBe(true)
+
+  await capturer.capture('builder-install-manage')
+  await closeTitlePopupIfOpen(ctx.app)
+})
+
+test('not-ready alert on a failed distribution install @capture', async () => {
+  await clickInstallTile(ctx.panel, FAILED_NAME)
+  await capturer.capture('builder-install-not-ready')
+
+  await ctx.panel.click(byTestId(TID.baseAlertAction))
+  await expectChooserVisible(ctx.panel)
+})
+
+test('install progress and its failure @capture', async () => {
+  // No real install: `startInFlightOp` opens the same ProgressModal the
+  // distribution flow drives, with an apiCall that stays pending until settled.
+  const title = `${en.newInstall.installing}: ${INSTALLED_NAME}`
+  await ctx.panel.evaluate<void>(`(async () => {
+    await window.__e2eRenderer.startInFlightOp({
+      installationId: ${JSON.stringify(INSTALLED_ID)},
+      title: ${JSON.stringify(title)},
+      opKind: 'install',
+    })
+  })()`)
+  await capturer.capture('builder-install-progress')
+
+  // Same op, now failed — the transition a real install makes.
+  expect(
+    await ctx.panel.evaluate<boolean>(`window.__e2eRenderer.settleInFlightOp({
+      installationId: ${JSON.stringify(INSTALLED_ID)},
+      result: { ok: false, message: ${JSON.stringify(en.errors.installFailedDetail)} },
+    })`),
+    'in-flight op settled',
+  ).toBe(true)
+  await capturer.capture('builder-install-failed')
+})
+
+test('every declared screen is captured or explained @capture', async () => {
+  const manifest = await capturer.writeManifest(DISTRIBUTION_STATES)
+  console.log(`[capture] ${manifest.captured.length} captured, ${manifest.skipped.length} skipped`)
+  // A screen that is neither shot nor explained fails the run rather than
+  // quietly shrinking the set.
+  expect(capturer.accountedIds()).toEqual(capturer.declaredIds())
+
+  // Two identical PNGs mean a screen was shot before the compositor caught up
+  // and the set silently under-covers — the whole point of the harness.
+  const byDigest = new Map<string, string>()
+  for (const record of manifest.captured) {
+    const digest = createHash('sha256')
+      .update(await readFile(path.join(outDir, record.file)))
+      .digest('hex')
+    expect(byDigest.get(digest), `${record.file} is byte-identical to ${byDigest.get(digest)}`).toBeUndefined()
+    byDigest.set(digest, record.file)
+  }
+})
+
+/**
+ * The harness seeds `installations.json` after launch, so the chooser may
+ * already have fetched an empty list and nothing tells it otherwise. Nudge it
+ * down the app's own `installations-changed` path, then hold until both seeded
+ * tiles are on screen — every capture assumes they are.
+ */
+async function waitForSeededTiles(): Promise<void> {
+  await ctx.app.evaluate(({ webContents }) => {
+    for (const wc of webContents.getAllWebContents()) {
+      if (wc.getURL().includes('panel.html')) wc.send('installations-changed', {})
+    }
+  })
+  for (const id of [INSTALLED_ID, FAILED_ID]) {
+    await ctx.panel.waitForVisible(byTestId(TID.dashboardTile(id)), { timeout: 15_000 })
+  }
+}
+
+/** The chip's Escape handler is bound to its own root, so a document-level key
+ *  event never reaches it; the outside-pointer dismissal does. */
+async function closeAccountMenu(): Promise<void> {
+  await ctx.panel.evaluate<boolean>(
+    `(() => { document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true })); return true })()`,
+  )
+  await ctx.panel.waitFor(async () => !(await ctx.panel.exists('.account-chip__menu')), {
+    message: 'account menu never closed',
+  })
+}

--- a/e2e/comfybuilder-capture.test.ts
+++ b/e2e/comfybuilder-capture.test.ts
@@ -35,9 +35,10 @@
  * macOS PROFILE. `dataDir()` resolves to `app.getPath('userData')`
  * (`src/main/lib/paths.ts`), which ignores the harness HOME override on macOS,
  * so seeding rewrites the operator's REAL `installations.json`. It is snapshot
- * before launch and restored in `afterAll`. The same path lets `E2E_SETTINGS_SEED`
- * replace the operator's `settings.json` wholesale — that is pre-existing
- * behaviour of every e2e run here and is deliberately not addressed by this file.
+ * before launch, checked against the launched app's own `userData`, and restored
+ * in `afterAll`. The same path lets `E2E_SETTINGS_SEED` replace the operator's
+ * `settings.json` wholesale — pre-existing behaviour of every e2e run here,
+ * deliberately not addressed by this file but flagged on the README row.
  */
 
 import os from 'node:os'
@@ -66,16 +67,26 @@ const INSTALLED_NAME = 'desktop-4target-stg-v0190'
 const FAILED_ID = 'inst-capture-builder-failed'
 const FAILED_NAME = 'desktop-4target-stg-v0192'
 
-/** Statuses the seeded records put on screen, echoed into the manifest. */
-const DISTRIBUTION_STATES = ['installed', 'failed']
+/** The distribution installs this run seeds. Their statuses are what the
+ *  manifest reports as covered, so a third seed can't leave it stale. */
+const SEEDS = [
+  { id: INSTALLED_ID, name: INSTALLED_NAME, status: 'installed' },
+  { id: FAILED_ID, name: FAILED_NAME, status: 'failed' },
+] as const
 
 const SIGNED_IN_ONLY = 'requires a signed-in dev-platform session'
+
+/** `useInstallContextMenu` always offers Manage on a chooser tile, so this item
+ *  is the kebab's open/closed gate. */
+const KEBAB_ITEM = 'manage'
 
 /** Declaration order IS file order. */
 const SCREENS: readonly CaptureTarget[] = [
   { id: 'chooser-signed-out', surface: PANEL, anchor: '.chooser-view .account-chip__signin' },
   { id: 'chooser-signed-in', surface: PANEL, anchor: '.chooser-view .account-chip__face' },
-  { id: 'workspace-switcher', surface: PANEL, anchor: '.account-chip__menu' },
+  // A row, not the menu: the list is fetched lazily on open, so the container's
+  // first frame is the "Loading…" hint.
+  { id: 'workspace-switcher', surface: PANEL, anchor: '.account-chip__workspace-item' },
   // Cropped for the same reason as the shelf below: the row of not-yet-installed
   // distributions, not another shot of the whole chooser.
   {
@@ -94,7 +105,7 @@ const SCREENS: readonly CaptureTarget[] = [
     anchor: byTestId(TID.dashboardTile(INSTALLED_ID)),
     crop: '.chooser-shelf:has(.chooser-shelf-head)',
   },
-  { id: 'builder-install-tile-kebab', surface: PANEL, anchor: '.context-menu' },
+  { id: 'builder-install-tile-kebab', surface: PANEL, anchor: byTestId(TID.contextMenuItem(KEBAB_ITEM)) },
   { id: 'builder-install-manage', surface: TITLE_POPUP, anchor: byTestId(TID.pickerRow(INSTALLED_ID)) },
   { id: 'builder-install-not-ready', surface: PANEL, anchor: byTestId(TID.baseAlertAction) },
   { id: 'builder-install-progress', surface: PANEL, anchor: '.brand-progress__bar' },
@@ -102,7 +113,9 @@ const SCREENS: readonly CaptureTarget[] = [
 ]
 
 /** macOS only — see the header. Null everywhere else, where the harness HOME
- *  override does isolate `userData`. */
+ *  override does isolate `userData`. Checked against the launched app's own
+ *  `userData` below: this is the one file the harness writes outside a tmp dir,
+ *  so the path must never be a silent guess. */
 const realInstallationsFile = process.platform === 'darwin'
   ? path.join(os.homedir(), 'Library', 'Application Support', 'comfyui-desktop-2', 'installations.json')
   : null
@@ -140,15 +153,15 @@ function distributionRecord(id: string, name: string, status: string): SeedInsta
 
 test.beforeAll(async () => {
   if (realInstallationsFile) {
-    realInstallationsBackup = await readFile(realInstallationsFile, 'utf8').catch(() => null)
+    realInstallationsBackup = await readIfPresent(realInstallationsFile)
   }
 
   rootDir = await mkdtemp(path.join(os.tmpdir(), 'comfyui-launcher-capture-e2e-'))
   // A missing folder earns the tile a "Folder Not Found" danger pill
   // (`enrichInstallationsForRenderer`), which would be a lie in the screenshot.
-  for (const id of [INSTALLED_ID, FAILED_ID]) {
-    await mkdir(path.join(rootDir, id, 'ComfyUI'), { recursive: true })
-    await writeFile(path.join(rootDir, id, 'ComfyUI', 'main.py'), '')
+  for (const seed of SEEDS) {
+    await mkdir(path.join(rootDir, seed.id, 'ComfyUI'), { recursive: true })
+    await writeFile(path.join(rootDir, seed.id, 'ComfyUI', 'main.py'), '')
   }
 
   outDir = captureDir()
@@ -157,20 +170,26 @@ test.beforeAll(async () => {
 
   ctx = await launchApp({
     settings: { firstUseCompleted: true, telemetryEnabled: false },
-    installations: [
-      distributionRecord(INSTALLED_ID, INSTALLED_NAME, 'installed'),
-      distributionRecord(FAILED_ID, FAILED_NAME, 'failed'),
-    ],
+    installations: SEEDS.map((s) => distributionRecord(s.id, s.name, s.status)),
   })
+  if (realInstallationsFile) {
+    expect(
+      path.join(ctx.userDataDir, 'installations.json'),
+      'seeded the installations.json that was snapshotted',
+    ).toBe(realInstallationsFile)
+  }
   await expectChooserVisible(ctx.panel)
   await waitForSeededTiles()
-  capturer = new ScreenCapturer(ctx.app, outDir, SCREENS)
+  capturer = await ScreenCapturer.create(ctx.app, outDir, SCREENS)
 })
 
 test.afterAll(async () => {
   await ctx?.cleanup()
   if (rootDir) await rm(rootDir, { recursive: true, force: true })
-  if (realInstallationsFile) {
+  // Only touch the real profile when the snapshot really is the file the app
+  // seeded; on a mismatch `beforeAll` already failed loudly and deleting would
+  // compound it.
+  if (realInstallationsFile && ctx?.userDataDir === path.dirname(realInstallationsFile)) {
     if (realInstallationsBackup !== null) await writeFile(realInstallationsFile, realInstallationsBackup)
     else await rm(realInstallationsFile, { force: true })
   }
@@ -206,7 +225,13 @@ test('chooser identity corner @capture', async () => {
   // The menu only. Selecting a row re-runs the browser handoff and Sign out is
   // real, so neither is ever clicked.
   expect(await ctx.panel.click('.account-chip__face'), 'account chip click dispatched').toBe(true)
-  await capturer.capture('workspace-switcher')
+  // The rows arrive on a lazy fetch; a list that never loads is a real product
+  // state, so record the gap rather than shooting the loading hint.
+  const hasRows = await ctx.panel
+    .waitForVisible('.account-chip__workspace-item', { timeout: 10_000 })
+    .then(() => true, () => false)
+  if (hasRows) await capturer.capture('workspace-switcher')
+  else capturer.skip('workspace-switcher', 'the workspace list did not load, so the switcher has no rows')
   await closeAccountMenu()
 })
 
@@ -224,9 +249,10 @@ test('workspace shelf tile and its kebab @capture', async () => {
   await capturer.capture('builder-install-tile-kebab')
 
   await dismissOverlay(ctx.panel)
-  await ctx.panel.waitFor(async () => !(await ctx.panel.exists('.context-menu')), {
-    message: 'kebab menu never closed',
-  })
+  await ctx.panel.waitFor(
+    async () => !(await ctx.panel.exists(byTestId(TID.contextMenuItem(KEBAB_ITEM)))),
+    { message: 'kebab menu never closed' },
+  )
 })
 
 test('manage popup for a distribution install @capture', async () => {
@@ -246,8 +272,13 @@ test('not-ready alert on a failed distribution install @capture', async () => {
   await clickInstallTile(ctx.panel, FAILED_NAME)
   await capturer.capture('builder-install-not-ready')
 
-  await ctx.panel.click(byTestId(TID.baseAlertAction))
-  await expectChooserVisible(ctx.panel)
+  // The alert is teleported and fixed, so `.chooser-view` stays visible under
+  // it — only its own disappearance proves it went away, and a modal left up
+  // would sit on top of the next two screens.
+  expect(await ctx.panel.click(byTestId(TID.baseAlertAction)), 'alert action click dispatched').toBe(true)
+  await ctx.panel.waitFor(async () => !(await ctx.panel.exists(byTestId(TID.baseAlertAction))), {
+    message: 'not-ready alert never closed',
+  })
 })
 
 test('install progress and its failure @capture', async () => {
@@ -263,11 +294,15 @@ test('install progress and its failure @capture', async () => {
   })()`)
   await capturer.capture('builder-install-progress')
 
-  // Same op, now failed — the transition a real install makes.
+  // Same op, now failed — the transition a real install makes. The modal shows
+  // `installInstance`'s own message, so use one the distribution install path
+  // really produces (`assertLayout` in `src/main/comfybuilder/install.ts`)
+  // rather than a string from another surface.
+  const failure = 'Extracted artifact is missing a real venv/ directory.'
   expect(
     await ctx.panel.evaluate<boolean>(`window.__e2eRenderer.settleInFlightOp({
       installationId: ${JSON.stringify(INSTALLED_ID)},
-      result: { ok: false, message: ${JSON.stringify(en.errors.installFailedDetail)} },
+      result: { ok: false, message: ${JSON.stringify(failure)} },
     })`),
     'in-flight op settled',
   ).toBe(true)
@@ -275,8 +310,6 @@ test('install progress and its failure @capture', async () => {
 })
 
 test('every declared screen is captured or explained @capture', async () => {
-  const manifest = await capturer.writeManifest(DISTRIBUTION_STATES)
-  console.log(`[capture] ${manifest.captured.length} captured, ${manifest.skipped.length} skipped`)
   // A screen that is neither shot nor explained fails the run rather than
   // quietly shrinking the set.
   expect(capturer.accountedIds()).toEqual(capturer.declaredIds())
@@ -284,13 +317,18 @@ test('every declared screen is captured or explained @capture', async () => {
   // Two identical PNGs mean a screen was shot before the compositor caught up
   // and the set silently under-covers — the whole point of the harness.
   const byDigest = new Map<string, string>()
-  for (const record of manifest.captured) {
+  for (const record of capturer.captured) {
     const digest = createHash('sha256')
       .update(await readFile(path.join(outDir, record.file)))
       .digest('hex')
     expect(byDigest.get(digest), `${record.file} is byte-identical to ${byDigest.get(digest)}`).toBeUndefined()
     byDigest.set(digest, record.file)
   }
+
+  // Written only once the set is known good: a red run must not leave a
+  // complete-looking contract behind for the Figma follow-up to consume.
+  const manifest = await capturer.writeManifest(SEEDS.map((s) => s.status))
+  console.log(`[capture] ${manifest.captured.length} captured, ${manifest.skipped.length} skipped`)
 })
 
 /**
@@ -300,13 +338,25 @@ test('every declared screen is captured or explained @capture', async () => {
  * tiles are on screen — every capture assumes they are.
  */
 async function waitForSeededTiles(): Promise<void> {
-  await ctx.app.evaluate(({ webContents }) => {
+  await ctx.app.evaluate(({ webContents }, marker) => {
     for (const wc of webContents.getAllWebContents()) {
-      if (wc.getURL().includes('panel.html')) wc.send('installations-changed', {})
+      if (wc.getURL().includes(marker)) wc.send('installations-changed', {})
     }
-  })
-  for (const id of [INSTALLED_ID, FAILED_ID]) {
-    await ctx.panel.waitForVisible(byTestId(TID.dashboardTile(id)), { timeout: 15_000 })
+  }, PANEL)
+  for (const seed of SEEDS) {
+    await ctx.panel.waitForVisible(byTestId(TID.dashboardTile(seed.id)), { timeout: 15_000 })
+  }
+}
+
+/** Null only when the file genuinely does not exist — any other read failure
+ *  must not pass as "the operator had none", which would lose their records. */
+async function readIfPresent(file: string): Promise<string | null> {
+  try {
+    return await readFile(file, 'utf8')
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err
+    console.log(`[capture] no installations.json to snapshot at ${file}`)
+    return null
   }
 }
 

--- a/e2e/launchApp.ts
+++ b/e2e/launchApp.ts
@@ -33,11 +33,14 @@ export interface AppContext {
   panel: WebContentsPage
   /** Eval-bridge facade over the chooser host's title-bar webContents. */
   titleBar: WebContentsPage
+  /** Where the launched app resolved `userData` to — the dir the harness
+   *  seeded `installations.json` into. */
+  userDataDir: string
   cleanup: () => Promise<void>
 }
 
 export async function launchApp(options?: SeedOptions): Promise<AppContext> {
-  const { application, cleanup: cleanupHarness } = await launchLauncherApp(options)
+  const { application, userDataDir, cleanup: cleanupHarness } = await launchLauncherApp(options)
 
   // Wait for the chooser host's panel + title-bar webContents to actually
   // exist on the main side BEFORE attempting CDP discovery. The parent
@@ -65,6 +68,7 @@ export async function launchApp(options?: SeedOptions): Promise<AppContext> {
     app: application,
     panel,
     titleBar,
+    userDataDir,
     cleanup: cleanupHarness,
   }
 }

--- a/e2e/support/electronHarness.ts
+++ b/e2e/support/electronHarness.ts
@@ -7,6 +7,9 @@ import { _electron as electron, type ElectronApplication } from 'playwright'
 export interface LauncherAppHandle {
   application: ElectronApplication
   homeDir: string
+  /** `app.getPath('userData')` as the launched app resolves it. On macOS this
+   *  is NOT under `homeDir` — Application Support ignores the HOME override. */
+  userDataDir: string
   /** CDP remote-debugging port for connecting to non-BrowserWindow webContents. */
   cdpPort: number
   cleanup: () => Promise<void>
@@ -162,12 +165,14 @@ export async function launchLauncherApp(options?: SeedOptions): Promise<Launcher
     electronApp.on('render-process-gone', () => electronApp.exit(1))
   })
 
-  // Seed installations after launch so we can query app.getPath('userData')
-  // for the correct dir (Electron may modify the app name per platform).
+  // Resolved from the running app rather than derived: Electron may modify the
+  // app name per platform, and callers that write here must not guess.
+  const userDataDir = await application.evaluate(async ({ app: electronApp }) => {
+    return electronApp.getPath('userData')
+  })
+
+  // Seed installations after launch so the write lands in that same dir.
   if (options?.installations && options.installations.length > 0) {
-    const userDataDir = await application.evaluate(async ({ app: electronApp }) => {
-      return electronApp.getPath('userData')
-    })
     const records = options.installations.map((inst, i) => {
       const { snapshots: _snapshots, ...rest } = inst
       return {
@@ -231,7 +236,7 @@ export async function launchLauncherApp(options?: SeedOptions): Promise<Launcher
     }
   }
 
-  return { application, homeDir, cdpPort, cleanup }
+  return { application, homeDir, userDataDir, cdpPort, cleanup }
 }
 
 export async function waitForAppExit(application: ElectronApplication, timeoutMs = 10_000): Promise<void> {

--- a/e2e/support/screenCapture.ts
+++ b/e2e/support/screenCapture.ts
@@ -1,0 +1,249 @@
+/**
+ * Screenshot harness behind the opt-in `capture` Playwright project.
+ *
+ * One PNG per surface via `webContents.capturePage()`, driven through
+ * `app.evaluate`. There is no single full-window shot to take: the host
+ * BrowserWindow has no DOM of its own — the title bar and the panel are sibling
+ * WebContentsViews composited natively (`src/main/host/createHostWindow.ts`), so
+ * `BrowserWindow.capturePage()` would hand back a blank plate. The image crosses
+ * the Playwright bridge as base64 because a Buffer does not survive it.
+ */
+
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { expect, type ElectronApplication } from '@playwright/test'
+import { WebContentsPage } from './cdpPages'
+
+/** Canonical chooser host size — `DEFAULT_HOST_WIDTH` / `DEFAULT_HOST_HEIGHT`
+ *  in `src/main/host/createHostWindow.ts`. Every screen is shot at it. */
+export const CAPTURE_CONTENT_WIDTH = 1280
+export const CAPTURE_CONTENT_HEIGHT = 900
+
+/** Stills the tile FLIP, the brand beams, the progress bar and the text caret,
+ *  so the shutter can't land mid-frame and two runs agree. */
+const FREEZE_CSS = `*, *::before, *::after {
+  animation: none !important;
+  transition: none !important;
+  caret-color: transparent !important;
+}`
+
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+
+interface CropRect {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+export interface CaptureTarget {
+  /** Stable id; also the filename stem after the ordinal prefix. */
+  id: string
+  /** URL marker of the webContents the screen lives in. */
+  surface: string
+  /** Selector that must be visible before the shutter fires. */
+  anchor: string
+  /** Crop the shot to this element's box. Omit for the whole surface; set it
+   *  when a screen would otherwise be pixel-identical to a wider one. */
+  crop?: string
+}
+
+export interface CaptureRecord extends CaptureTarget {
+  file: string
+  /** Real PNG pixel size, read back out of the IHDR — on a HiDPI display this
+   *  is `scaleFactor` times the CSS size, which is what Figma wants. */
+  width: number
+  height: number
+  /** Native pixels per DIP for this shot; 2 on a Retina display. */
+  scaleFactor: number
+}
+
+export interface SkippedCapture {
+  id: string
+  reason: string
+}
+
+export interface CaptureManifest {
+  createdAt: string
+  platform: string
+  contentSize: { width: number; height: number }
+  captured: CaptureRecord[]
+  skipped: SkippedCapture[]
+  /** Distribution-install statuses the run actually put on screen. */
+  distributionStates: string[]
+}
+
+/** `captures/` at the repo root, or `COMFY_CAPTURE_DIR`. */
+export function captureDir(): string {
+  const override = process.env['COMFY_CAPTURE_DIR']
+  return override ? path.resolve(override) : path.resolve(__dirname, '..', '..', 'captures')
+}
+
+/** Wipe and recreate, so a screen dropped from the declaration can't linger as
+ *  a stale PNG beside the fresh set. */
+export async function resetCaptureDir(dir: string): Promise<void> {
+  await rm(dir, { recursive: true, force: true })
+  await mkdir(dir, { recursive: true })
+}
+
+/** Pin the host window to the canonical size so every PNG is the same shape. */
+async function setHostContentSize(app: ElectronApplication): Promise<void> {
+  await app.evaluate(({ BrowserWindow }, size) => {
+    const win = BrowserWindow.getAllWindows().find((w) => !w.isDestroyed())
+    if (!win) throw new Error('no host window to size')
+    win.setContentSize(size.width, size.height)
+  }, { width: CAPTURE_CONTENT_WIDTH, height: CAPTURE_CONTENT_HEIGHT })
+}
+
+/**
+ * Wait for a painted frame. A visible anchor only proves the DOM changed;
+ * without this `capturePage` can hand back the previous screen, which is how
+ * two adjacent states of one operation end up byte-identical. Raced against a
+ * timeout because rAF stops firing on an occluded window and this must never
+ * be the thing that hangs a run.
+ */
+function paintBarrier(page: WebContentsPage): Promise<boolean> {
+  return page.evaluate<boolean>(`Promise.race([
+    new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve(true)))),
+    new Promise((resolve) => setTimeout(() => resolve(false), 2000)),
+  ])`)
+}
+
+/** The element's box in DIP, rounded outwards — `capturePage(rect)` wants
+ *  integers and a fractional box would shave an edge pixel. */
+function elementRect(page: WebContentsPage, selector: string): Promise<CropRect | null> {
+  return page.evaluate<CropRect | null>(`(() => {
+    const el = document.querySelector(${JSON.stringify(selector)})
+    if (!el) return null
+    const r = el.getBoundingClientRect()
+    return {
+      x: Math.floor(r.left),
+      y: Math.floor(r.top),
+      width: Math.ceil(r.right) - Math.floor(r.left),
+      height: Math.ceil(r.bottom) - Math.floor(r.top),
+    }
+  })()`)
+}
+
+/**
+ * Shoots the declared screens and keeps the books. Every declared id must end
+ * up either captured or skipped-with-a-reason; the caller asserts that, so a
+ * renamed selector fails the run instead of silently emitting a short set.
+ */
+export class ScreenCapturer {
+  readonly captured: CaptureRecord[] = []
+  readonly skipped: SkippedCapture[] = []
+  /** Surfaces already carrying the freeze rule; re-inserting is pointless. */
+  private readonly frozen = new Set<string>()
+  /** Last base64 shot per surface, to catch a repeated compositor frame. */
+  private readonly lastShot = new Map<string, string>()
+
+  constructor(
+    private readonly app: ElectronApplication,
+    private readonly outDir: string,
+    /** Every screen the harness claims, in file order. */
+    private readonly declared: readonly CaptureTarget[],
+  ) {}
+
+  /** Wait for the screen's anchor, then write `NN-<id>.png`. */
+  async capture(id: string): Promise<CaptureRecord> {
+    const index = this.declared.findIndex((t) => t.id === id)
+    const target = this.declared[index]
+    if (!target) throw new Error(`capture "${id}" is not declared`)
+
+    await setHostContentSize(this.app)
+    const page = new WebContentsPage(this.app, target.surface)
+    await page.waitForVisible(target.anchor, { timeout: 20_000 })
+    await this.freeze(target.surface)
+    await page.evaluate<boolean>('document.fonts.ready.then(() => true)')
+    await paintBarrier(page)
+
+    const rect = target.crop ? await elementRect(page, target.crop) : null
+    if (target.crop) expect(rect, `${id}: crop selector ${target.crop} matched nothing`).not.toBeNull()
+
+    let shot = await this.shoot(target.surface, rect)
+    // Byte-identical to the last shot of this surface almost always means the
+    // compositor hadn't presented the new state yet. Give it another frame and
+    // re-shoot; a screen that genuinely repeats simply keeps the second shot.
+    if (shot.png === this.lastShot.get(target.surface)) {
+      await paintBarrier(page)
+      shot = await this.shoot(target.surface, rect)
+    }
+    this.lastShot.set(target.surface, shot.png)
+
+    expect(shot.empty, `${id}: capturePage returned an empty NativeImage`).toBe(false)
+    const png = Buffer.from(shot.png, 'base64')
+    expect(
+      png.subarray(0, PNG_SIGNATURE.length).equals(PNG_SIGNATURE),
+      `${id}: capturePage returned no PNG data`,
+    ).toBe(true)
+    const width = png.readUInt32BE(16)
+    const height = png.readUInt32BE(20)
+    expect(Math.min(width, height), `${id}: capturePage returned a zero-sized image`).toBeGreaterThan(0)
+
+    const file = `${String(index + 1).padStart(2, '0')}-${id}.png`
+    await writeFile(path.join(this.outDir, file), png)
+
+    const record: CaptureRecord = { ...target, file, width, height, scaleFactor: shot.scaleFactor }
+    this.captured.push(record)
+    return record
+  }
+
+  /** Record a screen this run could not reach, and why. */
+  skip(id: string, reason: string): void {
+    if (!this.declared.some((t) => t.id === id)) throw new Error(`capture "${id}" is not declared`)
+    console.log(`[capture] skipped ${id}: ${reason}`)
+    this.skipped.push({ id, reason })
+  }
+
+  /** Declared ids, sorted — the expected side of the accounting assertion. */
+  declaredIds(): string[] {
+    return this.declared.map((t) => t.id).sort()
+  }
+
+  /** Captured + skipped ids, sorted. */
+  accountedIds(): string[] {
+    return [...this.captured.map((r) => r.id), ...this.skipped.map((s) => s.id)].sort()
+  }
+
+  /** The contract the Figma follow-up consumes; the gaps are explicit in it. */
+  async writeManifest(distributionStates: string[]): Promise<CaptureManifest> {
+    const manifest: CaptureManifest = {
+      createdAt: new Date().toISOString(),
+      platform: process.platform,
+      contentSize: { width: CAPTURE_CONTENT_WIDTH, height: CAPTURE_CONTENT_HEIGHT },
+      captured: this.captured,
+      skipped: this.skipped,
+      distributionStates,
+    }
+    await writeFile(path.join(this.outDir, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`)
+    return manifest
+  }
+
+  /** One `capturePage`, at the display's native scale — no resampling, so Figma
+   *  gets @2x on a Retina panel. */
+  private shoot(marker: string, rect: CropRect | null) {
+    return this.app.evaluate(async ({ BrowserWindow, screen, webContents }, payload) => {
+      const wc = webContents.getAllWebContents().find((w) => w.getURL().includes(payload.marker))
+      if (!wc || wc.isDestroyed()) throw new Error(`webContents not found (marker=${payload.marker})`)
+      const image = payload.rect ? await wc.capturePage(payload.rect) : await wc.capturePage()
+      const win = BrowserWindow.getAllWindows().find((w) => !w.isDestroyed())
+      const display = win ? screen.getDisplayMatching(win.getBounds()) : screen.getPrimaryDisplay()
+      return {
+        png: image.toPNG().toString('base64'),
+        empty: image.isEmpty(),
+        scaleFactor: display.scaleFactor,
+      }
+    }, { marker, rect })
+  }
+
+  private async freeze(marker: string): Promise<void> {
+    if (this.frozen.has(marker)) return
+    await this.app.evaluate(async ({ webContents }, payload) => {
+      const wc = webContents.getAllWebContents().find((w) => w.getURL().includes(payload.marker))
+      if (!wc || wc.isDestroyed()) throw new Error(`webContents not found (marker=${payload.marker})`)
+      await wc.insertCSS(payload.css)
+    }, { marker, css: FREEZE_CSS })
+    this.frozen.add(marker)
+  }
+}

--- a/e2e/support/screenCapture.ts
+++ b/e2e/support/screenCapture.ts
@@ -12,7 +12,7 @@
 import { mkdir, rm, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 import { expect, type ElectronApplication } from '@playwright/test'
-import { WebContentsPage } from './cdpPages'
+import { findWebContentsId, WebContentsPage } from './cdpPages'
 
 /** Canonical chooser host size — `DEFAULT_HOST_WIDTH` / `DEFAULT_HOST_HEIGHT`
  *  in `src/main/host/createHostWindow.ts`. Every screen is shot at it. */
@@ -54,7 +54,7 @@ export interface CaptureRecord extends CaptureTarget {
    *  is `scaleFactor` times the CSS size, which is what Figma wants. */
   width: number
   height: number
-  /** Native pixels per DIP for this shot; 2 on a Retina display. */
+  /** Native pixels per DIP for the run; 2 on a Retina display. */
   scaleFactor: number
 }
 
@@ -69,7 +69,8 @@ export interface CaptureManifest {
   contentSize: { width: number; height: number }
   captured: CaptureRecord[]
   skipped: SkippedCapture[]
-  /** Distribution-install statuses the run actually put on screen. */
+  /** Distribution-install statuses the run seeded — declared by the caller,
+   *  not observed here. */
   distributionStates: string[]
 }
 
@@ -86,12 +87,14 @@ export async function resetCaptureDir(dir: string): Promise<void> {
   await mkdir(dir, { recursive: true })
 }
 
-/** Pin the host window to the canonical size so every PNG is the same shape. */
-async function setHostContentSize(app: ElectronApplication): Promise<void> {
-  await app.evaluate(({ BrowserWindow }, size) => {
+/** Pin the host window to the canonical size so every PNG is the same shape,
+ *  and read the scale those shots land at. */
+function prepareHost(app: ElectronApplication): Promise<number> {
+  return app.evaluate(({ BrowserWindow, screen }, size) => {
     const win = BrowserWindow.getAllWindows().find((w) => !w.isDestroyed())
     if (!win) throw new Error('no host window to size')
     win.setContentSize(size.width, size.height)
+    return screen.getDisplayMatching(win.getBounds()).scaleFactor
   }, { width: CAPTURE_CONTENT_WIDTH, height: CAPTURE_CONTENT_HEIGHT })
 }
 
@@ -100,20 +103,24 @@ async function setHostContentSize(app: ElectronApplication): Promise<void> {
  * without this `capturePage` can hand back the previous screen, which is how
  * two adjacent states of one operation end up byte-identical. Raced against a
  * timeout because rAF stops firing on an occluded window and this must never
- * be the thing that hangs a run.
+ * be the thing that hangs a run; a barrier that times out is logged so a
+ * stale-frame run is visible after the fact.
  */
-function paintBarrier(page: WebContentsPage): Promise<boolean> {
-  return page.evaluate<boolean>(`Promise.race([
+async function paintBarrier(page: WebContentsPage, id: string): Promise<void> {
+  const painted = await page.evaluate<boolean>(`Promise.race([
     new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve(true)))),
     new Promise((resolve) => setTimeout(() => resolve(false), 2000)),
   ])`)
+  if (!painted) console.warn(`[capture] ${id}: no frame presented in 2s — this shot may be stale`)
 }
 
-/** The element's box in DIP, rounded outwards — `capturePage(rect)` wants
- *  integers and a fractional box would shave an edge pixel. */
-function elementRect(page: WebContentsPage, selector: string): Promise<CropRect | null> {
+/** The crop element's box in DIP, rounded outwards — `capturePage(rect)` wants
+ *  integers and a fractional box would shave an edge pixel. Resolved as the
+ *  anchor's nearest matching ancestor, so a shot always contains the element
+ *  the shutter waited for. */
+function cropRect(page: WebContentsPage, anchor: string, crop: string): Promise<CropRect | null> {
   return page.evaluate<CropRect | null>(`(() => {
-    const el = document.querySelector(${JSON.stringify(selector)})
+    const el = document.querySelector(${JSON.stringify(anchor)})?.closest(${JSON.stringify(crop)})
     if (!el) return null
     const r = el.getBoundingClientRect()
     return {
@@ -138,36 +145,52 @@ export class ScreenCapturer {
   /** Last base64 shot per surface, to catch a repeated compositor frame. */
   private readonly lastShot = new Map<string, string>()
 
-  constructor(
+  /** Sizes the host once — the canonical size is a launch concern, not a
+   *  per-shot one — and pins the scale every record reports. */
+  static async create(
+    app: ElectronApplication,
+    outDir: string,
+    declared: readonly CaptureTarget[],
+  ): Promise<ScreenCapturer> {
+    return new ScreenCapturer(app, outDir, declared, await prepareHost(app))
+  }
+
+  private constructor(
     private readonly app: ElectronApplication,
     private readonly outDir: string,
     /** Every screen the harness claims, in file order. */
     private readonly declared: readonly CaptureTarget[],
+    /** Native pixels per DIP for this run; 2 on a Retina display. */
+    private readonly scaleFactor: number,
   ) {}
 
   /** Wait for the screen's anchor, then write `NN-<id>.png`. */
-  async capture(id: string): Promise<CaptureRecord> {
+  async capture(id: string): Promise<void> {
     const index = this.declared.findIndex((t) => t.id === id)
     const target = this.declared[index]
     if (!target) throw new Error(`capture "${id}" is not declared`)
 
-    await setHostContentSize(this.app)
     const page = new WebContentsPage(this.app, target.surface)
     await page.waitForVisible(target.anchor, { timeout: 20_000 })
-    await this.freeze(target.surface)
+    const wcId = await findWebContentsId(this.app, target.surface)
+    if (wcId === null) throw new Error(`webContents not found (marker=${target.surface})`)
+
+    await this.freeze(wcId, target.surface)
     await page.evaluate<boolean>('document.fonts.ready.then(() => true)')
-    await paintBarrier(page)
+    await paintBarrier(page, id)
 
-    const rect = target.crop ? await elementRect(page, target.crop) : null
-    if (target.crop) expect(rect, `${id}: crop selector ${target.crop} matched nothing`).not.toBeNull()
+    const rect = target.crop ? await cropRect(page, target.anchor, target.crop) : null
+    if (target.crop) {
+      expect(rect, `${id}: crop ${target.crop} is not an ancestor of ${target.anchor}`).not.toBeNull()
+    }
 
-    let shot = await this.shoot(target.surface, rect)
+    let shot = await this.shoot(wcId, rect)
     // Byte-identical to the last shot of this surface almost always means the
     // compositor hadn't presented the new state yet. Give it another frame and
     // re-shoot; a screen that genuinely repeats simply keeps the second shot.
     if (shot.png === this.lastShot.get(target.surface)) {
-      await paintBarrier(page)
-      shot = await this.shoot(target.surface, rect)
+      await paintBarrier(page, id)
+      shot = await this.shoot(wcId, rect)
     }
     this.lastShot.set(target.surface, shot.png)
 
@@ -184,9 +207,7 @@ export class ScreenCapturer {
     const file = `${String(index + 1).padStart(2, '0')}-${id}.png`
     await writeFile(path.join(this.outDir, file), png)
 
-    const record: CaptureRecord = { ...target, file, width, height, scaleFactor: shot.scaleFactor }
-    this.captured.push(record)
-    return record
+    this.captured.push({ ...target, file, width, height, scaleFactor: this.scaleFactor })
   }
 
   /** Record a screen this run could not reach, and why. */
@@ -222,28 +243,22 @@ export class ScreenCapturer {
 
   /** One `capturePage`, at the display's native scale — no resampling, so Figma
    *  gets @2x on a Retina panel. */
-  private shoot(marker: string, rect: CropRect | null) {
-    return this.app.evaluate(async ({ BrowserWindow, screen, webContents }, payload) => {
-      const wc = webContents.getAllWebContents().find((w) => w.getURL().includes(payload.marker))
-      if (!wc || wc.isDestroyed()) throw new Error(`webContents not found (marker=${payload.marker})`)
+  private shoot(wcId: number, rect: CropRect | null) {
+    return this.app.evaluate(async ({ webContents }, payload) => {
+      const wc = webContents.fromId(payload.wcId)
+      if (!wc || wc.isDestroyed()) throw new Error(`webContents ${payload.wcId} is gone`)
       const image = payload.rect ? await wc.capturePage(payload.rect) : await wc.capturePage()
-      const win = BrowserWindow.getAllWindows().find((w) => !w.isDestroyed())
-      const display = win ? screen.getDisplayMatching(win.getBounds()) : screen.getPrimaryDisplay()
-      return {
-        png: image.toPNG().toString('base64'),
-        empty: image.isEmpty(),
-        scaleFactor: display.scaleFactor,
-      }
-    }, { marker, rect })
+      return { png: image.toPNG().toString('base64'), empty: image.isEmpty() }
+    }, { wcId, rect })
   }
 
-  private async freeze(marker: string): Promise<void> {
+  private async freeze(wcId: number, marker: string): Promise<void> {
     if (this.frozen.has(marker)) return
     await this.app.evaluate(async ({ webContents }, payload) => {
-      const wc = webContents.getAllWebContents().find((w) => w.getURL().includes(payload.marker))
-      if (!wc || wc.isDestroyed()) throw new Error(`webContents not found (marker=${payload.marker})`)
+      const wc = webContents.fromId(payload.wcId)
+      if (!wc || wc.isDestroyed()) throw new Error(`webContents ${payload.wcId} is gone`)
       await wc.insertCSS(payload.css)
-    }, { marker, css: FREEZE_CSS })
+    }, { wcId, css: FREEZE_CSS })
     this.frozen.add(marker)
   }
 }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "test:e2e:macos": "playwright test --project=macos",
     "test:e2e:windows": "playwright test --project=windows",
     "test:e2e:linux": "playwright test --project=linux",
+    "test:e2e:capture": "playwright test --project=capture",
     "test:watch": "vitest",
     "prepare": "node ./scripts/prepare.mjs"
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,5 +17,7 @@ export default defineConfig({
     { name: 'windows', grep: /@windows/ },
     { name: 'linux', grep: /@linux/ },
     { name: 'lifecycle', grep: /@lifecycle/, timeout: 180_000 },
+    // Opt-in screenshot harness; deliberately absent from the CI matrix.
+    { name: 'capture', grep: /@capture/, timeout: 120_000 },
   ],
 })


### PR DESCRIPTION
Part of DES-565.

## Change

An opt-in Playwright harness that drives the built app and captures the Comfy Builder flow screens to `captures/` at a consistent viewport and deterministic file names. Regenerate with `pnpm run test:e2e:capture` when the UI changes, instead of hand-grabbing once.

## Not in CI

The capture spec runs under its own `capture` Playwright project, gated on a `@capture` tag. The CI matrix runs `--project=macos|windows|linux` only, so a normal run never collects it. `captures/` is gitignored.

## Coverage and its gaps

The harness captures what is reachable **signed out**: chooser identity corner, host title bar, workspace shelf tile and kebab, manage popup, not-ready alert, install progress and failure.

Screens behind sign-in are **not** captured — that needs auth, which this PR deliberately does not implement. A final assertion fails if a declared screen is neither captured nor explicitly explained, so the set can't silently rot into claiming coverage it doesn't have.

## Figma upload

Out of scope here. This PR produces the PNG set; getting it into Figma is the follow-up.

## Shared harness change

`launchLauncherApp` now always resolves `app.getPath('userData')` rather than only when seeding installations, and exposes it on the context. One extra eval per launch; existing specs are unaffected.

## Testing

`pnpm run typecheck` (4 configs), `lint`, `test`, `test:integration` — green. Capture project verified absent from the CI matrix by inspection.