### PR TITLE
fix: stage login attribution from the verified auth flows

### DIFF
--- a/src/main/auth/desktopLoginCode/index.test.ts
+++ b/src/main/auth/desktopLoginCode/index.test.ts
@@ -239,10 +239,13 @@ describe('signInViaDesktopLoginCode', () => {
     expect(h.signInWithCustomToken).toHaveBeenCalledWith(expect.any(String), 'custom-token-value', {
       signal: expect.any(AbortSignal)
     })
-    expect(h.bindSignedInUser).toHaveBeenCalledWith(persistedUser, contents)
-    expect(h.capture).toHaveBeenCalledWith('comfy.desktop.identity.login_attributed', {
+    // The bind carries the attribution and runs only after injection succeeds.
+    expect(h.bindSignedInUser).toHaveBeenCalledWith(persistedUser, contents, {
       via: 'desktop_login_code'
     })
+    expect(h.bindSignedInUser.mock.invocationCallOrder[0]).toBeGreaterThan(
+      contents.mainFrame.executeJavaScript.mock.invocationCallOrder[1]!
+    )
     expect(contents.mainFrame.executeJavaScript).toHaveBeenCalledWith(
       expect.stringContaining('location.reload()'),
       true
@@ -430,10 +433,6 @@ describe('signInViaDesktopLoginCode', () => {
       true
     )
     expect(h.bindSignedInUser).not.toHaveBeenCalled()
-    expect(h.capture).not.toHaveBeenCalledWith(
-      'comfy.desktop.identity.login_attributed',
-      expect.anything()
-    )
     expect(h.emit).toHaveBeenCalledWith(
       'comfy.desktop.auth.sign_in_failed',
       expect.objectContaining({ flow: 'desktop_login_code' })
@@ -458,10 +457,6 @@ describe('signInViaDesktopLoginCode', () => {
 
     expect(await promise).toBe('handled')
     expect(h.bindSignedInUser).not.toHaveBeenCalled()
-    expect(h.capture).not.toHaveBeenCalledWith(
-      'comfy.desktop.identity.login_attributed',
-      expect.anything()
-    )
     expect(h.emit).toHaveBeenCalledWith(
       'comfy.desktop.auth.sign_in_failed',
       expect.objectContaining({ flow: 'desktop_login_code' })
@@ -678,10 +673,6 @@ describe('signInViaDesktopLoginCode', () => {
     // bind/attribution, no inject, no focus steal...
     expect(h.lookupAccount).not.toHaveBeenCalled()
     expect(h.bindSignedInUser).not.toHaveBeenCalled()
-    expect(h.capture).not.toHaveBeenCalledWith(
-      'comfy.desktop.identity.login_attributed',
-      expect.anything()
-    )
     expect(contents.mainFrame.executeJavaScript).not.toHaveBeenCalled()
     expect(parentWindow.focus).not.toHaveBeenCalled()
     // ...and did not tear down the newer flow's banner on the way out.

--- a/src/main/auth/desktopLoginCode/index.ts
+++ b/src/main/auth/desktopLoginCode/index.ts
@@ -257,13 +257,12 @@ export async function signInViaDesktopLoginCode(
     )
     if (!injected) return 'handled'
     if (controller.signal.aborted) return 'handled'
-    // Bind only after the session was successfully installed. Hosted Cloud
-    // views wait for their declarative auth reporter; local/legacy views use
-    // the main-verified fallback, so this produces exactly one success.
-    bindSignedInUser(user, comfyContents)
-    mainTelemetry.capture('comfy.desktop.identity.login_attributed', {
-      via: 'desktop_login_code'
-    })
+    // Bind only after the session was successfully installed. The injected
+    // session reloads hosted Cloud views, so the bind holds this user as
+    // pending and the consensus layer identifies — and emits the login
+    // attribution — once a document re-reports the same UID. Local/legacy
+    // views confirm through their scoped reporter the same way.
+    bindSignedInUser(user, comfyContents, { via: 'desktop_login_code' })
     restoreParentWindow(opts.parentWindow)
     return 'handled'
   } catch (err) {

--- a/src/main/auth/firebaseBridge/flowShared.ts
+++ b/src/main/auth/firebaseBridge/flowShared.ts
@@ -60,21 +60,38 @@ export function emitSignInFailure(
   return failure
 }
 
-/** Submit a Desktop-verified Firebase user to the process-wide identity consensus. */
-export function bindSignedInUser(user: Record<string, unknown>, source: WebContents): void {
+function verifiedIdentityFromUser(user: Record<string, unknown>): {
+  uid: string
+  properties: Record<string, string | number>
+} | null {
+  const uid = typeof user.uid === 'string' && user.uid.length > 0 ? user.uid : null
+  if (!uid) return null
+  const email = typeof user.email === 'string' && user.email.length > 0 ? user.email : null
+  const at = email ? email.lastIndexOf('@') : -1
+  const emailDomain = at >= 0 ? email!.slice(at + 1).toLowerCase() : null
+  const properties: Record<string, string | number> = {
+    signed_in_via: 'desktop_2',
+    signed_in_at_ms: Date.now()
+  }
+  if (email) properties.email = email
+  if (emailDomain) properties.email_domain = emailDomain
+  return { uid, properties }
+}
+
+/**
+ * Submit a Desktop-verified Firebase user to the process-wide identity
+ * consensus, with an optional one-shot login-attribution payload that the
+ * consensus layer emits once this UID is confirmed.
+ */
+export function bindSignedInUser(
+  user: Record<string, unknown>,
+  source: WebContents,
+  attribution: mainTelemetry.TelemetryContext | null = null
+): void {
   try {
-    const uid = typeof user.uid === 'string' && user.uid.length > 0 ? user.uid : null
-    if (!uid) return
-    const email = typeof user.email === 'string' && user.email.length > 0 ? user.email : null
-    const at = email ? email.lastIndexOf('@') : -1
-    const emailDomain = at >= 0 ? email!.slice(at + 1).toLowerCase() : null
-    const properties: Record<string, string | number> = {
-      signed_in_via: 'desktop_2',
-      signed_in_at_ms: Date.now()
-    }
-    if (email) properties.email = email
-    if (emailDomain) properties.email_domain = emailDomain
-    bindMainVerifiedFirebaseUser(uid, properties, source)
+    const identity = verifiedIdentityFromUser(user)
+    if (!identity) return
+    bindMainVerifiedFirebaseUser(identity.uid, identity.properties, source, attribution)
   } catch {
     // Telemetry must never break the auth flow.
   }

--- a/src/main/auth/firebaseBridge/index.test.ts
+++ b/src/main/auth/firebaseBridge/index.test.ts
@@ -1,5 +1,6 @@
 import type { WebContents } from 'electron'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as FlowSharedModule from './flowShared'
 
 import {
   closeActiveBridge,
@@ -10,7 +11,7 @@ import {
 
 const h = vi.hoisted(() => ({
   beginSessionInjection: vi.fn(() => ({ owner: 'test' })),
-  bindUserId: vi.fn(),
+  bindSignedInUser: vi.fn(),
   capture: vi.fn(),
   emit: vi.fn(),
   injectSession: vi.fn(() => Promise.resolve(true)),
@@ -35,12 +36,15 @@ vi.mock('./inject', () => ({
 }))
 vi.mock('./restoreParentWindow', () => ({ restoreParentWindow: h.restoreParentWindow }))
 vi.mock('./server', () => ({ startBridgeServer: h.startBridgeServer }))
+vi.mock('./flowShared', async (importOriginal) => ({
+  ...(await importOriginal<typeof FlowSharedModule>()),
+  bindSignedInUser: h.bindSignedInUser
+}))
 vi.mock('../desktopLoginCode', () => ({
   signInViaDesktopLoginCode: h.signInViaDesktopLoginCode
 }))
 vi.mock('../../lib/i18n', () => ({ t: (key: string) => key }))
 vi.mock('../../lib/telemetry', () => ({
-  bindUserId: h.bindUserId,
   bucketError: () => 'other',
   capture: h.capture,
   emit: h.emit
@@ -113,7 +117,7 @@ describe('handleFirebasePopup legacy flow', () => {
     await flow
 
     expect(h.injectSession).not.toHaveBeenCalled()
-    expect(h.bindUserId).not.toHaveBeenCalled()
+    expect(h.bindSignedInUser).not.toHaveBeenCalled()
     expect(h.restoreParentWindow).not.toHaveBeenCalled()
   })
 
@@ -130,7 +134,7 @@ describe('handleFirebasePopup legacy flow', () => {
     await flow
 
     expect(h.injectSession).not.toHaveBeenCalled()
-    expect(h.bindUserId).not.toHaveBeenCalled()
+    expect(h.bindSignedInUser).not.toHaveBeenCalled()
     expect(h.restoreParentWindow).not.toHaveBeenCalled()
   })
 
@@ -145,7 +149,7 @@ describe('handleFirebasePopup legacy flow', () => {
 
     const staleFlow = handleFirebasePopup(AUTH_URL, contents)
     await vi.advanceTimersByTimeAsync(0)
-    expect(h.bindUserId).not.toHaveBeenCalled()
+    expect(h.bindSignedInUser).not.toHaveBeenCalled()
     expect(h.capture).toHaveBeenCalledWith('comfy.desktop.auth.sign_in_started', {
       provider: 'google.com',
       flow: 'loopback_bridge'
@@ -158,7 +162,7 @@ describe('handleFirebasePopup legacy flow', () => {
     await staleFlow
 
     expect(h.injectSession).not.toHaveBeenCalled()
-    expect(h.bindUserId).not.toHaveBeenCalled()
+    expect(h.bindSignedInUser).not.toHaveBeenCalled()
     expect(h.restoreParentWindow).not.toHaveBeenCalled()
     expect(contents.off).toHaveBeenCalledTimes(1)
     runBannerCleanup()
@@ -244,5 +248,43 @@ describe('handleFirebasePopup legacy flow', () => {
 
     await expect(flow).resolves.toBeUndefined()
     expect(h.emit).not.toHaveBeenCalled()
+  })
+
+  it('binds the verified user only after the legacy session injection succeeds', async () => {
+    const contents = fakeContents()
+    const user = { uid: 'user-1', email: 'user@example.com' }
+    h.startBridgeServer.mockResolvedValue({
+      url: 'http://localhost:9876/',
+      signInPromise: Promise.resolve({ user, apiKey: 'api-key' }),
+      close: vi.fn()
+    })
+
+    const flow = handleFirebasePopup(AUTH_URL, contents)
+    await vi.runAllTimersAsync()
+    await flow
+
+    expect(h.bindSignedInUser).toHaveBeenCalledWith(user, contents)
+    expect(h.bindSignedInUser.mock.invocationCallOrder[0]).toBeGreaterThan(
+      h.injectSession.mock.invocationCallOrder[0]!
+    )
+    expect(h.restoreParentWindow).toHaveBeenCalledOnce()
+  })
+
+  it('does not bind when legacy session injection fails', async () => {
+    const contents = fakeContents()
+    h.injectSession.mockResolvedValueOnce(false)
+    h.startBridgeServer.mockResolvedValue({
+      url: 'http://localhost:9876/',
+      signInPromise: Promise.resolve({ user: { uid: 'user-1' }, apiKey: 'api-key' }),
+      close: vi.fn()
+    })
+
+    const flow = handleFirebasePopup(AUTH_URL, contents)
+    await vi.runAllTimersAsync()
+    await flow
+
+    expect(h.injectSession).toHaveBeenCalledOnce()
+    expect(h.bindSignedInUser).not.toHaveBeenCalled()
+    expect(h.restoreParentWindow).not.toHaveBeenCalled()
   })
 })

--- a/src/main/auth/firebaseBridge/index.ts
+++ b/src/main/auth/firebaseBridge/index.ts
@@ -150,8 +150,8 @@ export async function handleFirebasePopup(
     if (!injected) return
     if (signal.aborted || !isActiveBridgeFlow(flow)) return
     // Do not report success until the session is installed in the initiating
-    // view. Hosted Cloud views bind through declarative auth consensus;
-    // local/legacy views use the main-verified fallback.
+    // view. The bind holds this user as pending through the post-injection
+    // reload; the consensus layer identifies once a document re-reports it.
     bindSignedInUser(user, comfyContents)
     // Pull the user back into the app after the browser completes sign-in.
     restoreParentWindow(opts.parentWindow)

--- a/src/main/lib/ipc/registerTelemetryHandlers.test.ts
+++ b/src/main/lib/ipc/registerTelemetryHandlers.test.ts
@@ -2,9 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   capture: vi.fn(),
-  captureException: vi.fn((_error: unknown, _properties: unknown) => true),
+  captureExceptionAndForward: vi.fn((_error: unknown, _properties: unknown) => true),
   findEntryByComfySender: vi.fn(),
-  forwardExceptionToRenderer: vi.fn(),
   getFlag: vi.fn(),
   handle: vi.fn(),
   on: vi.fn(),
@@ -29,8 +28,7 @@ vi.mock('../telemetry', () => ({
   // pull in telemetry.ts's electron/posthog-node imports under the stub mock.
   asDeployment: (v: unknown) => (v === 'local' || v === 'cloud' || v === 'remote' ? v : null),
   emit: mocks.capture,
-  captureException: mocks.captureException,
-  forwardExceptionToRenderer: mocks.forwardExceptionToRenderer,
+  captureExceptionAndForward: mocks.captureExceptionAndForward,
   registerPersonProperties: mocks.registerPersonProperties
 }))
 
@@ -320,11 +318,13 @@ describe('registerTelemetryHandlers', () => {
       { message: 'boom', properties: { client: 'web', deployment: 'cloud' } }
     )
 
-    const [err, sent] = mocks.captureException.mock.calls[0]! as [Error, Record<string, unknown>]
+    const [err, sent] = mocks.captureExceptionAndForward.mock.calls[0]! as [
+      Error,
+      Record<string, unknown>
+    ]
     expect(err.message).toBe('boom')
     expect(sent.deployment).toBe('local')
     expect(sent.client).toBeUndefined()
-    expect(mocks.forwardExceptionToRenderer).toHaveBeenCalledWith(sent)
   })
 
   it('scrubs exception properties before applying string limits', () => {
@@ -334,7 +334,10 @@ describe('registerTelemetryHandlers', () => {
       { message: 'boom', properties: { detail: secret, nested: { secret } } }
     )
 
-    const [, sent] = mocks.captureException.mock.calls[0]! as [Error, Record<string, unknown>]
+    const [, sent] = mocks.captureExceptionAndForward.mock.calls[0]! as [
+      Error,
+      Record<string, unknown>
+    ]
     expect(sent.detail).toBe('password=[REDACTED]')
     expect(sent.nested).toBeUndefined()
   })

--- a/src/main/lib/ipc/registerTelemetryHandlers.ts
+++ b/src/main/lib/ipc/registerTelemetryHandlers.ts
@@ -12,7 +12,7 @@ import {
 import { normalizeExceptionContext } from '../../../shared/piiScrub'
 import { reportFirebaseAuthState } from '../firebaseAuthIdentity'
 import type { ComfyDesktop2FirebaseAuthState } from '../../../types/comfyDesktopBridge'
-import { isIllegalPostHogDistinctId, normalizeOpaqueIdentifier } from '../opaqueIdentifier'
+import { normalizePostHogUserId } from '../opaqueIdentifier'
 
 interface CapturePayload {
   event?: unknown
@@ -44,8 +44,8 @@ function asFirebaseAuthState(value: unknown): ComfyDesktop2FirebaseAuthState | n
     return { status: source.status }
   }
   if (source.status !== 'signed_in') return null
-  const userId = normalizeOpaqueIdentifier(source.userId, 256)
-  if (!userId || isIllegalPostHogDistinctId(userId)) return null
+  const userId = normalizePostHogUserId(source.userId)
+  if (!userId) return null
   return { status: 'signed_in', userId }
 }
 
@@ -204,8 +204,7 @@ export function registerTelemetryHandlers(): void {
     const err = new Error(message)
     if (stackStr) err.stack = stackStr
     const properties = withPlatformAxes(asExceptionProps(payload?.properties), event?.sender)
-    const accepted = mainTelemetry.captureException(err, properties)
-    if (accepted) mainTelemetry.forwardExceptionToRenderer(properties)
+    mainTelemetry.captureExceptionAndForward(err, properties)
   })
 
   ipcMain.on('telemetry:registerProperties', (_event, properties: unknown) => {

--- a/src/main/lib/processErrorHandlers.ts
+++ b/src/main/lib/processErrorHandlers.ts
@@ -40,26 +40,19 @@ export function forwardDatadogError(payload: DatadogForwardedError): void {
     // only and we don't double-count in PostHog.
     skipPostHog: true
   }
-  // Capture via PostHog Node and only mirror accepted exceptions to Datadog.
+  // Capture via PostHog Node and mirror to Datadog only when the capture
+  // actually ships (quarantined captures defer or drop the mirror with the
+  // write). forwardExceptionToRenderer allow-lists context keys, so
+  // reason/exitCode/type survive for child/renderer crashes.
   try {
     const err = new Error(scrubbed.message)
     if (scrubbed.stack) err.stack = scrubbed.stack
-    const accepted = mainTelemetry.captureException(err, {
+    mainTelemetry.captureExceptionAndForward(err, {
       ...(scrubbed.context || {}),
       origin: 'main-process',
       source: scrubbed.source,
       level: scrubbed.level ?? null
     })
-    if (accepted) {
-      // Carry the context through so Datadog keeps reason/exitCode/type for
-      // child/renderer crashes; forwardExceptionToRenderer allow-lists keys.
-      mainTelemetry.forwardExceptionToRenderer({
-        ...(scrubbed.context || {}),
-        origin: 'main-process',
-        source: scrubbed.source,
-        level: scrubbed.level ?? null
-      })
-    }
   } catch {}
 }
 


### PR DESCRIPTION
[GTM-393](https://linear.app/comfyorg/issue/GTM-393/prevent-duplicate-desktop-identify-during-post-login-cloud-navigation)

3 of 3, split out of #1390 for review. Stack: #1399 → #1400 → **#1401 (this)**. Merge #1399 and #1400 first.

Supersedes #1390.

Wires the desktop-verified sign-in flows into the consensus layer from #1399 and #1400, so an interactive login's conversion event is emitted once, against the confirmed UID.

**The verified flows stage attribution instead of capturing inline.** The OAuth loopback bridge and the desktop login-code flow hand `bindMainVerifiedFirebaseUser` a one-shot attribution payload; telemetry owns its lifecycle from there. `login_attributed` is emitted only when its UID is confirmed and discarded when consensus resolves signed out.

**Renderer-reported auth state routes through the frame-attributed entry point**, so a report carries the frame identity consensus needs to accept or ignore it.

**Captured exceptions mirror to renderer Datadog only when the PostHog write ships.** The forward rides the capture's disposition, so a quarantined write that is later discarded leaves no orphaned Datadog copy and the two systems cannot diverge on which exceptions exist.

This is the last layer; with it merged the tree is identical to #1390 at `4d5c836f`, which #1390 can be closed in favor of.

Validation:
- pnpm test — 3,891 passed, 1 skipped
- pnpm typecheck
- pnpm lint
- pnpm format:check
