### PR TITLE
fix: resolve Firebase auth consensus per committed frame

### DIFF
--- a/src/main/lib/firebaseAuthIdentity.test.ts
+++ b/src/main/lib/firebaseAuthIdentity.test.ts
@@ -1,12 +1,17 @@
 import { EventEmitter } from 'node:events'
 import type { WebContents } from 'electron'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const telemetry = vi.hoisted(() => ({
   applyFirebaseAnonymousConsensus: vi.fn(),
+  applyFirebasePendingConsensus: vi.fn(),
   applyFirebaseUserConsensus: vi.fn(),
   bindUserId: vi.fn(),
+  capture: vi.fn(),
+  isFirebaseConsensusPending: vi.fn(() => true),
   registerPersonProperties: vi.fn(),
+  releaseFirebasePendingConsensus: vi.fn(),
+  stageLoginAttribution: vi.fn(),
   discardUnmergeableAnonymousEpoch: vi.fn(() => true),
   hasUnmergeableAnonymousEpoch: vi.fn(() => false),
   markAnonymousEpochUnmergeable: vi.fn(() => true)
@@ -42,6 +47,7 @@ import {
   activateFirebaseAuthReporter,
   bindMainVerifiedFirebaseUser,
   deactivateFirebaseAuthReporter,
+  PENDING_CONSENSUS_DEADLINE_MS,
   reportFirebaseAuthState as recordFirebaseAuthState,
   trackFirebaseAuthReporter
 } from './firebaseAuthIdentity'
@@ -188,6 +194,7 @@ describe('firebaseAuthIdentity consensus', () => {
     vi.clearAllMocks()
     telemetry.discardUnmergeableAnonymousEpoch.mockReturnValue(true)
     telemetry.hasUnmergeableAnonymousEpoch.mockReturnValue(false)
+    telemetry.isFirebaseConsensusPending.mockReturnValue(true)
     telemetry.markAnonymousEpochUnmergeable.mockReturnValue(true)
     verifiedLocalUsers.clear()
     verifiedLocalPersistence.succeeds = true
@@ -229,8 +236,311 @@ describe('firebaseAuthIdentity consensus', () => {
     reporter.navigate(cloudUrl)
     reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
 
-    expect(telemetry.bindUserId).toHaveBeenCalledWith('F', {
-      signed_in_via: 'desktop_2'
+    expect(telemetry.bindUserId).toHaveBeenCalledWith('F', { signed_in_via: 'desktop_2' })
+  })
+
+  it('holds a Cloud bind through the reload and identifies once a document re-reports the user', () => {
+    const reporter = new FakeWebContents(cloudUrl)
+    activate(reporter)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_out' })
+    vi.clearAllMocks()
+
+    bindMainVerifiedFirebaseUser('F', { signed_in_via: 'desktop_2' }, reporter.asWebContents(), {
+      via: 'desktop_login_code'
+    })
+
+    // The attribution is staged with telemetry at bind time; the stale
+    // pre-login report is superseded, not trusted: no identify yet.
+    expect(telemetry.stageLoginAttribution).toHaveBeenCalledWith('F', {
+      via: 'desktop_login_code'
+    })
+    expect(telemetry.bindUserId).not.toHaveBeenCalled()
+
+    reporter.navigate('https://cloud.comfy.org/workspaces/final')
+    expect(telemetry.applyFirebaseAnonymousConsensus).not.toHaveBeenCalled()
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'pending' })
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+
+    expect(telemetry.bindUserId).toHaveBeenCalledTimes(1)
+    expect(telemetry.bindUserId).toHaveBeenCalledWith('F', { signed_in_via: 'desktop_2' })
+    expect(telemetry.applyFirebaseAnonymousConsensus).not.toHaveBeenCalled()
+  })
+
+  it('confirms a Cloud bind from the current document when cross-tab sync reports first', () => {
+    const reporter = new FakeWebContents(cloudUrl)
+    activate(reporter)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_out' })
+    vi.clearAllMocks()
+
+    bindMainVerifiedFirebaseUser('F', { signed_in_via: 'desktop_2' }, reporter.asWebContents())
+    // The injected session reaches the pre-reload document via Firebase's
+    // cross-tab sync; its report affirms the UID Desktop itself verified.
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+    expect(telemetry.bindUserId).toHaveBeenCalledTimes(1)
+
+    // The reload still happens; the final document produces no second identify.
+    reporter.navigate('https://cloud.comfy.org/workspaces/final')
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+    expect(telemetry.bindUserId).toHaveBeenCalledTimes(1)
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('F')
+    expect(telemetry.applyFirebaseAnonymousConsensus).not.toHaveBeenCalled()
+  })
+
+  it('switches cleanly when the reloaded document reports a different user', () => {
+    const reporter = new FakeWebContents(cloudUrl)
+    activate(reporter)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_out' })
+
+    bindMainVerifiedFirebaseUser('F', { email: 'f@example.com' }, reporter.asWebContents())
+    reporter.navigate('https://cloud.comfy.org/workspaces/final')
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'pending' })
+    vi.clearAllMocks()
+
+    reportFirebaseAuthState(reporter.asWebContents(), {
+      status: 'signed_in',
+      userId: 'other'
+    })
+
+    // A fresher session in the document outranks Desktop's verification; a
+    // single resolved reporter is not a conflict, so the epoch stays clean.
+    expect(telemetry.bindUserId).not.toHaveBeenCalled()
+    expect(telemetry.markAnonymousEpochUnmergeable).not.toHaveBeenCalled()
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('other')
+  })
+
+  it('returns to anonymous consensus when the final document confirms sign-out', () => {
+    const reporter = new FakeWebContents(cloudUrl)
+    activate(reporter)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_out' })
+
+    bindMainVerifiedFirebaseUser('F', {}, reporter.asWebContents())
+    vi.clearAllMocks()
+    reporter.navigate('https://cloud.comfy.org/workspaces/final')
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_out' })
+
+    expect(telemetry.applyFirebaseAnonymousConsensus).toHaveBeenCalledTimes(1)
+    expect(telemetry.bindUserId).not.toHaveBeenCalled()
+  })
+
+  it('recovers when the post-injection reload fails and the surviving document re-reports', () => {
+    const reporter = new FakeWebContents(cloudUrl)
+    activate(reporter)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_out' })
+    vi.clearAllMocks()
+
+    bindMainVerifiedFirebaseUser('F', { signed_in_via: 'desktop_2' }, reporter.asWebContents())
+    const reloadUrl = 'https://cloud.comfy.org/workspaces/final'
+    reporter.startNavigation(reloadUrl)
+    reporter.failProvisionalNavigation(reloadUrl)
+    expect(telemetry.bindUserId).not.toHaveBeenCalled()
+
+    // The injected session is already in IndexedDB, so the surviving
+    // pre-reload document observes it and reports the new UID.
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+
+    expect(telemetry.bindUserId).toHaveBeenCalledTimes(1)
+    expect(telemetry.bindUserId).toHaveBeenCalledWith('F', { signed_in_via: 'desktop_2' })
+    expect(telemetry.applyFirebaseAnonymousConsensus).not.toHaveBeenCalled()
+  })
+
+  it('holds the bind when the reload outraces it and then fails provisionally', () => {
+    const reporter = new FakeWebContents(cloudUrl)
+    activate(reporter)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_out' })
+    vi.clearAllMocks()
+
+    // The injected script reloads the document before executeJavaScript
+    // resolves, so the navigation can start before the bind runs and snapshot
+    // the stale pre-login signed_out report as the recoverable state.
+    const reloadUrl = 'https://cloud.comfy.org/workspaces/final'
+    reporter.startNavigation(reloadUrl)
+    bindMainVerifiedFirebaseUser('F', { signed_in_via: 'desktop_2' }, reporter.asWebContents(), {
+      via: 'desktop_login_code'
+    })
+    reporter.failProvisionalNavigation(reloadUrl)
+
+    expect(telemetry.applyFirebaseAnonymousConsensus).not.toHaveBeenCalled()
+
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+
+    expect(telemetry.bindUserId).toHaveBeenCalledTimes(1)
+    expect(telemetry.bindUserId).toHaveBeenCalledWith('F', { signed_in_via: 'desktop_2' })
+    expect(telemetry.stageLoginAttribution).toHaveBeenCalledWith('F', {
+      via: 'desktop_login_code'
+    })
+  })
+
+  it('ignores identity side effects from a mismatched report on an unaccepted frame', () => {
+    const localUrl = 'http://127.0.0.1:8188/'
+    verifiedLocalUsers.set('http://127.0.0.1:8188', 'A')
+    const reporter = new FakeWebContents(localUrl)
+    activate(reporter)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'A' })
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('A')
+    vi.clearAllMocks()
+
+    reporter.startNavigation(localUrl)
+    // Late IPC from a replaced document: the frame matches no accepted slot.
+    recordFirebaseAuthState(
+      reporter.asWebContents(),
+      { processId: 999, routingId: 999 },
+      { status: 'signed_in', userId: 'B' }
+    )
+    expect(telemetry.applyFirebaseAnonymousConsensus).not.toHaveBeenCalled()
+
+    reporter.commitNavigation(localUrl)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'A' })
+    expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('A')
+    expect(telemetry.applyFirebaseAnonymousConsensus).not.toHaveBeenCalled()
+  })
+
+  it('detaches the bound user only when a mismatched local report is accepted', () => {
+    const localUrl = 'http://127.0.0.1:8188/'
+    verifiedLocalUsers.set('http://127.0.0.1:8188', 'A')
+    const reporter = new FakeWebContents(localUrl)
+    activate(reporter)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'A' })
+    vi.clearAllMocks()
+
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'B' })
+
+    expect(telemetry.applyFirebaseAnonymousConsensus).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores a conflicting report on an unaccepted frame and keeps the pending Cloud bind', () => {
+    const reporter = new FakeWebContents(cloudUrl)
+    activate(reporter)
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_out' })
+    bindMainVerifiedFirebaseUser('F', { signed_in_via: 'desktop_2' }, reporter.asWebContents())
+    vi.clearAllMocks()
+
+    recordFirebaseAuthState(
+      reporter.asWebContents(),
+      { processId: 999, routingId: 999 },
+      { status: 'signed_in', userId: 'other' }
+    )
+    expect(telemetry.applyFirebaseAnonymousConsensus).not.toHaveBeenCalled()
+    expect(telemetry.markAnonymousEpochUnmergeable).not.toHaveBeenCalled()
+
+    reporter.navigate('https://cloud.comfy.org/workspaces/final')
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'pending' })
+    reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+
+    expect(telemetry.bindUserId).toHaveBeenCalledTimes(1)
+    expect(telemetry.bindUserId).toHaveBeenCalledWith('F', { signed_in_via: 'desktop_2' })
+  })
+
+  describe('pending consensus deadline', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('releases the quarantine without detaching when a bound pending window never resolves', () => {
+      const reporter = new FakeWebContents(cloudUrl)
+      activate(reporter)
+      reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+      vi.clearAllMocks()
+
+      reporter.startNavigation(cloudUrl)
+      expect(telemetry.applyFirebasePendingConsensus).toHaveBeenCalled()
+
+      vi.advanceTimersByTime(PENDING_CONSENSUS_DEADLINE_MS - 1)
+      expect(telemetry.releaseFirebasePendingConsensus).not.toHaveBeenCalled()
+
+      vi.advanceTimersByTime(1)
+      // An unresolved reporter is no evidence of sign-out: the identity stays
+      // bound and only the write quarantine ends.
+      expect(telemetry.releaseFirebasePendingConsensus).toHaveBeenCalledTimes(1)
+      expect(telemetry.applyFirebaseAnonymousConsensus).not.toHaveBeenCalled()
+      expect(telemetry.capture).toHaveBeenCalledWith(
+        'comfy.desktop.identity.pending_consensus_expired'
+      )
+    })
+
+    it('does not re-quarantine an expired pending episode until consensus resolves', () => {
+      const reporter = new FakeWebContents(cloudUrl)
+      activate(reporter)
+      reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+      vi.clearAllMocks()
+
+      reporter.startNavigation(cloudUrl)
+      vi.advanceTimersByTime(PENDING_CONSENSUS_DEADLINE_MS)
+      expect(telemetry.releaseFirebasePendingConsensus).toHaveBeenCalledTimes(1)
+      vi.clearAllMocks()
+
+      // Still the same wedged episode: commit re-runs reconcile while pending.
+      reporter.commitNavigation(cloudUrl)
+      expect(telemetry.applyFirebasePendingConsensus).not.toHaveBeenCalled()
+
+      reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+      expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('F')
+
+      // A fresh navigation after resolution quarantines (and arms) again.
+      vi.clearAllMocks()
+      reporter.startNavigation(cloudUrl)
+      expect(telemetry.applyFirebasePendingConsensus).toHaveBeenCalled()
+    })
+
+    it('lets healthy reporters resolve consensus once a wedged reporter expires', () => {
+      const wedged = new FakeWebContents(cloudUrl)
+      const healthy = new FakeWebContents(cloudUrl)
+      activate(wedged)
+      activate(healthy)
+      reportFirebaseAuthState(wedged.asWebContents(), { status: 'signed_in', userId: 'F' })
+      reportFirebaseAuthState(healthy.asWebContents(), { status: 'signed_in', userId: 'F' })
+      vi.clearAllMocks()
+
+      wedged.startNavigation(cloudUrl)
+      vi.advanceTimersByTime(PENDING_CONSENSUS_DEADLINE_MS)
+      vi.clearAllMocks()
+
+      // The wedge no longer vetoes: a real logout and account switch in the
+      // healthy window detach and rebind instead of staying attributed to F.
+      reportFirebaseAuthState(healthy.asWebContents(), { status: 'signed_out' })
+      expect(telemetry.applyFirebaseAnonymousConsensus).toHaveBeenCalledTimes(1)
+
+      reportFirebaseAuthState(healthy.asWebContents(), { status: 'signed_in', userId: 'B' })
+      expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('B')
+    })
+
+    it('applies a sign-out masked by a wedged reporter at the deadline instead of releasing', () => {
+      const wedged = new FakeWebContents(cloudUrl)
+      const healthy = new FakeWebContents(cloudUrl)
+      activate(wedged)
+      activate(healthy)
+      reportFirebaseAuthState(wedged.asWebContents(), { status: 'signed_in', userId: 'F' })
+      reportFirebaseAuthState(healthy.asWebContents(), { status: 'signed_in', userId: 'F' })
+      vi.clearAllMocks()
+
+      wedged.startNavigation(cloudUrl)
+      reportFirebaseAuthState(healthy.asWebContents(), { status: 'signed_out' })
+      expect(telemetry.applyFirebaseAnonymousConsensus).not.toHaveBeenCalled()
+
+      // Resolving detaches and discards held writes; releasing would replay
+      // them under the user who already logged out.
+      telemetry.isFirebaseConsensusPending.mockReturnValue(false)
+      vi.advanceTimersByTime(PENDING_CONSENSUS_DEADLINE_MS)
+      expect(telemetry.applyFirebaseAnonymousConsensus).toHaveBeenCalledTimes(1)
+      expect(telemetry.releaseFirebasePendingConsensus).not.toHaveBeenCalled()
+    })
+
+    it('does not fire the deadline once consensus resolves in time', () => {
+      const reporter = new FakeWebContents(cloudUrl)
+      activate(reporter)
+      reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+      vi.clearAllMocks()
+
+      reporter.startNavigation(cloudUrl)
+      reporter.commitNavigation(cloudUrl)
+      reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
+
+      vi.advanceTimersByTime(PENDING_CONSENSUS_DEADLINE_MS * 2)
+      expect(telemetry.releaseFirebasePendingConsensus).not.toHaveBeenCalled()
+      expect(telemetry.applyFirebaseAnonymousConsensus).not.toHaveBeenCalled()
     })
   })
 
@@ -245,15 +555,14 @@ describe('firebaseAuthIdentity consensus', () => {
 
     reporter.navigate(localUrl)
     reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
-    expect(telemetry.bindUserId).toHaveBeenCalledWith('F', {
-      signed_in_via: 'desktop_2'
-    })
+    expect(telemetry.bindUserId).toHaveBeenCalledWith('F', { signed_in_via: 'desktop_2' })
 
     vi.clearAllMocks()
     reporter.navigate(localUrl)
     reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F' })
 
-    expect(telemetry.applyFirebaseAnonymousConsensus).toHaveBeenCalledTimes(1)
+    expect(telemetry.applyFirebasePendingConsensus).toHaveBeenCalled()
+    expect(telemetry.applyFirebaseAnonymousConsensus).not.toHaveBeenCalled()
     expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('F')
     expect(telemetry.markAnonymousEpochUnmergeable).not.toHaveBeenCalled()
   })
@@ -345,7 +654,8 @@ describe('firebaseAuthIdentity consensus', () => {
     vi.clearAllMocks()
 
     reporter.startNavigation(remoteUrl)
-    expect(telemetry.applyFirebaseAnonymousConsensus).toHaveBeenCalledTimes(1)
+    expect(telemetry.applyFirebasePendingConsensus).toHaveBeenCalled()
+    expect(telemetry.applyFirebaseAnonymousConsensus).not.toHaveBeenCalled()
     reporter.commitNavigation(remoteUrl)
     expect(telemetry.applyFirebaseUserConsensus).not.toHaveBeenCalled()
 
@@ -427,7 +737,7 @@ describe('firebaseAuthIdentity consensus', () => {
     expect(telemetry.markAnonymousEpochUnmergeable).toHaveBeenCalled()
   })
 
-  it('unbinds while any live reporter is pending without tainting the epoch', () => {
+  it('keeps the current identity while any live reporter is pending', () => {
     const first = new FakeWebContents(cloudUrl)
     const second = new FakeWebContents(cloudUrl)
     activate(first)
@@ -437,7 +747,8 @@ describe('firebaseAuthIdentity consensus', () => {
     vi.clearAllMocks()
 
     second.navigate('https://cloud.comfy.org/workspaces/other')
-    expect(telemetry.applyFirebaseAnonymousConsensus).toHaveBeenCalledTimes(1)
+    expect(telemetry.applyFirebasePendingConsensus).toHaveBeenCalled()
+    expect(telemetry.applyFirebaseAnonymousConsensus).not.toHaveBeenCalled()
 
     reportFirebaseAuthState(second.asWebContents(), { status: 'signed_in', userId: 'F' })
     expect(telemetry.applyFirebaseUserConsensus).toHaveBeenCalledWith('F')
@@ -451,7 +762,7 @@ describe('firebaseAuthIdentity consensus', () => {
     vi.clearAllMocks()
 
     reporter.startNavigation(cloudUrl)
-    expect(telemetry.applyFirebaseAnonymousConsensus).toHaveBeenCalledTimes(1)
+    expect(telemetry.applyFirebasePendingConsensus).toHaveBeenCalledTimes(1)
 
     reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F1' })
     reportFirebaseAuthState(reporter.asWebContents(), { status: 'signed_in', userId: 'F2' })
@@ -473,7 +784,7 @@ describe('firebaseAuthIdentity consensus', () => {
     vi.clearAllMocks()
 
     first.startNavigation('https://attacker.example/')
-    expect(telemetry.applyFirebaseAnonymousConsensus).toHaveBeenCalledTimes(1)
+    expect(telemetry.applyFirebasePendingConsensus).toHaveBeenCalledTimes(1)
     vi.clearAllMocks()
 
     reportFirebaseAuthState(second.asWebContents(), { status: 'signed_in', userId: 'F2' })

--- a/src/main/lib/firebaseAuthIdentity.ts
+++ b/src/main/lib/firebaseAuthIdentity.ts
@@ -1,7 +1,7 @@
 import type { WebContents } from 'electron'
 import type { ComfyDesktop2FirebaseAuthState } from '../../types/comfyDesktopBridge'
 import * as mainTelemetry from './telemetry'
-import { isIllegalPostHogDistinctId, normalizeOpaqueIdentifier } from './opaqueIdentifier'
+import { normalizePostHogUserId } from './opaqueIdentifier'
 import { isTrustedCloudUrl } from './trustedCloudUrl'
 import {
   clearVerifiedLocalFirebaseUser,
@@ -13,6 +13,9 @@ import {
 interface Reporter {
   eligible: boolean
   active: boolean
+  /** Stayed pending past the consensus deadline: excluded from consensus
+   *  (no veto, no quarantine) until it produces a resolved contribution. */
+  pendingExpired: boolean
   localReportingAuthorized: boolean
   localExpectedUserId: string | null
   awaitingCommittedFrame: boolean
@@ -81,6 +84,9 @@ let requestedUserId: string | null = null
 let anonymousEpochIsUnmergeable = false
 let persistedEpochStateLoaded = false
 let epochTaintIsDurable = true
+/** A document that never resolves auth must not quarantine telemetry forever. */
+export const PENDING_CONSENSUS_DEADLINE_MS = 60_000
+let pendingConsensusDeadline: ReturnType<typeof setTimeout> | null = null
 
 function originOf(url: string): string | null {
   try {
@@ -140,10 +146,77 @@ function failureTerminalKey(
   return `${errorCode}\u0000${validatedURL}\u0000${frameProcessId}\u0000${frameRoutingId}`
 }
 
-function requestAnonymousIdentity(): void {
-  if (requestedUserId === null) return
+function clearPendingConsensusDeadline(): void {
+  if (pendingConsensusDeadline === null) return
+  clearTimeout(pendingConsensusDeadline)
+  pendingConsensusDeadline = null
+}
+
+/** Flag every contributor whose pending state has outlived the deadline. */
+function markExpiredPendingContributors(): void {
+  for (const [webContents, reporter] of reporters) {
+    if (webContents.isDestroyed()) continue
+    const navigationPending =
+      reporter.awaitingCommittedFrame || reporter.mainFrameNavigationsInFlight > 0
+    const contributesPending = reporter.active
+      ? reporter.state.status === 'pending'
+      : navigationPending && mainVerifiedStates.has(webContents)
+    if (contributesPending) reporter.pendingExpired = true
+  }
+}
+
+/** Unconditionally hand consensus back to the anonymous identity. */
+function detachToAnonymousIdentity(): void {
+  clearPendingConsensusDeadline()
   requestedUserId = null
   mainTelemetry.applyFirebaseAnonymousConsensus()
+}
+
+function requestAnonymousIdentity(): void {
+  if (requestedUserId === null) return
+  detachToAnonymousIdentity()
+}
+
+function requestPendingIdentity(): void {
+  // Before the first agreed UID there is no authenticated identity to
+  // quarantine; anonymous events should keep flowing into the eventual merge.
+  if (requestedUserId === null) return
+  mainTelemetry.applyFirebasePendingConsensus()
+  if (pendingConsensusDeadline === null) {
+    pendingConsensusDeadline = setTimeout(() => {
+      pendingConsensusDeadline = null
+      // Contributors still pending after the full deadline are wedged: stop
+      // letting them veto consensus so healthy reporters can resolve it (a
+      // masked logout or account switch applies right here), and do not
+      // re-quarantine for them until they produce a real report.
+      markExpiredPendingContributors()
+      reconcile()
+      if (pendingConsensusDeadline === null && mainTelemetry.isFirebaseConsensusPending()) {
+        // Nothing left can resolve consensus: an unresolved reporter is no
+        // evidence of sign-out, so release the quarantine and keep the bound
+        // identity. A real report still resolves through reconcile as usual.
+        mainTelemetry.releaseFirebasePendingConsensus()
+        mainTelemetry.capture('comfy.desktop.identity.pending_consensus_expired')
+      }
+    }, PENDING_CONSENSUS_DEADLINE_MS)
+    pendingConsensusDeadline.unref()
+  }
+}
+
+function requestConflictedIdentity(): void {
+  const wasAlreadyTainted = anonymousEpochIsUnmergeable
+  detachToAnonymousIdentity()
+  anonymousEpochIsUnmergeable = true
+  if (!wasAlreadyTainted || !epochTaintIsDurable) {
+    epochTaintIsDurable = mainTelemetry.markAnonymousEpochUnmergeable()
+    if (!epochTaintIsDurable && !wasAlreadyTainted) {
+      // The taint marker could not persist, so a restart would resurrect
+      // the conflicted anonymous ID untainted. Durably replace the epoch
+      // instead; attempted once per conflict episode to avoid rotation
+      // churn while the views still disagree.
+      epochTaintIsDurable = mainTelemetry.discardUnmergeableAnonymousEpoch()
+    }
+  }
 }
 
 function clearUnmergeableEpoch(): boolean {
@@ -168,20 +241,38 @@ function loadPersistedEpochState(): void {
 /**
  * Bind a user verified by Desktop's auth flow while keeping the declarative
  * renderer consensus authoritative once hosted views begin reporting.
+ *
+ * Called after the session was installed in the view. The injected session
+ * always reloads hosted Cloud views, so the view's current report predates
+ * this sign-in: the bind marks it stale (pending) and the identify fires,
+ * with `properties`, once a document re-reports this user — the same
+ * contract the loopback branch has always used. A view already affirming
+ * this exact UID confirms immediately. The one-shot `attribution` payload is
+ * staged with telemetry, which owns its lifecycle: emitted when this UID is
+ * confirmed, discarded on any other resolution, drained at shutdown.
  */
 export function bindMainVerifiedFirebaseUser(
   userId: string,
   properties: Record<string, mainTelemetry.TelemetryValue> = {},
-  source: WebContents
+  source: WebContents,
+  attribution: mainTelemetry.TelemetryContext | null = null
 ): void {
-  const normalizedUserId = normalizeOpaqueIdentifier(userId, 256)
-  if (!normalizedUserId || isIllegalPostHogDistinctId(normalizedUserId)) return
+  const normalizedUserId = normalizePostHogUserId(userId)
+  if (!normalizedUserId) return
+  if (attribution) mainTelemetry.stageLoginAttribution(normalizedUserId, attribution)
   loadPersistedEpochState()
   const origin = originOf(source.getURL())
   if (!origin) return
   trackFirebaseAuthReporter(source)
   const reporter = reporters.get(source)
   if (!reporter?.eligible) return
+  // Retained navigation snapshots predate this bind too: restoring one after
+  // a failed reload would resurrect a stale signed_out and discard the bind.
+  const staleSnapshotUnlessAffirming = (snapshot: ReporterFrameState | null): void => {
+    if (!snapshot) return
+    if (snapshot.state.status === 'signed_in' && snapshot.state.userId === normalizedUserId) return
+    snapshot.state = { status: 'pending' }
+  }
   if (isLoopbackOrigin(origin)) {
     if (!persistVerifiedLocalFirebaseUser(origin, normalizedUserId)) {
       return
@@ -190,6 +281,14 @@ export function bindMainVerifiedFirebaseUser(
     reporter.localExpectedUserId = normalizedUserId
     reporter.active = true
     reporter.state = { status: 'pending' }
+    staleSnapshotUnlessAffirming(reporter.recoverableState)
+    staleSnapshotUnlessAffirming(reporter.committedCandidate)
+  } else if (isTrustedCloudUrl(source.getURL())) {
+    if (reporter.state.status !== 'signed_in' || reporter.state.userId !== normalizedUserId) {
+      reporter.state = { status: 'pending' }
+    }
+    staleSnapshotUnlessAffirming(reporter.recoverableState)
+    staleSnapshotUnlessAffirming(reporter.committedCandidate)
   }
   mainVerifiedStates.set(source, {
     userId: normalizedUserId,
@@ -202,9 +301,18 @@ export function bindMainVerifiedFirebaseUser(
 }
 
 function reconcile(): void {
-  const activeReporterStates = [...reporters.entries()]
-    .filter(([webContents, reporter]) => !webContents.isDestroyed() && reporter.active)
-    .map(([webContents, reporter]) => ({ webContents, state: reporter.state }))
+  let expiredPendingContributors = 0
+  const activeReporterStates: ComfyDesktop2FirebaseAuthState[] = []
+  for (const [webContents, reporter] of reporters) {
+    if (webContents.isDestroyed() || !reporter.active) continue
+    if (reporter.state.status !== 'pending') {
+      reporter.pendingExpired = false
+    } else if (reporter.pendingExpired) {
+      expiredPendingContributors += 1
+      continue
+    }
+    activeReporterStates.push(reporter.state)
+  }
   const mainCandidates: Array<{
     webContents: WebContents
     state: MainVerifiedAuthState
@@ -227,24 +335,37 @@ function reconcile(): void {
     }
     const navigationPending =
       reporter?.awaitingCommittedFrame || (reporter?.mainFrameNavigationsInFlight ?? 0) > 0
+    if (reporter && !reporter.active && reporter.pendingExpired && !navigationPending) {
+      reporter.pendingExpired = false
+    }
+    const expiredNavigation = navigationPending === true && reporter?.pendingExpired === true
+    if (expiredNavigation) expiredPendingContributors += 1
     mainCandidates.push({
       webContents,
       state,
-      contributes: !reporter?.active,
+      contributes: !reporter?.active && !expiredNavigation,
       contributionState: navigationPending
         ? { status: 'pending' }
         : (state.reportedState ?? { status: 'signed_in', userId: state.userId })
     })
   }
   const states: ComfyDesktop2FirebaseAuthState[] = [
-    ...activeReporterStates.map(({ state }) => state),
+    ...activeReporterStates,
     ...mainCandidates
       .filter(({ contributes }) => contributes)
       .map(({ contributionState }) => contributionState)
   ]
 
-  if (states.length === 0 || states.some((state) => state.status === 'pending')) {
+  if (states.length === 0) {
+    // Only expired wedges remain. An unresolved document is evidence of
+    // nothing: keep the current identity until a real report resolves it.
+    if (expiredPendingContributors > 0) return
     requestAnonymousIdentity()
+    return
+  }
+
+  if (states.some((state) => state.status === 'pending')) {
+    requestPendingIdentity()
     return
   }
 
@@ -254,7 +375,9 @@ function reconcile(): void {
   )
 
   if (signedIn.length === 0) {
-    requestAnonymousIdentity()
+    // A resolved all-signed-out state also clears any pending/deferred user
+    // binding even when this process has not bound a UID yet.
+    detachToAnonymousIdentity()
     clearUnmergeableEpoch()
     return
   }
@@ -262,26 +385,14 @@ function reconcile(): void {
   const userIds = new Set(signedIn.map((state) => state.userId))
   const hasConflict = signedIn.length !== states.length || userIds.size !== 1
   if (hasConflict) {
-    const wasAlreadyTainted = anonymousEpochIsUnmergeable
-    requestedUserId = null
-    mainTelemetry.applyFirebaseAnonymousConsensus()
-    anonymousEpochIsUnmergeable = true
-    if (!wasAlreadyTainted || !epochTaintIsDurable) {
-      epochTaintIsDurable = mainTelemetry.markAnonymousEpochUnmergeable()
-      if (!epochTaintIsDurable && !wasAlreadyTainted) {
-        // The taint marker could not persist, so a restart would resurrect
-        // the conflicted anonymous ID untainted. Durably replace the epoch
-        // instead; attempted once per conflict episode to avoid rotation
-        // churn while the views still disagree.
-        epochTaintIsDurable = mainTelemetry.discardUnmergeableAnonymousEpoch()
-      }
-    }
+    requestConflictedIdentity()
     return
   }
 
   const userId = signedIn[0]!.userId
   if (!clearUnmergeableEpoch()) return
 
+  clearPendingConsensusDeadline()
   requestedUserId = userId
   const confirmedMainStates = mainCandidates.filter(({ webContents, state, contributes }) => {
     if (state.userId !== userId) return false
@@ -365,6 +476,7 @@ export function trackFirebaseAuthReporter(webContents: WebContents): void {
   const reporter: Reporter = {
     eligible: false,
     active: false,
+    pendingExpired: false,
     localReportingAuthorized: false,
     localExpectedUserId: null,
     awaitingCommittedFrame: true,
@@ -498,6 +610,7 @@ export function activateFirebaseAuthReporter(webContents: WebContents): void {
   const reporter = reporters.get(webContents)
   if (!reporter) return
   reporter.eligible = true
+  reporter.pendingExpired = false
   reporter.awaitingCommittedFrame = true
   reporter.committedFrame = null
   reporter.recoverableState = null
@@ -546,6 +659,7 @@ export function reportFirebaseAuthState(
     if (userMismatch || state.status === 'signed_out') {
       mainVerifiedState.rendererMayReaffirm = false
     }
+    if (userMismatch) requestAnonymousIdentity()
     reconcile()
     return
   }
@@ -554,8 +668,11 @@ export function reportFirebaseAuthState(
   const acceptedState: ComfyDesktop2FirebaseAuthState = localUserMismatch
     ? { status: 'pending' }
     : state
-  const candidate = reporter.committedCandidate
-  if (candidate && isSameFrame(candidate.frame, frame)) {
+  // Identity consequences must wait for frame attribution below: late IPC
+  // from a replaced document matches no accepted slot and must not detach
+  // the bound user or revoke local authorization.
+  const acceptReport = (): void => {
+    if (localUserMismatch) requestAnonymousIdentity()
     revokeAcceptedLocalAuthorization(
       webContents,
       reporter,
@@ -563,6 +680,10 @@ export function reportFirebaseAuthState(
       acceptedState,
       localUserMismatch
     )
+  }
+  const candidate = reporter.committedCandidate
+  if (candidate && isSameFrame(candidate.frame, frame)) {
+    acceptReport()
     candidate.state = acceptedState
     return
   }
@@ -572,13 +693,7 @@ export function reportFirebaseAuthState(
     isSameFrame(recoverable.frame, frame) &&
     isSameFrame(recoverable.frame, currentMainFrame(webContents))
   ) {
-    revokeAcceptedLocalAuthorization(
-      webContents,
-      reporter,
-      currentOrigin,
-      acceptedState,
-      localUserMismatch
-    )
+    acceptReport()
     recoverable.state = acceptedState
     return
   }
@@ -588,13 +703,7 @@ export function reportFirebaseAuthState(
     !isSameFrame(reporter.committedFrame, frame)
   )
     return
-  revokeAcceptedLocalAuthorization(
-    webContents,
-    reporter,
-    currentOrigin,
-    acceptedState,
-    localUserMismatch
-  )
+  acceptReport()
   reporter.active = true
   reporter.state = acceptedState
   reconcile()
@@ -613,6 +722,7 @@ export function _resetForTest(): void {
   }
   reporters.clear()
   mainVerifiedStates.clear()
+  clearPendingConsensusDeadline()
   requestedUserId = null
   anonymousEpochIsUnmergeable = false
   persistedEpochStateLoaded = false

--- a/src/main/lib/verifiedLocalFirebaseAuth.ts
+++ b/src/main/lib/verifiedLocalFirebaseAuth.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import { isLoopbackHostname } from '../auth/desktopLoginCode/origins'
 import { configDir } from './paths'
-import { isIllegalPostHogDistinctId, normalizeOpaqueIdentifier } from './opaqueIdentifier'
+import { normalizePostHogUserId } from './opaqueIdentifier'
 import { writeFileSafe } from './safe-file'
 
 const VERIFIED_LOCAL_FIREBASE_AUTH_FILE = 'verified-local-firebase-auth.json'
@@ -29,11 +29,6 @@ function normalizeLoopbackOrigin(value: unknown): string | null {
   }
 }
 
-function normalizeUserId(value: unknown): string | null {
-  const normalized = normalizeOpaqueIdentifier(value, 256)
-  return normalized && !isIllegalPostHogDistinctId(normalized) ? normalized : null
-}
-
 function readBindings(): Record<string, string> {
   try {
     const parsed: unknown = JSON.parse(fs.readFileSync(verifiedLocalFirebaseAuthPath(), 'utf-8'))
@@ -43,7 +38,7 @@ function readBindings(): Record<string, string> {
       -MAX_VERIFIED_LOCAL_ORIGINS
     )) {
       const origin = normalizeLoopbackOrigin(rawOrigin)
-      const userId = normalizeUserId(rawUserId)
+      const userId = normalizePostHogUserId(rawUserId)
       if (origin && userId) bindings[origin] = userId
     }
     return bindings
@@ -72,7 +67,7 @@ export function readVerifiedLocalFirebaseUser(origin: string): string | null {
 
 export function persistVerifiedLocalFirebaseUser(origin: string, userId: string): boolean {
   const normalizedOrigin = normalizeLoopbackOrigin(origin)
-  const normalizedUserId = normalizeUserId(userId)
+  const normalizedUserId = normalizePostHogUserId(userId)
   if (!normalizedOrigin || !normalizedUserId) return false
   const entries = Object.entries(readBindings()).filter(
     ([candidate]) => candidate !== normalizedOrigin


### PR DESCRIPTION
[GTM-393](https://linear.app/comfyorg/issue/GTM-393/prevent-duplicate-desktop-identify-during-post-login-cloud-navigation)

2 of 3, split out of #1390 for review. Stack: #1399 → **#1400 (this)** → #1401. Merge #1399 first.

Activates the quarantine primitives from #1399: reporters must agree on a resolved user before any identify fires, which is what stops the duplicate identify after a cloud login.

**Consensus resolves per committed frame.** Identity side effects apply only to reports attributed to an accepted frame, so late IPC from a replaced document is inert — it cannot detach the bound user or revoke local authorization. Retained navigation snapshots are marked stale unless they affirm the same UID, so a failed reload cannot resurrect a stale `signed_out` over a main-verified sign-in.

**A wedged reporter cannot quarantine telemetry forever.** A document still pending after 60s stops vetoing consensus so healthy reporters can resolve it (a masked logout or account switch applies right there), and it does not re-quarantine until it produces a real report. If nothing can resolve consensus, the quarantine is released keeping the bound identity: an unresolved reporter is no evidence of sign-out, and a real logout still arrives as a `signed_out` report.

**Sign-in flows bind once, after injection succeeds**, extending the loopback branch's existing contract to trusted Cloud views: the bind marks the view's current report stale (pending) unless it already affirms the same UID, and any document that re-reports the user — including the surviving pre-reload document after a failed reload — confirms it. The consensus layer identifies exactly once with the sign-in properties.

Validation:
- pnpm test — 3,889 passed, 1 skipped
- pnpm typecheck
- pnpm lint
- pnpm format:check
