### PR TITLE
Accept 30-minute desktop login codes

### DIFF
--- a/src/main/auth/desktopLoginCode/client.test.ts
+++ b/src/main/auth/desktopLoginCode/client.test.ts
@@ -249,7 +249,7 @@ describe('grant timing validation', () => {
   it.each([
     ['expires_in', 1.5, 3],
     ['poll_interval', 300, 1.5],
-    ['expires_in', 901, 3],
+    ['expires_in', 1801, 3],
     ['poll_interval', 300, 31],
     ['expires_in', 0, 3],
     ['poll_interval', 300, 0]
@@ -277,6 +277,11 @@ describe('grant timing validation', () => {
   it('accepts the one-second minimum poll interval issued by Cloud', async () => {
     const grant = await grantFrom(300, 1)
     expect(grant).toEqual({ code: 'dlc_abc', expires_in: 300, poll_interval: 1 })
+  })
+
+  it('accepts a 30-minute code lifetime', async () => {
+    const grant = await grantFrom(1800, 1)
+    expect(grant).toEqual({ code: 'dlc_abc', expires_in: 1800, poll_interval: 1 })
   })
 })
 

--- a/src/main/auth/desktopLoginCode/client.ts
+++ b/src/main/auth/desktopLoginCode/client.ts
@@ -9,7 +9,7 @@ const REQUEST_TIMEOUT_MS = 8000
 
 const MIN_POLL_INTERVAL_SEC = 1
 const MAX_POLL_INTERVAL_SEC = 30
-const MAX_EXPIRES_IN_SEC = 900
+const MAX_EXPIRES_IN_SEC = 1800
 
 function isIntegerInRange(value: unknown, min: number, max: number): value is number {
   return typeof value === 'number' && Number.isInteger(value) && value >= min && value <= max


### PR DESCRIPTION
## What

- raise the accepted `expires_in` ceiling for desktop login-code grants from 900 to 1,800 seconds
- pin the 30-minute boundary and the 1,801-second rejection boundary in the focused client tests

## Why

The current five-minute create-to-redeem lifetime is expiring while users complete the system-browser login, onboarding, and approval journey. Cloud cannot safely raise the lifetime to 30 minutes until Desktop accepts the longer grant; current builds reject values above 900 seconds and fall back to the legacy auth path.

## Impact and rollout

This PR only widens client-side response validation. It does not change the server-issued lifetime by itself.

Release an accepting Desktop build before deploying the companion Cloud change: https://github.com/Comfy-Org/cloud/pull/5928

## Checks

- `mise exec -- pnpm vitest run src/main/auth/desktopLoginCode/client.test.ts` — 30 tests passed
- commit hooks: node, web, E2E, and integration typechecks; ESLint