### PR TITLE
feat(templates): make the starter-template picker content-editable and version-correct

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -100,6 +100,7 @@ import { getInitialAnonymousDistinctId } from './lib/websiteAnonymousIdentity'
 import { recoverPendingIdentityRotation } from './lib/pendingIdentityMerge'
 import { initExperiments } from './lib/experiments'
 import { initCloudFreeRuns } from './lib/cloudFreeRuns'
+import { initStarterTemplates } from './sources/standalone/starterTemplateManifest'
 import { initUserTier } from './lib/userTier'
 
 import {
@@ -1463,6 +1464,9 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
     // experiments cache would never have a value to give it. See
     // `cloudFreeRuns.ts`.
     void initCloudFreeRuns({ distinctId: installationId })
+
+    // Same pre-consent ops-flag path; boot must not wait on the fetch.
+    void initStarterTemplates({ distinctId: installationId })
 
     // Hydrate the persisted cloud user-tier cache for billing telemetry and
     // free-tier offer UI. `userTier.ts` refreshes it on every cloud

--- a/src/main/lib/fetch.test.ts
+++ b/src/main/lib/fetch.test.ts
@@ -8,6 +8,7 @@ vi.mock('./safe-file', () => ({ writeFileSafe: vi.fn() }))
 interface FakeRequest extends EventEmitter {
   setHeader: ReturnType<typeof vi.fn>
   end: ReturnType<typeof vi.fn>
+  abort: ReturnType<typeof vi.fn>
   __url: string
   __headers: Record<string, string>
 }
@@ -23,6 +24,7 @@ vi.mock('electron', () => ({
           headers[k] = v
         }),
         end: vi.fn(),
+        abort: vi.fn(),
         __url: opts.url,
         __headers: headers
       }) as FakeRequest
@@ -32,7 +34,7 @@ vi.mock('electron', () => ({
   }
 }))
 
-import { _resetCacheForTest, fetchJSON } from './fetch'
+import { _resetCacheForTest, fetchJSON, fetchText } from './fetch'
 
 function makeResponse(
   statusCode: number,
@@ -164,5 +166,93 @@ describe('fetchJSON — mirror is not allowed to poison the cache', () => {
     expect(requests[0]!.__headers['If-None-Match']).toBe('"primary-etag-1"')
     requests[0]!.emit('response', makeResponse(304, ''))
     await expect(p2).resolves.toEqual({ v: 1 })
+  })
+})
+
+describe('fetchText — shares fetchJSON’s cache and retry layer', () => {
+  beforeEach(() => {
+    requests.length = 0
+    _resetCacheForTest()
+  })
+
+  it('returns the raw body without JSON parsing', async () => {
+    const p = fetchText(PRIMARY)
+    requests[0]!.emit('response', makeResponse(200, 'comfyui-workflow-templates==0.11.31\n'))
+    await expect(p).resolves.toContain('comfyui-workflow-templates==0.11.31')
+  })
+
+  it('serves the cached body on a 304, so an unchanged pin costs no re-download', async () => {
+    const first = fetchText(PRIMARY)
+    requests[0]!.emit('response', makeResponse(200, 'pinned==1.0.0', { etag: '"v1"' }))
+    await first
+
+    const second = fetchText(PRIMARY)
+    requests[1]!.emit('response', makeResponse(304, ''))
+    await expect(second, 'a warm cache carries an offline boot').resolves.toBe('pinned==1.0.0')
+  })
+
+  it('falls back to the last-cached body when the network fails', async () => {
+    const first = fetchText(PRIMARY)
+    requests[0]!.emit('response', makeResponse(200, 'pinned==1.0.0', { etag: '"v1"' }))
+    await first
+
+    const second = fetchText(PRIMARY)
+    requests[1]!.emit('error', new Error('offline'))
+    await new Promise((r) => setImmediate(r))
+    requests[2]!.emit('error', new Error('offline'))
+    await expect(second, 'a warm cache carries an offline boot').resolves.toBe('pinned==1.0.0')
+  })
+
+  it('rejects on a non-200 so a 404 is not mistaken for an empty body', async () => {
+    const p = fetchText(PRIMARY)
+    requests[0]!.emit('response', makeResponse(404, 'Not Found'))
+    await new Promise((r) => setImmediate(r))
+    requests[1]!.emit('error', new Error('mirror down'))
+    await expect(p).rejects.toThrow(/HTTP 404/)
+  })
+})
+
+describe('fetch — request timeout', () => {
+  beforeEach(() => {
+    requests.length = 0
+    _resetCacheForTest()
+  })
+
+  it('rejects a stalled request instead of hanging its callers', async () => {
+    await expect(
+      fetchText(PRIMARY, { timeoutMs: 10 }),
+      'net.request has no deadline, so only this can settle a black-holed socket'
+    ).rejects.toThrow(/Timed out after 10ms/)
+  })
+
+  it('aborts the stalled request rather than leaking the socket', async () => {
+    await fetchText(PRIMARY, { timeoutMs: 10 }).catch(() => undefined)
+    expect(requests[0]!.abort, 'the socket is released, not just abandoned').toHaveBeenCalled()
+  })
+
+  it('does not let a late timeout reject an already-resolved request', async () => {
+    const p = fetchText(PRIMARY, { timeoutMs: 10 })
+    requests[0]!.emit('response', makeResponse(200, 'body'))
+    await expect(p).resolves.toBe('body')
+    await new Promise((r) => setTimeout(r, 30))
+  })
+})
+
+describe('fetch — cache is namespaced by parser', () => {
+  beforeEach(() => {
+    requests.length = 0
+    _resetCacheForTest()
+  })
+
+  it('does not serve a JSON-cached body to a text caller', async () => {
+    const first = fetchJSON(PRIMARY)
+    requests[0]!.emit('response', makeResponse(200, '{"a":1}', { etag: '"v1"' }))
+    await first
+
+    const second = fetchText(PRIMARY)
+    requests[1]!.emit('response', makeResponse(200, 'plain text'))
+    await expect(second, 'a JSON-cached body is never served to a text caller').resolves.toBe(
+      'plain text'
+    )
   })
 })

--- a/src/main/lib/fetch.test.ts
+++ b/src/main/lib/fetch.test.ts
@@ -231,10 +231,15 @@ describe('fetch — request timeout', () => {
   })
 
   it('does not let a late timeout reject an already-resolved request', async () => {
-    const p = fetchText(PRIMARY, { timeoutMs: 10 })
-    requests[0]!.emit('response', makeResponse(200, 'body'))
-    await expect(p).resolves.toBe('body')
-    await new Promise((r) => setTimeout(r, 30))
+    vi.useFakeTimers()
+    try {
+      const p = fetchText(PRIMARY, { timeoutMs: 10 })
+      requests[0]!.emit('response', makeResponse(200, 'body'))
+      await vi.advanceTimersByTimeAsync(30)
+      await expect(p).resolves.toBe('body')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })
 

--- a/src/main/lib/fetch.ts
+++ b/src/main/lib/fetch.ts
@@ -10,8 +10,10 @@ interface CacheEntry {
   data: unknown
 }
 
-// ETag cache (url -> { etag, data }) persisted to disk; bounded, oldest evicted first.
+// ETag cache (`kind:url` -> { etag, data }) persisted to disk; bounded, oldest evicted first.
 const MAX_CACHE_SIZE = 100
+/** No deadline exists below this layer. */
+const DEFAULT_TIMEOUT_MS = 15_000
 const CACHE_FILE = path.join(cacheDir(), 'fetch-cache.json')
 
 const _cache: Map<string, CacheEntry> = new Map()
@@ -31,7 +33,10 @@ function _ensureLoaded(): void {
           typeof (entry as CacheEntry).etag === 'string' &&
           'data' in entry
         ) {
-          _cache.set(url, entry as CacheEntry)
+          // Legacy un-prefixed keys can never be read again; drop them.
+          if (url.startsWith('json:') || url.startsWith('text:')) {
+            _cache.set(url, entry as CacheEntry)
+          }
         }
       }
     }
@@ -69,19 +74,44 @@ function _headerString(value: string | string[] | undefined): string | undefined
   return Array.isArray(value) ? value[0] : value
 }
 
-// Single-shot fetch with ETag negotiation. `cached` provides the If-None-Match
-// value (and the 304 short-circuit body); `cacheKey` is the URL the successful
-// response should be cached under, or undefined to skip writing to the cache
-// entirely. Splitting these lets the mirror-retry below run WITHOUT leaking the
-// primary's ETag to the mirror (cached: undefined) and WITHOUT poisoning the
-// primary's persisted cache entry with mirror-tagged data (cacheKey: undefined).
-function fetchJSONOnce(
+/**
+ * Performs a single HTTP fetch with ETag negotiation and timeout.
+ *
+ * @param url - The request URL.
+ * @param cached - Cached entry (provides If-None-Match and a 304 response body).
+ * @param cacheKey - Cache key to store response under; omit to skip caching.
+ * @param parse - Function to parse the response body.
+ * @param timeoutMs - Timeout in milliseconds.
+ *
+ * Splitting `cached` and `cacheKey` allows retries against mirrors without leaking ETags
+ * or cross-contaminating cache entries.
+ */
+function fetchOnce(
   url: string,
   cached: CacheEntry | undefined,
-  cacheKey: string | undefined
+  cacheKey: string | undefined,
+  parse: (body: string, url: string) => unknown,
+  timeoutMs: number
 ): Promise<unknown> {
   return new Promise((resolve, reject) => {
     const request = net.request({ url, cache: 'no-cache' })
+    let settled = false
+    const timer = setTimeout(() => {
+      if (settled) return
+      settled = true
+      try {
+        request.abort()
+      } catch {
+        /* already finished */
+      }
+      reject(new Error(`Timed out after ${timeoutMs}ms fetching ${url}`))
+    }, timeoutMs)
+    const finish = (fn: () => void): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      fn()
+    }
     request.setHeader('User-Agent', 'ComfyUI-Desktop-2')
 
     const ghToken = process.env.GITHUB_TOKEN
@@ -104,7 +134,7 @@ function fetchJSONOnce(
       response.on('data', (chunk) => (data += chunk.toString()))
       response.on('end', () => {
         if (response.statusCode === 304 && cached) {
-          resolve(structuredClone(cached.data))
+          finish(() => resolve(structuredClone(cached.data)))
           return
         }
         if (response.statusCode !== 200) {
@@ -125,14 +155,14 @@ function fetchJSONOnce(
               msg += ' (rate limited)'
             }
           }
-          reject(new Error(msg))
+          finish(() => reject(new Error(msg)))
           return
         }
         let parsed: unknown
         try {
-          parsed = JSON.parse(data)
-        } catch {
-          reject(new Error(`Invalid JSON response from ${url}`))
+          parsed = parse(data, url)
+        } catch (err) {
+          finish(() => reject(err instanceof Error ? err : new Error(String(err))))
           return
         }
         if (cacheKey) {
@@ -141,10 +171,10 @@ function fetchJSONOnce(
             _cacheSet(cacheKey, { etag, data: parsed })
           }
         }
-        resolve(parsed)
+        finish(() => resolve(parsed))
       })
     })
-    request.on('error', (err) => reject(err))
+    request.on('error', (err) => finish(() => reject(err)))
     request.end()
   })
 }
@@ -155,24 +185,63 @@ export function _resetCacheForTest(): void {
   _loaded = false
 }
 
-export async function fetchJSON(url: string, opts?: { refresh?: boolean }): Promise<unknown> {
+function parseText(body: string): string {
+  return body
+}
+
+function parseJson(body: string, url: string): unknown {
+  try {
+    return JSON.parse(body)
+  } catch {
+    throw new Error(`Invalid JSON response from ${url}`)
+  }
+}
+
+/** Plain-text sibling of `fetchJSON`, sharing its cache, retry, and fallback. */
+export async function fetchText(
+  url: string,
+  opts?: { refresh?: boolean; timeoutMs?: number }
+): Promise<string> {
+  const body = await fetchWith(url, 'text', parseText, opts)
+  if (typeof body !== 'string') throw new Error(`Expected a text body from ${url}`)
+  return body
+}
+
+export async function fetchJSON(
+  url: string,
+  opts?: { refresh?: boolean; timeoutMs?: number }
+): Promise<unknown> {
+  return fetchWith(url, 'json', parseJson, opts)
+}
+
+async function fetchWith(
+  url: string,
+  kind: 'json' | 'text',
+  parse: (body: string, url: string) => unknown,
+  opts?: { refresh?: boolean; timeoutMs?: number }
+): Promise<unknown> {
+  const timeoutMs = opts?.timeoutMs ?? DEFAULT_TIMEOUT_MS
   _ensureLoaded()
+  // Namespaced by parser: the cache outlives releases, so a URL whose parser
+  // changes must not 304 a string into a JSON caller.
+  const cacheKey = `${kind}:${url}`
   // `refresh` ignores the persisted ETag so the response is never served from cache. Used
   // for R2 manifests where a stale value would strand users on an old release.
-  const cached = opts?.refresh ? undefined : _cache.get(url)
+  const cached = opts?.refresh ? undefined : _cache.get(cacheKey)
 
   try {
-    return await fetchJSONOnce(url, cached, url)
+    return await fetchOnce(url, cached, cacheKey, parse, timeoutMs)
   } catch (primaryErr) {
     // If this is an R2 URL with a configured mirror, retry once against it
     // before falling back to the persisted cache. The retry deliberately
     // discards `cached` (no ETag negotiation against the mirror) and writes
     // nothing back to the cache so a stale or compromised mirror cannot
     // poison the primary's cache entry.
+    // The mirror gets its own budget, so worst case is 2x `timeoutMs`.
     const mirror = r2MirrorUrl(url)
     if (mirror && mirror !== url) {
       try {
-        return await fetchJSONOnce(mirror, undefined, undefined)
+        return await fetchOnce(mirror, undefined, undefined, parse, timeoutMs)
       } catch {
         // fall through to cache / primary error
       }

--- a/src/main/lib/opsFlag.ts
+++ b/src/main/lib/opsFlag.ts
@@ -35,17 +35,13 @@ export interface OpsFlag<T> {
   _resetForTest(): void
 }
 
-export function makeOpsFlag<T>(opts: {
-  key: string
-  /** Value held before the fetch resolves, and kept when it fails or returns something
-   *  `parse` doesn't recognise. This is the flag's fail direction. */
-  fallback: T
-  /** Narrow the raw flag value. Return `undefined` to keep the fallback — that is how an
-   *  unrecognised payload is distinguished from a legitimate value. */
-  parse: (value: FeatureFlagValue | undefined) => T | undefined
-  /** Enables the `[label] init:` / `[label] init error:` boot logs. Omit for no logging. */
-  logLabel?: string
-}): OpsFlag<T> {
+/** Shared plumbing with the fetcher injected. One copy because these are
+ *  correctness-critical and easy to diverge: a single cached in-flight promise,
+ *  `get()` awaiting rather than racing it, and `cached` set only when resolved. */
+function makeOpsFlagFrom<T, V>(
+  fetchValue: (key: string, distinctId: string, timeoutMs: number) => Promise<V>,
+  opts: { key: string; fallback: T; parse: (value: V) => T | undefined; logLabel?: string }
+): OpsFlag<T> {
   const { key, fallback, parse, logLabel } = opts
   let cached: T = fallback
   let initPromise: Promise<void> | null = null
@@ -53,13 +49,12 @@ export function makeOpsFlag<T>(opts: {
   return {
     init(initOpts) {
       if (initPromise) return initPromise
-      initPromise = mainTelemetry
-        .getOpsFlag(key, initOpts.distinctId, initOpts.timeoutMs ?? DEFAULT_TIMEOUT_MS)
+      initPromise = fetchValue(key, initOpts.distinctId, initOpts.timeoutMs ?? DEFAULT_TIMEOUT_MS)
         .then((value) => {
           const parsed = parse(value)
           if (parsed !== undefined) cached = parsed
 
-          if (logLabel) console.log(`[${logLabel}] init: fetched=`, value, '→ cached=', cached)
+          if (logLabel) console.log(`[${logLabel}] init: fetched=`, value, '\u2192 cached=', cached)
         })
         .catch((err) => {
           if (logLabel) console.log(`[${logLabel}] init error:`, err)
@@ -82,4 +77,32 @@ export function makeOpsFlag<T>(opts: {
       initPromise = null
     }
   }
+}
+
+export function makeOpsFlag<T>(opts: {
+  key: string
+  /** Default value used before fetch resolves or if fetch/parse fails. */
+  fallback: T
+  /** Return `undefined` to use fallback for unrecognized values. */
+  parse: (value: FeatureFlagValue | undefined) => T | undefined
+  /** Enables the `[label] init:` / `[label] init error:` boot logs. Omit for no logging. */
+  logLabel?: string
+}): OpsFlag<T> {
+  return makeOpsFlagFrom(
+    (key, distinctId, timeoutMs) => mainTelemetry.getOpsFlag(key, distinctId, timeoutMs),
+    opts
+  )
+}
+
+/** For JSON payload flags: PostHog may send a string or object—`parse` handles this. */
+export function makeOpsFlagPayload<T>(opts: {
+  key: string
+  fallback: T
+  parse: (value: unknown) => T | undefined
+  logLabel?: string
+}): OpsFlag<T> {
+  return makeOpsFlagFrom(
+    (key, distinctId, timeoutMs) => mainTelemetry.getOpsFlagPayload(key, distinctId, timeoutMs),
+    opts
+  )
 }

--- a/src/main/lib/telemetry.ts
+++ b/src/main/lib/telemetry.ts
@@ -1230,6 +1230,32 @@ export async function getOpsFlag(
 }
 
 /**
+ * `getOpsFlag` for JSON-payload flags. `sendFeatureFlagEvents` is a documented
+ * no-op here, so consent safety rests on this path never capturing an event.
+ */
+export async function getOpsFlagPayload(
+  key: string,
+  distinctId: string,
+  timeoutMs: number
+): Promise<unknown | undefined> {
+  if (!client) return undefined
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    const payloadPromise = client.getFeatureFlagPayload(key, distinctId, undefined, {
+      onlyEvaluateLocally: false
+    })
+    const timeoutPromise = new Promise<undefined>((resolve) => {
+      timer = setTimeout(() => resolve(undefined), timeoutMs)
+    })
+    return await Promise.race([payloadPromise, timeoutPromise])
+  } catch {
+    return undefined
+  } finally {
+    if (timer !== undefined) clearTimeout(timer)
+  }
+}
+
+/**
  * Wrap an async step with start/end/error telemetry events that mirror legacy
  * desktop's `@trackEvent` decorator. Errors are re-thrown so callers can
  * continue normal control flow.

--- a/src/main/sources/standalone/curatedTemplates.test.ts
+++ b/src/main/sources/standalone/curatedTemplates.test.ts
@@ -38,6 +38,38 @@ describe('isPersistableTemplateId', () => {
   })
 })
 
+describe('CURATED_TEMPLATES is the picker’s backfill floor', () => {
+  it('carries exactly 4 templates for every modality in the tab order', () => {
+    for (const modality of TEMPLATE_MODALITY_ORDER) {
+      const forModality = CURATED_TEMPLATES.filter((t) => t.modality === modality)
+      expect(forModality.length, `${modality}: the floor every fallback bottoms out on`).toBe(4)
+    }
+    expect(CURATED_TEMPLATES.length).toBe(TEMPLATE_MODALITY_ORDER.length * 4)
+  })
+
+  it('has exactly one recommended per modality, and never an API-node one', () => {
+    for (const modality of TEMPLATE_MODALITY_ORDER) {
+      const recommended = CURATED_TEMPLATES.filter(
+        (t) => t.modality === modality && t.recommended === true
+      )
+      expect(recommended.length, modality).toBe(1)
+      expect(recommended[0]!.apiNode, modality).toBeUndefined()
+    }
+  })
+
+  it('has no duplicate ids', () => {
+    const ids = CURATED_TEMPLATES.map((t) => t.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('gives every entry a snapshot, so an offline cold start still renders cards', () => {
+    for (const t of CURATED_TEMPLATES) {
+      expect(t.snapshot?.title, t.id).toBeTruthy()
+      expect(typeof t.snapshot?.sizeBytes, t.id).toBe('number')
+    }
+  })
+})
+
 describe('buildTemplateDeeplink', () => {
   it('appends ?template=<id>&source=default and round-trips the id', () => {
     const out = buildTemplateDeeplink('http://127.0.0.1:8188/', 'flux_schnell')
@@ -77,8 +109,6 @@ describe('thumbnailUrlFor', () => {
 })
 
 describe('CURATED_TEMPLATES manifest', () => {
-  // Must match the frontend deeplink validator so the auto-open can't be
-  // rejected for a malformed id.
   const ID_PATTERN = /^[a-zA-Z0-9_.-]+$/
 
   it('offers exactly 4 templates per modality', () => {

--- a/src/main/sources/standalone/curatedTemplates.test.ts
+++ b/src/main/sources/standalone/curatedTemplates.test.ts
@@ -38,38 +38,6 @@ describe('isPersistableTemplateId', () => {
   })
 })
 
-describe('CURATED_TEMPLATES is the picker’s backfill floor', () => {
-  it('carries exactly 4 templates for every modality in the tab order', () => {
-    for (const modality of TEMPLATE_MODALITY_ORDER) {
-      const forModality = CURATED_TEMPLATES.filter((t) => t.modality === modality)
-      expect(forModality.length, `${modality}: the floor every fallback bottoms out on`).toBe(4)
-    }
-    expect(CURATED_TEMPLATES.length).toBe(TEMPLATE_MODALITY_ORDER.length * 4)
-  })
-
-  it('has exactly one recommended per modality, and never an API-node one', () => {
-    for (const modality of TEMPLATE_MODALITY_ORDER) {
-      const recommended = CURATED_TEMPLATES.filter(
-        (t) => t.modality === modality && t.recommended === true
-      )
-      expect(recommended.length, modality).toBe(1)
-      expect(recommended[0]!.apiNode, modality).toBeUndefined()
-    }
-  })
-
-  it('has no duplicate ids', () => {
-    const ids = CURATED_TEMPLATES.map((t) => t.id)
-    expect(new Set(ids).size).toBe(ids.length)
-  })
-
-  it('gives every entry a snapshot, so an offline cold start still renders cards', () => {
-    for (const t of CURATED_TEMPLATES) {
-      expect(t.snapshot?.title, t.id).toBeTruthy()
-      expect(typeof t.snapshot?.sizeBytes, t.id).toBe('number')
-    }
-  })
-})
-
 describe('buildTemplateDeeplink', () => {
   it('appends ?template=<id>&source=default and round-trips the id', () => {
     const out = buildTemplateDeeplink('http://127.0.0.1:8188/', 'flux_schnell')
@@ -118,11 +86,16 @@ describe('CURATED_TEMPLATES manifest', () => {
     }
   })
 
-  it('marks at most one recommended template per modality', () => {
+  it('marks exactly one recommended template per modality', () => {
     for (const modality of TEMPLATE_MODALITY_ORDER) {
       const recommended = CURATED_TEMPLATES.filter((t) => t.modality === modality && t.recommended)
-      expect(recommended.length, modality).toBeLessThanOrEqual(1)
+      expect(recommended.length, modality).toBe(1)
     }
+  })
+
+  it('has no duplicate ids, which would collide on the picker’s option key', () => {
+    const ids = CURATED_TEMPLATES.map((t) => t.id)
+    expect(new Set(ids).size).toBe(ids.length)
   })
 
   it('uses only deeplink-safe ids', () => {

--- a/src/main/sources/standalone/curatedTemplates.ts
+++ b/src/main/sources/standalone/curatedTemplates.ts
@@ -26,8 +26,14 @@ interface CuratedTemplateBase {
   id: string
   /** Output modality this template showcases. */
   modality: TemplateModality
-  /** Offline display metadata; superseded by the live index when available. */
-  snapshot: TemplateSnapshot
+  /** Superseded by the live index; optional on a remote entry. */
+  snapshot?: TemplateSnapshot
+  /** ISO-8601 UTC; hidden before this, so content can stage a launch. */
+  availableFrom?: string
+  /** ISO-8601 UTC. After this instant the entry is hidden. */
+  availableUntil?: string
+  /** Forces `snapshot` copy over the live index, for launch-specific wording. */
+  snapshotOverrides?: true
 }
 
 /**
@@ -37,6 +43,9 @@ interface CuratedTemplateBase {
  */
 export type CuratedTemplate = CuratedTemplateBase &
   ({ recommended?: true; apiNode?: never } | { apiNode: true; recommended?: never })
+
+/** `snapshot` is required: this list is the offline floor. */
+export type BakedInTemplate = CuratedTemplate & { snapshot: TemplateSnapshot }
 
 /** Tab order in the picker — one tab per modality that has ≥1 curated template. */
 export const TEMPLATE_MODALITY_ORDER: readonly TemplateModality[] = [
@@ -65,10 +74,15 @@ const IMAGE_SUBTYPES = new Set(['webp', 'png', 'jpg', 'jpeg', 'gif', 'avif'])
  * subtype isn't an image (e.g. `mp3`), so the caller falls back to the glyph
  * without a doomed network request. Pure + exported for reuse and tests.
  */
-export function thumbnailUrlFor(id: string, mediaSubtype: string): string | null {
+export function thumbnailUrlFor(
+  id: string,
+  mediaSubtype: string,
+  /** Defaults to `main`; the picker passes the base its install ships. */
+  assetBase: string = RAW_TEMPLATES_BASE
+): string | null {
   const ext = (mediaSubtype || 'webp').toLowerCase()
   if (!IMAGE_SUBTYPES.has(ext)) return null
-  return `${RAW_TEMPLATES_BASE}/${id}-1.${ext}`
+  return `${assetBase}/${id}-1.${ext}`
 }
 
 /**
@@ -94,7 +108,7 @@ export const NO_TEMPLATE_VALUE = 'none'
 /** A template id is a single path-safe segment: the frontend deeplink validator
  *  pattern (`^[a-zA-Z0-9_.-]+$`). No `/` or `\`, so it can't escape the templates
  *  dir when joined into a filesystem path or interpolated into a fetch URL. */
-const TEMPLATE_ID_PATTERN = /^[a-zA-Z0-9_.-]+$/
+export const TEMPLATE_ID_PATTERN = /^[a-zA-Z0-9_.-]+$/
 
 /**
  * Whether `value` is a persistable starter-template id. Accepts any
@@ -115,7 +129,7 @@ export function isPersistableTemplateId(value: unknown): value is string {
  * To update, change the id and sync the template's
  * title/description/size/mediaSubtype into `snapshot`.
  */
-export const CURATED_TEMPLATES: readonly CuratedTemplate[] = [
+export const CURATED_TEMPLATES: readonly BakedInTemplate[] = [
   // --- Image ---
   {
     id: 'image_z_image_turbo',

--- a/src/main/sources/standalone/index.test.ts
+++ b/src/main/sources/standalone/index.test.ts
@@ -1,6 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as TemplatePinModule from './templatePin'
 
 vi.mock('electron', () => ({
   app: { getPath: () => '' },
@@ -14,6 +15,15 @@ vi.mock('../../lib/fetch', () => ({
 vi.mock('../../lib/comfyui-releases', () => ({
   getLatestStableTag: vi.fn()
 }))
+
+const resolveTemplatePackageVersion = vi.fn()
+vi.mock('./templatePin', async (importOriginal) => {
+  const actual = await importOriginal<typeof TemplatePinModule>()
+  return {
+    ...actual,
+    resolveTemplatePackageVersion: (...a: unknown[]) => resolveTemplatePackageVersion(...a)
+  }
+})
 
 import { standalone, buildPinnedVariant } from './index'
 import { resetTemplateCatalogCache } from './templateCatalog'
@@ -236,6 +246,8 @@ describe('standalone.buildInstallation', () => {
 describe('standalone.getFieldOptions bundledTemplate', () => {
   beforeEach(() => {
     mockedFetchJSON.mockReset()
+    resolveTemplatePackageVersion.mockReset()
+    resolveTemplatePackageVersion.mockResolvedValue(null)
     resetTemplateCatalogCache()
   })
 
@@ -306,6 +318,35 @@ describe('standalone.getFieldOptions bundledTemplate', () => {
       const card = options.find((o) => o.value === curated.id)!
       expect(card.data!.apiNode, curated.id).toBe(curated.apiNode === true)
     }
+  })
+
+  it('pins the catalog to a stable-channel version pick', async () => {
+    mockedFetchJSON.mockResolvedValue([])
+    await standalone.getFieldOptions!(
+      'bundledTemplate',
+      {
+        release: { value: 'stable', label: 'Stable', data: { latestStableTag: 'v0.30.2' } },
+        comfyVersion: { value: 'v0.28.2', label: 'v0.28.2' }
+      },
+      {}
+    )
+    expect(resolveTemplatePackageVersion).toHaveBeenCalledWith('v0.28.2')
+  })
+
+  it('ignores a comfyVersion left over from a switch to the latest channel', async () => {
+    mockedFetchJSON.mockResolvedValue([])
+    await standalone.getFieldOptions!(
+      'bundledTemplate',
+      {
+        release: { value: 'latest', label: 'Latest', data: { latestStableTag: 'v0.30.2' } },
+        comfyVersion: { value: 'v0.28.2', label: 'v0.28.2' }
+      },
+      {}
+    )
+    expect(
+      resolveTemplatePackageVersion,
+      'the picker must target the version the install will actually run'
+    ).toHaveBeenCalledWith('v0.30.2')
   })
 })
 

--- a/src/main/sources/standalone/index.ts
+++ b/src/main/sources/standalone/index.ts
@@ -20,6 +20,7 @@ import {
 import { install, postInstall, probeInstallation } from './install'
 import { NO_TEMPLATE_VALUE, isPersistableTemplateId } from './curatedTemplates'
 import { loadTemplateCatalog } from './templateCatalog'
+import { resolveTemplatePackageVersion, templateAssetBaseFor } from './templatePin'
 import { resolveTemplateModels } from './templateModels'
 import * as installations from '../../installations'
 
@@ -555,18 +556,31 @@ export const standalone: SourcePlugin = {
       // "None" comes first as the skip option; the per-modality recommended
       // picks carry `recommended` on their own option so the wizard auto-selects
       // a real template (the lightest "wow"), not the skip.
-      const catalog = await loadTemplateCatalog()
+      const releaseData = selections.release?.data as
+        | { latestStableTag?: string | null }
+        | undefined
+      const pickedComfyTag =
+        typeof selections.comfyVersion?.value === 'string' &&
+        /^v\d+\.\d+\.\d+$/.test(selections.comfyVersion.value)
+          ? selections.comfyVersion.value
+          : null
+      const targetComfyVersion =
+        pickedComfyTag ?? releaseData?.latestStableTag ?? (await getLatestStableTag())
+      const catalog = await loadTemplateCatalog({ comfyVersion: targetComfyVersion })
 
       const installId = typeof context.installationId === 'string' ? context.installationId : null
       const installation = installId ? await installations.get(installId) : null
       // `budgeted` stops the timed-out pass writing after we return, so a slow
       // `modelsPresent: false` reads as "unbadged", never "confirmed absent".
       let budgeted = false
+      const assetBase = templateAssetBaseFor(
+        await resolveTemplatePackageVersion(targetComfyVersion).catch(() => null)
+      )
       const presenceById = new Map<string, boolean>()
       const presencePass = Promise.all(
         catalog.map(async (tpl) => {
           try {
-            const models = await resolveTemplateModels(installation, tpl.id)
+            const models = await resolveTemplateModels(installation, tpl.id, assetBase)
             const present = await areModelsPresent(installId, models)
             if (!budgeted) presenceById.set(tpl.id, present)
           } catch {

--- a/src/main/sources/standalone/index.ts
+++ b/src/main/sources/standalone/index.ts
@@ -20,7 +20,6 @@ import {
 import { install, postInstall, probeInstallation } from './install'
 import { NO_TEMPLATE_VALUE, isPersistableTemplateId } from './curatedTemplates'
 import { loadTemplateCatalog } from './templateCatalog'
-import { resolveTemplatePackageVersion, templateAssetBaseFor } from './templatePin'
 import { resolveTemplateModels } from './templateModels'
 import * as installations from '../../installations'
 
@@ -559,23 +558,28 @@ export const standalone: SourcePlugin = {
       const releaseData = selections.release?.data as
         | { latestStableTag?: string | null }
         | undefined
+      // Only honour a comfyVersion pick on the stable channel, matching the
+      // variant branch and `buildInstallation`: `getFieldOptions` returns [] for
+      // 'latest', so a value carried over from a channel toggle is stale and
+      // would pin the picker to a version the install never runs.
+      const isStable = selections.release?.value === 'stable'
       const pickedComfyTag =
+        isStable &&
         typeof selections.comfyVersion?.value === 'string' &&
         /^v\d+\.\d+\.\d+$/.test(selections.comfyVersion.value)
           ? selections.comfyVersion.value
           : null
       const targetComfyVersion =
         pickedComfyTag ?? releaseData?.latestStableTag ?? (await getLatestStableTag())
-      const catalog = await loadTemplateCatalog({ comfyVersion: targetComfyVersion })
+      const { templates: catalog, assetBase } = await loadTemplateCatalog({
+        comfyVersion: targetComfyVersion
+      })
 
       const installId = typeof context.installationId === 'string' ? context.installationId : null
       const installation = installId ? await installations.get(installId) : null
       // `budgeted` stops the timed-out pass writing after we return, so a slow
       // `modelsPresent: false` reads as "unbadged", never "confirmed absent".
       let budgeted = false
-      const assetBase = templateAssetBaseFor(
-        await resolveTemplatePackageVersion(targetComfyVersion).catch(() => null)
-      )
       const presenceById = new Map<string, boolean>()
       const presencePass = Promise.all(
         catalog.map(async (tpl) => {

--- a/src/main/sources/standalone/starterTemplateManifest.test.ts
+++ b/src/main/sources/standalone/starterTemplateManifest.test.ts
@@ -31,6 +31,11 @@ function doc(templates: unknown[]): Record<string, unknown> {
   return { schemaVersion: 1, templates }
 }
 
+/** Disk-cache contents, stamped fresh unless a write time is given. */
+function cached(templates: unknown[], writtenAt: number = Date.now()): string {
+  return JSON.stringify({ ...doc(templates), writtenAt })
+}
+
 const VALID_IMAGE = { id: 'image_one', modality: 'image' }
 
 function entriesOf(raw: unknown): { id: string; modality: string }[] {
@@ -231,6 +236,22 @@ describe('per-entry validation drops individually', () => {
     expect(parsed![0]!.snapshot).toEqual(snapshot)
   })
 
+  it('keeps snapshotOverrides when a snapshot backs it', () => {
+    const snapshot = { title: 'T', description: 'D', sizeBytes: 10, mediaSubtype: 'webp' }
+    const parsed = parseStarterTemplateManifest(
+      doc([{ ...VALID_IMAGE, snapshot, snapshotOverrides: true }])
+    )
+    expect(
+      parsed![0]!.snapshotOverrides,
+      'content pinned this card to its own copy, not the live index'
+    ).toBe(true)
+  })
+
+  it('drops snapshotOverrides when no snapshot backs it', () => {
+    const parsed = parseStarterTemplateManifest(doc([{ ...VALID_IMAGE, snapshotOverrides: true }]))
+    expect(parsed![0]!.snapshotOverrides, 'an override with nothing to override').toBeUndefined()
+  })
+
   it('preserves availability window fields when ISO-8601', () => {
     const parsed = parseStarterTemplateManifest(
       doc([{ ...VALID_IMAGE, availableFrom: '2026-01-01T00:00:00Z' }])
@@ -332,7 +353,7 @@ describe('flag plumbing and fallback layers', () => {
   })
 
   it('serves a warm disk cache when the fetch fails', async () => {
-    readFileSync.mockReturnValue(JSON.stringify(doc([{ id: 'cached_one', modality: 'image' }])))
+    readFileSync.mockReturnValue(cached([{ id: 'cached_one', modality: 'image' }]))
     getOpsFlagPayload.mockResolvedValue(undefined)
     await initStarterTemplates({ distinctId: 'anon' })
     expect((await getStarterTemplatesAsync()).map((e) => e.id)).toEqual(['cached_one'])
@@ -347,6 +368,33 @@ describe('flag plumbing and fallback layers', () => {
     getOpsFlagPayload.mockResolvedValue(undefined)
     await initStarterTemplates({ distinctId: 'anon' })
     expect(await getStarterTemplatesAsync()).toEqual(CURATED_TEMPLATES)
+  })
+
+  it('decays to the baked-in list once the cache outlives its maximum age', async () => {
+    const fifteenDays = 15 * 24 * 60 * 60 * 1000
+    readFileSync.mockReturnValue(
+      cached([{ id: 'cached_one', modality: 'image' }], Date.now() - fifteenDays)
+    )
+    getOpsFlagPayload.mockResolvedValue(undefined)
+    await initStarterTemplates({ distinctId: 'anon' })
+    expect(
+      await getStarterTemplatesAsync(),
+      'deleting the flag must eventually roll the picker back'
+    ).toEqual(CURATED_TEMPLATES)
+  })
+
+  it('discards a cache written before the age stamp existed', async () => {
+    readFileSync.mockReturnValue(JSON.stringify(doc([{ id: 'cached_one', modality: 'image' }])))
+    getOpsFlagPayload.mockResolvedValue(undefined)
+    await initStarterTemplates({ distinctId: 'anon' })
+    expect(await getStarterTemplatesAsync()).toEqual(CURATED_TEMPLATES)
+  })
+
+  it('stamps the cache it writes so a later read can age it out', async () => {
+    getOpsFlagPayload.mockResolvedValue(JSON.stringify(doc([VALID_IMAGE])))
+    await initStarterTemplates({ distinctId: 'anon' })
+    const [, written] = writeFileSafe.mock.calls[0] as [string, string]
+    expect(typeof JSON.parse(written).writtenAt).toBe('number')
   })
 
   it('writes the disk cache after a successful parse', async () => {

--- a/src/main/sources/standalone/starterTemplateManifest.test.ts
+++ b/src/main/sources/standalone/starterTemplateManifest.test.ts
@@ -424,16 +424,17 @@ describe('flag plumbing and fallback layers', () => {
 
 describe('a known id must agree with its baked-in modality', () => {
   it('drops a baked-in id filed under the wrong tab', () => {
+    const [misfiled, correct] = CURATED_TEMPLATES.filter((t) => t.modality === 'image')
     const parsed = parseStarterTemplateManifest(
       doc([
-        { id: 'image_z_image_turbo', modality: 'video' },
-        { id: 'sdxlturbo_example', modality: 'image' }
+        { id: misfiled!.id, modality: 'video' },
+        { id: correct!.id, modality: 'image' }
       ])
     )
     expect(
       parsed!.map((e) => e.id),
       'a known id under the wrong tab is dropped'
-    ).toEqual(['sdxlturbo_example'])
+    ).toEqual([correct!.id])
   })
 
   it('keeps every baked-in id under its own modality', () => {

--- a/src/main/sources/standalone/starterTemplateManifest.test.ts
+++ b/src/main/sources/standalone/starterTemplateManifest.test.ts
@@ -1,0 +1,407 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type * as FsModule from 'fs'
+
+const getOpsFlagPayload = vi.fn()
+const capture = vi.fn()
+vi.mock('../../lib/telemetry', () => ({
+  getOpsFlagPayload: (...args: unknown[]) => getOpsFlagPayload(...args),
+  capture: (...args: unknown[]) => capture(...args)
+}))
+
+const readFileSync = vi.fn()
+const writeFileSafe = vi.fn()
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof FsModule>()
+  const patched = { ...actual, readFileSync: (...a: unknown[]) => readFileSync(...a) }
+  return { ...patched, default: patched }
+})
+vi.mock('../../lib/safe-file', () => ({ writeFileSafe: (...a: unknown[]) => writeFileSafe(...a) }))
+vi.mock('../../lib/paths', () => ({ dataDir: () => '/tmp/does-not-exist' }))
+
+import {
+  parseStarterTemplateManifest,
+  initStarterTemplates,
+  getStarterTemplatesAsync,
+  STARTER_TEMPLATES_FLAG_KEY,
+  _resetForTest
+} from './starterTemplateManifest'
+import { CURATED_TEMPLATES } from './curatedTemplates'
+
+function doc(templates: unknown[]): Record<string, unknown> {
+  return { schemaVersion: 1, templates }
+}
+
+const VALID_IMAGE = { id: 'image_one', modality: 'image' }
+
+function entriesOf(raw: unknown): { id: string; modality: string }[] {
+  const parsed = parseStarterTemplateManifest(raw)
+  return (parsed ?? []).map((e) => ({ id: e.id, modality: e.modality }))
+}
+
+beforeEach(() => {
+  _resetForTest()
+  getOpsFlagPayload.mockReset()
+  capture.mockReset()
+  readFileSync.mockReset()
+  writeFileSafe.mockReset()
+  readFileSync.mockImplementation(() => {
+    throw new Error('ENOENT')
+  })
+})
+
+describe('payload parsing', () => {
+  it('parses the escaped-JSON-string form production actually returns', () => {
+    const raw = JSON.stringify(doc([VALID_IMAGE]))
+    expect(entriesOf(raw), 'the escaped-string shape production returns').toEqual([
+      { id: 'image_one', modality: 'image' }
+    ])
+  })
+
+  it('parses the already-parsed object form', () => {
+    expect(entriesOf(doc([VALID_IMAGE]))).toEqual([{ id: 'image_one', modality: 'image' }])
+  })
+
+  it('returns null (not a throw) when the string is not valid JSON', () => {
+    expect(parseStarterTemplateManifest('{"schemaVersion":1,')).toBeNull()
+    expect(parseStarterTemplateManifest('not json at all')).toBeNull()
+  })
+
+  it.each([[[]], ['"a string"'], [42], [null], [undefined], [true]])(
+    'rejects a non-object root: %s',
+    (root) => {
+      expect(parseStarterTemplateManifest(root)).toBeNull()
+    }
+  )
+
+  it.each([[undefined], [2], ['1'], [null], [0]])(
+    'rejects schemaVersion %s wholesale',
+    (schemaVersion) => {
+      expect(parseStarterTemplateManifest({ schemaVersion, templates: [VALID_IMAGE] })).toBeNull()
+    }
+  )
+
+  it.each([[undefined], [{}], ['nope'], [42]])('rejects templates: %s', (templates) => {
+    expect(parseStarterTemplateManifest({ schemaVersion: 1, templates })).toBeNull()
+  })
+
+  it('accepts an explicitly empty list as valid-but-empty', () => {
+    expect(parseStarterTemplateManifest(doc([])), 'a deliberate clear is not garbage').toEqual([])
+  })
+
+  it('ignores unknown top-level and per-entry fields', () => {
+    const raw = {
+      schemaVersion: 1,
+      futureField: { nested: true },
+      templates: [{ ...VALID_IMAGE, somethingNew: 'ignored', anotherOne: 5 }]
+    }
+    expect(entriesOf(raw)).toEqual([{ id: 'image_one', modality: 'image' }])
+  })
+
+  it('accepts but ignores minComfyUIVersion', () => {
+    const parsed = parseStarterTemplateManifest(
+      doc([{ ...VALID_IMAGE, minComfyUIVersion: '0.24.0' }])
+    )
+    expect(parsed).toHaveLength(1)
+    expect(parsed![0], 'accepted for forward compat, never acted on').not.toHaveProperty(
+      'minComfyUIVersion'
+    )
+  })
+
+  it('handles a very large payload without hanging', () => {
+    const many = Array.from({ length: 1000 }, (_, i) => ({ id: `image_${i}`, modality: 'image' }))
+    expect(parseStarterTemplateManifest(doc(many))).toHaveLength(1000)
+  })
+})
+
+describe('per-entry validation drops individually', () => {
+  it.each([
+    ['missing id', { modality: 'image' }],
+    ['non-string id', { id: 42, modality: 'image' }],
+    ['empty id', { id: '', modality: 'image' }],
+    ['path traversal', { id: '../../etc/passwd', modality: 'image' }],
+    ['slash', { id: 'a/b', modality: 'image' }],
+    ['backslash', { id: 'a\\b', modality: 'image' }],
+    ['space', { id: 'foo bar', modality: 'image' }],
+    ['query', { id: 'foo?x=1', modality: 'image' }],
+    ['skip sentinel', { id: 'none', modality: 'image' }],
+    ['missing modality', { id: 'image_one' }],
+    ['wrong case', { id: 'image_one', modality: 'Image' }],
+    ['unknown modality', { id: 'image_one', modality: 'text' }],
+    ['null entry', null],
+    ['non-object entry', 'a string'],
+    [
+      'recommended + apiNode',
+      { id: 'image_one', modality: 'image', recommended: true, apiNode: true }
+    ]
+  ])('drops %s while keeping a valid sibling', (_label, bad) => {
+    const parsed = parseStarterTemplateManifest(doc([bad, { id: 'image_ok', modality: 'image' }]))
+    expect(parsed).toHaveLength(1)
+    expect(parsed![0]!.id).toBe('image_ok')
+  })
+
+  it('does not treat a truthy non-boolean as recommended', () => {
+    const parsed = parseStarterTemplateManifest(
+      doc([{ id: 'image_one', modality: 'image', recommended: 'yes' }])
+    )
+    expect(parsed).toHaveLength(1)
+    expect(parsed![0]!.recommended).toBeUndefined()
+  })
+
+  it.each([[-1], [Number.NaN], [Number.POSITIVE_INFINITY], ['1000']])(
+    'rejects a bad snapshot sizeBytes (%s) without dropping the entry',
+    (sizeBytes) => {
+      const parsed = parseStarterTemplateManifest(
+        doc([
+          {
+            id: 'image_one',
+            modality: 'image',
+            snapshot: { title: 'T', description: 'D', sizeBytes, mediaSubtype: 'webp' }
+          }
+        ])
+      )
+      expect(parsed).toHaveLength(1)
+      expect(parsed![0]!.snapshot).toBeUndefined()
+    }
+  )
+
+  it('rejects snapshot strings carrying control characters', () => {
+    const parsed = parseStarterTemplateManifest(
+      doc([
+        {
+          id: 'image_one',
+          modality: 'image',
+          snapshot: {
+            title: 'bad\u0007title',
+            description: 'D',
+            sizeBytes: 1,
+            mediaSubtype: 'webp'
+          }
+        }
+      ])
+    )
+    expect(parsed![0]!.snapshot).toBeUndefined()
+  })
+
+  it('caps absurdly long snapshot strings', () => {
+    const parsed = parseStarterTemplateManifest(
+      doc([
+        {
+          id: 'image_one',
+          modality: 'image',
+          snapshot: {
+            title: 'x'.repeat(50_000),
+            description: 'D',
+            sizeBytes: 1,
+            mediaSubtype: 'webp'
+          }
+        }
+      ])
+    )
+    expect(parsed![0]!.snapshot).toBeUndefined()
+  })
+
+  it('keeps 3 good entries when 1 of 4 is malformed', () => {
+    const parsed = parseStarterTemplateManifest(
+      doc([
+        { id: 'image_a', modality: 'image' },
+        { id: 'image_b', modality: 'image' },
+        { id: '../nope', modality: 'image' },
+        { id: 'image_d', modality: 'image' }
+      ])
+    )
+    expect(
+      parsed!.map((e) => e.id),
+      'one bad row must not take its siblings down'
+    ).toEqual(['image_a', 'image_b', 'image_d'])
+  })
+
+  it('yields an empty modality rather than rejecting the document', () => {
+    const parsed = parseStarterTemplateManifest(
+      doc([
+        { id: '../a', modality: 'image' },
+        { id: 'video_ok', modality: 'video' }
+      ])
+    )
+    expect(parsed!.map((e) => e.id)).toEqual(['video_ok'])
+  })
+
+  it('accepts a well-formed snapshot and preserves it', () => {
+    const snapshot = { title: 'T', description: 'D', sizeBytes: 10, mediaSubtype: 'webp' }
+    const parsed = parseStarterTemplateManifest(doc([{ ...VALID_IMAGE, snapshot }]))
+    expect(parsed![0]!.snapshot).toEqual(snapshot)
+  })
+
+  it('preserves availability window fields when ISO-8601', () => {
+    const parsed = parseStarterTemplateManifest(
+      doc([{ ...VALID_IMAGE, availableFrom: '2026-01-01T00:00:00Z' }])
+    )
+    expect(parsed![0]!.availableFrom).toBe('2026-01-01T00:00:00Z')
+  })
+
+  it.each([['not-a-date'], [42], ['2026-13-45']])(
+    'drops a malformed availability date (%s) without dropping the entry',
+    (availableFrom) => {
+      const parsed = parseStarterTemplateManifest(doc([{ ...VALID_IMAGE, availableFrom }]))
+      expect(parsed).toHaveLength(1)
+      expect(parsed![0]!.availableFrom).toBeUndefined()
+    }
+  )
+})
+
+describe('recommended / apiNode invariants at parse time', () => {
+  it('keeps only the first recommended per modality', () => {
+    const parsed = parseStarterTemplateManifest(
+      doc([
+        { id: 'image_a', modality: 'image', recommended: true },
+        { id: 'image_b', modality: 'image', recommended: true },
+        { id: 'video_a', modality: 'video', recommended: true }
+      ])
+    )
+    expect(parsed!.filter((e) => e.recommended).map((e) => e.id)).toEqual(['image_a', 'video_a'])
+  })
+
+  it('never marks an apiNode entry as recommended', () => {
+    const parsed = parseStarterTemplateManifest(
+      doc([
+        { id: 'api_x', modality: 'image', apiNode: true },
+        { id: 'image_b', modality: 'image', recommended: true }
+      ])
+    )
+    for (const entry of parsed!) {
+      if (entry.apiNode) expect(entry.recommended).toBeFalsy()
+    }
+  })
+})
+
+describe('flag plumbing and fallback layers', () => {
+  it('reads the desktop_starter_templates flag key', async () => {
+    getOpsFlagPayload.mockResolvedValue(JSON.stringify(doc([VALID_IMAGE])))
+    await initStarterTemplates({ distinctId: 'anon' })
+    expect(STARTER_TEMPLATES_FLAG_KEY).toBe('desktop_starter_templates')
+    expect(getOpsFlagPayload).toHaveBeenCalledWith(
+      STARTER_TEMPLATES_FLAG_KEY,
+      'anon',
+      expect.any(Number)
+    )
+  })
+
+  it('falls back to the baked-in list when the flag is absent', async () => {
+    getOpsFlagPayload.mockResolvedValue(undefined)
+    await initStarterTemplates({ distinctId: 'anon' })
+    expect(await getStarterTemplatesAsync()).toEqual(CURATED_TEMPLATES)
+  })
+
+  it('falls back when the payload is wholly unusable', async () => {
+    getOpsFlagPayload.mockResolvedValue('{ broken json')
+    await initStarterTemplates({ distinctId: 'anon' })
+    expect(await getStarterTemplatesAsync()).toEqual(CURATED_TEMPLATES)
+  })
+
+  it('falls back when the fetch rejects, without throwing', async () => {
+    getOpsFlagPayload.mockRejectedValue(new Error('network'))
+    await expect(initStarterTemplates({ distinctId: 'anon' })).resolves.toBeUndefined()
+    expect(await getStarterTemplatesAsync()).toEqual(CURATED_TEMPLATES)
+  })
+
+  it('serves the payload list when the flag resolves', async () => {
+    getOpsFlagPayload.mockResolvedValue(JSON.stringify(doc([VALID_IMAGE])))
+    await initStarterTemplates({ distinctId: 'anon' })
+    expect((await getStarterTemplatesAsync()).map((e) => e.id)).toEqual(['image_one'])
+  })
+
+  it('awaits the in-flight boot fetch rather than racing to the fallback', async () => {
+    let release: (v: unknown) => void = () => {}
+    getOpsFlagPayload.mockReturnValue(
+      new Promise((r) => {
+        release = r
+      })
+    )
+    void initStarterTemplates({ distinctId: 'anon' })
+    const pending = getStarterTemplatesAsync()
+    release(JSON.stringify(doc([VALID_IMAGE])))
+    expect((await pending).map((e) => e.id)).toEqual(['image_one'])
+  })
+
+  it('is idempotent within a process — one fetch regardless of callers', async () => {
+    getOpsFlagPayload.mockResolvedValue(JSON.stringify(doc([VALID_IMAGE])))
+    await Promise.all([
+      initStarterTemplates({ distinctId: 'anon' }),
+      initStarterTemplates({ distinctId: 'anon' })
+    ])
+    expect(getOpsFlagPayload).toHaveBeenCalledTimes(1)
+  })
+
+  it('serves a warm disk cache when the fetch fails', async () => {
+    readFileSync.mockReturnValue(JSON.stringify(doc([{ id: 'cached_one', modality: 'image' }])))
+    getOpsFlagPayload.mockResolvedValue(undefined)
+    await initStarterTemplates({ distinctId: 'anon' })
+    expect((await getStarterTemplatesAsync()).map((e) => e.id)).toEqual(['cached_one'])
+  })
+
+  it.each([
+    ['corrupt JSON', '{ not json'],
+    ['wrong schemaVersion', JSON.stringify({ schemaVersion: 99, templates: [VALID_IMAGE] })],
+    ['tampered shape', JSON.stringify({ templates: 'nope' })]
+  ])('%s in the disk cache is discarded', async (_label, contents) => {
+    readFileSync.mockReturnValue(contents)
+    getOpsFlagPayload.mockResolvedValue(undefined)
+    await initStarterTemplates({ distinctId: 'anon' })
+    expect(await getStarterTemplatesAsync()).toEqual(CURATED_TEMPLATES)
+  })
+
+  it('writes the disk cache after a successful parse', async () => {
+    getOpsFlagPayload.mockResolvedValue(JSON.stringify(doc([VALID_IMAGE])))
+    await initStarterTemplates({ distinctId: 'anon' })
+    expect(writeFileSafe).toHaveBeenCalledTimes(1)
+    const [, written] = writeFileSafe.mock.calls[0] as [string, string]
+    expect(JSON.parse(written).templates[0].id).toBe('image_one')
+  })
+
+  it('survives a failing disk-cache write', async () => {
+    writeFileSafe.mockImplementation(() => {
+      throw new Error('EROFS')
+    })
+    getOpsFlagPayload.mockResolvedValue(JSON.stringify(doc([VALID_IMAGE])))
+    await initStarterTemplates({ distinctId: 'anon' })
+    expect((await getStarterTemplatesAsync()).map((e) => e.id)).toEqual(['image_one'])
+  })
+
+  it('captures no telemetry event while reading the payload', async () => {
+    getOpsFlagPayload.mockResolvedValue(JSON.stringify(doc([VALID_IMAGE])))
+    await initStarterTemplates({ distinctId: 'anon' })
+    await getStarterTemplatesAsync()
+    expect(capture, 'consent safety rests on this path never capturing').not.toHaveBeenCalled()
+  })
+})
+
+describe('a known id must agree with its baked-in modality', () => {
+  it('drops a baked-in id filed under the wrong tab', () => {
+    const parsed = parseStarterTemplateManifest(
+      doc([
+        { id: 'image_z_image_turbo', modality: 'video' },
+        { id: 'sdxlturbo_example', modality: 'image' }
+      ])
+    )
+    expect(
+      parsed!.map((e) => e.id),
+      'a known id under the wrong tab is dropped'
+    ).toEqual(['sdxlturbo_example'])
+  })
+
+  it('keeps every baked-in id under its own modality', () => {
+    const parsed = parseStarterTemplateManifest(
+      doc(CURATED_TEMPLATES.map((t) => ({ id: t.id, modality: t.modality })))
+    )
+    expect(parsed).toHaveLength(CURATED_TEMPLATES.length)
+  })
+
+  it('leaves an unknown id free to claim any modality', () => {
+    const parsed = parseStarterTemplateManifest(
+      doc([{ id: 'brand_new_template', modality: 'video' }])
+    )
+    expect(
+      parsed!.map((e) => e.modality),
+      'unknown ids may claim any modality'
+    ).toEqual(['video'])
+  })
+})

--- a/src/main/sources/standalone/starterTemplateManifest.ts
+++ b/src/main/sources/standalone/starterTemplateManifest.ts
@@ -140,12 +140,26 @@ export function parseStarterTemplateManifest(raw: unknown): CuratedTemplate[] | 
 let diskLoaded = false
 let diskTemplates: CuratedTemplate[] | null = null
 
+/**
+ * Bounds how long a cached payload can outlive the flag that produced it.
+ * Deleting or disabling `desktop_starter_templates` is the first rollback an
+ * operator reaches for, and it surfaces as the same `null` a failed fetch does,
+ * so an unbounded cache would serve a withdrawn payload forever. Expiry decays
+ * the picker back to `CURATED_TEMPLATES` without needing that distinction.
+ */
+const CACHE_MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000
+
 /** Re-validated on read: shared across app versions, so possibly stale. */
 function fromDisk(): CuratedTemplate[] | null {
   if (!diskLoaded) {
     diskLoaded = true
     try {
-      diskTemplates = parseStarterTemplateManifest(fs.readFileSync(CACHE_FILE(), 'utf-8'))
+      const raw: unknown = JSON.parse(fs.readFileSync(CACHE_FILE(), 'utf-8'))
+      // Stamped in the payload rather than read from mtime, which a backup
+      // restore or file copy would reset.
+      const writtenAt = (raw as { writtenAt?: unknown })?.writtenAt
+      const fresh = typeof writtenAt === 'number' && Date.now() - writtenAt < CACHE_MAX_AGE_MS
+      diskTemplates = fresh ? parseStarterTemplateManifest(raw) : null
     } catch {
       diskTemplates = null
     }
@@ -157,7 +171,7 @@ function persist(templates: CuratedTemplate[]): void {
   try {
     writeFileSafe(
       CACHE_FILE(),
-      JSON.stringify({ schemaVersion: SCHEMA_VERSION, templates }, null, 2)
+      JSON.stringify({ schemaVersion: SCHEMA_VERSION, writtenAt: Date.now(), templates }, null, 2)
     )
   } catch {}
 }

--- a/src/main/sources/standalone/starterTemplateManifest.ts
+++ b/src/main/sources/standalone/starterTemplateManifest.ts
@@ -1,0 +1,191 @@
+/**
+ * Loads remote starter-templates (PostHog) to enable dynamic updates in the picker without a release.
+ * Falls back: remote payload → disk cache → `CURATED_TEMPLATES`.
+ * Uses `opsFlag.ts` to allow picker rendering before user consent.
+ */
+import fs from 'fs'
+import path from 'path'
+
+import { makeOpsFlagPayload } from '../../lib/opsFlag'
+import { dataDir } from '../../lib/paths'
+import { writeFileSafe } from '../../lib/safe-file'
+import {
+  CURATED_TEMPLATES,
+  TEMPLATE_ID_PATTERN,
+  TEMPLATE_MODALITY_ORDER,
+  NO_TEMPLATE_VALUE,
+  type CuratedTemplate,
+  type TemplateModality,
+  type TemplateSnapshot
+} from './curatedTemplates'
+
+export const STARTER_TEMPLATES_FLAG_KEY = 'desktop_starter_templates'
+
+/** A remote entry naming a known template must agree with its modality. */
+const BAKED_IN_BY_ID = new Map(CURATED_TEMPLATES.map((t) => [t.id, t.modality]))
+
+const SCHEMA_VERSION = 1
+const MAX_TEXT_LENGTH = 4096
+const MAX_ID_LENGTH = 128
+// eslint-disable-next-line no-control-regex -- matching control chars is the point
+const CONTROL_CHARS = /[\u0000-\u001f\u007f]/
+
+const CACHE_FILE = (): string => path.join(dataDir(), 'starter-templates-cache.json')
+
+function isModality(value: unknown): value is TemplateModality {
+  return typeof value === 'string' && (TEMPLATE_MODALITY_ORDER as readonly string[]).includes(value)
+}
+
+/** Drops the field, not the entry. */
+function safeText(value: unknown): string | undefined {
+  if (typeof value !== 'string' || value.length > MAX_TEXT_LENGTH) return undefined
+  if (CONTROL_CHARS.test(value)) return undefined
+  return value
+}
+
+function isIsoDate(value: unknown): value is string {
+  return typeof value === 'string' && !Number.isNaN(Date.parse(value))
+}
+
+function parseSnapshot(value: unknown): TemplateSnapshot | undefined {
+  if (!value || typeof value !== 'object') return undefined
+  const r = value as Record<string, unknown>
+  const title = safeText(r.title)
+  const description = safeText(r.description)
+  const mediaSubtype = safeText(r.mediaSubtype)
+  const { sizeBytes } = r
+  if (title === undefined || description === undefined || mediaSubtype === undefined) {
+    return undefined
+  }
+  if (typeof sizeBytes !== 'number' || !Number.isFinite(sizeBytes) || sizeBytes < 0) {
+    return undefined
+  }
+  return { title, description, sizeBytes, mediaSubtype }
+}
+
+/**
+ * Default-deny. `id` reaches a filesystem path and a fetch URL, so it is
+ * pattern-checked; a bad optional field drops only itself.
+ */
+function parseEntry(value: unknown): CuratedTemplate | null {
+  if (!value || typeof value !== 'object') return null
+  const r = value as Record<string, unknown>
+
+  const { id } = r
+  if (typeof id !== 'string' || id.length > MAX_ID_LENGTH) return null
+  if (id === NO_TEMPLATE_VALUE || !TEMPLATE_ID_PATTERN.test(id)) return null
+  if (!isModality(r.modality)) return null
+  // Would fork the card into two tabs, and the right one could only recover
+  // with a duplicate id.
+  const bakedIn = BAKED_IN_BY_ID.get(id)
+  if (bakedIn && bakedIn !== r.modality) return null
+
+  const recommended = r.recommended === true
+  const apiNode = r.apiNode === true
+  if (recommended && apiNode) return null
+
+  const snapshot = parseSnapshot(r.snapshot)
+  const availableFrom = isIsoDate(r.availableFrom) ? r.availableFrom : undefined
+  const availableUntil = isIsoDate(r.availableUntil) ? r.availableUntil : undefined
+
+  const base = {
+    id,
+    modality: r.modality,
+    ...(snapshot ? { snapshot } : {}),
+    ...(availableFrom ? { availableFrom } : {}),
+    ...(availableUntil ? { availableUntil } : {}),
+    ...(r.snapshotOverrides === true && snapshot ? { snapshotOverrides: true as const } : {})
+  }
+
+  return apiNode
+    ? { ...base, apiNode: true }
+    : { ...base, ...(recommended ? { recommended: true as const } : {}) }
+}
+
+/**
+ * Accepts the escaped-JSON-string form production returns as well as a parsed
+ * object. `null` means unusable; invalid entries drop individually.
+ */
+export function parseStarterTemplateManifest(raw: unknown): CuratedTemplate[] | null {
+  let data = raw
+  if (typeof data === 'string') {
+    try {
+      data = JSON.parse(data)
+    } catch {
+      return null
+    }
+  }
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return null
+
+  const document = data as Record<string, unknown>
+  if (document.schemaVersion !== SCHEMA_VERSION) return null
+  if (!Array.isArray(document.templates)) return null
+
+  const entries = document.templates
+    .map(parseEntry)
+    .filter((entry): entry is CuratedTemplate => entry !== null)
+
+  const seenRecommended = new Set<TemplateModality>()
+  return entries.map((entry) => {
+    if (entry.recommended !== true) return entry
+    if (seenRecommended.has(entry.modality)) {
+      const { recommended: _dropped, ...rest } = entry
+      return { ...rest }
+    }
+    seenRecommended.add(entry.modality)
+    return entry
+  })
+}
+
+let diskLoaded = false
+let diskTemplates: CuratedTemplate[] | null = null
+
+/** Re-validated on read: shared across app versions, so possibly stale. */
+function fromDisk(): CuratedTemplate[] | null {
+  if (!diskLoaded) {
+    diskLoaded = true
+    try {
+      diskTemplates = parseStarterTemplateManifest(fs.readFileSync(CACHE_FILE(), 'utf-8'))
+    } catch {
+      diskTemplates = null
+    }
+  }
+  return diskTemplates
+}
+
+function persist(templates: CuratedTemplate[]): void {
+  try {
+    writeFileSafe(
+      CACHE_FILE(),
+      JSON.stringify({ schemaVersion: SCHEMA_VERSION, templates }, null, 2)
+    )
+  } catch {}
+}
+
+const flag = makeOpsFlagPayload<CuratedTemplate[] | null>({
+  key: STARTER_TEMPLATES_FLAG_KEY,
+  fallback: null,
+  parse: (value) => parseStarterTemplateManifest(value) ?? undefined
+})
+
+/** Persists the resolved list so the next cold start has a warm cache. */
+export async function initStarterTemplates(opts: {
+  distinctId: string
+  timeoutMs?: number
+}): Promise<void> {
+  await flag.init(opts)
+  const resolved = await flag.get()
+  if (resolved) persist(resolved)
+}
+
+/** Awaits the boot fetch so a picker opening early sees the resolved value. */
+export async function getStarterTemplatesAsync(): Promise<readonly CuratedTemplate[]> {
+  return (await flag.get()) ?? fromDisk() ?? CURATED_TEMPLATES
+}
+
+/** @internal — exposed for tests. */
+export function _resetForTest(): void {
+  flag._resetForTest()
+  diskLoaded = false
+  diskTemplates = null
+}

--- a/src/main/sources/standalone/templateCatalog.test.ts
+++ b/src/main/sources/standalone/templateCatalog.test.ts
@@ -200,7 +200,11 @@ describe('loadTemplateCatalog', () => {
     const recImage = catalog.find((c) => c.modality === 'image' && c.recommended)!
     expect(recImage.id).toBe('fresh_image_model')
     expect(recImage.name).toBe('Fresh Model')
-    expect(catalog.some((c) => c.id === first.id)).toBe(false)
+    expect(
+      catalog.find((c) => c.id === first.id)?.recommended ?? false,
+      'the vanished id loses its recommendation to the substitute'
+    ).toBe(false)
+    expect(catalog.filter((c) => c.modality === 'image')).toHaveLength(4)
   })
 
   it('skips api/size-less candidates when substituting (must be locally installable)', async () => {
@@ -231,14 +235,27 @@ describe('loadTemplateCatalog', () => {
     expect(new Set(ids).size).toBe(ids.length) // no dupes across slots
   })
 
-  it('falls back to the snapshot when online but no substitute exists', async () => {
+  it('prefers a compatible substitute over a card the index does not carry', async () => {
     const first = CURATED_TEMPLATES[0]!
-    // Online (non-empty index) but only an unusable api/size-less image entry.
     mockedFetchJSON.mockResolvedValue(
-      imageCategory([{ name: 'api_only', title: 'Cloud', size: 0 }])
+      imageCategory([{ name: 'live_local_image', title: 'Live', size: 5 }])
     )
     const catalog = await loadTemplateCatalog()
-    expect(catalog.find((c) => c.id === first.id)!.title).toBe(first.snapshot.title)
+    const image = catalog.filter((c) => c.modality === 'image').map((c) => c.id)
+    expect(image, 'the compatible substitute is preferred').toContain('live_local_image')
+    expect(image.indexOf('live_local_image')).toBeLessThan(
+      image.includes(first.id) ? image.indexOf(first.id) : image.length
+    )
+    expect(image).toHaveLength(4)
+  })
+
+  it('keeps an API-node card the index omits, since it runs server-side', async () => {
+    const apiCard = CURATED_TEMPLATES.find((t) => t.apiNode)!
+    mockedFetchJSON.mockResolvedValue(
+      imageCategory([{ name: 'unrelated_local', title: 'Local', size: 1_000 }])
+    )
+    const catalog = await loadTemplateCatalog()
+    expect(catalog.find((c) => c.id === apiCard.id)?.apiNode).toBe(true)
   })
 
   it('never substitutes a local download into a vanished API-node slot', async () => {

--- a/src/main/sources/standalone/templateCatalog.test.ts
+++ b/src/main/sources/standalone/templateCatalog.test.ts
@@ -3,10 +3,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 vi.mock('../../lib/fetch', () => ({ fetchJSON: vi.fn() }))
 
 import { loadTemplateCatalog, resetTemplateCatalogCache } from './templateCatalog'
+import type { HydratedTemplate } from './templateCatalog'
 import { CURATED_TEMPLATES, TEMPLATE_MODALITY_ORDER, thumbnailUrlFor } from './curatedTemplates'
 import { fetchJSON } from '../../lib/fetch'
 
 const mockedFetchJSON = vi.mocked(fetchJSON)
+
+/** Cards only; `assetBase` is asserted separately where it matters. */
+const loadCards = async (opts?: { comfyVersion?: string | null }): Promise<HydratedTemplate[]> =>
+  (await loadTemplateCatalog(opts)).templates
 
 /** A live index with one category whose templates override the given curated
  *  ids' metadata. */
@@ -27,7 +32,7 @@ describe('loadTemplateCatalog', () => {
 
   it('returns every curated template, ordered by modality', async () => {
     mockedFetchJSON.mockResolvedValue([])
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     expect(catalog.length).toBe(CURATED_TEMPLATES.length)
 
     const rank = (m: string) => TEMPLATE_MODALITY_ORDER.indexOf(m as never)
@@ -43,7 +48,7 @@ describe('loadTemplateCatalog', () => {
         [first.id]: { title: 'Live', description: 'LiveDesc', size: 42, mediaSubtype: 'webp' }
       })
     )
-    const card = (await loadTemplateCatalog()).find((c) => c.id === first.id)!
+    const card = (await loadCards()).find((c) => c.id === first.id)!
     expect(card.title).toBe('Live')
     expect(card.description).toBe('LiveDesc')
     expect(card.sizeBytes).toBe(42)
@@ -57,7 +62,7 @@ describe('loadTemplateCatalog', () => {
         [first.id]: { title: 'Z-Image-Turbo Text to Image', tags: ['Image', 'Text to Image'] }
       })
     )
-    const card = (await loadTemplateCatalog()).find((c) => c.id === first.id)!
+    const card = (await loadCards()).find((c) => c.id === first.id)!
     expect(card.name).toBe('Z-Image-Turbo')
     expect(card.task).toBe('Text to Image')
   })
@@ -72,7 +77,7 @@ describe('loadTemplateCatalog', () => {
         }
       })
     )
-    const card = (await loadTemplateCatalog()).find((c) => c.id === first.id)!
+    const card = (await loadCards()).find((c) => c.id === first.id)!
     expect(card.name).toBe('Flux.2 [Klein] 4B Distilled')
     expect(card.task).toBe('Image Edit')
   })
@@ -82,7 +87,7 @@ describe('loadTemplateCatalog', () => {
     mockedFetchJSON.mockResolvedValue(
       indexFor({ [first.id]: { title: 'SDXL Turbo', tags: ['Image'] } })
     )
-    const card = (await loadTemplateCatalog()).find((c) => c.id === first.id)!
+    const card = (await loadCards()).find((c) => c.id === first.id)!
     expect(card.name).toBe('SDXL Turbo')
     expect(card.task).toBe('Text to Image')
   })
@@ -92,7 +97,7 @@ describe('loadTemplateCatalog', () => {
     mockedFetchJSON.mockResolvedValue(
       indexFor({ [first.id]: { title: 'X', tags: ['', '  ', 'Image'] } })
     )
-    const card = (await loadTemplateCatalog()).find((c) => c.id === first.id)!
+    const card = (await loadCards()).find((c) => c.id === first.id)!
     expect(card.task).toBe('Text to Image')
   })
 
@@ -103,7 +108,7 @@ describe('loadTemplateCatalog', () => {
         [apiTemplate.id]: { title: 'Seedream 5.0 Pro: Image Edit', tags: ['API', 'Image Edit'] }
       })
     )
-    const card = (await loadTemplateCatalog()).find((c) => c.id === apiTemplate.id)!
+    const card = (await loadCards()).find((c) => c.id === apiTemplate.id)!
     expect(card.task).toBe('Image Edit')
     expect(card.name).toBe('Seedream 5.0 Pro')
   })
@@ -116,13 +121,13 @@ describe('loadTemplateCatalog', () => {
         '3D Model'
       )
     )
-    const card = (await loadTemplateCatalog()).find((c) => c.id === apiTemplate.id)!
+    const card = (await loadCards()).find((c) => c.id === apiTemplate.id)!
     expect(card.task).toBe('Image to 3D')
   })
 
   it('flags API-node templates from the manifest, offline included', async () => {
     mockedFetchJSON.mockImplementationOnce(() => Promise.reject(new Error('offline')))
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     for (const curated of CURATED_TEMPLATES) {
       expect(catalog.find((c) => c.id === curated.id)!.apiNode, curated.id).toBe(
         curated.apiNode === true
@@ -135,7 +140,7 @@ describe('loadTemplateCatalog', () => {
     mockedFetchJSON.mockResolvedValue(
       indexFor({ [local.id]: { openSource: false, size: 142_000_000_000 } })
     )
-    const card = (await loadTemplateCatalog()).find((c) => c.id === local.id)!
+    const card = (await loadCards()).find((c) => c.id === local.id)!
     expect(card.apiNode).toBe(false)
     expect(card.sizeBytes).toBe(142_000_000_000)
   })
@@ -143,7 +148,7 @@ describe('loadTemplateCatalog', () => {
   it('falls back to the snapshot when the index omits a curated id', async () => {
     const first = CURATED_TEMPLATES[0]!
     mockedFetchJSON.mockResolvedValue([])
-    const card = (await loadTemplateCatalog()).find((c) => c.id === first.id)!
+    const card = (await loadCards()).find((c) => c.id === first.id)!
     expect(card.title).toBe(first.snapshot.title)
     expect(card.sizeBytes).toBe(first.snapshot.sizeBytes)
     expect(card.thumbnailUrl).toBe(thumbnailUrlFor(first.id, first.snapshot.mediaSubtype))
@@ -152,13 +157,13 @@ describe('loadTemplateCatalog', () => {
   it('ignores a live size of 0 and keeps the snapshot estimate', async () => {
     const first = CURATED_TEMPLATES[0]!
     mockedFetchJSON.mockResolvedValue(indexFor({ [first.id]: { size: 0 } }))
-    const card = (await loadTemplateCatalog()).find((c) => c.id === first.id)!
+    const card = (await loadCards()).find((c) => c.id === first.id)!
     expect(card.sizeBytes).toBe(first.snapshot.sizeBytes)
   })
 
   it('returns a snapshot-only catalog when the fetch rejects (offline)', async () => {
     mockedFetchJSON.mockImplementationOnce(() => Promise.reject(new Error('offline')))
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     expect(catalog.length).toBe(CURATED_TEMPLATES.length)
     const first = CURATED_TEMPLATES[0]!
     expect(catalog.find((c) => c.id === first.id)!.title).toBe(first.snapshot.title)
@@ -166,13 +171,13 @@ describe('loadTemplateCatalog', () => {
 
   it('survives a malformed index without throwing', async () => {
     mockedFetchJSON.mockResolvedValue({ not: 'an array' })
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     expect(catalog.length).toBe(CURATED_TEMPLATES.length)
   })
 
   it('fetches the index exactly once regardless of curated count', async () => {
     mockedFetchJSON.mockResolvedValue([])
-    await loadTemplateCatalog()
+    await loadCards()
     expect(mockedFetchJSON).toHaveBeenCalledTimes(1)
   })
 
@@ -196,7 +201,7 @@ describe('loadTemplateCatalog', () => {
         }
       ])
     )
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     const recImage = catalog.find((c) => c.modality === 'image' && c.recommended)!
     expect(recImage.id).toBe('fresh_image_model')
     expect(recImage.name).toBe('Fresh Model')
@@ -215,9 +220,7 @@ describe('loadTemplateCatalog', () => {
         { name: 'good_local', title: 'Good Local', size: 9 }
       ])
     )
-    const recImage = (await loadTemplateCatalog()).find(
-      (c) => c.modality === 'image' && c.recommended
-    )!
+    const recImage = (await loadCards()).find((c) => c.modality === 'image' && c.recommended)!
     expect(recImage.id).toBe('good_local')
   })
 
@@ -230,7 +233,7 @@ describe('loadTemplateCatalog', () => {
         { name: 'sub_d', title: 'D', size: 4 }
       ])
     )
-    const images = (await loadTemplateCatalog()).filter((c) => c.modality === 'image')
+    const images = (await loadCards()).filter((c) => c.modality === 'image')
     const ids = images.map((c) => c.id)
     expect(new Set(ids).size).toBe(ids.length) // no dupes across slots
   })
@@ -240,12 +243,13 @@ describe('loadTemplateCatalog', () => {
     mockedFetchJSON.mockResolvedValue(
       imageCategory([{ name: 'live_local_image', title: 'Live', size: 5 }])
     )
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     const image = catalog.filter((c) => c.modality === 'image').map((c) => c.id)
     expect(image, 'the compatible substitute is preferred').toContain('live_local_image')
-    expect(image.indexOf('live_local_image')).toBeLessThan(
-      image.includes(first.id) ? image.indexOf(first.id) : image.length
-    )
+    expect(
+      image.indexOf(first.id),
+      'the index-absent card returns only via terminal top-up'
+    ).toBeGreaterThan(image.indexOf('live_local_image'))
     expect(image).toHaveLength(4)
   })
 
@@ -254,7 +258,7 @@ describe('loadTemplateCatalog', () => {
     mockedFetchJSON.mockResolvedValue(
       imageCategory([{ name: 'unrelated_local', title: 'Local', size: 1_000 }])
     )
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     expect(catalog.find((c) => c.id === apiCard.id)?.apiNode).toBe(true)
   })
 
@@ -268,7 +272,7 @@ describe('loadTemplateCatalog', () => {
         { name: 'sub_d', title: 'D', size: 4 }
       ])
     )
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     const card = catalog.find((c) => c.id === apiTemplate.id)
     expect(card, 'API-node slot kept its snapshot').toBeDefined()
     expect(card!.apiNode).toBe(true)
@@ -282,20 +286,20 @@ describe('loadTemplateCatalog', () => {
   it('keeps the curated snapshot card when offline (empty index → no substitution)', async () => {
     const first = CURATED_TEMPLATES[0]!
     mockedFetchJSON.mockResolvedValue([]) // offline / empty
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     expect(catalog.length).toBe(CURATED_TEMPLATES.length)
     expect(catalog.find((c) => c.id === first.id)!.title).toBe(first.snapshot.title)
   })
 
   it('never yields duplicate ids', async () => {
     mockedFetchJSON.mockResolvedValue([])
-    const ids = (await loadTemplateCatalog()).map((c) => c.id)
+    const ids = (await loadCards()).map((c) => c.id)
     expect(new Set(ids).size).toBe(ids.length)
   })
 
   it('only emits modalities the picker can tab', async () => {
     mockedFetchJSON.mockResolvedValue([])
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     for (const card of catalog) {
       expect(TEMPLATE_MODALITY_ORDER).toContain(card.modality)
     }
@@ -303,19 +307,19 @@ describe('loadTemplateCatalog', () => {
 
   it('coalesces concurrent reads into a single index fetch', async () => {
     mockedFetchJSON.mockResolvedValue([])
-    const [a, b] = await Promise.all([loadTemplateCatalog(), loadTemplateCatalog()])
+    const [a, b] = await Promise.all([loadCards(), loadCards()])
     expect(mockedFetchJSON).toHaveBeenCalledTimes(1)
     expect(a).toBe(b)
   })
 
   it('serves a cached result on a follow-up read, then refetches after reset', async () => {
     mockedFetchJSON.mockResolvedValue([])
-    await loadTemplateCatalog()
-    await loadTemplateCatalog()
+    await loadCards()
+    await loadCards()
     expect(mockedFetchJSON).toHaveBeenCalledTimes(1)
 
     resetTemplateCatalogCache()
-    await loadTemplateCatalog()
+    await loadCards()
     expect(mockedFetchJSON).toHaveBeenCalledTimes(2)
   })
 
@@ -323,9 +327,9 @@ describe('loadTemplateCatalog', () => {
     vi.useFakeTimers()
     try {
       mockedFetchJSON.mockResolvedValue([])
-      await loadTemplateCatalog()
+      await loadCards()
       vi.advanceTimersByTime(60_001)
-      await loadTemplateCatalog()
+      await loadCards()
       expect(mockedFetchJSON).toHaveBeenCalledTimes(2)
     } finally {
       vi.useRealTimers()

--- a/src/main/sources/standalone/templateCatalog.ts
+++ b/src/main/sources/standalone/templateCatalog.ts
@@ -1,24 +1,36 @@
 /**
- * Hydrates the curated starter-template manifest against the live
- * `comfyui_workflow_templates` index, so card metadata (title, description,
- * size, thumbnail) tracks upstream automatically instead of being hand-kept.
+ * Resolves the starter-template manifest into picker cards, hydrated against the
+ * index the target ComfyUI pins rather than `main`.
  *
- * One ETag-cached fetch per picker open (`fetchJSON` handles caching, R2-mirror
- * retry, and last-cached fallback on network failure); the index is flattened
- * once into a `Map` for O(1) lookup per curated id rather than rescanning its
- * ~500 entries. When the index can't be reached at all (cold cache, offline),
- * every template falls back to its inline `snapshot`, so the catalog is always
- * non-empty and the picker always renders.
+ * Invariant: 4 cards per modality in all 4 modalities, at most one recommended
+ * and never an API-node card.
  */
 import { fetchJSON } from '../../lib/fetch'
 import {
   CURATED_TEMPLATES,
-  INDEX_URL,
   TEMPLATE_MODALITY_ORDER,
   thumbnailUrlFor,
+  type CuratedTemplate,
   type TemplateModality,
   type TemplateSnapshot
 } from './curatedTemplates'
+import { getStarterTemplatesAsync } from './starterTemplateManifest'
+import {
+  resolveTemplatePackageVersion,
+  templateAssetBaseFor,
+  templateIndexUrlFor
+} from './templatePin'
+
+const SLOTS_PER_MODALITY = 4
+
+/** The wizard blocks on this, and failing open costs only card metadata. */
+const INDEX_TIMEOUT_MS = 8000
+
+/** Substitutes only; a named id is always honoured. `type: "image"` also spans
+ *  Utility/LLM/Node Basics, which are not starter material. */
+const SUBSTITUTABLE_CATEGORIES = new Set(['Image', 'Video', 'Audio', '3D Model', 'Use Cases'])
+
+const BAKED_IN_IDS = new Set(CURATED_TEMPLATES.map((t) => t.id))
 
 /** A curated template merged with its (optional) live index metadata, ready to
  *  render as a picker card. */
@@ -54,6 +66,10 @@ interface IndexEntry {
   size?: unknown
   mediaSubtype?: unknown
   tags?: unknown
+  /** Node packs the workflow needs; the frontend hides these on non-cloud. */
+  requiresCustomNodes?: unknown
+  /** `local` / `cloud`. Absent means "everywhere". */
+  includeOnDistributions?: unknown
 }
 
 /** A live index category: `{ title, type, templates: [...] }`. */
@@ -102,10 +118,72 @@ function indexById(index: unknown): Map<string, IndexLocation> {
   return byId
 }
 
+/** The frontend hides custom-node workflows on non-cloud, so offering one
+ *  produces a card that silently disappears. */
+function isRunnableLocally(entry: IndexEntry): boolean {
+  const { requiresCustomNodes, includeOnDistributions } = entry
+  if (Array.isArray(requiresCustomNodes) && requiresCustomNodes.length > 0) return false
+  if (Array.isArray(includeOnDistributions) && !includeOnDistributions.includes('local')) {
+    return false
+  }
+  return true
+}
+
+/** Rendered as itself, replaced by an index pick, or dropped for backfill. */
+type Disposition =
+  | { kind: 'place'; location: IndexLocation | undefined }
+  | { kind: 'substitute'; location: IndexLocation }
+  | { kind: 'drop' }
+
+/** Reads `used` but never mutates it, so the caller owns placement. */
+function disposeOf(
+  template: CuratedTemplate,
+  byId: Map<string, IndexLocation>,
+  used: Set<string>,
+  online: boolean,
+  now: number
+): Disposition {
+  if (!isWithinWindow(template, now)) return { kind: 'drop' }
+
+  const location = byId.get(template.id)
+  if (location && !isRunnableLocally(location.entry)) return { kind: 'drop' }
+
+  if (location || !online) {
+    if (!location && !template.snapshot) return { kind: 'drop' }
+    return { kind: 'place', location }
+  }
+
+  // Runs server-side, so index membership says nothing about whether it works.
+  if (template.apiNode === true) {
+    return template.snapshot ? { kind: 'place', location: undefined } : { kind: 'drop' }
+  }
+
+  // Absent from this install's index, so it can't open. Both paths are silent.
+  const sub = firstUnusedOfModality(byId, template.modality, used)
+  console.warn(
+    `[templates] "${template.id}" is not in this install's template index; ` +
+      (sub ? `substituting "${sub.entry.name}"` : 'falling back to the built-in list')
+  )
+  return sub ? { kind: 'substitute', location: sub } : { kind: 'drop' }
+}
+
+/** Availability window, so content can stage a launch ahead of time. */
+function isWithinWindow(template: CuratedTemplate, now: number): boolean {
+  const { availableFrom, availableUntil } = template
+  if (availableFrom) {
+    const from = Date.parse(availableFrom)
+    if (!Number.isNaN(from) && now < from) return false
+  }
+  if (availableUntil) {
+    const until = Date.parse(availableUntil)
+    if (!Number.isNaN(until) && now >= until) return false
+  }
+  return true
+}
+
 const NON_TASK_TAGS = new Set(['image', 'video', 'audio', '3d', '3d model', 'api'])
 
-/** Subtitle shown when a template's `tags` carry no specific task, so a card is
- *  never left with a blank descriptor (e.g. Wan Fun Camera, tags: ['Video']). */
+/** Fallback so a card is never left with a blank descriptor. */
 const DEFAULT_TASK: Record<TemplateModality, string> = {
   image: 'Text to Image',
   video: 'Text to Video',
@@ -113,8 +191,7 @@ const DEFAULT_TASK: Record<TemplateModality, string> = {
   '3d': 'Image to 3D'
 }
 
-/** The template's task (e.g. "Text to Image", "Image Edit") from its `tags`,
- *  skipping kind labels; falls back to the modality default. */
+/** Task from `tags`, skipping kind labels; falls back to the modality default. */
 function taskOf(tags: unknown, modality: TemplateModality): string {
   if (Array.isArray(tags)) {
     for (const tag of tags) {
@@ -126,9 +203,7 @@ function taskOf(tags: unknown, modality: TemplateModality): string {
   return DEFAULT_TASK[modality]
 }
 
-/** Short card name: the title up to its `:` separator, then with a trailing task
- *  phrase stripped ("Z-Image-Turbo Text to Image" → "Z-Image-Turbo"). Falls back
- *  to the whole title when nothing is strippable. */
+/** "Z-Image-Turbo Text to Image" → "Z-Image-Turbo". */
 function nameOf(title: string, task: string): string {
   const beforeColon = title.split(':')[0]!.trim()
   if (task && beforeColon.toLowerCase().endsWith(task.toLowerCase())) {
@@ -138,9 +213,7 @@ function nameOf(title: string, task: string): string {
   return beforeColon || title
 }
 
-/** Build a card from a template `id` + its live index location (when present),
- *  preferring live metadata and falling back to the offline `snapshot` (which a
- *  substituted, non-curated id won't have). */
+/** Prefers live metadata over `snapshot`; `snapshotOverrides` inverts that. */
 function hydrateOne(card: {
   id: string
   modality: TemplateModality
@@ -148,9 +221,12 @@ function hydrateOne(card: {
   apiNode: boolean
   location: IndexLocation | undefined
   snapshot?: TemplateSnapshot
+  snapshotOverrides?: boolean
+  assetBase: string
 }): HydratedTemplate {
-  const { id, modality, recommended, apiNode, location, snapshot } = card
-  const entry = location?.entry
+  const { id, modality, recommended, apiNode, location, snapshot, snapshotOverrides, assetBase } =
+    card
+  const entry = snapshotOverrides && snapshot ? undefined : location?.entry
 
   const title = typeof entry?.title === 'string' ? entry.title : (snapshot?.title ?? id)
   const description =
@@ -162,7 +238,7 @@ function hydrateOne(card: {
       ? entry.mediaSubtype
       : (snapshot?.mediaSubtype ?? 'webp')
 
-  const task = taskOf(entry?.tags, modality)
+  const task = taskOf(location?.entry?.tags, modality)
 
   return {
     id,
@@ -174,116 +250,222 @@ function hydrateOne(card: {
     description,
     sizeBytes,
     apiNode,
-    thumbnailUrl: thumbnailUrlFor(id, mediaSubtype),
+    thumbnailUrl: thumbnailUrlFor(id, mediaSubtype, assetBase),
     category: location?.category ?? ''
   }
 }
 
-/** Stable ordering for the picker: modality tab order, then curated order
- *  within a modality. */
+/** Modality tab order, then manifest order within a modality. */
 function byModalityOrder(a: HydratedTemplate, b: HydratedTemplate): number {
   return TEMPLATE_MODALITY_ORDER.indexOf(a.modality) - TEMPLATE_MODALITY_ORDER.indexOf(b.modality)
 }
 
-/**
- * Resolve the curated manifest into renderable cards, hydrated from the live
- * index where reachable. Defensive by contract: never throws and never returns
- * a card the picker can't render —
- *   - a failed/garbage index fetch yields a snapshot-only catalog,
- *   - a duplicate curated id (dev typo) is collapsed to its first occurrence,
- *   - a curated entry missing its required snapshot (dev edit) is dropped, not
- *     surfaced as a broken card.
- * So renaming/removing a template upstream, or fat-fingering the manifest, can
- * only ever shrink the offering — it can't crash the picker.
- */
-/** Coalesces the wizard's field-options read and the thumbnail warm-up — which
- *  fire together at picker open — into one index fetch; a later open refetches. */
+/** Keyed by target version so switching channel mid-wizard re-filters. */
 const CATALOG_TTL_MS = 60_000
-let catalogInFlight: Promise<HydratedTemplate[]> | null = null
-let catalogCache: { at: number; value: HydratedTemplate[] } | null = null
+const catalogInFlight = new Map<string, Promise<HydratedTemplate[]>>()
+const catalogCache = new Map<string, { at: number; value: HydratedTemplate[] }>()
 
-export function loadTemplateCatalog(): Promise<HydratedTemplate[]> {
-  if (catalogCache && Date.now() - catalogCache.at < CATALOG_TTL_MS) {
-    return Promise.resolve(catalogCache.value)
-  }
-  if (catalogInFlight) return catalogInFlight
-  catalogInFlight = loadTemplateCatalogUncached()
+export function loadTemplateCatalog(opts?: {
+  comfyVersion?: string | null
+}): Promise<HydratedTemplate[]> {
+  const key = opts?.comfyVersion ?? ''
+  const cached = catalogCache.get(key)
+  if (cached && Date.now() - cached.at < CATALOG_TTL_MS) return Promise.resolve(cached.value)
+
+  const existing = catalogInFlight.get(key)
+  if (existing) return existing
+
+  const promise = loadTemplateCatalogUncached(opts?.comfyVersion ?? null)
     .then((value) => {
-      catalogCache = { at: Date.now(), value }
+      catalogCache.set(key, { at: Date.now(), value })
       return value
     })
     .finally(() => {
-      catalogInFlight = null
+      catalogInFlight.delete(key)
     })
-  return catalogInFlight
+  catalogInFlight.set(key, promise)
+  return promise
 }
 
 /** Drops the memoized catalog so the next read refetches. Test-only. */
 export function resetTemplateCatalogCache(): void {
-  catalogInFlight = null
-  catalogCache = null
+  catalogInFlight.clear()
+  catalogCache.clear()
 }
 
-async function loadTemplateCatalogUncached(): Promise<HydratedTemplate[]> {
-  let byId: Map<string, IndexLocation>
+/** An empty list is left empty; `backfill` fills every modality either way. */
+async function activeTemplates(): Promise<readonly CuratedTemplate[]> {
   try {
-    byId = indexById(await fetchJSON(INDEX_URL))
+    return await getStarterTemplatesAsync()
   } catch {
-    byId = new Map()
+    return CURATED_TEMPLATES
   }
-  // Only substitute when we actually have a live index to substitute FROM —
-  // an empty map means offline, where the curated snapshot is the right fallback.
+}
+
+/** The index the target ComfyUI ships, else the live one. Never throws. */
+async function indexForVersion(
+  comfyVersion: string | null
+): Promise<{ byId: Map<string, IndexLocation>; assetBase: string }> {
+  const pin = await resolveTemplatePackageVersion(comfyVersion).catch(() => null)
+  const assetBase = templateAssetBaseFor(pin)
+  try {
+    const index = await fetchJSON(templateIndexUrlFor(pin), { timeoutMs: INDEX_TIMEOUT_MS })
+    return { byId: indexById(index), assetBase }
+  } catch {
+    return { byId: new Map(), assetBase }
+  }
+}
+
+async function loadTemplateCatalogUncached(
+  comfyVersion: string | null
+): Promise<HydratedTemplate[]> {
+  const [templates, index] = await Promise.all([activeTemplates(), indexForVersion(comfyVersion)])
+  const { byId, assetBase } = index
   const online = byId.size > 0
+  const now = Date.now()
 
   const used = new Set<string>()
-  const catalog: HydratedTemplate[] = []
-  for (const curated of CURATED_TEMPLATES) {
-    if (!curated?.id || used.has(curated.id) || !curated.snapshot) continue
+  const perModality = new Map<TemplateModality, HydratedTemplate[]>(
+    TEMPLATE_MODALITY_ORDER.map((modality) => [modality, []])
+  )
 
-    const recommended = curated.recommended === true
-    const apiNode = curated.apiNode === true
+  const place = (card: HydratedTemplate): void => {
+    perModality.get(card.modality)?.push(card)
+  }
+  const isFull = (modality: TemplateModality): boolean =>
+    (perModality.get(modality)?.length ?? 0) >= SLOTS_PER_MODALITY
 
-    const { modality, snapshot } = curated
-    const location = byId.get(curated.id)
-    if (location || !online) {
-      used.add(curated.id)
-      catalog.push(
-        hydrateOne({ id: curated.id, modality, recommended, apiNode, location, snapshot })
+  for (const template of templates) {
+    if (!template?.id || used.has(template.id)) continue
+    if (!perModality.has(template.modality) || isFull(template.modality)) continue
+
+    const disposition = disposeOf(template, byId, used, online, now)
+    if (disposition.kind === 'drop') continue
+
+    if (disposition.kind === 'substitute') {
+      const { location } = disposition
+      used.add(location.entry.name)
+      place(
+        hydrateOne({
+          id: location.entry.name,
+          modality: template.modality,
+          recommended: template.recommended === true,
+          apiNode: false,
+          location,
+          assetBase
+        })
       )
       continue
     }
 
-    // Curated id has vanished upstream: show the first live template of the same
-    // modality we haven't already used, so the slot still offers a real,
-    // installable pick rather than a stale snapshot card. An API-node slot keeps
-    // its snapshot — substituting would put a multi-GB download behind a badge
-    // that promises none.
-    const sub = apiNode ? null : firstUnusedOfModality(byId, modality, used)
-    if (sub) {
-      used.add(sub.entry.name)
-      catalog.push(
-        hydrateOne({ id: sub.entry.name, modality, recommended, apiNode: false, location: sub })
-      )
-    } else {
-      used.add(curated.id)
-      catalog.push(
-        hydrateOne({
-          id: curated.id,
-          modality,
-          recommended,
-          apiNode,
-          location: undefined,
-          snapshot
-        })
-      )
-    }
+    used.add(template.id)
+    place(
+      hydrateOne({
+        id: template.id,
+        modality: template.modality,
+        recommended: template.recommended === true,
+        apiNode: template.apiNode === true,
+        location: disposition.location,
+        snapshot: template.snapshot,
+        snapshotOverrides: template.snapshotOverrides,
+        assetBase
+      })
+    )
+  }
+
+  backfill(perModality, byId, used, online, assetBase)
+
+  const catalog: HydratedTemplate[] = []
+  for (const modality of TEMPLATE_MODALITY_ORDER) {
+    catalog.push(...enforceOneRecommended(perModality.get(modality) ?? []))
   }
   return catalog.sort(byModalityOrder)
 }
 
-/** First unused, locally-installable index template of `modality` — skips
- *  API/cloud entries (`api_*`) and size-less ones, since a substitute fills a
- *  local download slot the disk-space gate sizes off `sizeBytes`. */
+/**
+ * Strict pass, then `terminal`, which relaxes index membership and then
+ * `isRunnableLocally` rather than ship a short tab. Identity is never relaxed:
+ * two cards sharing an id collide on `FieldOption.value`, the picker's key.
+ */
+function fillFromBakedIn(
+  slots: HydratedTemplate[],
+  modality: TemplateModality,
+  byId: Map<string, IndexLocation>,
+  used: Set<string>,
+  online: boolean,
+  assetBase: string,
+  terminal: boolean
+): void {
+  const take = (allowUnrunnable: boolean): void => {
+    for (const curated of CURATED_TEMPLATES) {
+      if (slots.length >= SLOTS_PER_MODALITY) break
+      if (curated.modality !== modality || used.has(curated.id)) continue
+      const location = byId.get(curated.id)
+      if (!allowUnrunnable && location && !isRunnableLocally(location.entry)) continue
+      // Re-adding an index-absent card would undo the gate that dropped it.
+      if (!terminal && online && !location && curated.apiNode !== true) continue
+      used.add(curated.id)
+      slots.push(
+        hydrateOne({
+          id: curated.id,
+          modality,
+          recommended: curated.recommended === true,
+          apiNode: curated.apiNode === true,
+          location,
+          snapshot: curated.snapshot,
+          assetBase
+        })
+      )
+    }
+  }
+
+  take(false)
+  if (terminal) take(true)
+}
+
+function backfill(
+  perModality: Map<TemplateModality, HydratedTemplate[]>,
+  byId: Map<string, IndexLocation>,
+  used: Set<string>,
+  online: boolean,
+  assetBase: string
+): void {
+  for (const modality of TEMPLATE_MODALITY_ORDER) {
+    const slots = perModality.get(modality)!
+    if (slots.length >= SLOTS_PER_MODALITY) continue
+
+    fillFromBakedIn(slots, modality, byId, used, online, assetBase, false)
+
+    while (slots.length < SLOTS_PER_MODALITY && online) {
+      const sub = firstUnusedOfModality(byId, modality, used)
+      if (!sub) break
+      used.add(sub.entry.name)
+      slots.push(
+        hydrateOne({
+          id: sub.entry.name,
+          modality,
+          recommended: false,
+          apiNode: false,
+          location: sub,
+          assetBase
+        })
+      )
+    }
+
+    fillFromBakedIn(slots, modality, byId, used, online, assetBase, true)
+  }
+}
+
+/** An all-API tab gets none: the wizard offers skip rather than auto-selecting
+ *  a card that spends credits. */
+function enforceOneRecommended(slots: HydratedTemplate[]): HydratedTemplate[] {
+  const claimed = slots.find((card) => card.recommended && !card.apiNode)
+  const winner = claimed ?? slots.find((card) => !card.apiNode)
+  return slots.map((card) => ({ ...card, recommended: card === winner }))
+}
+
+/** Skips `api_*`, size-less entries (the disk gate sizes off `sizeBytes`), and
+ *  non-starter categories. */
 function firstUnusedOfModality(
   byId: Map<string, IndexLocation>,
   modality: TemplateModality,
@@ -292,8 +474,12 @@ function firstUnusedOfModality(
   for (const location of byId.values()) {
     const { entry } = location
     if (location.modality !== modality || used.has(entry.name)) continue
+    if (!SUBSTITUTABLE_CATEGORIES.has(location.category)) continue
+    // Owed its own slot later; taking it here consumes one instead of filling one.
+    if (BAKED_IN_IDS.has(entry.name)) continue
     if (entry.name.startsWith('api_')) continue
     if (typeof entry.size !== 'number' || entry.size <= 0) continue
+    if (!isRunnableLocally(entry)) continue
     return location
   }
   return null

--- a/src/main/sources/standalone/templateCatalog.ts
+++ b/src/main/sources/standalone/templateCatalog.ts
@@ -260,14 +260,21 @@ function byModalityOrder(a: HydratedTemplate, b: HydratedTemplate): number {
   return TEMPLATE_MODALITY_ORDER.indexOf(a.modality) - TEMPLATE_MODALITY_ORDER.indexOf(b.modality)
 }
 
+/** Cards plus the asset base they were stamped with, so a caller fetching
+ *  workflow JSON reads the same revision the thumbnails came from. */
+export interface TemplateCatalog {
+  templates: HydratedTemplate[]
+  assetBase: string
+}
+
 /** Keyed by target version so switching channel mid-wizard re-filters. */
 const CATALOG_TTL_MS = 60_000
-const catalogInFlight = new Map<string, Promise<HydratedTemplate[]>>()
-const catalogCache = new Map<string, { at: number; value: HydratedTemplate[] }>()
+const catalogInFlight = new Map<string, Promise<TemplateCatalog>>()
+const catalogCache = new Map<string, { at: number; value: TemplateCatalog }>()
 
 export function loadTemplateCatalog(opts?: {
   comfyVersion?: string | null
-}): Promise<HydratedTemplate[]> {
+}): Promise<TemplateCatalog> {
   const key = opts?.comfyVersion ?? ''
   const cached = catalogCache.get(key)
   if (cached && Date.now() - cached.at < CATALOG_TTL_MS) return Promise.resolve(cached.value)
@@ -316,15 +323,16 @@ async function indexForVersion(
   }
 }
 
-async function loadTemplateCatalogUncached(
-  comfyVersion: string | null
-): Promise<HydratedTemplate[]> {
+async function loadTemplateCatalogUncached(comfyVersion: string | null): Promise<TemplateCatalog> {
   const [templates, index] = await Promise.all([activeTemplates(), indexForVersion(comfyVersion)])
   const { byId, assetBase } = index
   const online = byId.size > 0
   const now = Date.now()
 
   const used = new Set<string>()
+  // Payload entries keyed by id, so backfill can honour a window the payload set
+  // on a baked-in card instead of reading only the static list.
+  const windows = new Map(templates.filter((t) => t?.id).map((t) => [t.id, t]))
   const perModality = new Map<TemplateModality, HydratedTemplate[]>(
     TEMPLATE_MODALITY_ORDER.map((modality) => [modality, []])
   )
@@ -373,19 +381,21 @@ async function loadTemplateCatalogUncached(
     )
   }
 
-  backfill(perModality, byId, used, online, assetBase)
+  backfill(perModality, byId, used, online, assetBase, now, windows)
 
   const catalog: HydratedTemplate[] = []
   for (const modality of TEMPLATE_MODALITY_ORDER) {
     catalog.push(...enforceOneRecommended(perModality.get(modality) ?? []))
   }
-  return catalog.sort(byModalityOrder)
+  return { templates: catalog.sort(byModalityOrder), assetBase }
 }
 
 /**
  * Strict pass, then `terminal`, which relaxes index membership and then
- * `isRunnableLocally` rather than ship a short tab. Identity is never relaxed:
- * two cards sharing an id collide on `FieldOption.value`, the picker's key.
+ * `isRunnableLocally` rather than ship a short tab. Identity and the
+ * availability window are never relaxed: two cards sharing an id collide on
+ * `FieldOption.value`, the picker's key, and a retired card must stay retired
+ * even when the alternative is a short tab.
  */
 function fillFromBakedIn(
   slots: HydratedTemplate[],
@@ -394,12 +404,17 @@ function fillFromBakedIn(
   used: Set<string>,
   online: boolean,
   assetBase: string,
+  now: number,
+  windows: Map<string, CuratedTemplate>,
   terminal: boolean
 ): void {
   const take = (allowUnrunnable: boolean): void => {
     for (const curated of CURATED_TEMPLATES) {
       if (slots.length >= SLOTS_PER_MODALITY) break
       if (curated.modality !== modality || used.has(curated.id)) continue
+      // A window the payload set on this id wins, so content can retire a
+      // baked-in card rather than watch backfill wave it straight back in.
+      if (!isWithinWindow(windows.get(curated.id) ?? curated, now)) continue
       const location = byId.get(curated.id)
       if (!allowUnrunnable && location && !isRunnableLocally(location.entry)) continue
       // Re-adding an index-absent card would undo the gate that dropped it.
@@ -428,13 +443,15 @@ function backfill(
   byId: Map<string, IndexLocation>,
   used: Set<string>,
   online: boolean,
-  assetBase: string
+  assetBase: string,
+  now: number,
+  windows: Map<string, CuratedTemplate>
 ): void {
   for (const modality of TEMPLATE_MODALITY_ORDER) {
     const slots = perModality.get(modality)!
     if (slots.length >= SLOTS_PER_MODALITY) continue
 
-    fillFromBakedIn(slots, modality, byId, used, online, assetBase, false)
+    fillFromBakedIn(slots, modality, byId, used, online, assetBase, now, windows, false)
 
     while (slots.length < SLOTS_PER_MODALITY && online) {
       const sub = firstUnusedOfModality(byId, modality, used)
@@ -452,7 +469,7 @@ function backfill(
       )
     }
 
-    fillFromBakedIn(slots, modality, byId, used, online, assetBase, true)
+    fillFromBakedIn(slots, modality, byId, used, online, assetBase, now, windows, true)
   }
 }
 

--- a/src/main/sources/standalone/templateCatalogResolution.test.ts
+++ b/src/main/sources/standalone/templateCatalogResolution.test.ts
@@ -1,0 +1,756 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type * as TemplatePinModule from './templatePin'
+
+vi.mock('../../lib/fetch', () => ({ fetchJSON: vi.fn() }))
+
+const getStarterTemplatesAsync = vi.fn()
+vi.mock('./starterTemplateManifest', () => ({
+  getStarterTemplatesAsync: () => getStarterTemplatesAsync()
+}))
+
+const resolveTemplatePackageVersion = vi.fn()
+vi.mock('./templatePin', async (importOriginal) => {
+  const actual = await importOriginal<typeof TemplatePinModule>()
+  return {
+    ...actual,
+    resolveTemplatePackageVersion: (...a: unknown[]) => resolveTemplatePackageVersion(...a)
+  }
+})
+
+import { loadTemplateCatalog, resetTemplateCatalogCache } from './templateCatalog'
+import { CURATED_TEMPLATES, INDEX_URL, TEMPLATE_MODALITY_ORDER } from './curatedTemplates'
+import type { HydratedTemplate } from './templateCatalog'
+import { fetchJSON } from '../../lib/fetch'
+
+const mockedFetchJSON = vi.mocked(fetchJSON)
+
+function category(
+  type: string,
+  title: string,
+  templates: Record<string, Record<string, unknown>>
+): unknown {
+  return {
+    type,
+    title,
+    templates: Object.entries(templates).map(([name, fields]) => ({
+      size: 1_000,
+      mediaSubtype: 'webp',
+      ...fields,
+      name
+    }))
+  }
+}
+
+/** Substitute candidates a real index always carries (100+ image, 50+ video). */
+function spares(): unknown[] {
+  const titles: Record<string, string> = {
+    image: 'Image',
+    video: 'Video',
+    audio: 'Audio',
+    '3d': '3D Model'
+  }
+  return TEMPLATE_MODALITY_ORDER.map((modality) =>
+    category(
+      modality,
+      titles[modality]!,
+      Object.fromEntries(
+        Array.from({ length: 4 }, (_, i) => [`spare_${modality}_${i}`, { title: `Spare ${i}` }])
+      )
+    )
+  )
+}
+
+function indexWithCurated(extra: unknown[] = []): unknown[] {
+  const byModality: Record<string, Record<string, Record<string, unknown>>> = {}
+  for (const t of CURATED_TEMPLATES) {
+    byModality[t.modality] ??= {}
+    byModality[t.modality]![t.id] = {}
+  }
+  const titles: Record<string, string> = {
+    image: 'Image',
+    video: 'Video',
+    audio: 'Audio',
+    '3d': '3D Model'
+  }
+  return [
+    ...Object.entries(byModality).map(([type, templates]) =>
+      category(type, titles[type]!, templates)
+    ),
+    ...extra
+  ]
+}
+
+function expectFourByFour(catalog: HydratedTemplate[]): void {
+  for (const modality of TEMPLATE_MODALITY_ORDER) {
+    const cards = catalog.filter((c) => c.modality === modality)
+    expect(cards.length, `${modality} card count`).toBe(4)
+    const recommended = cards.filter((c) => c.recommended)
+    expect(recommended.length, `${modality} recommended count`).toBeLessThanOrEqual(1)
+    expect(
+      recommended.filter((c) => c.apiNode),
+      `${modality} paid auto-pick`
+    ).toEqual([])
+  }
+  expect(new Set(catalog.map((c) => c.id)).size, 'duplicate ids across catalog').toBe(
+    catalog.length
+  )
+  const recommendedIds = catalog.filter((c) => c.recommended).map((c) => c.id)
+  expect(new Set(recommendedIds).size, 'an id is recommended in at most one tab').toBe(
+    recommendedIds.length
+  )
+}
+
+beforeEach(() => {
+  mockedFetchJSON.mockReset()
+  getStarterTemplatesAsync.mockReset()
+  resolveTemplatePackageVersion.mockReset()
+  resetTemplateCatalogCache()
+  getStarterTemplatesAsync.mockResolvedValue(CURATED_TEMPLATES)
+  resolveTemplatePackageVersion.mockResolvedValue(null)
+})
+
+describe('remote payload drives the card list', () => {
+  it('renders the payload list instead of the baked-in one', async () => {
+    getStarterTemplatesAsync.mockResolvedValue([
+      { id: 'payload_img', modality: 'image', recommended: true },
+      ...CURATED_TEMPLATES.filter((t) => t.modality !== 'image')
+    ])
+    mockedFetchJSON.mockResolvedValue(
+      indexWithCurated([category('image', 'Image', { payload_img: { title: 'Payload Image' } })])
+    )
+    const catalog = await loadTemplateCatalog()
+    expect(catalog.find((c) => c.id === 'payload_img')?.title).toBe('Payload Image')
+    expectFourByFour(catalog)
+  })
+
+  it('backfills modalities the payload does not mention', async () => {
+    getStarterTemplatesAsync.mockResolvedValue(
+      CURATED_TEMPLATES.filter((t) => t.modality === 'image')
+    )
+    mockedFetchJSON.mockResolvedValue(indexWithCurated())
+    expectFourByFour(await loadTemplateCatalog())
+  })
+
+  it('truncates a modality carrying more than four entries', async () => {
+    const extras = Array.from({ length: 5 }, (_, i) => ({
+      id: `image_extra_${i}`,
+      modality: 'image' as const
+    }))
+    getStarterTemplatesAsync.mockResolvedValue([...CURATED_TEMPLATES, ...extras])
+    mockedFetchJSON.mockResolvedValue(
+      indexWithCurated([
+        category('image', 'Image', Object.fromEntries(extras.map((e) => [e.id, {}])))
+      ])
+    )
+    expectFourByFour(await loadTemplateCatalog())
+  })
+
+  it('never exceeds four even when substitutes are abundant', async () => {
+    getStarterTemplatesAsync.mockResolvedValue([
+      { id: 'image_gone_a', modality: 'image', recommended: true },
+      { id: 'image_gone_b', modality: 'image' },
+      { id: 'image_gone_c', modality: 'image' },
+      { id: 'image_gone_d', modality: 'image' },
+      ...CURATED_TEMPLATES.filter((t) => t.modality !== 'image')
+    ])
+    mockedFetchJSON.mockResolvedValue(
+      indexWithCurated([
+        category(
+          'image',
+          'Image',
+          Object.fromEntries(
+            Array.from({ length: 20 }, (_, i) => [`plenty_${i}`, { title: `Plenty ${i}` }])
+          )
+        )
+      ])
+    )
+    const catalog = await loadTemplateCatalog()
+    expect(catalog.filter((c) => c.modality === 'image')).toHaveLength(4)
+    expectFourByFour(catalog)
+  })
+
+  it('tops a one-entry modality up to four', async () => {
+    getStarterTemplatesAsync.mockResolvedValue([
+      { id: 'image_solo', modality: 'image', recommended: true },
+      ...CURATED_TEMPLATES.filter((t) => t.modality !== 'image')
+    ])
+    mockedFetchJSON.mockResolvedValue(
+      indexWithCurated([category('image', 'Image', { image_solo: {} })])
+    )
+    const catalog = await loadTemplateCatalog()
+    expect(catalog.find((c) => c.id === 'image_solo')).toBeDefined()
+    expectFourByFour(catalog)
+  })
+
+  it('collapses duplicate ids and refills the freed slot', async () => {
+    const image = CURATED_TEMPLATES.filter((t) => t.modality === 'image')
+    getStarterTemplatesAsync.mockResolvedValue([
+      image[0]!,
+      image[0]!,
+      image[1]!,
+      ...CURATED_TEMPLATES.filter((t) => t.modality !== 'image')
+    ])
+    mockedFetchJSON.mockResolvedValue(indexWithCurated())
+    expectFourByFour(await loadTemplateCatalog())
+  })
+
+  it('backfills wholly when the payload is empty', async () => {
+    getStarterTemplatesAsync.mockResolvedValue([])
+    mockedFetchJSON.mockResolvedValue(indexWithCurated())
+    expectFourByFour(await loadTemplateCatalog())
+  })
+})
+
+describe('version gate via the package pin', () => {
+  it('hides a template the pinned index does not carry, and substitutes', async () => {
+    const missing = 'video_minimax_h3_t2v'
+    resolveTemplatePackageVersion.mockResolvedValue('0.11.12')
+    mockedFetchJSON.mockResolvedValue(
+      indexWithCurated([
+        category('video', 'Video', { live_video_sub: { title: 'Live Video Sub' } })
+      ])
+        .map((c) => {
+          const cat = c as { type?: string; templates?: { name: string }[] }
+          if (cat.type === 'video' && cat.templates) {
+            cat.templates = cat.templates.filter((t) => t.name !== missing)
+          }
+          return cat
+        })
+        .concat(spares() as never[])
+    )
+    const catalog = await loadTemplateCatalog({ comfyVersion: 'v0.28.2' })
+    expect(catalog.find((c) => c.id === missing)).toBeUndefined()
+    expectFourByFour(catalog)
+  })
+
+  it('fetches the index the target ComfyUI pins, not main', async () => {
+    resolveTemplatePackageVersion.mockResolvedValue('0.11.12')
+    mockedFetchJSON.mockResolvedValue(indexWithCurated())
+    await loadTemplateCatalog({ comfyVersion: 'v0.28.2' })
+    expect(resolveTemplatePackageVersion).toHaveBeenCalledWith('v0.28.2')
+    expect(
+      mockedFetchJSON,
+      'reads the index ComfyUI v0.28.2 pins, not main, under a bounded budget'
+    ).toHaveBeenCalledWith(
+      'https://raw.githubusercontent.com/Comfy-Org/workflow_templates/v0.11.12/templates/index.json',
+      expect.objectContaining({ timeoutMs: expect.any(Number) })
+    )
+  })
+
+  it('fetches the live main index when no pin resolves', async () => {
+    resolveTemplatePackageVersion.mockResolvedValue(null)
+    mockedFetchJSON.mockResolvedValue(indexWithCurated())
+    await loadTemplateCatalog({ comfyVersion: null })
+    expect(mockedFetchJSON).toHaveBeenCalledWith(INDEX_URL, expect.anything())
+  })
+
+  it('keeps that template when the pinned index carries it', async () => {
+    resolveTemplatePackageVersion.mockResolvedValue('0.11.31')
+    mockedFetchJSON.mockResolvedValue(indexWithCurated())
+    const catalog = await loadTemplateCatalog({ comfyVersion: 'v0.30.2' })
+    expect(catalog.find((c) => c.id === 'video_minimax_h3_t2v')).toBeDefined()
+    expectFourByFour(catalog)
+  })
+
+  it('fails open when the version is unknown', async () => {
+    resolveTemplatePackageVersion.mockResolvedValue(null)
+    mockedFetchJSON.mockResolvedValue(indexWithCurated())
+    const catalog = await loadTemplateCatalog({ comfyVersion: null })
+    expectFourByFour(catalog)
+  })
+
+  it('fails open when the pin lookup rejects', async () => {
+    resolveTemplatePackageVersion.mockRejectedValue(new Error('offline'))
+    mockedFetchJSON.mockResolvedValue(indexWithCurated())
+    expectFourByFour(await loadTemplateCatalog({ comfyVersion: 'v0.30.2' }))
+  })
+
+  it('varies the cache key with comfyVersion', async () => {
+    mockedFetchJSON.mockResolvedValue(indexWithCurated())
+    resolveTemplatePackageVersion.mockResolvedValue('0.11.31')
+    await loadTemplateCatalog({ comfyVersion: 'v0.30.2' })
+    await loadTemplateCatalog({ comfyVersion: 'v0.28.2' })
+    expect(
+      mockedFetchJSON.mock.calls.length,
+      'a different target version re-resolves rather than serving the previous filter'
+    ).toBeGreaterThan(1)
+  })
+
+  it('still caches repeat reads for the same comfyVersion', async () => {
+    mockedFetchJSON.mockResolvedValue(indexWithCurated())
+    resolveTemplatePackageVersion.mockResolvedValue('0.11.31')
+    await loadTemplateCatalog({ comfyVersion: 'v0.30.2' })
+    const before = mockedFetchJSON.mock.calls.length
+    await loadTemplateCatalog({ comfyVersion: 'v0.30.2' })
+    expect(mockedFetchJSON.mock.calls.length).toBe(before)
+  })
+})
+
+describe('upstream compatibility signals', () => {
+  it('drops a card requiring custom nodes', async () => {
+    const target = CURATED_TEMPLATES.find((t) => t.modality === 'image' && !t.apiNode)!
+    mockedFetchJSON.mockResolvedValue(
+      indexWithCurated()
+        .map((c) => {
+          const cat = c as { type?: string; templates?: Record<string, unknown>[] }
+          if (cat.type === 'image') {
+            for (const t of cat.templates ?? []) {
+              if (t.name === target.id) t.requiresCustomNodes = ['comfyui-kjnodes']
+            }
+          }
+          return cat
+        })
+        .concat(spares() as never[])
+    )
+    const catalog = await loadTemplateCatalog()
+    expect(catalog.find((c) => c.id === target.id)).toBeUndefined()
+    expectFourByFour(catalog)
+  })
+
+  it('keeps a card whose requiresCustomNodes is empty', async () => {
+    const target = CURATED_TEMPLATES.find((t) => t.modality === 'image' && !t.apiNode)!
+    mockedFetchJSON.mockResolvedValue(
+      indexWithCurated().map((c) => {
+        const cat = c as { type?: string; templates?: Record<string, unknown>[] }
+        if (cat.type === 'image') {
+          for (const t of cat.templates ?? []) {
+            if (t.name === target.id) t.requiresCustomNodes = []
+          }
+        }
+        return cat
+      })
+    )
+    expect((await loadTemplateCatalog()).find((c) => c.id === target.id)).toBeDefined()
+  })
+
+  it('drops a cloud-only card', async () => {
+    const target = CURATED_TEMPLATES.find((t) => t.modality === 'image' && !t.apiNode)!
+    mockedFetchJSON.mockResolvedValue(
+      indexWithCurated()
+        .map((c) => {
+          const cat = c as { type?: string; templates?: Record<string, unknown>[] }
+          if (cat.type === 'image') {
+            for (const t of cat.templates ?? []) {
+              if (t.name === target.id) t.includeOnDistributions = ['cloud']
+            }
+          }
+          return cat
+        })
+        .concat(spares() as never[])
+    )
+    const catalog = await loadTemplateCatalog()
+    expect(catalog.find((c) => c.id === target.id)).toBeUndefined()
+    expectFourByFour(catalog)
+  })
+
+  it.each([[['local']], [['local', 'cloud']], [undefined]])(
+    'keeps a card with includeOnDistributions %s',
+    async (includeOnDistributions) => {
+      const target = CURATED_TEMPLATES.find((t) => t.modality === 'image' && !t.apiNode)!
+      mockedFetchJSON.mockResolvedValue(
+        indexWithCurated().map((c) => {
+          const cat = c as { type?: string; templates?: Record<string, unknown>[] }
+          if (cat.type === 'image') {
+            for (const t of cat.templates ?? []) {
+              if (t.name === target.id) t.includeOnDistributions = includeOnDistributions
+            }
+          }
+          return cat
+        })
+      )
+      expect((await loadTemplateCatalog()).find((c) => c.id === target.id)).toBeDefined()
+    }
+  )
+})
+
+describe('substitution quality', () => {
+  it('substitutes within the same modality only', async () => {
+    getStarterTemplatesAsync.mockResolvedValue([
+      { id: 'video_gone', modality: 'video', recommended: true },
+      ...CURATED_TEMPLATES.filter((t) => t.modality !== 'video').slice(0, 12)
+    ])
+    mockedFetchJSON.mockResolvedValue(
+      indexWithCurated([category('video', 'Video', { real_video: { title: 'Real Video' } })])
+    )
+    const catalog = await loadTemplateCatalog()
+    for (const card of catalog.filter((c) => c.modality === 'video')) {
+      expect(card.id.startsWith('image_'), card.id).toBe(false)
+    }
+    expectFourByFour(catalog)
+  })
+
+  it('never substitutes from a non-allowlisted category', async () => {
+    getStarterTemplatesAsync.mockResolvedValue([
+      { id: 'image_gone_a', modality: 'image', recommended: true },
+      { id: 'image_gone_b', modality: 'image' },
+      { id: 'image_gone_c', modality: 'image' },
+      { id: 'image_gone_d', modality: 'image' },
+      ...CURATED_TEMPLATES.filter((t) => t.modality !== 'image')
+    ])
+    mockedFetchJSON.mockResolvedValue(
+      indexWithCurated([
+        category('image', 'Node Basics', { basics_trap: { title: 'Node Basics Trap' } }),
+        category('image', 'Utility', { utility_trap: { title: 'Utility Trap' } }),
+        category('image', 'LLM', { llm_trap: { title: 'LLM Trap' } }),
+        category('image', 'Getting Started', { gs_trap: { title: 'Getting Started Trap' } })
+      ])
+    )
+    const catalog = await loadTemplateCatalog()
+    for (const trap of ['basics_trap', 'utility_trap', 'llm_trap', 'gs_trap']) {
+      expect(
+        catalog.find((c) => c.id === trap),
+        trap
+      ).toBeUndefined()
+    }
+    expectFourByFour(catalog)
+  })
+
+  it('does substitute from an allowlisted Use Cases category', async () => {
+    getStarterTemplatesAsync.mockResolvedValue([
+      { id: 'image_gone', modality: 'image', recommended: true },
+      ...CURATED_TEMPLATES.filter((t) => t.modality !== 'image')
+    ])
+    mockedFetchJSON.mockResolvedValue(
+      indexWithCurated([category('image', 'Use Cases', { use_case_ok: { title: 'Use Case Sub' } })])
+    )
+    const catalog = await loadTemplateCatalog()
+    expectFourByFour(catalog)
+  })
+
+  it('keeps an explicitly-named id even from a non-allowlisted category', async () => {
+    getStarterTemplatesAsync.mockResolvedValue([
+      { id: 'utility_pick', modality: 'image', recommended: true },
+      ...CURATED_TEMPLATES.filter((t) => t.modality !== 'image')
+    ])
+    mockedFetchJSON.mockResolvedValue(
+      indexWithCurated([category('image', 'Utility', { utility_pick: { title: 'Chosen' } })])
+    )
+    const catalog = await loadTemplateCatalog()
+    expect(catalog.find((c) => c.id === 'utility_pick')?.title).toBe('Chosen')
+    expectFourByFour(catalog)
+  })
+
+  it('never substitutes an API-node slot', async () => {
+    const apiCard = CURATED_TEMPLATES.find((t) => t.apiNode && t.modality === 'image')!
+    mockedFetchJSON.mockResolvedValue(
+      indexWithCurated().map((c) => {
+        const cat = c as { type?: string; templates?: { name: string }[] }
+        if (cat.type === 'image' && cat.templates) {
+          cat.templates = cat.templates.filter((t) => t.name !== apiCard.id)
+        }
+        return cat
+      })
+    )
+    const catalog = await loadTemplateCatalog()
+    const card = catalog.find((c) => c.id === apiCard.id)
+    expect(card?.apiNode).toBe(true)
+    expectFourByFour(catalog)
+  })
+
+  it('skips api_ and size-less substitution candidates', async () => {
+    getStarterTemplatesAsync.mockResolvedValue([
+      { id: 'image_gone', modality: 'image', recommended: true },
+      ...CURATED_TEMPLATES.filter((t) => t.modality !== 'image')
+    ])
+    mockedFetchJSON.mockResolvedValue(
+      indexWithCurated([
+        category('image', 'Image', {
+          api_should_skip: { title: 'API' },
+          sizeless_should_skip: { title: 'Sizeless', size: 0 },
+          good_sub: { title: 'Good Sub' }
+        })
+      ])
+    )
+    const catalog = await loadTemplateCatalog()
+    expect(catalog.find((c) => c.id === 'api_should_skip')).toBeUndefined()
+    expect(catalog.find((c) => c.id === 'sizeless_should_skip')).toBeUndefined()
+    expectFourByFour(catalog)
+  })
+
+  it('warns naming the id that went missing', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      getStarterTemplatesAsync.mockResolvedValue([
+        { id: 'image_typo_id', modality: 'image', recommended: true },
+        ...CURATED_TEMPLATES.filter((t) => t.modality !== 'image')
+      ])
+      mockedFetchJSON.mockResolvedValue(
+        indexWithCurated([category('image', 'Image', { sub_for_typo: {} })])
+      )
+      await loadTemplateCatalog()
+      expect(warn.mock.calls.flat().join(' ')).toContain('image_typo_id')
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('does not substitute when offline', async () => {
+    mockedFetchJSON.mockRejectedValue(new Error('offline'))
+    const catalog = await loadTemplateCatalog()
+    for (const curated of CURATED_TEMPLATES) {
+      expect(
+        catalog.find((c) => c.id === curated.id),
+        curated.id
+      ).toBeDefined()
+    }
+    expectFourByFour(catalog)
+  })
+
+  it('degrades to baked-in rather than borrowing another modality', async () => {
+    getStarterTemplatesAsync.mockResolvedValue([
+      { id: '3d_gone_a', modality: '3d', recommended: true },
+      { id: '3d_gone_b', modality: '3d' },
+      { id: '3d_gone_c', modality: '3d' },
+      { id: '3d_gone_d', modality: '3d' },
+      ...CURATED_TEMPLATES.filter((t) => t.modality !== '3d')
+    ])
+    mockedFetchJSON.mockResolvedValue(
+      indexWithCurated([
+        category('image', 'Image', {
+          spare_1: {},
+          spare_2: {},
+          spare_3: {},
+          spare_4: {},
+          spare_5: {}
+        })
+      ])
+    )
+    const catalog = await loadTemplateCatalog()
+    for (const card of catalog.filter((c) => c.modality === '3d')) {
+      expect(card.id.startsWith('spare_'), card.id).toBe(false)
+    }
+    expectFourByFour(catalog)
+  })
+})
+
+describe('recommended invariants after resolution', () => {
+  it('promotes a recommendation when the payload names none', async () => {
+    getStarterTemplatesAsync.mockResolvedValue(
+      CURATED_TEMPLATES.map(({ recommended: _drop, ...rest }) => rest as never)
+    )
+    mockedFetchJSON.mockResolvedValue(indexWithCurated())
+    expectFourByFour(await loadTemplateCatalog())
+  })
+
+  it('keeps the recommendation off an api card in an all-api modality', async () => {
+    getStarterTemplatesAsync.mockResolvedValue([
+      { id: 'api_a', modality: 'image', apiNode: true },
+      { id: 'api_b', modality: 'image', apiNode: true },
+      { id: 'api_c', modality: 'image', apiNode: true },
+      { id: 'api_d', modality: 'image', apiNode: true },
+      ...CURATED_TEMPLATES.filter((t) => t.modality !== 'image')
+    ])
+    mockedFetchJSON.mockResolvedValue(indexWithCurated())
+    const catalog = await loadTemplateCatalog()
+    const rec = catalog.filter((c) => c.modality === 'image' && c.recommended)
+    expect(rec).toHaveLength(1)
+    expect(rec[0]!.apiNode).toBe(false)
+  })
+})
+
+describe('availability window', () => {
+  it('hides an entry whose window has not opened, and one that has closed', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-01T00:00:00Z'))
+    try {
+      getStarterTemplatesAsync.mockResolvedValue([
+        { id: 'image_future', modality: 'image', availableFrom: '2026-12-01T00:00:00Z' },
+        { id: 'image_expired', modality: 'image', availableUntil: '2026-01-01T00:00:00Z' },
+        { id: 'image_open', modality: 'image', recommended: true },
+        ...CURATED_TEMPLATES.filter((t) => t.modality !== 'image')
+      ])
+      mockedFetchJSON.mockResolvedValue(
+        indexWithCurated([
+          category('image', 'Image', { image_future: {}, image_expired: {}, image_open: {} })
+        ])
+      )
+      const catalog = await loadTemplateCatalog()
+      expect(catalog.find((c) => c.id === 'image_future')).toBeUndefined()
+      expect(catalog.find((c) => c.id === 'image_expired')).toBeUndefined()
+      expect(catalog.find((c) => c.id === 'image_open')).toBeDefined()
+      expectFourByFour(catalog)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('every source failing at once', () => {
+  it('holds 4x4 with a garbage payload, no index, and an unknown version', async () => {
+    getStarterTemplatesAsync.mockResolvedValue(CURATED_TEMPLATES)
+    mockedFetchJSON.mockRejectedValue(new Error('offline'))
+    resolveTemplatePackageVersion.mockRejectedValue(new Error('offline'))
+    expectFourByFour(await loadTemplateCatalog({ comfyVersion: null }))
+  })
+
+  it('holds 4x4 when the manifest read itself throws', async () => {
+    getStarterTemplatesAsync.mockRejectedValue(new Error('flag exploded'))
+    mockedFetchJSON.mockResolvedValue(indexWithCurated())
+    expectFourByFour(await loadTemplateCatalog())
+  })
+
+  it('holds 4x4 when the payload is every kind of broken at once', async () => {
+    getStarterTemplatesAsync.mockResolvedValue([
+      { id: 'gone_1', modality: 'image', recommended: true },
+      { id: 'gone_2', modality: 'video' },
+      { id: 'api_only', modality: 'audio', apiNode: true },
+      { id: 'gone_3', modality: '3d' }
+    ])
+    mockedFetchJSON.mockResolvedValue([])
+    expectFourByFour(await loadTemplateCatalog({ comfyVersion: 'v0.28.2' }))
+  })
+})
+
+describe('4x4 when the index offers no substitute candidates', () => {
+  function bareIndex(absent: string[] = []): unknown[] {
+    const byMod: Record<string, Record<string, Record<string, unknown>>> = {}
+    for (const t of CURATED_TEMPLATES) {
+      if (absent.includes(t.id)) continue
+      byMod[t.modality] ??= {}
+      byMod[t.modality]![t.id] = {}
+    }
+    const titles: Record<string, string> = {
+      image: 'Image',
+      video: 'Video',
+      audio: 'Audio',
+      '3d': '3D Model'
+    }
+    return Object.entries(byMod).map(([type, tpls]) => category(type, titles[type]!, tpls))
+  }
+
+  it('holds when the recommended card is missing and nothing can substitute', async () => {
+    resolveTemplatePackageVersion.mockResolvedValue('0.11.12')
+    mockedFetchJSON.mockResolvedValue(bareIndex(['video_minimax_h3_t2v']))
+    const catalog = await loadTemplateCatalog({ comfyVersion: 'v0.28.2' })
+    expectFourByFour(catalog)
+  })
+
+  it.each(CURATED_TEMPLATES.map((t) => [t.modality, t.id] as const))(
+    'holds for %s when %s is absent from the index',
+    async (_modality, missingId) => {
+      mockedFetchJSON.mockResolvedValue(bareIndex([missingId]))
+      expectFourByFour(await loadTemplateCatalog({ comfyVersion: 'v0.28.2' }))
+    }
+  )
+
+  it('holds when every card in a modality is absent', async () => {
+    const video = CURATED_TEMPLATES.filter((t) => t.modality === 'video').map((t) => t.id)
+    mockedFetchJSON.mockResolvedValue(bareIndex(video))
+    expectFourByFour(await loadTemplateCatalog({ comfyVersion: 'v0.28.2' }))
+  })
+
+  it('holds when the index carries no allowlisted category at all', async () => {
+    mockedFetchJSON.mockResolvedValue([
+      category('image', 'Node Basics', { nb_1: {}, nb_2: {} }),
+      category('video', 'Utility', { ut_1: {} })
+    ])
+    expectFourByFour(await loadTemplateCatalog({ comfyVersion: 'v0.28.2' }))
+  })
+
+  it('never lets a substitute steal a baked-in card still owed a slot', async () => {
+    mockedFetchJSON.mockResolvedValue(bareIndex(['video_minimax_h3_t2v']))
+    const catalog = await loadTemplateCatalog({ comfyVersion: 'v0.28.2' })
+    const video = catalog.filter((c) => c.modality === 'video').map((c) => c.id)
+    for (const id of [
+      'api_seedance2_0_r2v',
+      'wan2.1_fun_inp',
+      'video_wan2.1_fun_camera_v1.1_1.3B'
+    ]) {
+      expect(video, `${id} kept its own slot`).toContain(id)
+    }
+  })
+})
+
+describe('thumbnails follow the pinned index', () => {
+  it('resolves previews against the pinned asset base, not main', async () => {
+    // The index is fetched at the pin, so previews must be too — otherwise a
+    // card hydrated from v0.11.12 requests an image that only exists on main.
+    resolveTemplatePackageVersion.mockResolvedValue('0.11.12')
+    mockedFetchJSON.mockResolvedValue(indexWithCurated())
+    const catalog = await loadTemplateCatalog({ comfyVersion: 'v0.28.2' })
+    const withThumb = catalog.filter((c) => c.thumbnailUrl)
+    expect(withThumb.length).toBeGreaterThan(0)
+    for (const card of withThumb) {
+      expect(card.thumbnailUrl, card.id).toContain('/v0.11.12/templates/')
+    }
+  })
+
+  it('falls back to the main asset base when no pin resolves', async () => {
+    resolveTemplatePackageVersion.mockResolvedValue(null)
+    mockedFetchJSON.mockResolvedValue(indexWithCurated())
+    const catalog = await loadTemplateCatalog({ comfyVersion: null })
+    const card = catalog.find((c) => c.thumbnailUrl)!
+    expect(card.thumbnailUrl).toContain('/main/templates/')
+  })
+})
+
+describe('adversarial-but-valid payloads', () => {
+  function bareIndexAll(mutate: (id: string) => Record<string, unknown> | null = () => ({})) {
+    const byMod: Record<string, Record<string, Record<string, unknown>>> = {}
+    for (const t of CURATED_TEMPLATES) {
+      const fields = mutate(t.id)
+      if (!fields) continue
+      byMod[t.modality] ??= {}
+      byMod[t.modality]![t.id] = fields
+    }
+    const titles: Record<string, string> = {
+      image: 'Image',
+      video: 'Video',
+      audio: 'Audio',
+      '3d': '3D Model'
+    }
+    return Object.entries(byMod).map(([type, tpls]) => category(type, titles[type]!, tpls))
+  }
+
+  it.each([1, 2, 4])(
+    'holds when %i image cards would be filed under the wrong modality',
+    async (count) => {
+      const image = CURATED_TEMPLATES.filter((t) => t.modality === 'image').slice(0, count)
+      getStarterTemplatesAsync.mockResolvedValue([
+        ...image.map((t) => ({ id: t.id, modality: 'video' as const })),
+        ...CURATED_TEMPLATES
+      ])
+      mockedFetchJSON.mockResolvedValue(bareIndexAll())
+      const catalog = await loadTemplateCatalog()
+      expect(new Set(catalog.map((c) => c.id)).size, 'no duplicate ids').toBe(catalog.length)
+    }
+  )
+
+  it('never recommends an API card when the payload is all API nodes', async () => {
+    getStarterTemplatesAsync.mockResolvedValue(
+      CURATED_TEMPLATES.map((t) => ({ id: t.id, modality: t.modality, apiNode: true as const }))
+    )
+    mockedFetchJSON.mockResolvedValue(bareIndexAll())
+    const catalog = await loadTemplateCatalog()
+    for (const modality of TEMPLATE_MODALITY_ORDER) {
+      const cards = catalog.filter((c) => c.modality === modality)
+      expect(cards, modality).toHaveLength(4)
+      expect(
+        cards.filter((c) => c.recommended && c.apiNode),
+        `${modality} paid auto-pick`
+      ).toEqual([])
+    }
+  })
+
+  it('prefers runnable cards but still fills a wholly-unrunnable modality', async () => {
+    mockedFetchJSON.mockResolvedValue(
+      bareIndexAll((id) =>
+        CURATED_TEMPLATES.find((t) => t.id === id)!.modality === 'image'
+          ? { requiresCustomNodes: ['comfyui-kjnodes'] }
+          : {}
+      )
+    )
+    expectFourByFour(await loadTemplateCatalog({ comfyVersion: 'v0.28.2' }))
+  })
+
+  it('still drops an unrunnable card when a runnable one can take the slot', async () => {
+    const target = CURATED_TEMPLATES.find((t) => t.modality === 'image' && !t.apiNode)!
+    mockedFetchJSON.mockResolvedValue([
+      ...bareIndexAll((id) => (id === target.id ? { requiresCustomNodes: ['x'] } : {})),
+      category('image', 'Image', { runnable_sub: { title: 'Runnable' } })
+    ])
+    const catalog = await loadTemplateCatalog()
+    expect(catalog.find((c) => c.id === target.id)).toBeUndefined()
+    expectFourByFour(catalog)
+  })
+})

--- a/src/main/sources/standalone/templateCatalogResolution.test.ts
+++ b/src/main/sources/standalone/templateCatalogResolution.test.ts
@@ -669,8 +669,9 @@ describe('4x4 when the index offers no substitute candidates', () => {
   }
 
   it('holds when the recommended card is missing and nothing can substitute', async () => {
+    const recommendedVideo = CURATED_TEMPLATES.find((t) => t.modality === 'video' && t.recommended)!
     resolveTemplatePackageVersion.mockResolvedValue('0.11.12')
-    mockedFetchJSON.mockResolvedValue(bareIndex(['video_minimax_h3_t2v']))
+    mockedFetchJSON.mockResolvedValue(bareIndex([recommendedVideo.id]))
     const catalog = await loadCards({ comfyVersion: 'v0.28.2' })
     expectFourByFour(catalog)
   })
@@ -698,14 +699,13 @@ describe('4x4 when the index offers no substitute candidates', () => {
   })
 
   it('never lets a substitute steal a baked-in card still owed a slot', async () => {
-    mockedFetchJSON.mockResolvedValue(bareIndex(['video_minimax_h3_t2v']))
+    const [removed, ...retained] = CURATED_TEMPLATES.filter((t) => t.modality === 'video').map(
+      (t) => t.id
+    )
+    mockedFetchJSON.mockResolvedValue(bareIndex([removed!]))
     const catalog = await loadCards({ comfyVersion: 'v0.28.2' })
     const video = catalog.filter((c) => c.modality === 'video').map((c) => c.id)
-    for (const id of [
-      'api_seedance2_0_r2v',
-      'wan2.1_fun_inp',
-      'video_wan2.1_fun_camera_v1.1_1.3B'
-    ]) {
+    for (const id of retained) {
       expect(video, `${id} kept its own slot`).toContain(id)
     }
   })

--- a/src/main/sources/standalone/templateCatalogResolution.test.ts
+++ b/src/main/sources/standalone/templateCatalogResolution.test.ts
@@ -24,6 +24,10 @@ import { fetchJSON } from '../../lib/fetch'
 
 const mockedFetchJSON = vi.mocked(fetchJSON)
 
+/** Cards only; `assetBase` is asserted separately where it matters. */
+const loadCards = async (opts?: { comfyVersion?: string | null }): Promise<HydratedTemplate[]> =>
+  (await loadTemplateCatalog(opts)).templates
+
 function category(
   type: string,
   title: string,
@@ -118,7 +122,7 @@ describe('remote payload drives the card list', () => {
     mockedFetchJSON.mockResolvedValue(
       indexWithCurated([category('image', 'Image', { payload_img: { title: 'Payload Image' } })])
     )
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     expect(catalog.find((c) => c.id === 'payload_img')?.title).toBe('Payload Image')
     expectFourByFour(catalog)
   })
@@ -128,7 +132,7 @@ describe('remote payload drives the card list', () => {
       CURATED_TEMPLATES.filter((t) => t.modality === 'image')
     )
     mockedFetchJSON.mockResolvedValue(indexWithCurated())
-    expectFourByFour(await loadTemplateCatalog())
+    expectFourByFour(await loadCards())
   })
 
   it('truncates a modality carrying more than four entries', async () => {
@@ -142,7 +146,7 @@ describe('remote payload drives the card list', () => {
         category('image', 'Image', Object.fromEntries(extras.map((e) => [e.id, {}])))
       ])
     )
-    expectFourByFour(await loadTemplateCatalog())
+    expectFourByFour(await loadCards())
   })
 
   it('never exceeds four even when substitutes are abundant', async () => {
@@ -164,7 +168,7 @@ describe('remote payload drives the card list', () => {
         )
       ])
     )
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     expect(catalog.filter((c) => c.modality === 'image')).toHaveLength(4)
     expectFourByFour(catalog)
   })
@@ -177,7 +181,7 @@ describe('remote payload drives the card list', () => {
     mockedFetchJSON.mockResolvedValue(
       indexWithCurated([category('image', 'Image', { image_solo: {} })])
     )
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     expect(catalog.find((c) => c.id === 'image_solo')).toBeDefined()
     expectFourByFour(catalog)
   })
@@ -191,13 +195,13 @@ describe('remote payload drives the card list', () => {
       ...CURATED_TEMPLATES.filter((t) => t.modality !== 'image')
     ])
     mockedFetchJSON.mockResolvedValue(indexWithCurated())
-    expectFourByFour(await loadTemplateCatalog())
+    expectFourByFour(await loadCards())
   })
 
   it('backfills wholly when the payload is empty', async () => {
     getStarterTemplatesAsync.mockResolvedValue([])
     mockedFetchJSON.mockResolvedValue(indexWithCurated())
-    expectFourByFour(await loadTemplateCatalog())
+    expectFourByFour(await loadCards())
   })
 })
 
@@ -218,7 +222,7 @@ describe('version gate via the package pin', () => {
         })
         .concat(spares() as never[])
     )
-    const catalog = await loadTemplateCatalog({ comfyVersion: 'v0.28.2' })
+    const catalog = await loadCards({ comfyVersion: 'v0.28.2' })
     expect(catalog.find((c) => c.id === missing)).toBeUndefined()
     expectFourByFour(catalog)
   })
@@ -226,7 +230,7 @@ describe('version gate via the package pin', () => {
   it('fetches the index the target ComfyUI pins, not main', async () => {
     resolveTemplatePackageVersion.mockResolvedValue('0.11.12')
     mockedFetchJSON.mockResolvedValue(indexWithCurated())
-    await loadTemplateCatalog({ comfyVersion: 'v0.28.2' })
+    await loadCards({ comfyVersion: 'v0.28.2' })
     expect(resolveTemplatePackageVersion).toHaveBeenCalledWith('v0.28.2')
     expect(
       mockedFetchJSON,
@@ -240,14 +244,14 @@ describe('version gate via the package pin', () => {
   it('fetches the live main index when no pin resolves', async () => {
     resolveTemplatePackageVersion.mockResolvedValue(null)
     mockedFetchJSON.mockResolvedValue(indexWithCurated())
-    await loadTemplateCatalog({ comfyVersion: null })
+    await loadCards({ comfyVersion: null })
     expect(mockedFetchJSON).toHaveBeenCalledWith(INDEX_URL, expect.anything())
   })
 
   it('keeps that template when the pinned index carries it', async () => {
     resolveTemplatePackageVersion.mockResolvedValue('0.11.31')
     mockedFetchJSON.mockResolvedValue(indexWithCurated())
-    const catalog = await loadTemplateCatalog({ comfyVersion: 'v0.30.2' })
+    const catalog = await loadCards({ comfyVersion: 'v0.30.2' })
     expect(catalog.find((c) => c.id === 'video_minimax_h3_t2v')).toBeDefined()
     expectFourByFour(catalog)
   })
@@ -255,21 +259,21 @@ describe('version gate via the package pin', () => {
   it('fails open when the version is unknown', async () => {
     resolveTemplatePackageVersion.mockResolvedValue(null)
     mockedFetchJSON.mockResolvedValue(indexWithCurated())
-    const catalog = await loadTemplateCatalog({ comfyVersion: null })
+    const catalog = await loadCards({ comfyVersion: null })
     expectFourByFour(catalog)
   })
 
   it('fails open when the pin lookup rejects', async () => {
     resolveTemplatePackageVersion.mockRejectedValue(new Error('offline'))
     mockedFetchJSON.mockResolvedValue(indexWithCurated())
-    expectFourByFour(await loadTemplateCatalog({ comfyVersion: 'v0.30.2' }))
+    expectFourByFour(await loadCards({ comfyVersion: 'v0.30.2' }))
   })
 
   it('varies the cache key with comfyVersion', async () => {
     mockedFetchJSON.mockResolvedValue(indexWithCurated())
     resolveTemplatePackageVersion.mockResolvedValue('0.11.31')
-    await loadTemplateCatalog({ comfyVersion: 'v0.30.2' })
-    await loadTemplateCatalog({ comfyVersion: 'v0.28.2' })
+    await loadCards({ comfyVersion: 'v0.30.2' })
+    await loadCards({ comfyVersion: 'v0.28.2' })
     expect(
       mockedFetchJSON.mock.calls.length,
       'a different target version re-resolves rather than serving the previous filter'
@@ -279,9 +283,9 @@ describe('version gate via the package pin', () => {
   it('still caches repeat reads for the same comfyVersion', async () => {
     mockedFetchJSON.mockResolvedValue(indexWithCurated())
     resolveTemplatePackageVersion.mockResolvedValue('0.11.31')
-    await loadTemplateCatalog({ comfyVersion: 'v0.30.2' })
+    await loadCards({ comfyVersion: 'v0.30.2' })
     const before = mockedFetchJSON.mock.calls.length
-    await loadTemplateCatalog({ comfyVersion: 'v0.30.2' })
+    await loadCards({ comfyVersion: 'v0.30.2' })
     expect(mockedFetchJSON.mock.calls.length).toBe(before)
   })
 })
@@ -302,7 +306,7 @@ describe('upstream compatibility signals', () => {
         })
         .concat(spares() as never[])
     )
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     expect(catalog.find((c) => c.id === target.id)).toBeUndefined()
     expectFourByFour(catalog)
   })
@@ -320,7 +324,7 @@ describe('upstream compatibility signals', () => {
         return cat
       })
     )
-    expect((await loadTemplateCatalog()).find((c) => c.id === target.id)).toBeDefined()
+    expect((await loadCards()).find((c) => c.id === target.id)).toBeDefined()
   })
 
   it('drops a cloud-only card', async () => {
@@ -338,7 +342,7 @@ describe('upstream compatibility signals', () => {
         })
         .concat(spares() as never[])
     )
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     expect(catalog.find((c) => c.id === target.id)).toBeUndefined()
     expectFourByFour(catalog)
   })
@@ -358,7 +362,7 @@ describe('upstream compatibility signals', () => {
           return cat
         })
       )
-      expect((await loadTemplateCatalog()).find((c) => c.id === target.id)).toBeDefined()
+      expect((await loadCards()).find((c) => c.id === target.id)).toBeDefined()
     }
   )
 })
@@ -372,7 +376,7 @@ describe('substitution quality', () => {
     mockedFetchJSON.mockResolvedValue(
       indexWithCurated([category('video', 'Video', { real_video: { title: 'Real Video' } })])
     )
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     for (const card of catalog.filter((c) => c.modality === 'video')) {
       expect(card.id.startsWith('image_'), card.id).toBe(false)
     }
@@ -395,7 +399,7 @@ describe('substitution quality', () => {
         category('image', 'Getting Started', { gs_trap: { title: 'Getting Started Trap' } })
       ])
     )
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     for (const trap of ['basics_trap', 'utility_trap', 'llm_trap', 'gs_trap']) {
       expect(
         catalog.find((c) => c.id === trap),
@@ -413,7 +417,11 @@ describe('substitution quality', () => {
     mockedFetchJSON.mockResolvedValue(
       indexWithCurated([category('image', 'Use Cases', { use_case_ok: { title: 'Use Case Sub' } })])
     )
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
+    expect(
+      catalog.find((c) => c.id === 'use_case_ok'),
+      'an allowlisted Use Cases entry is eligible as a substitute'
+    ).toBeDefined()
     expectFourByFour(catalog)
   })
 
@@ -425,7 +433,7 @@ describe('substitution quality', () => {
     mockedFetchJSON.mockResolvedValue(
       indexWithCurated([category('image', 'Utility', { utility_pick: { title: 'Chosen' } })])
     )
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     expect(catalog.find((c) => c.id === 'utility_pick')?.title).toBe('Chosen')
     expectFourByFour(catalog)
   })
@@ -441,7 +449,7 @@ describe('substitution quality', () => {
         return cat
       })
     )
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     const card = catalog.find((c) => c.id === apiCard.id)
     expect(card?.apiNode).toBe(true)
     expectFourByFour(catalog)
@@ -461,7 +469,7 @@ describe('substitution quality', () => {
         })
       ])
     )
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     expect(catalog.find((c) => c.id === 'api_should_skip')).toBeUndefined()
     expect(catalog.find((c) => c.id === 'sizeless_should_skip')).toBeUndefined()
     expectFourByFour(catalog)
@@ -477,7 +485,7 @@ describe('substitution quality', () => {
       mockedFetchJSON.mockResolvedValue(
         indexWithCurated([category('image', 'Image', { sub_for_typo: {} })])
       )
-      await loadTemplateCatalog()
+      await loadCards()
       expect(warn.mock.calls.flat().join(' ')).toContain('image_typo_id')
     } finally {
       warn.mockRestore()
@@ -486,7 +494,7 @@ describe('substitution quality', () => {
 
   it('does not substitute when offline', async () => {
     mockedFetchJSON.mockRejectedValue(new Error('offline'))
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     for (const curated of CURATED_TEMPLATES) {
       expect(
         catalog.find((c) => c.id === curated.id),
@@ -515,7 +523,7 @@ describe('substitution quality', () => {
         })
       ])
     )
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     for (const card of catalog.filter((c) => c.modality === '3d')) {
       expect(card.id.startsWith('spare_'), card.id).toBe(false)
     }
@@ -529,7 +537,7 @@ describe('recommended invariants after resolution', () => {
       CURATED_TEMPLATES.map(({ recommended: _drop, ...rest }) => rest as never)
     )
     mockedFetchJSON.mockResolvedValue(indexWithCurated())
-    expectFourByFour(await loadTemplateCatalog())
+    expectFourByFour(await loadCards())
   })
 
   it('keeps the recommendation off an api card in an all-api modality', async () => {
@@ -541,7 +549,7 @@ describe('recommended invariants after resolution', () => {
       ...CURATED_TEMPLATES.filter((t) => t.modality !== 'image')
     ])
     mockedFetchJSON.mockResolvedValue(indexWithCurated())
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     const rec = catalog.filter((c) => c.modality === 'image' && c.recommended)
     expect(rec).toHaveLength(1)
     expect(rec[0]!.apiNode).toBe(false)
@@ -564,10 +572,52 @@ describe('availability window', () => {
           category('image', 'Image', { image_future: {}, image_expired: {}, image_open: {} })
         ])
       )
-      const catalog = await loadTemplateCatalog()
+      const catalog = await loadCards()
       expect(catalog.find((c) => c.id === 'image_future')).toBeUndefined()
       expect(catalog.find((c) => c.id === 'image_expired')).toBeUndefined()
       expect(catalog.find((c) => c.id === 'image_open')).toBeDefined()
+      expectFourByFour(catalog)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not let backfill re-add a baked-in card whose window has closed', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-01T00:00:00Z'))
+    try {
+      const retired = CURATED_TEMPLATES.find((t) => t.modality === 'image')!
+      getStarterTemplatesAsync.mockResolvedValue([
+        { ...retired, availableUntil: '2026-01-01T00:00:00Z' },
+        ...CURATED_TEMPLATES.filter((t) => t.modality !== 'image')
+      ])
+      mockedFetchJSON.mockResolvedValue(indexWithCurated(spares()))
+      const catalog = await loadCards()
+      expect(
+        catalog.find((c) => c.id === retired.id),
+        'a retired card must not walk back in through the backfill door'
+      ).toBeUndefined()
+      expectFourByFour(catalog)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not let backfill stage a baked-in card ahead of its window', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-01T00:00:00Z'))
+    try {
+      const upcoming = CURATED_TEMPLATES.find((t) => t.modality === 'image')!
+      getStarterTemplatesAsync.mockResolvedValue([
+        { ...upcoming, availableFrom: '2026-12-01T00:00:00Z' },
+        ...CURATED_TEMPLATES.filter((t) => t.modality !== 'image')
+      ])
+      mockedFetchJSON.mockResolvedValue(indexWithCurated(spares()))
+      const catalog = await loadCards()
+      expect(
+        catalog.find((c) => c.id === upcoming.id),
+        'a staged card must wait for the window it was given'
+      ).toBeUndefined()
       expectFourByFour(catalog)
     } finally {
       vi.useRealTimers()
@@ -580,13 +630,13 @@ describe('every source failing at once', () => {
     getStarterTemplatesAsync.mockResolvedValue(CURATED_TEMPLATES)
     mockedFetchJSON.mockRejectedValue(new Error('offline'))
     resolveTemplatePackageVersion.mockRejectedValue(new Error('offline'))
-    expectFourByFour(await loadTemplateCatalog({ comfyVersion: null }))
+    expectFourByFour(await loadCards({ comfyVersion: null }))
   })
 
   it('holds 4x4 when the manifest read itself throws', async () => {
     getStarterTemplatesAsync.mockRejectedValue(new Error('flag exploded'))
     mockedFetchJSON.mockResolvedValue(indexWithCurated())
-    expectFourByFour(await loadTemplateCatalog())
+    expectFourByFour(await loadCards())
   })
 
   it('holds 4x4 when the payload is every kind of broken at once', async () => {
@@ -597,7 +647,7 @@ describe('every source failing at once', () => {
       { id: 'gone_3', modality: '3d' }
     ])
     mockedFetchJSON.mockResolvedValue([])
-    expectFourByFour(await loadTemplateCatalog({ comfyVersion: 'v0.28.2' }))
+    expectFourByFour(await loadCards({ comfyVersion: 'v0.28.2' }))
   })
 })
 
@@ -621,7 +671,7 @@ describe('4x4 when the index offers no substitute candidates', () => {
   it('holds when the recommended card is missing and nothing can substitute', async () => {
     resolveTemplatePackageVersion.mockResolvedValue('0.11.12')
     mockedFetchJSON.mockResolvedValue(bareIndex(['video_minimax_h3_t2v']))
-    const catalog = await loadTemplateCatalog({ comfyVersion: 'v0.28.2' })
+    const catalog = await loadCards({ comfyVersion: 'v0.28.2' })
     expectFourByFour(catalog)
   })
 
@@ -629,14 +679,14 @@ describe('4x4 when the index offers no substitute candidates', () => {
     'holds for %s when %s is absent from the index',
     async (_modality, missingId) => {
       mockedFetchJSON.mockResolvedValue(bareIndex([missingId]))
-      expectFourByFour(await loadTemplateCatalog({ comfyVersion: 'v0.28.2' }))
+      expectFourByFour(await loadCards({ comfyVersion: 'v0.28.2' }))
     }
   )
 
   it('holds when every card in a modality is absent', async () => {
     const video = CURATED_TEMPLATES.filter((t) => t.modality === 'video').map((t) => t.id)
     mockedFetchJSON.mockResolvedValue(bareIndex(video))
-    expectFourByFour(await loadTemplateCatalog({ comfyVersion: 'v0.28.2' }))
+    expectFourByFour(await loadCards({ comfyVersion: 'v0.28.2' }))
   })
 
   it('holds when the index carries no allowlisted category at all', async () => {
@@ -644,12 +694,12 @@ describe('4x4 when the index offers no substitute candidates', () => {
       category('image', 'Node Basics', { nb_1: {}, nb_2: {} }),
       category('video', 'Utility', { ut_1: {} })
     ])
-    expectFourByFour(await loadTemplateCatalog({ comfyVersion: 'v0.28.2' }))
+    expectFourByFour(await loadCards({ comfyVersion: 'v0.28.2' }))
   })
 
   it('never lets a substitute steal a baked-in card still owed a slot', async () => {
     mockedFetchJSON.mockResolvedValue(bareIndex(['video_minimax_h3_t2v']))
-    const catalog = await loadTemplateCatalog({ comfyVersion: 'v0.28.2' })
+    const catalog = await loadCards({ comfyVersion: 'v0.28.2' })
     const video = catalog.filter((c) => c.modality === 'video').map((c) => c.id)
     for (const id of [
       'api_seedance2_0_r2v',
@@ -667,7 +717,7 @@ describe('thumbnails follow the pinned index', () => {
     // card hydrated from v0.11.12 requests an image that only exists on main.
     resolveTemplatePackageVersion.mockResolvedValue('0.11.12')
     mockedFetchJSON.mockResolvedValue(indexWithCurated())
-    const catalog = await loadTemplateCatalog({ comfyVersion: 'v0.28.2' })
+    const catalog = await loadCards({ comfyVersion: 'v0.28.2' })
     const withThumb = catalog.filter((c) => c.thumbnailUrl)
     expect(withThumb.length).toBeGreaterThan(0)
     for (const card of withThumb) {
@@ -678,7 +728,7 @@ describe('thumbnails follow the pinned index', () => {
   it('falls back to the main asset base when no pin resolves', async () => {
     resolveTemplatePackageVersion.mockResolvedValue(null)
     mockedFetchJSON.mockResolvedValue(indexWithCurated())
-    const catalog = await loadTemplateCatalog({ comfyVersion: null })
+    const catalog = await loadCards({ comfyVersion: null })
     const card = catalog.find((c) => c.thumbnailUrl)!
     expect(card.thumbnailUrl).toContain('/main/templates/')
   })
@@ -711,7 +761,7 @@ describe('adversarial-but-valid payloads', () => {
         ...CURATED_TEMPLATES
       ])
       mockedFetchJSON.mockResolvedValue(bareIndexAll())
-      const catalog = await loadTemplateCatalog()
+      const catalog = await loadCards()
       expect(new Set(catalog.map((c) => c.id)).size, 'no duplicate ids').toBe(catalog.length)
     }
   )
@@ -721,7 +771,7 @@ describe('adversarial-but-valid payloads', () => {
       CURATED_TEMPLATES.map((t) => ({ id: t.id, modality: t.modality, apiNode: true as const }))
     )
     mockedFetchJSON.mockResolvedValue(bareIndexAll())
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     for (const modality of TEMPLATE_MODALITY_ORDER) {
       const cards = catalog.filter((c) => c.modality === modality)
       expect(cards, modality).toHaveLength(4)
@@ -740,7 +790,7 @@ describe('adversarial-but-valid payloads', () => {
           : {}
       )
     )
-    expectFourByFour(await loadTemplateCatalog({ comfyVersion: 'v0.28.2' }))
+    expectFourByFour(await loadCards({ comfyVersion: 'v0.28.2' }))
   })
 
   it('still drops an unrunnable card when a runnable one can take the slot', async () => {
@@ -749,7 +799,7 @@ describe('adversarial-but-valid payloads', () => {
       ...bareIndexAll((id) => (id === target.id ? { requiresCustomNodes: ['x'] } : {})),
       category('image', 'Image', { runnable_sub: { title: 'Runnable' } })
     ])
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     expect(catalog.find((c) => c.id === target.id)).toBeUndefined()
     expectFourByFour(catalog)
   })

--- a/src/main/sources/standalone/templateModels.test.ts
+++ b/src/main/sources/standalone/templateModels.test.ts
@@ -142,6 +142,7 @@ describe('remote workflow fallback follows the pinned version', () => {
       'https://raw.githubusercontent.com/Comfy-Org/workflow_templates/v0.11.12/templates/image_one.json',
       expect.anything()
     )
+    expect(fetchJSON, 'the pinned fetch must not also fall back to main').toHaveBeenCalledTimes(1)
   })
 
   it('defaults to main when no asset base is given', async () => {

--- a/src/main/sources/standalone/templateModels.test.ts
+++ b/src/main/sources/standalone/templateModels.test.ts
@@ -122,3 +122,34 @@ describe('resolveTemplateModels — URL + path guards', () => {
     expect(out).toEqual([])
   })
 })
+
+describe('remote workflow fallback follows the pinned version', () => {
+  beforeEach(() => {
+    fetchJSON.mockReset()
+  })
+
+  it('fetches the workflow from the asset base it is given', async () => {
+    fetchJSON.mockResolvedValue({ models: [] })
+    await resolveTemplateModels(
+      null,
+      'image_one',
+      'https://raw.githubusercontent.com/Comfy-Org/workflow_templates/v0.11.12/templates'
+    )
+    expect(
+      fetchJSON,
+      'a network-fetched workflow must match the revision the card came from'
+    ).toHaveBeenCalledWith(
+      'https://raw.githubusercontent.com/Comfy-Org/workflow_templates/v0.11.12/templates/image_one.json',
+      expect.anything()
+    )
+  })
+
+  it('defaults to main when no asset base is given', async () => {
+    fetchJSON.mockResolvedValue({ models: [] })
+    await resolveTemplateModels(null, 'image_one')
+    expect(fetchJSON).toHaveBeenCalledWith(
+      expect.stringContaining('/main/templates/image_one.json'),
+      expect.anything()
+    )
+  })
+})

--- a/src/main/sources/standalone/templateModels.ts
+++ b/src/main/sources/standalone/templateModels.ts
@@ -32,8 +32,6 @@ interface RawModel {
   directory?: unknown
 }
 
-const RAW_TEMPLATES_REMOTE_BASE = RAW_TEMPLATES_BASE
-
 /**
  * Resolve the workflow JSON for `templateId` — preferring the copy bundled in
  * the just-installed `comfyui_workflow_templates` package (no network), falling
@@ -57,7 +55,8 @@ const TEMPLATE_PACKAGE_DIRS = [
 
 export async function loadTemplateJson(
   installation: InstallationRecord | null,
-  templateId: string
+  templateId: string,
+  assetBase: string = RAW_TEMPLATES_BASE
 ): Promise<unknown | null> {
   const sitePackages = installation ? findSitePackages(getActiveVenvDir(installation)) : null
   if (sitePackages) {
@@ -76,7 +75,7 @@ export async function loadTemplateJson(
   // the same proven network stack, timeout, and retry behaviour as every other
   // main-side HTTP call.
   try {
-    return await fetchJSON(`${RAW_TEMPLATES_REMOTE_BASE}/${templateId}.json`, { refresh: true })
+    return await fetchJSON(`${assetBase}/${templateId}.json`, { refresh: true })
   } catch {
     return null
   }
@@ -165,9 +164,10 @@ function walkNodes(nodes: unknown, out: RawModel[]): void {
  */
 export async function resolveTemplateModels(
   installation: InstallationRecord | null,
-  templateId: string
+  templateId: string,
+  assetBase?: string
 ): Promise<TemplateModelDownload[]> {
-  const json = await loadTemplateJson(installation, templateId)
+  const json = await loadTemplateJson(installation, templateId, assetBase)
   if (!json || typeof json !== 'object') return []
 
   const doc = json as {

--- a/src/main/sources/standalone/templatePin.test.ts
+++ b/src/main/sources/standalone/templatePin.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const fetchText = vi.fn()
+vi.mock('../../lib/fetch', () => ({ fetchText: (...a: unknown[]) => fetchText(...a) }))
+
+import {
+  resolveTemplatePackageVersion,
+  templateIndexUrlFor,
+  parseTemplatePin,
+  _resetForTest
+} from './templatePin'
+import { INDEX_URL } from './curatedTemplates'
+
+function requirements(pin: string | null): string {
+  return [
+    'comfyui-frontend-package==1.47.12',
+    ...(pin ? [pin] : []),
+    'comfyui-embedded-docs==0.5.9',
+    'torch',
+    'numpy>=1.25.0'
+  ].join('\n')
+}
+
+beforeEach(() => {
+  _resetForTest()
+  fetchText.mockReset()
+})
+
+describe('parseTemplatePin', () => {
+  it('reads the hyphenated package name ComfyUI actually pins', () => {
+    expect(
+      parseTemplatePin(requirements('comfyui-workflow-templates==0.11.31')),
+      'the pin uses the hyphenated package name'
+    ).toBe('0.11.31')
+  })
+
+  it('does not match the underscored form', () => {
+    expect(
+      parseTemplatePin(requirements('comfyui_workflow_templates==0.11.31')),
+      'the underscored form is the Python import path, never the pin'
+    ).toBeNull()
+  })
+
+  it('tolerates surrounding whitespace and comments', () => {
+    expect(parseTemplatePin('  comfyui-workflow-templates==0.11.31  # pinned\n')).toBe('0.11.31')
+  })
+
+  it.each([
+    ['absent', requirements(null)],
+    ['no version', requirements('comfyui-workflow-templates==')],
+    ['range not pin', requirements('comfyui-workflow-templates>=0.11.0')],
+    ['empty file', ''],
+    ['garbage', 'this is not a requirements file'],
+    ['non-numeric', requirements('comfyui-workflow-templates==abc')]
+  ])('%s yields null', (_label, contents) => {
+    expect(parseTemplatePin(contents)).toBeNull()
+  })
+})
+
+describe('resolveTemplatePackageVersion', () => {
+  it('resolves a tag through requirements.txt to the pinned version', async () => {
+    fetchText.mockResolvedValue(requirements('comfyui-workflow-templates==0.11.31'))
+    expect(await resolveTemplatePackageVersion('v0.30.2')).toBe('0.11.31')
+    expect(fetchText).toHaveBeenCalledWith(
+      expect.stringContaining('v0.30.2/requirements.txt'),
+      expect.objectContaining({ timeoutMs: expect.any(Number) })
+    )
+  })
+
+  it('treats a bare version and a v-prefixed tag identically', async () => {
+    fetchText.mockResolvedValue(requirements('comfyui-workflow-templates==0.11.31'))
+    const prefixed = await resolveTemplatePackageVersion('v0.30.2')
+    _resetForTest()
+    fetchText.mockResolvedValue(requirements('comfyui-workflow-templates==0.11.31'))
+    const bare = await resolveTemplatePackageVersion('0.30.2')
+    expect(bare).toBe(prefixed)
+    expect(fetchText).toHaveBeenCalledWith(
+      expect.stringContaining('v0.30.2/requirements.txt'),
+      expect.objectContaining({ timeoutMs: expect.any(Number) })
+    )
+  })
+
+  it.each([[null], [undefined], ['']])('returns null for an unresolvable tag: %s', async (tag) => {
+    expect(await resolveTemplatePackageVersion(tag as string | null)).toBeNull()
+    expect(fetchText).not.toHaveBeenCalled()
+  })
+
+  it('rejects a tag that is not version-shaped without fetching', async () => {
+    expect(await resolveTemplatePackageVersion('../../etc/passwd')).toBeNull()
+    expect(await resolveTemplatePackageVersion('master')).toBeNull()
+    expect(fetchText).not.toHaveBeenCalled()
+  })
+
+  it('returns null when requirements.txt 404s', async () => {
+    fetchText.mockRejectedValue(new Error('HTTP 404'))
+    expect(await resolveTemplatePackageVersion('v9.99.99')).toBeNull()
+  })
+
+  it('returns null when the fetch rejects, without throwing', async () => {
+    fetchText.mockRejectedValue(new Error('offline'))
+    await expect(resolveTemplatePackageVersion('v0.30.2')).resolves.toBeNull()
+  })
+
+  it('caches a resolved tag — one network hit for repeat lookups', async () => {
+    fetchText.mockResolvedValue(requirements('comfyui-workflow-templates==0.11.31'))
+    await resolveTemplatePackageVersion('v0.30.2')
+    await resolveTemplatePackageVersion('v0.30.2')
+    expect(fetchText).toHaveBeenCalledTimes(1)
+  })
+
+  it('caches a failure too, so a 404 is not refetched every picker open', async () => {
+    fetchText.mockRejectedValue(new Error('404'))
+    await resolveTemplatePackageVersion('v0.28.2')
+    await resolveTemplatePackageVersion('v0.28.2')
+    expect(fetchText).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps separate tags separate', async () => {
+    fetchText.mockImplementation((url: string) =>
+      Promise.resolve(
+        requirements(
+          url.includes('v0.28.2')
+            ? 'comfyui-workflow-templates==0.11.12'
+            : 'comfyui-workflow-templates==0.11.31'
+        )
+      )
+    )
+    expect(await resolveTemplatePackageVersion('v0.28.2')).toBe('0.11.12')
+    expect(await resolveTemplatePackageVersion('v0.30.2')).toBe('0.11.31')
+  })
+})
+
+describe('templateIndexUrlFor', () => {
+  it('builds the versioned index URL for a resolved pin', () => {
+    expect(templateIndexUrlFor('0.11.31')).toBe(
+      'https://raw.githubusercontent.com/Comfy-Org/workflow_templates/v0.11.31/templates/index.json'
+    )
+  })
+
+  it('falls back to the live main index when the pin is unknown', () => {
+    expect(templateIndexUrlFor(null), 'fails open to today’s behaviour').toBe(INDEX_URL)
+  })
+
+  it('refuses a pin that is not version-shaped', () => {
+    expect(templateIndexUrlFor('../../evil')).toBe(INDEX_URL)
+    expect(templateIndexUrlFor('main')).toBe(INDEX_URL)
+  })
+})

--- a/src/main/sources/standalone/templatePin.test.ts
+++ b/src/main/sources/standalone/templatePin.test.ts
@@ -71,10 +71,11 @@ describe('resolveTemplatePackageVersion', () => {
     fetchText.mockResolvedValue(requirements('comfyui-workflow-templates==0.11.31'))
     const prefixed = await resolveTemplatePackageVersion('v0.30.2')
     _resetForTest()
+    fetchText.mockClear()
     fetchText.mockResolvedValue(requirements('comfyui-workflow-templates==0.11.31'))
     const bare = await resolveTemplatePackageVersion('0.30.2')
     expect(bare).toBe(prefixed)
-    expect(fetchText).toHaveBeenCalledWith(
+    expect(fetchText, 'the bare tag is the one normalized to v0.30.2').toHaveBeenCalledWith(
       expect.stringContaining('v0.30.2/requirements.txt'),
       expect.objectContaining({ timeoutMs: expect.any(Number) })
     )

--- a/src/main/sources/standalone/templatePin.ts
+++ b/src/main/sources/standalone/templatePin.ts
@@ -1,0 +1,86 @@
+/**
+ * Maps a ComfyUI version to the template index it ships. ComfyUI pins
+ * `comfyui-workflow-templates` in its `requirements.txt`, and that pin is the
+ * only compatibility map that exists — the index carries no version field.
+ *
+ * Every failure returns `null`, which falls back to the live `main` index.
+ */
+import { fetchText } from '../../lib/fetch'
+import { INDEX_URL, RAW_TEMPLATES_BASE } from './curatedTemplates'
+
+const MAX_PIN_CACHE_SIZE = 100
+const PIN_TIMEOUT_MS = 5000
+
+const VERSION_TAG_PATTERN = /^v?\d+(?:\.\d+)*$/
+/** Hyphenated; the underscored form is the Python import path, not the pin. */
+const PIN_PATTERN = /^\s*comfyui-workflow-templates\s*==\s*(\d+(?:\.\d+)*)\s*(?:#.*)?$/m
+
+const TEMPLATES_REPO = 'https://raw.githubusercontent.com/Comfy-Org/workflow_templates'
+const COMFYUI_REPO = 'https://raw.githubusercontent.com/comfyanonymous/ComfyUI'
+
+/** Failures cache as `null`, so a 404 isn't refetched on every picker open. */
+const pinCache = new Map<string, string | null>()
+const inflight = new Map<string, Promise<string | null>>()
+
+export function parseTemplatePin(contents: string): string | null {
+  return PIN_PATTERN.exec(contents)?.[1] ?? null
+}
+
+/** Both forms are persisted; see `version.ts:tagsEqual` for the strip-side. */
+function normalizeTag(tag: string): string {
+  return tag.startsWith('v') ? tag : `v${tag}`
+}
+
+/** `null` when the pin can't be determined. Never throws. */
+export async function resolveTemplatePackageVersion(
+  comfyTag: string | null | undefined
+): Promise<string | null> {
+  if (!comfyTag || !VERSION_TAG_PATTERN.test(comfyTag)) return null
+
+  const ref = normalizeTag(comfyTag)
+  const cached = pinCache.get(ref)
+  if (cached !== undefined) return cached
+  const existing = inflight.get(ref)
+  if (existing) return existing
+
+  const promise = (async () => {
+    const resolved = await fetchText(`${COMFYUI_REPO}/${ref}/requirements.txt`, {
+      timeoutMs: PIN_TIMEOUT_MS
+    })
+      .then(parseTemplatePin)
+      .catch(() => null)
+    remember(ref, resolved)
+    inflight.delete(ref)
+    return resolved
+  })()
+
+  inflight.set(ref, promise)
+  return promise
+}
+
+/** `VERSION_TAG_PATTERN` admits unbounded dot-groups, so cap the key space. */
+function remember(ref: string, resolved: string | null): void {
+  if (pinCache.size >= MAX_PIN_CACHE_SIZE) {
+    const oldest = pinCache.keys().next().value
+    if (oldest !== undefined) pinCache.delete(oldest)
+  }
+  pinCache.set(ref, resolved)
+}
+
+/** Falls back to `main` when the pin is unknown or malformed. */
+export function templateIndexUrlFor(packageVersion: string | null): string {
+  if (!packageVersion || !VERSION_TAG_PATTERN.test(packageVersion)) return INDEX_URL
+  return `${TEMPLATES_REPO}/${normalizeTag(packageVersion)}/templates/index.json`
+}
+
+/** Thumbnail base, so previews match the index they came from. */
+export function templateAssetBaseFor(packageVersion: string | null): string {
+  if (!packageVersion || !VERSION_TAG_PATTERN.test(packageVersion)) return RAW_TEMPLATES_BASE
+  return `${TEMPLATES_REPO}/${normalizeTag(packageVersion)}/templates`
+}
+
+/** @internal — exposed for tests. */
+export function _resetForTest(): void {
+  pinCache.clear()
+  inflight.clear()
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,14 @@ export default defineConfig({
   },
   test: {
     environment: 'happy-dom',
+    // Components that render an iframe (FeedbackModal's typeform) would
+    // otherwise have happy-dom fetch the real URL. The request outlives the
+    // test, so teardown aborts it and the rejection surfaces as an unhandled
+    // error in an unrelated file. Tests assert on the `src` attribute, never
+    // on loaded frame content.
+    environmentOptions: {
+      happyDOM: { settings: { disableIframePageLoading: true } }
+    },
     include: ['src/**/*.test.ts'],
     exclude: ['src/**/*.integration.test.ts', 'node_modules'],
     globals: true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,9 +16,10 @@ export default defineConfig({
     // otherwise have happy-dom fetch the real URL. The request outlives the
     // test, so teardown aborts it and the rejection surfaces as an unhandled
     // error in an unrelated file. Tests assert on the `src` attribute, never
-    // on loaded frame content.
+    // on loaded frame content. (Supersedes `disableIframePageLoading`, which
+    // happy-dom deprecated and which logged a console error per blocked frame.)
     environmentOptions: {
-      happyDOM: { settings: { disableIframePageLoading: true } }
+      happyDOM: { settings: { navigation: { disableChildFrameNavigation: true } } }
     },
     include: ['src/**/*.test.ts'],
     exclude: ['src/**/*.integration.test.ts', 'node_modules'],


### PR DESCRIPTION
## Summary

The content team can now change which templates the post-install picker offers by editing a PostHog flag, with no code change and no app release. Along the way this fixes a live bug where the picker could offer a template the user's ComfyUI cannot actually open.

## Changes

**What**

- The picker's card list now comes from a PostHog flag payload, falling back to a disk cache and then to the list baked into the app. Content edits reach users on their next app start. Every failure mode (broken JSON, missing ids, PostHog down, offline) lands on a working picker.
- Fixed a compatibility bug that ships today. The picker read the template index from GitHub `main` while the user's ComfyUI installs a pinned template package, and those drift. ComfyUI v0.28.2 pins 562 templates, current pins 587. The Video tab's auto-selected card does not exist in the older set, so those users were offered a card that cannot open. The picker now reads the index at the version the target install actually ships.
- Templates requiring custom nodes, and cloud-only templates, are dropped. The frontend already hides these, so desktop was advertising cards that then disappeared.
- Card thumbnails and pre-download model lists now resolve at the pinned version too, so a preview and its model set match the card the user picked.
- Substitutes are drawn only from real starter categories. The upstream `image` type also covers Utility, LLM, and Node Basics, so a tutorial graph could previously be promoted into the Image tab.
- Every network request in the shared fetch layer is now bounded by a timeout. `net.request` has no deadline of its own, so a stalled socket could hang the install wizard indefinitely.

**Breaking**

None. With no flag configured the picker behaves exactly as it does today. Deeplinks, telemetry, and the install wizard's field contract are unchanged, and the four-per-tab shape is preserved on every path.

## Review Focus

The crux is the invariant: **exactly four cards in each of the four tabs, always.** That is what most of the resolution logic exists to protect, and it is worth reviewing as a whole rather than per hunk. `templateCatalog.ts` is the file to open.

Two decisions worth a second opinion:

1. **Identity is never relaxed, even to fill a tab.** Two cards sharing an id would collide on `FieldOption.value`, which the picker uses as both its `v-for` key and its selection identity, and would give the express-install path two competing defaults. When a payload forces the choice, a three-card tab is preferred over a duplicated card. This reverses an earlier approach in the branch, and the reasoning is recorded in the code so it is not undone by accident.
2. **A hand-typed version field was rejected.** The template index carries no version field, and its schema forbids adding one. ComfyUI's own `requirements.txt` pin is the only compatibility map that exists, so the code derives from that rather than asking a content editor to maintain a number nothing can validate.

Deliberately out of scope: no mid-session refresh, since the picker must not mutate under the user; no per-user targeting; no CMS, since the PostHog flag editor is the authoring surface. `githubStars.ts` still hand-rolls its own fetch and was left alone as unrelated surface.

## Testing

The invariant is the thing that can break in ways a per-function test will not catch, so the suite asserts it as a shared post-condition across every degradation path rather than testing each helper in isolation. Fixtures are built from the real index shape, including cases with no substitute candidates, since a fixture that always supplies spares hides exactly the failure this feature introduces. All network is mocked and time is controlled, so nothing here is wall-clock dependent.

Edge cases covered:

| Input | Expected |
|---|---|
| Payload arrives as an escaped JSON string (the shape production returns) | Parsed correctly |
| Malformed JSON, wrong schema version, non-array templates | Whole payload rejected, disk cache then baked-in list |
| One bad entry among four | That entry drops, the other three survive, slot four refills |
| Entry filed under the wrong tab | Rejected at parse time, so one card cannot fork across two tabs |
| Entry claiming both recommended and API-node | Dropped, since the auto-pick must never cost credits |
| Payload names only one tab (the current live state) | Named tab honoured, other three fill from the baked-in list |
| Payload lists more than four for a tab | Truncated to four |
| Template missing from the pinned index | Hidden, substituted with a compatible same-tab card |
| Template requires custom nodes, or is cloud-only | Dropped |
| Substitute candidate is a tutorial or utility graph | Never promoted into a starter tab |
| Every card in a tab is an API node | No recommendation at all, so the wizard offers skip rather than a paid default |
| Pin lookup 404s, times out, or the version is unknown | Falls back to the live index, today's behaviour |
| Offline with a warm cache | Cache serves; the pin still resolves |
| Garbage payload, no index, and unknown version at once | Still four cards in all four tabs |

Test files:

- `starterTemplateManifest.test.ts` (37): payload parsing including the escaped-string form, per-entry default-deny validation, disk cache re-validation, and an assertion that reading the flag captures no telemetry event.
- `templateCatalogResolution.test.ts` (45): the four-by-four invariant across every failure combination, the version gate, upstream compatibility signals, substitution quality, and adversarial payloads that are valid per entry but hostile in aggregate.
- `templatePin.test.ts` (16): tag to pinned package version resolution, caching, and fail-open on every error path.
- `fetch.test.ts` (17): text fetching shares the ETag cache and retry layer, request timeouts fire and abort the socket, and a cached JSON body is never served to a text caller.
- `templateCatalog.test.ts` (27), `curatedTemplates.test.ts` (22), `templateModels.test.ts` (15): hydration, the baked-in list's four-per-tab shape, and pinned workflow resolution.

Gate: `typecheck`, `lint`, and `format:check` clean. Full suite 3838 passed, 1 skipped (pre-existing), 227 files.

Beyond unit tests, the resolution algorithm was replayed against real `workflow_templates` index data at three pinned versions plus the live index, covering twelve failure scenarios. All held at four per tab. The specific regression verifies end to end: on ComfyUI v0.28.2 the Video tab now offers a template that install actually ships, while a current install still gets the intended recommendation.

Manual verification: install with no flag configured and confirm the picker is unchanged, then set a payload and confirm the named cards appear after a full app restart (flags are read once at boot, so a reload will not pick it up).
