### PR TITLE
Reduce Desktop authentication return latency

### DIFF
--- a/src/main/auth/desktopLoginCode/client.test.ts
+++ b/src/main/auth/desktopLoginCode/client.test.ts
@@ -274,9 +274,9 @@ describe('grant timing validation', () => {
     )
   })
 
-  it('leaves a sane grant untouched', async () => {
-    const grant = await grantFrom(300, 3)
-    expect(grant).toEqual({ code: 'dlc_abc', expires_in: 300, poll_interval: 3 })
+  it('accepts the one-second minimum poll interval issued by Cloud', async () => {
+    const grant = await grantFrom(300, 1)
+    expect(grant).toEqual({ code: 'dlc_abc', expires_in: 300, poll_interval: 1 })
   })
 })
 

--- a/src/main/auth/desktopLoginCode/index.test.ts
+++ b/src/main/auth/desktopLoginCode/index.test.ts
@@ -255,6 +255,42 @@ describe('signInViaDesktopLoginCode', () => {
     expect(h.closeActiveBridge).toHaveBeenCalledTimes(1)
   })
 
+  it('returns focus after the brief login-code hold instead of the legacy countdown', async () => {
+    h.createDesktopLoginCode.mockResolvedValue({
+      ...GRANT,
+      poll_interval: 1
+    })
+    h.exchangeDesktopLoginCode.mockResolvedValue({
+      status: 'complete',
+      custom_token: 'custom-token-value'
+    })
+    mockSignInChain({ uid: 'uid-1' })
+    const mod = await loadOrchestrator()
+    const parentWindow = {
+      isDestroyed: vi.fn(() => false),
+      isMinimized: vi.fn(() => false),
+      restore: vi.fn(),
+      show: vi.fn(),
+      focus: vi.fn()
+    }
+
+    const promise = mod.signInViaDesktopLoginCode(AUTH_URL, fakeContents(), {
+      parentWindow: parentWindow as unknown as BrowserWindow
+    })
+
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(h.exchangeDesktopLoginCode).toHaveBeenCalledTimes(1)
+    expect(parentWindow.focus).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(499)
+    expect(parentWindow.focus).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(await promise).toBe('handled')
+    expect(parentWindow.show).toHaveBeenCalledTimes(1)
+    expect(parentWindow.focus).toHaveBeenCalledTimes(1)
+  })
+
   it('continues through the banner when the initial browser open rejects', async () => {
     h.openExternal.mockRejectedValueOnce(new Error('no default browser'))
     h.createDesktopLoginCode.mockResolvedValue(GRANT)

--- a/src/main/auth/desktopLoginCode/index.ts
+++ b/src/main/auth/desktopLoginCode/index.ts
@@ -27,8 +27,7 @@ import {
   emitSignInFailure,
   type HandleFirebasePopupOpts,
   isOnOrigin,
-  originOf,
-  POST_SIGNIN_HOLD_MS
+  originOf
 } from '../firebaseBridge/flowShared'
 import {
   beginFirebaseSessionInjection,
@@ -46,6 +45,12 @@ const CREATE_CODE_TIMEOUT_MS = 8000
 
 /** Random 0-500ms added to each poll so a fleet of desktops doesn't sync-poll. */
 const POLL_JITTER_MS = 500
+
+/**
+ * Brief visual beat after the system browser confirms redemption. The browser
+ * already shows a success toast; the legacy bridge keeps its 3s countdown.
+ */
+const LOGIN_CODE_POST_SIGNIN_HOLD_MS = 500
 
 /** Cloud currently keeps a redeemed grant exchangeable for this long. */
 const POST_REDEEM_RETRY_GRACE_MS = 120_000
@@ -231,10 +236,10 @@ export async function signInViaDesktopLoginCode(
     if (controller.signal.aborted) return 'handled'
     const user = buildPersistedUserFromCustomToken(firebaseConfig, signIn, account)
     if (comfyContents.isDestroyed()) return 'handled'
-    // Same hold as the legacy bridge: let the user see the browser's
-    // signed-in state before Desktop pulls focus back. Abort-aware — a
-    // re-click during the hold rejects into the catch below as 'handled'.
-    await abortableSleep(POST_SIGNIN_HOLD_MS, controller.signal)
+    // The system browser already shows its own success toast, so keep only a
+    // brief visual beat before Desktop pulls focus back. The legacy loopback
+    // bridge retains its full three-second countdown.
+    await abortableSleep(LOGIN_CODE_POST_SIGNIN_HOLD_MS, controller.signal)
     if (controller.signal.aborted || comfyContents.isDestroyed()) return 'handled'
     // The backend/login origin and the embedded session target are distinct:
     // local and preview views authenticate through production Cloud, but the


### PR DESCRIPTION
## Summary
- Reduce the login-code-only post-sign-in focus hold from 3 seconds to 500 ms.
- Keep the legacy loopback bridge countdown at 3 seconds.
- Cover the shorter focus timing and the 1-second Cloud grant contract with deterministic tests.

## Why
The system browser already displays a success confirmation after redeeming the login code, but Desktop then deliberately waited another 3 seconds before injecting the session and restoring focus. Production event pairs showed a 6.2-second median and 8.28-second p90 from browser redemption to Desktop completion.

This removes 2.5 seconds of fixed delay without changing PKCE, token exchange, session injection, stale-flow cancellation, or the legacy fallback UX.

Companion cloud PR: https://github.com/Comfy-Org/cloud/pull/5921

## Testing
- pnpm exec prettier --check src/main/auth/desktopLoginCode/client.test.ts src/main/auth/desktopLoginCode/index.ts src/main/auth/desktopLoginCode/index.test.ts
- pnpm exec vitest run src/main/auth/desktopLoginCode/client.test.ts src/main/auth/desktopLoginCode/index.test.ts src/main/auth/firebaseBridge/index.test.ts
- Repository commit hook: full typecheck and lint

No manual packaged end-to-end authentication run was performed.