### PR TITLE
feat(templates): swap in Seedance 2.5 as the video API-node starter

### DIFF
--- a/src/main/sources/standalone/curatedTemplates.ts
+++ b/src/main/sources/standalone/curatedTemplates.ts
@@ -177,13 +177,13 @@ export const CURATED_TEMPLATES: readonly CuratedTemplate[] = [
     }
   },
   {
-    id: 'api_seedance2_0_r2v',
+    id: 'api_seedance2_5_r2v',
     modality: 'video',
     apiNode: true,
     snapshot: {
-      title: 'Seedance 2.0: Reference to Video',
+      title: 'Seedance 2.5: Reference to Video',
       description:
-        'Generate cinematic videos from reference images and text prompts. Preserve subject identity and composition while adding expressive motion with synchronized audio. Control camera movement and lighting through detailed prompts.',
+        'Generate reference-driven videos with Seedance 2.5 by supplying up to 20 images, 6 video clips, and 6 audio clips to control character consistency, visual style, and motion rhythm in a single 4–30 second output with synchronized sound and lip-synced dialogue. Ideal for e-commerce product showcases, brand advertising, and character-driven short series.',
       sizeBytes: 0,
       mediaSubtype: 'webp'
     }


### PR DESCRIPTION
## Why

Lead the install picker with the **latest** Seedance. Per the thread: the goal is just to show we have the newest Seedance; people can browse the other variants in the templates library after. MiniMax H3 stays the recommended video pick.

## What

- Video tab, API-node slot: replace `api_seedance2_0_r2v` (Seedance 2.0: Reference to Video) with **`api_seedance2_5_r2v`** (Seedance 2.5: Reference to Video). Snapshot title/description synced from the live templates index.
- Same modality + same slot type, so tab order, per-modality counts, and the auto-selected pick are unchanged: **MiniMax H3 remains the recommended, zero-cost** video pick; 2.5 only fills the API-node demo slot.

Follows the pattern in #1371 (which added H3 and led with video).

## Not this

- Skipped the 4K Seedance 2.0 variant (`api_seedance2_0_r2v_4k`) — the call was "show the latest," and 2.5 does up to 4-30s with synced audio + lip-sync.

## Verified

- `prettier` clean, `typecheck` (node/web/e2e/integration) clean, `eslint` clean
- 122/122 tests pass (`curatedTemplates` / `index` / `TemplatePickerStep` / `useTemplateTabs`) — no test changes needed since nothing hardcodes the swapped id/title
