### PR TITLE
feat(telemetry): remove the comfy.desktop.comfyui.model_usage event

### DIFF
--- a/src/main/lib/hardwareTap.test.ts
+++ b/src/main/lib/hardwareTap.test.ts
@@ -11,15 +11,7 @@ vi.mock('electron', () => ({
   BrowserWindow: { getAllWindows: () => [] }
 }))
 
-const {
-  createHardwareTap,
-  parseDeviceLine,
-  parseVramLine,
-  parseRequestedModelLoad,
-  parseDynamicVramPrepare,
-  parseModelDeepclone,
-  parseModelLoad
-} = await import('./hardwareTap')
+const { createHardwareTap, parseDeviceLine, parseVramLine } = await import('./hardwareTap')
 const telemetry = await import('./telemetry')
 
 describe('parseDeviceLine', () => {
@@ -74,78 +66,13 @@ describe('parseDeviceLine', () => {
   })
 })
 
-describe('parseVramLine / parseRequestedModelLoad', () => {
+describe('parseVramLine', () => {
   it('parses VRAM/RAM amounts', () => {
     expect(parseVramLine('Total VRAM 24576 MB, total RAM 65461 MB')).toEqual({
       vramMb: 24576,
       ramMb: 65461
     })
     expect(parseVramLine('nope')).toBeNull()
-  })
-
-  it('parses the loaded model class name', () => {
-    expect(parseRequestedModelLoad('Requested to load Lumina2')).toBe('Lumina2')
-    expect(parseRequestedModelLoad('Requested to load ZImageTEModel_')).toBe('ZImageTEModel_')
-    expect(parseRequestedModelLoad('Requested to load AutoencodingEngine')).toBe(
-      'AutoencodingEngine'
-    )
-    expect(parseRequestedModelLoad('something else')).toBeNull()
-  })
-
-  it('rejects non-identifier load tokens (paths, filenames, trailing words)', () => {
-    expect(
-      parseRequestedModelLoad('Requested to load C:\\Users\\me\\secret.safetensors')
-    ).toBeNull()
-    expect(parseRequestedModelLoad('Requested to load my-private-model.safetensors')).toBeNull()
-    expect(parseRequestedModelLoad('Requested to load Lumina2 and free memory')).toBeNull()
-  })
-
-  it('parses the dynamic-VRAM prepare class name', () => {
-    expect(
-      parseDynamicVramPrepare(
-        'Model Lumina2 prepared for dynamic VRAM loading. 11738MB Staged. 0 patches attached.'
-      )
-    ).toBe('Lumina2')
-    expect(
-      parseDynamicVramPrepare(
-        'Model ZImageTEModel_ prepared for dynamic VRAM loading. 7671MB Staged.'
-      )
-    ).toBe('ZImageTEModel_')
-    expect(parseDynamicVramPrepare('Requested to load Lumina2')).toBeNull()
-    expect(parseDynamicVramPrepare('Model prepared for something else')).toBeNull()
-  })
-
-  it('parses a multi-GPU deepclone line into class + target device', () => {
-    expect(parseModelDeepclone('Creating deepclone of Lumina2 for cuda:1.')).toEqual({
-      modelClass: 'Lumina2',
-      targetDevice: 'cuda:1'
-    })
-    expect(parseModelDeepclone('Reusing loaded multigpu deepclone of Lumina2 for cuda:1')).toEqual({
-      modelClass: 'Lumina2',
-      targetDevice: 'cuda:1'
-    })
-    expect(parseModelDeepclone('Creating deepclone of ZImageTEModel_ for xpu:2')).toEqual({
-      modelClass: 'ZImageTEModel_',
-      targetDevice: 'xpu:2'
-    })
-    expect(parseModelDeepclone('Requested to load Lumina2')).toBeNull()
-    expect(parseModelDeepclone('Creating deepclone of some file.safetensors for cuda:1')).toBeNull()
-  })
-
-  it('classifies a model-load line by trigger', () => {
-    expect(parseModelLoad('Requested to load Lumina2')).toEqual({
-      modelClass: 'Lumina2',
-      trigger: 'requested'
-    })
-    expect(
-      parseModelLoad('Model AutoencodingEngine prepared for dynamic VRAM loading. 159MB Staged.')
-    ).toEqual({ modelClass: 'AutoencodingEngine', trigger: 'dynamic_prepare' })
-    expect(parseModelLoad('Creating deepclone of Lumina2 for cuda:1.')).toEqual({
-      modelClass: 'Lumina2',
-      trigger: 'deepclone',
-      targetDevice: 'cuda:1'
-    })
-    expect(parseModelLoad('unrelated noise')).toBeNull()
   })
 })
 
@@ -209,7 +136,7 @@ describe('createHardwareTap', () => {
   it('parses current ComfyUI log lines carrying a colored [LEVEL] prefix', () => {
     // ComfyUI's ColoredFormatter emits `\x1b[32m[INFO]\x1b[0m <message>`, not
     // the bare `%(message)s` the parsers are anchored against. The tap must
-    // strip ANSI then the level tag for accelerator + model-usage to fire.
+    // strip ANSI then the level tag for the accelerator event to fire.
     const tap = createHardwareTap({ installationId: 'inst-1' })
     tap.ingest('\u001b[32m[INFO]\u001b[0m Total VRAM 32607 MB, total RAM 97430 MB\n', 'stdout')
     tap.ingest('\u001b[32m[INFO]\u001b[0m pytorch version: 2.10.0+cu130\n', 'stdout')
@@ -217,7 +144,7 @@ describe('createHardwareTap', () => {
       '\u001b[32m[INFO]\u001b[0m Device: cuda:0 NVIDIA GeForce RTX 5090 : cudaMallocAsync\n',
       'stdout'
     )
-    tap.ingest('\u001b[32m[INFO]\u001b[0m Requested to load Lumina2\n', 'stdout')
+    tap.ingest('\u001b[32m[INFO]\u001b[0m Using xformers attention\n', 'stdout')
 
     const accel = captured.filter((c) => c.event === 'comfy.desktop.comfyui.accelerator_detected')
     expect(accel).toHaveLength(1)
@@ -228,14 +155,6 @@ describe('createHardwareTap', () => {
       backend: 'cudaMallocAsync',
       vram_mb: 32607,
       pytorch_version: '2.10.0+cu130'
-    })
-
-    tap.flushSummary()
-    const usage = captured.filter((c) => c.event === 'comfy.desktop.comfyui.model_usage')
-    expect(usage).toHaveLength(1)
-    expect(usage[0]!.ctx).toMatchObject({
-      model_class: 'Lumina2',
-      count: 1
     })
   })
 
@@ -322,112 +241,6 @@ describe('createHardwareTap', () => {
     })
   })
 
-  it('aggregates model loads into per-class deltas flushed on session end', () => {
-    const tap = createHardwareTap({ installationId: 'inst-1' })
-    tap.ingest('Requested to load Lumina2\n', 'stdout')
-    tap.ingest('Requested to load Lumina2\n', 'stdout')
-    tap.ingest('Requested to load AutoencodingEngine\n', 'stdout')
-    // Nothing emitted until flush.
-    expect(captured.filter((c) => c.event === 'comfy.desktop.comfyui.model_usage')).toHaveLength(0)
-
-    tap.flushSummary()
-    const usage = captured.filter((c) => c.event === 'comfy.desktop.comfyui.model_usage')
-    expect(usage).toHaveLength(2)
-    expect(usage.find((u) => u.ctx['model_class'] === 'Lumina2')!.ctx).toMatchObject({
-      count: 2
-    })
-    expect(usage.find((u) => u.ctx['model_class'] === 'AutoencodingEngine')!.ctx).toMatchObject({
-      count: 1
-    })
-  })
-
-  it('flushes deltas: a second flush only reports loads since the first', () => {
-    const tap = createHardwareTap({ installationId: 'inst-1' })
-    tap.ingest('Requested to load Lumina2\n', 'stdout')
-    tap.flushSummary()
-    tap.ingest('Requested to load Lumina2\nRequested to load Lumina2\n', 'stdout')
-    tap.flushSummary()
-    const usage = captured.filter((c) => c.event === 'comfy.desktop.comfyui.model_usage')
-    expect(usage.map((u) => u.ctx['count'])).toEqual([1, 2])
-  })
-
-  it('tags each model_usage event with its load_trigger', () => {
-    const tap = createHardwareTap({ installationId: 'inst-1' })
-    tap.ingest('Requested to load Lumina2\n', 'stdout')
-    tap.flushSummary()
-    const usage = captured.filter((c) => c.event === 'comfy.desktop.comfyui.model_usage')
-    expect(usage).toHaveLength(1)
-    expect(usage[0]!.ctx).toMatchObject({
-      model_class: 'Lumina2',
-      load_trigger: 'requested',
-      count: 1,
-      target_device: null
-    })
-  })
-
-  it('emits multi-GPU deepclones with their target device, counted per device', () => {
-    const tap = createHardwareTap({ installationId: 'inst-1' })
-    // Desktop's bundled build prefixes lines with a level tag.
-    tap.ingest('[INFO] Creating deepclone of Lumina2 for cuda:1.\n', 'stdout')
-    tap.ingest('[INFO] Reusing loaded multigpu deepclone of Lumina2 for cuda:1\n', 'stdout')
-    tap.ingest('[INFO] Creating deepclone of Lumina2 for cuda:2.\n', 'stdout')
-    tap.flushSummary()
-    const usage = captured.filter((c) => c.event === 'comfy.desktop.comfyui.model_usage')
-    expect(usage).toHaveLength(2)
-    expect(usage.find((u) => u.ctx['target_device'] === 'cuda:1')!.ctx).toMatchObject({
-      model_class: 'Lumina2',
-      load_trigger: 'deepclone',
-      count: 2
-    })
-    expect(usage.find((u) => u.ctx['target_device'] === 'cuda:2')!.ctx).toMatchObject({
-      model_class: 'Lumina2',
-      load_trigger: 'deepclone',
-      count: 1
-    })
-  })
-
-  it('counts dynamic-VRAM prepares separately from cold loads of the same class', () => {
-    const tap = createHardwareTap({ installationId: 'inst-1' })
-    tap.ingest('Requested to load Lumina2\n', 'stdout')
-    tap.ingest(
-      'Model Lumina2 prepared for dynamic VRAM loading. 11738MB Staged. 0 patches attached.\n',
-      'stdout'
-    )
-    tap.ingest(
-      'Model Lumina2 prepared for dynamic VRAM loading. 11738MB Staged. 0 patches attached.\n',
-      'stdout'
-    )
-    tap.flushSummary()
-    const usage = captured.filter((c) => c.event === 'comfy.desktop.comfyui.model_usage')
-    expect(usage).toHaveLength(2)
-    expect(usage.find((u) => u.ctx['load_trigger'] === 'requested')!.ctx).toMatchObject({
-      model_class: 'Lumina2',
-      count: 1
-    })
-    expect(usage.find((u) => u.ctx['load_trigger'] === 'dynamic_prepare')!.ctx).toMatchObject({
-      model_class: 'Lumina2',
-      count: 2
-    })
-  })
-
-  it('caps distinct model classes across the tap lifetime, not per flush', () => {
-    const tap = createHardwareTap({ installationId: 'inst-1' })
-    // MAX_TRACKED_ARCHITECTURES (60) distinct classes across two flush windows,
-    // then one more. The cap must persist across the clear() that flushSummary
-    // performs, so the 61st distinct class is rejected.
-    for (let i = 0; i < 30; i++) tap.ingest(`Requested to load Model${i}\n`, 'stdout')
-    tap.flushSummary()
-    for (let i = 30; i < 60; i++) tap.ingest(`Requested to load Model${i}\n`, 'stdout')
-    tap.ingest('Requested to load OverflowModel\n', 'stdout')
-    tap.flushSummary()
-
-    const classes = captured
-      .filter((c) => c.event === 'comfy.desktop.comfyui.model_usage')
-      .map((c) => c.ctx['model_class'])
-    expect(classes).toHaveLength(60)
-    expect(classes).not.toContain('OverflowModel')
-  })
-
   it('re-emits accelerator_detected after beginBoot (ComfyUI restart in one launch)', () => {
     const tap = createHardwareTap({ installationId: 'inst-1' })
     tap.ingest('Total VRAM 24576 MB, total RAM 65461 MB\n', 'stdout')
@@ -453,26 +266,6 @@ describe('createHardwareTap', () => {
     expect(accel[1]!.ctx).toMatchObject({ gpu_model: 'NVIDIA GeForce RTX 4080', vram_mb: 16384 })
   })
 
-  it('preserves model-usage counts across beginBoot (aggregate per launch)', () => {
-    const tap = createHardwareTap({ installationId: 'inst-1' })
-    tap.ingest('Requested to load Lumina2\n', 'stdout')
-    tap.beginBoot()
-    tap.ingest('Requested to load Lumina2\n', 'stdout')
-    tap.flushSummary()
-    const usage = captured.filter((c) => c.event === 'comfy.desktop.comfyui.model_usage')
-    expect(usage).toHaveLength(1)
-    expect(usage[0]!.ctx).toMatchObject({ model_class: 'Lumina2', count: 2 })
-  })
-
-  it('flushes a trailing unterminated load line on session end', () => {
-    const tap = createHardwareTap({ installationId: 'inst-1' })
-    tap.ingest('Requested to load Lumina2', 'stdout') // no newline
-    tap.flushSummary()
-    const usage = captured.filter((c) => c.event === 'comfy.desktop.comfyui.model_usage')
-    expect(usage).toHaveLength(1)
-    expect(usage[0]!.ctx).toMatchObject({ model_class: 'Lumina2', count: 1 })
-  })
-
   it('handles lines split across chunk boundaries', () => {
     const tap = createHardwareTap({ installationId: 'inst-1' })
     tap.ingest('Device: cuda:0 NVIDIA GeForce ', 'stdout')
@@ -487,29 +280,22 @@ describe('createHardwareTap', () => {
     const tap = createHardwareTap({ installationId: 'inst-1' })
     // Interleaved partial lines from two streams must not be concatenated into
     // a bogus combined line; each stream's buffer completes independently.
-    tap.ingest('Requested to load ', 'stdout')
+    tap.ingest('Device: cuda:0 NVIDIA GeForce ', 'stdout')
     tap.ingest('some unrelated stderr noise\n', 'stderr')
-    tap.ingest('Lumina2\n', 'stdout')
+    tap.ingest('RTX 4090 : native\n', 'stdout')
     tap.flushSummary()
-    const usage = captured.filter((c) => c.event === 'comfy.desktop.comfyui.model_usage')
-    expect(usage).toHaveLength(1)
-    expect(usage[0]!.ctx).toMatchObject({ model_class: 'Lumina2', count: 1 })
+    const accel = captured.filter((c) => c.event === 'comfy.desktop.comfyui.accelerator_detected')
+    expect(accel).toHaveLength(1)
+    expect(accel[0]!.ctx).toMatchObject({ gpu_model: 'NVIDIA GeForce RTX 4090' })
   })
 
-  it('flushes trailing unterminated lines from both stdout and stderr', () => {
+  it('flushes a trailing unterminated Device line on session end', () => {
     const tap = createHardwareTap({ installationId: 'inst-1' })
-    tap.ingest('Requested to load Lumina2', 'stdout') // no newline
-    tap.ingest('Requested to load Flux', 'stderr') // no newline
+    tap.ingest('Total VRAM 24576 MB, total RAM 65461 MB\n', 'stdout')
+    tap.ingest('Device: cuda:0 NVIDIA GeForce RTX 4090 : native', 'stdout') // no newline
     tap.flushSummary()
-    const usage = captured.filter((c) => c.event === 'comfy.desktop.comfyui.model_usage')
-    expect(usage).toHaveLength(2)
-    expect(usage).toContainEqual(
-      expect.objectContaining({
-        ctx: expect.objectContaining({ model_class: 'Lumina2', count: 1 })
-      })
-    )
-    expect(usage).toContainEqual(
-      expect.objectContaining({ ctx: expect.objectContaining({ model_class: 'Flux', count: 1 }) })
-    )
+    const accel = captured.filter((c) => c.event === 'comfy.desktop.comfyui.accelerator_detected')
+    expect(accel).toHaveLength(1)
+    expect(accel[0]!.ctx).toMatchObject({ gpu_model: 'NVIDIA GeForce RTX 4090', vram_mb: 24576 })
   })
 })

--- a/src/main/lib/hardwareTap.ts
+++ b/src/main/lib/hardwareTap.ts
@@ -4,45 +4,19 @@
  * The launcher's `system_info` event reports the GPU the OS sees, which on
  * Windows is frequently a virtual display adapter and never reflects which
  * device PyTorch actually selected for compute. ComfyUI's own startup logs
- * are the authoritative source: they print the selected accelerator, its
- * VRAM, and the architecture of every model loaded. We tail that output —
- * already piped through `proc.stdout` / `proc.stderr` in
- * `sessionActions/launch.ts`, the same stream `executionTap` consumes.
+ * are the authoritative source: they print the selected accelerator and its
+ * VRAM. We tail that output — already piped through `proc.stdout` /
+ * `proc.stderr` in `sessionActions/launch.ts`, the same stream `executionTap`
+ * consumes.
  *
- * Two signals, two shapes:
- *   - `comfy.desktop.comfyui.accelerator_detected` — emitted ONCE per boot,
- *     after the consecutive run of `Device:` lines ends (ComfyUI logs the
- *     selected device first, then one line per other GPU). Top-level fields
- *     describe the selected device (the authoritative compute GPU); every
- *     detected GPU is reported via `device_count` plus the index-aligned
- *     parallel arrays `device_types` / `device_indices` / `gpu_models` /
- *     `device_backends`. Also carries VRAM/RAM and torch/xformers versions
- *     accumulated from earlier lines.
- *   - `comfy.desktop.comfyui.model_usage` — model loads happen many times per
- *     session, so per-load events would blow past the telemetry rate limiter
- *     and corrupt the very counts we want. Instead we count loads per
- *     (model class, trigger) in memory and flush DELTAS (periodically + on
- *     session end), at most one event per distinct (class, trigger) per flush.
- *     Summing `count` gives total loads; counting distinct `installation_id`
- *     gives reach (no person-property marker needed — reach is derivable from
- *     the events). `model_class` is the loaded module's Python class name
- *     (`x.model.__class__.__name__`) — the real architecture (e.g. `Lumina2`,
- *     `Flux`), text encoder (`ZImageTEModel_`), or VAE (`AutoencodingEngine`) —
- *     NOT the sampling `model_type` enum, which can't identify an architecture.
- *     `load_trigger` distinguishes the log signals:
- *       - `requested` — "Requested to load X": a cold load (model not resident).
- *         Misses runs that reuse an already-loaded model.
- *       - `dynamic_prepare` — "Model X prepared for dynamic VRAM loading":
- *         emitted per prepare when dynamic VRAM (aimdo) is enabled, so it tracks
- *         models that stay staged across runs. Absent when dynamic VRAM is off.
- *       - `deepclone` — "Creating deepclone of X for <device>" / "Reusing loaded
- *         multigpu deepclone of X for <device>": a multi-GPU feature (MultiGPU
- *         CFG Split, per-device ControlNets, …) cloning the model onto another
- *         device. Carries `target_device` (e.g. `cuda:1`) so cross-GPU spread is
- *         visible; presence + distinct `installation_id` = who uses these
- *         features. `target_device` is null for the two load triggers.
- *     Neither load line is a perfect per-run-per-model signal on its own — see
- *     the PR discussion — but together they cover cold loads and dynamic reuse.
+ * One signal: `comfy.desktop.comfyui.accelerator_detected` — emitted ONCE per
+ * boot, after the consecutive run of `Device:` lines ends (ComfyUI logs the
+ * selected device first, then one line per other GPU). Top-level fields
+ * describe the selected device (the authoritative compute GPU); every
+ * detected GPU is reported via `device_count` plus the index-aligned
+ * parallel arrays `device_types` / `device_indices` / `gpu_models` /
+ * `device_backends`. Also carries VRAM/RAM and torch/xformers versions
+ * accumulated from earlier lines.
  *
  * Log strings parsed (current ComfyUI main branch):
  *   - "Device: cuda:0 NVIDIA GeForce RTX 4090 : native"   (model_management.py)
@@ -51,14 +25,6 @@
  *   - "Set cuda device to: 0"                              (main.py)
  *   - "Using directml with device: AMD Radeon RX 6800"     (model_management.py)
  *   - "Device: cuda:0 …" / "xpu:0 …" / "npu:0 …" / "mlu:0 …" / "cpu" / "mps"
- *   - "Requested to load Lumina2"                          (model_management.py)
- *   - "Model Lumina2 prepared for dynamic VRAM loading. …" (dynamic VRAM / aimdo)
- *   - "Creating deepclone of Lumina2 for cuda:1."          (model_patcher.py, multi-GPU)
- *   - "Reusing loaded multigpu deepclone of Lumina2 for cuda:1" (multigpu.py)
- *
- * NOTE: the architecture is the loaded class name on the `Requested to load`
- * line, NOT the `model_type <ENUM>` sampling tag — `model_type` is the same
- * `EPS` / `FLOW` for many distinct architectures and so can't identify one.
  *
  * NOTE: ComfyUI Desktop's bundled build prefixes every log line with a level
  * tag (`[INFO] Device: ...`), unlike the bare `%(message)s` format. `handleLine`
@@ -83,30 +49,6 @@ const CUDA_DEVICE_LINE = /^Set cuda device to:\s*(\d+)/i
 // separate line that precedes a nameless `Device: privateuseone` line — so it's
 // the only way to recover the model for those vendors.
 const DIRECTML_LINE = /^Using directml with device:\s*(.+)$/i
-// ComfyUI logs `Requested to load <ClassName>` once per cold GPU load, where the
-// name is the loaded module's Python class (`x.model.__class__.__name__`) — the
-// real architecture (`Lumina2`, `Flux`), text encoder (`ZImageTEModel_`), or
-// VAE (`AutoencodingEngine`). Match a whole Python identifier only: custom
-// nodes write to the same stdout, so a loose `.+` could turn an arbitrary
-// string into a high-cardinality event value. The length cap bounds a
-// pathological match.
-const REQUESTED_LOAD_LINE = /^Requested to load\s+([A-Za-z_][A-Za-z0-9_]{0,63})\s*$/
-// With dynamic VRAM (aimdo) enabled, ComfyUI logs `Model <ClassName> prepared
-// for dynamic VRAM loading. <N>MB Staged. …` per prepare — the same class name
-// as `Requested to load`, but emitted for models that stay staged across runs
-// (so it captures reuse that the cold-load line misses). Same identifier-only
-// constraint and length cap as above.
-const DYNAMIC_PREPARE_LINE =
-  /^Model\s+([A-Za-z_][A-Za-z0-9_]{0,63})\s+prepared for dynamic VRAM loading\b/
-// Multi-GPU features (MultiGPU CFG Split, per-device ControlNets, …) deepclone a
-// model onto another device. ComfyUI logs `Creating deepclone of <ClassName>
-// for <device>.` on a fresh clone (model_patcher.py) and `Reusing loaded
-// multigpu deepclone of <ClassName> for <device>` when the clone is reused
-// (multigpu.py). Either line means the install uses a deepclone-based multi-GPU
-// feature; the captured `<device>` (e.g. `cuda:1`) shows the cross-GPU spread.
-// Same identifier-only + length-cap constraint on the class as the load lines.
-const DEEPCLONE_LINE =
-  /^(?:Creating deepclone of|Reusing loaded multigpu deepclone of)\s+([A-Za-z_][A-Za-z0-9_]{0,63})\s+for\s+([a-z][a-z0-9]*(?::\d+)?)/
 
 /**
  * Parse a ComfyUI `Device:` line into its components. Handles the cuda
@@ -152,69 +94,6 @@ function parseTail(line: string, re: RegExp): string | null {
   return m && m[1] ? m[1].trim() : null
 }
 
-/**
- * How a model load/clone was observed in the logs.
- *   - `requested` / `dynamic_prepare` — a model load (see the line comments).
- *   - `deepclone` — a multi-GPU deepclone onto another device; carries a
- *     `targetDevice` the load triggers don't.
- */
-export type ModelLoadTrigger = 'requested' | 'dynamic_prepare' | 'deepclone'
-
-/** Parse "Requested to load Lumina2" → "Lumina2". */
-export function parseRequestedModelLoad(line: string): string | null {
-  return parseTail(line, REQUESTED_LOAD_LINE)
-}
-
-/** Parse "Model Lumina2 prepared for dynamic VRAM loading. …" → "Lumina2". */
-export function parseDynamicVramPrepare(line: string): string | null {
-  return parseTail(line, DYNAMIC_PREPARE_LINE)
-}
-
-/**
- * Parse a multi-GPU deepclone line → its class + target device, or null.
- * Matches both "Creating deepclone of X for cuda:1." and "Reusing loaded
- * multigpu deepclone of X for cuda:1".
- */
-export function parseModelDeepclone(
-  line: string
-): { modelClass: string; targetDevice: string } | null {
-  const m = line.match(DEEPCLONE_LINE)
-  if (!m || !m[1] || !m[2]) return null
-  return { modelClass: m[1], targetDevice: m[2] }
-}
-
-/**
- * Match any model load/clone log line, returning the class, which signal
- * produced it, and (for deepclones) the target device, or null. `Requested to
- * load` is a cold load; `Model X prepared for dynamic VRAM loading` is a
- * dynamic-VRAM (aimdo) prepare; the deepclone lines are multi-GPU clones.
- */
-export function parseModelLoad(
-  line: string
-): { modelClass: string; trigger: ModelLoadTrigger; targetDevice?: string } | null {
-  const requested = parseRequestedModelLoad(line)
-  if (requested) return { modelClass: requested, trigger: 'requested' }
-  const prepared = parseDynamicVramPrepare(line)
-  if (prepared) return { modelClass: prepared, trigger: 'dynamic_prepare' }
-  const deepclone = parseModelDeepclone(line)
-  if (deepclone)
-    return {
-      modelClass: deepclone.modelClass,
-      trigger: 'deepclone',
-      targetDevice: deepclone.targetDevice
-    }
-  return null
-}
-
-/** Flush model-usage deltas at most this often while a session keeps loading models. */
-const MODEL_USAGE_FLUSH_INTERVAL_MS = 5 * 60_000
-/**
- * Hard cap on distinct (class, trigger) keys tracked, so a malformed log can't
- * grow the map. Kept at/under the telemetry per-event-name rate limit (60/min)
- * because a flush emits every pending key synchronously into one window — a
- * larger cap would let a single full flush self-throttle and drop its tail.
- */
-const MAX_TRACKED_ARCHITECTURES = 60
 /** Cap on devices reported in one accelerator event, so a malformed log can't grow the array. */
 const MAX_DEVICES = 16
 
@@ -246,61 +125,6 @@ export function createHardwareTap(opts: {
   let cudaDeviceSet: number | null = null
   let directmlDeviceName: string | null = null
   const devices: AcceleratorInfo[] = []
-
-  // Per-(class, trigger, device) load counts since the last flush (deltas). The
-  // map key is `<trigger>\t<class>\t<device>` (device is empty for the load
-  // triggers, a device token like `cuda:1` for deepclones); `\t` can't appear in
-  // any part (trigger is a literal, class is a Python identifier, device is a
-  // `<type>:<n>` token), so it's a safe composite key.
-  const pendingCounts = new Map<string, number>()
-  // Every (class, trigger) key ever recorded by this tap. Persists across
-  // flushes (which clear `pendingCounts`) so the cardinality cap below bounds
-  // distinct `model_class` values over the tap's whole lifetime, not just the
-  // current flush window — a malformed log can't grow the event-value space.
-  const seenKeys = new Set<string>()
-
-  let flushTimer: ReturnType<typeof setInterval> | null = null
-
-  function recordLoad(
-    modelClass: string,
-    trigger: ModelLoadTrigger,
-    targetDevice: string | null
-  ): void {
-    const key = `${trigger}\t${modelClass}\t${targetDevice ?? ''}`
-    // Reject brand-new (class, trigger, device) keys once the cap is hit; keep
-    // counting ones already seen so existing series stay accurate.
-    if (!seenKeys.has(key)) {
-      if (seenKeys.size >= MAX_TRACKED_ARCHITECTURES) return
-      seenKeys.add(key)
-    }
-    pendingCounts.set(key, (pendingCounts.get(key) ?? 0) + 1)
-    ensureFlushTimer()
-  }
-
-  function emitModelUsage(): void {
-    if (pendingCounts.size === 0) return
-    for (const [key, count] of pendingCounts) {
-      if (count <= 0) continue
-      const [trigger, modelClass, targetDevice] = key.split('\t')
-      telemetry.emit('comfy.desktop.comfyui.model_usage', {
-        ...baseContext,
-        model_class: modelClass,
-        load_trigger: trigger,
-        // Only deepclones carry a target device; null keeps the column stable
-        // for the load triggers.
-        target_device: targetDevice ? targetDevice : null,
-        count
-      })
-    }
-    pendingCounts.clear()
-  }
-
-  function ensureFlushTimer(): void {
-    if (flushTimer) return
-    flushTimer = setInterval(emitModelUsage, MODEL_USAGE_FLUSH_INTERVAL_MS)
-    // Don't keep the event loop / process quit waiting on this timer.
-    flushTimer.unref?.()
-  }
 
   /**
    * Emit the single per-boot `accelerator_detected` event for the collected run
@@ -360,51 +184,42 @@ export function createHardwareTap(opts: {
     // Strip a leading `[LEVEL] ` tag (ComfyUI Desktop's bundled build) so the
     // anchored parsers below match both the prefixed and bare log formats.
     const trimmed = stripLogLevelPrefix(stripAnsi(line).trim())
-    if (trimmed.length === 0) return
+    if (trimmed.length === 0 || acceleratorEmitted) return
 
-    if (!acceleratorEmitted) {
-      const vram = parseVramLine(trimmed)
-      if (vram) {
-        vramMb = vram.vramMb
-        ramMb = vram.ramMb
-        return
-      }
-      const pytorch = parseTail(trimmed, PYTORCH_LINE)
-      if (pytorch) {
-        pytorchVersion = pytorch
-        return
-      }
-      const xformers = parseTail(trimmed, XFORMERS_LINE)
-      if (xformers) {
-        xformersVersion = xformers
-        return
-      }
-      const cudaDevice = parseTail(trimmed, CUDA_DEVICE_LINE)
-      if (cudaDevice) {
-        cudaDeviceSet = Number(cudaDevice)
-        return
-      }
-      const directml = parseTail(trimmed, DIRECTML_LINE)
-      if (directml) {
-        directmlDeviceName = directml
-        return
-      }
-      const device = parseDeviceLine(trimmed)
-      if (device) {
-        // Collect the consecutive run; the event is emitted when the run ends.
-        if (devices.length < MAX_DEVICES) devices.push(device)
-        return
-      }
-      // First non-`Device:` line after a run of them: the run is complete, so
-      // emit, then fall through (this line may itself be a model-load line).
-      if (devices.length > 0) emitAccelerator()
-    }
-
-    const load = parseModelLoad(trimmed)
-    if (load) {
-      recordLoad(load.modelClass, load.trigger, load.targetDevice ?? null)
+    const vram = parseVramLine(trimmed)
+    if (vram) {
+      vramMb = vram.vramMb
+      ramMb = vram.ramMb
       return
     }
+    const pytorch = parseTail(trimmed, PYTORCH_LINE)
+    if (pytorch) {
+      pytorchVersion = pytorch
+      return
+    }
+    const xformers = parseTail(trimmed, XFORMERS_LINE)
+    if (xformers) {
+      xformersVersion = xformers
+      return
+    }
+    const cudaDevice = parseTail(trimmed, CUDA_DEVICE_LINE)
+    if (cudaDevice) {
+      cudaDeviceSet = Number(cudaDevice)
+      return
+    }
+    const directml = parseTail(trimmed, DIRECTML_LINE)
+    if (directml) {
+      directmlDeviceName = directml
+      return
+    }
+    const device = parseDeviceLine(trimmed)
+    if (device) {
+      // Collect the consecutive run; the event is emitted when the run ends.
+      if (devices.length < MAX_DEVICES) devices.push(device)
+      return
+    }
+    // First non-`Device:` line after a run of them: the run is complete.
+    if (devices.length > 0) emitAccelerator()
   }
 
   // Separate per-stream buffers: stdout and stderr arrive as independent
@@ -418,9 +233,9 @@ export function createHardwareTap(opts: {
   }
 
   function appendChunk(source: 'stdout' | 'stderr', chunk: string): string[] {
-    // Split first so a large chunk's complete lines (e.g. `Device:` /
-    // `Requested to load`) are never lost; cap only the unterminated tail we
-    // carry over, which is the sole unbounded-growth risk.
+    // Split first so a large chunk's complete lines (e.g. `Device:`) are never
+    // lost; cap only the unterminated tail we carry over, which is the sole
+    // unbounded-growth risk.
     const lines = (pendingBySource[source] + chunk).split(/\r?\n/)
     const tail = lines.pop() ?? ''
     pendingBySource[source] =
@@ -444,8 +259,7 @@ export function createHardwareTap(opts: {
      * ComfyUI several times (port/reboot retries, model-folder relaunch,
      * Manager restarts), each reusing this tap. Without this, only the first
      * boot would emit `accelerator_detected` and stale fields would suppress
-     * later boots. Model-usage counts intentionally persist across reboots —
-     * they aggregate per launch, not per boot.
+     * later boots.
      */
     beginBoot(): void {
       acceleratorEmitted = false
@@ -462,12 +276,8 @@ export function createHardwareTap(opts: {
     },
     flushSummary(): void {
       try {
-        if (flushTimer) {
-          clearInterval(flushTimer)
-          flushTimer = null
-        }
-        // Process complete-but-unterminated final lines so trailing model
-        // loads aren't dropped when the process exits without a newline.
+        // Process complete-but-unterminated final lines so a trailing `Device:`
+        // line isn't dropped when the process exits without a newline.
         for (const source of ['stdout', 'stderr'] as const) {
           const pending = pendingBySource[source]
           if (pending.trim()) handleLine(pending)
@@ -476,7 +286,6 @@ export function createHardwareTap(opts: {
         // Emit the accelerator event if the process exited right after its
         // `Device:` lines with no following line to close the run.
         emitAccelerator()
-        emitModelUsage()
       } catch {
         // ignore – telemetry side effect, not user-visible
       }

--- a/src/main/lib/ipc/sessionActions/launch.ts
+++ b/src/main/lib/ipc/sessionActions/launch.ts
@@ -1116,7 +1116,7 @@ async function runLaunch(
 
   async function spawnComfy(): Promise<{ proc: ChildProcess; getStderr: () => string }> {
     // Reset per-boot accelerator state so each (re)spawn re-emits
-    // accelerator_detected; model-usage counts persist across the launch.
+    // accelerator_detected.
     hwTap.beginBoot()
     const p = spawnProcess(launchCmd.cmd!, launchCmd.args!, launchCmd.cwd!, launchEnv, {
       showWindow: launchCmd.showWindow
@@ -1331,7 +1331,7 @@ async function runLaunch(
     _clearLaunchingFailed(installationId)
     // Flush the hardware tap on terminal failure/cancel too: the exit handler
     // covers a process that exits, but a waitForPort timeout can return here
-    // with the proc still alive, leaving the model-usage flush interval armed.
+    // with the proc still alive, leaving a pending accelerator event unemitted.
     // flushSummary is idempotent, so a later exit re-flush is harmless.
     hwTap.flushSummary()
     if (launchResult.cancelled) {
@@ -1460,8 +1460,8 @@ async function runLaunch(
         logStream.end()
         await killProcessTree(proc)
         // This relaunch path returns before the normal exit handler is
-        // attached; flush so pending model-usage deltas aren't dropped and the
-        // hardware-tap interval doesn't stay armed. flushSummary is idempotent.
+        // attached; flush so a pending accelerator event isn't dropped.
+        // flushSummary is idempotent.
         execTap.flushSummary()
         hwTap.flushSummary()
         _removeSession(installationId)


### PR DESCRIPTION
## Why

`comfy.desktop.comfyui.model_usage` ships **~46M events/month from ~347k installs** into PostHog — and onward into Snowflake via the `Events to Snowflake (Prod)` batch export — with effectively no readers:

- **PostHog**: zero insights (searched the query JSON of all saved + deleted insights, not just names), zero dashboards, alerts, cohorts, actions, experiments, notebooks, CDP destinations, or saved SQL views reference the event.
- **Snowflake / data-platform (dbt)**: nothing selects the event by name or touches its `model_class` / `load_trigger` properties. It only passes through the generic `stg_posthog__events` → `int_events_unified` layers as anonymous `comfy_desktop` rows. (`fct_cloud_model_usage` is the cloud backend's unrelated `model_usage` event.) Desktop run metrics key on `comfy.desktop.execution.session_summary`.
- The only consumer ever was a one-off HogQL analysis in `comfy-desktop-metrics` (`queries/model_class_by_custom_node.sql`, findings 2026-07-08). That query stops working, by design; everything else is unaffected.

## What

- Remove the model-load half of the hardware tap: the three log-line parsers (`Requested to load` / dynamic-VRAM prepare / multi-GPU deepclone), the per-(class, trigger, device) delta counter, the cardinality cap, and the 5-minute flush interval.
- `accelerator_detected` is untouched, and the tap keeps its `ingest` / `beginBoot` / `flushSummary` interface — `flushSummary` still drains unterminated trailing lines and emits a pending accelerator event.
- The two stream-buffering tests that used model-load lines (stdout/stderr splice guard, trailing unterminated line) are rewritten against `Device:` lines so those guarantees stay covered.
- Update the three `launch.ts` comments that referenced the model-usage flush interval.

## Testing

- Full unit suite: 226 files / 3,678 tests pass.
- `typecheck`, `eslint`, `prettier --check` clean.