### PR TITLE
fix(billing): open credits checkout in the system browser

### DIFF
--- a/src/main/host/createHostWindow.ts
+++ b/src/main/host/createHostWindow.ts
@@ -255,7 +255,6 @@ function injectMacPasskeyWarning(childWindow: BrowserWindow): void {
   childWindow.webContents.on('did-navigate-in-page', inject)
 }
 
-
 /** Max wait for the host reload to paint before closing the popup
  *  anyway, so a stalled reload can't trap the user on checkout. */
 const CHECKOUT_RELOAD_TIMEOUT_MS = 4000

--- a/src/main/host/createHostWindow.ts
+++ b/src/main/host/createHostWindow.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, WebContentsView, ipcMain, screen, shell } from 'electron'
+import { BrowserWindow, WebContentsView, ipcMain, shell } from 'electron'
 import path from 'path'
 import type { DatadogForwardedError } from '../../types/ipc'
 import type { InstallationRecord } from '../installations'
@@ -255,57 +255,6 @@ function injectMacPasskeyWarning(childWindow: BrowserWindow): void {
   childWindow.webContents.on('did-navigate-in-page', inject)
 }
 
-/** Credits-checkout popup sizing. A landscape rectangle scaled to the
- *  parent display's work area: most of the width, a shorter height, so
- *  the checkout reads as a wide app-sized surface rather than a tall
- *  dialog. Clamped to a min/max band and to a max aspect ratio so it
- *  stays horizontal on a large monitor and never shrinks below what the
- *  checkout content needs on a laptop. */
-const CHECKOUT_MIN_WIDTH = 720
-const CHECKOUT_MAX_WIDTH = 1280
-const CHECKOUT_MIN_HEIGHT = 560
-const CHECKOUT_MAX_HEIGHT = 860
-const CHECKOUT_WIDTH_FRACTION = 0.82
-const CHECKOUT_HEIGHT_FRACTION = 0.82
-/** Keep it a horizontal rectangle: width is at least this × height. */
-const CHECKOUT_MIN_ASPECT = 1.4
-
-/**
- * Compute centered, work-area-fitted bounds for the checkout popup on
- * whichever display the parent window currently sits on. Width is a
- * large fraction of the work area, height a smaller one, both clamped to
- * the min/max band; then width is widened (within the band) so the
- * window stays a landscape rectangle. Centered over the parent.
- * Cross-platform: `screen.workArea` already excludes the macOS menu bar
- * / Dock and the Windows taskbar.
- */
-function checkoutPopupBounds(parent: BrowserWindow): Electron.Rectangle {
-  const parentBounds = parent.getBounds()
-  const { workArea } = screen.getDisplayMatching(parentBounds)
-  const clamp = (v: number, lo: number, hi: number): number => Math.max(lo, Math.min(hi, v))
-
-  const height = clamp(
-    Math.round(workArea.height * CHECKOUT_HEIGHT_FRACTION),
-    CHECKOUT_MIN_HEIGHT,
-    Math.min(CHECKOUT_MAX_HEIGHT, workArea.height)
-  )
-  const maxWidth = Math.min(CHECKOUT_MAX_WIDTH, workArea.width)
-  const width = clamp(
-    Math.max(
-      Math.round(workArea.width * CHECKOUT_WIDTH_FRACTION),
-      Math.round(height * CHECKOUT_MIN_ASPECT)
-    ),
-    Math.min(CHECKOUT_MIN_WIDTH, maxWidth),
-    maxWidth
-  )
-
-  // Center over the parent, then nudge fully inside the work area.
-  const cx = parentBounds.x + Math.round((parentBounds.width - width) / 2)
-  const cy = parentBounds.y + Math.round((parentBounds.height - height) / 2)
-  const x = clamp(cx, workArea.x, workArea.x + workArea.width - width)
-  const y = clamp(cy, workArea.y, workArea.y + workArea.height - height)
-  return { x, y, width, height }
-}
 
 /** Max wait for the host reload to paint before closing the popup
  *  anyway, so a stalled reload can't trap the user on checkout. */
@@ -1197,35 +1146,23 @@ export function buildComfyView(
       return { action: 'deny' }
     }
     if (isCheckoutUrl(childUrl)) {
-      // `checkout.comfy.org` forbids iframing, so checkout has to be a
-      // real popup — styled to read as in-app (parented, centered, sized
-      // to the work area) and wired up in `wireCheckoutPopup`. Frameless
-      // on Windows/Linux only: there the checkout page's own ✕/back is
-      // enough, but a frameless `window.open` child on macOS can't be
-      // dragged/closed reliably, so it keeps its frame. preload:
-      // undefined strips our title-bar bridge.
-      nextPopupIsCheckout = true
-      nextCheckoutOpenedAt = Date.now()
+      // Hosted Stripe Checkout runs in the user's real browser, not this
+      // embedded window. Alipay (and any redirect-based method) navigates to a
+      // third-party authorization page whose return leg hangs/blanks inside an
+      // embedded webview (a documented Stripe + webview failure), and the
+      // browser-vs-in-app choice can't be deferred until after the user picks a
+      // method inside Stripe -- so the whole checkout opens externally, up
+      // front. Card/WeChat keep working there too. Credits are granted
+      // server-side by the Stripe webhook and the renderer refetches balance on
+      // return, so nothing needs to redirect back into the app.
       mainTelemetry.capture('comfy.desktop.billing.checkout_opened', {
-        source: 'cloud_webview',
+        source: 'system_browser',
         user_tier: getUserTier()
       })
-      const bounds = checkoutPopupBounds(comfyWindow)
-      return {
-        action: 'allow',
-        overrideBrowserWindowOptions: {
-          parent: comfyWindow,
-          ...bounds,
-          minWidth: CHECKOUT_MIN_WIDTH,
-          minHeight: CHECKOUT_MIN_HEIGHT,
-          frame: process.platform !== 'darwin' ? false : undefined,
-          backgroundColor: COMFY_BG,
-          title: 'Purchase Credits',
-          show: false,
-          webPreferences: { preload: undefined }
-        }
-      }
+      void shell.openExternal(childUrl)
+      return { action: 'deny' }
     }
+
     if (shouldOpenInPopup(childUrl)) {
       // preload: undefined strips our title-bar bridge so OAuth/cloud-login
       // popups can't reach the file menu IPCs.


### PR DESCRIPTION
## Summary

Credits top-up opened hosted Stripe Checkout in an embedded Electron window. Alipay top-ups fail there while working in a normal browser. This routes the checkout to the user's system browser so every method works.

## Problem

- Empirical (incident #88): in Desktop, **card works, WeChat works, Alipay fails**; all three work in a normal browser, same accounts.
- Mechanism: hosted Stripe Checkout opens via `window.open` in an embedded window. Card and WeChat complete inline on the checkout page (WeChat is an inline QR). **Alipay is the only method that navigates the embedded webview to a third-party authorization page**, and that redirect/return leg hangs or blanks inside an embedded webview — a documented Stripe + webview failure class ([stripe-android#12699](https://github.com/stripe/stripe-android/issues/12699), [#2763](https://github.com/stripe/stripe-android/issues/2763)). The documented workaround is to run it in the system browser.

## Change

`createHostWindow.ts` `setWindowOpenHandler`: the `isCheckoutUrl` branch now `shell.openExternal(url)` + `deny` instead of opening an in-app popup. The browser-vs-in-app decision is made **up front** at window-open, before the Stripe method chooser, because it can't be deferred until after the user picks Alipay. Also removes the now-orphaned `checkoutPopupBounds` + sizing constants.

## Return / credits

No redirect back into the app is needed. Credits are granted server-side by the Stripe `invoice.paid` webhook, and the renderer already refetches balance on `visibilitychange` / when the Credits panel reopens, so credits reconcile when the user returns from the browser.

## Tradeoff

Card and WeChat also move to the system browser now — we can't single out Alipay up front. This is functional, not a regression. The in-app experience for embedded-friendly methods can be restored as part of the checkout-flow rework.

## Notes for review

- The in-app popup helpers (`wireCheckoutPopup`, `checkoutBackdrop`, `isCheckoutReturnUrl`) are now unreachable but still referenced, so CI stays clean. Left in place to minimize churn against the in-flight checkout-flow rework — remove there or in a follow-up.
- Verified locally: `typecheck` (node/web/e2e/integration) clean, `eslint` clean, `allowedPopups` + `createHostWindow` tests 54/54 pass.

## Test plan

- [ ] Top up in Desktop: checkout opens in the system browser, Alipay completes, returning to the app shows updated credits.
- [ ] Card and WeChat still complete (in the browser).
