### PR TITLE
Make Desktop browser handoff observable

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -786,11 +786,18 @@
     "label": "Cloud",
     "desc": "Run workflows on managed GPUs.",
     "signInBanner": {
-      "message": "We opened your browser to sign in. Didn’t open?",
+      "title": "Finish signing in in your browser",
+      "opening": "Opening your browser…",
+      "waiting": "Waiting for you to finish signing in.",
+      "openFailed": "We couldn’t open your browser. Try again or copy the link.",
+      "expired": "This sign-in link expired. Start over to try again.",
+      "failed": "Sign-in didn’t complete. Start over to try again.",
+      "remaining": "{time} remaining",
       "copy": "Copy link",
       "copied": "Copied",
-      "openAgain": "Open again",
-      "dismiss": "Dismiss"
+      "openAgain": "Open browser again",
+      "cancel": "Cancel",
+      "startOver": "Start over"
     },
     "capacityDegraded": "Heavy usage",
     "capacityDegradedHint": "ComfyUI Cloud is under heavy load right now — you may see slower response times. Please try again later for the best experience.",

--- a/src/main/auth/desktopLoginCode/index.test.ts
+++ b/src/main/auth/desktopLoginCode/index.test.ts
@@ -15,6 +15,7 @@ const h = vi.hoisted(() => ({
   bucketError: vi.fn(() => 'bucketed'),
   bindSignedInUser: vi.fn(),
   showCopyLinkBanner: vi.fn(),
+  updateSignInPanelStatus: vi.fn(),
   runBannerCleanup: vi.fn(),
   closeActiveBridge: vi.fn(),
   settingsGet: vi.fn(),
@@ -48,10 +49,16 @@ vi.mock('../../settings', () => ({ get: h.settingsGet }))
 
 vi.mock('../firebaseBridge/flowState', () => ({
   showCopyLinkBanner: h.showCopyLinkBanner,
+  updateSignInPanelStatus: h.updateSignInPanelStatus,
   runBannerCleanup: h.runBannerCleanup,
   closeActiveBridge: h.closeActiveBridge,
-  openExternalSafely: (url: string) => {
-    void h.openExternal(url).catch(() => {})
+  openExternalSafely: async (url: string) => {
+    try {
+      await h.openExternal(url)
+      return true
+    } catch {
+      return false
+    }
   }
 }))
 
@@ -210,7 +217,23 @@ describe('signInViaDesktopLoginCode', () => {
     expect(openedUrl).toContain('desktop_login_code=dlc_test-code')
     expect(openedUrl).not.toContain('installation_id')
     expect(openedUrl).not.toContain('machine-hash-1234')
-    expect(h.showCopyLinkBanner).toHaveBeenCalledWith(contents, openedUrl)
+    expect(h.showCopyLinkBanner).toHaveBeenCalledWith(
+      contents,
+      openedUrl,
+      expect.objectContaining({
+        expiresAtMs: expect.any(Number),
+        onCancel: expect.any(Function),
+        onStartOver: undefined,
+        onBrowserOpenResult: expect.any(Function)
+      })
+    )
+    expect(h.capture).toHaveBeenCalledWith('comfy.desktop.auth.browser_handoff', {
+      provider: 'google.com',
+      flow: 'desktop_login_code',
+      result: 'accepted',
+      trigger: 'automatic'
+    })
+    expect(h.updateSignInPanelStatus).toHaveBeenCalledWith(contents, 'waiting')
 
     expect(h.createDesktopLoginCode).toHaveBeenCalledWith(
       'https://cloud.comfy.org',
@@ -306,6 +329,13 @@ describe('signInViaDesktopLoginCode', () => {
 
     expect(await promise).toBe('handled')
     expect(h.showCopyLinkBanner).toHaveBeenCalledOnce()
+    expect(h.capture).toHaveBeenCalledWith('comfy.desktop.auth.browser_handoff', {
+      provider: 'google.com',
+      flow: 'desktop_login_code',
+      result: 'rejected',
+      trigger: 'automatic'
+    })
+    expect(h.updateSignInPanelStatus).toHaveBeenCalledWith(expect.anything(), 'open_failed')
     expect(h.emit).not.toHaveBeenCalled()
   })
 
@@ -513,8 +543,9 @@ describe('signInViaDesktopLoginCode', () => {
     h.exchangeDesktopLoginCode.mockResolvedValue({ status: 'pending' })
     const onError = vi.fn()
     const mod = await loadOrchestrator()
+    const contents = fakeContents()
 
-    const promise = mod.signInViaDesktopLoginCode(AUTH_URL, fakeContents(), { onError })
+    const promise = mod.signInViaDesktopLoginCode(AUTH_URL, contents, { onError })
     await vi.runAllTimersAsync()
 
     expect(await promise).toBe('handled')
@@ -532,6 +563,10 @@ describe('signInViaDesktopLoginCode', () => {
         flow: 'desktop_login_code'
       })
     )
+    expect(h.updateSignInPanelStatus).toHaveBeenCalledWith(contents, 'expired')
+    // The only cleanup is the stale-panel cleanup at flow start. The expired
+    // panel remains available for explicit cancellation or start-over.
+    expect(h.runBannerCleanup).toHaveBeenCalledOnce()
   })
 
   it('honors a redeem that landed in the last poll interval via a final exchange at the deadline', async () => {
@@ -585,6 +620,24 @@ describe('signInViaDesktopLoginCode', () => {
     expect(h.signInWithCustomToken).toHaveBeenCalledWith(expect.any(String), 'late-token', {
       signal: expect.any(AbortSignal)
     })
+  })
+
+  it('settles without failure when the persistent panel explicitly cancels', async () => {
+    h.createDesktopLoginCode.mockResolvedValue(GRANT)
+    h.exchangeDesktopLoginCode.mockResolvedValue({ status: 'pending' })
+    const mod = await loadOrchestrator()
+
+    const promise = mod.signInViaDesktopLoginCode(AUTH_URL, fakeContents(), {})
+    await vi.advanceTimersByTimeAsync(0)
+    const handlers = h.showCopyLinkBanner.mock.lastCall?.[2] as
+      | { onCancel?: () => void }
+      | undefined
+    handlers?.onCancel?.()
+
+    await expect(promise).resolves.toBe('handled')
+    expect(h.emit).not.toHaveBeenCalled()
+    expect(h.exchangeDesktopLoginCode).not.toHaveBeenCalled()
+    expect(h.runBannerCleanup).toHaveBeenCalledTimes(2)
   })
 
   it('aborts the prior poll loop on re-entry without reporting a failure', async () => {

--- a/src/main/auth/desktopLoginCode/index.ts
+++ b/src/main/auth/desktopLoginCode/index.ts
@@ -18,7 +18,8 @@ import {
   closeActiveBridge,
   openExternalSafely,
   runBannerCleanup,
-  showCopyLinkBanner
+  showCopyLinkBanner,
+  updateSignInPanelStatus
 } from '../firebaseBridge/flowState'
 import { detectFirebaseEnv, getFirebaseConfig } from '../firebaseBridge/config'
 import { abortableSleep } from '../firebaseBridge/flowControl'
@@ -57,6 +58,10 @@ const POST_REDEEM_RETRY_GRACE_MS = 120_000
 
 const DESKTOP_LOGIN_CODE_FLOW = 'desktop_login_code'
 
+export interface DesktopLoginCodeFlowControls {
+  onStartOver?: () => void
+}
+
 /**
  * In-flight flow, aborted on re-entry (mirror of firebaseBridge's
  * `activeBridgeFlow`): if the user clicks Sign in again while a previous
@@ -89,7 +94,8 @@ function cancelActiveFlow(): void {
 export async function signInViaDesktopLoginCode(
   interceptedAuthUrl: string,
   comfyContents: WebContents,
-  opts: HandleFirebasePopupOpts = {}
+  opts: HandleFirebasePopupOpts = {},
+  controls: DesktopLoginCodeFlowControls = {}
 ): Promise<'handled' | 'fallback'> {
   const sessionTargetOrigin = originOf(comfyContents.getURL())
   const firebaseEnv = detectFirebaseEnv(interceptedAuthUrl)
@@ -170,15 +176,41 @@ export async function signInViaDesktopLoginCode(
   })
 
   let retriedPollErrors = 0
+  let keepPanelForRecovery = false
+  let deadlineMs = 0
   try {
     // Only the opaque one-time code transits the browser — never
     // installation_id or any auth material.
     const loginUrl = new URL('/cloud/login', cloudOrigin)
     loginUrl.searchParams.set('desktop_login_code', grant.code)
-    openExternalSafely(loginUrl.href)
-    showCopyLinkBanner(comfyContents, loginUrl.href)
+    deadlineMs = Date.now() + grant.expires_in * 1000
+    await showCopyLinkBanner(comfyContents, loginUrl.href, {
+      expiresAtMs: deadlineMs,
+      onCancel: () => {
+        if (activeFlow === controller) controller.abort()
+      },
+      onStartOver: controls.onStartOver,
+      onBrowserOpenResult: (accepted, trigger) => {
+        mainTelemetry.capture('comfy.desktop.auth.browser_handoff', {
+          provider,
+          flow: DESKTOP_LOGIN_CODE_FLOW,
+          result: accepted ? 'accepted' : 'rejected',
+          trigger
+        })
+      }
+    })
+    const browserOpenAccepted = await openExternalSafely(loginUrl.href)
+    if (controller.signal.aborted || activeFlow !== controller || comfyContents.isDestroyed()) {
+      return 'handled'
+    }
+    mainTelemetry.capture('comfy.desktop.auth.browser_handoff', {
+      provider,
+      flow: DESKTOP_LOGIN_CODE_FLOW,
+      result: browserOpenAccepted ? 'accepted' : 'rejected',
+      trigger: 'automatic'
+    })
+    updateSignInPanelStatus(comfyContents, browserOpenAccepted ? 'waiting' : 'open_failed')
 
-    const deadlineMs = Date.now() + grant.expires_in * 1000
     const retryDeadlineMs = deadlineMs + POST_REDEEM_RETRY_GRACE_MS
     let customToken: string | null = null
     while (customToken === null) {
@@ -270,6 +302,15 @@ export async function signInViaDesktopLoginCode(
     // A superseded attempt isn't a failure — the newer one owns the UX.
     if (controller.signal.aborted) return 'handled'
     const error = err instanceof Error ? err : new Error(String(err))
+    keepPanelForRecovery =
+      !comfyContents.isDestroyed() &&
+      sessionTargetOrigin !== null &&
+      isOnOrigin(comfyContents, sessionTargetOrigin)
+    if (keepPanelForRecovery) {
+      const expired =
+        Date.now() >= deadlineMs || (error instanceof DesktopLoginCodeError && error.status === 404)
+      updateSignInPanelStatus(comfyContents, expired ? 'expired' : 'failed')
+    }
     const failure = emitSignInFailure(provider, DESKTOP_LOGIN_CODE_FLOW, error, {
       retried_poll_errors: retriedPollErrors
     })
@@ -281,7 +322,7 @@ export async function signInViaDesktopLoginCode(
     const ownsUx = activeFlow === controller
     if (ownsUx) {
       activeFlow = null
-      runBannerCleanup()
+      if (!keepPanelForRecovery) runBannerCleanup()
     }
     releaseFirebaseSessionInjection(sessionInjection)
   }

--- a/src/main/auth/firebaseBridge/copyLinkBanner.test.ts
+++ b/src/main/auth/firebaseBridge/copyLinkBanner.test.ts
@@ -3,17 +3,27 @@ import { describe, expect, it } from 'vitest'
 import {
   buildCopyLinkBannerScript,
   buildRemoveCopyLinkBannerScript,
+  buildUpdateCopyLinkBannerScript,
+  CANCEL_SIGN_IN_SENTINEL,
   COPY_LINK_BANNER_ID,
   OPEN_LINK_SENTINEL,
+  START_OVER_SENTINEL,
   type CopyLinkBannerLabels
 } from './copyLinkBanner'
 
 const labels: CopyLinkBannerLabels = {
-  message: 'We opened your browser to sign in. Didn’t open?',
+  title: 'Finish signing in in your browser',
+  opening: 'Opening your browser…',
+  waiting: 'Waiting for you to finish signing in.',
+  openFailed: 'We couldn’t open your browser. Try again or copy the link.',
+  expired: 'This sign-in link expired. Start over to try again.',
+  failed: 'Sign-in didn’t complete. Start over to try again.',
+  remaining: '{time} remaining',
   copy: 'Copy link',
   copied: 'Copied',
-  openAgain: 'Open again',
-  dismiss: 'Dismiss'
+  openAgain: 'Open browser again',
+  cancel: 'Cancel',
+  startOver: 'Start over'
 }
 
 const url = 'http://localhost:9876/?provider=google.com&n=abc123'
@@ -30,11 +40,25 @@ describe('buildCopyLinkBannerScript', () => {
     expect(script).toContain(JSON.stringify(COPY_LINK_BANNER_ID))
   })
 
-  it('emits only the Open-again sentinel (copy never reaches main)', () => {
-    const script = buildCopyLinkBannerScript(url, labels)
+  it('emits explicit open, cancel, and start-over commands (copy stays in-page)', () => {
+    const script = buildCopyLinkBannerScript(url, labels, {
+      expiresAtMs: Date.now() + 300_000
+    })
     expect(script).toContain(JSON.stringify(OPEN_LINK_SENTINEL))
+    expect(script).toContain(JSON.stringify(CANCEL_SIGN_IN_SENTINEL))
+    expect(script).toContain(JSON.stringify(START_OVER_SENTINEL))
     // Copy is in-page only — no console sentinel a remote page could abuse.
     expect(script).not.toContain('__comfyCopyLoginLink')
+  })
+
+  it('renders a countdown from an absolute expiry without embedding the code in status', () => {
+    const expiresAtMs = 1_234_567
+    const script = buildCopyLinkBannerScript(url, labels, { expiresAtMs })
+
+    expect(script).toContain(String(expiresAtMs))
+    expect(script).toContain('formatRemaining(remaining)')
+    expect(script).toContain('setInterval(render,1000)')
+    expect(script).toContain(JSON.stringify(labels.remaining))
   })
 
   it('copies in-page with a clipboard primary and execCommand fallback', () => {
@@ -61,7 +85,7 @@ describe('buildCopyLinkBannerScript', () => {
     const tricky = 'http://x/?q="; alert(1); //</script>'
     const hostileLabels: CopyLinkBannerLabels = {
       ...labels,
-      message: '"; document.title="x"; //'
+      title: '"; document.title="x"; //'
     }
     const script = buildCopyLinkBannerScript(tricky, hostileLabels)
     expect(() => new Function(script)).not.toThrow()
@@ -70,10 +94,22 @@ describe('buildCopyLinkBannerScript', () => {
 })
 
 describe('buildRemoveCopyLinkBannerScript', () => {
-  it('is parseable and tears down the node + observer', () => {
+  it('is parseable and tears down the node, countdown, and observer', () => {
     const script = buildRemoveCopyLinkBannerScript()
     expect(() => new Function(script)).not.toThrow()
     expect(script).toContain(JSON.stringify(COPY_LINK_BANNER_ID))
+    expect(script).toContain('clearInterval')
     expect(script).toContain('disconnect()')
+  })
+})
+
+describe('buildUpdateCopyLinkBannerScript', () => {
+  it('updates an existing panel without rebuilding it', () => {
+    const script = buildUpdateCopyLinkBannerScript('open_failed')
+
+    expect(() => new Function(script)).not.toThrow()
+    expect(script).toContain(JSON.stringify(COPY_LINK_BANNER_ID))
+    expect(script).toContain(JSON.stringify('open_failed'))
+    expect(script).toContain('__cclRender')
   })
 })

--- a/src/main/auth/firebaseBridge/copyLinkBanner.ts
+++ b/src/main/auth/firebaseBridge/copyLinkBanner.ts
@@ -1,128 +1,171 @@
 /**
- * Sign-in "copy login link" card.
+ * Persistent Desktop sign-in panel injected into the embedded Cloud view.
  *
- * When `handleFirebasePopup` opens the loopback login URL in the user's
- * DEFAULT browser, that browser may not be where they're signed into
- * Google/GitHub. We inject a small floating card into the embedded Cloud
- * view (the surface the user is looking at) offering "Copy link" / "Open
- * again" so they can finish sign-in in a browser of their choice — the
- * same affordance Notion / Claude / Zoom provide.
- *
- * Injected with `insertCSS` + `executeJavaScript`, like
- * `injectMacPasskeyWarning`. The URL is string-baked via `JSON.stringify`
- * so a hostile URL can't break the Cloud page. Copy stays in-page; only
- * "Open again" reaches main (see `OPEN_LINK_SENTINEL`).
+ * The system-browser handoff is not proof that a browser page loaded:
+ * `shell.openExternal()` only confirms that the OS accepted the request. This
+ * panel therefore stays visible for the lifetime of the sign-in attempt and
+ * gives the user durable recovery controls.
  */
 
 export const COPY_LINK_BANNER_ID = 'comfy-copy-login-banner'
 
 /**
- * Open-again → main, so it can `shell.openExternal` (page JS can't). The
- * only page→main channel — copy stays in-page so a remote page can't
- * drive a no-gesture clipboard write — and it re-opens only our own URL.
+ * Page-to-main commands. The listener is installed only while a Desktop-owned
+ * auth attempt is active, and every command operates on that attempt's trusted
+ * URL or AbortController.
  */
 export const OPEN_LINK_SENTINEL = '__comfyOpenLoginLink'
+export const CANCEL_SIGN_IN_SENTINEL = '__comfyCancelLogin'
+export const START_OVER_SENTINEL = '__comfyStartLoginOver'
+
+export type SignInPanelStatus = 'opening' | 'waiting' | 'open_failed' | 'expired' | 'failed'
 
 export interface CopyLinkBannerLabels {
-  message: string
+  title: string
+  opening: string
+  waiting: string
+  openFailed: string
+  expired: string
+  failed: string
+  remaining: string
   copy: string
   copied: string
   openAgain: string
-  dismiss: string
+  cancel: string
+  startOver: string
+}
+
+export interface CopyLinkBannerOptions {
+  /** Absolute wall-clock deadline. Omit for the legacy loopback flow. */
+  expiresAtMs?: number
+  status?: SignInPanelStatus
 }
 
 // Values mirror the Comfy Desktop brand tokens defined in
-// `src/renderer/src/assets/main.css` — CSS vars don't cross into the
-// cloud webview, so we inline the resolved hex/rgba so this banner
-// reads as Desktop chrome on top of whatever cloud is rendering. Key
-// tokens used:
-//   --neutral-700: #2c2533   (deep plum surface)
-//   --neutral-100: #c2bfb9   (warm off-white text)
-//   --neutral-300: #8a8688   (muted text — close ✕, secondary copy)
-//   --accent-primary: #0b8ce9 (brand blue — primary CTA)
-//   --comfy-yellow: #f2ff59  (used for the success/copied flash so
-//                             the confirmation reads as branded)
+// `src/renderer/src/assets/main.css`. CSS vars do not cross into the Cloud
+// webview, so resolved colors are inlined here.
 export const COPY_LINK_BANNER_CSS =
-  // Width hugs the content (so the message stays on one line) but is
-  // capped at the viewport, so as the window shrinks the card grows
-  // toward full-width instead of wrapping the text.
   `#${COPY_LINK_BANNER_ID}{position:fixed;bottom:20px;left:50%;transform:translateX(-50%);` +
-  `z-index:2147483647;display:flex;align-items:center;gap:10px;` +
-  `width:max-content;max-width:calc(100vw - 32px);` +
+  `z-index:2147483647;display:grid;gap:12px;width:min(620px,calc(100vw - 32px));` +
   `background:#2c2533;color:#c2bfb9;font:13px/1.45 system-ui,-apple-system,sans-serif;` +
-  `padding:10px 12px;border:1px solid rgba(255,255,255,0.12);border-radius:12px;` +
+  `padding:14px 16px;border:1px solid rgba(255,255,255,0.12);border-radius:12px;` +
   `box-shadow:0 12px 36px rgba(0,0,0,.5),0 0 0 1px rgba(0,0,0,.2);box-sizing:border-box;}` +
-  `#${COPY_LINK_BANNER_ID} .ccl-msg{flex:0 1 auto;min-width:0;white-space:nowrap;}` +
+  `#${COPY_LINK_BANNER_ID} .ccl-head{display:flex;align-items:flex-start;gap:10px;min-width:0;}` +
+  `#${COPY_LINK_BANNER_ID} .ccl-dot{flex:0 0 auto;width:8px;height:8px;margin-top:6px;border-radius:50%;background:#0b8ce9;}` +
+  `#${COPY_LINK_BANNER_ID}[data-status="open_failed"] .ccl-dot,` +
+  `#${COPY_LINK_BANNER_ID}[data-status="failed"] .ccl-dot{background:#f59e0b;}` +
+  `#${COPY_LINK_BANNER_ID}[data-status="expired"] .ccl-dot{background:#8a8688;}` +
+  `#${COPY_LINK_BANNER_ID} .ccl-copy{flex:1 1 auto;min-width:0;}` +
+  `#${COPY_LINK_BANNER_ID} .ccl-title{display:block;color:#fff;font-weight:600;font-size:14px;}` +
+  `#${COPY_LINK_BANNER_ID} .ccl-status{display:block;color:#c2bfb9;margin-top:2px;}` +
+  `#${COPY_LINK_BANNER_ID} .ccl-time{flex:0 0 auto;color:#8a8688;font-variant-numeric:tabular-nums;white-space:nowrap;}` +
+  `#${COPY_LINK_BANNER_ID} .ccl-actions{display:flex;align-items:center;gap:8px;flex-wrap:wrap;}` +
   `#${COPY_LINK_BANNER_ID} button{flex:0 0 auto;display:inline-flex;align-items:center;gap:6px;` +
-  `cursor:pointer;border-radius:8px;font:13px/1 system-ui,sans-serif;padding:7px 12px;` +
+  `cursor:pointer;border-radius:8px;font:13px/1 system-ui,sans-serif;padding:8px 12px;` +
   `border:1px solid rgba(255,255,255,0.14);background:rgba(255,255,255,0.06);color:#c2bfb9;` +
   `transition:background 120ms ease,border-color 120ms ease,color 120ms ease;}` +
-  `#${COPY_LINK_BANNER_ID} button:hover{background:rgba(255,255,255,0.1);border-color:rgba(255,255,255,0.22);color:#ffffff;}` +
+  `#${COPY_LINK_BANNER_ID} button:hover{background:rgba(255,255,255,0.1);border-color:rgba(255,255,255,0.22);color:#fff;}` +
+  `#${COPY_LINK_BANNER_ID} button:disabled{cursor:not-allowed;opacity:.45;}` +
   `#${COPY_LINK_BANNER_ID} .ccl-ico{display:inline-flex;align-items:center;}` +
-  `#${COPY_LINK_BANNER_ID} button.ccl-primary{background:#0b8ce9;color:#ffffff;border-color:#0b8ce9;}` +
-  `#${COPY_LINK_BANNER_ID} button.ccl-primary:hover{background:#0a7dd1;border-color:#0a7dd1;color:#ffffff;}` +
+  `#${COPY_LINK_BANNER_ID} button.ccl-primary{background:#0b8ce9;color:#fff;border-color:#0b8ce9;}` +
+  `#${COPY_LINK_BANNER_ID} button.ccl-primary:hover{background:#0a7dd1;border-color:#0a7dd1;color:#fff;}` +
   `#${COPY_LINK_BANNER_ID} button.ccl-done{background:#f2ff59;color:#100c13;border-color:#f2ff59;}` +
-  `#${COPY_LINK_BANNER_ID} button.ccl-done:hover{background:#f2ff59;border-color:#f2ff59;color:#100c13;}` +
-  `#${COPY_LINK_BANNER_ID} button.ccl-close{border:none;background:transparent;color:#8a8688;` +
-  `padding:4px 6px;font-size:16px;line-height:1;}` +
-  `#${COPY_LINK_BANNER_ID} button.ccl-close:hover{background:transparent;color:#c2bfb9;}`
+  `#${COPY_LINK_BANNER_ID} button.ccl-link{margin-left:auto;border-color:transparent;background:transparent;color:#8a8688;}` +
+  `#${COPY_LINK_BANNER_ID} button.ccl-link:hover{background:transparent;color:#fff;}` +
+  `@media(max-width:560px){#${COPY_LINK_BANNER_ID} .ccl-time{width:100%;padding-left:18px;}` +
+  `#${COPY_LINK_BANNER_ID} button.ccl-link{margin-left:0;}}`
 
 /**
- * Build the page-context IIFE that renders the card. Every interpolated
- * value (the URL and each label) is escaped via `JSON.stringify`, so the
- * script is safe to hand to `executeJavaScript` even for hostile input.
+ * Build the page-context IIFE that renders the panel. Every interpolated value
+ * is JSON-escaped before it enters executable source.
  */
-export function buildCopyLinkBannerScript(url: string, labels: CopyLinkBannerLabels): string {
+export function buildCopyLinkBannerScript(
+  url: string,
+  labels: CopyLinkBannerLabels,
+  options: CopyLinkBannerOptions = {}
+): string {
   const u = JSON.stringify(url)
   const id = JSON.stringify(COPY_LINK_BANNER_ID)
+  const status = JSON.stringify(options.status ?? 'opening')
+  const expiresAt = JSON.stringify(options.expiresAtMs ?? null)
   const openToken = JSON.stringify(OPEN_LINK_SENTINEL)
-  const l = {
-    message: JSON.stringify(labels.message),
-    copy: JSON.stringify(labels.copy),
-    copied: JSON.stringify(labels.copied),
-    openAgain: JSON.stringify(labels.openAgain),
-    dismiss: JSON.stringify(labels.dismiss)
-  }
+  const cancelToken = JSON.stringify(CANCEL_SIGN_IN_SENTINEL)
+  const startOverToken = JSON.stringify(START_OVER_SENTINEL)
+  const l = Object.fromEntries(
+    Object.entries(labels).map(([key, value]) => [key, JSON.stringify(value)])
+  ) as Record<keyof CopyLinkBannerLabels, string>
+
   return `(function(){try{
-    var URL=${u}, ID=${id};
+    var URL=${u},ID=${id},STATUS=${status},EXPIRES_AT=${expiresAt};
     var existing=document.getElementById(ID);
-    if(existing){existing.__cclUrl=URL;return;}
-    var bar=document.createElement('div');bar.id=ID;bar.__cclUrl=URL;
-    // Lucide icons (copy / check / external-link), inlined as exact path
-    // data — no asset/font load, identical on every OS. Static trusted
-    // constants, set via innerHTML; user labels stay in textContent spans.
+    if(existing){
+      existing.__cclUrl=URL;existing.__cclStatus=STATUS;existing.__cclExpiresAt=EXPIRES_AT;
+      if(existing.__cclRender)existing.__cclRender();return;
+    }
+    var bar=document.createElement('section');bar.id=ID;bar.setAttribute('role','status');
+    bar.__cclUrl=URL;bar.__cclStatus=STATUS;bar.__cclExpiresAt=EXPIRES_AT;
     function svg(p){return '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">'+p+'</svg>';}
     var ICON_COPY=svg('<rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/>');
     var ICON_TICK=svg('<path d="M20 6 9 17l-5-5"/>');
     var ICON_OPEN=svg('<path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>');
     function makeBtn(cls,icon,text){
-      var b=document.createElement('button');if(cls)b.className=cls;
-      var i=document.createElement('span');i.className='ccl-ico';i.innerHTML=icon;
-      var t=document.createElement('span');t.textContent=text;
-      b.appendChild(i);b.appendChild(t);b.__ico=i;b.__lbl=t;return b;
+      var b=document.createElement('button');b.type='button';if(cls)b.className=cls;
+      if(icon){var i=document.createElement('span');i.className='ccl-ico';i.innerHTML=icon;b.appendChild(i);b.__ico=i;}
+      var t=document.createElement('span');t.textContent=text;b.appendChild(t);b.__lbl=t;return b;
     }
-    var msg=document.createElement('span');msg.className='ccl-msg';msg.textContent=${l.message};
-    var copy=makeBtn('ccl-primary',ICON_COPY,${l.copy});
-    var open=makeBtn('',ICON_OPEN,${l.openAgain});
-    var close=document.createElement('button');close.className='ccl-close';close.setAttribute('aria-label',${l.dismiss});close.textContent='\\u00d7';
-    function fallbackCopy(text){try{var ta=document.createElement('textarea');ta.value=text;ta.style.position='fixed';ta.style.opacity='0';document.body.appendChild(ta);ta.select();document.execCommand('copy');document.body.removeChild(ta);}catch(e){}}
+    var head=document.createElement('div');head.className='ccl-head';
+    var dot=document.createElement('span');dot.className='ccl-dot';dot.setAttribute('aria-hidden','true');
+    var text=document.createElement('div');text.className='ccl-copy';
+    var title=document.createElement('span');title.className='ccl-title';title.textContent=${l.title};
+    var statusEl=document.createElement('span');statusEl.className='ccl-status';
+    var timeEl=document.createElement('span');timeEl.className='ccl-time';
+    text.appendChild(title);text.appendChild(statusEl);head.appendChild(dot);head.appendChild(text);head.appendChild(timeEl);
+    var actions=document.createElement('div');actions.className='ccl-actions';
+    var open=makeBtn('ccl-primary',ICON_OPEN,${l.openAgain});
+    var copy=makeBtn('',ICON_COPY,${l.copy});
+    var startOver=makeBtn('',null,${l.startOver});
+    var cancel=makeBtn('ccl-link',null,${l.cancel});
+    actions.appendChild(open);actions.appendChild(copy);actions.appendChild(startOver);actions.appendChild(cancel);
+    bar.appendChild(head);bar.appendChild(actions);
+    function fallbackCopy(value){try{var ta=document.createElement('textarea');ta.value=value;ta.style.position='fixed';ta.style.opacity='0';document.body.appendChild(ta);ta.select();document.execCommand('copy');document.body.removeChild(ta);}catch(e){}}
     copy.addEventListener('click',function(){
-      var text=bar.__cclUrl;
+      var value=bar.__cclUrl;
       var flash=function(){copy.__ico.innerHTML=ICON_TICK;copy.__lbl.textContent=${l.copied};copy.classList.add('ccl-done');setTimeout(function(){copy.__ico.innerHTML=ICON_COPY;copy.__lbl.textContent=${l.copy};copy.classList.remove('ccl-done');},1500);};
-      if(navigator.clipboard&&navigator.clipboard.writeText){navigator.clipboard.writeText(text).then(flash,function(){fallbackCopy(text);flash();});}
-      else{fallbackCopy(text);flash();}
+      if(navigator.clipboard&&navigator.clipboard.writeText){navigator.clipboard.writeText(value).then(flash,function(){fallbackCopy(value);flash();});}
+      else{fallbackCopy(value);flash();}
     });
     open.addEventListener('click',function(){try{console.info(${openToken});}catch(e){}});
-    close.addEventListener('click',function(){try{if(bar.__cclObs)bar.__cclObs.disconnect();bar.remove();}catch(e){}});
-    bar.appendChild(msg);bar.appendChild(copy);bar.appendChild(open);bar.appendChild(close);
+    startOver.addEventListener('click',function(){try{console.info(${startOverToken});}catch(e){}});
+    cancel.addEventListener('click',function(){try{console.info(${cancelToken});}catch(e){}});
+    function formatRemaining(ms){var total=Math.max(0,Math.ceil(ms/1000));var m=Math.floor(total/60);var s=String(total%60).padStart(2,'0');return m+':'+s;}
+    function render(){
+      var mode=bar.__cclStatus;
+      var remaining=typeof bar.__cclExpiresAt==='number'?bar.__cclExpiresAt-Date.now():null;
+      if(remaining!==null&&remaining<=0)mode=bar.__cclStatus='expired';
+      bar.dataset.status=mode;
+      statusEl.textContent=mode==='opening'?${l.opening}:mode==='open_failed'?${l.openFailed}:mode==='expired'?${l.expired}:mode==='failed'?${l.failed}:${l.waiting};
+      timeEl.textContent=remaining!==null&&remaining>0?${l.remaining}.replace('{time}',formatRemaining(remaining)):'';
+      var terminal=mode==='expired'||mode==='failed';
+      open.disabled=terminal;copy.disabled=terminal;
+      startOver.classList.toggle('ccl-primary',terminal);
+    }
+    bar.__cclRender=render;render();
+    bar.__cclTimer=setInterval(render,1000);
     document.body.appendChild(bar);
     var obs=new MutationObserver(function(){if(!document.getElementById(ID)&&bar.__cclUrl){document.body.appendChild(bar);}});
     obs.observe(document.body,{childList:true});bar.__cclObs=obs;
   }catch(e){}})()`
 }
 
-/** Remove the card and detach its observer. Idempotent. */
+/** Update the live panel without rebuilding it. */
+export function buildUpdateCopyLinkBannerScript(status: SignInPanelStatus): string {
+  const id = JSON.stringify(COPY_LINK_BANNER_ID)
+  const nextStatus = JSON.stringify(status)
+  return `(function(){try{var b=document.getElementById(${id});if(b){b.__cclStatus=${nextStatus};if(b.__cclRender)b.__cclRender();}}catch(e){}})()`
+}
+
+/** Remove the panel, its countdown, and its resurrection observer. */
 export function buildRemoveCopyLinkBannerScript(): string {
   const id = JSON.stringify(COPY_LINK_BANNER_ID)
-  return `(function(){try{var b=document.getElementById(${id});if(b){if(b.__cclObs)b.__cclObs.disconnect();b.remove();}}catch(e){}})()`
+  return `(function(){try{var b=document.getElementById(${id});if(b){if(b.__cclTimer)clearInterval(b.__cclTimer);if(b.__cclObs)b.__cclObs.disconnect();b.remove();}}catch(e){}})()`
 }

--- a/src/main/auth/firebaseBridge/flowState.ts
+++ b/src/main/auth/firebaseBridge/flowState.ts
@@ -3,8 +3,12 @@ import { shell, type WebContents } from 'electron'
 import {
   buildCopyLinkBannerScript,
   buildRemoveCopyLinkBannerScript,
+  buildUpdateCopyLinkBannerScript,
+  CANCEL_SIGN_IN_SENTINEL,
   COPY_LINK_BANNER_CSS,
-  OPEN_LINK_SENTINEL
+  OPEN_LINK_SENTINEL,
+  type SignInPanelStatus,
+  START_OVER_SENTINEL
 } from './copyLinkBanner'
 import type { BridgeHandle } from './server'
 import * as i18n from '../../lib/i18n'
@@ -17,9 +21,20 @@ export interface ActiveBridgeFlow {
 let activeBridgeFlow: ActiveBridgeFlow | null = null
 let activeBannerCleanup: (() => void) | null = null
 
-/** Open a trusted auth URL without leaking a rejected Electron promise. */
-export function openExternalSafely(url: string): void {
-  void shell.openExternal(url).catch(() => {})
+/**
+ * Ask the OS to open a trusted auth URL.
+ *
+ * A resolved promise means only that the OS accepted the request; it does not
+ * prove that a browser page loaded. Callers intentionally keep the sign-in
+ * panel visible until the auth flow itself reaches a terminal result.
+ */
+export async function openExternalSafely(url: string): Promise<boolean> {
+  try {
+    await shell.openExternal(url)
+    return true
+  } catch {
+    return false
+  }
 }
 
 /** Replace any in-flight loopback flow with a new singleton owner. */
@@ -61,35 +76,90 @@ export function runBannerCleanup(): void {
   cleanup?.()
 }
 
-/** Inject the browser-opened card and own its singleton teardown. */
-export function showCopyLinkBanner(comfyContents: WebContents, loginUrl: string): void {
+export interface SignInPanelHandlers {
+  expiresAtMs?: number
+  onCancel?: () => void
+  onStartOver?: () => void
+  onBrowserOpenResult?: (accepted: boolean, trigger: 'retry') => void
+}
+
+/** Inject the persistent sign-in panel and own its singleton teardown. */
+export async function showCopyLinkBanner(
+  comfyContents: WebContents,
+  loginUrl: string,
+  handlers: SignInPanelHandlers = {}
+): Promise<void> {
   if (comfyContents.isDestroyed()) return
+  let panelActive = true
 
   const labels = {
-    message: i18n.t('cloud.signInBanner.message'),
+    title: i18n.t('cloud.signInBanner.title'),
+    opening: i18n.t('cloud.signInBanner.opening'),
+    waiting: i18n.t('cloud.signInBanner.waiting'),
+    openFailed: i18n.t('cloud.signInBanner.openFailed'),
+    expired: i18n.t('cloud.signInBanner.expired'),
+    failed: i18n.t('cloud.signInBanner.failed'),
+    remaining: i18n.t('cloud.signInBanner.remaining'),
     copy: i18n.t('cloud.signInBanner.copy'),
     copied: i18n.t('cloud.signInBanner.copied'),
     openAgain: i18n.t('cloud.signInBanner.openAgain'),
-    dismiss: i18n.t('cloud.signInBanner.dismiss')
+    cancel: i18n.t('cloud.signInBanner.cancel'),
+    startOver: i18n.t('cloud.signInBanner.startOver')
   }
-
-  void comfyContents
-    .insertCSS(COPY_LINK_BANNER_CSS)
-    .then(() => comfyContents.executeJavaScript(buildCopyLinkBannerScript(loginUrl, labels), true))
-    .catch(() => {})
 
   const onConsoleMessage = (
     details: Electron.Event<Electron.WebContentsConsoleMessageEventParams>
   ): void => {
-    if (details.frame?.parent != null || details.message !== OPEN_LINK_SENTINEL) return
-    openExternalSafely(loginUrl)
+    if (details.frame?.parent != null) return
+    if (details.message === OPEN_LINK_SENTINEL) {
+      void openExternalSafely(loginUrl).then((accepted) => {
+        if (!panelActive) return
+        updateSignInPanelStatus(comfyContents, accepted ? 'waiting' : 'open_failed')
+        handlers.onBrowserOpenResult?.(accepted, 'retry')
+      })
+      return
+    }
+    if (details.message === CANCEL_SIGN_IN_SENTINEL) {
+      handlers.onCancel?.()
+      runBannerCleanup()
+      return
+    }
+    if (details.message === START_OVER_SENTINEL) {
+      handlers.onStartOver?.()
+    }
   }
   comfyContents.on('console-message', onConsoleMessage)
 
   activeBannerCleanup = () => {
+    panelActive = false
     comfyContents.off('console-message', onConsoleMessage)
     if (!comfyContents.isDestroyed()) {
       void comfyContents.executeJavaScript(buildRemoveCopyLinkBannerScript(), true).catch(() => {})
     }
   }
+
+  await comfyContents
+    .insertCSS(COPY_LINK_BANNER_CSS)
+    .then(() => {
+      if (!panelActive || comfyContents.isDestroyed()) return
+      return comfyContents.executeJavaScript(
+        buildCopyLinkBannerScript(loginUrl, labels, {
+          expiresAtMs: handlers.expiresAtMs,
+          status: 'opening'
+        }),
+        true
+      )
+    })
+    .catch(() => {})
+}
+
+/** Best-effort status update for the current panel. */
+export function updateSignInPanelStatus(
+  comfyContents: WebContents,
+  status: SignInPanelStatus
+): void {
+  if (comfyContents.isDestroyed()) return
+  void comfyContents
+    .executeJavaScript(buildUpdateCopyLinkBannerScript(status), true)
+    .catch(() => {})
 }

--- a/src/main/auth/firebaseBridge/index.test.ts
+++ b/src/main/auth/firebaseBridge/index.test.ts
@@ -25,8 +25,11 @@ vi.mock('electron', () => ({ shell: { openExternal: h.openExternal } }))
 vi.mock('./copyLinkBanner', () => ({
   buildCopyLinkBannerScript: () => 'show-banner',
   buildRemoveCopyLinkBannerScript: () => 'remove-banner',
+  buildUpdateCopyLinkBannerScript: () => 'update-banner',
+  CANCEL_SIGN_IN_SENTINEL: 'cancel',
   COPY_LINK_BANNER_CSS: '',
-  OPEN_LINK_SENTINEL: 'open-again'
+  OPEN_LINK_SENTINEL: 'open-again',
+  START_OVER_SENTINEL: 'start-over'
 }))
 vi.mock('./inject', () => ({
   beginFirebaseSessionInjection: h.beginSessionInjection,
@@ -52,6 +55,7 @@ function fakeContents(url = 'https://cloud.comfy.org/'): WebContents & {
   executeJavaScript: ReturnType<typeof vi.fn>
   off: ReturnType<typeof vi.fn>
   getURL: ReturnType<typeof vi.fn>
+  on: ReturnType<typeof vi.fn>
 } {
   return {
     executeJavaScript: vi.fn(() => Promise.resolve()),
@@ -64,7 +68,16 @@ function fakeContents(url = 'https://cloud.comfy.org/'): WebContents & {
     executeJavaScript: ReturnType<typeof vi.fn>
     off: ReturnType<typeof vi.fn>
     getURL: ReturnType<typeof vi.fn>
+    on: ReturnType<typeof vi.fn>
   }
+}
+
+function consoleListenerFor(
+  contents: ReturnType<typeof fakeContents>
+): (details: { frame?: { parent: unknown }; message: string }) => void {
+  const call = contents.on.mock.calls.find(([event]) => event === 'console-message')
+  if (!call) throw new Error('console-message listener was not installed')
+  return call[1] as (details: { frame?: { parent: unknown }; message: string }) => void
 }
 
 beforeEach(() => {
@@ -77,6 +90,43 @@ afterEach(() => {
   closeActiveBridge()
   runBannerCleanup()
   vi.useRealTimers()
+})
+
+describe('persistent sign-in panel', () => {
+  it('routes explicit start-over and cancel controls to the owning flow', async () => {
+    const contents = fakeContents()
+    const onStartOver = vi.fn()
+    const onCancel = vi.fn()
+    await showCopyLinkBanner(contents, 'https://cloud.comfy.org/login', {
+      onStartOver,
+      onCancel
+    })
+    const listener = consoleListenerFor(contents)
+
+    listener({ frame: { parent: null }, message: 'start-over' })
+    expect(onStartOver).toHaveBeenCalledOnce()
+
+    listener({ frame: { parent: null }, message: 'cancel' })
+    expect(onCancel).toHaveBeenCalledOnce()
+    expect(contents.off).toHaveBeenCalledOnce()
+    expect(contents.executeJavaScript).toHaveBeenCalledWith('remove-banner', true)
+  })
+
+  it('reports a rejected manual browser retry and keeps recovery in the panel', async () => {
+    h.openExternal.mockRejectedValueOnce(new Error('no default browser'))
+    const contents = fakeContents()
+    const onBrowserOpenResult = vi.fn()
+    await showCopyLinkBanner(contents, 'https://cloud.comfy.org/login', {
+      onBrowserOpenResult
+    })
+
+    consoleListenerFor(contents)({ frame: { parent: null }, message: 'open-again' })
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(onBrowserOpenResult).toHaveBeenCalledWith(false, 'retry')
+    expect(contents.executeJavaScript).toHaveBeenCalledWith('update-banner', true)
+    expect(contents.off).not.toHaveBeenCalled()
+  })
 })
 
 describe('handleFirebasePopup legacy flow', () => {
@@ -153,7 +203,7 @@ describe('handleFirebasePopup legacy flow', () => {
 
     closeActiveBridge()
     runBannerCleanup()
-    showCopyLinkBanner(contents, 'https://cloud.comfy.org/new-login')
+    await showCopyLinkBanner(contents, 'https://cloud.comfy.org/new-login')
     await vi.advanceTimersByTimeAsync(3000)
     await staleFlow
 
@@ -243,6 +293,12 @@ describe('handleFirebasePopup legacy flow', () => {
     await vi.runAllTimersAsync()
 
     await expect(flow).resolves.toBeUndefined()
+    expect(h.capture).toHaveBeenCalledWith('comfy.desktop.auth.browser_handoff', {
+      provider: 'google.com',
+      flow: 'loopback_bridge',
+      result: 'rejected',
+      trigger: 'automatic'
+    })
     expect(h.emit).not.toHaveBeenCalled()
   })
 })

--- a/src/main/auth/firebaseBridge/index.ts
+++ b/src/main/auth/firebaseBridge/index.ts
@@ -7,7 +7,8 @@ import {
   openExternalSafely,
   releaseActiveBridgeFlow,
   runBannerCleanup,
-  showCopyLinkBanner
+  showCopyLinkBanner,
+  updateSignInPanelStatus
 } from './flowState'
 import { abortable, abortableSleep } from './flowControl'
 import {
@@ -30,6 +31,20 @@ import { signInViaDesktopLoginCode } from '../desktopLoginCode'
 import * as mainTelemetry from '../../lib/telemetry'
 
 const LEGACY_AUTH_FLOW = 'loopback_bridge'
+
+function captureBrowserHandoff(
+  provider: string,
+  flow: typeof LEGACY_AUTH_FLOW,
+  accepted: boolean,
+  trigger: 'automatic' | 'retry'
+): void {
+  mainTelemetry.capture('comfy.desktop.auth.browser_handoff', {
+    provider,
+    flow,
+    result: accepted ? 'accepted' : 'rejected',
+    trigger
+  })
+}
 
 export { extractProviderId, isFirebaseAuthHandlerUrl } from './intercept'
 export { bindSignedInUser, POST_SIGNIN_HOLD_MS } from './flowShared'
@@ -65,7 +80,12 @@ export async function handleFirebasePopup(
   // user with no login-code flow, no legacy fallback, no sign_in_failed, and an
   // unhandled rejection — a Sign in button that silently does nothing. Degrade
   // to the legacy bridge instead.
-  const outcome = await signInViaDesktopLoginCode(url, comfyContents, opts).catch(() => {
+  const startOver = (): void => {
+    void handleFirebasePopup(url, comfyContents, opts)
+  }
+  const outcome = await signInViaDesktopLoginCode(url, comfyContents, opts, {
+    onStartOver: startOver
+  }).catch(() => {
     console.error('Desktop login-code flow failed unexpectedly; using legacy fallback')
     return 'fallback' as const
   })
@@ -104,6 +124,7 @@ export async function handleFirebasePopup(
   // before injecting rather than assuming the view stayed put.
   const startOrigin = originOf(comfyContents.getURL())
   let handle: BridgeHandle | null = null
+  let keepPanelForRecovery = false
   try {
     const startingBridge = startBridgeServer({ env, providerId })
     void startingBridge.then(
@@ -127,10 +148,17 @@ export async function handleFirebasePopup(
     // Capture the full nonce'd URL once so the auto-opened tab, the
     // "Copy link" button, and "Open again" all hand out the same link.
     const loginUrl = `${handle.url}?n=${Date.now().toString(36)}`
-    openExternalSafely(loginUrl)
-    // Surface a Notion/Claude-style "didn't open? copy the link" card in
-    // the Cloud view so users can finish sign-in in a non-default browser.
-    showCopyLinkBanner(comfyContents, loginUrl)
+    await showCopyLinkBanner(comfyContents, loginUrl, {
+      onCancel: () => flow.controller.abort(),
+      onStartOver: startOver,
+      onBrowserOpenResult: (accepted, trigger) => {
+        captureBrowserHandoff(providerId, LEGACY_AUTH_FLOW, accepted, trigger)
+      }
+    })
+    const browserOpenAccepted = await openExternalSafely(loginUrl)
+    if (signal.aborted || !isActiveBridgeFlow(flow) || comfyContents.isDestroyed()) return
+    captureBrowserHandoff(providerId, LEGACY_AUTH_FLOW, browserOpenAccepted, 'automatic')
+    updateSignInPanelStatus(comfyContents, browserOpenAccepted ? 'waiting' : 'open_failed')
     const { user, apiKey } = await abortable(handle.signInPromise, signal)
     if (signal.aborted || !isActiveBridgeFlow(flow)) return
     if (comfyContents.isDestroyed()) return
@@ -158,6 +186,9 @@ export async function handleFirebasePopup(
   } catch (err) {
     if (signal.aborted || !isActiveBridgeFlow(flow)) return
     const error = err instanceof Error ? err : new Error(String(err))
+    keepPanelForRecovery =
+      !comfyContents.isDestroyed() && startOrigin !== null && isOnOrigin(comfyContents, startOrigin)
+    if (keepPanelForRecovery) updateSignInPanelStatus(comfyContents, 'failed')
     // Mirrored to Datadog (allow-list) so ops can alert if sign-in
     // breaks for a provider. error_bucket keeps the dashboard low-
     // cardinality; error_class adds a locale-independent type for grouping.
@@ -171,7 +202,7 @@ export async function handleFirebasePopup(
     if (releaseActiveBridgeFlow(flow)) {
       // Tear down the card only if this attempt still owns it; a superseded
       // flow must not remove the newer attempt's banner.
-      runBannerCleanup()
+      if (!keepPanelForRecovery) runBannerCleanup()
     }
   }
 }


### PR DESCRIPTION
Desktop previously fire-and-forgot `shell.openExternal()`, swallowed rejection, and exposed only a dismissible recovery banner. This change awaits and records OS acceptance or rejection, keeps a persistent sign-in panel with countdown/status, Open browser again, Copy link, Cancel, and Start over, and preserves recovery after expiry or failure.

The OS result is deliberately treated only as handoff acceptance; Comfy-Org/ComfyUI_frontend#14457 adds the code-free browser page-arrival event.

Validation: full Desktop typecheck and ESLint pre-commit gates; 73 focused auth tests.