### PR TITLE
chore(devplatform): default builder + cloud issuer to prod

### DIFF
--- a/src/main/devplatform/config.ts
+++ b/src/main/devplatform/config.ts
@@ -1,19 +1,9 @@
 /**
- * Dev-platform glue config: points the cloud + comfy-builder libraries at
- * staging for now.
- *
- * These are env DEFAULTS, not hardcodes: a real deployment can still override
- * `COMFY_CLOUD_ISSUER` / `COMFY_BUILDER_BASE_URL` via the environment. This
- * module is imported (for its side effect) BEFORE the cloud library's own
- * `config` module, so the issuer default is in place by the time
- * `CLOUD_ISSUER` is computed: do not reorder the import in `./session`.
+ * Dev-platform glue config: env DEFAULTS for the comfy-builder base URL. A real
+ * deployment can override `COMFY_BUILDER_BASE_URL` via the environment. The
+ * cloud issuer default lives in `../cloud/config.ts` (prod).
  */
-const STAGING_CLOUD_ISSUER = 'https://stagingcloud.comfy.org'
-const STAGING_BUILDER_BASE_URL = 'https://stagingplatformapi.comfy.org/builder'
+const PROD_BUILDER_BASE_URL = 'https://platformapi.comfy.org/builder'
 
-if (!process.env.COMFY_CLOUD_ISSUER) {
-  process.env.COMFY_CLOUD_ISSUER = STAGING_CLOUD_ISSUER
-}
-
-/** Builder gateway base URL the client targets. Staging default; env override. */
-export const BUILDER_BASE_URL = process.env.COMFY_BUILDER_BASE_URL || STAGING_BUILDER_BASE_URL
+/** Builder gateway base URL the client targets. Prod default; env override. */
+export const BUILDER_BASE_URL = process.env.COMFY_BUILDER_BASE_URL || PROD_BUILDER_BASE_URL

--- a/src/main/devplatform/session.ts
+++ b/src/main/devplatform/session.ts
@@ -6,9 +6,6 @@
  * sign-in, workspace switch, or sign-out is reflected everywhere without any of
  * them owning their own token state. The client pulls a bearer token from the
  * session's `TokenProvider` per request; the token never leaves this process.
- *
- * `./config` is imported first, for its side effect: it seeds the staging
- * `COMFY_CLOUD_ISSUER` default before the cloud library's config reads it.
  */
 import { BUILDER_BASE_URL } from './config'
 import { CloudSession } from '../cloud'


### PR DESCRIPTION
## TL;DR

Flip Desktop's compiled-in defaults for the dev-platform surface from staging to prod: builder base URL to `https://platformapi.comfy.org/builder`, cloud issuer to `https://cloud.comfy.org` (via `cloud/config.ts`'s existing prod default). Env overrides (`COMFY_BUILDER_BASE_URL`, `COMFY_CLOUD_ISSUER`) still win for local staging work.

## Intent / Why

`devplatform/config.ts` was pinned to staging with a "for now" comment. The `integ/dist-ux` chain is queued to land on `main` behind [BE-4428](https://linear.app/comfyorg/issue/BE-4428/desktop-land-the-comfy-builder-integration-branch-on-main); if the client lands with staging baked in, the first prod-signed-in user will silently hit staging APIs. Flipping the default here, on the `comfy-builder` base, means the integration lands pointing at production the moment it merges.

## Decision

- **Removed the `COMFY_CLOUD_ISSUER` side-effect seed.** With staging gone, `cloud/config.ts`'s `DEFAULT_ISSUER = 'https://cloud.comfy.org'` already gives us prod. No reason to keep a module-load `process.env` mutation just to point at where the fallback already points.
- **Dropped the "do not reorder the import" note in `session.ts`.** `./config` no longer mutates `process.env`, so the import order is no longer load-bearing. Left stale, that note is worse than none.
- **Did NOT touch `integ/dist-ux`.** That branch will need to rebase onto `comfy-builder` after this lands, or it will re-introduce the staging strings on its next PR back. Called out as a follow-up on [BE-4428](https://linear.app/comfyorg/issue/BE-4428).
- **Kept env-override semantics unchanged.** `COMFY_BUILDER_BASE_URL` / `COMFY_CLOUD_ISSUER` still win, so local dev against staging is a one-liner in `.env`.

## Illustration

```mermaid
flowchart LR
  subgraph Before["Before"]
    B1[Desktop launch] --> B2["devplatform/config.ts<br/>seeds staging into<br/>process.env.COMFY_CLOUD_ISSUER"]
    B2 --> B3["cloud/config.ts reads<br/>process.env -> stagingcloud"]
    B1 --> B4["BUILDER_BASE_URL:<br/>stagingplatformapi.comfy.org/builder"]
  end
  subgraph After["After"]
    A1[Desktop launch] --> A2["cloud/config.ts default:<br/>cloud.comfy.org"]
    A1 --> A3["BUILDER_BASE_URL:<br/>platformapi.comfy.org/builder"]
  end
```

## Validation

- Confirmed both prod endpoints serve:
  - `HEAD https://platformapi.comfy.org/builder` -> `401` (auth gate, same shape as staging)
  - `GET https://cloud.comfy.org/.well-known/jwks.json` -> real prod JWK (`kid=cloud-jwt-prod-slot1-20260115-172105`)
- `grep -rn "COMFY_CLOUD_ISSUER\|stagingcloud\|stagingplatformapi\|STAGING_"` across `src/` returns only the reader-facing docstring in `cloud/config.ts`. No lingering references to the removed seed.
- Env-override path is a straight `env || DEFAULT`, unchanged from before.
- Pre-commit typecheck (`node`, `web`, `e2e`, `integration`) + lint passed.

Not exercised: end-to-end sign-in against prod (needs a real OAuth flow) and an authenticated builder-distributions round trip. Those are behavioral tests that don't depend on this diff.

## Follow-up

- **[BE-4428](https://linear.app/comfyorg/issue/BE-4428): rebase `integ/dist-ux` onto `comfy-builder` before its next PR back**, so the staging strings don't get re-introduced by a stale-branch merge.
