### PR TITLE
docs: tighten download-manager comments

### DIFF
--- a/src/main/lib/comfyDownloadManager.test.ts
+++ b/src/main/lib/comfyDownloadManager.test.ts
@@ -543,11 +543,9 @@ describe('asset download retries', () => {
 
   it('re-downloads a URL that completed earlier and keeps a single copy when identical', async () => {
     // The same output event can be delivered again after the download has
-    // already finished (a replay across a reconnect, a second view of the
-    // session, or a re-run of a cached workflow re-serving the same URL).
-    // No time-based suppression: the repeat downloads again, and the
-    // content-identity check discards it in favor of the existing file so
-    // no "repeat (1).png" appears. A changed file (covered below) is kept.
+    // finished (a replay across a reconnect, a re-run re-serving the URL).
+    // The repeat downloads again and the content-identity check discards it
+    // in favor of the existing file, so no "repeat (1).png" appears.
     const outputDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'comfy-output-'))
     const url = 'https://remote.example/api/view?filename=repeat.png'
     const h = makeAssetHarness()

--- a/src/main/lib/comfyDownloadManager.ts
+++ b/src/main/lib/comfyDownloadManager.ts
@@ -306,8 +306,7 @@ const DEDUP_RESERVE = 6
 /**
  * Unique temp file name for an in-flight download. A random nonce (not just
  * a timestamp) prevents collisions when two downloads with the same leaf
- * name start in the same millisecond - plausible now that nested output
- * subfolders make identical basenames (a/video.mp4, b/video.mp4) common.
+ * name (a/video.mp4, b/video.mp4) start in the same millisecond.
  */
 function tempFileNameFor(filename: string): string {
   return `${Date.now()}-${randomUUID().slice(0, 8)}-${filename}.tmp`
@@ -695,10 +694,9 @@ export async function startAssetDownload(
   }
   pendingDownloads.set(url, pending)
 
-  // Failures below report a terminal `error` entry and resolve false instead
-  // of rethrowing: `retryDownload` re-dispatches fire-and-forget, so a
-  // rejection here would surface as an unhandled promise rejection rather
-  // than an error row, unlike `startModelDownload`'s failure paths.
+  // Setup failures report a terminal `error` entry and resolve false:
+  // `retryDownload` re-dispatches fire-and-forget, so a rejection here
+  // would become an unhandled promise rejection.
   let savePath: string
   try {
     savePath = await deduplicatePath(path.join(outputDir, safeFilename))
@@ -820,10 +818,8 @@ function attachDownloadListeners(item: Electron.DownloadItem, pending: PendingDo
     if (state === 'completed') {
       // If a byte-identical file already sits at the originally requested
       // destination, keep it and discard the temp copy instead of saving a
-      // duplicate "name (1)" file. This is the normal case when the "remote"
-      // server is actually local and writes its outputs into the same
-      // directory the auto-download saves to, and when a re-run re-serves an
-      // output that was already downloaded.
+      // duplicate "name (1)" file - e.g. a local "remote" server writing its
+      // outputs into the same directory the auto-download saves to.
       if (
         pending.tempPath &&
         pending.outputDir &&


### PR DESCRIPTION
Follow-up to #1277: trims comments in `comfyDownloadManager.ts`/`.test.ts` that were overly verbose or referenced other code paths and prior behavior instead of describing the current one. Comment-only, no behavior change.

- Setup-failure comment: 4 lines -> 3, drops the `startModelDownload` comparison
- `tempFileNameFor` doc: drops the "plausible now that" milestone framing
- Byte-identical discard comment: 6 lines -> 4
- Re-download test comment: 6 lines -> 4

Validation: `comfyDownloadManager.test.ts` 115/115; pre-push hooks (typecheck + lint) passed.