### PR TITLE
fix(comfybuilder): read the windows interpreter from venv/base

### DIFF
--- a/src/main/comfybuilder/launch.test.ts
+++ b/src/main/comfybuilder/launch.test.ts
@@ -27,6 +27,15 @@ describe('launch', () => {
     expect(venvPython(dir)).toBe(isWin ? path.join(dir, 'venv', 'python.exe') : path.join(dir, 'venv', 'bin', 'python3'))
   })
 
+  it.runIf(isWin)('venvPython prefers the staged windows interpreter at venv/base', () => {
+    const staged = path.join(dir, 'venv', 'base', 'python.exe')
+    fs.mkdirSync(path.dirname(staged), { recursive: true })
+    fs.writeFileSync(staged, '')
+    // Current archives stage it below the venv root; that placement is what keeps the
+    // venv's entry points relocatable (Comfy-Org/cloud#6138).
+    expect(venvPython(dir)).toBe(staged)
+  })
+
   it('builds a spec that drives the venv python against ComfyUI/main.py', () => {
     const p = path.join(dir, 'install')
     layout(p)

--- a/src/main/comfybuilder/launch.ts
+++ b/src/main/comfybuilder/launch.ts
@@ -14,11 +14,22 @@ import type { LaunchSpec } from './types'
 
 const DEFAULT_LAUNCH_ARGS = '--enable-manager'
 
-/** The archive's bundled interpreter. */
+/**
+ * The archive's bundled interpreter.
+ *
+ * Windows archives stage the interpreter one level below the venv root, at
+ * `venv/base/python.exe`. That placement is what keeps the venv relocatable: CPython
+ * resolves a venv's `sys.prefix` as `dirname(dirname(executable))`, so an interpreter
+ * sitting AT the venv root resolves to the venv's parent and every entry point uv writes
+ * bakes an absolute build path (Comfy-Org/cloud#6138). POSIX already had this shape via
+ * `venv/bin/`.
+ *
+ * Falls back to the old root path so archives cut before that change still launch.
+ */
 export function venvPython(installPath: string): string {
-  return process.platform === 'win32'
-    ? path.join(installPath, 'venv', 'python.exe')
-    : path.join(installPath, 'venv', 'bin', 'python3')
+  if (process.platform !== 'win32') return path.join(installPath, 'venv', 'bin', 'python3')
+  const staged = path.join(installPath, 'venv', 'base', 'python.exe')
+  return fs.existsSync(staged) ? staged : path.join(installPath, 'venv', 'python.exe')
 }
 
 export interface LaunchOptions {


### PR DESCRIPTION
### TL;DR

Windows archives now stage the interpreter at `venv/base/python.exe` instead of `venv/python.exe`. This points `venvPython()` at it, with a fallback so older archives still launch.

### Intent (Why)

The builder's shipped venv had every uv-written entry point (`huggingface-cli`, `torchrun`, and anything a custom node shells out to) baking the absolute build path, so they died the moment the archive was extracted anywhere else. On a real native-built Windows archive, **137 of 143 `.exe` trampolines** embedded `C:\comfy\workspace\venv\python.exe` — a path that never exists on a user's machine.

Fixing that required moving the interpreter. CPython resolves a venv's `sys.prefix` as `dirname(dirname(executable))` — PEP 405 expects the interpreter one level below the venv root. POSIX already satisfied that via `venv/bin/`. A Windows python-build-standalone tree puts `python.exe` at *its* root, so staged directly into `venv/` the interpreter sat beside `pyvenv.cfg`, `sys.prefix` resolved to the venv's **parent**, and uv installed packages outside the archive entirely.

Builder side: Comfy-Org/cloud#6138, merged.

### Decision

Prefer `venv/base/python.exe` on Windows, fall back to `venv/python.exe` when absent.

The fallback is deliberate. Nothing has shipped to users, but internal installs from the Desktop Distribution launch may hold pre-change archives, and a fallback costs one line versus making those unlaunchable. POSIX is untouched.

### Illustration of the change

```mermaid
flowchart LR
    A["venvPython(installPath)"] -->|"win32"| B{"venv/base/python.exe exists?"}
    A -->|"posix"| C["venv/bin/python3"]
    B -->|"yes"| D["venv/base/python.exe<br/>(current archives)"]
    B -->|"no"| E["venv/python.exe<br/>(pre-#6138 archives)"]
```

### Validation

```bash
npx vitest run src/main/comfybuilder/launch.test.ts
```

Existing per-platform assertion still covers the fallback. Added a Windows-only case asserting `venv/base` wins when staged — it skips on non-Windows runners, so on macOS/Linux CI the new branch is typechecked but not executed. The builder-side behaviour it mirrors was verified on the real Windows build image in cloud#6138, both directions.

`typecheck:node` clean.

**Note on branches:** this targets the desktop initial-launch feature branch `comfy-builder`. Other in-flight branches carrying `launch.ts` (`james/builder-ux`, `james/comfybuilder-artifact-install`, `james/comfybuilder-desktop-e2e`) need the same one-liner when they rebase.
