### PR TITLE
fix(auth): route main-process auth HTTP through proxy-aware net.fetch

### DIFF
--- a/src/main/auth/desktopLoginCode/client.test.ts
+++ b/src/main/auth/desktopLoginCode/client.test.ts
@@ -3,6 +3,12 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createDesktopLoginCode, DesktopLoginCodeError, exchangeDesktopLoginCode } from './client'
 import { hangingFetch, jsonResponse } from './testHelpers'
 
+// postJson goes through Chromium's net.fetch; delegate to the current global
+// fetch so the vi.stubGlobal('fetch', ...) stubs below keep driving it.
+vi.mock('electron', () => ({
+  net: { fetch: (...args: Parameters<typeof fetch>) => globalThis.fetch(...args) }
+}))
+
 const ORIGIN = 'https://cloud.comfy.org'
 
 const CREATE_REQUEST = {

--- a/src/main/auth/desktopLoginCode/client.ts
+++ b/src/main/auth/desktopLoginCode/client.ts
@@ -5,6 +5,8 @@
  * URL to configure.
  */
 
+import { net } from 'electron'
+
 const REQUEST_TIMEOUT_MS = 8000
 
 const MIN_POLL_INTERVAL_SEC = 1
@@ -94,11 +96,15 @@ export async function postJson(
   if (opts.signal?.aborted) controller.abort()
   else opts.signal?.addEventListener('abort', forwardAbort, { once: true })
   try {
-    const resp = await fetch(url, {
+    // net.fetch (Chromium's stack), not Node's undici: it resolves the OS
+    // proxy, which is the only route to Google endpoints for many CN users.
+    // credentials 'omit' keeps the request cookie-free, matching undici.
+    const resp = await net.fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
-      signal: controller.signal
+      signal: controller.signal,
+      credentials: 'omit'
     })
     // Fetch resolves when response headers arrive. Consume the body before
     // clearing the timer so a headers-only response cannot stall auth forever.

--- a/src/main/auth/desktopLoginCode/customTokenSignIn.test.ts
+++ b/src/main/auth/desktopLoginCode/customTokenSignIn.test.ts
@@ -8,6 +8,12 @@ import {
 import { hangingFetch, jsonResponse } from './testHelpers'
 import { getFirebaseConfig } from '../firebaseBridge/config'
 
+// postJson goes through Chromium's net.fetch; delegate to the current global
+// fetch so the vi.stubGlobal('fetch', ...) stubs below keep driving it.
+vi.mock('electron', () => ({
+  net: { fetch: (...args: Parameters<typeof fetch>) => globalThis.fetch(...args) }
+}))
+
 const IDP_BASE = 'https://identitytoolkit.googleapis.com/v1'
 
 afterEach(() => {

--- a/src/main/auth/desktopLoginCode/index.test.ts
+++ b/src/main/auth/desktopLoginCode/index.test.ts
@@ -33,6 +33,7 @@ vi.mock('electron', () => ({
       return h.appIsPackaged
     }
   },
+  net: { fetch: (...args: Parameters<typeof fetch>) => globalThis.fetch(...args) },
   shell: { openExternal: h.openExternal }
 }))
 

--- a/src/main/auth/firebaseBridge/oauth.ts
+++ b/src/main/auth/firebaseBridge/oauth.ts
@@ -1,6 +1,10 @@
+import { net } from 'electron'
+
 import type { FirebaseProjectConfig } from './config'
 import type { SupportedProvider } from './intercept'
 
+// Reached via net.fetch (Chromium's stack), not Node's undici: it resolves
+// the OS proxy, which is the only route to Google endpoints for many CN users.
 const IDP_BASE = 'https://identitytoolkit.googleapis.com/v1'
 
 interface CreateAuthUriResponse {
@@ -50,10 +54,11 @@ export async function createOauthAuthUri(
 ): Promise<CreateAuthUriResponse> {
   // Scopes mirror Firebase's signInWithPopup to keep the consent screen identical.
   const oauthScope = providerId === 'github.com' ? 'read:user user:email' : 'profile email'
-  const resp = await fetch(`${IDP_BASE}/accounts:createAuthUri?key=${apiKey}`, {
+  const resp = await net.fetch(`${IDP_BASE}/accounts:createAuthUri?key=${apiKey}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ providerId, continueUri, oauthScope })
+    body: JSON.stringify({ providerId, continueUri, oauthScope }),
+    credentials: 'omit'
   })
   if (!resp.ok) {
     const text = await resp.text().catch(() => '')
@@ -80,7 +85,7 @@ export async function signInWithIdpExchange(
   const queryParams = queryStart >= 0 ? requestUri.slice(queryStart + 1) : ''
   // Firebase expects providerId echoed in the postBody alongside the raw OAuth response.
   const postBody = `${queryParams}&providerId=${encodeURIComponent(providerId)}`
-  const resp = await fetch(`${IDP_BASE}/accounts:signInWithIdp?key=${apiKey}`, {
+  const resp = await net.fetch(`${IDP_BASE}/accounts:signInWithIdp?key=${apiKey}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -89,7 +94,8 @@ export async function signInWithIdpExchange(
       sessionId,
       returnIdpCredential: true,
       returnSecureToken: true
-    })
+    }),
+    credentials: 'omit'
   })
   if (!resp.ok) {
     const text = await resp.text().catch(() => '')

--- a/src/main/auth/firebaseBridge/server.test.ts
+++ b/src/main/auth/firebaseBridge/server.test.ts
@@ -1,6 +1,12 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { BRIDGE_PORT, startBridgeServer } from './server'
+
+// oauth.ts goes through Chromium's net.fetch; delegate to the global fetch so
+// the raw-OAuth initiator arm keeps its pre-existing live-call behavior here.
+vi.mock('electron', () => ({
+  net: { fetch: (...args: Parameters<typeof fetch>) => globalThis.fetch(...args) }
+}))
 
 describe('startBridgeServer', () => {
   it('serves a 204 for /favicon.ico', async () => {


### PR DESCRIPTION
## Problem

Since the desktop_login_code flow was enabled server-side on 2026-07-29, sign-in has been effectively dead for China-based users: **456 of 626 CN installations that started a sign-in hit a no-status `DesktopLoginCodeError`, and only 15 ever succeeded** (PostHog, [rollout dashboard](https://us.posthog.com/project/204330/dashboard/1931839)). Baseline was ~600 CN logged-in installs/week on v1.0.29.

Root cause: the new auth flow moved Firebase REST calls (`identitytoolkit.googleapis.com`) from the renderer into the main process, where `postJson` uses the global `fetch` — Node's undici, which **ignores OS/system proxy settings**. Google endpoints are unreachable from CN on a direct connection; the renderer's Chromium stack honored the system proxy those users run, which is why sign-in worked before the overhaul. The failure signature (no HTTP status, `retried_poll_errors: 0`, 22–305s after start, 98% CN) matches the two identitytoolkit calls exclusively — the code create/exchange against the Cloud origin succeeds first.

The legacy loopback bridge has the same defect in `oauth.ts`, so the fallback path fails for the same users.

## Change

Swap the main-process auth HTTP transport from global `fetch` (undici) to Electron's **`net.fetch`** (Chromium network stack: OS proxy resolution incl. PAC, OS certificate store):

- `desktopLoginCode/client.ts` `postJson` — covers login-code create/exchange **and** both identitytoolkit calls in `customTokenSignIn.ts`
- `firebaseBridge/oauth.ts` — `accounts:createAuthUri` / `accounts:signInWithIdp` on the legacy loopback path

`credentials: 'omit'` on every call keeps requests cookie-free, byte-identical to undici's behavior, so nothing changes server-side. Timeout/abort wrappers, retry classification, and failure telemetry are untouched (`net.fetch` is WHATWG-fetch-compatible and non-abort failures land in the same catch).

Tests: affected suites now mock `electron` with a `net.fetch` that delegates to `globalThis.fetch`, so all existing `vi.stubGlobal('fetch', …)` stubs keep driving the code unchanged (`server.test.ts` raw-OAuth test keeps its pre-existing live-call behavior).

## Verification

- `pnpm test`: 224 files / 3,684 tests pass; full typecheck + eslint + prettier clean.
- Post-release: the no-status `DesktopLoginCodeError` class (98% CN) on the [rollout dashboard](https://us.posthog.com/project/204330/dashboard/1931839) should collapse and CN `comfy.desktop.identity.login_attributed` should recover toward baseline; slice by `app_version` to compare against 1.0.33.
- Local repro: with a system proxy set and direct egress to `identitytoolkit.googleapis.com` blocked, sign-in fails on 1.0.33 and succeeds with this patch.

Complements #1356 (30-minute login codes) for the next release; the 5-minute-TTL 404 class is separate and needs the backend TTL raise.