### PR TITLE
feat(templates): lead with video and swap in the open-source MiniMax H3

### DIFF
--- a/src/main/sources/standalone/curatedTemplates.ts
+++ b/src/main/sources/standalone/curatedTemplates.ts
@@ -40,8 +40,8 @@ export type CuratedTemplate = CuratedTemplateBase &
 
 /** Tab order in the picker — one tab per modality that has ≥1 curated template. */
 export const TEMPLATE_MODALITY_ORDER: readonly TemplateModality[] = [
-  'image',
   'video',
+  'image',
   '3d',
   'audio'
 ]
@@ -165,13 +165,14 @@ export const CURATED_TEMPLATES: readonly CuratedTemplate[] = [
 
   // --- Video ---
   {
-    id: 'text_to_video_wan',
+    id: 'video_minimax_h3_t2v',
     modality: 'video',
     recommended: true,
     snapshot: {
-      title: 'Wan 2.1 Text to Video',
-      description: 'Generate videos from text prompts using Wan 2.1.',
-      sizeBytes: 9824737690,
+      title: 'MiniMax H3: Text to Video',
+      description:
+        'Generate video with native stereo audio directly from a text prompt using MiniMax H3, an omni-modal model that synthesizes voice, sound effects, and music in a single pass. Output is up to 2K resolution, 24fps, and roughly 15 seconds long, with no file inputs required — just a prompt to one video output. Ideal for rapid concept visualization, social media content creation, and audio-synced storytelling.',
+      sizeBytes: 56908316672,
       mediaSubtype: 'webp'
     }
   },

--- a/src/main/sources/standalone/index.test.ts
+++ b/src/main/sources/standalone/index.test.ts
@@ -251,8 +251,13 @@ describe('standalone.getFieldOptions bundledTemplate', () => {
     const options = await standalone.getFieldOptions!('bundledTemplate', {}, {})
     const skip = options.find((o) => o.value === NO_TEMPLATE_VALUE)!
     expect(skip.recommended).toBeFalsy()
+    // Options come back in tab order, which the manifest does not follow.
     const recommendedIds = options.filter((o) => o.recommended).map((o) => o.value)
-    expect(recommendedIds).toEqual(CURATED_TEMPLATES.filter((t) => t.recommended).map((t) => t.id))
+    expect(recommendedIds.sort()).toEqual(
+      CURATED_TEMPLATES.filter((t) => t.recommended)
+        .map((t) => t.id)
+        .sort()
+    )
   })
 
   it('falls back to snapshot metadata when the index fetch fails (offline)', async () => {

--- a/src/renderer/src/components/TemplatePickerStep.test.ts
+++ b/src/renderer/src/components/TemplatePickerStep.test.ts
@@ -57,9 +57,9 @@ function mountPicker(
 describe('TemplatePickerStep', () => {
   it('renders one tab per populated modality, excluding the none sentinel', () => {
     const tabs = mountPicker().findAll('[role="tab"]')
-    expect(tabs).toHaveLength(2) // Image + Video
-    expect(tabs[0]!.text()).toContain('Image')
-    expect(tabs[1]!.text()).toContain('Video')
+    expect(tabs).toHaveLength(2) // Video + Image
+    expect(tabs[0]!.text()).toContain('Video')
+    expect(tabs[1]!.text()).toContain('Image')
   })
 
   it("shows only the active tab's templates and never the none sentinel", () => {
@@ -72,7 +72,7 @@ describe('TemplatePickerStep', () => {
 
   it('switches visible templates when another tab is clicked', async () => {
     const wrapper = mountPicker()
-    await wrapper.findAll('[role="tab"]')[1]!.trigger('click') // Video
+    await wrapper.findAll('[role="tab"]')[0]!.trigger('click') // Video
     const rows = wrapper.findAll('button[role="radio"]')
     expect(rows).toHaveLength(1)
     expect(rows[0]!.text()).toContain('Wan Video')

--- a/src/renderer/src/composables/useTemplateTabs.test.ts
+++ b/src/renderer/src/composables/useTemplateTabs.test.ts
@@ -25,9 +25,9 @@ function setup(options: FieldOption[], selectedValue: string | null = null) {
 }
 
 describe('useTemplateTabs', () => {
-  it('builds one tab per populated modality, in Image → Video → 3D → Audio order', () => {
+  it('builds one tab per populated modality, in Video → Image → 3D → Audio order', () => {
     const { tabs } = setup([NONE, AUD, THREED, VID, IMG_A])
-    expect(tabs.value.map((tab) => tab.modality)).toEqual(['image', 'video', '3d', 'audio'])
+    expect(tabs.value.map((tab) => tab.modality)).toEqual(['video', 'image', '3d', 'audio'])
   })
 
   it('counts templates per modality', () => {

--- a/src/renderer/src/composables/useTemplateTabs.ts
+++ b/src/renderer/src/composables/useTemplateTabs.ts
@@ -5,7 +5,7 @@ import type { FieldOption } from '../types/ipc'
 /** Modality tab order + its glyph. Mirrors the main-process curated manifest's
  *  `TEMPLATE_MODALITY_ORDER`; kept here so the renderer owns its own UI ordering
  *  without reaching across the process boundary. */
-const MODALITY_ORDER = ['image', 'video', '3d', 'audio'] as const
+const MODALITY_ORDER = ['video', 'image', '3d', 'audio'] as const
 type Modality = (typeof MODALITY_ORDER)[number]
 
 const MODALITY_GLYPH: Record<Modality, Component> = {


### PR DESCRIPTION
## Summary

The picker now leads with Video instead of Image, and the recommended video template is the open-source MiniMax H3 build rather than Wan 2.1.

## Changes

**What**

- Video tab moves ahead of Image, in both the manifest order and the renderer's mirror of it.
- The recommended video pick becomes `video_minimax_h3_t2v`, the open-source MiniMax H3 (native stereo audio, up to 2K, ~15s, no file inputs), replacing Wan 2.1 Text to Video.
- Three tests hardcoded Image-first; the recommended-picks assertion now compares sets, since options come back in tab order and the manifest does not follow it.

**Breaking**

None. Tab grouping, the API-node slot, deeplinks, and the disk gate are unchanged.

## Review Focus

MiniMax H3 is **56.9 GB** against Wan 2.1's 9.8 GB, so the default video pick is now ~6x heavier and the largest template in the picker. Two knock-ons worth a decision:

- It is auto-selected on the first tab a user lands on, so the default install path is a 56.9 GB download unless they change it.
- `diskTooSmallForAnyTemplate` keys off the cheapest model-bearing template, so the picker still shows, but this card will be disk-blocked on many machines.

`video_minimax_h3_r2v` and `video_minimax_h3_i2v` are the same size, so there is no lighter H3 variant. If the weight is a problem, keeping Wan 2.1 as recommended and putting H3 in a non-default slot preserves both.

## Testing

`pnpm typecheck` and `pnpm lint` clean, 3689 tests passing. `TitlePopupApp` fails only under full-suite parallelism and passes in isolation, unchanged from before this branch.

Manual: open the picker and confirm Video is the first tab with MiniMax H3 selected, that its size reads ~57 GB, and that switching to Image still shows the Z-Image-Turbo default.

<img width="1276" height="860" alt="image" src="https://github.com/user-attachments/assets/2bdd438f-79d3-497b-b0ad-d4ccd8bda522" />

