### PR TITLE
fix(chooser): relabel the cloud pill 5 FREE RUNS -> TRY FREE

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -624,7 +624,7 @@
     "pickLead": "Choose the setup that fits how you work. You can switch later.",
     "cloudTagline": "Full power. Instant setup.",
     "cloudDesc": "Best for **most users** who want powerful GPUs and popular custom nodes, ready anywhere.",
-    "cloudFreeRunsPill": "5 FREE RUNS",
+    "cloudFreeRunsPill": "TRY FREE",
     "cloudRecommendedForHardware": "Recommended for your hardware",
     "cloudRecommendedForHardwareTooltip": "This device doesn't have a GPU powerful enough for most workflows. Cloud runs them on hosted GPUs instead.",
     "localLabel": "Local",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -624,7 +624,7 @@
     "pickLead": "选择适合你工作方式的设置。之后仍可切换。",
     "cloudTagline": "完整性能。即时设置。",
     "cloudDesc": "最适合希望使用强大 GPU 和热门自定义节点、随时随地开始工作的**大多数用户**。",
-    "cloudFreeRunsPill": "5次免费运行",
+    "cloudFreeRunsPill": "免费试用",
     "cloudRecommendedForHardware": "推荐用于你的硬件",
     "cloudRecommendedForHardwareTooltip": "此设备的显卡性能不足以运行大多数工作流。Cloud 会改为在托管 GPU 上运行。",
     "localLabel": "本地",


### PR DESCRIPTION
## Summary

The dashboard/takeover cloud pill from #1336 now reads **TRY FREE** instead of **5 FREE RUNS**. The run count is not the hook; trying for free is. Matches the comfy.org nav CTA wording (TRY FREE / 免费试用).

## Changes

- `locales/en.json`: `5 FREE RUNS` -> `TRY FREE`
- `locales/zh.json`: `5次免费运行` -> `免费试用` (same translation the website CTA uses)
- No code changes: both render sites (`ChooserInstallTile`, `FirstUseTakeover`) read `firstUse.cloudFreeRunsPill`, and no test asserts the literal text. Gating (`cloudFreeRunsEnabled`, capacity, paid checks) untouched.