### PR TITLE
feat(templates): offer API-node starter templates in the install picker

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -857,6 +857,7 @@
     "templatePickerLead": "Opens a ready-to-run workflow. Models download during setup.",
     "templateModelsDownloaded": "Downloaded",
     "templateTabsAria": "Filter starter workflows by type",
+    "templateApiBadge": "Requires credits",
     "templateInstall": "Install",
     "templateSkipAndInstall": "Skip & Install",
     "templateSkipAndInstallAria": "Skip starter workflow and install ComfyUI",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -857,6 +857,7 @@
     "templatePickerLead": "打开即可运行的工作流。模型会在安装期间下载。",
     "templateModelsDownloaded": "已下载",
     "templateTabsAria": "按类型筛选入门工作流",
+    "templateApiBadge": "需要积分",
     "templateInstall": "安装",
     "templateSkipAndInstall": "跳过并安装",
     "templateSkipAndInstallAria": "跳过入门工作流并安装 ComfyUI",

--- a/src/main/lib/ipc/sessionActions/launch.ts
+++ b/src/main/lib/ipc/sessionActions/launch.ts
@@ -249,14 +249,12 @@ async function runLaunch(
   const sender = event.sender
   const sendProgress = makeSendProgress(sender, installationId)
 
-  // Show the starter-template model-download phase in THIS launch only on the
-  // first launch after install (one-shot `pendingTemplateOpen`), and only when a
-  // background download task actually exists for it. Covers the skip cases
-  // (no template / consent off / zero-model / relaunch).
+  /** Show template model-download phase for first launch if needed. */
   const showTemplatePhase =
     inst.sourceId === 'standalone' &&
     !!inst.bundledTemplateId &&
     inst.downloadTemplateModels === true &&
+    (inst.bundledTemplateSizeBytes ?? 0) > 0 &&
     !!inst.pendingTemplateOpen &&
     getTemplateDownloadState(installationId) !== undefined
 

--- a/src/main/sources/standalone/curatedTemplates.test.ts
+++ b/src/main/sources/standalone/curatedTemplates.test.ts
@@ -103,8 +103,27 @@ describe('CURATED_TEMPLATES manifest', () => {
     for (const t of CURATED_TEMPLATES) {
       expect(t.snapshot.title, t.id).toBeTruthy()
       expect(t.snapshot.description, t.id).toBeTruthy()
-      expect(t.snapshot.sizeBytes, t.id).toBeGreaterThan(0)
       expect(t.snapshot.mediaSubtype, t.id).toBeTruthy()
+    }
+  })
+
+  it('sizes every local template and no API-node one', () => {
+    for (const t of CURATED_TEMPLATES) {
+      if (t.apiNode) expect(t.snapshot.sizeBytes, t.id).toBe(0)
+      else expect(t.snapshot.sizeBytes, t.id).toBeGreaterThan(0)
+    }
+  })
+
+  it('offers exactly one API-node template per modality', () => {
+    for (const modality of TEMPLATE_MODALITY_ORDER) {
+      const apiTemplate = CURATED_TEMPLATES.filter((t) => t.modality === modality && t.apiNode)
+      expect(apiTemplate.length, modality).toBe(1)
+    }
+  })
+
+  it('never auto-selects a template that spends credits', () => {
+    for (const t of CURATED_TEMPLATES) {
+      if (t.apiNode) expect(t.recommended, t.id).toBeFalsy()
     }
   })
 

--- a/src/main/sources/standalone/curatedTemplates.ts
+++ b/src/main/sources/standalone/curatedTemplates.ts
@@ -109,9 +109,10 @@ export function isPersistableTemplateId(value: unknown): value is string {
 }
 
 /**
- * 4 templates per modality, sorted by size (lightest first):
+ * 4 templates per modality:
  * - Slot 1 (`recommended`): default open-source pick
- * - Slot 4: API-node demo
+ * - Slot 2: API-node demo
+ * - Slots 3-4: remaining open-source picks, lightest first
  * To update, change the id and sync the template's
  * title/description/size/mediaSubtype into `snapshot`.
  */
@@ -126,6 +127,18 @@ export const CURATED_TEMPLATES: readonly CuratedTemplate[] = [
       description:
         'An Efficient Image Generation Foundation Model with Single-Stream Diffusion Transformer, supports English & Chinese.',
       sizeBytes: 20830591386,
+      mediaSubtype: 'webp',
+    },
+  },
+  {
+    id: 'api_bytedance_seedream_5_0_pro_image_edit',
+    modality: 'image',
+    apiNode: true,
+    snapshot: {
+      title: 'Seedream 5.0 Pro: Image Edit',
+      description:
+        'Edit images with precision using Seedream 5.0 Pro, targeting specific regions while preserving lighting, depth, and texture. The workflow takes 1 input image and produces 2 output images through an optional Painter node and preview. Ideal for product photography edits, portrait consistency adjustments, and creating structured layouts with multilingual text.',
+      sizeBytes: 0,
       mediaSubtype: 'webp',
     },
   },
@@ -150,18 +163,6 @@ export const CURATED_TEMPLATES: readonly CuratedTemplate[] = [
       mediaSubtype: 'webp',
     },
   },
-  {
-    id: 'api_bytedance_seedream_5_0_pro_image_edit',
-    modality: 'image',
-    apiNode: true,
-    snapshot: {
-      title: 'Seedream 5.0 Pro: Image Edit',
-      description:
-        'Edit images with precision using Seedream 5.0 Pro, targeting specific regions while preserving lighting, depth, and texture. The workflow takes 1 input image and produces 2 output images through an optional Painter node and preview. Ideal for product photography edits, portrait consistency adjustments, and creating structured layouts with multilingual text.',
-      sizeBytes: 0,
-      mediaSubtype: 'webp',
-    },
-  },
 
   // --- Video ---
   {
@@ -172,6 +173,18 @@ export const CURATED_TEMPLATES: readonly CuratedTemplate[] = [
       title: 'Wan 2.1 Text to Video',
       description: 'Generate videos from text prompts using Wan 2.1.',
       sizeBytes: 9824737690,
+      mediaSubtype: 'webp',
+    },
+  },
+  {
+    id: 'api_seedance2_0_r2v',
+    modality: 'video',
+    apiNode: true,
+    snapshot: {
+      title: 'Seedance 2.0: Reference to Video',
+      description:
+        'Generate cinematic videos from reference images and text prompts. Preserve subject identity and composition while adding expressive motion with synchronized audio. Control camera movement and lighting through detailed prompts.',
+      sizeBytes: 0,
       mediaSubtype: 'webp',
     },
   },
@@ -196,18 +209,6 @@ export const CURATED_TEMPLATES: readonly CuratedTemplate[] = [
       mediaSubtype: 'webp',
     },
   },
-  {
-    id: 'api_seedance2_0_r2v',
-    modality: 'video',
-    apiNode: true,
-    snapshot: {
-      title: 'Seedance 2.0: Reference to Video',
-      description:
-        'Generate cinematic videos from reference images and text prompts. Preserve subject identity and composition while adding expressive motion with synchronized audio. Control camera movement and lighting through detailed prompts.',
-      sizeBytes: 0,
-      mediaSubtype: 'webp',
-    },
-  },
 
   // --- 3D ---
   {
@@ -219,6 +220,18 @@ export const CURATED_TEMPLATES: readonly CuratedTemplate[] = [
       description:
         'Upload a single 2D image. Generate a high-quality 3D Gaussian splat representation with controllable density and budget for rendering.',
       sizeBytes: 3972844749,
+      mediaSubtype: 'webp',
+    },
+  },
+  {
+    id: 'api_tripo3_1_image_to_model',
+    modality: '3d',
+    apiNode: true,
+    snapshot: {
+      title: 'Tripo H3.1: Image to Model',
+      description:
+        'Upload a reference image of your object. Generate a high-detail 3D model with dense geometry and PBR-ready materials.',
+      sizeBytes: 0,
       mediaSubtype: 'webp',
     },
   },
@@ -243,18 +256,6 @@ export const CURATED_TEMPLATES: readonly CuratedTemplate[] = [
       mediaSubtype: 'webp',
     },
   },
-  {
-    id: 'api_tripo3_1_image_to_model',
-    modality: '3d',
-    apiNode: true,
-    snapshot: {
-      title: 'Tripo H3.1: Image to Model',
-      description:
-        'Upload a reference image of your object. Generate a high-detail 3D model with dense geometry and PBR-ready materials.',
-      sizeBytes: 0,
-      mediaSubtype: 'webp',
-    },
-  },
 
   // --- Audio ---
   {
@@ -266,6 +267,18 @@ export const CURATED_TEMPLATES: readonly CuratedTemplate[] = [
       description:
         'Input a short text idea, optional duration, seed, and category. Generate stereo audio (music, SFX, or instruments) using Stable Audio 3 with optional AI-driven text expansion.',
       sizeBytes: 15676630630,
+      mediaSubtype: 'webp',
+    },
+  },
+  {
+    id: 'api_bytedance_seed_audio1_0_t2a',
+    modality: 'audio',
+    apiNode: true,
+    snapshot: {
+      title: 'Seed Audio 1.0: Text to Audio',
+      description:
+        'Input a text prompt to generate speech, dialogue, background music, and sound effects in one audio file. Describe voices, emotion, and scene details to create multi-speaker audio up to 2 minutes.',
+      sizeBytes: 0,
       mediaSubtype: 'webp',
     },
   },
@@ -288,18 +301,6 @@ export const CURATED_TEMPLATES: readonly CuratedTemplate[] = [
         'Input style tags and lyrics to generate a full song. The workflow uses the ACE-Step 1.5 model to produce commercial-grade music in under 10 seconds on consumer hardware.',
       sizeBytes: 10737418240,
       mediaSubtype: 'mp3',
-    },
-  },
-  {
-    id: 'api_bytedance_seed_audio1_0_t2a',
-    modality: 'audio',
-    apiNode: true,
-    snapshot: {
-      title: 'Seed Audio 1.0: Text to Audio',
-      description:
-        'Input a text prompt to generate speech, dialogue, background music, and sound effects in one audio file. Describe voices, emotion, and scene details to create multi-speaker audio up to 2 minutes.',
-      sizeBytes: 0,
-      mediaSubtype: 'webp',
     },
   },
 ] as const

--- a/src/main/sources/standalone/curatedTemplates.ts
+++ b/src/main/sources/standalone/curatedTemplates.ts
@@ -20,18 +20,23 @@ export interface TemplateSnapshot {
   mediaSubtype: string
 }
 
-export interface CuratedTemplate {
+interface CuratedTemplateBase {
   /** Real `comfyui_workflow_templates` id; matches the frontend deeplink
    *  validator `^[a-zA-Z0-9_.-]+$`. */
   id: string
   /** Output modality this template showcases. */
   modality: TemplateModality
-  /** The single recommended pick for its modality (auto-selected in the wizard).
-   *  At most one per modality. */
-  recommended?: boolean
   /** Offline display metadata; superseded by the live index when available. */
   snapshot: TemplateSnapshot
 }
+
+/**
+ * `recommended` is the auto-selected pick for its modality (at most one each);
+ * `apiNode` runs on API nodes, downloading nothing but spending credits per run.
+ * Mutually exclusive by type — the auto-selected pick must never cost money.
+ */
+export type CuratedTemplate = CuratedTemplateBase &
+  ({ recommended?: true; apiNode?: never } | { apiNode: true; recommended?: never })
 
 /** Tab order in the picker — one tab per modality that has ≥1 curated template. */
 export const TEMPLATE_MODALITY_ORDER: readonly TemplateModality[] = [
@@ -104,10 +109,11 @@ export function isPersistableTemplateId(value: unknown): value is string {
 }
 
 /**
- * 4 per modality, lightest-first; slot 1 (`recommended`) is the auto-selected
- * "wow", slot 4 the heavier flagship. To change an offering, edit the id and
- * paste that template's index `title`/`description`/`size`/`mediaSubtype` into
- * its `snapshot`.
+ * 4 templates per modality, sorted by size (lightest first):
+ * - Slot 1 (`recommended`): default open-source pick
+ * - Slot 4: API-node demo
+ * To update, change the id and sync the template's
+ * title/description/size/mediaSubtype into `snapshot`.
  */
 export const CURATED_TEMPLATES: readonly CuratedTemplate[] = [
   // --- Image ---
@@ -145,13 +151,14 @@ export const CURATED_TEMPLATES: readonly CuratedTemplate[] = [
     },
   },
   {
-    id: 'image_flux2_klein_image_edit_4b_distilled',
+    id: 'api_bytedance_seedream_5_0_pro_image_edit',
     modality: 'image',
+    apiNode: true,
     snapshot: {
-      title: 'Flux.2 [Klein] 4B Distilled: Image Edit',
+      title: 'Seedream 5.0 Pro: Image Edit',
       description:
-        'The fastest variant in the Klein family. Built for interactive applications and real-time image editing.',
-      sizeBytes: 12455405158,
+        'Edit images with precision using Seedream 5.0 Pro, targeting specific regions while preserving lighting, depth, and texture. The workflow takes 1 input image and produces 2 output images through an optional Painter node and preview. Ideal for product photography edits, portrait consistency adjustments, and creating structured layouts with multilingual text.',
+      sizeBytes: 0,
       mediaSubtype: 'webp',
     },
   },
@@ -190,13 +197,14 @@ export const CURATED_TEMPLATES: readonly CuratedTemplate[] = [
     },
   },
   {
-    id: 'video_kandinsky5_i2v',
+    id: 'api_seedance2_0_r2v',
     modality: 'video',
+    apiNode: true,
     snapshot: {
-      title: 'Kandinsky 5.0 Video Lite Image to Video',
+      title: 'Seedance 2.0: Reference to Video',
       description:
-        'A lightweight 2B model that generates videos from English and Russian prompts with high visual quality.',
-      sizeBytes: 14710262989,
+        'Generate cinematic videos from reference images and text prompts. Preserve subject identity and composition while adding expressive motion with synchronized audio. Control camera movement and lighting through detailed prompts.',
+      sizeBytes: 0,
       mediaSubtype: 'webp',
     },
   },
@@ -236,12 +244,14 @@ export const CURATED_TEMPLATES: readonly CuratedTemplate[] = [
     },
   },
   {
-    id: '3d_hunyuan3d-v2.1',
+    id: 'api_tripo3_1_image_to_model',
     modality: '3d',
+    apiNode: true,
     snapshot: {
-      title: 'HY 3D 2.1',
-      description: 'Generate 3D models from single images using Hunyuan3D 2.1.',
-      sizeBytes: 4928474972,
+      title: 'Tripo H3.1: Image to Model',
+      description:
+        'Upload a reference image of your object. Generate a high-detail 3D model with dense geometry and PBR-ready materials.',
+      sizeBytes: 0,
       mediaSubtype: 'webp',
     },
   },
@@ -281,13 +291,14 @@ export const CURATED_TEMPLATES: readonly CuratedTemplate[] = [
     },
   },
   {
-    id: 'audio_ace_step1_5_xl_turbo',
+    id: 'api_bytedance_seed_audio1_0_t2a',
     modality: 'audio',
+    apiNode: true,
     snapshot: {
-      title: 'ACE-Step 1.5XL Turbo: Text to Music',
+      title: 'Seed Audio 1.0: Text to Audio',
       description:
-        'Generate high-quality music from text prompts using the distilled 4B ACE-Step model. Produces commercial-ready audio in just 8 inference steps without CFG.',
-      sizeBytes: 19864223744,
+        'Input a text prompt to generate speech, dialogue, background music, and sound effects in one audio file. Describe voices, emotion, and scene details to create multi-speaker audio up to 2 minutes.',
+      sizeBytes: 0,
       mediaSubtype: 'webp',
     },
   },

--- a/src/main/sources/standalone/index.test.ts
+++ b/src/main/sources/standalone/index.test.ts
@@ -132,6 +132,18 @@ describe('standalone.buildInstallation', () => {
       ...(sizeBytes !== undefined ? { data: { sizeBytes } } : {}),
     })
 
+    it('records an API-node pick for auto-open even though it downloads nothing', () => {
+      const apiTemplate = CURATED_TEMPLATES.find((t) => t.apiNode)!
+      const result = standalone.buildInstallation({
+        ...base,
+        bundledTemplate: template(apiTemplate.id, 0),
+      })
+      expect(result.bundledTemplateId).toBe(apiTemplate.id)
+      expect(result.pendingTemplateOpen).toBe(apiTemplate.id)
+      // Zero bytes is what keeps the launch stepper from showing a model phase.
+      expect(result.bundledTemplateSizeBytes).toBe(0)
+    })
+
     it('"Skip & Install" (template = none) builds NO model download', () => {
       const result = standalone.buildInstallation({ ...base, bundledTemplate: template(NO_TEMPLATE_VALUE) })
       expect(result.bundledTemplateId).toBeUndefined()
@@ -247,6 +259,16 @@ describe('standalone.getFieldOptions bundledTemplate', () => {
     expect(card.description).toBe('Live desc')
     expect(card.data!.sizeBytes).toBe(999)
     expect(card.data!.category).toBe('Image')
+  })
+
+  it('carries the API-node flag to the card, and never on the skip option', async () => {
+    mockedFetchJSON.mockResolvedValue([])
+    const options = await standalone.getFieldOptions!('bundledTemplate', {}, {})
+    expect(options.find((o) => o.value === NO_TEMPLATE_VALUE)!.data?.apiNode).toBeUndefined()
+    for (const curated of CURATED_TEMPLATES) {
+      const card = options.find((o) => o.value === curated.id)!
+      expect(card.data!.apiNode, curated.id).toBe(curated.apiNode === true)
+    }
   })
 })
 

--- a/src/main/sources/standalone/index.ts
+++ b/src/main/sources/standalone/index.ts
@@ -553,6 +553,7 @@ export const standalone: SourcePlugin = {
             thumbnailUrl: tpl.thumbnailUrl,
             sizeBytes: tpl.sizeBytes,
             modelsPresent: presenceById.get(tpl.id) ?? false,
+            apiNode: tpl.apiNode,
           },
         })),
       ]

--- a/src/main/sources/standalone/templateCatalog.test.ts
+++ b/src/main/sources/standalone/templateCatalog.test.ts
@@ -91,6 +91,43 @@ describe('loadTemplateCatalog', () => {
     expect(card.task).toBe('Text to Image')
   })
 
+  it('skips the API tag so an API-node card is not subtitled "API"', async () => {
+    const apiTemplate = CURATED_TEMPLATES.find((t) => t.apiNode)!
+    mockedFetchJSON.mockResolvedValue(
+      indexFor({ [apiTemplate.id]: { title: 'Seedream 5.0 Pro: Image Edit', tags: ['API', 'Image Edit'] } })
+    )
+    const card = (await loadTemplateCatalog()).find((c) => c.id === apiTemplate.id)!
+    expect(card.task).toBe('Image Edit')
+    expect(card.name).toBe('Seedream 5.0 Pro')
+  })
+
+  it('treats "3D Model" as a kind, not a task', async () => {
+    const apiTemplate = CURATED_TEMPLATES.find((t) => t.apiNode && t.modality === '3d')!
+    mockedFetchJSON.mockResolvedValue(
+      indexFor({ [apiTemplate.id]: { title: 'Tripo H3.1: Image to Model', tags: ['3D Model', 'API'] } }, '3D Model')
+    )
+    const card = (await loadTemplateCatalog()).find((c) => c.id === apiTemplate.id)!
+    expect(card.task).toBe('Image to 3D')
+  })
+
+  it('flags API-node templates from the manifest, offline included', async () => {
+    mockedFetchJSON.mockImplementationOnce(() => Promise.reject(new Error('offline')))
+    const catalog = await loadTemplateCatalog()
+    for (const curated of CURATED_TEMPLATES) {
+      expect(catalog.find((c) => c.id === curated.id)!.apiNode, curated.id).toBe(curated.apiNode === true)
+    }
+  })
+
+  it('does not infer API-node status from a closed-source index flag', async () => {
+    const local = CURATED_TEMPLATES.find((t) => !t.apiNode)!
+    mockedFetchJSON.mockResolvedValue(
+      indexFor({ [local.id]: { openSource: false, size: 142_000_000_000 } })
+    )
+    const card = (await loadTemplateCatalog()).find((c) => c.id === local.id)!
+    expect(card.apiNode).toBe(false)
+    expect(card.sizeBytes).toBe(142_000_000_000)
+  })
+
   it('falls back to the snapshot when the index omits a curated id', async () => {
     const first = CURATED_TEMPLATES[0]!
     mockedFetchJSON.mockResolvedValue([])
@@ -179,6 +216,24 @@ describe('loadTemplateCatalog', () => {
     mockedFetchJSON.mockResolvedValue(imageCategory([{ name: 'api_only', title: 'Cloud', size: 0 }]))
     const catalog = await loadTemplateCatalog()
     expect(catalog.find((c) => c.id === first.id)!.title).toBe(first.snapshot.title)
+  })
+
+  it('never substitutes a local download into a vanished API-node slot', async () => {
+    const apiTemplate = CURATED_TEMPLATES.find((t) => t.apiNode && t.modality === 'image')!
+    mockedFetchJSON.mockResolvedValue(
+      imageCategory([
+        { name: 'sub_a', title: 'A', size: 1 },
+        { name: 'sub_b', title: 'B', size: 2 },
+        { name: 'sub_c', title: 'C', size: 3 },
+        { name: 'sub_d', title: 'D', size: 4 },
+      ])
+    )
+    const catalog = await loadTemplateCatalog()
+    const card = catalog.find((c) => c.id === apiTemplate.id)
+    expect(card, 'API-node slot kept its snapshot').toBeDefined()
+    expect(card!.apiNode).toBe(true)
+    expect(card!.sizeBytes).toBe(0)
+    expect(catalog.some((c) => c.id === 'sub_d'), 'no local substitute took the slot').toBe(false)
   })
 
   it('keeps the curated snapshot card when offline (empty index → no substitution)', async () => {

--- a/src/main/sources/standalone/templateCatalog.ts
+++ b/src/main/sources/standalone/templateCatalog.ts
@@ -36,6 +36,8 @@ export interface HydratedTemplate {
   description: string
   /** Coarse total download estimate (bytes); 0 when unknown. */
   sizeBytes: number
+  /** Runs on API nodes — nothing to download, but each run spends credits. */
+  apiNode: boolean
   /** Card preview image URL, or `null` for non-image previews (audio → glyph). */
   thumbnailUrl: string | null
   /** Index `title` (e.g. "Image", "Video") of the category the template lives
@@ -100,8 +102,7 @@ function indexById(index: unknown): Map<string, IndexLocation> {
   return byId
 }
 
-/** Bare modality labels that aren't a task — dropped when picking the task tag. */
-const MODALITY_TAGS = new Set(['image', 'video', 'audio', '3d'])
+const NON_TASK_TAGS = new Set(['image', 'video', 'audio', '3d', '3d model', 'api'])
 
 /** Subtitle shown when a template's `tags` carry no specific task, so a card is
  *  never left with a blank descriptor (e.g. Wan Fun Camera, tags: ['Video']). */
@@ -113,13 +114,13 @@ const DEFAULT_TASK: Record<TemplateModality, string> = {
 }
 
 /** The template's task (e.g. "Text to Image", "Image Edit") from its `tags`,
- *  skipping the bare modality label; falls back to the modality default. */
+ *  skipping kind labels; falls back to the modality default. */
 function taskOf(tags: unknown, modality: TemplateModality): string {
   if (Array.isArray(tags)) {
     for (const tag of tags) {
       if (typeof tag !== 'string') continue
       const trimmed = tag.trim()
-      if (trimmed && !MODALITY_TAGS.has(trimmed.toLowerCase())) return trimmed
+      if (trimmed && !NON_TASK_TAGS.has(trimmed.toLowerCase())) return trimmed
     }
   }
   return DEFAULT_TASK[modality]
@@ -140,13 +141,15 @@ function nameOf(title: string, task: string): string {
 /** Build a card from a template `id` + its live index location (when present),
  *  preferring live metadata and falling back to the offline `snapshot` (which a
  *  substituted, non-curated id won't have). */
-function hydrateOne(
-  id: string,
-  modality: TemplateModality,
-  recommended: boolean,
-  location: IndexLocation | undefined,
-  snapshot?: TemplateSnapshot,
-): HydratedTemplate {
+function hydrateOne(card: {
+  id: string
+  modality: TemplateModality
+  recommended: boolean
+  apiNode: boolean
+  location: IndexLocation | undefined
+  snapshot?: TemplateSnapshot
+}): HydratedTemplate {
+  const { id, modality, recommended, apiNode, location, snapshot } = card
   const entry = location?.entry
 
   const title =
@@ -169,6 +172,7 @@ function hydrateOne(
     task,
     description,
     sizeBytes,
+    apiNode,
     thumbnailUrl: thumbnailUrlFor(id, mediaSubtype),
     category: location?.category ?? '',
   }
@@ -235,26 +239,32 @@ async function loadTemplateCatalogUncached(): Promise<HydratedTemplate[]> {
   for (const curated of CURATED_TEMPLATES) {
     if (!curated?.id || used.has(curated.id) || !curated.snapshot) continue
 
+    const recommended = curated.recommended === true
+    const apiNode = curated.apiNode === true
+
+    const { modality, snapshot } = curated
     const location = byId.get(curated.id)
     if (location || !online) {
       used.add(curated.id)
-      catalog.push(
-        hydrateOne(curated.id, curated.modality, curated.recommended === true, location, curated.snapshot)
-      )
+      catalog.push(hydrateOne({ id: curated.id, modality, recommended, apiNode, location, snapshot }))
       continue
     }
 
     // Curated id has vanished upstream: show the first live template of the same
     // modality we haven't already used, so the slot still offers a real,
-    // installable pick rather than a stale snapshot card.
-    const sub = firstUnusedOfModality(byId, curated.modality, used)
+    // installable pick rather than a stale snapshot card. An API-node slot keeps
+    // its snapshot — substituting would put a multi-GB download behind a badge
+    // that promises none.
+    const sub = apiNode ? null : firstUnusedOfModality(byId, modality, used)
     if (sub) {
       used.add(sub.entry.name)
-      catalog.push(hydrateOne(sub.entry.name, curated.modality, curated.recommended === true, sub))
+      catalog.push(
+        hydrateOne({ id: sub.entry.name, modality, recommended, apiNode: false, location: sub })
+      )
     } else {
       used.add(curated.id)
       catalog.push(
-        hydrateOne(curated.id, curated.modality, curated.recommended === true, undefined, curated.snapshot)
+        hydrateOne({ id: curated.id, modality, recommended, apiNode, location: undefined, snapshot })
       )
     }
   }

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -90,6 +90,7 @@
   --danger: #e05858;
   --danger-hover: #ef6b6b;
   --warning: #fd9903;
+  --upgrade: #e9c422;
   --success: #00cd72;
   --info: #58a6ff;
   --terminal-bg: #111112;
@@ -190,6 +191,7 @@
   --danger: #f75951;
   --danger-hover: #ff7a73;
   --warning: #fcbf64;
+  --upgrade: #e9c422;
   --success: #00cd72;
   --info: #2563eb;
   --terminal-bg: #f3f3f3;

--- a/src/renderer/src/components/BrandVariantList.vue
+++ b/src/renderer/src/components/BrandVariantList.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
-import { Check } from 'lucide-vue-next'
+import { Check, Crown } from 'lucide-vue-next'
 import type { FieldOption } from '../types/ipc'
 import { getVariantImage } from '../lib/variants'
+import { isApiNodeTemplate } from '../lib/installHelpers'
 
 defineProps<{
   options: FieldOption[]
@@ -41,6 +42,10 @@ const { t } = useI18n()
           {{ opt.label }}
           <span v-if="opt.recommended" class="brand-tag-recommended">
             {{ t('newInstall.recommended') }}
+          </span>
+          <span v-if="isApiNodeTemplate(opt)" class="brand-variant-row__credits">
+            <Crown :size="12" :stroke-width="2.5" aria-hidden="true" />
+            {{ t('standalone.templateApiBadge') }}
           </span>
         </span>
         <span v-if="opt.description" class="brand-variant-row__meta">
@@ -127,6 +132,15 @@ const { t } = useI18n()
   font-size: var(--takeover-fs-body);
   font-weight: 600;
   color: var(--neutral-100);
+}
+.brand-variant-row__credits {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: 8px;
+  font-size: var(--takeover-fs-caption);
+  font-weight: 500;
+  color: var(--upgrade);
 }
 .brand-variant-row__meta {
   font-size: var(--takeover-fs-caption);

--- a/src/renderer/src/components/TemplatePickerStep.test.ts
+++ b/src/renderer/src/components/TemplatePickerStep.test.ts
@@ -178,6 +178,56 @@ describe('TemplatePickerStep', () => {
     expect(card.find('.tps__card-size').text()).toContain('GB')
   })
 
+  describe('API-node templates', () => {
+    const API_NODE: FieldOption = {
+      value: 'api_bytedance_seedream_5_0_pro_image_edit',
+      label: 'Seedream 5.0 Pro: Image Edit',
+      data: { modality: 'image', sizeBytes: 0, apiNode: true, name: 'Seedream 5.0 Pro', task: 'Image Edit' },
+    }
+    const apiCard = (option: FieldOption = API_NODE) =>
+      mountPicker({ options: [NONE, option], selectedValue: option.value })
+        .findAll('button[role="radio"]')[0]!
+
+    it('badges the card and swaps the size for the crown', () => {
+      const card = apiCard()
+      expect(card.find('.tps__api').text()).toContain('Requires credits')
+      expect(card.find('.tps__card-crown').exists()).toBe(true)
+      expect(card.find('.tps__card-size').exists()).toBe(false)
+    })
+
+    it('keeps the credit badge out of the aria-hidden subtree', () => {
+      const card = apiCard()
+      expect(card.find('.tps__api').exists()).toBe(true)
+      expect(card.find('.tps__card-media .tps__api').exists()).toBe(false)
+    })
+
+    it('leaves local templates unbadged', () => {
+      const card = mountPicker().findAll('button[role="radio"]')[0]!
+      expect(card.find('.tps__api').exists()).toBe(false)
+      expect(card.find('.tps__card-crown').exists()).toBe(false)
+      expect(card.find('.tps__card-size').text()).toContain('GB')
+    })
+
+    it('shows the real size, not the crown, when an API-node template has models', () => {
+      const card = apiCard({
+        ...API_NODE,
+        data: { ...API_NODE.data, sizeBytes: 9 * GB },
+      })
+      expect(card.find('.tps__api').exists()).toBe(true)
+      expect(card.find('.tps__card-crown').exists()).toBe(false)
+      expect(card.find('.tps__card-size').text()).toContain('GB')
+    })
+
+    it('never blocks an API-node card on a full disk', () => {
+      const wrapper = mountPicker({
+        options: [NONE, API_NODE],
+        selectedValue: API_NODE.value,
+        diskSpace: { total: 100 * GB, free: 1 * GB },
+      })
+      expect(wrapper.vm.shownDiskError).toBeNull()
+    })
+  })
+
   it('falls back to the full label when no short name is provided', () => {
     const card = mountPicker().findAll('button[role="radio"]')[0]!
     expect(card.find('.tps__card-title').text()).toBe('SDXL Turbo')

--- a/src/renderer/src/components/TemplatePickerStep.vue
+++ b/src/renderer/src/components/TemplatePickerStep.vue
@@ -201,7 +201,7 @@ defineExpose({ shownDiskError })
 
         <!-- Outside the aria-hidden media span so the cost reaches the accessible name. -->
         <span v-if="isApiNodeTemplate(opt)" class="tps__api">
-          <Crown :size="13" :stroke-width="2.5" aria-hidden="true" />
+          <Crown :size="12" :stroke-width="2.5" aria-hidden="true" />
           {{ t('standalone.templateApiBadge') }}
         </span>
 
@@ -401,8 +401,7 @@ defineExpose({ shownDiskError })
   box-shadow: 0 2px 8px color-mix(in oklab, var(--neutral-950) 55%, transparent);
 }
 
-.tps__recommended,
-.tps__api {
+.tps__recommended {
   position: absolute;
   top: 8px;
   left: 8px;
@@ -413,21 +412,30 @@ defineExpose({ shownDiskError })
   font-weight: 400;
   line-height: normal;
   letter-spacing: 0;
-  white-space: nowrap;
+  color: var(--neutral-100);
   background: color-mix(in oklab, var(--neutral-950) 30%, transparent);
   -webkit-backdrop-filter: blur(20px);
   backdrop-filter: blur(20px);
 }
 
-.tps__recommended {
-  color: var(--neutral-100);
-}
-
 .tps__api {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  z-index: 1;
   display: inline-flex;
   align-items: center;
-  gap: 5px;
+  gap: 4px;
+  padding: 4px 9px;
+  border-radius: 999px;
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  white-space: nowrap;
   color: var(--upgrade);
+  background: var(--neutral-900);
+  box-shadow: 0 2px 10px color-mix(in oklab, var(--neutral-950) 55%, transparent);
 }
 
 .tps__card-crown {

--- a/src/renderer/src/components/TemplatePickerStep.vue
+++ b/src/renderer/src/components/TemplatePickerStep.vue
@@ -1,10 +1,15 @@
 <script setup lang="ts">
 import { computed, nextTick, reactive, ref, toRef } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { Check, HardDriveDownload } from 'lucide-vue-next'
+import { Check, Crown, HardDriveDownload } from 'lucide-vue-next'
 import type { DiskSpaceInfo, FieldOption } from '../types/ipc'
 import { formatBytesCoarse } from '../lib/formatting'
-import { templateDiskRequiredBytes, isTemplateDiskBlocked } from '../lib/installHelpers'
+import {
+  templateDiskRequiredBytes,
+  isTemplateDiskBlocked,
+  isApiNodeTemplate,
+  templateSizeBytes
+} from '../lib/installHelpers'
 import { useTemplateTabs } from '../composables/useTemplateTabs'
 import ComfyCLogo from './icons/ComfyCLogo.vue'
 import TruncatedText from './TruncatedText.vue'
@@ -47,10 +52,7 @@ const thumbFailed = reactive<Record<string, boolean>>({})
  *  placeholder meanwhile) instead of flashing a blank box. */
 const thumbLoaded = reactive<Record<string, boolean>>({})
 
-function sizeBytesOf(option: FieldOption | null): number {
-  const size = option?.data?.sizeBytes
-  return typeof size === 'number' ? size : 0
-}
+const sizeBytesOf = templateSizeBytes
 /** Card preview URL, or null for non-image previews (audio → branded tile). */
 function thumbnailOf(option: FieldOption): string | null {
   const url = option.data?.thumbnailUrl
@@ -68,6 +70,9 @@ function presentLabelOf(option: FieldOption): string {
   const downloaded = t('standalone.templateModelsDownloaded')
   const size = sizeLabelOf(option)
   return size ? `${downloaded} · ${size}` : downloaded
+}
+function hasNothingToDownload(option: FieldOption): boolean {
+  return isApiNodeTemplate(option) && sizeBytesOf(option) === 0
 }
 /** Short model name (falls back to the full label). */
 function nameOf(option: FieldOption): string {
@@ -194,6 +199,12 @@ defineExpose({ shownDiskError })
           </span>
         </span>
 
+        <!-- Outside the aria-hidden media span so the cost reaches the accessible name. -->
+        <span v-if="isApiNodeTemplate(opt)" class="tps__api">
+          <Crown :size="13" :stroke-width="2.5" aria-hidden="true" />
+          {{ t('standalone.templateApiBadge') }}
+        </span>
+
         <span class="tps__card-footer">
           <span class="tps__card-text">
             <TruncatedText class="tps__card-title" :text="nameOf(opt)" />
@@ -207,6 +218,14 @@ defineExpose({ shownDiskError })
           >
             <HardDriveDownload :size="14" :stroke-width="2" aria-hidden="true" />
           </Tooltip>
+          <!-- Decorative: the badge above already names the cost. -->
+          <Crown
+            v-else-if="hasNothingToDownload(opt)"
+            class="tps__card-crown"
+            :size="14"
+            :stroke-width="2.5"
+            :aria-hidden="true"
+          />
           <span v-else-if="sizeLabelOf(opt)" class="tps__card-size">{{ sizeLabelOf(opt) }}</span>
         </span>
       </button>
@@ -241,6 +260,7 @@ defineExpose({ shownDiskError })
 }
 
 .tps__card {
+  position: relative;
   display: flex;
   flex-direction: column;
   border: 1px solid var(--brand-surface-border);
@@ -381,7 +401,8 @@ defineExpose({ shownDiskError })
   box-shadow: 0 2px 8px color-mix(in oklab, var(--neutral-950) 55%, transparent);
 }
 
-.tps__recommended {
+.tps__recommended,
+.tps__api {
   position: absolute;
   top: 8px;
   left: 8px;
@@ -392,10 +413,26 @@ defineExpose({ shownDiskError })
   font-weight: 400;
   line-height: normal;
   letter-spacing: 0;
-  color: var(--neutral-100);
+  white-space: nowrap;
   background: color-mix(in oklab, var(--neutral-950) 30%, transparent);
   -webkit-backdrop-filter: blur(20px);
   backdrop-filter: blur(20px);
+}
+
+.tps__recommended {
+  color: var(--neutral-100);
+}
+
+.tps__api {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--upgrade);
+}
+
+.tps__card-crown {
+  flex: 0 0 auto;
+  color: var(--upgrade);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/renderer/src/lib/installHelpers.ts
+++ b/src/renderer/src/lib/installHelpers.ts
@@ -1,5 +1,5 @@
 import { ref, onUnmounted } from 'vue'
-import type { DiskSpaceInfo, PathIssue } from '../types/ipc'
+import type { DiskSpaceInfo, FieldOption, PathIssue } from '../types/ipc'
 import { emitTelemetryAction } from './telemetry'
 import { formatBytes } from './formatting'
 
@@ -205,6 +205,17 @@ export function isTemplateDiskBlocked(
 export function minTemplateModelBytes(modelByteSizes: number[]): number {
   const withModels = modelByteSizes.filter((b) => b > 0)
   return withModels.length ? Math.min(...withModels) : 0
+}
+
+/** A template option's model footprint, or 0 when it carries none. */
+export function templateSizeBytes(option: FieldOption | null | undefined): number {
+  const size = option?.data?.sizeBytes
+  return typeof size === 'number' && size > 0 ? size : 0
+}
+
+/** Runs on API nodes: no models to download, but every run spends credits. */
+export function isApiNodeTemplate(option: FieldOption | null | undefined): boolean {
+  return option?.data?.apiNode === true
 }
 
 export async function checkTemplateDiskOrBlock(opts: {

--- a/src/renderer/src/views/InstallWizardModal.vue
+++ b/src/renderer/src/views/InstallWizardModal.vue
@@ -240,10 +240,6 @@ async function handleConfigureContinue(): Promise<void> {
     })
     return
   }
-  if (templateIsApiNode.value) {
-    const none = templateOptions.value.find((o) => o.value === NO_TEMPLATE_VALUE)
-    if (none) selections.value.bundledTemplate = none
-  }
   await handleSave()
 }
 

--- a/src/renderer/src/views/InstallWizardModal.vue
+++ b/src/renderer/src/views/InstallWizardModal.vue
@@ -22,7 +22,9 @@ import {
   checkDiskSpaceOrWarn,
   checkTemplateDiskOrBlock,
   isTemplateDiskBlocked,
-  minTemplateModelBytes
+  minTemplateModelBytes,
+  isApiNodeTemplate,
+  templateSizeBytes
 } from '../lib/installHelpers'
 import TakeoverBack from '../components/TakeoverBack.vue'
 import BrandTakeoverLayout from '../components/BrandTakeoverLayout.vue'
@@ -134,6 +136,8 @@ const templateHasModels = computed(() => {
   return typeof size === 'number' && size > 0
 })
 
+const templateIsApiNode = computed(() => isApiNodeTemplate(selectedTemplate.value))
+
 /** Proactive disk guard — shares `isTemplateDiskBlocked` with TemplatePickerStep
  *  so the alert, the disabled Install button, and the save-time hard block can't
  *  drift. */
@@ -182,9 +186,8 @@ const templateOptions = computed<FieldOption[]>(
  *  while disk space is unknown/loading — we only skip on a confirmed shortfall. */
 const diskTooSmallForAnyTemplate = computed(() => {
   if (diskSpaceLoading.value || !diskSpace.value) return false
-  const cheapest = minTemplateModelBytes(
-    templateOptions.value.map((o) => (o.data?.sizeBytes as number | undefined) ?? 0)
-  )
+  if (templateOptions.value.some(isApiNodeTemplate)) return false
+  const cheapest = minTemplateModelBytes(templateOptions.value.map(templateSizeBytes))
   return isTemplateDiskBlocked(diskSpace.value, cheapest)
 })
 
@@ -209,7 +212,8 @@ function selectTemplate(option: FieldOption): void {
     const sizeBytes = (option.data?.sizeBytes as number | undefined) ?? 0
     emitTelemetryAction('comfy.desktop.template.selected', {
       template_id: option.value,
-      size_bucket: toSizeBucket(sizeBytes)
+      size_bucket: toSizeBucket(sizeBytes),
+      is_api_node: isApiNodeTemplate(option)
     })
   }
 }
@@ -236,6 +240,10 @@ async function handleConfigureContinue(): Promise<void> {
     })
     return
   }
+  if (templateIsApiNode.value) {
+    const none = templateOptions.value.find((o) => o.value === NO_TEMPLATE_VALUE)
+    if (none) selections.value.bundledTemplate = none
+  }
   await handleSave()
 }
 
@@ -253,6 +261,7 @@ async function handleTemplateInstall(): Promise<void> {
     template_id: tpl?.value ?? NO_TEMPLATE_VALUE,
     size_bucket: toSizeBucket((tpl?.data?.sizeBytes as number | undefined) ?? 0),
     has_models: templateHasModels.value,
+    is_api_node: templateIsApiNode.value,
     dont_show_again: dontShowTemplatePicker.value
   })
   await persistDontShowAgain()
@@ -1042,10 +1051,7 @@ defineExpose({ open })
                     type="button"
                     role="radio"
                     :aria-checked="currentSource?.id === s.id"
-                    :class="[
-                      'brand-pill',
-                      { 'brand-pill--selected': currentSource?.id === s.id }
-                    ]"
+                    :class="['brand-pill', { 'brand-pill--selected': currentSource?.id === s.id }]"
                     @click="selectSourceCard(s)"
                   >
                     <span>{{ s.label }}</span>


### PR DESCRIPTION
## Summary

The install picker only offered local-model templates, so a new user's first run was always a multi-GB download. Each modality now also offers one API-node template, badged with its credit cost before Install.

## Changes

**What**

- Swaps each modality's heaviest pick for its top API-node equivalent, placed second so it sits right after the recommended card: Seedream 5.0 Pro, Seedance 2.0, Tripo H3.1, Seed Audio 1.0.
- API-node cards get a crown chip reading "Requires credits", replacing the size in the footer. It sits outside the aria-hidden thumbnail so the cost reaches the accessible name.
- The auto-selected pick can never cost money: `recommended` and `apiNode` are mutually exclusive by type.
- API-node status comes from the manifest, not the index's `openSource` flag (that means closed weights, and 13 entries carry it alongside a multi-GB size).
- Fixes a card tagged `["API", "Image Edit"]` being subtitled "API", and a model-download phase showing for zero-model picks.
- Adds `is_api_node` to both template telemetry events.


https://github.com/user-attachments/assets/37c38f06-e315-4b66-934a-733869d36652


