### PR TITLE
fix: prevent duplicate identify after cloud login

### DIFF
--- a/src/main/auth/desktopLoginCode/index.test.ts
+++ b/src/main/auth/desktopLoginCode/index.test.ts
@@ -239,10 +239,13 @@ describe('signInViaDesktopLoginCode', () => {
     expect(h.signInWithCustomToken).toHaveBeenCalledWith(expect.any(String), 'custom-token-value', {
       signal: expect.any(AbortSignal)
     })
-    expect(h.bindSignedInUser).toHaveBeenCalledWith(persistedUser, contents)
-    expect(h.capture).toHaveBeenCalledWith('comfy.desktop.identity.login_attributed', {
+    // The bind carries the attribution and runs only after injection succeeds.
+    expect(h.bindSignedInUser).toHaveBeenCalledWith(persistedUser, contents, {
       via: 'desktop_login_code'
     })
+    expect(h.bindSignedInUser.mock.invocationCallOrder[0]).toBeGreaterThan(
+      contents.mainFrame.executeJavaScript.mock.invocationCallOrder[1]!
+    )
     expect(contents.mainFrame.executeJavaScript).toHaveBeenCalledWith(
       expect.stringContaining('location.reload()'),
       true
@@ -430,10 +433,6 @@ describe('signInViaDesktopLoginCode', () => {
       true
     )
     expect(h.bindSignedInUser).not.toHaveBeenCalled()
-    expect(h.capture).not.toHaveBeenCalledWith(
-      'comfy.desktop.identity.login_attributed',
-      expect.anything()
-    )
     expect(h.emit).toHaveBeenCalledWith(
       'comfy.desktop.auth.sign_in_failed',
       expect.objectContaining({ flow: 'desktop_login_code' })
@@ -458,10 +457,6 @@ describe('signInViaDesktopLoginCode', () => {
 
     expect(await promise).toBe('handled')
     expect(h.bindSignedInUser).not.toHaveBeenCalled()
-    expect(h.capture).not.toHaveBeenCalledWith(
-      'comfy.desktop.identity.login_attributed',
-      expect.anything()
-    )
     expect(h.emit).toHaveBeenCalledWith(
       'comfy.desktop.auth.sign_in_failed',
       expect.objectContaining({ flow: 'desktop_login_code' })
@@ -678,10 +673,6 @@ describe('signInViaDesktopLoginCode', () => {
     // bind/attribution, no inject, no focus steal...
     expect(h.lookupAccount).not.toHaveBeenCalled()
     expect(h.bindSignedInUser).not.toHaveBeenCalled()
-    expect(h.capture).not.toHaveBeenCalledWith(
-      'comfy.desktop.identity.login_attributed',
-      expect.anything()
-    )
     expect(contents.mainFrame.executeJavaScript).not.toHaveBeenCalled()
     expect(parentWindow.focus).not.toHaveBeenCalled()
     // ...and did not tear down the newer flow's banner on the way out.

--- a/src/main/auth/desktopLoginCode/index.ts
+++ b/src/main/auth/desktopLoginCode/index.ts
@@ -257,13 +257,12 @@ export async function signInViaDesktopLoginCode(
     )
     if (!injected) return 'handled'
     if (controller.signal.aborted) return 'handled'
-    // Bind only after the session was successfully installed. Hosted Cloud
-    // views wait for their declarative auth reporter; local/legacy views use
-    // the main-verified fallback, so this produces exactly one success.
-    bindSignedInUser(user, comfyContents)
-    mainTelemetry.capture('comfy.desktop.identity.login_attributed', {
-      via: 'desktop_login_code'
-    })
+    // Bind only after the session was successfully installed. The injected
+    // session reloads hosted Cloud views, so the bind holds this user as
+    // pending and the consensus layer identifies — and emits the login
+    // attribution — once a document re-reports the same UID. Local/legacy
+    // views confirm through their scoped reporter the same way.
+    bindSignedInUser(user, comfyContents, { via: 'desktop_login_code' })
     restoreParentWindow(opts.parentWindow)
     return 'handled'
   } catch (err) {

--- a/src/main/auth/firebaseBridge/flowShared.ts
+++ b/src/main/auth/firebaseBridge/flowShared.ts
@@ -60,21 +60,38 @@ export function emitSignInFailure(
   return failure
 }
 
-/** Submit a Desktop-verified Firebase user to the process-wide identity consensus. */
-export function bindSignedInUser(user: Record<string, unknown>, source: WebContents): void {
+function verifiedIdentityFromUser(user: Record<string, unknown>): {
+  uid: string
+  properties: Record<string, string | number>
+} | null {
+  const uid = typeof user.uid === 'string' && user.uid.length > 0 ? user.uid : null
+  if (!uid) return null
+  const email = typeof user.email === 'string' && user.email.length > 0 ? user.email : null
+  const at = email ? email.lastIndexOf('@') : -1
+  const emailDomain = at >= 0 ? email!.slice(at + 1).toLowerCase() : null
+  const properties: Record<string, string | number> = {
+    signed_in_via: 'desktop_2',
+    signed_in_at_ms: Date.now()
+  }
+  if (email) properties.email = email
+  if (emailDomain) properties.email_domain = emailDomain
+  return { uid, properties }
+}
+
+/**
+ * Submit a Desktop-verified Firebase user to the process-wide identity
+ * consensus, with an optional one-shot login-attribution payload that the
+ * consensus layer emits once this UID is confirmed.
+ */
+export function bindSignedInUser(
+  user: Record<string, unknown>,
+  source: WebContents,
+  attribution: mainTelemetry.TelemetryContext | null = null
+): void {
   try {
-    const uid = typeof user.uid === 'string' && user.uid.length > 0 ? user.uid : null
-    if (!uid) return
-    const email = typeof user.email === 'string' && user.email.length > 0 ? user.email : null
-    const at = email ? email.lastIndexOf('@') : -1
-    const emailDomain = at >= 0 ? email!.slice(at + 1).toLowerCase() : null
-    const properties: Record<string, string | number> = {
-      signed_in_via: 'desktop_2',
-      signed_in_at_ms: Date.now()
-    }
-    if (email) properties.email = email
-    if (emailDomain) properties.email_domain = emailDomain
-    bindMainVerifiedFirebaseUser(uid, properties, source)
+    const identity = verifiedIdentityFromUser(user)
+    if (!identity) return
+    bindMainVerifiedFirebaseUser(identity.uid, identity.properties, source, attribution)
   } catch {
     // Telemetry must never break the auth flow.
   }

--- a/src/main/auth/firebaseBridge/index.test.ts
+++ b/src/main/auth/firebaseBridge/index.test.ts
@@ -1,5 +1,6 @@
 import type { WebContents } from 'electron'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as FlowSharedModule from './flowShared'
 
 import {
   closeActiveBridge,
@@ -10,7 +11,7 @@ import {
 
 const h = vi.hoisted(() => ({
   beginSessionInjection: vi.fn(() => ({ owner: 'test' })),
-  bindUserId: vi.fn(),
+  bindSignedInUser: vi.fn(),
   capture: vi.fn(),
   emit: vi.fn(),
   injectSession: vi.fn(() => Promise.resolve(true)),
@@ -35,12 +36,15 @@ vi.mock('./inject', () => ({
 }))
 vi.mock('./restoreParentWindow', () => ({ restoreParentWindow: h.restoreParentWindow }))
 vi.mock('./server', () => ({ startBridgeServer: h.startBridgeServer }))
+vi.mock('./flowShared', async (importOriginal) => ({
+  ...(await importOriginal<typeof FlowSharedModule>()),
+  bindSignedInUser: h.bindSignedInUser
+}))
 vi.mock('../desktopLoginCode', () => ({
   signInViaDesktopLoginCode: h.signInViaDesktopLoginCode
 }))
 vi.mock('../../lib/i18n', () => ({ t: (key: string) => key }))
 vi.mock('../../lib/telemetry', () => ({
-  bindUserId: h.bindUserId,
   bucketError: () => 'other',
   capture: h.capture,
   emit: h.emit
@@ -113,7 +117,7 @@ describe('handleFirebasePopup legacy flow', () => {
     await flow
 
     expect(h.injectSession).not.toHaveBeenCalled()
-    expect(h.bindUserId).not.toHaveBeenCalled()
+    expect(h.bindSignedInUser).not.toHaveBeenCalled()
     expect(h.restoreParentWindow).not.toHaveBeenCalled()
   })
 
@@ -130,7 +134,7 @@ describe('handleFirebasePopup legacy flow', () => {
     await flow
 
     expect(h.injectSession).not.toHaveBeenCalled()
-    expect(h.bindUserId).not.toHaveBeenCalled()
+    expect(h.bindSignedInUser).not.toHaveBeenCalled()
     expect(h.restoreParentWindow).not.toHaveBeenCalled()
   })
 
@@ -145,7 +149,7 @@ describe('handleFirebasePopup legacy flow', () => {
 
     const staleFlow = handleFirebasePopup(AUTH_URL, contents)
     await vi.advanceTimersByTimeAsync(0)
-    expect(h.bindUserId).not.toHaveBeenCalled()
+    expect(h.bindSignedInUser).not.toHaveBeenCalled()
     expect(h.capture).toHaveBeenCalledWith('comfy.desktop.auth.sign_in_started', {
       provider: 'google.com',
       flow: 'loopback_bridge'
@@ -158,7 +162,7 @@ describe('handleFirebasePopup legacy flow', () => {
     await staleFlow
 
     expect(h.injectSession).not.toHaveBeenCalled()
-    expect(h.bindUserId).not.toHaveBeenCalled()
+    expect(h.bindSignedInUser).not.toHaveBeenCalled()
     expect(h.restoreParentWindow).not.toHaveBeenCalled()
     expect(contents.off).toHaveBeenCalledTimes(1)
     runBannerCleanup()
@@ -244,5 +248,43 @@ describe('handleFirebasePopup legacy flow', () => {
 
     await expect(flow).resolves.toBeUndefined()
     expect(h.emit).not.toHaveBeenCalled()
+  })
+
+  it('binds the verified user only after the legacy session injection succeeds', async () => {
+    const contents = fakeContents()
+    const user = { uid: 'user-1', email: 'user@example.com' }
+    h.startBridgeServer.mockResolvedValue({
+      url: 'http://localhost:9876/',
+      signInPromise: Promise.resolve({ user, apiKey: 'api-key' }),
+      close: vi.fn()
+    })
+
+    const flow = handleFirebasePopup(AUTH_URL, contents)
+    await vi.runAllTimersAsync()
+    await flow
+
+    expect(h.bindSignedInUser).toHaveBeenCalledWith(user, contents)
+    expect(h.bindSignedInUser.mock.invocationCallOrder[0]).toBeGreaterThan(
+      h.injectSession.mock.invocationCallOrder[0]!
+    )
+    expect(h.restoreParentWindow).toHaveBeenCalledOnce()
+  })
+
+  it('does not bind when legacy session injection fails', async () => {
+    const contents = fakeContents()
+    h.injectSession.mockResolvedValueOnce(false)
+    h.startBridgeServer.mockResolvedValue({
+      url: 'http://localhost:9876/',
+      signInPromise: Promise.resolve({ user: { uid: 'user-1' }, apiKey: 'api-key' }),
+      close: vi.fn()
+    })
+
+    const flow = handleFirebasePopup(AUTH_URL, contents)
+    await vi.runAllTimersAsync()
+    await flow
+
+    expect(h.injectSession).toHaveBeenCalledOnce()
+    expect(h.bindSignedInUser).not.toHaveBeenCalled()
+    expect(h.restoreParentWindow).not.toHaveBeenCalled()
   })
 })

--- a/src/main/auth/firebaseBridge/index.ts
+++ b/src/main/auth/firebaseBridge/index.ts
@@ -150,8 +150,8 @@ export async function handleFirebasePopup(
     if (!injected) return
     if (signal.aborted || !isActiveBridgeFlow(flow)) return
     // Do not report success until the session is installed in the initiating
-    // view. Hosted Cloud views bind through declarative auth consensus;
-    // local/legacy views use the main-verified fallback.
+    // view. The bind holds this user as pending through the post-injection
+    // reload; the consensus layer identifies once a document re-reports it.
     bindSignedInUser(user, comfyContents)
     // Pull the user back into the app after the browser completes sign-in.
     restoreParentWindow(opts.parentWindow)

--- a/src/main/lib/firebaseAuthIdentity.test.ts
+++ b/src/main/lib/firebaseAuthIdentity.test.ts
@@ -9,9 +9,9 @@ const telemetry = vi.hoisted(() => ({
   bindUserId: vi.fn(),
   capture: vi.fn(),
   isFirebaseConsensusPending: vi.fn(() => true),
-  registerIdentityShutdownDrain: vi.fn(),
   registerPersonProperties: vi.fn(),
   releaseFirebasePendingConsensus: vi.fn(),
+  stageLoginAttribution: vi.fn(),
   discardUnmergeableAnonymousEpoch: vi.fn(() => true),
   hasUnmergeableAnonymousEpoch: vi.fn(() => false),
   markAnonymousEpochUnmergeable: vi.fn(() => true)
@@ -236,7 +236,7 @@ describe('firebaseAuthIdentity consensus', () => {
     reporter.navigate(cloudUrl)
     reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
 
-    expect(telemetry.bindUserId).toHaveBeenCalledWith('F', { signed_in_via: 'desktop_2' }, null)
+    expect(telemetry.bindUserId).toHaveBeenCalledWith('F', { signed_in_via: 'desktop_2' })
   })
 
   it('holds a Cloud bind through the reload and identifies once a document re-reports the user', () => {
@@ -249,7 +249,11 @@ describe('firebaseAuthIdentity consensus', () => {
       via: 'desktop_login_code'
     })
 
-    // The stale pre-login report is superseded, not trusted: no identify yet.
+    // The attribution is staged with telemetry at bind time; the stale
+    // pre-login report is superseded, not trusted: no identify yet.
+    expect(telemetry.stageLoginAttribution).toHaveBeenCalledWith('F', {
+      via: 'desktop_login_code'
+    })
     expect(telemetry.bindUserId).not.toHaveBeenCalled()
 
     reporter.navigate('https://cloud.comfy.org/workspaces/final')
@@ -258,11 +262,7 @@ describe('firebaseAuthIdentity consensus', () => {
     reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
 
     expect(telemetry.bindUserId).toHaveBeenCalledTimes(1)
-    expect(telemetry.bindUserId).toHaveBeenCalledWith(
-      'F',
-      { signed_in_via: 'desktop_2' },
-      { via: 'desktop_login_code' }
-    )
+    expect(telemetry.bindUserId).toHaveBeenCalledWith('F', { signed_in_via: 'desktop_2' })
     expect(telemetry.applyFirebaseAnonymousConsensus).not.toHaveBeenCalled()
   })
 
@@ -339,7 +339,7 @@ describe('firebaseAuthIdentity consensus', () => {
     reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
 
     expect(telemetry.bindUserId).toHaveBeenCalledTimes(1)
-    expect(telemetry.bindUserId).toHaveBeenCalledWith('F', { signed_in_via: 'desktop_2' }, null)
+    expect(telemetry.bindUserId).toHaveBeenCalledWith('F', { signed_in_via: 'desktop_2' })
     expect(telemetry.applyFirebaseAnonymousConsensus).not.toHaveBeenCalled()
   })
 
@@ -364,11 +364,10 @@ describe('firebaseAuthIdentity consensus', () => {
     reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
 
     expect(telemetry.bindUserId).toHaveBeenCalledTimes(1)
-    expect(telemetry.bindUserId).toHaveBeenCalledWith(
-      'F',
-      { signed_in_via: 'desktop_2' },
-      { via: 'desktop_login_code' }
-    )
+    expect(telemetry.bindUserId).toHaveBeenCalledWith('F', { signed_in_via: 'desktop_2' })
+    expect(telemetry.stageLoginAttribution).toHaveBeenCalledWith('F', {
+      via: 'desktop_login_code'
+    })
   })
 
   it('ignores identity side effects from a mismatched report on an unaccepted frame', () => {
@@ -428,7 +427,7 @@ describe('firebaseAuthIdentity consensus', () => {
     reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
 
     expect(telemetry.bindUserId).toHaveBeenCalledTimes(1)
-    expect(telemetry.bindUserId).toHaveBeenCalledWith('F', { signed_in_via: 'desktop_2' }, null)
+    expect(telemetry.bindUserId).toHaveBeenCalledWith('F', { signed_in_via: 'desktop_2' })
   })
 
   describe('pending consensus deadline', () => {
@@ -556,7 +555,7 @@ describe('firebaseAuthIdentity consensus', () => {
 
     reporter.navigate(localUrl)
     reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
-    expect(telemetry.bindUserId).toHaveBeenCalledWith('F', { signed_in_via: 'desktop_2' }, null)
+    expect(telemetry.bindUserId).toHaveBeenCalledWith('F', { signed_in_via: 'desktop_2' })
 
     vi.clearAllMocks()
     reporter.navigate(localUrl)
@@ -617,7 +616,7 @@ describe('firebaseAuthIdentity consensus', () => {
     const reporter = new FakeWebContents(remoteUrl)
     activate(reporter)
     bindMainVerifiedFirebaseUser('F', {}, reporter.asWebContents())
-    expect(telemetry.bindUserId).toHaveBeenCalledWith('F', {}, null)
+    expect(telemetry.bindUserId).toHaveBeenCalledWith('F', {})
     vi.clearAllMocks()
 
     reportFirebaseAuthState(reporter.asWebContents(), {

--- a/src/main/lib/firebaseAuthIdentity.test.ts
+++ b/src/main/lib/firebaseAuthIdentity.test.ts
@@ -1,12 +1,15 @@
 import { EventEmitter } from 'node:events'
 import type { WebContents } from 'electron'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const telemetry = vi.hoisted(() => ({
   applyFirebaseAnonymousConsensus: vi.fn(),
+  applyFirebasePendingConsensus: vi.fn(),
   applyFirebaseUserConsensus: vi.fn(),
   bindUserId: vi.fn(),
+  capture: vi.fn(),
   registerPersonProperties: vi.fn(),
+  releaseFirebasePendingConsensus: vi.fn(),
   discardUnmergeableAnonymousEpoch: vi.fn(() => true),
   hasUnmergeableAnonymousEpoch: vi.fn(() => false),
   markAnonymousEpochUnmergeable: vi.fn(() => true)
@@ -42,6 +45,7 @@ import {
   activateFirebaseAuthReporter,
   bindMainVerifiedFirebaseUser,
   deactivateFirebaseAuthReporter,
+  PENDING_CONSENSUS_DEADLINE_MS,
   reportFirebaseAuthState as recordFirebaseAuthState,
   trackFirebaseAuthReporter
 } from './firebaseAuthIdentity'
@@ -229,8 +233,241 @@ describe('firebaseAuthIdentity consensus', () => {
     reporter.navigate(cloudUrl)
     reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
 
-    expect(telemetry.bindUserId).toHaveBeenCalledWith('F', {
-      signed_in_via: 'desktop_2'
+    expect(telemetry.bindUserId).toHaveBeenCalledWith('F', { signed_in_via: 'desktop_2' }, null)
+  })
+
+  it('holds a Cloud bind through the reload and identifies once a document re-reports the user', () => {
+    const reporter = new FakeWebContents(cloudUrl)
+    activate(reporter)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_out' })
+    vi.clearAllMocks()
+
+    bindMainVerifiedFirebaseUser('F', { signed_in_via: 'desktop_2' }, reporter.asWebContents(), {
+      via: 'desktop_login_code'
+    })
+
+    // The stale pre-login report is superseded, not trusted: no identify yet.
+    expect(telemetry.bindUserId).not.toHaveBeenCalled()
+
+    reporter.navigate('https://cloud.comfy.org/workspaces/final')
+    expect(telemetry.applyFirebaseAnonymousConsensus).not.toHaveBeenCalled()
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'pending' })
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+
+    expect(telemetry.bindUserId).toHaveBeenCalledTimes(1)
+    expect(telemetry.bindUserId).toHaveBeenCalledWith(
+      'F',
+      { signed_in_via: 'desktop_2' },
+      { via: 'desktop_login_code' }
+    )
+    expect(telemetry.applyFirebaseAnonymousConsensus).not.toHaveBeenCalled()
+  })
+
+  it('confirms a Cloud bind from the current document when cross-tab sync reports first', () => {
+    const reporter = new FakeWebContents(cloudUrl)
+    activate(reporter)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_out' })
+    vi.clearAllMocks()
+
+    bindMainVerifiedFirebaseUser('F', { signed_in_via: 'desktop_2' }, reporter.asWebContents())
+    // The injected session reaches the pre-reload document via Firebase's
+    // cross-tab sync; its report affirms the UID Desktop itself verified.
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+    expect(telemetry.bindUserId).toHaveBeenCalledTimes(1)
+
+    // The reload still happens; the final document produces no second identify.
+    reporter.navigate('https://cloud.comfy.org/workspaces/final')
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+    expect(telemetry.bindUserId).toHaveBeenCalledTimes(1)
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('F')
+    expect(telemetry.applyFirebaseAnonymousConsensus).not.toHaveBeenCalled()
+  })
+
+  it('switches cleanly when the reloaded document reports a different user', () => {
+    const reporter = new FakeWebContents(cloudUrl)
+    activate(reporter)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_out' })
+
+    bindMainVerifiedFirebaseUser('F', { email: 'f@example.com' }, reporter.asWebContents())
+    reporter.navigate('https://cloud.comfy.org/workspaces/final')
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'pending' })
+    vi.clearAllMocks()
+
+    reportFirebaseAuthState(reporter.asWebContents(), {
+      status: 'signed_in',
+      userId: 'other'
+    })
+
+    // A fresher session in the document outranks Desktop's verification; a
+    // single resolved reporter is not a conflict, so the epoch stays clean.
+    expect(telemetry.bindUserId).not.toHaveBeenCalled()
+    expect(telemetry.markAnonymousEpochUnmergeable).not.toHaveBeenCalled()
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('other')
+  })
+
+  it('returns to anonymous consensus when the final document confirms sign-out', () => {
+    const reporter = new FakeWebContents(cloudUrl)
+    activate(reporter)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_out' })
+
+    bindMainVerifiedFirebaseUser('F', {}, reporter.asWebContents())
+    vi.clearAllMocks()
+    reporter.navigate('https://cloud.comfy.org/workspaces/final')
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_out' })
+
+    expect(telemetry.applyFirebaseAnonymousConsensus).toHaveBeenCalledTimes(1)
+    expect(telemetry.bindUserId).not.toHaveBeenCalled()
+  })
+
+  it('recovers when the post-injection reload fails and the surviving document re-reports', () => {
+    const reporter = new FakeWebContents(cloudUrl)
+    activate(reporter)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_out' })
+    vi.clearAllMocks()
+
+    bindMainVerifiedFirebaseUser('F', { signed_in_via: 'desktop_2' }, reporter.asWebContents())
+    const reloadUrl = 'https://cloud.comfy.org/workspaces/final'
+    reporter.startNavigation(reloadUrl)
+    reporter.failProvisionalNavigation(reloadUrl)
+    expect(telemetry.bindUserId).not.toHaveBeenCalled()
+
+    // The injected session is already in IndexedDB, so the surviving
+    // pre-reload document observes it and reports the new UID.
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+
+    expect(telemetry.bindUserId).toHaveBeenCalledTimes(1)
+    expect(telemetry.bindUserId).toHaveBeenCalledWith('F', { signed_in_via: 'desktop_2' }, null)
+    expect(telemetry.applyFirebaseAnonymousConsensus).not.toHaveBeenCalled()
+  })
+
+  it('ignores identity side effects from a mismatched report on an unaccepted frame', () => {
+    const localUrl = 'http://127.0.0.1:8188/'
+    verifiedLocalUsers.set('http://127.0.0.1:8188', 'A')
+    const reporter = new FakeWebContents(localUrl)
+    activate(reporter)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'A' })
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('A')
+    vi.clearAllMocks()
+
+    reporter.startNavigation(localUrl)
+    // Late IPC from a replaced document: the frame matches no accepted slot.
+    recordFirebaseAuthState(
+      reporter.asWebContents(),
+      { processId: 999, routingId: 999 },
+      { status: 'signed_in', userId: 'B' }
+    )
+    expect(telemetry.applyFirebaseAnonymousConsensus).not.toHaveBeenCalled()
+
+    reporter.commitNavigation(localUrl)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'A' })
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('A')
+    expect(telemetry.applyFirebaseAnonymousConsensus).not.toHaveBeenCalled()
+  })
+
+  it('detaches the bound user only when a mismatched local report is accepted', () => {
+    const localUrl = 'http://127.0.0.1:8188/'
+    verifiedLocalUsers.set('http://127.0.0.1:8188', 'A')
+    const reporter = new FakeWebContents(localUrl)
+    activate(reporter)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'A' })
+    vi.clearAllMocks()
+
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'B' })
+
+    expect(telemetry.applyFirebaseAnonymousConsensus).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores a conflicting report on an unaccepted frame and keeps the pending Cloud bind', () => {
+    const reporter = new FakeWebContents(cloudUrl)
+    activate(reporter)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_out' })
+    bindMainVerifiedFirebaseUser('F', { signed_in_via: 'desktop_2' }, reporter.asWebContents())
+    vi.clearAllMocks()
+
+    recordFirebaseAuthState(
+      reporter.asWebContents(),
+      { processId: 999, routingId: 999 },
+      { status: 'signed_in', userId: 'other' }
+    )
+    expect(telemetry.applyFirebaseAnonymousConsensus).not.toHaveBeenCalled()
+    expect(telemetry.markAnonymousEpochUnmergeable).not.toHaveBeenCalled()
+
+    reporter.navigate('https://cloud.comfy.org/workspaces/final')
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'pending' })
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+
+    expect(telemetry.bindUserId).toHaveBeenCalledTimes(1)
+    expect(telemetry.bindUserId).toHaveBeenCalledWith('F', { signed_in_via: 'desktop_2' }, null)
+  })
+
+  describe('pending consensus deadline', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('releases the quarantine without detaching when a bound pending window never resolves', () => {
+      const reporter = new FakeWebContents(cloudUrl)
+      activate(reporter)
+      reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+      vi.clearAllMocks()
+
+      reporter.startNavigation(cloudUrl)
+      expect(telemetry.applyFirebasePendingConsensus).toHaveBeenCalled()
+
+      vi.advanceTimersByTime(PENDING_CONSENSUS_DEADLINE_MS - 1)
+      expect(telemetry.releaseFirebasePendingConsensus).not.toHaveBeenCalled()
+
+      vi.advanceTimersByTime(1)
+      // An unresolved reporter is no evidence of sign-out: the identity stays
+      // bound and only the write quarantine ends.
+      expect(telemetry.releaseFirebasePendingConsensus).toHaveBeenCalledTimes(1)
+      expect(telemetry.applyFirebaseAnonymousConsensus).not.toHaveBeenCalled()
+      expect(telemetry.capture).toHaveBeenCalledWith(
+        'comfy.desktop.identity.pending_consensus_expired'
+      )
+    })
+
+    it('does not re-quarantine an expired pending episode until consensus resolves', () => {
+      const reporter = new FakeWebContents(cloudUrl)
+      activate(reporter)
+      reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+      vi.clearAllMocks()
+
+      reporter.startNavigation(cloudUrl)
+      vi.advanceTimersByTime(PENDING_CONSENSUS_DEADLINE_MS)
+      expect(telemetry.releaseFirebasePendingConsensus).toHaveBeenCalledTimes(1)
+      vi.clearAllMocks()
+
+      // Still the same wedged episode: commit re-runs reconcile while pending.
+      reporter.commitNavigation(cloudUrl)
+      expect(telemetry.applyFirebasePendingConsensus).not.toHaveBeenCalled()
+
+      reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+      expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('F')
+
+      // A fresh navigation after resolution quarantines (and arms) again.
+      vi.clearAllMocks()
+      reporter.startNavigation(cloudUrl)
+      expect(telemetry.applyFirebasePendingConsensus).toHaveBeenCalled()
+    })
+
+    it('does not fire the deadline once consensus resolves in time', () => {
+      const reporter = new FakeWebContents(cloudUrl)
+      activate(reporter)
+      reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+      vi.clearAllMocks()
+
+      reporter.startNavigation(cloudUrl)
+      reporter.commitNavigation(cloudUrl)
+      reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+
+      vi.advanceTimersByTime(PENDING_CONSENSUS_DEADLINE_MS * 2)
+      expect(telemetry.releaseFirebasePendingConsensus).not.toHaveBeenCalled()
+      expect(telemetry.applyFirebaseAnonymousConsensus).not.toHaveBeenCalled()
     })
   })
 
@@ -245,15 +482,14 @@ describe('firebaseAuthIdentity consensus', () => {
 
     reporter.navigate(localUrl)
     reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
-    expect(telemetry.bindUserId).toHaveBeenCalledWith('F', {
-      signed_in_via: 'desktop_2'
-    })
+    expect(telemetry.bindUserId).toHaveBeenCalledWith('F', { signed_in_via: 'desktop_2' }, null)
 
     vi.clearAllMocks()
     reporter.navigate(localUrl)
     reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
 
-    expect(telemetry.applyFirebaseAnonymousConsensus).toHaveBeenCalledTimes(1)
+    expect(telemetry.applyFirebasePendingConsensus).toHaveBeenCalled()
+    expect(telemetry.applyFirebaseAnonymousConsensus).not.toHaveBeenCalled()
     expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('F')
     expect(telemetry.markAnonymousEpochUnmergeable).not.toHaveBeenCalled()
   })
@@ -307,7 +543,7 @@ describe('firebaseAuthIdentity consensus', () => {
     const reporter = new FakeWebContents(remoteUrl)
     activate(reporter)
     bindMainVerifiedFirebaseUser('F', {}, reporter.asWebContents())
-    expect(telemetry.bindUserId).toHaveBeenCalledWith('F', {})
+    expect(telemetry.bindUserId).toHaveBeenCalledWith('F', {}, null)
     vi.clearAllMocks()
 
     reportFirebaseAuthState(reporter.asWebContents(), {
@@ -345,7 +581,8 @@ describe('firebaseAuthIdentity consensus', () => {
     vi.clearAllMocks()
 
     reporter.startNavigation(remoteUrl)
-    expect(telemetry.applyFirebaseAnonymousConsensus).toHaveBeenCalledTimes(1)
+    expect(telemetry.applyFirebasePendingConsensus).toHaveBeenCalled()
+    expect(telemetry.applyFirebaseAnonymousConsensus).not.toHaveBeenCalled()
     reporter.commitNavigation(remoteUrl)
     expect(telemetry.applyFirebaseUserConsensus).not.toHaveBeenCalled()
 
@@ -427,7 +664,7 @@ describe('firebaseAuthIdentity consensus', () => {
     expect(telemetry.markAnonymousEpochUnmergeable).toHaveBeenCalled()
   })
 
-  it('unbinds while any live reporter is pending without tainting the epoch', () => {
+  it('keeps the current identity while any live reporter is pending', () => {
     const first = new FakeWebContents(cloudUrl)
     const second = new FakeWebContents(cloudUrl)
     activate(first)
@@ -437,7 +674,8 @@ describe('firebaseAuthIdentity consensus', () => {
     vi.clearAllMocks()
 
     second.navigate('https://cloud.comfy.org/workspaces/other')
-    expect(telemetry.applyFirebaseAnonymousConsensus).toHaveBeenCalledTimes(1)
+    expect(telemetry.applyFirebasePendingConsensus).toHaveBeenCalled()
+    expect(telemetry.applyFirebaseAnonymousConsensus).not.toHaveBeenCalled()
 
     reportFirebaseAuthState(second.asWebContents(), { status: 'signed_in', userId: 'F' })
     expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('F')
@@ -451,7 +689,7 @@ describe('firebaseAuthIdentity consensus', () => {
     vi.clearAllMocks()
 
     reporter.startNavigation(cloudUrl)
-    expect(telemetry.applyFirebaseAnonymousConsensus).toHaveBeenCalledTimes(1)
+    expect(telemetry.applyFirebasePendingConsensus).toHaveBeenCalledTimes(1)
 
     reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F1' })
     reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F2' })
@@ -473,7 +711,7 @@ describe('firebaseAuthIdentity consensus', () => {
     vi.clearAllMocks()
 
     first.startNavigation('https://attacker.example/')
-    expect(telemetry.applyFirebaseAnonymousConsensus).toHaveBeenCalledTimes(1)
+    expect(telemetry.applyFirebasePendingConsensus).toHaveBeenCalledTimes(1)
     vi.clearAllMocks()
 
     reportFirebaseAuthState(second.asWebContents(), { status: 'signed_in', userId: 'F2' })

--- a/src/main/lib/firebaseAuthIdentity.test.ts
+++ b/src/main/lib/firebaseAuthIdentity.test.ts
@@ -8,6 +8,8 @@ const telemetry = vi.hoisted(() => ({
   applyFirebaseUserConsensus: vi.fn(),
   bindUserId: vi.fn(),
   capture: vi.fn(),
+  isFirebaseConsensusPending: vi.fn(() => true),
+  registerIdentityShutdownDrain: vi.fn(),
   registerPersonProperties: vi.fn(),
   releaseFirebasePendingConsensus: vi.fn(),
   discardUnmergeableAnonymousEpoch: vi.fn(() => true),
@@ -192,6 +194,7 @@ describe('firebaseAuthIdentity consensus', () => {
     vi.clearAllMocks()
     telemetry.discardUnmergeableAnonymousEpoch.mockReturnValue(true)
     telemetry.hasUnmergeableAnonymousEpoch.mockReturnValue(false)
+    telemetry.isFirebaseConsensusPending.mockReturnValue(true)
     telemetry.markAnonymousEpochUnmergeable.mockReturnValue(true)
     verifiedLocalUsers.clear()
     verifiedLocalPersistence.succeeds = true
@@ -340,6 +343,34 @@ describe('firebaseAuthIdentity consensus', () => {
     expect(telemetry.applyFirebaseAnonymousConsensus).not.toHaveBeenCalled()
   })
 
+  it('holds the bind when the reload outraces it and then fails provisionally', () => {
+    const reporter = new FakeWebContents(cloudUrl)
+    activate(reporter)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_out' })
+    vi.clearAllMocks()
+
+    // The injected script reloads the document before executeJavaScript
+    // resolves, so the navigation can start before the bind runs and snapshot
+    // the stale pre-login signed_out report as the recoverable state.
+    const reloadUrl = 'https://cloud.comfy.org/workspaces/final'
+    reporter.startNavigation(reloadUrl)
+    bindMainVerifiedFirebaseUser('F', { signed_in_via: 'desktop_2' }, reporter.asWebContents(), {
+      via: 'desktop_login_code'
+    })
+    reporter.failProvisionalNavigation(reloadUrl)
+
+    expect(telemetry.applyFirebaseAnonymousConsensus).not.toHaveBeenCalled()
+
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+
+    expect(telemetry.bindUserId).toHaveBeenCalledTimes(1)
+    expect(telemetry.bindUserId).toHaveBeenCalledWith(
+      'F',
+      { signed_in_via: 'desktop_2' },
+      { via: 'desktop_login_code' }
+    )
+  })
+
   it('ignores identity side effects from a mismatched report on an unaccepted frame', () => {
     const localUrl = 'http://127.0.0.1:8188/'
     verifiedLocalUsers.set('http://127.0.0.1:8188', 'A')
@@ -453,6 +484,49 @@ describe('firebaseAuthIdentity consensus', () => {
       vi.clearAllMocks()
       reporter.startNavigation(cloudUrl)
       expect(telemetry.applyFirebasePendingConsensus).toHaveBeenCalled()
+    })
+
+    it('lets healthy reporters resolve consensus once a wedged reporter expires', () => {
+      const wedged = new FakeWebContents(cloudUrl)
+      const healthy = new FakeWebContents(cloudUrl)
+      activate(wedged)
+      activate(healthy)
+      reportFirebaseAuthState(wedged.asWebContents(), { status: 'signed_in', userId: 'F' })
+      reportFirebaseAuthState(healthy.asWebContents(), { status: 'signed_in', userId: 'F' })
+      vi.clearAllMocks()
+
+      wedged.startNavigation(cloudUrl)
+      vi.advanceTimersByTime(PENDING_CONSENSUS_DEADLINE_MS)
+      vi.clearAllMocks()
+
+      // The wedge no longer vetoes: a real logout and account switch in the
+      // healthy window detach and rebind instead of staying attributed to F.
+      reportFirebaseAuthState(healthy.asWebContents(), { status: 'signed_out' })
+      expect(telemetry.applyFirebaseAnonymousConsensus).toHaveBeenCalledTimes(1)
+
+      reportFirebaseAuthState(healthy.asWebContents(), { status: 'signed_in', userId: 'B' })
+      expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('B')
+    })
+
+    it('applies a sign-out masked by a wedged reporter at the deadline instead of releasing', () => {
+      const wedged = new FakeWebContents(cloudUrl)
+      const healthy = new FakeWebContents(cloudUrl)
+      activate(wedged)
+      activate(healthy)
+      reportFirebaseAuthState(wedged.asWebContents(), { status: 'signed_in', userId: 'F' })
+      reportFirebaseAuthState(healthy.asWebContents(), { status: 'signed_in', userId: 'F' })
+      vi.clearAllMocks()
+
+      wedged.startNavigation(cloudUrl)
+      reportFirebaseAuthState(healthy.asWebContents(), { status: 'signed_out' })
+      expect(telemetry.applyFirebaseAnonymousConsensus).not.toHaveBeenCalled()
+
+      // Resolving detaches and discards held writes; releasing would replay
+      // them under the user who already logged out.
+      telemetry.isFirebaseConsensusPending.mockReturnValue(false)
+      vi.advanceTimersByTime(PENDING_CONSENSUS_DEADLINE_MS)
+      expect(telemetry.applyFirebaseAnonymousConsensus).toHaveBeenCalledTimes(1)
+      expect(telemetry.releaseFirebasePendingConsensus).not.toHaveBeenCalled()
     })
 
     it('does not fire the deadline once consensus resolves in time', () => {

--- a/src/main/lib/firebaseAuthIdentity.ts
+++ b/src/main/lib/firebaseAuthIdentity.ts
@@ -1,7 +1,7 @@
 import type { WebContents } from 'electron'
 import type { ComfyDesktop2FirebaseAuthState } from '../../types/comfyDesktopBridge'
 import * as mainTelemetry from './telemetry'
-import { isIllegalPostHogDistinctId, normalizeOpaqueIdentifier } from './opaqueIdentifier'
+import { normalizePostHogUserId } from './opaqueIdentifier'
 import { isTrustedCloudUrl } from './trustedCloudUrl'
 import {
   clearVerifiedLocalFirebaseUser,
@@ -73,6 +73,8 @@ interface MainVerifiedAuthState {
   propertiesApplied: boolean
   reportedState?: ComfyDesktop2FirebaseAuthState
   rendererMayReaffirm: boolean
+  /** One-shot login-attribution event payload delivered with the bind. */
+  attribution: mainTelemetry.TelemetryContext | null
 }
 
 const reporters = new Map<WebContents, Reporter>()
@@ -81,6 +83,11 @@ let requestedUserId: string | null = null
 let anonymousEpochIsUnmergeable = false
 let persistedEpochStateLoaded = false
 let epochTaintIsDurable = true
+/** A document that never resolves auth must not quarantine telemetry forever. */
+export const PENDING_CONSENSUS_DEADLINE_MS = 60_000
+let pendingConsensusDeadline: ReturnType<typeof setTimeout> | null = null
+/** True after the deadline released a still-unresolved pending episode. */
+let pendingConsensusExpired = false
 
 function originOf(url: string): string | null {
   try {
@@ -140,10 +147,58 @@ function failureTerminalKey(
   return `${errorCode}\u0000${validatedURL}\u0000${frameProcessId}\u0000${frameRoutingId}`
 }
 
-function requestAnonymousIdentity(): void {
-  if (requestedUserId === null) return
+function clearPendingConsensusDeadline(): void {
+  pendingConsensusExpired = false
+  if (pendingConsensusDeadline === null) return
+  clearTimeout(pendingConsensusDeadline)
+  pendingConsensusDeadline = null
+}
+
+function requestAnonymousIdentity(force = false): void {
+  if (requestedUserId === null && !force) return
+  clearPendingConsensusDeadline()
   requestedUserId = null
   mainTelemetry.applyFirebaseAnonymousConsensus()
+}
+
+function requestPendingIdentity(): void {
+  // Before the first agreed UID there is no authenticated identity to
+  // quarantine; anonymous events should keep flowing into the eventual merge.
+  if (requestedUserId === null) return
+  // Once the deadline released a stuck episode, do not re-quarantine until
+  // some report resolves consensus — the reporter is still the same wedge.
+  if (pendingConsensusExpired) return
+  mainTelemetry.applyFirebasePendingConsensus()
+  if (pendingConsensusDeadline === null) {
+    pendingConsensusDeadline = setTimeout(() => {
+      pendingConsensusDeadline = null
+      pendingConsensusExpired = true
+      // An unresolved reporter is no evidence of sign-out: release the
+      // quarantine and keep the bound identity. A real logout arrives as an
+      // actual signed_out report and detaches through reconcile as usual.
+      mainTelemetry.releaseFirebasePendingConsensus()
+      mainTelemetry.capture('comfy.desktop.identity.pending_consensus_expired')
+    }, PENDING_CONSENSUS_DEADLINE_MS)
+    pendingConsensusDeadline.unref()
+  }
+}
+
+function requestConflictedIdentity(): void {
+  clearPendingConsensusDeadline()
+  const wasAlreadyTainted = anonymousEpochIsUnmergeable
+  requestedUserId = null
+  mainTelemetry.applyFirebaseAnonymousConsensus()
+  anonymousEpochIsUnmergeable = true
+  if (!wasAlreadyTainted || !epochTaintIsDurable) {
+    epochTaintIsDurable = mainTelemetry.markAnonymousEpochUnmergeable()
+    if (!epochTaintIsDurable && !wasAlreadyTainted) {
+      // The taint marker could not persist, so a restart would resurrect
+      // the conflicted anonymous ID untainted. Durably replace the epoch
+      // instead; attempted once per conflict episode to avoid rotation
+      // churn while the views still disagree.
+      epochTaintIsDurable = mainTelemetry.discardUnmergeableAnonymousEpoch()
+    }
+  }
 }
 
 function clearUnmergeableEpoch(): boolean {
@@ -168,14 +223,22 @@ function loadPersistedEpochState(): void {
 /**
  * Bind a user verified by Desktop's auth flow while keeping the declarative
  * renderer consensus authoritative once hosted views begin reporting.
+ *
+ * Called after the session was installed in the view. The injected session
+ * always reloads hosted Cloud views, so the view's current report predates
+ * this sign-in: the bind marks it stale (pending) and the identify fires,
+ * with `properties` and the one-shot `attribution` payload, once a document
+ * re-reports this user — the same contract the loopback branch has always
+ * used. A view already affirming this exact UID confirms immediately.
  */
 export function bindMainVerifiedFirebaseUser(
   userId: string,
   properties: Record<string, mainTelemetry.TelemetryValue> = {},
-  source: WebContents
+  source: WebContents,
+  attribution: mainTelemetry.TelemetryContext | null = null
 ): void {
-  const normalizedUserId = normalizeOpaqueIdentifier(userId, 256)
-  if (!normalizedUserId || isIllegalPostHogDistinctId(normalizedUserId)) return
+  const normalizedUserId = normalizePostHogUserId(userId)
+  if (!normalizedUserId) return
   loadPersistedEpochState()
   const origin = originOf(source.getURL())
   if (!origin) return
@@ -190,13 +253,19 @@ export function bindMainVerifiedFirebaseUser(
     reporter.localExpectedUserId = normalizedUserId
     reporter.active = true
     reporter.state = { status: 'pending' }
+  } else if (
+    isTrustedCloudUrl(source.getURL()) &&
+    (reporter.state.status !== 'signed_in' || reporter.state.userId !== normalizedUserId)
+  ) {
+    reporter.state = { status: 'pending' }
   }
   mainVerifiedStates.set(source, {
     userId: normalizedUserId,
     origin,
     properties,
     propertiesApplied: false,
-    rendererMayReaffirm: true
+    rendererMayReaffirm: true,
+    attribution
   })
   reconcile()
 }
@@ -243,8 +312,13 @@ function reconcile(): void {
       .map(({ contributionState }) => contributionState)
   ]
 
-  if (states.length === 0 || states.some((state) => state.status === 'pending')) {
+  if (states.length === 0) {
     requestAnonymousIdentity()
+    return
+  }
+
+  if (states.some((state) => state.status === 'pending')) {
+    requestPendingIdentity()
     return
   }
 
@@ -254,7 +328,9 @@ function reconcile(): void {
   )
 
   if (signedIn.length === 0) {
-    requestAnonymousIdentity()
+    // A resolved all-signed-out state also clears any pending/deferred user
+    // binding even when this process has not bound a UID yet.
+    requestAnonymousIdentity(true)
     clearUnmergeableEpoch()
     return
   }
@@ -262,26 +338,14 @@ function reconcile(): void {
   const userIds = new Set(signedIn.map((state) => state.userId))
   const hasConflict = signedIn.length !== states.length || userIds.size !== 1
   if (hasConflict) {
-    const wasAlreadyTainted = anonymousEpochIsUnmergeable
-    requestedUserId = null
-    mainTelemetry.applyFirebaseAnonymousConsensus()
-    anonymousEpochIsUnmergeable = true
-    if (!wasAlreadyTainted || !epochTaintIsDurable) {
-      epochTaintIsDurable = mainTelemetry.markAnonymousEpochUnmergeable()
-      if (!epochTaintIsDurable && !wasAlreadyTainted) {
-        // The taint marker could not persist, so a restart would resurrect
-        // the conflicted anonymous ID untainted. Durably replace the epoch
-        // instead; attempted once per conflict episode to avoid rotation
-        // churn while the views still disagree.
-        epochTaintIsDurable = mainTelemetry.discardUnmergeableAnonymousEpoch()
-      }
-    }
+    requestConflictedIdentity()
     return
   }
 
   const userId = signedIn[0]!.userId
   if (!clearUnmergeableEpoch()) return
 
+  clearPendingConsensusDeadline()
   requestedUserId = userId
   const confirmedMainStates = mainCandidates.filter(({ webContents, state, contributes }) => {
     if (state.userId !== userId) return false
@@ -295,9 +359,13 @@ function reconcile(): void {
       {},
       ...unappliedMainStates.map(({ state }) => state.properties)
     ) as Record<string, mainTelemetry.TelemetryValue>
-    mainTelemetry.bindUserId(userId, properties)
+    const attribution =
+      unappliedMainStates.map(({ state }) => state.attribution).find((entry) => entry !== null) ??
+      null
+    mainTelemetry.bindUserId(userId, properties, attribution)
     for (const { webContents, state, contributes } of unappliedMainStates) {
       state.propertiesApplied = true
+      state.attribution = null
       if (!contributes) mainVerifiedStates.delete(webContents)
     }
   } else {
@@ -546,6 +614,7 @@ export function reportFirebaseAuthState(
     if (userMismatch || state.status === 'signed_out') {
       mainVerifiedState.rendererMayReaffirm = false
     }
+    if (userMismatch) requestAnonymousIdentity()
     reconcile()
     return
   }
@@ -554,8 +623,11 @@ export function reportFirebaseAuthState(
   const acceptedState: ComfyDesktop2FirebaseAuthState = localUserMismatch
     ? { status: 'pending' }
     : state
-  const candidate = reporter.committedCandidate
-  if (candidate && isSameFrame(candidate.frame, frame)) {
+  // Identity consequences must wait for frame attribution below: late IPC
+  // from a replaced document matches no accepted slot and must not detach
+  // the bound user or revoke local authorization.
+  const acceptReport = (): void => {
+    if (localUserMismatch) requestAnonymousIdentity()
     revokeAcceptedLocalAuthorization(
       webContents,
       reporter,
@@ -563,6 +635,10 @@ export function reportFirebaseAuthState(
       acceptedState,
       localUserMismatch
     )
+  }
+  const candidate = reporter.committedCandidate
+  if (candidate && isSameFrame(candidate.frame, frame)) {
+    acceptReport()
     candidate.state = acceptedState
     return
   }
@@ -572,13 +648,7 @@ export function reportFirebaseAuthState(
     isSameFrame(recoverable.frame, frame) &&
     isSameFrame(recoverable.frame, currentMainFrame(webContents))
   ) {
-    revokeAcceptedLocalAuthorization(
-      webContents,
-      reporter,
-      currentOrigin,
-      acceptedState,
-      localUserMismatch
-    )
+    acceptReport()
     recoverable.state = acceptedState
     return
   }
@@ -588,13 +658,7 @@ export function reportFirebaseAuthState(
     !isSameFrame(reporter.committedFrame, frame)
   )
     return
-  revokeAcceptedLocalAuthorization(
-    webContents,
-    reporter,
-    currentOrigin,
-    acceptedState,
-    localUserMismatch
-  )
+  acceptReport()
   reporter.active = true
   reporter.state = acceptedState
   reconcile()
@@ -613,6 +677,7 @@ export function _resetForTest(): void {
   }
   reporters.clear()
   mainVerifiedStates.clear()
+  clearPendingConsensusDeadline()
   requestedUserId = null
   anonymousEpochIsUnmergeable = false
   persistedEpochStateLoaded = false

--- a/src/main/lib/firebaseAuthIdentity.ts
+++ b/src/main/lib/firebaseAuthIdentity.ts
@@ -13,6 +13,9 @@ import {
 interface Reporter {
   eligible: boolean
   active: boolean
+  /** Stayed pending past the consensus deadline: excluded from consensus
+   *  (no veto, no quarantine) until it produces a resolved contribution. */
+  pendingExpired: boolean
   localReportingAuthorized: boolean
   localExpectedUserId: string | null
   awaitingCommittedFrame: boolean
@@ -86,8 +89,6 @@ let epochTaintIsDurable = true
 /** A document that never resolves auth must not quarantine telemetry forever. */
 export const PENDING_CONSENSUS_DEADLINE_MS = 60_000
 let pendingConsensusDeadline: ReturnType<typeof setTimeout> | null = null
-/** True after the deadline released a still-unresolved pending episode. */
-let pendingConsensusExpired = false
 
 function originOf(url: string): string | null {
   try {
@@ -148,10 +149,22 @@ function failureTerminalKey(
 }
 
 function clearPendingConsensusDeadline(): void {
-  pendingConsensusExpired = false
   if (pendingConsensusDeadline === null) return
   clearTimeout(pendingConsensusDeadline)
   pendingConsensusDeadline = null
+}
+
+/** Flag every contributor whose pending state has outlived the deadline. */
+function markExpiredPendingContributors(): void {
+  for (const [webContents, reporter] of reporters) {
+    if (webContents.isDestroyed()) continue
+    const navigationPending =
+      reporter.awaitingCommittedFrame || reporter.mainFrameNavigationsInFlight > 0
+    const contributesPending = reporter.active
+      ? reporter.state.status === 'pending'
+      : navigationPending && mainVerifiedStates.has(webContents)
+    if (contributesPending) reporter.pendingExpired = true
+  }
 }
 
 function requestAnonymousIdentity(force = false): void {
@@ -165,19 +178,23 @@ function requestPendingIdentity(): void {
   // Before the first agreed UID there is no authenticated identity to
   // quarantine; anonymous events should keep flowing into the eventual merge.
   if (requestedUserId === null) return
-  // Once the deadline released a stuck episode, do not re-quarantine until
-  // some report resolves consensus — the reporter is still the same wedge.
-  if (pendingConsensusExpired) return
   mainTelemetry.applyFirebasePendingConsensus()
   if (pendingConsensusDeadline === null) {
     pendingConsensusDeadline = setTimeout(() => {
       pendingConsensusDeadline = null
-      pendingConsensusExpired = true
-      // An unresolved reporter is no evidence of sign-out: release the
-      // quarantine and keep the bound identity. A real logout arrives as an
-      // actual signed_out report and detaches through reconcile as usual.
-      mainTelemetry.releaseFirebasePendingConsensus()
-      mainTelemetry.capture('comfy.desktop.identity.pending_consensus_expired')
+      // Contributors still pending after the full deadline are wedged: stop
+      // letting them veto consensus so healthy reporters can resolve it (a
+      // masked logout or account switch applies right here), and do not
+      // re-quarantine for them until they produce a real report.
+      markExpiredPendingContributors()
+      reconcile()
+      if (pendingConsensusDeadline === null && mainTelemetry.isFirebaseConsensusPending()) {
+        // Nothing left can resolve consensus: an unresolved reporter is no
+        // evidence of sign-out, so release the quarantine and keep the bound
+        // identity. A real report still resolves through reconcile as usual.
+        mainTelemetry.releaseFirebasePendingConsensus()
+        mainTelemetry.capture('comfy.desktop.identity.pending_consensus_expired')
+      }
     }, PENDING_CONSENSUS_DEADLINE_MS)
     pendingConsensusDeadline.unref()
   }
@@ -220,6 +237,29 @@ function loadPersistedEpochState(): void {
   anonymousEpochIsUnmergeable = mainTelemetry.hasUnmergeableAnonymousEpoch()
 }
 
+let shutdownAttributionDrainRegistered = false
+
+/**
+ * A quit can outrun the document re-report that would confirm a held bind;
+ * hand any still-held one-shot attributions to telemetry's shutdown so a
+ * successful sign-in is not silently uncounted. Registered on first bind
+ * (not at module load) so telemetry test doubles without the hook stay valid.
+ */
+function registerShutdownAttributionDrain(): void {
+  if (shutdownAttributionDrainRegistered) return
+  shutdownAttributionDrainRegistered = true
+  mainTelemetry.registerIdentityShutdownDrain(() => {
+    const held: mainTelemetry.TelemetryContext[] = []
+    for (const state of mainVerifiedStates.values()) {
+      if (state.attribution) {
+        held.push(state.attribution)
+        state.attribution = null
+      }
+    }
+    return held
+  })
+}
+
 /**
  * Bind a user verified by Desktop's auth flow while keeping the declarative
  * renderer consensus authoritative once hosted views begin reporting.
@@ -239,12 +279,20 @@ export function bindMainVerifiedFirebaseUser(
 ): void {
   const normalizedUserId = normalizePostHogUserId(userId)
   if (!normalizedUserId) return
+  registerShutdownAttributionDrain()
   loadPersistedEpochState()
   const origin = originOf(source.getURL())
   if (!origin) return
   trackFirebaseAuthReporter(source)
   const reporter = reporters.get(source)
   if (!reporter?.eligible) return
+  // Retained navigation snapshots predate this bind too: restoring one after
+  // a failed reload would resurrect a stale signed_out and discard the bind.
+  const staleSnapshotUnlessAffirming = (snapshot: ReporterFrameState | null): void => {
+    if (!snapshot) return
+    if (snapshot.state.status === 'signed_in' && snapshot.state.userId === normalizedUserId) return
+    snapshot.state = { status: 'pending' }
+  }
   if (isLoopbackOrigin(origin)) {
     if (!persistVerifiedLocalFirebaseUser(origin, normalizedUserId)) {
       return
@@ -253,11 +301,14 @@ export function bindMainVerifiedFirebaseUser(
     reporter.localExpectedUserId = normalizedUserId
     reporter.active = true
     reporter.state = { status: 'pending' }
-  } else if (
-    isTrustedCloudUrl(source.getURL()) &&
-    (reporter.state.status !== 'signed_in' || reporter.state.userId !== normalizedUserId)
-  ) {
-    reporter.state = { status: 'pending' }
+    staleSnapshotUnlessAffirming(reporter.recoverableState)
+    staleSnapshotUnlessAffirming(reporter.committedCandidate)
+  } else if (isTrustedCloudUrl(source.getURL())) {
+    if (reporter.state.status !== 'signed_in' || reporter.state.userId !== normalizedUserId) {
+      reporter.state = { status: 'pending' }
+    }
+    staleSnapshotUnlessAffirming(reporter.recoverableState)
+    staleSnapshotUnlessAffirming(reporter.committedCandidate)
   }
   mainVerifiedStates.set(source, {
     userId: normalizedUserId,
@@ -271,8 +322,18 @@ export function bindMainVerifiedFirebaseUser(
 }
 
 function reconcile(): void {
+  let expiredPendingContributors = 0
   const activeReporterStates = [...reporters.entries()]
     .filter(([webContents, reporter]) => !webContents.isDestroyed() && reporter.active)
+    .filter(([, reporter]) => {
+      if (reporter.state.status !== 'pending') {
+        reporter.pendingExpired = false
+        return true
+      }
+      if (!reporter.pendingExpired) return true
+      expiredPendingContributors += 1
+      return false
+    })
     .map(([webContents, reporter]) => ({ webContents, state: reporter.state }))
   const mainCandidates: Array<{
     webContents: WebContents
@@ -296,10 +357,15 @@ function reconcile(): void {
     }
     const navigationPending =
       reporter?.awaitingCommittedFrame || (reporter?.mainFrameNavigationsInFlight ?? 0) > 0
+    if (reporter && !reporter.active && reporter.pendingExpired && !navigationPending) {
+      reporter.pendingExpired = false
+    }
+    const expiredNavigation = navigationPending === true && reporter?.pendingExpired === true
+    if (expiredNavigation) expiredPendingContributors += 1
     mainCandidates.push({
       webContents,
       state,
-      contributes: !reporter?.active,
+      contributes: !reporter?.active && !expiredNavigation,
       contributionState: navigationPending
         ? { status: 'pending' }
         : (state.reportedState ?? { status: 'signed_in', userId: state.userId })
@@ -313,6 +379,9 @@ function reconcile(): void {
   ]
 
   if (states.length === 0) {
+    // Only expired wedges remain. An unresolved document is evidence of
+    // nothing: keep the current identity until a real report resolves it.
+    if (expiredPendingContributors > 0) return
     requestAnonymousIdentity()
     return
   }
@@ -433,6 +502,7 @@ export function trackFirebaseAuthReporter(webContents: WebContents): void {
   const reporter: Reporter = {
     eligible: false,
     active: false,
+    pendingExpired: false,
     localReportingAuthorized: false,
     localExpectedUserId: null,
     awaitingCommittedFrame: true,
@@ -566,6 +636,7 @@ export function activateFirebaseAuthReporter(webContents: WebContents): void {
   const reporter = reporters.get(webContents)
   if (!reporter) return
   reporter.eligible = true
+  reporter.pendingExpired = false
   reporter.awaitingCommittedFrame = true
   reporter.committedFrame = null
   reporter.recoverableState = null

--- a/src/main/lib/firebaseAuthIdentity.ts
+++ b/src/main/lib/firebaseAuthIdentity.ts
@@ -76,8 +76,6 @@ interface MainVerifiedAuthState {
   propertiesApplied: boolean
   reportedState?: ComfyDesktop2FirebaseAuthState
   rendererMayReaffirm: boolean
-  /** One-shot login-attribution event payload delivered with the bind. */
-  attribution: mainTelemetry.TelemetryContext | null
 }
 
 const reporters = new Map<WebContents, Reporter>()
@@ -167,11 +165,16 @@ function markExpiredPendingContributors(): void {
   }
 }
 
-function requestAnonymousIdentity(force = false): void {
-  if (requestedUserId === null && !force) return
+/** Unconditionally hand consensus back to the anonymous identity. */
+function detachToAnonymousIdentity(): void {
   clearPendingConsensusDeadline()
   requestedUserId = null
   mainTelemetry.applyFirebaseAnonymousConsensus()
+}
+
+function requestAnonymousIdentity(): void {
+  if (requestedUserId === null) return
+  detachToAnonymousIdentity()
 }
 
 function requestPendingIdentity(): void {
@@ -201,10 +204,8 @@ function requestPendingIdentity(): void {
 }
 
 function requestConflictedIdentity(): void {
-  clearPendingConsensusDeadline()
   const wasAlreadyTainted = anonymousEpochIsUnmergeable
-  requestedUserId = null
-  mainTelemetry.applyFirebaseAnonymousConsensus()
+  detachToAnonymousIdentity()
   anonymousEpochIsUnmergeable = true
   if (!wasAlreadyTainted || !epochTaintIsDurable) {
     epochTaintIsDurable = mainTelemetry.markAnonymousEpochUnmergeable()
@@ -237,29 +238,6 @@ function loadPersistedEpochState(): void {
   anonymousEpochIsUnmergeable = mainTelemetry.hasUnmergeableAnonymousEpoch()
 }
 
-let shutdownAttributionDrainRegistered = false
-
-/**
- * A quit can outrun the document re-report that would confirm a held bind;
- * hand any still-held one-shot attributions to telemetry's shutdown so a
- * successful sign-in is not silently uncounted. Registered on first bind
- * (not at module load) so telemetry test doubles without the hook stay valid.
- */
-function registerShutdownAttributionDrain(): void {
-  if (shutdownAttributionDrainRegistered) return
-  shutdownAttributionDrainRegistered = true
-  mainTelemetry.registerIdentityShutdownDrain(() => {
-    const held: mainTelemetry.TelemetryContext[] = []
-    for (const state of mainVerifiedStates.values()) {
-      if (state.attribution) {
-        held.push(state.attribution)
-        state.attribution = null
-      }
-    }
-    return held
-  })
-}
-
 /**
  * Bind a user verified by Desktop's auth flow while keeping the declarative
  * renderer consensus authoritative once hosted views begin reporting.
@@ -267,9 +245,11 @@ function registerShutdownAttributionDrain(): void {
  * Called after the session was installed in the view. The injected session
  * always reloads hosted Cloud views, so the view's current report predates
  * this sign-in: the bind marks it stale (pending) and the identify fires,
- * with `properties` and the one-shot `attribution` payload, once a document
- * re-reports this user — the same contract the loopback branch has always
- * used. A view already affirming this exact UID confirms immediately.
+ * with `properties`, once a document re-reports this user — the same
+ * contract the loopback branch has always used. A view already affirming
+ * this exact UID confirms immediately. The one-shot `attribution` payload is
+ * staged with telemetry, which owns its lifecycle: emitted when this UID is
+ * confirmed, discarded on any other resolution, drained at shutdown.
  */
 export function bindMainVerifiedFirebaseUser(
   userId: string,
@@ -279,7 +259,7 @@ export function bindMainVerifiedFirebaseUser(
 ): void {
   const normalizedUserId = normalizePostHogUserId(userId)
   if (!normalizedUserId) return
-  registerShutdownAttributionDrain()
+  if (attribution) mainTelemetry.stageLoginAttribution(normalizedUserId, attribution)
   loadPersistedEpochState()
   const origin = originOf(source.getURL())
   if (!origin) return
@@ -315,26 +295,24 @@ export function bindMainVerifiedFirebaseUser(
     origin,
     properties,
     propertiesApplied: false,
-    rendererMayReaffirm: true,
-    attribution
+    rendererMayReaffirm: true
   })
   reconcile()
 }
 
 function reconcile(): void {
   let expiredPendingContributors = 0
-  const activeReporterStates = [...reporters.entries()]
-    .filter(([webContents, reporter]) => !webContents.isDestroyed() && reporter.active)
-    .filter(([, reporter]) => {
-      if (reporter.state.status !== 'pending') {
-        reporter.pendingExpired = false
-        return true
-      }
-      if (!reporter.pendingExpired) return true
+  const activeReporterStates: ComfyDesktop2FirebaseAuthState[] = []
+  for (const [webContents, reporter] of reporters) {
+    if (webContents.isDestroyed() || !reporter.active) continue
+    if (reporter.state.status !== 'pending') {
+      reporter.pendingExpired = false
+    } else if (reporter.pendingExpired) {
       expiredPendingContributors += 1
-      return false
-    })
-    .map(([webContents, reporter]) => ({ webContents, state: reporter.state }))
+      continue
+    }
+    activeReporterStates.push(reporter.state)
+  }
   const mainCandidates: Array<{
     webContents: WebContents
     state: MainVerifiedAuthState
@@ -372,7 +350,7 @@ function reconcile(): void {
     })
   }
   const states: ComfyDesktop2FirebaseAuthState[] = [
-    ...activeReporterStates.map(({ state }) => state),
+    ...activeReporterStates,
     ...mainCandidates
       .filter(({ contributes }) => contributes)
       .map(({ contributionState }) => contributionState)
@@ -399,7 +377,7 @@ function reconcile(): void {
   if (signedIn.length === 0) {
     // A resolved all-signed-out state also clears any pending/deferred user
     // binding even when this process has not bound a UID yet.
-    requestAnonymousIdentity(true)
+    detachToAnonymousIdentity()
     clearUnmergeableEpoch()
     return
   }
@@ -428,13 +406,9 @@ function reconcile(): void {
       {},
       ...unappliedMainStates.map(({ state }) => state.properties)
     ) as Record<string, mainTelemetry.TelemetryValue>
-    const attribution =
-      unappliedMainStates.map(({ state }) => state.attribution).find((entry) => entry !== null) ??
-      null
-    mainTelemetry.bindUserId(userId, properties, attribution)
+    mainTelemetry.bindUserId(userId, properties)
     for (const { webContents, state, contributes } of unappliedMainStates) {
       state.propertiesApplied = true
-      state.attribution = null
       if (!contributes) mainVerifiedStates.delete(webContents)
     }
   } else {

--- a/src/main/lib/ipc/registerTelemetryHandlers.test.ts
+++ b/src/main/lib/ipc/registerTelemetryHandlers.test.ts
@@ -2,9 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   capture: vi.fn(),
-  captureException: vi.fn((_error: unknown, _properties: unknown) => true),
+  captureExceptionAndForward: vi.fn((_error: unknown, _properties: unknown) => true),
   findEntryByComfySender: vi.fn(),
-  forwardExceptionToRenderer: vi.fn(),
   getFlag: vi.fn(),
   handle: vi.fn(),
   on: vi.fn(),
@@ -29,8 +28,7 @@ vi.mock('../telemetry', () => ({
   // pull in telemetry.ts's electron/posthog-node imports under the stub mock.
   asDeployment: (v: unknown) => (v === 'local' || v === 'cloud' || v === 'remote' ? v : null),
   emit: mocks.capture,
-  captureException: mocks.captureException,
-  forwardExceptionToRenderer: mocks.forwardExceptionToRenderer,
+  captureExceptionAndForward: mocks.captureExceptionAndForward,
   registerPersonProperties: mocks.registerPersonProperties
 }))
 
@@ -320,11 +318,13 @@ describe('registerTelemetryHandlers', () => {
       { message: 'boom', properties: { client: 'web', deployment: 'cloud' } }
     )
 
-    const [err, sent] = mocks.captureException.mock.calls[0]! as [Error, Record<string, unknown>]
+    const [err, sent] = mocks.captureExceptionAndForward.mock.calls[0]! as [
+      Error,
+      Record<string, unknown>
+    ]
     expect(err.message).toBe('boom')
     expect(sent.deployment).toBe('local')
     expect(sent.client).toBeUndefined()
-    expect(mocks.forwardExceptionToRenderer).toHaveBeenCalledWith(sent)
   })
 
   it('scrubs exception properties before applying string limits', () => {
@@ -334,7 +334,10 @@ describe('registerTelemetryHandlers', () => {
       { message: 'boom', properties: { detail: secret, nested: { secret } } }
     )
 
-    const [, sent] = mocks.captureException.mock.calls[0]! as [Error, Record<string, unknown>]
+    const [, sent] = mocks.captureExceptionAndForward.mock.calls[0]! as [
+      Error,
+      Record<string, unknown>
+    ]
     expect(sent.detail).toBe('password=[REDACTED]')
     expect(sent.nested).toBeUndefined()
   })

--- a/src/main/lib/ipc/registerTelemetryHandlers.ts
+++ b/src/main/lib/ipc/registerTelemetryHandlers.ts
@@ -12,7 +12,7 @@ import {
 import { normalizeExceptionContext } from '../../../shared/piiScrub'
 import { reportFirebaseAuthState } from '../firebaseAuthIdentity'
 import type { ComfyDesktop2FirebaseAuthState } from '../../../types/comfyDesktopBridge'
-import { isIllegalPostHogDistinctId, normalizeOpaqueIdentifier } from '../opaqueIdentifier'
+import { normalizePostHogUserId } from '../opaqueIdentifier'
 
 interface CapturePayload {
   event?: unknown
@@ -44,8 +44,8 @@ function asFirebaseAuthState(value: unknown): ComfyDesktop2FirebaseAuthState | n
     return { status: source.status }
   }
   if (source.status !== 'signed_in') return null
-  const userId = normalizeOpaqueIdentifier(source.userId, 256)
-  if (!userId || isIllegalPostHogDistinctId(userId)) return null
+  const userId = normalizePostHogUserId(source.userId)
+  if (!userId) return null
   return { status: 'signed_in', userId }
 }
 

--- a/src/main/lib/ipc/registerTelemetryHandlers.ts
+++ b/src/main/lib/ipc/registerTelemetryHandlers.ts
@@ -204,8 +204,7 @@ export function registerTelemetryHandlers(): void {
     const err = new Error(message)
     if (stackStr) err.stack = stackStr
     const properties = withPlatformAxes(asExceptionProps(payload?.properties), event?.sender)
-    const accepted = mainTelemetry.captureException(err, properties)
-    if (accepted) mainTelemetry.forwardExceptionToRenderer(properties)
+    mainTelemetry.captureExceptionAndForward(err, properties)
   })
 
   ipcMain.on('telemetry:registerProperties', (_event, properties: unknown) => {

--- a/src/main/lib/opaqueIdentifier.ts
+++ b/src/main/lib/opaqueIdentifier.ts
@@ -41,3 +41,12 @@ export function normalizeOpaqueIdentifier(value: unknown, maxLength: number): st
   }
   return normalized
 }
+
+/**
+ * Normalize a Firebase UID for use as a PostHog distinct id, or null when it
+ * can never merge. The single gate for every layer that handles user ids.
+ */
+export function normalizePostHogUserId(value: unknown): string | null {
+  const normalized = normalizeOpaqueIdentifier(value, 256)
+  return normalized !== null && !isIllegalPostHogDistinctId(normalized) ? normalized : null
+}

--- a/src/main/lib/processErrorHandlers.ts
+++ b/src/main/lib/processErrorHandlers.ts
@@ -40,26 +40,19 @@ export function forwardDatadogError(payload: DatadogForwardedError): void {
     // only and we don't double-count in PostHog.
     skipPostHog: true
   }
-  // Capture via PostHog Node and only mirror accepted exceptions to Datadog.
+  // Capture via PostHog Node and mirror to Datadog only when the capture
+  // actually ships (quarantined captures defer or drop the mirror with the
+  // write). forwardExceptionToRenderer allow-lists context keys, so
+  // reason/exitCode/type survive for child/renderer crashes.
   try {
     const err = new Error(scrubbed.message)
     if (scrubbed.stack) err.stack = scrubbed.stack
-    const accepted = mainTelemetry.captureException(err, {
+    mainTelemetry.captureExceptionAndForward(err, {
       ...(scrubbed.context || {}),
       origin: 'main-process',
       source: scrubbed.source,
       level: scrubbed.level ?? null
     })
-    if (accepted) {
-      // Carry the context through so Datadog keeps reason/exitCode/type for
-      // child/renderer crashes; forwardExceptionToRenderer allow-lists keys.
-      mainTelemetry.forwardExceptionToRenderer({
-        ...(scrubbed.context || {}),
-        origin: 'main-process',
-        source: scrubbed.source,
-        level: scrubbed.level ?? null
-      })
-    }
   } catch {}
 }
 

--- a/src/main/lib/telemetry.test.ts
+++ b/src/main/lib/telemetry.test.ts
@@ -933,6 +933,27 @@ describe('telemetry Firebase consensus identity lifecycle', () => {
     })
   })
 
+  it('requeues an unacknowledged identity merge on a later same-process trigger', async () => {
+    posthogClientMock.autoFailNextIdentifies = 1
+
+    telemetry.applyFirebaseUserConsensus('user-123')
+    expect(pendingIdentityMergeMock.entries).toHaveLength(1)
+    // Let the failed flush settle so the in-flight dedup releases before the
+    // next trigger, as it does for any real later trigger.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    identifies.length = 0
+
+    telemetry.applyFirebaseUserConsensus('user-123')
+
+    await vi.waitFor(() => expect(pendingIdentityMergeMock.entries).toHaveLength(0))
+    expect(identifies).toContainEqual(
+      expect.objectContaining({
+        distinctId: 'user-123',
+        properties: expect.objectContaining({ $anon_distinct_id: 'anonymous-start' })
+      })
+    )
+  })
+
   it('keeps repeated binds of the same Firebase UID idempotent', () => {
     telemetry.applyFirebaseUserConsensus('user-123')
     expect(identifies).toHaveLength(1)
@@ -1070,6 +1091,21 @@ describe('telemetry Firebase consensus identity lifecycle', () => {
         properties: expect.objectContaining({ via: 'desktop_login_code' })
       })
     ])
+  })
+
+  it('discards a staged attribution at shutdown while a different user is still bound', async () => {
+    telemetry.applyFirebaseUserConsensus('user-a')
+    telemetry.applyFirebasePendingConsensus()
+    telemetry.stageLoginAttribution('user-b', { via: 'desktop_login_code' })
+    captured.length = 0
+
+    await telemetry.shutdown('quit')
+
+    expect(
+      captured.filter((call) => call.event === 'comfy.desktop.identity.login_attributed')
+    ).toHaveLength(0)
+    const ended = captured.find((call) => call.event === 'comfy.desktop.session.ended')
+    expect(ended?.distinctId).toBe('user-a')
   })
 
   it('rate-limits at queue time and replays without re-tripping the limiter', () => {

--- a/src/main/lib/telemetry.test.ts
+++ b/src/main/lib/telemetry.test.ts
@@ -1057,8 +1057,8 @@ describe('telemetry Firebase consensus identity lifecycle', () => {
     expect(ended?.distinctId).toBe('user-123')
   })
 
-  it('captures identity-held login attributions during shutdown', async () => {
-    telemetry.registerIdentityShutdownDrain(() => [{ via: 'desktop_login_code' }])
+  it('captures a still-staged login attribution during shutdown', async () => {
+    telemetry.stageLoginAttribution('user-123', { via: 'desktop_login_code' })
     captured.length = 0
 
     await telemetry.shutdown('quit')
@@ -1161,7 +1161,8 @@ describe('telemetry Firebase consensus identity lifecycle', () => {
     captured.length = 0
 
     telemetry.applyFirebasePendingConsensus()
-    telemetry.bindUserId('user-123', {}, { via: 'desktop_login_code' })
+    telemetry.stageLoginAttribution('user-123', { via: 'desktop_login_code' })
+    telemetry.bindUserId('user-123', {})
 
     expect(identifies).toHaveLength(0)
     expect(
@@ -1180,7 +1181,8 @@ describe('telemetry Firebase consensus identity lifecycle', () => {
     captured.length = 0
 
     telemetry.applyFirebasePendingConsensus()
-    telemetry.bindUserId('user-b', {}, { via: 'desktop_login_code' })
+    telemetry.stageLoginAttribution('user-b', { via: 'desktop_login_code' })
+    telemetry.bindUserId('user-b', {})
 
     expect(identifies).toHaveLength(1)
     expect(identifies[0]).toMatchObject({
@@ -1197,12 +1199,25 @@ describe('telemetry Firebase consensus identity lifecycle', () => {
     ])
   })
 
-  it('discards a deferred login attribution when consensus resolves signed out first', () => {
+  it('discards a staged login attribution when consensus resolves signed out first', () => {
     telemetry.setConsentState('undecided')
-    telemetry.bindUserId('user-b', {}, { via: 'desktop_login_code' })
+    telemetry.stageLoginAttribution('user-b', { via: 'desktop_login_code' })
+    telemetry.bindUserId('user-b', {})
     telemetry.applyFirebaseAnonymousConsensus()
     telemetry.setConsentState('granted')
     telemetry.applyFirebaseUserConsensus('user-b')
+
+    expect(
+      captured.filter((call) => call.event === 'comfy.desktop.identity.login_attributed')
+    ).toHaveLength(0)
+  })
+
+  it('discards a staged login attribution when a different user is confirmed', () => {
+    telemetry.stageLoginAttribution('user-a', { via: 'desktop_login_code' })
+    telemetry.applyFirebaseUserConsensus('user-b')
+    // Even a later confirmation of the original UID stays silent: the switch
+    // already contradicted the staged sign-in.
+    telemetry.applyFirebaseUserConsensus('user-a')
 
     expect(
       captured.filter((call) => call.event === 'comfy.desktop.identity.login_attributed')

--- a/src/main/lib/telemetry.test.ts
+++ b/src/main/lib/telemetry.test.ts
@@ -980,6 +980,209 @@ describe('telemetry Firebase consensus identity lifecycle', () => {
     })
   })
 
+  it('quarantines authenticated writes while pending and replays them on same-user resolution', () => {
+    telemetry.applyFirebaseUserConsensus('user-123')
+    identifies.length = 0
+    captured.length = 0
+    exceptions.length = 0
+
+    telemetry.applyFirebasePendingConsensus()
+    expect(telemetry.capture('pending.event')).toBe(true)
+    telemetry.captureException(new Error('pending'))
+    telemetry.registerPersonProperties({ plan: 'pro' })
+
+    expect(identifies).toHaveLength(0)
+    expect(captured).toHaveLength(0)
+    expect(exceptions).toHaveLength(0)
+    expect(anonymousIdentityMock.index).toBe(1)
+
+    telemetry.applyFirebaseUserConsensus('user-123')
+
+    expect(identifies).toHaveLength(0)
+    expect(captured.map((call) => call.event)).toContain('pending.event')
+    expect(exceptions).toHaveLength(1)
+    expect(captured.every((call) => call.distinctId === 'user-123')).toBe(true)
+    expect(captured.at(-1)).toMatchObject({
+      distinctId: 'user-123',
+      event: 'comfy.desktop.person.set',
+      properties: { $set: { plan: 'pro' } }
+    })
+    telemetry.capture('resolved.event')
+    expect(captured.at(-1)?.distinctId).toBe('user-123')
+  })
+
+  it('discards quarantined writes when pending resolves to a different user', () => {
+    telemetry.applyFirebaseUserConsensus('user-a')
+    captured.length = 0
+    exceptions.length = 0
+
+    telemetry.applyFirebasePendingConsensus()
+    telemetry.capture('during.switch')
+    telemetry.captureException(new Error('during switch'))
+    telemetry.applyFirebaseUserConsensus('user-b')
+
+    expect(captured.filter((call) => call.event === 'during.switch')).toHaveLength(0)
+    expect(exceptions).toHaveLength(0)
+  })
+
+  it('release ends the quarantine keeping the bound identity and replays held writes', () => {
+    telemetry.applyFirebaseUserConsensus('user-123')
+    identifies.length = 0
+    captured.length = 0
+
+    telemetry.applyFirebasePendingConsensus()
+    telemetry.capture('held.event')
+    expect(captured).toHaveLength(0)
+
+    telemetry.releaseFirebasePendingConsensus()
+
+    expect(identifies).toHaveLength(0)
+    expect(captured.map((call) => call.event)).toContain('held.event')
+    expect(captured.every((call) => call.distinctId === 'user-123')).toBe(true)
+    telemetry.capture('after.release')
+    expect(captured.at(-1)?.distinctId).toBe('user-123')
+  })
+
+  it('drains quarantined writes and the session end through a mid-navigation quit', async () => {
+    telemetry.applyFirebaseUserConsensus('user-123')
+    captured.length = 0
+
+    telemetry.applyFirebasePendingConsensus()
+    telemetry.capture('before.quit')
+    await telemetry.shutdown('quit')
+
+    expect(captured.map((call) => call.event)).toContain('before.quit')
+    const ended = captured.find((call) => call.event === 'comfy.desktop.session.ended')
+    expect(ended?.distinctId).toBe('user-123')
+  })
+
+  it('keeps anonymous events flowing while first-login consensus is pending', () => {
+    telemetry.applyFirebasePendingConsensus()
+    telemetry.capture('anon.event')
+
+    expect(captured.at(-1)).toMatchObject({
+      distinctId: 'anonymous-start',
+      event: 'anon.event',
+      properties: expect.objectContaining({ $process_person_profile: false })
+    })
+  })
+
+  it('emits login attribution when a same-user re-authentication resolves', () => {
+    telemetry.applyFirebaseUserConsensus('user-123')
+    identifies.length = 0
+    captured.length = 0
+
+    telemetry.applyFirebasePendingConsensus()
+    telemetry.bindUserId('user-123', {}, { via: 'desktop_login_code' })
+
+    expect(identifies).toHaveLength(0)
+    expect(
+      captured.filter((call) => call.event === 'comfy.desktop.identity.login_attributed')
+    ).toEqual([
+      expect.objectContaining({
+        distinctId: 'user-123',
+        properties: expect.objectContaining({ via: 'desktop_login_code' })
+      })
+    ])
+  })
+
+  it('attributes an account-switch login to the new UID at bind time', () => {
+    telemetry.applyFirebaseUserConsensus('user-a')
+    identifies.length = 0
+    captured.length = 0
+
+    telemetry.applyFirebasePendingConsensus()
+    telemetry.bindUserId('user-b', {}, { via: 'desktop_login_code' })
+
+    expect(identifies).toHaveLength(1)
+    expect(identifies[0]).toMatchObject({
+      distinctId: 'user-b',
+      properties: { $anon_distinct_id: 'anonymous-next-1' }
+    })
+    expect(
+      captured.filter((call) => call.event === 'comfy.desktop.identity.login_attributed')
+    ).toEqual([
+      expect.objectContaining({
+        distinctId: 'user-b',
+        properties: expect.objectContaining({ via: 'desktop_login_code' })
+      })
+    ])
+  })
+
+  it('discards a deferred login attribution when consensus resolves signed out first', () => {
+    telemetry.setConsentState('undecided')
+    telemetry.bindUserId('user-b', {}, { via: 'desktop_login_code' })
+    telemetry.applyFirebaseAnonymousConsensus()
+    telemetry.setConsentState('granted')
+    telemetry.applyFirebaseUserConsensus('user-b')
+
+    expect(
+      captured.filter((call) => call.event === 'comfy.desktop.identity.login_attributed')
+    ).toHaveLength(0)
+  })
+
+  it('does not flush a deferred UID while renderer consensus is pending', () => {
+    telemetry.setConsentState('undecided')
+    telemetry.applyFirebaseUserConsensus('user-123')
+    telemetry.applyFirebasePendingConsensus()
+
+    telemetry.setConsentState('granted')
+    expect(identifies).toHaveLength(0)
+
+    telemetry.applyFirebaseUserConsensus('user-123')
+    expect(identifies).toHaveLength(1)
+    expect(identifies[0]?.distinctId).toBe('user-123')
+  })
+
+  it('performs the full anonymous transition only after pending resolves signed out', () => {
+    telemetry.applyFirebaseUserConsensus('user-123')
+    captured.length = 0
+
+    telemetry.applyFirebasePendingConsensus()
+    telemetry.applyFirebaseAnonymousConsensus()
+
+    const personSet = captured.find((call) => call.event === 'comfy.desktop.person.set')
+    expect(personSet).toMatchObject({
+      distinctId: 'user-123',
+      properties: { $set: { is_authenticated: false } }
+    })
+    telemetry.capture('after.confirmed.logout')
+    expect(captured.at(-1)?.distinctId).toBe('anonymous-next-1')
+  })
+
+  it('ends the pending quarantine when consensus resolves while consent is denied', () => {
+    telemetry.applyFirebaseUserConsensus('user-123')
+    telemetry.applyFirebasePendingConsensus()
+
+    telemetry.setConsentState('denied')
+    telemetry.applyFirebaseUserConsensus('user-123')
+    telemetry.setConsentState('granted')
+    captured.length = 0
+
+    expect(telemetry.capture('after.denied.resolution')).toBe(true)
+    expect(captured.at(-1)?.distinctId).toBe('user-123')
+  })
+
+  it('detaches the stale binding when an account switch resolves during denied consent', () => {
+    telemetry.applyFirebaseUserConsensus('user-123')
+    telemetry.applyFirebasePendingConsensus()
+
+    telemetry.setConsentState('denied')
+    telemetry.applyFirebaseUserConsensus('user-456')
+    telemetry.setConsentState('granted')
+
+    captured.length = 0
+    expect(telemetry.capture('between.replays')).toBe(true)
+    // The switched-away user must not receive events recorded after their
+    // switch resolved; the gap runs anonymous until the new UID rebinds.
+    expect(captured.at(-1)?.distinctId).toBe('anonymous-next-1')
+
+    telemetry.applyFirebaseUserConsensus('user-456')
+    captured.length = 0
+    telemetry.capture('after.switch')
+    expect(captured.at(-1)?.distinctId).toBe('user-456')
+  })
+
   it('uses a different anonymous D for an account switch', () => {
     telemetry.applyFirebaseUserConsensus('user-123')
     captured.length = 0

--- a/src/main/lib/telemetry.test.ts
+++ b/src/main/lib/telemetry.test.ts
@@ -47,6 +47,7 @@ interface CapturedCall {
   distinctId: string
   event: string
   properties?: Record<string, unknown>
+  timestamp?: Date
 }
 const captured: CapturedCall[] = []
 
@@ -1054,6 +1055,93 @@ describe('telemetry Firebase consensus identity lifecycle', () => {
     expect(captured.map((call) => call.event)).toContain('before.quit')
     const ended = captured.find((call) => call.event === 'comfy.desktop.session.ended')
     expect(ended?.distinctId).toBe('user-123')
+  })
+
+  it('captures identity-held login attributions during shutdown', async () => {
+    telemetry.registerIdentityShutdownDrain(() => [{ via: 'desktop_login_code' }])
+    captured.length = 0
+
+    await telemetry.shutdown('quit')
+
+    expect(
+      captured.filter((call) => call.event === 'comfy.desktop.identity.login_attributed')
+    ).toEqual([
+      expect.objectContaining({
+        properties: expect.objectContaining({ via: 'desktop_login_code' })
+      })
+    ])
+  })
+
+  it('rate-limits at queue time and replays without re-tripping the limiter', () => {
+    telemetry.applyFirebaseUserConsensus('user-123')
+    captured.length = 0
+
+    telemetry.applyFirebasePendingConsensus()
+    for (let i = 0; i < 60; i++) {
+      expect(telemetry.capture('burst.event', { i })).toBe(true)
+    }
+    // The 61st is refused up front instead of being buffered and then
+    // silently dropped at replay after having been acknowledged.
+    expect(telemetry.capture('burst.event', { i: 60 })).toBe(false)
+
+    telemetry.applyFirebaseUserConsensus('user-123')
+
+    expect(captured.filter((call) => call.event === 'burst.event')).toHaveLength(60)
+    expect(
+      captured.filter((call) => call.event === 'comfy.desktop.telemetry.rate_limited')
+    ).toHaveLength(0)
+    expect(captured.find((call) => call.event === 'burst.event')?.timestamp).toBeInstanceOf(Date)
+  })
+
+  it('defers emit() renderer forwarding with the quarantined write until it ships', () => {
+    const { wc, sends } = makeStubWebContents()
+    telemetry.registerTelemetryRelayTarget(wc)
+    telemetry.applyFirebaseUserConsensus('user-123')
+    captured.length = 0
+
+    telemetry.applyFirebasePendingConsensus()
+    telemetry.emit('comfy.desktop.execution.error', { variant: 'standalone' })
+    expect(sends).toHaveLength(0)
+
+    telemetry.applyFirebaseUserConsensus('user-123')
+
+    expect(captured.map((call) => call.event)).toContain('comfy.desktop.execution.error')
+    expect(sends).toHaveLength(1)
+  })
+
+  it('drops the deferred Datadog mirror when a quarantined exception is discarded', () => {
+    const { wc, sends } = makeStubWebContents()
+    telemetry.registerTelemetryRelayTarget(wc)
+    telemetry.applyFirebaseUserConsensus('user-a')
+    captured.length = 0
+    exceptions.length = 0
+
+    telemetry.applyFirebasePendingConsensus()
+    expect(telemetry.captureExceptionAndForward(new Error('boom'), { source: 'test' })).toBe(true)
+    expect(sends).toHaveLength(0)
+    expect(exceptions).toHaveLength(0)
+
+    telemetry.applyFirebaseUserConsensus('user-b')
+
+    expect(exceptions).toHaveLength(0)
+    expect(sends).toHaveLength(0)
+  })
+
+  it('applies $set_once markers deferred by the quarantine before a signed-out detach', () => {
+    telemetry.applyFirebaseUserConsensus('user-123')
+    captured.length = 0
+
+    telemetry.applyFirebasePendingConsensus()
+    telemetry.registerPersonPropertiesOnce({ first_local_install_completed_at: 't1' })
+    expect(captured).toHaveLength(0)
+
+    telemetry.applyFirebaseAnonymousConsensus()
+
+    const sets = captured.filter((call) => call.event === 'comfy.desktop.person.set')
+    expect(sets[0]).toMatchObject({
+      distinctId: 'user-123',
+      properties: { $set_once: { first_local_install_completed_at: 't1' } }
+    })
   })
 
   it('keeps anonymous events flowing while first-login consensus is pending', () => {

--- a/src/main/lib/telemetry.ts
+++ b/src/main/lib/telemetry.ts
@@ -582,7 +582,10 @@ export function initTelemetry(opts: InitOptions): void {
     client.on('error', () => {
       // The SDK removes HTTP-failed non-network batches from memory. Keep the
       // disk queue authoritative and allow a later trigger/restart to requeue.
+      // Re-dirtying is what makes the later trigger actually reread the file:
+      // a prior flush may have marked it clean once every entry was queued.
       queuedPendingIdentityMergeIds.clear()
+      pendingIdentityMergeFileDirty = true
     })
   } catch {
     client = null
@@ -1651,9 +1654,17 @@ export async function shutdown(reason: string): Promise<void> {
     if (firebaseConsensusPending) releaseFirebasePendingConsensus()
     // A successful sign-in whose confirming re-report is outrun by the quit
     // still deserves its attribution; no contrary resolution was observed.
+    // Unless a DIFFERENT user is still bound (a mid-switch quit): capture()
+    // would land the event under their distinct id, crediting the new
+    // sign-in to the previous account, so an unconfirmed switch discards.
+    // Unbound is safe - the event lands on the anonymous id, which only
+    // ever merges into the staged user if they are later confirmed.
     if (pendingLoginAttribution) {
-      capture(FIREBASE_LOGIN_ATTRIBUTION_EVENT, pendingLoginAttribution.context)
+      const { userId, context } = pendingLoginAttribution
       pendingLoginAttribution = null
+      if (boundUserId === null || userId === boundUserId) {
+        capture(FIREBASE_LOGIN_ATTRIBUTION_EVENT, context)
+      }
     }
     capture('comfy.desktop.session.ended', {
       reason,

--- a/src/main/lib/telemetry.ts
+++ b/src/main/lib/telemetry.ts
@@ -196,6 +196,7 @@ export function _resetForTest(): void {
   pendingIdentityMergeFlush = null
   pendingIdentityMergeFileDirty = true
   queuedPendingIdentityMergeIds.clear()
+  identityShutdownDrain = null
 }
 
 /** @internal - exposed for tests. */
@@ -235,6 +236,13 @@ let suppressEmit = false
  * the first bind, anonymous events can continue and will be merged normally.
  */
 let firebaseConsensusPending = false
+
+/** Whether writes are currently held for renderer auth consensus. Lets the
+ *  consensus module's deadline distinguish "still unresolved" from "already
+ *  resolved by the reconcile it just ran" without mirroring the flag. */
+export function isFirebaseConsensusPending(): boolean {
+  return firebaseConsensusPending
+}
 
 /** Short-circuit guard for all PostHog emission paths. Centralized so
  *  the dev-mode suppression and a missing client are checked
@@ -623,6 +631,12 @@ interface QuarantinedWrite {
   event?: string
   error?: unknown
   properties: TelemetryContext
+  /** Mirror to the renderer relay on delivery. Deferred with the write so the
+   *  Datadog copy exists only when the PostHog copy actually ships. */
+  forward: boolean
+  /** Original capture time, restored on replay (events only - the SDK's
+   *  captureException accepts no timestamp). */
+  timestamp: Date
 }
 
 /**
@@ -644,14 +658,23 @@ function queueQuarantinedWrite(write: QuarantinedWrite): boolean {
   return true
 }
 
-/** Only call with the quarantine already lifted — replays re-enter capture(). */
+/**
+ * Only call with the quarantine already lifted. Replays deliver directly,
+ * bypassing the rate limiter — each write was already charged against it at
+ * queue time, so a released burst cannot retro-drop acknowledged writes.
+ * Consent is re-checked: it may have flipped during the pending window.
+ */
 function flushQuarantinedWrites(): void {
   if (quarantinedWrites.length === 0) return
   const writes = quarantinedWrites
   quarantinedWrites = []
+  if (!canEmit() || !distinctId) return
   for (const write of writes) {
-    if (write.kind === 'exception') captureException(write.error, write.properties)
-    else if (write.event) capture(write.event, write.properties)
+    if (write.kind === 'exception') {
+      if (consentState === 'granted') deliverException(write.error, write.properties, write.forward)
+    } else if (write.event && isAllowedToFire(write.event)) {
+      deliverEvent(write.event, write.properties, write.forward, write.timestamp)
+    }
   }
 }
 
@@ -665,8 +688,10 @@ let nextAnonymousDistinctId: string | null = null
 let boundUserId: string | null = null
 let installationIdProperty: string | null = null
 let pendingIdentityMergeFlush: Promise<void> | null = null
-/** Skips the merge file's synchronous read on flush triggers once it is
- *  known empty; starts true because a previous run may have left entries. */
+/** Skips the merge file's synchronous read (and the redundant retry flush)
+ *  on later triggers once every persisted entry has been handed to the SDK;
+ *  reservations re-dirty it. Starts true because a previous run may have
+ *  left entries. */
 let pendingIdentityMergeFileDirty = true
 const queuedPendingIdentityMergeIds = new Set<string>()
 
@@ -737,6 +762,13 @@ function flushPendingIdentityMerges(): Promise<void> {
       }
     }
   }
+  // Fully-queued entries need no further reads or flush retries from this
+  // path: delivery is the SDK's (and the ack handler's) job. Otherwise an
+  // offline stretch turns every consensus confirmation into sync file I/O
+  // plus a doomed network flush. Entries whose identify threw stay dirty.
+  pendingIdentityMergeFileDirty = pending.some(
+    (merge) => !queuedPendingIdentityMergeIds.has(merge.id)
+  )
   if (!admittedAny && queuedPendingIdentityMergeIds.size === 0) return Promise.resolve()
 
   const activeClient = client!
@@ -884,6 +916,12 @@ function applyFirebaseUserBinding(
     // These buffers may contain updates collected for the current account
     // while consent was not granted. Never carry them into another Firebase
     // person; properties collected before the first login remain intact.
+    // Under granted consent they were merely deferred (e.g. by the write
+    // quarantine): apply them to the person they were collected for before
+    // detaching, or burned-guard $set_once markers are lost forever.
+    if (canEmit() && consentState === 'granted' && (pendingPersonSet || pendingPersonSetOnce)) {
+      capturePersonProperties(pendingPersonSet, pendingPersonSetOnce)
+    }
     pendingPersonSet = null
     pendingPersonSetOnce = null
   }
@@ -1010,6 +1048,11 @@ export function applyFirebaseAnonymousConsensus(): void {
   pendingUserBinding = null
   if (!boundUserId) return
   // Wiping these while unbound would permanently lose burned-guard $set_once markers.
+  // Bound with granted consent, deferred markers (e.g. quarantined during the
+  // pending window) belong to the user they fired under: apply before detach.
+  if (canEmit() && consentState === 'granted' && (pendingPersonSet || pendingPersonSetOnce)) {
+    capturePersonProperties(pendingPersonSet, pendingPersonSetOnce)
+  }
   pendingPersonSet = null
   pendingPersonSetOnce = null
   if (canEmit() && consentState === 'granted') {
@@ -1106,17 +1149,40 @@ function capturePersonProperties(
 }
 
 /**
- * Returns whether the event was admitted to the SDK. A `false` means it was
- * dropped (consent gate, volume guard, or SDK failure); one-shot callers use
- * this to keep their deferred payload instead of losing it.
+ * Returns whether the event was admitted. A `false` means it was dropped
+ * (consent gate, volume guard, or SDK failure); one-shot callers use this to
+ * keep their deferred payload instead of losing it. While consensus is
+ * quarantined, `true` means the write was buffered for the bound user's
+ * confirmation — it ships on a same-user resolution or release and is
+ * discarded when consensus resolves to anyone else.
  */
 export function capture(event: string, properties: TelemetryContext = {}): boolean {
+  return captureEvent(event, properties, false)
+}
+
+function captureEvent(event: string, properties: TelemetryContext, forward: boolean): boolean {
   if (!canEmit() || !distinctId) return false
   if (!isAllowedToFire(event)) return false
-  if (firebaseWritesQuarantined()) {
-    return queueQuarantinedWrite({ kind: 'event', event, properties })
-  }
   if (!_checkRateLimit(event)) return false
+  if (firebaseWritesQuarantined()) {
+    if (
+      !queueQuarantinedWrite({ kind: 'event', event, properties, forward, timestamp: new Date() })
+    )
+      return false
+    _recordCapturedEvent(event)
+    return true
+  }
+  if (!deliverEvent(event, properties, forward, null)) return false
+  _recordCapturedEvent(event)
+  return true
+}
+
+function deliverEvent(
+  event: string,
+  properties: TelemetryContext,
+  forward: boolean,
+  timestamp: Date | null
+): boolean {
   try {
     // Per-call properties override defaults on key collision - callers
     // that explicitly pass `app_version` (e.g. session-start payload,
@@ -1127,11 +1193,12 @@ export function capture(event: string, properties: TelemetryContext = {}): boole
     // only the country code/name is retained. See the init comment.
     const merged = enforcePersonProcessingPolicy({ ...defaultEventProperties, ...properties })
     client!.capture({
-      distinctId,
+      distinctId: distinctId!,
       event,
-      properties: scrubProperties(merged)
+      properties: scrubProperties(merged),
+      ...(timestamp ? { timestamp } : {})
     })
-    _recordCapturedEvent(event)
+    if (forward) forwardToRenderer(event, properties)
     return true
   } catch {
     // swallow - telemetry must never break the app
@@ -1244,13 +1311,51 @@ export function captureInstallCompleted(opts: {
 }
 
 export function captureException(error: unknown, properties: TelemetryContext = {}): boolean {
+  return captureExceptionWrite(error, properties, false)
+}
+
+/**
+ * Capture an exception and, once the PostHog write actually ships, mirror it
+ * to the renderer-only Datadog SDK. During quarantine the mirror is deferred
+ * with the write (and dropped with it on a non-same-user resolution), so the
+ * two systems cannot diverge on which exceptions exist.
+ */
+export function captureExceptionAndForward(
+  error: unknown,
+  properties: TelemetryContext = {}
+): boolean {
+  return captureExceptionWrite(error, properties, true)
+}
+
+function captureExceptionWrite(
+  error: unknown,
+  properties: TelemetryContext,
+  forward: boolean
+): boolean {
   if (!canEmit() || !distinctId) return false
   // Exceptions are reliability data; suppress them outside `'granted'`.
   if (consentState !== 'granted') return false
-  if (firebaseWritesQuarantined()) {
-    return queueQuarantinedWrite({ kind: 'exception', error, properties })
-  }
   if (!_checkRateLimit('comfy.desktop.exception.error')) return false
+  if (firebaseWritesQuarantined()) {
+    if (
+      !queueQuarantinedWrite({
+        kind: 'exception',
+        error,
+        properties,
+        forward,
+        timestamp: new Date()
+      })
+    )
+      return false
+    _recordCapturedEvent('comfy.desktop.exception.error')
+    return true
+  }
+  if (!deliverException(error, properties, forward)) return false
+  _recordCapturedEvent('comfy.desktop.exception.error')
+  return true
+}
+
+function deliverException(error: unknown, properties: TelemetryContext, forward: boolean): boolean {
   try {
     // Same default merge as capture() so exception events stay filterable by
     // the shared axes (app_version, client, ...) instead of arriving bare.
@@ -1266,12 +1371,12 @@ export function captureException(error: unknown, properties: TelemetryContext = 
     }
     client!.captureException(
       safeError,
-      distinctId,
+      distinctId!,
       normalizeExceptionContext(
         enforcePersonProcessingPolicy({ ...defaultEventProperties, ...properties })
       ) as TelemetryContext
     )
-    _recordCapturedEvent('comfy.desktop.exception.error')
+    if (forward) forwardExceptionToRenderer(properties)
     return true
   } catch {
     // ignore
@@ -1491,10 +1596,24 @@ export function forwardExceptionToRenderer(context: TelemetryContext = {}): void
 }
 
 /**
- * Capture an event and forward it to the renderer in one call.
+ * Capture an event and forward it to the renderer in one call. The forward
+ * rides the capture's disposition: quarantined writes mirror on replay, not
+ * at queue time, so a discarded PostHog write has no orphaned Datadog copy.
  */
 export function emit(event: string, context: TelemetryContext = {}): void {
-  if (capture(event, context)) forwardToRenderer(event, context)
+  captureEvent(event, context, true)
+}
+
+/**
+ * One-shot payloads the identity-consensus layer is still holding for a
+ * document re-report that will now never arrive. Registered lazily by
+ * `firebaseAuthIdentity` to avoid an import cycle; each returned context is
+ * captured as a login-attribution event during shutdown.
+ */
+let identityShutdownDrain: (() => TelemetryContext[]) | null = null
+
+export function registerIdentityShutdownDrain(drain: () => TelemetryContext[]): void {
+  identityShutdownDrain = drain
 }
 
 /**
@@ -1507,6 +1626,11 @@ export async function shutdown(reason: string): Promise<void> {
     // A quit mid-navigation must not strand quarantined writes (or the
     // session-ended capture below) — the pending document will never resolve.
     if (firebaseConsensusPending) releaseFirebasePendingConsensus()
+    // A successful sign-in whose confirming re-report is outrun by the quit
+    // still deserves its attribution; no contrary resolution was observed.
+    for (const attribution of identityShutdownDrain?.() ?? []) {
+      capture(FIREBASE_LOGIN_ATTRIBUTION_EVENT, attribution)
+    }
     capture('comfy.desktop.session.ended', {
       reason,
       uptime_ms: uptimeMs,

--- a/src/main/lib/telemetry.ts
+++ b/src/main/lib/telemetry.ts
@@ -125,7 +125,7 @@ import {
   persistUnmergeableAnonymousEpoch,
   rotatePersistedAnonymousDistinctId
 } from './anonymousIdentity'
-import { isIllegalPostHogDistinctId, normalizeOpaqueIdentifier } from './opaqueIdentifier'
+import { normalizePostHogUserId } from './opaqueIdentifier'
 import {
   clearPendingIdentityMerges,
   type PendingIdentityProperties,
@@ -181,6 +181,7 @@ export function _resetForTest(): void {
   anonymousDistinctId = null
   nextAnonymousDistinctId = null
   boundUserId = null
+  firebaseConsensusPending = false
   installationIdProperty = null
   consentState = 'undecided'
   pendingSessionStart = null
@@ -188,10 +189,12 @@ export function _resetForTest(): void {
   pendingPersonSet = null
   pendingPersonSetOnce = null
   pendingUserBinding = null
+  quarantinedWrites = []
   defaultEventProperties = {}
   initialized = false
   drainingForQuit = false
   pendingIdentityMergeFlush = null
+  pendingIdentityMergeFileDirty = true
   queuedPendingIdentityMergeIds.clear()
 }
 
@@ -223,6 +226,15 @@ let initialized = false
  *  `loadFeatureFlagsImmediate`, `shutdown`) deliberately ignore this
  *  so devs can still resolve feature flags in `pnpm dev`. */
 let suppressEmit = false
+
+/**
+ * A trusted auth reporter is between authoritative documents. Keep the
+ * current identity intact so a same-user navigation does not manufacture a
+ * logout/login pair, but quarantine PostHog writes until the new document
+ * resolves. This matters only after a Firebase user has been bound; before
+ * the first bind, anonymous events can continue and will be merged normally.
+ */
+let firebaseConsensusPending = false
 
 /** Short-circuit guard for all PostHog emission paths. Centralized so
  *  the dev-mode suppression and a missing client are checked
@@ -383,7 +395,10 @@ function enforcePersonProcessingPolicy(properties: TelemetryContext): TelemetryC
 }
 
 function _emitWarning(event: string, properties: TelemetryContext): void {
-  if (!canEmit() || !distinctId) return
+  // Volume-guard warnings describe the moment they fire; dropping (not
+  // buffering) them during the quarantine keeps stale warnings from
+  // replaying after the state they warned about is gone.
+  if (!canEmit() || !distinctId || firebaseWritesQuarantined()) return
   try {
     client!.capture({
       distinctId,
@@ -596,9 +611,49 @@ interface PendingUserBinding {
   userId: string
   emitLoginEvent: boolean
   properties: Record<string, TelemetryValue>
+  attribution: TelemetryContext | null
 }
 
 let pendingUserBinding: PendingUserBinding | null = null
+
+const FIREBASE_LOGIN_ATTRIBUTION_EVENT = 'comfy.desktop.identity.login_attributed'
+
+interface QuarantinedWrite {
+  kind: 'event' | 'exception'
+  event?: string
+  error?: unknown
+  properties: TelemetryContext
+}
+
+/**
+ * Writes held while renderer consensus is pending. Bounded: a wedged
+ * document must not grow this forever; the deadline in firebaseAuthIdentity
+ * releases the quarantine long before the cap matters in practice.
+ */
+let quarantinedWrites: QuarantinedWrite[] = []
+const QUARANTINED_WRITES_CAP = 200
+
+/** True when writes for the bound user must be held for consensus. */
+function firebaseWritesQuarantined(): boolean {
+  return firebaseConsensusPending && boundUserId !== null
+}
+
+function queueQuarantinedWrite(write: QuarantinedWrite): boolean {
+  if (quarantinedWrites.length >= QUARANTINED_WRITES_CAP) return false
+  quarantinedWrites.push(write)
+  return true
+}
+
+/** Only call with the quarantine already lifted — replays re-enter capture(). */
+function flushQuarantinedWrites(): void {
+  if (quarantinedWrites.length === 0) return
+  const writes = quarantinedWrites
+  quarantinedWrites = []
+  for (const write of writes) {
+    if (write.kind === 'exception') captureException(write.error, write.properties)
+    else if (write.event) capture(write.event, write.properties)
+  }
+}
 
 /**
  * `anonymousDistinctId` is the active W/D for the current anonymous period.
@@ -610,6 +665,9 @@ let nextAnonymousDistinctId: string | null = null
 let boundUserId: string | null = null
 let installationIdProperty: string | null = null
 let pendingIdentityMergeFlush: Promise<void> | null = null
+/** Skips the merge file's synchronous read on flush triggers once it is
+ *  known empty; starts true because a previous run may have left entries. */
+let pendingIdentityMergeFileDirty = true
 const queuedPendingIdentityMergeIds = new Set<string>()
 
 function discardDeferredTelemetry(): void {
@@ -618,6 +676,7 @@ function discardDeferredTelemetry(): void {
   pendingPersonSet = null
   pendingPersonSetOnce = null
   pendingUserBinding = null
+  quarantinedWrites = []
 }
 
 function acknowledgeDeliveredIdentityMerges(messages: unknown): void {
@@ -648,8 +707,13 @@ function acknowledgeDeliveredIdentityMerges(messages: unknown): void {
 function flushPendingIdentityMerges(): Promise<void> {
   if (pendingIdentityMergeFlush) return pendingIdentityMergeFlush
   if (!canEmit() || consentState !== 'granted') return Promise.resolve()
+  if (!pendingIdentityMergeFileDirty) return Promise.resolve()
 
   const pending = readPendingIdentityMerges()
+  if (pending.length === 0 && queuedPendingIdentityMergeIds.size === 0) {
+    pendingIdentityMergeFileDirty = false
+    return Promise.resolve()
+  }
   const pendingIds = new Set(pending.map((merge) => merge.id))
   for (const id of queuedPendingIdentityMergeIds) {
     if (!pendingIds.has(id)) queuedPendingIdentityMergeIds.delete(id)
@@ -693,6 +757,10 @@ function flushPendingIdentityMerges(): Promise<void> {
 function tryFlushDeferred(): void {
   if (!canEmit() || !distinctId) return
   if (consentState !== 'granted') return
+  // While quarantined, hold everything: flushing one-shots here would route
+  // them into the volatile quarantine buffer, which an account-switch
+  // resolution discards. Resolution paths re-trigger this flush.
+  if (firebaseWritesQuarantined()) return
   if (boundUserId && (pendingPersonSet || pendingPersonSetOnce)) {
     if (capturePersonProperties(pendingPersonSet, pendingPersonSetOnce)) {
       pendingPersonSet = null
@@ -705,10 +773,13 @@ function tryFlushDeferred(): void {
   if (pendingFirstLaunch && capture('comfy.desktop.app.first_launch', pendingFirstLaunch)) {
     pendingFirstLaunch = null
   }
-  if (pendingUserBinding) {
-    const { userId, emitLoginEvent, properties } = pendingUserBinding
+  // The binding flush also waits on the raw flag: consensus can be pending
+  // before the first bind ever lands (queued under undecided consent), and
+  // the deferred UID must not identify until that pending window resolves.
+  if (pendingUserBinding && !firebaseConsensusPending) {
+    const { userId, emitLoginEvent, properties, attribution } = pendingUserBinding
     pendingUserBinding = null
-    applyFirebaseUserBinding(userId, emitLoginEvent, properties)
+    applyFirebaseUserBinding(userId, emitLoginEvent, properties, attribution)
   }
   void flushPendingIdentityMerges()
 }
@@ -759,34 +830,54 @@ function persistablePersonProperties(properties: TelemetryContext): PendingIdent
 function queuePendingUserBinding(
   userId: string,
   emitLoginEvent: boolean,
-  properties: Record<string, TelemetryValue>
+  properties: Record<string, TelemetryValue>,
+  attribution: TelemetryContext | null
 ): void {
   const existing = pendingUserBinding?.userId === userId ? pendingUserBinding : null
   pendingUserBinding = {
     userId,
     emitLoginEvent: emitLoginEvent || existing?.emitLoginEvent === true,
-    properties: { ...(existing?.properties ?? {}), ...properties }
+    properties: { ...(existing?.properties ?? {}), ...properties },
+    attribution: attribution ?? existing?.attribution ?? null
   }
 }
 
 function applyFirebaseUserBinding(
   userId: string,
   emitLoginEvent: boolean,
-  properties: Record<string, TelemetryValue> = {}
+  properties: Record<string, TelemetryValue> = {},
+  attribution: TelemetryContext | null = null
 ): void {
-  const normalizedUserId = normalizeOpaqueIdentifier(userId, 256)
+  // Resolved consensus always ends the pending quarantine, even when this
+  // binding cannot proceed (denied consent, unusable UID) — otherwise
+  // bound-user telemetry stays dropped until an unrelated consensus replay.
+  firebaseConsensusPending = false
+  const normalizedUserId = normalizePostHogUserId(userId)
+  // Writes quarantined during the pending window belong to the user who was
+  // bound while they fired; any other resolution leaves their attribution
+  // ambiguous, so only a same-user confirmation replays them.
+  if (normalizedUserId !== null && normalizedUserId === boundUserId) flushQuarantinedWrites()
+  else quarantinedWrites = []
   // Reject early rather than burn an anonymous rotation on an identify that
   // can never merge.
-  if (!normalizedUserId || isIllegalPostHogDistinctId(normalizedUserId)) return
-  if (consentState === 'denied') return
+  if (!normalizedUserId) return
+  if (consentState === 'denied') {
+    // The old binding must not survive a resolved account switch: once
+    // consent returns, events would land on the previous user. Detach now
+    // (silently — consent is denied) and let a later replay bind the new UID.
+    if (boundUserId && boundUserId !== normalizedUserId) applyFirebaseAnonymousConsensus()
+    return
+  }
 
   if (!canEmit() || !anonymousDistinctId || !installationIdProperty) {
-    queuePendingUserBinding(normalizedUserId, emitLoginEvent, properties)
+    queuePendingUserBinding(normalizedUserId, emitLoginEvent, properties, attribution)
     return
   }
   if (boundUserId === normalizedUserId) {
     if (Object.keys(properties).length > 0) registerPersonProperties(properties)
     if (emitLoginEvent) capture('app:user_logged_in', { user_id: normalizedUserId })
+    if (attribution) capture(FIREBASE_LOGIN_ATTRIBUTION_EVENT, attribution)
+    tryFlushDeferred()
     return
   }
   if (boundUserId) {
@@ -801,7 +892,7 @@ function applyFirebaseUserBinding(
       applyFirebaseAnonymousConsensus()
       if (!anonymousDistinctId) return
     }
-    queuePendingUserBinding(normalizedUserId, emitLoginEvent, properties)
+    queuePendingUserBinding(normalizedUserId, emitLoginEvent, properties, attribution)
     return
   }
 
@@ -828,9 +919,10 @@ function applyFirebaseUserBinding(
     ...(personSetOnce ? { personSetOnce: persistablePersonProperties(personSetOnce) } : {})
   })
   if (!pendingMerge) {
-    queuePendingUserBinding(normalizedUserId, emitLoginEvent, properties)
+    queuePendingUserBinding(normalizedUserId, emitLoginEvent, properties, attribution)
     return
   }
+  pendingIdentityMergeFileDirty = true
   const reservedNextAnonymousId = pendingMerge.nextAnonymousId
 
   distinctId = normalizedUserId
@@ -849,7 +941,7 @@ function applyFirebaseUserBinding(
     anonymousDistinctId = reservedNextAnonymousId
     nextAnonymousDistinctId = null
     distinctId = reservedNextAnonymousId
-    queuePendingUserBinding(normalizedUserId, emitLoginEvent, properties)
+    queuePendingUserBinding(normalizedUserId, emitLoginEvent, properties, attribution)
     return
   }
   boundUserId = normalizedUserId
@@ -860,7 +952,8 @@ function applyFirebaseUserBinding(
   if (emitLoginEvent) {
     capture('app:user_logged_in', { user_id: normalizedUserId })
   }
-  void flushPendingIdentityMerges()
+  if (attribution) capture(FIREBASE_LOGIN_ATTRIBUTION_EVENT, attribution)
+  tryFlushDeferred()
 }
 
 /** Apply declarative renderer consensus without emitting an interactive login conversion. */
@@ -872,15 +965,48 @@ export function applyFirebaseUserConsensus(userId: string): void {
  * Bind a main-process-verified interactive sign-in (OAuth loopback bridge or
  * desktop login code). The verified flow owns the login-success conversion;
  * declarative Cloud and scoped-local restored-session consensus stays silent.
+ * `attribution`, when present, is the one-shot login-attribution payload
+ * emitted alongside the conversion — never before the UID is confirmed, and
+ * never for a UID that fails to bind.
  */
-export function bindUserId(userId: string, properties: Record<string, TelemetryValue> = {}): void {
-  applyFirebaseUserBinding(userId, true, properties)
+export function bindUserId(
+  userId: string,
+  properties: Record<string, TelemetryValue> = {},
+  attribution: TelemetryContext | null = null
+): void {
+  applyFirebaseUserBinding(userId, true, properties, attribution)
+}
+
+/**
+ * Quarantine writes while an authoritative Firebase reporter is pending.
+ * Deliberately does not emit `is_authenticated: false`, rotate the anonymous
+ * identity, or clear the current Firebase binding. Held writes are replayed
+ * when the same user is confirmed and discarded on any other resolution.
+ */
+export function applyFirebasePendingConsensus(): void {
+  firebaseConsensusPending = true
+}
+
+/**
+ * End the pending quarantine without resolving consensus, keeping the bound
+ * identity. Used when a reporter exceeds its resolution deadline (and on
+ * shutdown): an unresolved document is no evidence of sign-out, and the held
+ * writes fired while the current user was bound, so they replay under it.
+ */
+export function releaseFirebasePendingConsensus(): void {
+  firebaseConsensusPending = false
+  flushQuarantinedWrites()
+  tryFlushDeferred()
 }
 
 /**
  * Detach from F and adopt the fresh D that was durably reserved before bind.
+ * Quarantined writes are discarded — an anonymous or conflicted resolution
+ * leaves their attribution ambiguous.
  */
 export function applyFirebaseAnonymousConsensus(): void {
+  firebaseConsensusPending = false
+  quarantinedWrites = []
   pendingUserBinding = null
   if (!boundUserId) return
   // Wiping these while unbound would permanently lose burned-guard $set_once markers.
@@ -987,6 +1113,9 @@ function capturePersonProperties(
 export function capture(event: string, properties: TelemetryContext = {}): boolean {
   if (!canEmit() || !distinctId) return false
   if (!isAllowedToFire(event)) return false
+  if (firebaseWritesQuarantined()) {
+    return queueQuarantinedWrite({ kind: 'event', event, properties })
+  }
   if (!_checkRateLimit(event)) return false
   try {
     // Per-call properties override defaults on key collision - callers
@@ -1047,7 +1176,7 @@ export function captureFirstLaunch(properties: TelemetryContext = {}): void {
  */
 export function registerPersonProperties(properties: Record<string, TelemetryValue>): void {
   if (!canEmit() || consentState === 'denied') return
-  if (consentState !== 'granted' || !distinctId || !boundUserId) {
+  if (consentState !== 'granted' || !distinctId || !boundUserId || firebaseWritesQuarantined()) {
     pendingPersonSet = { ...(pendingPersonSet || {}), ...properties }
     return
   }
@@ -1067,7 +1196,7 @@ export function registerPersonProperties(properties: Record<string, TelemetryVal
  */
 export function registerPersonPropertiesOnce(properties: Record<string, TelemetryValue>): void {
   if (!canEmit() || consentState === 'denied') return
-  if (consentState !== 'granted' || !distinctId || !boundUserId) {
+  if (consentState !== 'granted' || !distinctId || !boundUserId || firebaseWritesQuarantined()) {
     pendingPersonSetOnce = { ...properties, ...(pendingPersonSetOnce || {}) }
     return
   }
@@ -1118,6 +1247,9 @@ export function captureException(error: unknown, properties: TelemetryContext = 
   if (!canEmit() || !distinctId) return false
   // Exceptions are reliability data; suppress them outside `'granted'`.
   if (consentState !== 'granted') return false
+  if (firebaseWritesQuarantined()) {
+    return queueQuarantinedWrite({ kind: 'exception', error, properties })
+  }
   if (!_checkRateLimit('comfy.desktop.exception.error')) return false
   try {
     // Same default merge as capture() so exception events stay filterable by
@@ -1372,6 +1504,9 @@ export async function shutdown(reason: string): Promise<void> {
   if (!client) return
   const uptimeMs = Date.now() - bootstrapTimeMs
   try {
+    // A quit mid-navigation must not strand quarantined writes (or the
+    // session-ended capture below) — the pending document will never resolve.
+    if (firebaseConsensusPending) releaseFirebasePendingConsensus()
     capture('comfy.desktop.session.ended', {
       reason,
       uptime_ms: uptimeMs,

--- a/src/main/lib/telemetry.ts
+++ b/src/main/lib/telemetry.ts
@@ -196,7 +196,7 @@ export function _resetForTest(): void {
   pendingIdentityMergeFlush = null
   pendingIdentityMergeFileDirty = true
   queuedPendingIdentityMergeIds.clear()
-  identityShutdownDrain = null
+  pendingLoginAttribution = null
 }
 
 /** @internal - exposed for tests. */
@@ -619,12 +619,36 @@ interface PendingUserBinding {
   userId: string
   emitLoginEvent: boolean
   properties: Record<string, TelemetryValue>
-  attribution: TelemetryContext | null
 }
 
 let pendingUserBinding: PendingUserBinding | null = null
 
 const FIREBASE_LOGIN_ATTRIBUTION_EVENT = 'comfy.desktop.identity.login_attributed'
+
+/**
+ * One-shot login-attribution payload for a Desktop-verified sign-in. Held
+ * here rather than riding the consensus layer's per-view state so view
+ * destruction or a cross-origin navigation cannot drop it. Emitted once
+ * consensus confirms `userId`, discarded when consensus resolves to anyone
+ * else or to anonymous, and drained at shutdown when the quit outruns the
+ * confirming re-report.
+ */
+let pendingLoginAttribution: { userId: string; context: TelemetryContext } | null = null
+
+export function stageLoginAttribution(userId: string, context: TelemetryContext): void {
+  // A 'denied' choice never defers a login conversion for later.
+  if (consentState === 'denied') return
+  pendingLoginAttribution = { userId, context }
+}
+
+/** A confirmation for any user settles the staged attribution: emitted for
+ *  the same UID, discarded as contradicted for any other. */
+function emitStagedLoginAttribution(confirmedUserId: string): void {
+  if (!pendingLoginAttribution) return
+  const { userId, context } = pendingLoginAttribution
+  pendingLoginAttribution = null
+  if (userId === confirmedUserId) capture(FIREBASE_LOGIN_ATTRIBUTION_EVENT, context)
+}
 
 interface QuarantinedWrite {
   kind: 'event' | 'exception'
@@ -701,6 +725,7 @@ function discardDeferredTelemetry(): void {
   pendingPersonSet = null
   pendingPersonSetOnce = null
   pendingUserBinding = null
+  pendingLoginAttribution = null
   quarantinedWrites = []
 }
 
@@ -809,9 +834,9 @@ function tryFlushDeferred(): void {
   // before the first bind ever lands (queued under undecided consent), and
   // the deferred UID must not identify until that pending window resolves.
   if (pendingUserBinding && !firebaseConsensusPending) {
-    const { userId, emitLoginEvent, properties, attribution } = pendingUserBinding
+    const { userId, emitLoginEvent, properties } = pendingUserBinding
     pendingUserBinding = null
-    applyFirebaseUserBinding(userId, emitLoginEvent, properties, attribution)
+    applyFirebaseUserBinding(userId, emitLoginEvent, properties)
   }
   void flushPendingIdentityMerges()
 }
@@ -862,34 +887,56 @@ function persistablePersonProperties(properties: TelemetryContext): PendingIdent
 function queuePendingUserBinding(
   userId: string,
   emitLoginEvent: boolean,
-  properties: Record<string, TelemetryValue>,
-  attribution: TelemetryContext | null
+  properties: Record<string, TelemetryValue>
 ): void {
   const existing = pendingUserBinding?.userId === userId ? pendingUserBinding : null
   pendingUserBinding = {
     userId,
     emitLoginEvent: emitLoginEvent || existing?.emitLoginEvent === true,
-    properties: { ...(existing?.properties ?? {}), ...properties },
-    attribution: attribution ?? existing?.attribution ?? null
+    properties: { ...(existing?.properties ?? {}), ...properties }
   }
+}
+
+/**
+ * The single exit from the write quarantine: the flag never goes false while
+ * the buffer still holds writes. Held writes belong to the user who was bound
+ * while they fired, so only a same-user confirmation (or a release that keeps
+ * the binding) replays them; any other resolution leaves their attribution
+ * ambiguous and discards.
+ */
+function endFirebaseWriteQuarantine(disposition: 'replay' | 'discard'): void {
+  firebaseConsensusPending = false
+  if (disposition === 'replay') flushQuarantinedWrites()
+  else quarantinedWrites = []
+}
+
+/**
+ * Apply deferred person updates to the still-bound person before a detach,
+ * then wipe the buffers. They were collected for that account: never carry
+ * them into another Firebase person, but under granted consent they were
+ * merely deferred (e.g. by the write quarantine) and wiping them unapplied
+ * would permanently lose burned-guard $set_once markers.
+ */
+function settlePendingPersonBuffersForDetach(): void {
+  if (canEmit() && consentState === 'granted' && (pendingPersonSet || pendingPersonSetOnce)) {
+    capturePersonProperties(pendingPersonSet, pendingPersonSetOnce)
+  }
+  pendingPersonSet = null
+  pendingPersonSetOnce = null
 }
 
 function applyFirebaseUserBinding(
   userId: string,
   emitLoginEvent: boolean,
-  properties: Record<string, TelemetryValue> = {},
-  attribution: TelemetryContext | null = null
+  properties: Record<string, TelemetryValue> = {}
 ): void {
   // Resolved consensus always ends the pending quarantine, even when this
   // binding cannot proceed (denied consent, unusable UID) — otherwise
   // bound-user telemetry stays dropped until an unrelated consensus replay.
-  firebaseConsensusPending = false
   const normalizedUserId = normalizePostHogUserId(userId)
-  // Writes quarantined during the pending window belong to the user who was
-  // bound while they fired; any other resolution leaves their attribution
-  // ambiguous, so only a same-user confirmation replays them.
-  if (normalizedUserId !== null && normalizedUserId === boundUserId) flushQuarantinedWrites()
-  else quarantinedWrites = []
+  endFirebaseWriteQuarantine(
+    normalizedUserId !== null && normalizedUserId === boundUserId ? 'replay' : 'discard'
+  )
   // Reject early rather than burn an anonymous rotation on an identify that
   // can never merge.
   if (!normalizedUserId) return
@@ -897,45 +944,33 @@ function applyFirebaseUserBinding(
     // The old binding must not survive a resolved account switch: once
     // consent returns, events would land on the previous user. Detach now
     // (silently — consent is denied) and let a later replay bind the new UID.
-    if (boundUserId && boundUserId !== normalizedUserId) applyFirebaseAnonymousConsensus()
+    if (boundUserId && boundUserId !== normalizedUserId) detachFromBoundUser()
     return
   }
 
   if (!canEmit() || !anonymousDistinctId || !installationIdProperty) {
-    queuePendingUserBinding(normalizedUserId, emitLoginEvent, properties, attribution)
+    queuePendingUserBinding(normalizedUserId, emitLoginEvent, properties)
     return
   }
   if (boundUserId === normalizedUserId) {
     if (Object.keys(properties).length > 0) registerPersonProperties(properties)
     if (emitLoginEvent) capture('app:user_logged_in', { user_id: normalizedUserId })
-    if (attribution) capture(FIREBASE_LOGIN_ATTRIBUTION_EVENT, attribution)
+    emitStagedLoginAttribution(normalizedUserId)
     tryFlushDeferred()
     return
   }
-  if (boundUserId) {
-    // These buffers may contain updates collected for the current account
-    // while consent was not granted. Never carry them into another Firebase
-    // person; properties collected before the first login remain intact.
-    // Under granted consent they were merely deferred (e.g. by the write
-    // quarantine): apply them to the person they were collected for before
-    // detaching, or burned-guard $set_once markers are lost forever.
-    if (canEmit() && consentState === 'granted' && (pendingPersonSet || pendingPersonSetOnce)) {
-      capturePersonProperties(pendingPersonSet, pendingPersonSetOnce)
-    }
-    pendingPersonSet = null
-    pendingPersonSetOnce = null
-  }
+  if (boundUserId) settlePendingPersonBuffersForDetach()
   if (consentState !== 'granted') {
     if (boundUserId) {
-      applyFirebaseAnonymousConsensus()
+      detachFromBoundUser()
       if (!anonymousDistinctId) return
     }
-    queuePendingUserBinding(normalizedUserId, emitLoginEvent, properties, attribution)
+    queuePendingUserBinding(normalizedUserId, emitLoginEvent, properties)
     return
   }
 
   if (boundUserId) {
-    applyFirebaseAnonymousConsensus()
+    detachFromBoundUser()
     if (!anonymousDistinctId) return
   }
 
@@ -957,7 +992,7 @@ function applyFirebaseUserBinding(
     ...(personSetOnce ? { personSetOnce: persistablePersonProperties(personSetOnce) } : {})
   })
   if (!pendingMerge) {
-    queuePendingUserBinding(normalizedUserId, emitLoginEvent, properties, attribution)
+    queuePendingUserBinding(normalizedUserId, emitLoginEvent, properties)
     return
   }
   pendingIdentityMergeFileDirty = true
@@ -979,7 +1014,7 @@ function applyFirebaseUserBinding(
     anonymousDistinctId = reservedNextAnonymousId
     nextAnonymousDistinctId = null
     distinctId = reservedNextAnonymousId
-    queuePendingUserBinding(normalizedUserId, emitLoginEvent, properties, attribution)
+    queuePendingUserBinding(normalizedUserId, emitLoginEvent, properties)
     return
   }
   boundUserId = normalizedUserId
@@ -990,7 +1025,7 @@ function applyFirebaseUserBinding(
   if (emitLoginEvent) {
     capture('app:user_logged_in', { user_id: normalizedUserId })
   }
-  if (attribution) capture(FIREBASE_LOGIN_ATTRIBUTION_EVENT, attribution)
+  emitStagedLoginAttribution(normalizedUserId)
   tryFlushDeferred()
 }
 
@@ -1003,16 +1038,11 @@ export function applyFirebaseUserConsensus(userId: string): void {
  * Bind a main-process-verified interactive sign-in (OAuth loopback bridge or
  * desktop login code). The verified flow owns the login-success conversion;
  * declarative Cloud and scoped-local restored-session consensus stays silent.
- * `attribution`, when present, is the one-shot login-attribution payload
- * emitted alongside the conversion — never before the UID is confirmed, and
- * never for a UID that fails to bind.
+ * A login-attribution payload staged via `stageLoginAttribution` is emitted
+ * alongside the conversion — never before the UID is confirmed.
  */
-export function bindUserId(
-  userId: string,
-  properties: Record<string, TelemetryValue> = {},
-  attribution: TelemetryContext | null = null
-): void {
-  applyFirebaseUserBinding(userId, true, properties, attribution)
+export function bindUserId(userId: string, properties: Record<string, TelemetryValue> = {}): void {
+  applyFirebaseUserBinding(userId, true, properties)
 }
 
 /**
@@ -1032,29 +1062,24 @@ export function applyFirebasePendingConsensus(): void {
  * writes fired while the current user was bound, so they replay under it.
  */
 export function releaseFirebasePendingConsensus(): void {
-  firebaseConsensusPending = false
-  flushQuarantinedWrites()
+  endFirebaseWriteQuarantine('replay')
   tryFlushDeferred()
 }
 
 /**
  * Detach from F and adopt the fresh D that was durably reserved before bind.
- * Quarantined writes are discarded — an anonymous or conflicted resolution
- * leaves their attribution ambiguous.
+ * Shared by the anonymous consensus outcome and the detach-before-rebind
+ * step of an account switch — which is why it does not touch the staged
+ * login attribution: during a switch that payload may belong to the
+ * incoming user, and its fate is settled at their confirmation instead.
  */
-export function applyFirebaseAnonymousConsensus(): void {
-  firebaseConsensusPending = false
-  quarantinedWrites = []
+function detachFromBoundUser(): void {
+  endFirebaseWriteQuarantine('discard')
   pendingUserBinding = null
   if (!boundUserId) return
-  // Wiping these while unbound would permanently lose burned-guard $set_once markers.
-  // Bound with granted consent, deferred markers (e.g. quarantined during the
-  // pending window) belong to the user they fired under: apply before detach.
-  if (canEmit() && consentState === 'granted' && (pendingPersonSet || pendingPersonSetOnce)) {
-    capturePersonProperties(pendingPersonSet, pendingPersonSetOnce)
-  }
-  pendingPersonSet = null
-  pendingPersonSetOnce = null
+  // Wiping the person buffers while unbound would permanently lose
+  // burned-guard $set_once markers; bound, they settle to the old person.
+  settlePendingPersonBuffersForDetach()
   if (canEmit() && consentState === 'granted') {
     capturePersonProperties({ is_authenticated: false }, null)
   }
@@ -1068,6 +1093,16 @@ export function applyFirebaseAnonymousConsensus(): void {
   }
   anonymousDistinctId = safeAnonymousId
   distinctId = safeAnonymousId
+}
+
+/**
+ * Detach from F as a resolved consensus outcome. Quarantined writes and any
+ * staged login attribution are discarded — an anonymous or conflicted
+ * resolution leaves their attribution ambiguous.
+ */
+export function applyFirebaseAnonymousConsensus(): void {
+  pendingLoginAttribution = null
+  detachFromBoundUser()
 }
 
 /**
@@ -1605,18 +1640,6 @@ export function emit(event: string, context: TelemetryContext = {}): void {
 }
 
 /**
- * One-shot payloads the identity-consensus layer is still holding for a
- * document re-report that will now never arrive. Registered lazily by
- * `firebaseAuthIdentity` to avoid an import cycle; each returned context is
- * captured as a login-attribution event during shutdown.
- */
-let identityShutdownDrain: (() => TelemetryContext[]) | null = null
-
-export function registerIdentityShutdownDrain(drain: () => TelemetryContext[]): void {
-  identityShutdownDrain = drain
-}
-
-/**
  * Drain queued events. Safe to await during `app.before-quit`.
  */
 export async function shutdown(reason: string): Promise<void> {
@@ -1628,8 +1651,9 @@ export async function shutdown(reason: string): Promise<void> {
     if (firebaseConsensusPending) releaseFirebasePendingConsensus()
     // A successful sign-in whose confirming re-report is outrun by the quit
     // still deserves its attribution; no contrary resolution was observed.
-    for (const attribution of identityShutdownDrain?.() ?? []) {
-      capture(FIREBASE_LOGIN_ATTRIBUTION_EVENT, attribution)
+    if (pendingLoginAttribution) {
+      capture(FIREBASE_LOGIN_ATTRIBUTION_EVENT, pendingLoginAttribution.context)
+      pendingLoginAttribution = null
     }
     capture('comfy.desktop.session.ended', {
       reason,

--- a/src/main/lib/verifiedLocalFirebaseAuth.ts
+++ b/src/main/lib/verifiedLocalFirebaseAuth.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import { isLoopbackHostname } from '../auth/desktopLoginCode/origins'
 import { configDir } from './paths'
-import { isIllegalPostHogDistinctId, normalizeOpaqueIdentifier } from './opaqueIdentifier'
+import { normalizePostHogUserId } from './opaqueIdentifier'
 import { writeFileSafe } from './safe-file'
 
 const VERIFIED_LOCAL_FIREBASE_AUTH_FILE = 'verified-local-firebase-auth.json'
@@ -29,11 +29,6 @@ function normalizeLoopbackOrigin(value: unknown): string | null {
   }
 }
 
-function normalizeUserId(value: unknown): string | null {
-  const normalized = normalizeOpaqueIdentifier(value, 256)
-  return normalized && !isIllegalPostHogDistinctId(normalized) ? normalized : null
-}
-
 function readBindings(): Record<string, string> {
   try {
     const parsed: unknown = JSON.parse(fs.readFileSync(verifiedLocalFirebaseAuthPath(), 'utf-8'))
@@ -43,7 +38,7 @@ function readBindings(): Record<string, string> {
       -MAX_VERIFIED_LOCAL_ORIGINS
     )) {
       const origin = normalizeLoopbackOrigin(rawOrigin)
-      const userId = normalizeUserId(rawUserId)
+      const userId = normalizePostHogUserId(rawUserId)
       if (origin && userId) bindings[origin] = userId
     }
     return bindings
@@ -72,7 +67,7 @@ export function readVerifiedLocalFirebaseUser(origin: string): string | null {
 
 export function persistVerifiedLocalFirebaseUser(origin: string, userId: string): boolean {
   const normalizedOrigin = normalizeLoopbackOrigin(origin)
-  const normalizedUserId = normalizeUserId(userId)
+  const normalizedUserId = normalizePostHogUserId(userId)
   if (!normalizedOrigin || !normalizedUserId) return false
   const entries = Object.entries(readBindings()).filter(
     ([candidate]) => candidate !== normalizedOrigin


### PR DESCRIPTION
[GTM-393](https://linear.app/comfyorg/issue/GTM-393/prevent-duplicate-desktop-identify-during-post-login-cloud-navigation)

Desktop previously bound the Firebase UID immediately after session injection. The expected Cloud reload then made auth consensus temporarily pending, which was treated as signed out and caused an anonymous-ID rotation plus a second identify when the final document reported the same UID.

Fixed at the consensus layer, with no staging machinery:

**Pending is a real third state.** While any trusted reporter is pending, telemetry keeps the current binding and quarantines writes into a bounded buffer instead of logging out. Held writes replay when the same user is confirmed and are discarded on any other resolution, so navigations no longer drop events (`sign_in_failed`, exceptions, `session.ended`) or manufacture logout/login pairs.
- A window that never resolves releases the quarantine after 60s while keeping the bound identity: an unresolved reporter is no evidence of sign-out; a real logout still arrives as a `signed_out` report. A released episode does not re-quarantine until consensus resolves.
- An account switch that resolves while consent is denied detaches the old binding, so re-granted consent cannot attribute events to the previous user.
- `shutdown()` releases an active quarantine so `session.ended` and held writes survive a mid-navigation quit.
- Identity side effects apply only to reports attributed to an accepted frame; late IPC from replaced documents is inert.

**Sign-in flows bind once, after injection succeeds**, extending the loopback branch's existing contract to trusted Cloud views: the bind marks the view's current report stale (pending) unless it already affirms the same UID, and any document that re-reports the user — including the surviving pre-reload document after a failed reload — confirms it. The consensus layer identifies exactly once with the sign-in properties.

`login_attributed` rides the bind as a one-shot attribution payload, emitted only when its UID is confirmed and discarded when consensus resolves signed out.

Also: the UID-validation gate is shared as `normalizePostHogUserId` across the four call sites, and `flushPendingIdentityMerges` skips its synchronous file read once the merge file is known empty.

Validation:
- pnpm test — 3,691 passed, 1 skipped
- pnpm typecheck
- pnpm lint
- pnpm format:check
