### PR TITLE
fix(auth): reuse active desktop login attempt

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -790,6 +790,7 @@
       "copy": "Copy link",
       "copied": "Copied",
       "openAgain": "Open again",
+      "startOver": "Start over",
       "dismiss": "Dismiss"
     },
     "capacityDegraded": "Heavy usage",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -790,6 +790,7 @@
       "copy": "复制链接",
       "copied": "已复制",
       "openAgain": "再次打开",
+      "startOver": "重新开始",
       "dismiss": "忽略"
     },
     "capacityDegraded": "高负载",

--- a/src/main/auth/desktopLoginCode/index.test.ts
+++ b/src/main/auth/desktopLoginCode/index.test.ts
@@ -587,32 +587,57 @@ describe('signInViaDesktopLoginCode', () => {
     })
   })
 
-  it('aborts the prior poll loop on re-entry without reporting a failure', async () => {
+  it('reopens the same URL and keeps polling the same code on repeat clicks', async () => {
     h.settingsGet.mockReturnValue(true)
     h.createDesktopLoginCode.mockResolvedValue(GRANT)
-    h.exchangeDesktopLoginCode.mockResolvedValue({ status: 'pending' })
+    h.exchangeDesktopLoginCode
+      .mockResolvedValueOnce({ status: 'pending' })
+      .mockResolvedValueOnce({ status: 'complete', custom_token: 'custom-token-value' })
+    mockSignInChain({ uid: 'uid-1' })
     const mod = await loadOrchestrator()
+    const contents = fakeContents()
 
-    const first = mod.signInViaDesktopLoginCode(AUTH_URL, fakeContents(), {})
+    const first = mod.signInViaDesktopLoginCode(AUTH_URL, contents, {})
     await vi.advanceTimersByTimeAsync(3500)
     expect(h.exchangeDesktopLoginCode).toHaveBeenCalledTimes(1)
+    const openedUrl = h.openExternal.mock.calls[0]![0]
 
-    // Second click: the new attempt cancels the stale poll loop. Its own
-    // create fails fast so the test doesn't leave a flow in flight.
-    h.createDesktopLoginCode.mockRejectedValueOnce(new Error('create failed'))
-    const second = mod.signInViaDesktopLoginCode(AUTH_URL, fakeContents(), {})
+    const second = mod.signInViaDesktopLoginCode(AUTH_URL, contents, {})
 
+    expect(h.createDesktopLoginCode).toHaveBeenCalledTimes(1)
+    expect(h.openExternal).toHaveBeenCalledTimes(2)
+    expect(h.openExternal.mock.calls[1]![0]).toBe(openedUrl)
+
+    await vi.runAllTimersAsync()
     expect(await first).toBe('handled')
-    expect(await second).toBe('fallback')
-    // A superseded attempt is not a failure.
+    expect(await second).toBe('handled')
+    expect(h.exchangeDesktopLoginCode).toHaveBeenCalledTimes(2)
+    expect(h.signInWithCustomToken).toHaveBeenCalledWith(expect.any(String), 'custom-token-value', {
+      signal: expect.any(AbortSignal)
+    })
     expect(h.emit).not.toHaveBeenCalled()
-
-    // The stale loop is dead: no further polls happen.
-    await vi.advanceTimersByTimeAsync(30_000)
-    expect(h.exchangeDesktopLoginCode).toHaveBeenCalledTimes(1)
   })
 
-  it('cancels a prior code flow before falling back to the legacy bridge', async () => {
+  it('joins code creation without giving a repeat caller ownership of fallback', async () => {
+    let rejectCreate!: (reason: unknown) => void
+    h.createDesktopLoginCode.mockImplementation(
+      () => new Promise((_, reject) => (rejectCreate = reject))
+    )
+    const mod = await loadOrchestrator()
+    const contents = fakeContents()
+
+    const first = mod.signInViaDesktopLoginCode(AUTH_URL, contents, {})
+    const second = mod.signInViaDesktopLoginCode(AUTH_URL, contents, {})
+
+    expect(h.createDesktopLoginCode).toHaveBeenCalledTimes(1)
+    rejectCreate(new Error('create failed'))
+
+    expect(await first).toBe('fallback')
+    expect(await second).toBe('handled')
+    expect(h.openExternal).not.toHaveBeenCalled()
+  })
+
+  it('cancels a prior code flow only when start-over is explicit', async () => {
     h.settingsGet.mockReturnValue(true)
     h.createDesktopLoginCode.mockResolvedValue(GRANT)
     h.exchangeDesktopLoginCode.mockResolvedValue({ status: 'pending' })
@@ -625,7 +650,7 @@ describe('signInViaDesktopLoginCode', () => {
     const fallback = await mod.signInViaDesktopLoginCode(
       'https://dreamboothy-dev.firebaseapp.com/__/auth/handler?providerId=google.com',
       fakeContents('https://cloud.comfy.org/'),
-      {}
+      { startOver: true }
     )
 
     expect(fallback).toBe('fallback')
@@ -663,10 +688,10 @@ describe('signInViaDesktopLoginCode', () => {
     await vi.advanceTimersByTimeAsync(3000)
     expect(h.signInWithCustomToken).toHaveBeenCalledTimes(1)
 
-    // Re-click while A is mid-tail: B aborts A, then fails create fast so
-    // the test doesn't leave a second flow in flight.
+    // An explicit start-over while A is mid-tail aborts A, then B fails create
+    // fast so the test doesn't leave a second flow in flight.
     h.createDesktopLoginCode.mockRejectedValueOnce(new Error('create failed'))
-    const second = mod.signInViaDesktopLoginCode(AUTH_URL, contents, {})
+    const second = mod.signInViaDesktopLoginCode(AUTH_URL, contents, { startOver: true })
     const bannerCleanupsAfterSecondStart = h.runBannerCleanup.mock.calls.length
 
     resolveSignIn({ idToken: 'id-token', refreshToken: 'refresh-token', expiresIn: '3600' })

--- a/src/main/auth/desktopLoginCode/index.test.ts
+++ b/src/main/auth/desktopLoginCode/index.test.ts
@@ -210,7 +210,8 @@ describe('signInViaDesktopLoginCode', () => {
     expect(openedUrl).toContain('desktop_login_code=dlc_test-code')
     expect(openedUrl).not.toContain('installation_id')
     expect(openedUrl).not.toContain('machine-hash-1234')
-    expect(h.showCopyLinkBanner).toHaveBeenCalledWith(contents, openedUrl)
+    // No restart hook in opts → the card renders without Start over.
+    expect(h.showCopyLinkBanner).toHaveBeenCalledWith(contents, openedUrl, undefined)
 
     expect(h.createDesktopLoginCode).toHaveBeenCalledWith(
       'https://cloud.comfy.org',
@@ -596,17 +597,23 @@ describe('signInViaDesktopLoginCode', () => {
     mockSignInChain({ uid: 'uid-1' })
     const mod = await loadOrchestrator()
     const contents = fakeContents()
+    const restartSignIn = vi.fn()
 
-    const first = mod.signInViaDesktopLoginCode(AUTH_URL, contents, {})
+    const first = mod.signInViaDesktopLoginCode(AUTH_URL, contents, { restartSignIn })
     await vi.advanceTimersByTimeAsync(3500)
     expect(h.exchangeDesktopLoginCode).toHaveBeenCalledTimes(1)
     const openedUrl = h.openExternal.mock.calls[0]![0]
 
-    const second = mod.signInViaDesktopLoginCode(AUTH_URL, contents, {})
+    const second = mod.signInViaDesktopLoginCode(AUTH_URL, contents, { restartSignIn })
 
     expect(h.createDesktopLoginCode).toHaveBeenCalledTimes(1)
     expect(h.openExternal).toHaveBeenCalledTimes(2)
     expect(h.openExternal.mock.calls[1]![0]).toBe(openedUrl)
+    // The re-click restores the card (it may have been dismissed) and hands
+    // its Start over the same restart hook as the original attempt.
+    expect(h.showCopyLinkBanner).toHaveBeenCalledTimes(2)
+    expect(h.showCopyLinkBanner.mock.calls[0]).toEqual([contents, openedUrl, restartSignIn])
+    expect(h.showCopyLinkBanner.mock.calls[1]).toEqual([contents, openedUrl, restartSignIn])
 
     await vi.runAllTimersAsync()
     expect(await first).toBe('handled')
@@ -635,6 +642,50 @@ describe('signInViaDesktopLoginCode', () => {
     expect(await first).toBe('fallback')
     expect(await second).toBe('handled')
     expect(h.openExternal).not.toHaveBeenCalled()
+  })
+
+  it('recovers after an attempt crashes before its own cleanup paths', async () => {
+    h.settingsGet.mockReturnValue(true)
+    h.getDeviceId.mockImplementation(() => {
+      throw new Error('device id unavailable')
+    })
+    const mod = await loadOrchestrator()
+    const contents = fakeContents()
+
+    await expect(mod.signInViaDesktopLoginCode(AUTH_URL, contents, {})).rejects.toThrow(
+      'device id unavailable'
+    )
+
+    // The crashed attempt must not stay joinable — that would turn every
+    // later click into a silent no-op. The next click starts fresh instead.
+    h.getDeviceId.mockReturnValue('machine-hash-1234')
+    h.createDesktopLoginCode.mockRejectedValueOnce(new Error('create failed'))
+    const second = await mod.signInViaDesktopLoginCode(AUTH_URL, contents, {})
+    expect(second).toBe('fallback')
+    expect(h.createDesktopLoginCode).toHaveBeenCalledTimes(1)
+  })
+
+  it('replaces the active attempt when its originating view is gone', async () => {
+    h.createDesktopLoginCode.mockResolvedValue(GRANT)
+    h.exchangeDesktopLoginCode.mockResolvedValue({ status: 'pending' })
+    const mod = await loadOrchestrator()
+    let destroyed = false
+    const contents = fakeContents()
+    contents.isDestroyed = vi.fn(() => destroyed)
+
+    const first = mod.signInViaDesktopLoginCode(AUTH_URL, contents, {})
+    await vi.advanceTimersByTimeAsync(3500)
+    expect(h.createDesktopLoginCode).toHaveBeenCalledTimes(1)
+
+    // A click from a recreated view must not join a flow that can never
+    // inject its session; it cancels the orphan and starts over. The fresh
+    // attempt's create fails fast so the test leaves no flow in flight.
+    destroyed = true
+    h.createDesktopLoginCode.mockRejectedValueOnce(new Error('create failed'))
+    const second = await mod.signInViaDesktopLoginCode(AUTH_URL, fakeContents(), {})
+    expect(second).toBe('fallback')
+    expect(h.createDesktopLoginCode).toHaveBeenCalledTimes(2)
+    expect(await first).toBe('handled')
   })
 
   it('cancels a prior code flow only when start-over is explicit', async () => {

--- a/src/main/auth/desktopLoginCode/index.ts
+++ b/src/main/auth/desktopLoginCode/index.ts
@@ -93,7 +93,10 @@ function cancelActiveFlow(): void {
  * 'handled': restarting the legacy bridge would fight the login tab the
  * user may be halfway through.
  */
-export function signInViaDesktopLoginCode(
+// `async` is load-bearing despite the missing awaits: a synchronous throw
+// (e.g. getURL() on a just-destroyed view) must reject rather than escape
+// the caller's degrade-to-legacy `.catch`.
+export async function signInViaDesktopLoginCode(
   interceptedAuthUrl: string,
   comfyContents: WebContents,
   opts: HandleFirebasePopupOpts = {}
@@ -105,7 +108,14 @@ export function signInViaDesktopLoginCode(
     !existing.controller.signal.aborted &&
     !existing.comfyContents.isDestroyed()
   ) {
-    if (existing.loginUrl) openExternalSafely(existing.loginUrl)
+    if (existing.loginUrl) {
+      openExternalSafely(existing.loginUrl)
+      // Restore the card (the user may have dismissed it) so a repeat click
+      // leaves visible feedback even when the browser silently fails to
+      // open. Cleanup first: each card owns one console listener.
+      runBannerCleanup()
+      showCopyLinkBanner(existing.comfyContents, existing.loginUrl, opts.restartSignIn)
+    }
     // Only the original caller may start the legacy fallback if code creation
     // fails. Repeat callers merely re-open/join the one active attempt.
     return existing.outcome.then(
@@ -129,7 +139,7 @@ export function signInViaDesktopLoginCode(
   if (firebaseEnv === 'dev' && cloudOrigin === CLOUD_LOGIN_ORIGIN) {
     runBannerCleanup()
     closeActiveBridge()
-    return Promise.resolve('fallback')
+    return 'fallback'
   }
 
   const controller = new AbortController()
@@ -148,6 +158,12 @@ export function signInViaDesktopLoginCode(
     loginUrl: null,
     outcome
   }
+  // A crash before the runner's own cleanup paths (e.g. while building the
+  // create request) must not leave `activeFlow` dead-but-set: every later
+  // click would silently join it, and Sign in would no-op until app restart.
+  void outcome.catch(() => {
+    if (activeFlow?.controller === controller) activeFlow = null
+  })
   return outcome
 }
 
@@ -166,7 +182,6 @@ async function runDesktopLoginCodeFlow(
   // as the legacy bridge path).
   runBannerCleanup()
   closeActiveBridge()
-  const sessionInjection = beginFirebaseSessionInjection(comfyContents)
 
   // The Cloud page owns provider choice when Firebase omitted or supplied an
   // unsupported providerId, so keep that widened path visible in the funnel.
@@ -185,6 +200,10 @@ async function runDesktopLoginCodeFlow(
   if (settings.get('telemetryEnabled') === true) {
     request.installation_id = getDeviceId()
   }
+
+  // Claimed only after the fallible prep above: from here every exit path
+  // releases it (create-catch, the abort checks, the main finally).
+  const sessionInjection = beginFirebaseSessionInjection(comfyContents)
 
   let grant: DesktopLoginCodeGrant
   try {
@@ -225,7 +244,7 @@ async function runDesktopLoginCodeFlow(
     loginUrl.searchParams.set('desktop_login_code', grant.code)
     if (activeFlow?.controller === controller) activeFlow.loginUrl = loginUrl.href
     openExternalSafely(loginUrl.href)
-    showCopyLinkBanner(comfyContents, loginUrl.href)
+    showCopyLinkBanner(comfyContents, loginUrl.href, opts.restartSignIn)
 
     const deadlineMs = Date.now() + grant.expires_in * 1000
     const retryDeadlineMs = deadlineMs + POST_REDEEM_RETRY_GRACE_MS

--- a/src/main/auth/desktopLoginCode/index.ts
+++ b/src/main/auth/desktopLoginCode/index.ts
@@ -57,16 +57,23 @@ const POST_REDEEM_RETRY_GRACE_MS = 120_000
 
 const DESKTOP_LOGIN_CODE_FLOW = 'desktop_login_code'
 
+type DesktopLoginCodeOutcome = 'handled' | 'fallback'
+
+interface ActiveDesktopLoginCodeFlow {
+  controller: AbortController
+  comfyContents: WebContents
+  loginUrl: string | null
+  outcome: Promise<DesktopLoginCodeOutcome>
+}
+
 /**
- * In-flight flow, aborted on re-entry (mirror of firebaseBridge's
- * `activeBridgeFlow`): if the user clicks Sign in again while a previous
- * attempt is still parked on an open browser tab, the stale poll loop is
- * cancelled before the new one starts.
+ * The in-flight login-code attempt. Repeat clicks reuse this flow and reopen
+ * its exact browser URL; replacing it requires the explicit `startOver` opt.
  */
-let activeFlow: AbortController | null = null
+let activeFlow: ActiveDesktopLoginCodeFlow | null = null
 
 function cancelActiveFlow(): void {
-  activeFlow?.abort()
+  activeFlow?.controller.abort()
   activeFlow = null
 }
 
@@ -86,11 +93,28 @@ function cancelActiveFlow(): void {
  * 'handled': restarting the legacy bridge would fight the login tab the
  * user may be halfway through.
  */
-export async function signInViaDesktopLoginCode(
+export function signInViaDesktopLoginCode(
   interceptedAuthUrl: string,
   comfyContents: WebContents,
   opts: HandleFirebasePopupOpts = {}
-): Promise<'handled' | 'fallback'> {
+): Promise<DesktopLoginCodeOutcome> {
+  const existing = activeFlow
+  if (
+    existing &&
+    !opts.startOver &&
+    !existing.controller.signal.aborted &&
+    !existing.comfyContents.isDestroyed()
+  ) {
+    if (existing.loginUrl) openExternalSafely(existing.loginUrl)
+    // Only the original caller may start the legacy fallback if code creation
+    // fails. Repeat callers merely re-open/join the one active attempt.
+    return existing.outcome.then(
+      () => 'handled',
+      () => 'handled'
+    )
+  }
+  if (existing) cancelActiveFlow()
+
   const sessionTargetOrigin = originOf(comfyContents.getURL())
   const firebaseEnv = detectFirebaseEnv(interceptedAuthUrl)
   const cloudOrigin = cloudLoginOriginForUrl(
@@ -103,15 +127,39 @@ export async function signInViaDesktopLoginCode(
   // (whose /api fronts a matching dev backend) can serve the dev flow, so
   // anything else hands off to the legacy loopback bridge.
   if (firebaseEnv === 'dev' && cloudOrigin === CLOUD_LOGIN_ORIGIN) {
-    cancelActiveFlow()
     runBannerCleanup()
     closeActiveBridge()
-    return 'fallback'
+    return Promise.resolve('fallback')
   }
 
-  cancelActiveFlow()
   const controller = new AbortController()
-  activeFlow = controller
+  const outcome = runDesktopLoginCodeFlow(
+    interceptedAuthUrl,
+    comfyContents,
+    opts,
+    sessionTargetOrigin,
+    firebaseEnv,
+    cloudOrigin,
+    controller
+  )
+  activeFlow = {
+    controller,
+    comfyContents,
+    loginUrl: null,
+    outcome
+  }
+  return outcome
+}
+
+async function runDesktopLoginCodeFlow(
+  interceptedAuthUrl: string,
+  comfyContents: WebContents,
+  opts: HandleFirebasePopupOpts,
+  sessionTargetOrigin: string | null,
+  firebaseEnv: ReturnType<typeof detectFirebaseEnv>,
+  cloudOrigin: string,
+  controller: AbortController
+): Promise<DesktopLoginCodeOutcome> {
   // Clear a prior attempt's "copy link" card so this attempt doesn't
   // stack a second one, and kill any stale legacy loopback bridge so it
   // can't complete a competing sign-in underneath this flow (same hygiene
@@ -150,12 +198,12 @@ export async function signInViaDesktopLoginCode(
     // transparently and emit its own funnel events. A superseded attempt
     // reports 'handled' instead so the caller doesn't start a second
     // sign-in underneath the newer one.
-    if (activeFlow === controller) activeFlow = null
+    if (activeFlow?.controller === controller) activeFlow = null
     releaseFirebaseSessionInjection(sessionInjection)
     return controller.signal.aborted || comfyContents.isDestroyed() ? 'handled' : 'fallback'
   }
   if (controller.signal.aborted || comfyContents.isDestroyed()) {
-    if (activeFlow === controller) activeFlow = null
+    if (activeFlow?.controller === controller) activeFlow = null
     releaseFirebaseSessionInjection(sessionInjection)
     return 'handled'
   }
@@ -175,6 +223,7 @@ export async function signInViaDesktopLoginCode(
     // installation_id or any auth material.
     const loginUrl = new URL('/cloud/login', cloudOrigin)
     loginUrl.searchParams.set('desktop_login_code', grant.code)
+    if (activeFlow?.controller === controller) activeFlow.loginUrl = loginUrl.href
     openExternalSafely(loginUrl.href)
     showCopyLinkBanner(comfyContents, loginUrl.href)
 
@@ -217,9 +266,9 @@ export async function signInViaDesktopLoginCode(
         throw new Error('desktop login code expired before sign-in completed')
       }
     }
-    // A re-click may supersede this flow at any await from here on —
-    // check before every await/side-effect so a stale flow never signs
-    // in, injects a user, or steals focus underneath the newer one.
+    // An explicit start-over may supersede this flow at any await from here
+    // on — check before every await/side-effect so a stale flow never signs in,
+    // injects a user, or steals focus underneath the newer one.
     if (controller.signal.aborted) return 'handled'
     if (comfyContents.isDestroyed()) {
       controller.abort()
@@ -278,7 +327,7 @@ export async function signInViaDesktopLoginCode(
   } finally {
     // Capture ownership before nulling: a superseded flow finishing late
     // must not tear down the banner the newer flow just put up.
-    const ownsUx = activeFlow === controller
+    const ownsUx = activeFlow?.controller === controller
     if (ownsUx) {
       activeFlow = null
       runBannerCleanup()

--- a/src/main/auth/firebaseBridge/copyLinkBanner.test.ts
+++ b/src/main/auth/firebaseBridge/copyLinkBanner.test.ts
@@ -5,6 +5,7 @@ import {
   buildRemoveCopyLinkBannerScript,
   COPY_LINK_BANNER_ID,
   OPEN_LINK_SENTINEL,
+  START_OVER_SENTINEL,
   type CopyLinkBannerLabels
 } from './copyLinkBanner'
 
@@ -35,6 +36,21 @@ describe('buildCopyLinkBannerScript', () => {
     expect(script).toContain(JSON.stringify(OPEN_LINK_SENTINEL))
     // Copy is in-page only — no console sentinel a remote page could abuse.
     expect(script).not.toContain('__comfyCopyLoginLink')
+  })
+
+  it('renders no Start over button (and no sentinel) without the label', () => {
+    const script = buildCopyLinkBannerScript(url, labels)
+    expect(script).not.toContain(JSON.stringify(START_OVER_SENTINEL))
+    expect(script).not.toContain('bar.appendChild(restart)')
+  })
+
+  it('renders a one-shot Start over button when the label is provided', () => {
+    const script = buildCopyLinkBannerScript(url, { ...labels, startOver: 'Start over' })
+    expect(script).toContain(JSON.stringify(START_OVER_SENTINEL))
+    expect(script).toContain('bar.appendChild(restart)')
+    // Disabled after the first click so a double-click can't mint two codes.
+    expect(script).toContain('restart.disabled=true')
+    expect(() => new Function(script)).not.toThrow()
   })
 
   it('copies in-page with a clipboard primary and execCommand fallback', () => {

--- a/src/main/auth/firebaseBridge/copyLinkBanner.ts
+++ b/src/main/auth/firebaseBridge/copyLinkBanner.ts
@@ -11,17 +11,25 @@
  * Injected with `insertCSS` + `executeJavaScript`, like
  * `injectMacPasskeyWarning`. The URL is string-baked via `JSON.stringify`
  * so a hostile URL can't break the Cloud page. Copy stays in-page; only
- * "Open again" reaches main (see `OPEN_LINK_SENTINEL`).
+ * "Open again" and "Start over" reach main (see the sentinels below).
  */
 
 export const COPY_LINK_BANNER_ID = 'comfy-copy-login-banner'
 
 /**
- * Open-again → main, so it can `shell.openExternal` (page JS can't). The
- * only page→main channel — copy stays in-page so a remote page can't
- * drive a no-gesture clipboard write — and it re-opens only our own URL.
+ * Open-again → main, so it can `shell.openExternal` (page JS can't). Copy
+ * stays in-page so a remote page can't drive a no-gesture clipboard write —
+ * and this sentinel re-opens only our own URL.
  */
 export const OPEN_LINK_SENTINEL = '__comfyOpenLoginLink'
+
+/**
+ * Start-over → main, so it can replace the in-flight sign-in attempt (page
+ * JS can't). Carries no data: main re-enters its own flow with its own
+ * URLs, so a hostile page can at worst restart our sign-in (and the
+ * console listener one-shots it per card).
+ */
+export const START_OVER_SENTINEL = '__comfyStartOverLogin'
 
 export interface CopyLinkBannerLabels {
   message: string
@@ -29,6 +37,8 @@ export interface CopyLinkBannerLabels {
   copied: string
   openAgain: string
   dismiss: string
+  /** Omitted → the card renders without a Start over button. */
+  startOver?: string
 }
 
 // Values mirror the Comfy Desktop brand tokens defined in
@@ -65,7 +75,8 @@ export const COPY_LINK_BANNER_CSS =
   `#${COPY_LINK_BANNER_ID} button.ccl-done:hover{background:#f2ff59;border-color:#f2ff59;color:#100c13;}` +
   `#${COPY_LINK_BANNER_ID} button.ccl-close{border:none;background:transparent;color:#8a8688;` +
   `padding:4px 6px;font-size:16px;line-height:1;}` +
-  `#${COPY_LINK_BANNER_ID} button.ccl-close:hover{background:transparent;color:#c2bfb9;}`
+  `#${COPY_LINK_BANNER_ID} button.ccl-close:hover{background:transparent;color:#c2bfb9;}` +
+  `#${COPY_LINK_BANNER_ID} button:disabled{opacity:.55;cursor:default;pointer-events:none;}`
 
 /**
  * Build the page-context IIFE that renders the card. Every interpolated
@@ -83,6 +94,13 @@ export function buildCopyLinkBannerScript(url: string, labels: CopyLinkBannerLab
     openAgain: JSON.stringify(labels.openAgain),
     dismiss: JSON.stringify(labels.dismiss)
   }
+  // One-shot in-page: disabled after click so a double-click can't mint two
+  // replacement codes (main's console listener is the real guard).
+  const startOverBtn =
+    labels.startOver === undefined
+      ? ''
+      : `var restart=makeBtn('',ICON_RESTART,${JSON.stringify(labels.startOver)});` +
+        `restart.addEventListener('click',function(){try{restart.disabled=true;console.info(${JSON.stringify(START_OVER_SENTINEL)});}catch(e){}});`
   return `(function(){try{
     var URL=${u}, ID=${id};
     var existing=document.getElementById(ID);
@@ -95,6 +113,7 @@ export function buildCopyLinkBannerScript(url: string, labels: CopyLinkBannerLab
     var ICON_COPY=svg('<rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/>');
     var ICON_TICK=svg('<path d="M20 6 9 17l-5-5"/>');
     var ICON_OPEN=svg('<path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>');
+    var ICON_RESTART=svg('<path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/>');
     function makeBtn(cls,icon,text){
       var b=document.createElement('button');if(cls)b.className=cls;
       var i=document.createElement('span');i.className='ccl-ico';i.innerHTML=icon;
@@ -113,8 +132,9 @@ export function buildCopyLinkBannerScript(url: string, labels: CopyLinkBannerLab
       else{fallbackCopy(text);flash();}
     });
     open.addEventListener('click',function(){try{console.info(${openToken});}catch(e){}});
+    ${startOverBtn}
     close.addEventListener('click',function(){try{if(bar.__cclObs)bar.__cclObs.disconnect();bar.remove();}catch(e){}});
-    bar.appendChild(msg);bar.appendChild(copy);bar.appendChild(open);bar.appendChild(close);
+    bar.appendChild(msg);bar.appendChild(copy);bar.appendChild(open);${startOverBtn ? 'bar.appendChild(restart);' : ''}bar.appendChild(close);
     document.body.appendChild(bar);
     var obs=new MutationObserver(function(){if(!document.getElementById(ID)&&bar.__cclUrl){document.body.appendChild(bar);}});
     obs.observe(document.body,{childList:true});bar.__cclObs=obs;

--- a/src/main/auth/firebaseBridge/flowShared.ts
+++ b/src/main/auth/firebaseBridge/flowShared.ts
@@ -84,6 +84,8 @@ export interface HandleFirebasePopupOpts {
   /** Window restored after sign-in completes. */
   parentWindow?: BrowserWindow
   onError?: (failure: SignInFailureContext) => void
+  /** Explicitly replace an in-flight Desktop login-code attempt. */
+  startOver?: boolean
 }
 
 /** Keep in sync with the countdown rendered by the legacy bridge page. */

--- a/src/main/auth/firebaseBridge/flowShared.ts
+++ b/src/main/auth/firebaseBridge/flowShared.ts
@@ -86,6 +86,12 @@ export interface HandleFirebasePopupOpts {
   onError?: (failure: SignInFailureContext) => void
   /** Explicitly replace an in-flight Desktop login-code attempt. */
   startOver?: boolean
+  /**
+   * Installed by `handleFirebasePopup`, not external callers: the banner's
+   * "Start over" re-enters the full popup orchestration with `startOver`, so
+   * a replacement attempt keeps the legacy-bridge fallback.
+   */
+  restartSignIn?: () => void
 }
 
 /** Keep in sync with the countdown rendered by the legacy bridge page. */

--- a/src/main/auth/firebaseBridge/flowState.ts
+++ b/src/main/auth/firebaseBridge/flowState.ts
@@ -4,7 +4,9 @@ import {
   buildCopyLinkBannerScript,
   buildRemoveCopyLinkBannerScript,
   COPY_LINK_BANNER_CSS,
-  OPEN_LINK_SENTINEL
+  type CopyLinkBannerLabels,
+  OPEN_LINK_SENTINEL,
+  START_OVER_SENTINEL
 } from './copyLinkBanner'
 import type { BridgeHandle } from './server'
 import * as i18n from '../../lib/i18n'
@@ -61,28 +63,45 @@ export function runBannerCleanup(): void {
   cleanup?.()
 }
 
-/** Inject the browser-opened card and own its singleton teardown. */
-export function showCopyLinkBanner(comfyContents: WebContents, loginUrl: string): void {
+/**
+ * Inject the browser-opened card and own its singleton teardown. With
+ * `onStartOver` the card offers a "Start over" button that replaces the
+ * in-flight sign-in attempt.
+ */
+export function showCopyLinkBanner(
+  comfyContents: WebContents,
+  loginUrl: string,
+  onStartOver?: () => void
+): void {
   if (comfyContents.isDestroyed()) return
 
-  const labels = {
+  const labels: CopyLinkBannerLabels = {
     message: i18n.t('cloud.signInBanner.message'),
     copy: i18n.t('cloud.signInBanner.copy'),
     copied: i18n.t('cloud.signInBanner.copied'),
     openAgain: i18n.t('cloud.signInBanner.openAgain'),
     dismiss: i18n.t('cloud.signInBanner.dismiss')
   }
+  if (onStartOver) labels.startOver = i18n.t('cloud.signInBanner.startOver')
 
   void comfyContents
     .insertCSS(COPY_LINK_BANNER_CSS)
     .then(() => comfyContents.executeJavaScript(buildCopyLinkBannerScript(loginUrl, labels), true))
     .catch(() => {})
 
+  // One-shot per card: the page can emit the sentinel too, so a spammy page
+  // (or double-click) must not restart sign-in more than once per attempt.
+  let startedOver = false
   const onConsoleMessage = (
     details: Electron.Event<Electron.WebContentsConsoleMessageEventParams>
   ): void => {
-    if (details.frame?.parent != null || details.message !== OPEN_LINK_SENTINEL) return
-    openExternalSafely(loginUrl)
+    if (details.frame?.parent != null) return
+    if (details.message === OPEN_LINK_SENTINEL) {
+      openExternalSafely(loginUrl)
+    } else if (details.message === START_OVER_SENTINEL && onStartOver && !startedOver) {
+      startedOver = true
+      onStartOver()
+    }
   }
   comfyContents.on('console-message', onConsoleMessage)
 

--- a/src/main/auth/firebaseBridge/index.test.ts
+++ b/src/main/auth/firebaseBridge/index.test.ts
@@ -26,7 +26,8 @@ vi.mock('./copyLinkBanner', () => ({
   buildCopyLinkBannerScript: () => 'show-banner',
   buildRemoveCopyLinkBannerScript: () => 'remove-banner',
   COPY_LINK_BANNER_CSS: '',
-  OPEN_LINK_SENTINEL: 'open-again'
+  OPEN_LINK_SENTINEL: 'open-again',
+  START_OVER_SENTINEL: 'start-over'
 }))
 vi.mock('./inject', () => ({
   beginFirebaseSessionInjection: h.beginSessionInjection,
@@ -229,6 +230,49 @@ describe('handleFirebasePopup legacy flow', () => {
       error_bucket: 'other',
       flow: 'loopback_bridge'
     })
+  })
+
+  it('installs a restart hook that re-enters the flow with an explicit start-over', async () => {
+    h.signInViaDesktopLoginCode.mockResolvedValue('handled')
+
+    await handleFirebasePopup(AUTH_URL, fakeContents(), {})
+
+    const firstOpts = h.signInViaDesktopLoginCode.mock.calls[0]![2] as {
+      startOver?: boolean
+      restartSignIn: () => void
+    }
+    expect(firstOpts.startOver).toBeUndefined()
+
+    firstOpts.restartSignIn()
+
+    const secondOpts = h.signInViaDesktopLoginCode.mock.calls[1]![2] as {
+      startOver?: boolean
+      restartSignIn?: () => void
+    }
+    expect(secondOpts.startOver).toBe(true)
+    // The replacement attempt's own banner gets a fresh hook in turn.
+    expect(typeof secondOpts.restartSignIn).toBe('function')
+  })
+
+  it('start-over from the card fires once per card; open-again reopens the URL', () => {
+    const contents = fakeContents()
+    const onStartOver = vi.fn()
+
+    showCopyLinkBanner(contents, 'https://cloud.comfy.org/login?code=x', onStartOver)
+
+    const onCall = (contents.on as unknown as ReturnType<typeof vi.fn>).mock.calls[0]!
+    expect(onCall[0]).toBe('console-message')
+    const listener = onCall[1] as (details: {
+      frame: { parent: null } | null
+      message: string
+    }) => void
+
+    listener({ frame: { parent: null }, message: 'start-over' })
+    listener({ frame: { parent: null }, message: 'start-over' })
+    expect(onStartOver).toHaveBeenCalledTimes(1)
+
+    listener({ frame: { parent: null }, message: 'open-again' })
+    expect(h.openExternal).toHaveBeenCalledWith('https://cloud.comfy.org/login?code=x')
   })
 
   it('continues through the banner when the initial browser open rejects', async () => {

--- a/src/main/auth/firebaseBridge/index.ts
+++ b/src/main/auth/firebaseBridge/index.ts
@@ -55,6 +55,15 @@ export async function handleFirebasePopup(
   comfyContents: WebContents,
   opts: HandleFirebasePopupOpts = {}
 ): Promise<void> {
+  // The banner's "Start over" re-enters this whole orchestration — not just
+  // the code flow — so a replacement attempt keeps the legacy-bridge fallback.
+  // Spread `opts` (not `optsWithRestart`) so each entry installs a fresh hook.
+  const optsWithRestart: HandleFirebasePopupOpts = {
+    ...opts,
+    restartSignIn: () => {
+      void handleFirebasePopup(url, comfyContents, { ...opts, startOver: true })
+    }
+  }
   // Prefer the cloud login-code flow (GTM-93): sign-in happens on the
   // real Cloud login page and Desktop polls for a one-time custom token —
   // no loopback server. 'fallback' means the flow died before the browser
@@ -65,7 +74,7 @@ export async function handleFirebasePopup(
   // user with no login-code flow, no legacy fallback, no sign_in_failed, and an
   // unhandled rejection — a Sign in button that silently does nothing. Degrade
   // to the legacy bridge instead.
-  const outcome = await signInViaDesktopLoginCode(url, comfyContents, opts).catch(() => {
+  const outcome = await signInViaDesktopLoginCode(url, comfyContents, optsWithRestart).catch(() => {
     console.error('Desktop login-code flow failed unexpectedly; using legacy fallback')
     return 'fallback' as const
   })
@@ -130,7 +139,7 @@ export async function handleFirebasePopup(
     openExternalSafely(loginUrl)
     // Surface a Notion/Claude-style "didn't open? copy the link" card in
     // the Cloud view so users can finish sign-in in a non-default browser.
-    showCopyLinkBanner(comfyContents, loginUrl)
+    showCopyLinkBanner(comfyContents, loginUrl, optsWithRestart.restartSignIn)
     const { user, apiKey } = await abortable(handle.signInPromise, signal)
     if (signal.aborted || !isActiveBridgeFlow(flow)) return
     if (comfyContents.isDestroyed()) return


### PR DESCRIPTION
## Summary

- keep the active Desktop login-code attempt alive when Sign in is clicked again
- reopen or focus the exact browser URL for the existing code instead of minting a replacement, and restore the copy-link card in case it was dismissed
- let repeat callers join the original attempt without taking ownership of legacy fallback
- require an explicit `startOver` option to cancel and replace an in-flight attempt
- add a one-shot **Start over** button to the sign-in card (en/zh) that re-enters the popup orchestration with `startOver: true` — the user-facing escape hatch from a wedged attempt
- clear `activeFlow` when an attempt's outcome rejects, and keep the entry point `async`, so a crashed attempt degrades to the legacy bridge instead of turning every later click into a silent no-op

## Why

A repeat click previously aborted Desktop's poller while leaving the original browser tab and login code alive. The replacement attempt then polled a different code, which made multi-click users disproportionately likely to hit terminal exchange failures such as 404s.

The active attempt now owns its code, URL, poller, fallback decision, and completion until it finishes or an explicit start-over replaces it.

Join-by-default makes the Sign in button idempotent — Desktop cannot close the tab it already opened, so converging on the existing code is the only state both sides can agree on. But it also means a wedged attempt has no recovery path until the code expires (30 minutes since #1356). The banner's Start over button provides that recovery, and the rejection guard closes the one state where recovery would otherwise require an app restart.

## Validation

- `mise exec -- pnpm exec vitest run src/main/auth` — 139 tests passed across 12 files
- repository commit hook: `pnpm run typecheck` — passed
- repository commit hook: `pnpm run lint` — passed
- targeted Prettier checks for the touched files — passed
- `git diff --check origin/main...HEAD` — passed