### PR TITLE
fix: isolate hosted terminal access

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
         input: {
           index: resolve(__dirname, 'src/preload/index.ts'),
           comfyPreload: resolve(__dirname, 'src/preload/comfyPreload.ts'),
+          terminalPreload: resolve(__dirname, 'src/preload/terminalPreload.ts'),
           comfyTitleBarPreload: resolve(__dirname, 'src/preload/comfyTitleBarPreload.ts'),
           comfyTitlePopupPreload: resolve(__dirname, 'src/preload/comfyTitlePopupPreload.ts'),
           comfyTitleTooltipPreload: resolve(__dirname, 'src/preload/comfyTitleTooltipPreload.ts'),

--- a/src/main/host/attach.ts
+++ b/src/main/host/attach.ts
@@ -410,11 +410,7 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
   const onDomReady = (): void => {
     comfyContents.executeJavaScript(COMFY_THEME_OBSERVER_JS).catch(() => {})
     comfyContents.executeJavaScript(getModelDownloadContentScript()).catch(() => {})
-    // Inject the Terminal bottom-panel tab on local managed installs that
-    // back it with a per-install shell (standalone, portable, git). They all
-    // ship the same served frontend and expose the same
-    // `window.__comfyDesktop2.Terminal` bridge + per-install PTY, so the
-    // injection works identically everywhere.
+    // Inject the Terminal bottom-panel entry on local managed installs.
     //
     // Originally gated on `!supports_terminal` to avoid duplicating the
     // flag-gated frontend tab. Day-3 launch feedback put terminal

--- a/src/main/lib/comfyTerminalContentScript.test.ts
+++ b/src/main/lib/comfyTerminalContentScript.test.ts
@@ -1,8 +1,21 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { getComfyTerminalContentScript } from './comfyTerminalContentScript'
 
 describe('getComfyTerminalContentScript', () => {
   const script = getComfyTerminalContentScript()
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+    document.body.innerHTML = ''
+    Reflect.deleteProperty(window, '__comfyDesktop2')
+    Reflect.deleteProperty(window, '__comfyDesktopTerminalStopgap')
+    Reflect.deleteProperty(window, 'comfyAPI')
+  })
 
   it('returns a syntactically valid, self-contained IIFE', () => {
     expect(script.startsWith('(function () {')).toBe(true)
@@ -44,6 +57,53 @@ describe('getComfyTerminalContentScript', () => {
     for (const member of ['terminal-write', 'terminal-resize', 'terminal-restart']) {
       expect(script).not.toContain(member)
     }
+  })
+
+  it('adds working popout buttons for Terminal and Logs', () => {
+    const openTerminalPopout = vi.fn()
+    const openLogsPopout = vi.fn()
+    Reflect.set(window, '__comfyDesktop2', {
+      openTerminal: vi.fn(),
+      Terminal: { openPopout: openTerminalPopout },
+      Logs: { openPopout: openLogsPopout }
+    })
+    Reflect.set(window, 'comfyAPI', {
+      app: {
+        app: {
+          extensions: [],
+          extensionManager: {
+            bottomPanel: {
+              panels: {
+                terminal: {
+                  tabs: [{ id: 'logs-terminal' }, { id: 'command-terminal' }]
+                }
+              }
+            }
+          },
+          registerExtension: vi.fn()
+        }
+      }
+    })
+    document.body.innerHTML = `
+      <div>
+        <button role="tab"><span>Logs</span></button>
+        <button role="tab"><span>Terminal</span></button>
+        <button aria-label="Close"></button>
+      </div>
+    `
+
+    new Function(script)()
+
+    const terminalButton = document.querySelector<HTMLButtonElement>(
+      '[data-popout-kind="terminal"]'
+    )
+    const logsButton = document.querySelector<HTMLButtonElement>('[data-popout-kind="logs"]')
+    if (!terminalButton || !logsButton) throw new Error('Expected popout buttons')
+    terminalButton.click()
+    logsButton.click()
+
+    expect(openTerminalPopout).toHaveBeenCalledOnce()
+    expect(openLogsPopout).toHaveBeenCalledOnce()
   })
 
   it('memoizes the assembled script', () => {

--- a/src/main/lib/comfyTerminalContentScript.test.ts
+++ b/src/main/lib/comfyTerminalContentScript.test.ts
@@ -9,6 +9,10 @@ describe('getComfyTerminalContentScript', () => {
   })
 
   afterEach(() => {
+    const state = Reflect.get(window, '__comfyDesktopTerminalStopgap') as
+      | { tabBarObserver?: MutationObserver }
+      | undefined
+    state?.tabBarObserver?.disconnect()
     vi.clearAllTimers()
     vi.useRealTimers()
     document.body.innerHTML = ''

--- a/src/main/lib/comfyTerminalContentScript.test.ts
+++ b/src/main/lib/comfyTerminalContentScript.test.ts
@@ -10,24 +10,12 @@ describe('getComfyTerminalContentScript', () => {
     expect(() => new Function(script)).not.toThrow()
   })
 
-  it('bails when the desktop terminal bridge is absent', () => {
-    expect(script).toContain('!window.__comfyDesktop2.Terminal')
+  it('bails when the desktop terminal opener is absent', () => {
+    expect(script).toContain(`typeof window.__comfyDesktop2.openTerminal !== 'function'`)
   })
 
   it('guards against double injection', () => {
     expect(script).toContain('window.__comfyDesktopTerminalStopgap')
-  })
-
-  it('inlines the xterm UMD build and its fit addon', () => {
-    expect(script).toContain('__xt.exports')
-    expect(script).toContain('__fit.exports')
-    expect(script).toContain('var XTerm =')
-    expect(script).toContain('var FitAddon =')
-  })
-
-  it('injects the xterm stylesheet exactly once via a stable id', () => {
-    expect(script).toContain('__comfyDesktopXtermCss')
-    expect(script).toContain('.xterm')
   })
 
   it('registers a custom bottom-panel tab through the extension API', () => {
@@ -51,9 +39,10 @@ describe('getComfyTerminalContentScript', () => {
     expect(script).toContain(`bottomPanelHasTab(app, 'command-terminal')`)
   })
 
-  it('uses the shared desktop terminal transport', () => {
-    for (const member of ['subscribe', 'write', 'resize', 'restart', 'onOutput', 'onExited']) {
-      expect(script).toContain(member)
+  it('opens the trusted Desktop terminal without exposing PTY operations', () => {
+    expect(script).toContain('window.__comfyDesktop2.openTerminal()')
+    for (const member of ['terminal-write', 'terminal-resize', 'terminal-restart']) {
+      expect(script).not.toContain(member)
     }
   })
 

--- a/src/main/lib/comfyTerminalContentScript.ts
+++ b/src/main/lib/comfyTerminalContentScript.ts
@@ -1,260 +1,71 @@
-/**
- * Stopgap injection of an interactive "Terminal" bottom-panel tab into the
- * served ComfyUI frontend, for the window between our frontend/backend terminal
- * PRs landing and a stable release shipping them.
- *
- * It is injected (via `webContents.executeJavaScript`) for local managed
- * installs that back a per-install shell (standalone, portable, git). It runs
- * always-on and dedupes in JS: the script bails before registering if it sees
- * an existing native `command-terminal` tab, so a frontend that ships the real
- * flag-gated tab never ends up with a duplicate. Delete this module (and its
- * call site in `attach.ts`) once stable ships the official tab.
- *
- * The transport is the already-injected `window.__comfyDesktop2.Terminal`
- * bridge (see `comfyPreload.ts`). xterm isn't exposed on `window.comfyAPI`, so
- * we inline the installed `@xterm/xterm` + `@xterm/addon-fit` UMD builds (read
- * from node_modules at runtime; works in dev and inside asar) and register a
- * `type: 'custom'` tab that renders a vanilla xterm view mirroring the real
- * CommandTerminal behavior (focus-reclaims the shared PTY size, restart banner,
- * clear-on-output revives the session, refit-after-restore).
- */
-
-import { createRequire } from 'module'
-import { readFileSync } from 'fs'
-import { decideTerminalKeyAction } from '../../shared/terminalShortcuts'
-
-// The main bundle is CommonJS, so `__filename` is the right anchor for
-// require.resolve (import.meta.url is unavailable there).
-const require = createRequire(__filename)
-
 let cachedScript: string | null = null
 
-function readPackageFile(id: string): string {
-  return readFileSync(require.resolve(id), 'utf8')
-}
-
-function stripSourceMapComment(source: string): string {
-  return source.replace(/\n?\/\/# sourceMappingURL=.*$/u, '')
-}
-
-/**
- * Vanilla browser code that registers and renders the stopgap terminal tab.
- * Runs in the ComfyUI page main world; `XTerm` and `FitAddon` are the UMD
- * exports captured above it, and `window.__comfyDesktop2.Terminal` is the host
- * bridge. Kept as a string (not a stringified function) to stay consistent with
- * the other injected scripts and to avoid bundler/`toString` surprises.
- */
 const TERMINAL_TAB_MAIN_JS = `
 var STATE = window.__comfyDesktopTerminalStopgap;
-var mounted = null;
 
-// Coarse OS bucket for the copy/paste shortcut matrix (mirrors the desktop
-// console's terminalShortcuts.ts). navigator.userAgent is reliable in Electron.
-var TERM_PLATFORM = (function () {
-  var ua = (navigator.userAgent || '').toLowerCase();
-  if (ua.indexOf('mac') !== -1) return 'mac';
-  if (ua.indexOf('win') !== -1) return 'windows';
-  return 'linux';
-})();
-
-// Single source of truth for the shortcut matrix: this injected terminal and
-// the desktop console (ConsoleTerminalPane.vue) both use
-// src/shared/terminalShortcuts.ts, embedded here verbatim via .toString() so
-// the two can't drift. decideTermKeyAction just binds the detected platform.
-var decideTerminalKeyAction = ${decideTerminalKeyAction.toString()};
-function decideTermKeyAction(e, hasSelection) {
-  return decideTerminalKeyAction(e, TERM_PLATFORM, hasSelection);
-}
-
-function destroyTerminal() {
-  if (!mounted) return;
-  var m = mounted;
-  mounted = null;
-  m.disposed = true;
-  try { if (m.onData) m.onData.dispose(); } catch (e) {}
-  try { if (m.offOutput) m.offOutput(); } catch (e) {}
-  try { if (m.offExited) m.offExited(); } catch (e) {}
-  try { if (m.host && m.onFocus) m.host.removeEventListener('focusin', m.onFocus); } catch (e) {}
-  try { if (m.ro) m.ro.disconnect(); } catch (e) {}
-  if (m.resizeTimer) { clearTimeout(m.resizeTimer); }
-  try { window.__comfyDesktop2.Terminal.unsubscribe(); } catch (e) {}
-  try { if (m.term) m.term.dispose(); } catch (e) {}
-  try { if (m.container) m.container.innerHTML = ''; } catch (e) {}
+function openDesktopTerminal() {
+  try {
+    var result = window.__comfyDesktop2.openTerminal();
+    if (result && typeof result.catch === 'function') result.catch(function () {});
+  } catch (e) {}
 }
 
 function renderTerminal(container) {
-  destroyTerminal();
-  var bridge = window.__comfyDesktop2 && window.__comfyDesktop2.Terminal;
-  if (!bridge) return;
-
-  container.style.position = 'relative';
-  container.style.width = '100%';
+  container.innerHTML = '';
+  container.style.display = 'flex';
+  container.style.alignItems = 'center';
+  container.style.justifyContent = 'center';
   container.style.height = '100%';
-  container.style.minWidth = '0';
-  container.style.overflow = 'hidden';
-  container.style.background = '#171717';
 
-  var host = document.createElement('div');
-  host.style.position = 'absolute';
-  host.style.inset = '0';
-  host.style.padding = '8px';
-  container.appendChild(host);
+  var content = document.createElement('div');
+  content.style.display = 'flex';
+  content.style.flexDirection = 'column';
+  content.style.alignItems = 'center';
+  content.style.gap = '12px';
+  content.style.color = 'var(--fg-color, #e5e5e5)';
 
-  var banner = document.createElement('div');
-  banner.style.cssText = 'position:absolute;left:0;right:0;bottom:0;display:none;align-items:center;justify-content:space-between;gap:12px;padding:8px 12px;background:#262626;color:#e5e5e5;font-size:13px;';
-  var bannerText = document.createElement('span');
-  bannerText.textContent = 'This terminal session ended.';
-  var restartBtn = document.createElement('button');
-  restartBtn.textContent = 'Restart';
-  restartBtn.style.cssText = 'cursor:pointer;border:0;border-radius:6px;padding:4px 12px;background:#3b82f6;color:#fff;font-size:12px;';
-  banner.appendChild(bannerText);
-  banner.appendChild(restartBtn);
-  container.appendChild(banner);
+  var message = document.createElement('div');
+  message.textContent = 'Terminal commands run in a protected Desktop window.';
 
-  var term = new XTerm({ convertEol: true, theme: { background: '#171717' } });
-  var fitAddon = new FitAddon();
-  term.loadAddon(fitAddon);
-  term.open(host);
+  var button = document.createElement('button');
+  button.type = 'button';
+  button.textContent = 'Open Desktop Terminal';
+  button.style.cssText = 'cursor:pointer;border:0;border-radius:6px;padding:8px 14px;background:#3b82f6;color:#fff;';
+  button.addEventListener('click', openDesktopTerminal);
 
-  var m = {
-    disposed: false, container: container, host: host, term: term,
-    fitAddon: fitAddon, exited: false, resizeTimer: 0,
-    onData: null, offOutput: null, offExited: null, onFocus: null, ro: null
-  };
-  mounted = m;
-
-  function updateBanner() { banner.style.display = m.exited ? 'flex' : 'none'; }
-
-  // Re-fit to our own container and (re)claim the shared PTY size. forceReclaim
-  // pushes even when our dims are unchanged, because the launcher settings
-  // console may have resized the one PTY out from under us.
-  function doFit(forceReclaim) {
-    if (m.disposed || !host.offsetParent) return;
-    var dims = fitAddon.proposeDimensions();
-    if (!dims || !dims.cols || !dims.rows) return;
-    var changed = dims.cols !== term.cols || dims.rows !== term.rows;
-    if (changed) term.resize(dims.cols, dims.rows);
-    if (changed || forceReclaim) { try { bridge.resize(term.cols, term.rows); } catch (e) {} }
-  }
-
-  function applyRestore(restore) {
-    if (m.disposed || !restore) return;
-    if (restore.buffer && restore.buffer.length) {
-      term.resize(restore.size.cols, restore.size.rows);
-      term.write(restore.buffer.join(''));
-    }
-    m.exited = !!restore.exited;
-    updateBanner();
-    window.requestAnimationFrame(function () { doFit(true); });
-  }
-
-  // Copy/paste shortcuts: intercept before xterm forwards keys to the PTY so
-  // e.g. Ctrl+C can copy a selection instead of always sending SIGINT.
-  term.attachCustomKeyEventHandler(function (e) {
-    var action = decideTermKeyAction(e, term.hasSelection());
-    if (action === 'copy') {
-      var text = term.getSelection();
-      // writeText is async: also swallow promise rejections, not just sync throws.
-      if (text) { try { navigator.clipboard.writeText(text).catch(function () {}); } catch (err) {} }
-      return false;
-    }
-    if (action === 'paste') {
-      // xterm pastes natively via the browser's paste event; just swallow the
-      // keydown so no stray ^V is sent. A manual paste here would double-paste.
-      return false;
-    }
-    if (action === 'swallow') return false;
-    return true;
-  });
-
-  m.onData = term.onData(function (d) { try { bridge.write(d); } catch (e) {} });
-  m.offOutput = bridge.onOutput(function (msg) {
-    if (m.disposed) return;
-    if (m.exited) { m.exited = false; updateBanner(); }
-    term.write(msg);
-  });
-  m.offExited = bridge.onExited(function () {
-    if (m.disposed) return;
-    m.exited = true; updateBanner();
-  });
-  m.onFocus = function () { doFit(true); };
-  host.addEventListener('focusin', m.onFocus);
-
-  m.ro = new ResizeObserver(function () {
-    if (m.resizeTimer) clearTimeout(m.resizeTimer);
-    m.resizeTimer = setTimeout(function () { doFit(false); }, 50);
-  });
-  m.ro.observe(container);
-
-  function doRestart() {
-    if (m.disposed) return;
-    term.reset();
-    m.exited = false; updateBanner();
-    bridge.restart().then(applyRestore).catch(function () {});
-  }
-  restartBtn.addEventListener('click', doRestart);
-
-  bridge.subscribe().then(function (restore) {
-    if (m.disposed) return;
-    if (restore && restore.exited) doRestart();
-    else applyRestore(restore);
-    // Force an immediate fit; ResizeObserver may not fire on first mount if
-    // the container's layout was already settled before we attached. Decides
-    // whether the user sees a 0×0 invisible xterm or an actual 80×24 prompt.
-    window.requestAnimationFrame(function () { doFit(true); });
-  }).catch(function () {});
+  content.appendChild(message);
+  content.appendChild(button);
+  container.appendChild(content);
+  openDesktopTerminal();
 }
 
-// True if a bottom-panel tab with this id is already registered in the
-// frontend store. This is where the native frontend registers both its Logs
-// ('logs-terminal') and Terminal ('command-terminal') tabs.
 function bottomPanelHasTab(app, id) {
   try {
-    var bp = app && app.extensionManager && app.extensionManager.bottomPanel;
-    var terminalPanel = bp && bp.panels && bp.panels.terminal;
+    var bottomPanel = app && app.extensionManager && app.extensionManager.bottomPanel;
+    var terminalPanel = bottomPanel && bottomPanel.panels && bottomPanel.panels.terminal;
     var tabs = terminalPanel && terminalPanel.tabs;
-    if (tabs) {
-      for (var i = 0; i < tabs.length; i++) {
-        if (tabs[i] && tabs[i].id === id) return true;
-      }
+    if (!tabs) return false;
+    for (var i = 0; i < tabs.length; i++) {
+      if (tabs[i] && tabs[i].id === id) return true;
     }
   } catch (e) {}
   return false;
 }
 
-// Dedupe guard. The frontend ships a native flag-gated 'command-terminal'
-// bottom-panel tab via the companion ComfyUI_frontend PR; when that lands
-// it registers itself before we tick. Bail out if we see it so the user
-// never gets two tabs with the same id. Defensive over the shapes ComfyUI
-// exposes: the bottom-panel store, an extensions array, and a future-proof
-// tab registry.
 function alreadyHasTerminalTab(app) {
   if (bottomPanelHasTab(app, 'command-terminal')) return true;
   try {
-    var exts = (app && app.extensions) || [];
-    for (var i = 0; i < exts.length; i++) {
-      var ext = exts[i] || {};
-      if (ext.name === 'Comfy.Desktop.TerminalStopgap') continue;
-      var tabs = ext.bottomPanelTabs || [];
+    var extensions = (app && app.extensions) || [];
+    for (var i = 0; i < extensions.length; i++) {
+      var extension = extensions[i] || {};
+      if (extension.name === 'Comfy.Desktop.TerminalStopgap') continue;
+      var tabs = extension.bottomPanelTabs || [];
       for (var j = 0; j < tabs.length; j++) {
         if (tabs[j] && tabs[j].id === 'command-terminal') return true;
       }
     }
   } catch (e) {}
-  try {
-    var registry =
-      app && (app.bottomPanelTabRegistry || (app.workbench && app.workbench.bottomPanelTabRegistry));
-    if (registry && typeof registry.get === 'function' && registry.get('command-terminal')) return true;
-  } catch (e) {}
   return false;
-}
-
-// The native Logs tab is registered asynchronously into the bottom-panel
-// store. We register our Terminal tab AFTER it so Logs stays first + default
-// and Terminal lands second, matching the native frontend ordering (the store
-// makes the first-registered tab the default active one).
-function hasLogsTab(app) {
-  return bottomPanelHasTab(app, 'logs-terminal');
 }
 
 function waitForRegister(timeoutMs) {
@@ -262,240 +73,48 @@ function waitForRegister(timeoutMs) {
   (function tick() {
     if (STATE.registered) return;
     var app = window.comfyAPI && window.comfyAPI.app && window.comfyAPI.app.app;
-    var reg = app && app.registerExtension;
-    if (typeof reg === 'function') {
-      // Native frontend tab already mounted — leave it alone.
+    var register = app && app.registerExtension;
+    if (typeof register === 'function') {
       if (alreadyHasTerminalTab(app)) {
         STATE.registered = true;
         return;
       }
-      // Hold until the native Logs tab exists so ours registers second. Fall
-      // back to registering anyway once the timeout elapses, so a frontend
-      // without a Logs tab never strands the user without a terminal.
-      if (!hasLogsTab(app) && Date.now() - startedAt <= timeoutMs) {
+      if (!bottomPanelHasTab(app, 'logs-terminal') && Date.now() - startedAt <= timeoutMs) {
         setTimeout(tick, 100);
         return;
       }
       try {
-        reg.call(app, {
+        register.call(app, {
           name: 'Comfy.Desktop.TerminalStopgap',
           bottomPanelTabs: [{
             id: 'command-terminal',
             title: 'Terminal',
             type: 'custom',
             render: renderTerminal,
-            destroy: destroyTerminal
+            destroy: function () {}
           }]
         });
         STATE.registered = true;
-        startTerminalTabPopoutInjector();
       } catch (e) {}
       return;
     }
-    if (Date.now() - startedAt > timeoutMs) return;
+    if (Date.now() > startedAt + timeoutMs) return;
     setTimeout(tick, 100);
   })();
-}
-
-// Inject a small ↗ "open in new window" button onto the Terminal tab's
-// header (the bottom-panel tab strip), positioned right after the
-// "Terminal" label. Vue re-renders that strip on tab switches, so we
-// keep a MutationObserver running for the page's lifetime and re-add
-// the button whenever the previous one disappears. Idempotent: each
-// pass checks for our existing button before re-injecting.
-function startTerminalTabPopoutInjector() {
-  if (STATE.tabBarInjectorStarted) return;
-  STATE.tabBarInjectorStarted = true;
-
-  // Find the bottom-panel header strip — the row that contains both
-  // "Terminal" and "Logs" tab labels. Lock onto its close (✕) button
-  // (the only unique landmark with a stable accessibility label), then
-  // walk up to the smallest ancestor that ALSO has both tabs as leaf
-  // descendants. From there we can enumerate the tab buttons.
-  function findBottomPanelHeader() {
-    var closes = document.querySelectorAll(
-      'button[aria-label="Close"], [role="button"][aria-label="Close"], button[title="Close"]'
-    );
-    for (var i = 0; i < closes.length; i++) {
-      var close = closes[i];
-      if (!close) continue;
-      if (close.classList && close.classList.contains('__comfy-desktop-popout-btn')) continue;
-      var testid = (close.getAttribute && close.getAttribute('data-testid')) || '';
-      if (/minimap/i.test(testid)) continue;
-      var anc = close.parentElement;
-      for (var depth = 0; depth < 6 && anc; depth++) {
-        if (containsLeafText(anc, 'Terminal') && containsLeafText(anc, 'Logs')) {
-          return anc;
-        }
-        anc = anc.parentElement;
-      }
-    }
-    return null;
-  }
-
-  function containsLeafText(root, target) {
-    if (!root || !root.querySelectorAll) return false;
-    var leaves = root.querySelectorAll('*');
-    var pattern = new RegExp('^' + target + '$', 'i');
-    for (var i = 0; i < leaves.length; i++) {
-      var e = leaves[i];
-      if (!e || e.children.length > 0) continue;
-      var txt = (e.textContent || '').trim();
-      if (pattern.test(txt)) return true;
-    }
-    return false;
-  }
-
-  // Inside the bottom-panel header, find each tab BUTTON by walking up
-  // from the leaf that holds the label text. We want the smallest
-  // interactive ancestor (button / role=tab / clickable div) so the
-  // popout icon sits in the same row as the label without disrupting
-  // the tab's own hit area.
-  function findTabButton(headerRoot, labelText) {
-    if (!headerRoot) return null;
-    var leaves = headerRoot.querySelectorAll('*');
-    var pattern = new RegExp('^' + labelText + '$', 'i');
-    for (var i = 0; i < leaves.length; i++) {
-      var leaf = leaves[i];
-      if (!leaf || leaf.children.length > 0) continue;
-      if (leaf.classList && leaf.classList.contains('__comfy-desktop-popout-btn')) continue;
-      var txt = (leaf.textContent || '').trim();
-      if (!pattern.test(txt)) continue;
-      var cur = leaf;
-      for (var d = 0; d < 6 && cur && cur.parentElement; d++) {
-        var p = cur.parentElement;
-        if (p === headerRoot) break;
-        var role = p.getAttribute && p.getAttribute('role');
-        var tag = (p.tagName || '').toLowerCase();
-        var cls = (p.className && p.className.baseVal != null ? p.className.baseVal : p.className) || '';
-        if (role === 'tab' || tag === 'button' || tag === 'a' || /tab/i.test(String(cls))) {
-          return p;
-        }
-        cur = p;
-      }
-      // Fall back to the leaf's parent — better than nothing.
-      return leaf.parentElement || leaf;
-    }
-    return null;
-  }
-
-  function findInsertionPoint() {
-    var close = findCloseButtonNearTerminalAndLogs();
-    if (close && close.parentElement) {
-      return { parent: close.parentElement, before: close };
-    }
-    return null;
-  }
-
-  function makePopoutButton(kind) {
-    var btn = document.createElement('button');
-    btn.className = '__comfy-desktop-popout-btn';
-    btn.setAttribute('data-popout-kind', kind);
-    btn.type = 'button';
-    var ariaLabel = kind === 'terminal'
-      ? 'Open terminal in a new window'
-      : 'Open logs in a new window';
-    btn.title = 'Open in a new window';
-    btn.setAttribute('aria-label', ariaLabel);
-    btn.style.cssText =
-      'display:inline-flex;align-items:center;justify-content:center;' +
-      'width:18px;height:18px;margin-left:6px;padding:0;border:0;' +
-      'background:transparent;color:currentColor;cursor:pointer;' +
-      'opacity:0.55;border-radius:4px;transition:opacity 120ms ease, background 120ms ease;' +
-      'vertical-align:middle;';
-    btn.innerHTML =
-      '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" ' +
-      'stroke="currentColor" stroke-width="2.4" stroke-linecap="round" ' +
-      'stroke-linejoin="round" aria-hidden="true">' +
-      '<path d="M14 3h7v7"/><path d="M21 3l-9 9"/>' +
-      '<path d="M21 14v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5"/>' +
-      '</svg>';
-    btn.addEventListener('mouseenter', function () {
-      btn.style.opacity = '1';
-      btn.style.background = 'rgba(255,255,255,0.08)';
-    });
-    btn.addEventListener('mouseleave', function () {
-      btn.style.opacity = '0.55';
-      btn.style.background = 'transparent';
-    });
-    btn.addEventListener('click', function (e) {
-      e.preventDefault();
-      e.stopPropagation();
-      if (kind === 'terminal') {
-        try { window.__comfyDesktop2.Terminal.openPopout(); } catch (err) {}
-      } else {
-        try { window.__comfyDesktop2.Logs.openPopout(); } catch (err) {}
-      }
-    });
-    return btn;
-  }
-
-  function injectIntoTab(headerRoot, label, kind) {
-    var tab = findTabButton(headerRoot, label);
-    if (!tab) return false;
-    // Don't double-inject if our previous pass already added a button.
-    var existing = tab.querySelector('.__comfy-desktop-popout-btn[data-popout-kind="' + kind + '"]');
-    if (existing) return true;
-    tab.appendChild(makePopoutButton(kind));
-    return true;
-  }
-
-  function tryInject() {
-    var header = findBottomPanelHeader();
-    if (!header) return;
-    injectIntoTab(header, 'Terminal', 'terminal');
-    injectIntoTab(header, 'Logs', 'logs');
-  }
-
-  // Initial attempt + periodic retry while the page is settling.
-  tryInject();
-  var settleTries = 0;
-  var settleInterval = setInterval(function () {
-    settleTries++;
-    tryInject();
-    if (settleTries > 50) clearInterval(settleInterval);
-  }, 200);
-
-  // Persistent observer — re-add the button whenever Vue re-renders
-  // the tab strip. Throttled by re-checking inside tryInject().
-  var observer = new MutationObserver(function () { tryInject(); });
-  observer.observe(document.body, { childList: true, subtree: true });
 }
 
 waitForRegister(30000);
 `
 
-/**
- * Build the self-contained injection script. Memoized: the UMD payloads are
- * large and never change at runtime.
- */
 export function getComfyTerminalContentScript(): string {
   if (cachedScript) return cachedScript
-
-  const xtermJs = stripSourceMapComment(readPackageFile('@xterm/xterm/lib/xterm.js'))
-  const fitJs = stripSourceMapComment(readPackageFile('@xterm/addon-fit/lib/addon-fit.js'))
-  const css = readPackageFile('@xterm/xterm/css/xterm.css')
-
   cachedScript =
     `(function () {\n` +
     `'use strict';\n` +
-    `if (typeof window === 'undefined' || !window.__comfyDesktop2 || !window.__comfyDesktop2.Terminal) return;\n` +
+    `if (typeof window === 'undefined' || !window.__comfyDesktop2 || typeof window.__comfyDesktop2.openTerminal !== 'function') return;\n` +
     `if (window.__comfyDesktopTerminalStopgap) return;\n` +
-    `window.__comfyDesktopTerminalStopgap = { started: true, registered: false, tabBarInjectorStarted: false };\n` +
-    // Capture the UMD modules into locals so we never touch window.Terminal.
-    `var __xt = { exports: {} };\n` +
-    `(function () { var module = __xt; var exports = __xt.exports;\n${xtermJs}\n}).call(window);\n` +
-    `var __fit = { exports: {} };\n` +
-    `(function () { var module = __fit; var exports = __fit.exports; var self = window;\n${fitJs}\n}).call(window);\n` +
-    `var XTerm = __xt.exports && __xt.exports.Terminal;\n` +
-    `var FitAddon = __fit.exports && __fit.exports.FitAddon;\n` +
-    `if (!XTerm || !FitAddon) return;\n` +
-    `(function () {\n` +
-    `var s = document.getElementById('__comfyDesktopXtermCss');\n` +
-    `if (!s) { s = document.createElement('style'); s.id = '__comfyDesktopXtermCss'; s.textContent = ${JSON.stringify(css)}; (document.head || document.documentElement).appendChild(s); }\n` +
-    `})();\n` +
+    `window.__comfyDesktopTerminalStopgap = { registered: false };\n` +
     TERMINAL_TAB_MAIN_JS +
     `})();\n`
-
   return cachedScript
 }

--- a/src/main/lib/comfyTerminalContentScript.ts
+++ b/src/main/lib/comfyTerminalContentScript.ts
@@ -185,6 +185,14 @@ function startTabPopoutInjector() {
     injectButton(header, 'Logs', 'logs');
   }
 
+  function scheduleInjectButtons() {
+    if (STATE.tabBarInjectTimer != null) return;
+    STATE.tabBarInjectTimer = setTimeout(function () {
+      STATE.tabBarInjectTimer = null;
+      injectButtons();
+    }, 0);
+  }
+
   injectButtons();
   var settleTries = 0;
   var settleInterval = setInterval(function () {
@@ -192,8 +200,9 @@ function startTabPopoutInjector() {
     injectButtons();
     if (settleTries > 50) clearInterval(settleInterval);
   }, 200);
-  var observer = new MutationObserver(injectButtons);
-  observer.observe(document.body, { childList: true, subtree: true });
+  // Vue recreates the tab strip on tab switches, so keep restoring the buttons.
+  STATE.tabBarObserver = new MutationObserver(scheduleInjectButtons);
+  STATE.tabBarObserver.observe(document.body, { childList: true, subtree: true });
 }
 
 function waitForRegister(timeoutMs) {

--- a/src/main/lib/comfyTerminalContentScript.ts
+++ b/src/main/lib/comfyTerminalContentScript.ts
@@ -68,6 +68,134 @@ function alreadyHasTerminalTab(app) {
   return false;
 }
 
+function startTabPopoutInjector() {
+  if (STATE.tabBarInjectorStarted) return;
+  STATE.tabBarInjectorStarted = true;
+
+  function containsLeafText(root, target) {
+    if (!root || !root.querySelectorAll) return false;
+    var leaves = root.querySelectorAll('*');
+    var pattern = new RegExp('^' + target + '$', 'i');
+    for (var i = 0; i < leaves.length; i++) {
+      var element = leaves[i];
+      if (!element || element.children.length > 0) continue;
+      if (pattern.test((element.textContent || '').trim())) return true;
+    }
+    return false;
+  }
+
+  function findBottomPanelHeader() {
+    var closes = document.querySelectorAll(
+      'button[aria-label="Close"], [role="button"][aria-label="Close"], button[title="Close"]'
+    );
+    for (var i = 0; i < closes.length; i++) {
+      var close = closes[i];
+      if (!close) continue;
+      var testid = (close.getAttribute && close.getAttribute('data-testid')) || '';
+      if (/minimap/i.test(testid)) continue;
+      var ancestor = close.parentElement;
+      for (var depth = 0; depth < 6 && ancestor; depth++) {
+        if (containsLeafText(ancestor, 'Terminal') && containsLeafText(ancestor, 'Logs')) {
+          return ancestor;
+        }
+        ancestor = ancestor.parentElement;
+      }
+    }
+    return null;
+  }
+
+  function findTabButton(header, label) {
+    var leaves = header.querySelectorAll('*');
+    var pattern = new RegExp('^' + label + '$', 'i');
+    for (var i = 0; i < leaves.length; i++) {
+      var leaf = leaves[i];
+      if (!leaf || leaf.children.length > 0) continue;
+      if (!pattern.test((leaf.textContent || '').trim())) continue;
+      var current = leaf;
+      for (var depth = 0; depth < 6 && current && current.parentElement; depth++) {
+        var parent = current.parentElement;
+        if (parent === header) break;
+        var role = parent.getAttribute && parent.getAttribute('role');
+        var tag = (parent.tagName || '').toLowerCase();
+        var classes = parent.className || '';
+        if (role === 'tab' || tag === 'button' || tag === 'a' || /tab/i.test(String(classes))) {
+          return parent;
+        }
+        current = parent;
+      }
+      return leaf.parentElement || leaf;
+    }
+    return null;
+  }
+
+  function makePopoutButton(kind) {
+    var button = document.createElement('button');
+    button.className = '__comfy-desktop-popout-btn';
+    button.setAttribute('data-popout-kind', kind);
+    button.type = 'button';
+    var label = kind === 'terminal'
+      ? 'Open terminal in a new window'
+      : 'Open logs in a new window';
+    button.title = 'Open in a new window';
+    button.setAttribute('aria-label', label);
+    button.style.cssText =
+      'display:inline-flex;align-items:center;justify-content:center;' +
+      'width:18px;height:18px;margin-left:6px;padding:0;border:0;' +
+      'background:transparent;color:currentColor;cursor:pointer;' +
+      'opacity:0.55;border-radius:4px;transition:opacity 120ms ease, background 120ms ease;' +
+      'vertical-align:middle;';
+    button.innerHTML =
+      '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" ' +
+      'stroke="currentColor" stroke-width="2.4" stroke-linecap="round" ' +
+      'stroke-linejoin="round" aria-hidden="true">' +
+      '<path d="M14 3h7v7"/><path d="M21 3l-9 9"/>' +
+      '<path d="M21 14v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5"/>' +
+      '</svg>';
+    button.addEventListener('mouseenter', function () {
+      button.style.opacity = '1';
+      button.style.background = 'rgba(255,255,255,0.08)';
+    });
+    button.addEventListener('mouseleave', function () {
+      button.style.opacity = '0.55';
+      button.style.background = 'transparent';
+    });
+    button.addEventListener('click', function (event) {
+      event.preventDefault();
+      event.stopPropagation();
+      var bridge = window.__comfyDesktop2;
+      var target = kind === 'terminal' ? bridge.Terminal : bridge.Logs;
+      try {
+        if (target && typeof target.openPopout === 'function') target.openPopout();
+      } catch (error) {}
+    });
+    return button;
+  }
+
+  function injectButton(header, label, kind) {
+    var tab = findTabButton(header, label);
+    if (!tab) return;
+    var selector = '.__comfy-desktop-popout-btn[data-popout-kind="' + kind + '"]';
+    if (!tab.querySelector(selector)) tab.appendChild(makePopoutButton(kind));
+  }
+
+  function injectButtons() {
+    var header = findBottomPanelHeader();
+    if (!header) return;
+    injectButton(header, 'Terminal', 'terminal');
+    injectButton(header, 'Logs', 'logs');
+  }
+
+  injectButtons();
+  var settleTries = 0;
+  var settleInterval = setInterval(function () {
+    settleTries++;
+    injectButtons();
+    if (settleTries > 50) clearInterval(settleInterval);
+  }, 200);
+  var observer = new MutationObserver(injectButtons);
+  observer.observe(document.body, { childList: true, subtree: true });
+}
+
 function waitForRegister(timeoutMs) {
   var startedAt = Date.now();
   (function tick() {
@@ -103,6 +231,7 @@ function waitForRegister(timeoutMs) {
   })();
 }
 
+startTabPopoutInjector();
 waitForRegister(30000);
 `
 

--- a/src/main/lib/ipc/registerTerminalHandlers.test.ts
+++ b/src/main/lib/ipc/registerTerminalHandlers.test.ts
@@ -4,6 +4,7 @@ type IpcHandler = (event: { sender: object }, ...args: unknown[]) => unknown
 
 const mocks = vi.hoisted(() => ({
   handlers: new Map<string, IpcHandler>(),
+  findEntryByComfySender: vi.fn(),
   isTitlePopupSender: vi.fn(),
   findTerminalPopoutInstallationIdBySender: vi.fn(),
   openTerminalPopout: vi.fn(),
@@ -25,6 +26,10 @@ vi.mock('electron', () => ({
 
 vi.mock('../../popups/titlePopup', () => ({
   isTitlePopupSender: mocks.isTitlePopupSender
+}))
+
+vi.mock('../../host/registry', () => ({
+  findEntryByComfySender: mocks.findEntryByComfySender
 }))
 
 vi.mock('../terminalPopoutWindow', () => ({
@@ -53,6 +58,7 @@ describe('registerTerminalHandlers', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.handlers.clear()
+    mocks.findEntryByComfySender.mockReturnValue(null)
     mocks.isTitlePopupSender.mockReturnValue(false)
     mocks.findTerminalPopoutInstallationIdBySender.mockReturnValue(null)
     registerTerminalHandlers()
@@ -68,6 +74,7 @@ describe('registerTerminalHandlers', () => {
     const restartRestore = await getHandler('terminal-restart')(event, 'inst-a')
     const restore = await getHandler('terminal-restore')(event, 'inst-a')
     await getHandler('terminal-popout-open')(event, 'inst-a')
+    await getHandler('desktop2-open-terminal-popout')(event, 'inst-a')
 
     expect(mocks.writeTerminal).not.toHaveBeenCalled()
     expect(mocks.unsubscribeTerminal).not.toHaveBeenCalled()
@@ -84,6 +91,18 @@ describe('registerTerminalHandlers', () => {
     expect(subscribeRestore).toEqual(emptyRestore)
     expect(restartRestore).toEqual(emptyRestore)
     expect(restore).toEqual(emptyRestore)
+  })
+
+  it('opens a popout bound to the local installation resolved by main', async () => {
+    const event = { sender: {} }
+    mocks.findEntryByComfySender.mockReturnValue({
+      installationId: 'inst-a',
+      sourceCategory: 'local'
+    })
+
+    await getHandler('desktop2-open-terminal-popout')(event, 'inst-b')
+
+    expect(mocks.openTerminalPopout).toHaveBeenCalledWith('inst-a')
   })
 
   it('allows the trusted title popup to operate on its selected installation', async () => {

--- a/src/main/lib/ipc/registerTerminalHandlers.test.ts
+++ b/src/main/lib/ipc/registerTerminalHandlers.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+type IpcHandler = (event: { sender: object }, ...args: unknown[]) => unknown
+
+const mocks = vi.hoisted(() => ({
+  handlers: new Map<string, IpcHandler>(),
+  isTitlePopupSender: vi.fn(),
+  findTerminalPopoutInstallationIdBySender: vi.fn(),
+  openTerminalPopout: vi.fn(),
+  subscribeTerminal: vi.fn(),
+  unsubscribeTerminal: vi.fn(),
+  writeTerminal: vi.fn(),
+  resizeTerminal: vi.fn(),
+  restartTerminal: vi.fn(),
+  getTerminalRestore: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: IpcHandler) => {
+      mocks.handlers.set(channel, handler)
+    })
+  }
+}))
+
+vi.mock('../../popups/titlePopup', () => ({
+  isTitlePopupSender: mocks.isTitlePopupSender
+}))
+
+vi.mock('../terminalPopoutWindow', () => ({
+  findTerminalPopoutInstallationIdBySender: mocks.findTerminalPopoutInstallationIdBySender,
+  openTerminalPopout: mocks.openTerminalPopout
+}))
+
+vi.mock('../terminal', () => ({
+  subscribeTerminal: mocks.subscribeTerminal,
+  unsubscribeTerminal: mocks.unsubscribeTerminal,
+  writeTerminal: mocks.writeTerminal,
+  resizeTerminal: mocks.resizeTerminal,
+  restartTerminal: mocks.restartTerminal,
+  getTerminalRestore: mocks.getTerminalRestore
+}))
+
+import { registerTerminalHandlers } from './registerTerminalHandlers'
+
+function getHandler(channel: string): IpcHandler {
+  const handler = mocks.handlers.get(channel)
+  expect(handler).toBeDefined()
+  return handler!
+}
+
+describe('registerTerminalHandlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.handlers.clear()
+    mocks.isTitlePopupSender.mockReturnValue(false)
+    mocks.findTerminalPopoutInstallationIdBySender.mockReturnValue(null)
+    registerTerminalHandlers()
+  })
+
+  it('rejects PTY access from an untrusted sender with an explicit installation', async () => {
+    const event = { sender: {} }
+
+    await getHandler('terminal-write')(event, 'inst-a', 'whoami\r')
+    await getHandler('terminal-unsubscribe')(event, 'inst-a')
+    await getHandler('terminal-resize')(event, 'inst-a', 120, 40)
+    const subscribeRestore = await getHandler('terminal-subscribe')(event, 'inst-a')
+    const restartRestore = await getHandler('terminal-restart')(event, 'inst-a')
+    const restore = await getHandler('terminal-restore')(event, 'inst-a')
+    await getHandler('terminal-popout-open')(event, 'inst-a')
+
+    expect(mocks.writeTerminal).not.toHaveBeenCalled()
+    expect(mocks.unsubscribeTerminal).not.toHaveBeenCalled()
+    expect(mocks.resizeTerminal).not.toHaveBeenCalled()
+    expect(mocks.subscribeTerminal).not.toHaveBeenCalled()
+    expect(mocks.restartTerminal).not.toHaveBeenCalled()
+    expect(mocks.getTerminalRestore).not.toHaveBeenCalled()
+    expect(mocks.openTerminalPopout).not.toHaveBeenCalled()
+    const emptyRestore = {
+      buffer: [],
+      size: { cols: 80, rows: 30 },
+      exited: true
+    }
+    expect(subscribeRestore).toEqual(emptyRestore)
+    expect(restartRestore).toEqual(emptyRestore)
+    expect(restore).toEqual(emptyRestore)
+  })
+
+  it('allows the trusted title popup to operate on its selected installation', async () => {
+    const event = { sender: {} }
+    mocks.isTitlePopupSender.mockReturnValue(true)
+
+    await getHandler('terminal-write')(event, 'inst-a', 'pwd\r')
+
+    expect(mocks.writeTerminal).toHaveBeenCalledWith('inst-a', 'pwd\r')
+  })
+
+  it('binds a terminal popout to the installation registered by main', async () => {
+    const event = { sender: {} }
+    mocks.findTerminalPopoutInstallationIdBySender.mockReturnValue('inst-a')
+
+    await getHandler('terminal-resize')(event, null, 120, 40)
+
+    expect(mocks.resizeTerminal).toHaveBeenCalledWith('inst-a', 120, 40)
+  })
+
+  it('rejects a popout request for a different installation', async () => {
+    const event = { sender: {} }
+    mocks.findTerminalPopoutInstallationIdBySender.mockReturnValue('inst-a')
+
+    await getHandler('terminal-write')(event, 'inst-b', 'pwd\r')
+
+    expect(mocks.writeTerminal).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/lib/ipc/registerTerminalHandlers.ts
+++ b/src/main/lib/ipc/registerTerminalHandlers.ts
@@ -1,6 +1,6 @@
 import { ipcMain } from 'electron'
 import type { IpcMainInvokeEvent } from 'electron'
-import { findInstallationIdByComfySender } from '../../host/registry'
+import { isTitlePopupSender } from '../../popups/titlePopup'
 import {
   subscribeTerminal,
   unsubscribeTerminal,
@@ -10,19 +10,16 @@ import {
   getTerminalRestore,
   type TerminalRestore
 } from '../terminal'
-import { openTerminalPopout } from '../terminalPopoutWindow'
+import {
+  findTerminalPopoutInstallationIdBySender,
+  openTerminalPopout
+} from '../terminalPopoutWindow'
 
 /**
  * IPC for the interactive per-installation console.
  *
- * Two kinds of caller share these channels:
- *   - The desktop renderer (Settings "Console" tab), which knows the
- *     installationId and passes it explicitly.
- *   - The served ComfyUI frontend inside a comfyView, which does NOT know its
- *     installationId — we resolve it from the sender via the host registry.
- *
- * Output/exit are pushed straight to the subscribing webContents, so the
- * frontend never needs to know its own installationId.
+ * Only bundled Desktop terminal renderers may use these channels. The served
+ * ComfyUI renderer has a separate navigation-only bridge.
  */
 
 const EMPTY_RESTORE: TerminalRestore = {
@@ -35,8 +32,11 @@ function resolveInstallationId(
   event: IpcMainInvokeEvent,
   explicit: string | null | undefined
 ): string | null {
-  if (explicit) return explicit
-  return findInstallationIdByComfySender(event.sender)
+  const requestedId = typeof explicit === 'string' && explicit.length > 0 ? explicit : null
+  if (isTitlePopupSender(event.sender)) return requestedId
+  const popoutId = findTerminalPopoutInstallationIdBySender(event.sender)
+  if (!popoutId || (requestedId && requestedId !== popoutId)) return null
+  return popoutId
 }
 
 export function registerTerminalHandlers(): void {
@@ -82,10 +82,6 @@ export function registerTerminalHandlers(): void {
     return getTerminalRestore(id) ?? EMPTY_RESTORE
   })
 
-  // Pop the inline terminal out into a standalone Electron window.
-  // Caller (the inline injection in the comfyView) doesn't pass an
-  // installationId — we resolve it from the sender's registered
-  // comfyView so the popout always targets the right shell.
   ipcMain.handle(
     'terminal-popout-open',
     async (event, installationId?: string | null): Promise<void> => {

--- a/src/main/lib/ipc/registerTerminalHandlers.ts
+++ b/src/main/lib/ipc/registerTerminalHandlers.ts
@@ -1,5 +1,6 @@
 import { ipcMain } from 'electron'
 import type { IpcMainInvokeEvent } from 'electron'
+import { findEntryByComfySender } from '../../host/registry'
 import { isTitlePopupSender } from '../../popups/titlePopup'
 import {
   subscribeTerminal,
@@ -40,6 +41,12 @@ function resolveInstallationId(
 }
 
 export function registerTerminalHandlers(): void {
+  ipcMain.handle('desktop2-open-terminal-popout', async (event): Promise<void> => {
+    const entry = findEntryByComfySender(event.sender)
+    if (!entry?.installationId || entry.sourceCategory !== 'local') return
+    await openTerminalPopout(entry.installationId)
+  })
+
   ipcMain.handle(
     'terminal-subscribe',
     async (event, installationId?: string | null): Promise<TerminalRestore> => {

--- a/src/main/lib/ipc/sessionActions/launch.test.ts
+++ b/src/main/lib/ipc/sessionActions/launch.test.ts
@@ -38,7 +38,7 @@ describe('desktopFeatureFlags', () => {
   it('always injects the unconditional desktop flags', () => {
     const flags = desktopFeatureFlags(installOf('standalone'), false)
     expect(flags.show_signin_button).toBe('true')
-    expect(flags.supports_terminal).toBe('true')
+    expect(flags.supports_terminal).toBe('false')
   })
 
   it('injects enable_telemetry only for standalone installs that opted in', () => {

--- a/src/main/lib/ipc/sessionActions/launch.ts
+++ b/src/main/lib/ipc/sessionActions/launch.ts
@@ -101,10 +101,9 @@ export function desktopFeatureFlags(
 ): Record<string, string> {
   const flags: Record<string, string> = {
     show_signin_button: 'true',
-    // Advertises that an interactive terminal host is available, so the frontend
-    // may surface its bottom-panel terminal. The actual transport is the
-    // __comfyDesktop2.Terminal bridge; the flag only gates visibility.
-    supports_terminal: 'true'
+    // Do not advertise inline PTY support. Desktop injects a navigation-only
+    // terminal entry instead.
+    supports_terminal: 'false'
   }
   // Telemetry is opt-in (default off) and only signaled for managed standalone
   // installs — never for portable or user-managed git clones.

--- a/src/main/lib/terminalPopoutWindow.test.ts
+++ b/src/main/lib/terminalPopoutWindow.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => {
+  const webContents = {
+    once: vi.fn(),
+    executeJavaScript: vi.fn(async () => {})
+  }
+  const window = {
+    webContents,
+    isDestroyed: vi.fn(() => false),
+    focus: vi.fn(),
+    on: vi.fn(),
+    loadURL: vi.fn(async (_url: string) => {}),
+    setTitle: vi.fn(),
+    destroy: vi.fn()
+  }
+  return {
+    BrowserWindow: vi.fn(function () {
+      return window
+    }),
+    getInstallation: vi.fn(),
+    webContents,
+    window
+  }
+})
+
+vi.mock('electron', () => ({ BrowserWindow: mocks.BrowserWindow }))
+vi.mock('../installations', () => ({ get: mocks.getInstallation }))
+
+import { closeAllTerminalPopouts, openTerminalPopout } from './terminalPopoutWindow'
+
+describe('terminalPopoutWindow', () => {
+  beforeEach(() => {
+    closeAllTerminalPopouts()
+    vi.clearAllMocks()
+    mocks.window.isDestroyed.mockReturnValue(false)
+  })
+
+  it('keeps installation names out of the privileged renderer HTML', async () => {
+    const name = '</title><script>window.__comfyDesktopTerminal.write("whoami")</script>'
+    mocks.getInstallation.mockResolvedValue({ name })
+
+    await openTerminalPopout('install-a')
+
+    const url = mocks.window.loadURL.mock.calls[0]?.[0]
+    if (!url) throw new Error('Expected terminal popout URL')
+    const html = decodeURIComponent(url.slice(url.indexOf(',') + 1))
+    expect(html).toContain('<title>Comfy Terminal</title>')
+    expect(html).not.toContain(name)
+    expect(mocks.BrowserWindow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        webPreferences: expect.objectContaining({
+          contextIsolation: true,
+          nodeIntegration: false,
+          sandbox: true
+        })
+      })
+    )
+  })
+})

--- a/src/main/lib/terminalPopoutWindow.ts
+++ b/src/main/lib/terminalPopoutWindow.ts
@@ -1,20 +1,15 @@
 /**
  * Pop-out terminal window. A small standalone Electron BrowserWindow that
- * runs the same xterm renderer as the inline injection but is decoupled
- * from the ComfyUI frontend's bottom panel. Uses the same per-install
- * shared shell as the inline view (`terminal-*` IPC handlers in
- * `registerTerminalHandlers.ts`), so output stays in lockstep between the
- * pop-out and any other surface still subscribed to the same install.
+ * runs xterm in a bundled Desktop renderer that is isolated from the served
+ * ComfyUI frontend. Uses the same per-install shared shell as the trusted
+ * console view (`terminal-*` IPC handlers in `registerTerminalHandlers.ts`).
  *
- * Why a dedicated module instead of reusing `comfyTerminalContentScript`:
- * the inline script registers itself as a ComfyUI extension and renders
- * into a bottom-panel tab container. A pop-out has no extension system —
- * the xterm has to mount directly onto `document.body`. The render logic
- * is essentially identical; only the host + dedupe and the explicit
- * installationId passing differ.
+ * The dedicated preload is the security boundary: this renderer gets PTY
+ * access while the served ComfyUI renderer gets only an open/focus request.
  */
 
 import { BrowserWindow } from 'electron'
+import type { WebContents } from 'electron'
 import path from 'path'
 import { readFileSync } from 'fs'
 import { createRequire } from 'module'
@@ -36,9 +31,8 @@ function stripSourceMapComment(source: string): string {
 /**
  * Build the standalone xterm bootstrap script for the pop-out window.
  * Memoised — the UMD payloads are large and never change at runtime.
- * The injected `INSTALLATION_ID` literal is substituted per window.
  */
-function buildPopoutScript(installationId: string): string {
+function buildPopoutScript(): string {
   if (!cachedScript) {
     const xtermJs = stripSourceMapComment(readPackageFile('@xterm/xterm/lib/xterm.js'))
     const fitJs = stripSourceMapComment(readPackageFile('@xterm/addon-fit/lib/addon-fit.js'))
@@ -47,7 +41,7 @@ function buildPopoutScript(installationId: string): string {
     cachedScript =
       `(function () {\n` +
       `'use strict';\n` +
-      `if (typeof window === 'undefined' || !window.__comfyDesktop2 || !window.__comfyDesktop2.Terminal) return;\n` +
+      `if (typeof window === 'undefined' || !window.__comfyDesktopTerminal) return;\n` +
       `if (window.__comfyDesktopTerminalPopoutMounted) return;\n` +
       `window.__comfyDesktopTerminalPopoutMounted = true;\n` +
       `var __xt = { exports: {} };\n` +
@@ -64,13 +58,7 @@ function buildPopoutScript(installationId: string): string {
       POPOUT_MAIN_JS +
       `})();\n`
   }
-  // installationId interpolation goes after the cached payload — keeps
-  // the UMD bundle re-used across windows but lets each window target its
-  // own installation. The bootstrap reads it from a top-level constant.
-  return (
-    `window.__comfyDesktopPopoutInstallationId = ${JSON.stringify(installationId)};\n` +
-    cachedScript
-  )
+  return cachedScript
 }
 
 /**
@@ -80,9 +68,8 @@ function buildPopoutScript(installationId: string): string {
  * bottom-panel tab plumbing.
  */
 const POPOUT_MAIN_JS = `
-var INSTALL_ID = window.__comfyDesktopPopoutInstallationId;
-var bridge = window.__comfyDesktop2.Terminal;
-if (!INSTALL_ID || !bridge) return;
+var bridge = window.__comfyDesktopTerminal;
+if (!bridge) return;
 
 var root = document.body;
 root.style.background = '#171717';
@@ -126,7 +113,7 @@ function doFit(forceReclaim) {
   var changed = dims.cols !== term.cols || dims.rows !== term.rows;
   if (changed) term.resize(dims.cols, dims.rows);
   if (changed || forceReclaim) {
-    try { bridge.resize(term.cols, term.rows, INSTALL_ID); } catch (e) {}
+    try { bridge.resize(term.cols, term.rows); } catch (e) {}
   }
 }
 
@@ -145,11 +132,11 @@ function doRestart() {
   if (state.disposed) return;
   term.reset();
   state.exited = false; updateBanner();
-  bridge.restart(INSTALL_ID).then(applyRestore).catch(function () {});
+  bridge.restart().then(applyRestore).catch(function () {});
 }
 restartBtn.addEventListener('click', doRestart);
 
-term.onData(function (d) { try { bridge.write(d, INSTALL_ID); } catch (e) {} });
+term.onData(function (d) { try { bridge.write(d); } catch (e) {} });
 var offOutput = bridge.onOutput(function (msg) {
   if (state.disposed) return;
   if (state.exited) { state.exited = false; updateBanner(); }
@@ -171,11 +158,11 @@ window.addEventListener('beforeunload', function () {
   try { offOutput && offOutput(); } catch (e) {}
   try { offExited && offExited(); } catch (e) {}
   try { ro.disconnect(); } catch (e) {}
-  try { bridge.unsubscribe(INSTALL_ID); } catch (e) {}
+  try { bridge.unsubscribe(); } catch (e) {}
   try { term.dispose(); } catch (e) {}
 });
 
-bridge.subscribe(INSTALL_ID).then(function (restore) {
+bridge.subscribe().then(function (restore) {
   if (state.disposed) return;
   if (restore && restore.exited) doRestart();
   else applyRestore(restore);
@@ -186,6 +173,13 @@ bridge.subscribe(INSTALL_ID).then(function (restore) {
 // Track open pop-outs per installation so a second click on the inline
 // button focuses the existing window instead of spawning a duplicate.
 const popoutsByInstallation = new Map<string, BrowserWindow>()
+
+export function findTerminalPopoutInstallationIdBySender(sender: WebContents): string | null {
+  for (const [installationId, window] of popoutsByInstallation) {
+    if (!window.isDestroyed() && window.webContents === sender) return installationId
+  }
+  return null
+}
 
 export async function openTerminalPopout(installationId: string): Promise<void> {
   const existing = popoutsByInstallation.get(installationId)
@@ -212,9 +206,10 @@ export async function openTerminalPopout(installationId: string): Promise<void> 
     backgroundColor: COMFY_BG,
     autoHideMenuBar: true,
     webPreferences: {
-      preload: path.join(__dirname, '../preload/comfyPreload.js'),
+      preload: path.join(__dirname, '../preload/terminalPreload.js'),
       contextIsolation: true,
-      sandbox: false
+      nodeIntegration: false,
+      sandbox: true
     }
   })
 
@@ -225,13 +220,14 @@ export async function openTerminalPopout(installationId: string): Promise<void> 
   })
 
   const html =
-    `<!DOCTYPE html><html><head><meta charset="utf-8"><title>${label}</title>` +
+    `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Comfy Terminal</title>` +
     `<style>html,body{margin:0;padding:0;height:100%;background:${COMFY_BG};}</style>` +
     `</head><body></body></html>`
   void win.loadURL('data:text/html;charset=utf-8,' + encodeURIComponent(html))
 
   win.webContents.once('did-finish-load', () => {
-    void win.webContents.executeJavaScript(buildPopoutScript(installationId)).catch(() => {})
+    win.setTitle(label)
+    void win.webContents.executeJavaScript(buildPopoutScript()).catch(() => {})
   })
 }
 

--- a/src/main/popups/titlePopup.ts
+++ b/src/main/popups/titlePopup.ts
@@ -40,6 +40,7 @@ import * as installations from '../installations'
 import { getCachedGithubStarCount, getGithubStarCount } from '../lib/githubStars'
 import {
   comfyWindows,
+  findEntryByComfySender,
   findEntryByTitleBarSender,
   getEntryByInstallationId,
   hostInstallEvents,
@@ -483,6 +484,10 @@ interface TitlePopupEntry {
  *  `event.sender`. */
 const titlePopupsByParent = new Map<number, TitlePopupEntry>()
 const titlePopupsByWebContents = new Map<number, TitlePopupEntry>()
+
+export function isTitlePopupSender(sender: Electron.WebContents): boolean {
+  return titlePopupsByWebContents.has(sender.id)
+}
 
 /** Timestamp of the most recent downloads-popup dismiss per parent
  *  window. The downloads tray relies on blur-dismiss (no backdrop),
@@ -2175,6 +2180,21 @@ export function registerTitlePopupIpc(bindings: TitlePopupHostBindings): void {
   // Stash for `prewarmTitlePopup` (host-construction site doesn't have
   // bindings). Last writer wins; only called once at `whenReady`.
   activeBindings = bindings
+
+  ipcMain.handle('desktop2-open-terminal', (event): boolean => {
+    const parentEntry = findEntryByComfySender(event.sender)
+    if (!parentEntry?.installationId || parentEntry.sourceCategory !== 'local') return false
+    openInstancePickerForHost(
+      parentEntry,
+      parentEntry.windowKey,
+      bindings,
+      parentEntry.titleBarView.webContents,
+      { x: 0, y: TITLEBAR_HEIGHT },
+      parentEntry.installationId,
+      'console'
+    )
+    return true
+  })
 
   ipcMain.on('comfy-titlepopup:ready', (event) => {
     const entry = titlePopupsByWebContents.get(event.sender.id)

--- a/src/preload/comfyPreload.test.ts
+++ b/src/preload/comfyPreload.test.ts
@@ -100,5 +100,6 @@ describe('comfyPreload model access bridge', () => {
     )
     expect(mocks.invoke).toHaveBeenCalledTimes(3)
     expect(mocks.invoke).toHaveBeenCalledWith('desktop2-open-terminal')
+    expect(mocks.invoke).toHaveBeenCalledWith('desktop2-open-terminal-popout')
   })
 })

--- a/src/preload/comfyPreload.test.ts
+++ b/src/preload/comfyPreload.test.ts
@@ -58,7 +58,7 @@ function hostedBridge(): HostedFrontendBridge {
 
 describe('comfyPreload model access bridge', () => {
   beforeEach(() => {
-    mocks.invoke.mockClear()
+    mocks.invoke.mockReset()
   })
 
   it('forwards the repository URL through the desktop2 IPC contract', async () => {
@@ -94,9 +94,9 @@ describe('comfyPreload model access bridge', () => {
     expect(bridge.Terminal.onOutput(() => {})).toEqual(expect.any(Function))
     expect(bridge.Terminal.onExited(() => {})).toEqual(expect.any(Function))
 
-    expect(mocks.invoke).not.toHaveBeenCalledWith(
-      expect.stringMatching(/^terminal-/),
-      expect.anything()
+    const invokedChannels = mocks.invoke.mock.calls.map(([channel]) => channel)
+    expect(invokedChannels).not.toEqual(
+      expect.arrayContaining([expect.stringMatching(/^terminal-/)])
     )
     expect(mocks.invoke).toHaveBeenCalledTimes(3)
     expect(mocks.invoke).toHaveBeenCalledWith('desktop2-open-terminal')

--- a/src/preload/comfyPreload.test.ts
+++ b/src/preload/comfyPreload.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   exposeInMainWorld: vi.fn(),
@@ -26,9 +26,43 @@ type ModelAccessBridge = {
   openModelAccessPage: (url: string) => Promise<boolean>
 }
 
+type HostedFrontendBridge = ModelAccessBridge & {
+  openTerminal: () => Promise<boolean>
+  Terminal: {
+    subscribe: () => Promise<{
+      buffer: string[]
+      size: { cols: number; rows: number }
+      exited: boolean
+    }>
+    write: (data: string) => Promise<void>
+    resize: (cols: number, rows: number) => Promise<void>
+    restart: () => Promise<{
+      buffer: string[]
+      size: { cols: number; rows: number }
+      exited: boolean
+    }>
+    restore: () => Promise<{
+      buffer: string[]
+      size: { cols: number; rows: number }
+      exited: boolean
+    }>
+    openPopout: () => Promise<void>
+    onOutput: (callback: (data: string) => void) => () => void
+    onExited: (callback: () => void) => () => void
+  }
+}
+
+function hostedBridge(): HostedFrontendBridge {
+  return mocks.exposeInMainWorld.mock.calls[0]![1] as HostedFrontendBridge
+}
+
 describe('comfyPreload model access bridge', () => {
+  beforeEach(() => {
+    mocks.invoke.mockClear()
+  })
+
   it('forwards the repository URL through the desktop2 IPC contract', async () => {
-    const bridge = mocks.exposeInMainWorld.mock.calls[0]![1] as ModelAccessBridge
+    const bridge = hostedBridge()
     const url = 'https://huggingface.co/black-forest-labs/FLUX.1-dev'
     mocks.invoke.mockResolvedValueOnce(true)
 
@@ -36,5 +70,35 @@ describe('comfyPreload model access bridge', () => {
 
     expect(mocks.exposeInMainWorld).toHaveBeenCalledWith('__comfyDesktop2', expect.any(Object))
     expect(mocks.invoke).toHaveBeenCalledWith('desktop2-open-model-access-page', { url })
+  })
+
+  it('exposes only a navigation request for the hosted terminal', async () => {
+    const bridge = hostedBridge()
+    mocks.invoke.mockResolvedValueOnce(true)
+
+    await expect(bridge.openTerminal()).resolves.toBe(true)
+
+    expect(mocks.invoke).toHaveBeenCalledWith('desktop2-open-terminal')
+  })
+
+  it('redirects legacy terminal calls without invoking PTY channels', async () => {
+    const bridge = hostedBridge()
+    mocks.invoke.mockResolvedValue(true)
+
+    await bridge.Terminal.subscribe()
+    await bridge.Terminal.write('whoami\r')
+    await bridge.Terminal.resize(120, 40)
+    await bridge.Terminal.restart()
+    await bridge.Terminal.restore()
+    await bridge.Terminal.openPopout()
+    expect(bridge.Terminal.onOutput(() => {})).toEqual(expect.any(Function))
+    expect(bridge.Terminal.onExited(() => {})).toEqual(expect.any(Function))
+
+    expect(mocks.invoke).not.toHaveBeenCalledWith(
+      expect.stringMatching(/^terminal-/),
+      expect.anything()
+    )
+    expect(mocks.invoke).toHaveBeenCalledTimes(3)
+    expect(mocks.invoke).toHaveBeenCalledWith('desktop2-open-terminal')
   })
 })

--- a/src/preload/comfyPreload.ts
+++ b/src/preload/comfyPreload.ts
@@ -34,6 +34,10 @@ function openTerminal(): Promise<boolean> {
   return ipcRenderer.invoke('desktop2-open-terminal')
 }
 
+function openTerminalPopout(): Promise<void> {
+  return ipcRenderer.invoke('desktop2-open-terminal-popout')
+}
+
 async function openTerminalWithEmptyRestore(): Promise<TerminalRestore> {
   await openTerminal()
   return EMPTY_TERMINAL_RESTORE
@@ -45,9 +49,7 @@ const Terminal: LegacyTerminalBridge = {
   write: async (): Promise<void> => {},
   resize: async (): Promise<void> => {},
   restart: async (): Promise<TerminalRestore> => EMPTY_TERMINAL_RESTORE,
-  openPopout: async (): Promise<void> => {
-    await openTerminal()
-  },
+  openPopout: openTerminalPopout,
   onOutput: (): (() => void) => () => {},
   onExited: (): (() => void) => () => {},
   restore: openTerminalWithEmptyRestore

--- a/src/preload/comfyPreload.ts
+++ b/src/preload/comfyPreload.ts
@@ -12,6 +12,16 @@ import type {
 import type { ComfyDesktop2TelemetryBridge } from '../types/comfyDesktopBridge'
 import { startLocalFirebaseAuthMonitor } from './localFirebaseAuthMonitor'
 
+type LegacyTerminalBridge = ComfyDesktop2TerminalBridge & {
+  restore(): Promise<TerminalRestore>
+}
+
+const EMPTY_TERMINAL_RESTORE: TerminalRestore = {
+  buffer: [],
+  size: { cols: 80, rows: 30 },
+  exited: true
+}
+
 function sendTelemetry(channel: string, payload: unknown): void {
   try {
     ipcRenderer.send(channel, payload)
@@ -20,43 +30,27 @@ function sendTelemetry(channel: string, payload: unknown): void {
   }
 }
 
-/**
- * Interactive terminal bridge for the served ComfyUI frontend.
- *
- * Main resolves the installationId from the sending webContents when no
- * explicit one is passed. The inline injection (running inside the
- * comfyView) omits it; the pop-out window passes its installationId
- * explicitly because its webContents isn't registered as a comfyView.
- * Per-install shared shell — multiple subscribers see the same output.
- */
-const Terminal: ComfyDesktop2TerminalBridge = {
-  /** Spawn the shell if needed, register this view as a subscriber, and
-   *  return the current scrollback/size/exited state. */
-  subscribe: (installationId?: string): Promise<TerminalRestore> =>
-    ipcRenderer.invoke('terminal-subscribe', installationId ?? null),
-  unsubscribe: (installationId?: string): Promise<void> =>
-    ipcRenderer.invoke('terminal-unsubscribe', installationId ?? null),
-  write: (data: string, installationId?: string): Promise<void> =>
-    ipcRenderer.invoke('terminal-write', installationId ?? null, data),
-  resize: (cols: number, rows: number, installationId?: string): Promise<void> =>
-    ipcRenderer.invoke('terminal-resize', installationId ?? null, cols, rows),
-  /** Kill the current shell (if any) and start a fresh one. */
-  restart: (installationId?: string): Promise<TerminalRestore> =>
-    ipcRenderer.invoke('terminal-restart', installationId ?? null),
-  /** Open a separate Electron window subscribed to the same shell. Main
-   *  resolves the installationId from the caller's comfyView sender so
-   *  the inline injection doesn't need to know its own ID. */
-  openPopout: (): Promise<void> => ipcRenderer.invoke('terminal-popout-open', null),
-  onOutput: (callback: (data: string) => void): (() => void) => {
-    const handler = (_event: IpcRendererEvent, payload: { data: string }) => callback(payload.data)
-    ipcRenderer.on('terminal-output', handler)
-    return () => ipcRenderer.removeListener('terminal-output', handler)
+function openTerminal(): Promise<boolean> {
+  return ipcRenderer.invoke('desktop2-open-terminal')
+}
+
+async function openTerminalWithEmptyRestore(): Promise<TerminalRestore> {
+  await openTerminal()
+  return EMPTY_TERMINAL_RESTORE
+}
+
+const Terminal: LegacyTerminalBridge = {
+  subscribe: openTerminalWithEmptyRestore,
+  unsubscribe: async (): Promise<void> => {},
+  write: async (): Promise<void> => {},
+  resize: async (): Promise<void> => {},
+  restart: async (): Promise<TerminalRestore> => EMPTY_TERMINAL_RESTORE,
+  openPopout: async (): Promise<void> => {
+    await openTerminal()
   },
-  onExited: (callback: () => void): (() => void) => {
-    const handler = () => callback()
-    ipcRenderer.on('terminal-exited', handler)
-    return () => ipcRenderer.removeListener('terminal-exited', handler)
-  }
+  onOutput: (): (() => void) => () => {},
+  onExited: (): (() => void) => () => {},
+  restore: openTerminalWithEmptyRestore
 }
 
 /**
@@ -98,6 +92,7 @@ startLocalFirebaseAuthMonitor(reportFirebaseAuthState)
 type ComfyDesktop2RuntimeBridge = ComfyDesktop2Bridge & {
   Telemetry: ComfyDesktop2TelemetryBridge
   openModelAccessPage: (url: string) => Promise<boolean>
+  openTerminal: () => Promise<boolean>
 }
 
 const bridge = {
@@ -133,6 +128,7 @@ const bridge = {
   reportTheme: (bg: string, text: string): void => {
     ipcRenderer.send('desktop2-theme-report', { bg, text })
   },
+  openTerminal,
   Terminal,
   Logs,
   Telemetry

--- a/src/preload/terminalPreload.ts
+++ b/src/preload/terminalPreload.ts
@@ -1,0 +1,28 @@
+import { contextBridge, ipcRenderer } from 'electron'
+import type { IpcRendererEvent } from 'electron'
+import type {
+  ComfyDesktop2TerminalBridge,
+  TerminalRestore
+} from '@comfyorg/comfyui-desktop-bridge-types'
+
+const Terminal: ComfyDesktop2TerminalBridge = {
+  subscribe: (): Promise<TerminalRestore> => ipcRenderer.invoke('terminal-subscribe', null),
+  unsubscribe: (): Promise<void> => ipcRenderer.invoke('terminal-unsubscribe', null),
+  write: (data: string): Promise<void> => ipcRenderer.invoke('terminal-write', null, data),
+  resize: (cols: number, rows: number): Promise<void> =>
+    ipcRenderer.invoke('terminal-resize', null, cols, rows),
+  restart: (): Promise<TerminalRestore> => ipcRenderer.invoke('terminal-restart', null),
+  openPopout: async (): Promise<void> => {},
+  onOutput: (callback: (data: string) => void): (() => void) => {
+    const handler = (_event: IpcRendererEvent, payload: { data: string }) => callback(payload.data)
+    ipcRenderer.on('terminal-output', handler)
+    return () => ipcRenderer.removeListener('terminal-output', handler)
+  },
+  onExited: (callback: () => void): (() => void) => {
+    const handler = () => callback()
+    ipcRenderer.on('terminal-exited', handler)
+    return () => ipcRenderer.removeListener('terminal-exited', handler)
+  }
+}
+
+contextBridge.exposeInMainWorld('__comfyDesktopTerminal', Terminal)

--- a/src/types/comfyDesktopBridge.ts
+++ b/src/types/comfyDesktopBridge.ts
@@ -65,6 +65,7 @@ export interface ComfyDesktop2TelemetryBridge {
 
 export interface ComfyDesktop2Bridge {
   isRemote(): boolean
+  openTerminal?: () => Promise<boolean>
   downloadModel?: (url: string, filename: string, directory: string) => Promise<boolean>
   downloadAsset?: (url: string, filename: string, authToken?: string) => Promise<boolean>
   pauseDownload?: (url: string) => Promise<boolean>


### PR DESCRIPTION
## Summary

- remove terminal read/write/resize/restart capabilities from hosted ComfyUI while preserving legacy frontend compatibility through navigation-only terminal actions
- authorize terminal IPC handlers by trusted sender and bind terminal popouts to installation identity held by the main process
- move terminal popouts to a dedicated sandboxed preload and restore the separate Terminal and Logs popout actions
- advertise inline terminal support as disabled so frontend builds use the Desktop-managed terminal UI

## Testing

- manually reproduced the bug before the fix and confirmed terminal commands are blocked after the fix using the same affected frontend
- `pnpm exec vitest run src/preload/comfyPreload.test.ts src/main/lib/ipc/registerTerminalHandlers.test.ts src/main/lib/terminalPopoutWindow.test.ts src/main/lib/comfyTerminalContentScript.test.ts src/main/lib/ipc/sessionActions/launch.test.ts`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run build`