### PR TITLE
Remove duplicate per-execution telemetry events

### DIFF
--- a/src/main/lib/executionTap.test.ts
+++ b/src/main/lib/executionTap.test.ts
@@ -28,21 +28,17 @@ describe('executionTap', () => {
     vi.restoreAllMocks()
   })
 
-  it('emits started when "got prompt" appears in stdout', () => {
+  it('aggregates starts and completions into the session summary', () => {
     const tap = createExecutionTap({ installationId: 'inst-1' })
-    tap.ingest('got prompt\n', 'stdout')
-    expect(captured.map((c) => c.event)).toEqual(['comfy.desktop.execution.started'])
-    expect(captured[0]!.ctx).toMatchObject({ installation_id: 'inst-1', started_count: 1 })
-  })
+    tap.ingest('got prompt\ngot prompt\nPrompt executed in 12.5 seconds\n', 'stdout')
+    tap.flushSummary()
 
-  it('emits completed with parsed duration_seconds', () => {
-    const tap = createExecutionTap({ installationId: 'inst-1' })
-    tap.ingest('got prompt\nPrompt executed in 12.5 seconds\n', 'stdout')
-    const completed = captured.find((c) => c.event === 'comfy.desktop.execution.completed')
-    expect(completed).toBeDefined()
-    expect(completed!.ctx).toMatchObject({
+    expect(captured.map((c) => c.event)).not.toContain('comfy.desktop.execution.started')
+    expect(captured.map((c) => c.event)).not.toContain('comfy.desktop.execution.completed')
+    const summary = captured.find((c) => c.event === 'comfy.desktop.execution.session_summary')
+    expect(summary!.ctx).toMatchObject({
       installation_id: 'inst-1',
-      duration_seconds: 12.5,
+      started_count: 2,
       completed_count: 1
     })
   })
@@ -87,7 +83,7 @@ describe('executionTap', () => {
   it('parses current ComfyUI log lines carrying a colored [LEVEL] prefix', () => {
     // ComfyUI's ColoredFormatter emits `\x1b[32m[INFO]\x1b[0m got prompt` etc.,
     // not the bare strings the anchored patterns expect — ANSI must be stripped
-    // before the level tag for the funnel events to fire.
+    // before the level tag for the aggregate counters and errors to update.
     const tap = createExecutionTap({ installationId: 'inst-1' })
     tap.ingest('\u001b[32m[INFO]\u001b[0m got prompt\n', 'stdout')
     tap.ingest('\u001b[32m[INFO]\u001b[0m Prompt executed in 7.78 seconds\n', 'stdout')
@@ -98,10 +94,8 @@ describe('executionTap', () => {
     // Deferred validation error flushes when the block ends.
     tap.flushSummary()
 
-    const started = captured.find((c) => c.event === 'comfy.desktop.execution.started')
-    expect(started).toBeDefined()
-    const completed = captured.find((c) => c.event === 'comfy.desktop.execution.completed')
-    expect(completed!.ctx).toMatchObject({ duration_seconds: 7.78, completed_count: 1 })
+    const summary = captured.find((c) => c.event === 'comfy.desktop.execution.session_summary')
+    expect(summary!.ctx).toMatchObject({ started_count: 1, completed_count: 1, error_count: 1 })
     const err = captured.find((c) => c.event === 'comfy.desktop.execution.error')
     expect(err!.ctx).toMatchObject({ error_class: 'validation_failed', node_id: '9' })
   })
@@ -357,15 +351,16 @@ describe('executionTap', () => {
     expect(String(err!.ctx.error_message)).toContain('Value not in list')
   })
 
-  it('caps promptStartTimes so unpaired starts cannot grow unbounded', () => {
+  it('retains error wall-clock tracking after many unpaired starts', () => {
     const tap = createExecutionTap({ installationId: 'inst-1' })
     // Far more than the cap (256).
     for (let i = 0; i < 1000; i++) tap.ingest('got prompt\n', 'stdout')
-    // Then complete one — wall_clock_ms should still be a finite number.
-    tap.ingest('Prompt executed in 1 seconds\n', 'stdout')
-    const completed = captured.find((c) => c.event === 'comfy.desktop.execution.completed')
-    expect(completed).toBeDefined()
-    expect(typeof completed!.ctx.wall_clock_ms).toBe('number')
+    tap.ingest(
+      ['Traceback (most recent call last):', 'RuntimeError: boom', '', 'next-line'].join('\n'),
+      'stderr'
+    )
+    const error = captured.find((c) => c.event === 'comfy.desktop.execution.error')
+    expect(typeof error!.ctx.wall_clock_ms).toBe('number')
   })
 
   it('emits a session_summary on flush even when nothing was captured', () => {
@@ -385,9 +380,9 @@ describe('executionTap', () => {
     const tap = createExecutionTap({ installationId: 'inst-1' })
     tap.ingest('got pro', 'stdout')
     tap.ingest('mpt\nPrompt executed in 2 seconds\n', 'stdout')
-    const events = captured.map((c) => c.event)
-    expect(events).toContain('comfy.desktop.execution.started')
-    expect(events).toContain('comfy.desktop.execution.completed')
+    tap.flushSummary()
+    const summary = captured.find((c) => c.event === 'comfy.desktop.execution.session_summary')
+    expect(summary!.ctx).toMatchObject({ started_count: 1, completed_count: 1 })
   })
 
   it('redacts Bearer tokens and api keys from traceback messages (secret scrub)', () => {

--- a/src/main/lib/executionTap.ts
+++ b/src/main/lib/executionTap.ts
@@ -8,7 +8,7 @@
  *
  * Patterns we detect (current ComfyUI main branch):
  *   - "got prompt"                        → execution started
- *   - "Prompt executed in X.X seconds"    → execution completed (with duration)
+ *   - "Prompt executed in X.X seconds"    → execution completed
  *   - "Failed to validate prompt"         → validation error
  *   - Python tracebacks                   → execution error
  *
@@ -176,11 +176,9 @@ export function createExecutionTap(opts: {
       }
     }
     state.errorCount++
-    // Wall-clock between the matching `Got prompt` and the error end —
-    // mirror what `execution.completed` already emits so error-vs-success
-    // duration can be compared directly on the dashboard. Null when the
-    // error fired without a paired start (already-pending traceback at
-    // boot, etc.).
+    // Wall-clock between the matching `Got prompt` and the error end. Null
+    // when the error fired without a paired start (already-pending traceback
+    // at boot, etc.).
     const wallMs = consumePromptStart()
     // Standard error schema derived from the final exception line (class /
     // message / bucket / signature).
@@ -265,24 +263,14 @@ export function createExecutionTap(opts: {
     if (PROMPT_GOT.test(trimmed)) {
       state.startedCount++
       pushPromptStart()
-      telemetry.emit('comfy.desktop.execution.started', {
-        ...baseContext,
-        started_count: state.startedCount
-      })
       return
     }
 
-    const doneMatch = trimmed.match(PROMPT_DONE)
-    if (doneMatch?.groups) {
-      const seconds = Number(doneMatch.groups['seconds'])
-      const wallMs = consumePromptStart()
+    if (PROMPT_DONE.test(trimmed)) {
+      // Keep the timing queue paired so a later failed prompt receives the
+      // correct start time in its error event.
+      consumePromptStart()
       state.completedCount++
-      telemetry.emit('comfy.desktop.execution.completed', {
-        ...baseContext,
-        duration_seconds: Number.isFinite(seconds) ? seconds : null,
-        wall_clock_ms: wallMs,
-        completed_count: state.completedCount
-      })
       emitFirstCompletedIfNeeded()
       return
     }
@@ -386,8 +374,8 @@ export function createExecutionTap(opts: {
       ) {
         emitTracebackError()
       }
-      // Per-session summary so analytics always has a row, even if a session
-      // produced no individual prompt events.
+      // Per-session summary so analytics always has a row, even if the session
+      // produced no prompts.
       telemetry.emit('comfy.desktop.execution.session_summary', {
         ...baseContext,
         started_count: state.startedCount,

--- a/src/main/lib/ipc/launchCancel.test.ts
+++ b/src/main/lib/ipc/launchCancel.test.ts
@@ -21,6 +21,7 @@ import {
   _endLaunch,
   _hasActiveLaunch,
   _operationAborts,
+  cancelAll,
   cancelLaunching,
   _test_addRunningSession,
   _test_clearRunningSessions
@@ -34,6 +35,17 @@ afterEach(() => {
   _operationAborts.delete(INSTALL)
   _test_clearRunningSessions()
   expect(_hasActiveLaunch(INSTALL)).toBe(false)
+})
+
+describe('cancelAll', () => {
+  it('flushes running-session telemetry synchronously before process teardown', () => {
+    const flushTelemetry = vi.fn()
+    _test_addRunningSession(INSTALL, 'install-under-test-name', flushTelemetry)
+
+    cancelAll()
+
+    expect(flushTelemetry).toHaveBeenCalledOnce()
+  })
 })
 
 describe('launch tracking (_beginLaunch/_endLaunch/_hasActiveLaunch)', () => {

--- a/src/main/lib/ipc/sessionActions/launch.ts
+++ b/src/main/lib/ipc/sessionActions/launch.ts
@@ -925,7 +925,16 @@ async function runLaunch(
     const mode = (inst.launchMode as string | undefined) || 'window'
     _addSession(
       installationId,
-      { proc, port: 0, mode, installationName: inst.name },
+      {
+        proc,
+        port: 0,
+        mode,
+        installationName: inst.name,
+        flushTelemetry: () => {
+          execTap.flushSummary()
+          hwTap.flushSummary()
+        }
+      },
       Date.now() - launchStartedAt
     )
 
@@ -1384,7 +1393,16 @@ async function runLaunch(
   const bootTimeMs = Date.now() - launchStartedAt
   _addSession(
     installationId,
-    { proc, port: launchCmd.port!, mode, installationName: inst.name },
+    {
+      proc,
+      port: launchCmd.port!,
+      mode,
+      installationName: inst.name,
+      flushTelemetry: () => {
+        execTap.flushSummary()
+        hwTap.flushSummary()
+      }
+    },
     bootTimeMs,
     { portRetries, rebootRetries }
   )

--- a/src/main/lib/ipc/shared.ts
+++ b/src/main/lib/ipc/shared.ts
@@ -272,6 +272,8 @@ export interface SessionInfo {
   mode: string
   installationName: string
   startedAt: number
+  /** Synchronously queue final telemetry before app-level shutdown drains the SDK. */
+  flushTelemetry?: () => void
 }
 
 export interface LaunchCallbackInfo {
@@ -1034,7 +1036,7 @@ export {
 
 export function _addSession(
   installationId: string,
-  { proc, port, url, mode, installationName }: Omit<SessionInfo, 'startedAt'>,
+  { proc, port, url, mode, installationName, flushTelemetry }: Omit<SessionInfo, 'startedAt'>,
   bootTimeMs?: number,
   /** Spawn-retry counts for THIS boot, folded onto the broadcast so the
    *  renderer's `instance_started` telemetry can carry them without a
@@ -1048,6 +1050,7 @@ export function _addSession(
     url,
     mode,
     installationName,
+    flushTelemetry,
     startedAt: Date.now()
   })
   // Clear the launching marker first so subscribers never double-count this id across the
@@ -1614,13 +1617,18 @@ export async function getActiveDetails(): Promise<QuitActiveItem[]> {
 /** Test-only: register a synthetic running session without spawning ComfyUI. Mirrors
  *  `_addSession`'s side effects so the REQUIRES_STOPPED guard fires; `stopRunning` handles
  *  the null `proc`. Called only via `__e2e.seedRunningSession`. */
-export function _test_addRunningSession(installationId: string, installationName: string): void {
+export function _test_addRunningSession(
+  installationId: string,
+  installationName: string,
+  flushTelemetry?: () => void
+): void {
   _runningSessions.set(installationId, {
     proc: null,
     port: 0,
     url: undefined,
     mode: 'window',
     installationName,
+    flushTelemetry,
     startedAt: Date.now()
   })
   _broadcastToRenderer('instance-started', {
@@ -1646,5 +1654,15 @@ export function cancelAll(): void {
     abort.abort()
   }
   _operationAborts.clear()
-  stopRunning()
+  // `before-quit` starts draining PostHog before asynchronous process kills
+  // settle. Queue each session's final summary synchronously so shutdown cannot
+  // clear the client before the process-exit handlers get a chance to flush.
+  for (const session of _runningSessions.values()) {
+    try {
+      session.flushTelemetry?.()
+    } catch {
+      // Telemetry must never block application teardown.
+    }
+  }
+  void stopRunning()
 }

--- a/src/main/lib/telemetry.test.ts
+++ b/src/main/lib/telemetry.test.ts
@@ -403,7 +403,7 @@ describe('telemetry default event properties', () => {
 
     // A main-process event and a renderer-routed event both go through
     // capture(), so both must carry installation_id from the defaults.
-    telemetry.capture('comfy.desktop.execution.completed', { foo: 'bar' })
+    telemetry.capture('comfy.desktop.execution.session_summary', { foo: 'bar' })
     telemetry.capture('comfy.desktop.template.fork', { template_id: 't1' })
 
     expect(captured).toHaveLength(2)
@@ -667,13 +667,11 @@ describe('telemetry SDK-level privacy safety nets', () => {
 
   it('leaves non-string property types untouched', () => {
     captured.length = 0
-    telemetry.capture('comfy.desktop.execution.completed', {
-      duration_seconds: 12.5,
+    telemetry.capture('comfy.desktop.execution.session_summary', {
       completed_count: 7,
       crashed: false
     })
     const props = captured[0]!.properties
-    expect(props?.duration_seconds).toBe(12.5)
     expect(props?.completed_count).toBe(7)
     expect(props?.crashed).toBe(false)
   })
@@ -690,7 +688,7 @@ describe('telemetry consent state (3-state)', () => {
     bindTestAnonymous('test-distinct-id')
     captured.length = 0
 
-    telemetry.capture('comfy.desktop.execution.started', { foo: 'bar' })
+    telemetry.capture('comfy.desktop.session.started', { foo: 'bar' })
     telemetry.capture('comfy.desktop.first_use.consent_decision', { accepted: false })
 
     const events = captured.map((c) => c.event)
@@ -708,7 +706,7 @@ describe('telemetry consent state (3-state)', () => {
     bindTestAnonymous('test-distinct-id')
     captured.length = 0
 
-    telemetry.capture('comfy.desktop.execution.started', {})
+    telemetry.capture('comfy.desktop.session.started', {})
     telemetry.capture('comfy.desktop.first_use.consent_decision', {
       decision: 'decline',
       telemetry_enabled: false

--- a/src/main/lib/telemetry.ts
+++ b/src/main/lib/telemetry.ts
@@ -342,9 +342,8 @@ function isAllowedToFire(event: string): boolean {
  *
  * Layer 1: per-event-name sliding window.
  *   Drop further emits of the same event name once 60 fire in 60s.
- *   60/min is well above any legitimate product event rate (the
- *   loudest healthy event was `execution.completed` at ~36/user/day)
- *   and well below any loop signature (the incident was ~2/sec).
+ *   60/min is well above any legitimate product event rate and well below
+ *   any loop signature (the incident was ~2/sec).
  *   One `comfy.desktop.telemetry.rate_limited` warning fires per (event ×
  *   process) so dashboards surface that it happened.
  *


### PR DESCRIPTION
## What changed

- stop emitting the native `comfy.desktop.execution.started` and `comfy.desktop.execution.completed` events for every prompt
- keep the frontend `execution_start` and `execution_success` events; Desktop continues relaying them through main with host-authoritative `client=desktop` and `deployment`
- keep aggregating native started/completed/error counters into `comfy.desktop.execution.session_summary`
- preserve `comfy.desktop.execution.first_completed` and execution error telemetry
- synchronously queue session summaries before telemetry shutdown during app quit
- update telemetry tests and stale references to the removed native event names

## Why

The native pair duplicates execution telemetry already available from the frontend relay and repeats aggregate counters already reported by the session summary at much higher event volume. Existing native-identity count analytics can use `sum(started_count)` and `sum(completed_count)` from the summary. Per-execution UI analytics can use the relayed frontend events filtered to `client=desktop` and the appropriate `deployment`.

This intentionally removes native per-prompt duration and timestamp granularity. The relayed frontend events remain the per-execution source; the native session summary remains the aggregate source.

## Analytics migration

- the data platform already consumes `comfy.desktop.execution.session_summary`; no data-platform code change is required
- direct repository consumers are migrated in [comfy-desktop-metrics#1](https://github.com/Comfy-Org/comfy-desktop-metrics/pull/1)
- 30 current PostHog insights were migrated to the preserved relayed events, including all 10 shared dashboard tiles
- only six explicitly version-pinned v1.0.24 insights retain the native event names as historical snapshots
- production PostHog schema, identity overlap, and summary counter expressions were verified against live data

## User impact

No execution behavior changes. This reduces Desktop telemetry volume while retaining per-execution frontend telemetry, per-session run counts, activation tracking, and error reporting.

## Validation

- focused tests: `launchCancel`, `sessionActions/launch`, `executionTap`, and `telemetry` (145 tests)
- focused Prettier and ESLint checks
- `git diff --check`
- repository commit hooks: full typecheck and lint
- GitHub CI