### PR TITLE
Add spelling suggestions to native context menus

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1320,7 +1320,8 @@
     "cut": "Cut",
     "copy": "Copy",
     "paste": "Paste",
-    "selectAll": "Select All"
+    "selectAll": "Select All",
+    "addToDictionary": "Add to Dictionary"
   },
   "statusFactPanel": {
     "editName": "Edit instance name",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -1320,7 +1320,8 @@
     "cut": "剪切",
     "copy": "复制",
     "paste": "粘贴",
-    "selectAll": "全选"
+    "selectAll": "全选",
+    "addToDictionary": "添加到词典"
   },
   "statusFactPanel": {
     "editName": "编辑实例名称",

--- a/src/main/lib/contextMenu.test.ts
+++ b/src/main/lib/contextMenu.test.ts
@@ -22,7 +22,9 @@ const noopActions: ContextMenuActions = {
   saveImage: vi.fn(),
   copyImage: vi.fn(),
   openLink: vi.fn(),
-  copyLink: vi.fn()
+  copyLink: vi.fn(),
+  replaceMisspelling: vi.fn(),
+  addWordToDictionary: vi.fn()
 }
 
 function makeParams(overrides: Partial<ContextMenuParams> = {}): ContextMenuParams {
@@ -39,6 +41,8 @@ function makeParams(overrides: Partial<ContextMenuParams> = {}): ContextMenuPara
     mediaType: 'none',
     srcURL: '',
     hasImageContents: false,
+    misspelledWord: '',
+    dictionarySuggestions: [],
     ...overrides
   }
 }
@@ -49,6 +53,56 @@ const ids = (items: Electron.MenuItemConstructorOptions[]): string[] =>
 describe('buildContextMenuItems', () => {
   it('returns no items when nothing is actionable', () => {
     expect(buildContextMenuItems(makeParams(), noopActions)).toEqual([])
+  })
+
+  it('adds spelling suggestions before editable actions', () => {
+    const items = buildContextMenuItems(
+      makeParams({
+        isEditable: true,
+        misspelledWord: 'relaly',
+        dictionarySuggestions: ['really', 'relay']
+      }),
+      noopActions
+    )
+
+    expect(items.map((item) => item.label ?? item.type ?? item.role)).toEqual([
+      'really',
+      'relay',
+      'contextMenu.addToDictionary',
+      'separator',
+      'contextMenu.cut',
+      'contextMenu.copy',
+      'contextMenu.paste',
+      'separator',
+      'contextMenu.selectAll'
+    ])
+  })
+
+  it('wires spelling suggestions and dictionary additions to their actions', () => {
+    const actions: ContextMenuActions = {
+      ...noopActions,
+      replaceMisspelling: vi.fn(),
+      addWordToDictionary: vi.fn()
+    }
+    const items = buildContextMenuItems(
+      makeParams({ misspelledWord: 'relaly', dictionarySuggestions: ['really'] }),
+      actions
+    )
+
+    ;(items[0]!.click as () => void)()
+    ;(items[1]!.click as () => void)()
+
+    expect(actions.replaceMisspelling).toHaveBeenCalledWith('really')
+    expect(actions.addWordToDictionary).toHaveBeenCalledWith('relaly')
+  })
+
+  it('offers adding a misspelling when there are no suggestions', () => {
+    const items = buildContextMenuItems(
+      makeParams({ misspelledWord: 'qzqx', dictionarySuggestions: [] }),
+      noopActions
+    )
+
+    expect(items.map((item) => item.label ?? item.type)).toEqual(['contextMenu.addToDictionary'])
   })
 
   it('adds Save/Copy image entries for an image with contents', () => {

--- a/src/main/lib/contextMenu.test.ts
+++ b/src/main/lib/contextMenu.test.ts
@@ -68,6 +68,7 @@ describe('buildContextMenuItems', () => {
     expect(items.map((item) => item.label ?? item.type ?? item.role)).toEqual([
       'really',
       'relay',
+      'separator',
       'contextMenu.addToDictionary',
       'separator',
       'contextMenu.cut',
@@ -90,7 +91,7 @@ describe('buildContextMenuItems', () => {
     )
 
     ;(items[0]!.click as () => void)()
-    ;(items[1]!.click as () => void)()
+    ;(items[2]!.click as () => void)()
 
     expect(actions.replaceMisspelling).toHaveBeenCalledWith('really')
     expect(actions.addWordToDictionary).toHaveBeenCalledWith('relaly')

--- a/src/main/lib/contextMenu.ts
+++ b/src/main/lib/contextMenu.ts
@@ -16,6 +16,8 @@ export interface ContextMenuActions {
   copyImage: () => void
   openLink: (linkURL: string) => void
   copyLink: (linkURL: string) => void
+  replaceMisspelling: (suggestion: string) => void
+  addWordToDictionary: (word: string) => void
 }
 
 /** Subset of Electron's context-menu params the builder reads. */
@@ -28,6 +30,8 @@ export type ContextMenuParams = Pick<
   | 'mediaType'
   | 'srcURL'
   | 'hasImageContents'
+  | 'misspelledWord'
+  | 'dictionarySuggestions'
 >
 
 /**
@@ -35,7 +39,7 @@ export type ContextMenuParams = Pick<
  * when nothing is actionable so callers can skip popping an empty menu.
  *
  * Images get Save/Copy entries so right-clicking an output image (including
- * the fullscreen viewer) matches the browser's native "Save image" — the
+ * the fullscreen viewer) matches the browser's native "Save image" - the
  * launcher overrides Chromium's default menu, so without this there is no
  * way to save an image in-app.
  */
@@ -43,15 +47,39 @@ export function buildContextMenuItems(
   params: ContextMenuParams,
   actions: ContextMenuActions
 ): Electron.MenuItemConstructorOptions[] {
-  const { editFlags, isEditable, selectionText, linkURL, mediaType, srcURL, hasImageContents } =
-    params
+  const {
+    editFlags,
+    isEditable,
+    selectionText,
+    linkURL,
+    mediaType,
+    srcURL,
+    hasImageContents,
+    misspelledWord,
+    dictionarySuggestions
+  } = params
   const hasSelection = selectionText.trim().length > 0
   const hasLink = linkURL.length > 0
   const hasImage = mediaType === 'image' && hasImageContents && srcURL.length > 0
+  const hasMisspelling = misspelledWord.length > 0
 
   const menuItems: Electron.MenuItemConstructorOptions[] = []
 
+  if (hasMisspelling) {
+    menuItems.push(
+      ...dictionarySuggestions.map((suggestion) => ({
+        label: suggestion,
+        click: () => actions.replaceMisspelling(suggestion)
+      })),
+      {
+        label: i18n.t('contextMenu.addToDictionary'),
+        click: () => actions.addWordToDictionary(misspelledWord)
+      }
+    )
+  }
+
   if (hasLink) {
+    if (menuItems.length > 0) menuItems.push({ type: 'separator' })
     menuItems.push(
       {
         id: 'openLink',
@@ -78,7 +106,7 @@ export function buildContextMenuItems(
     )
   }
 
-  if ((hasLink || hasImage) && (isEditable || hasSelection)) {
+  if (menuItems.length > 0 && (isEditable || hasSelection)) {
     menuItems.push({ type: 'separator' })
   }
 
@@ -113,7 +141,9 @@ export function attachContextMenu(
       saveImage: (srcURL) => wc.session.downloadURL(srcURL),
       copyImage: () => wc.copyImageAt(params.x, params.y),
       openLink: (linkURL) => shell.openExternal(linkURL),
-      copyLink: (linkURL) => clipboard.writeText(linkURL)
+      copyLink: (linkURL) => clipboard.writeText(linkURL),
+      replaceMisspelling: (suggestion) => wc.replaceMisspelling(suggestion),
+      addWordToDictionary: (word) => wc.session.addWordToSpellCheckerDictionary(word)
     })
 
     if (menuItems.length === 0) return

--- a/src/main/lib/contextMenu.ts
+++ b/src/main/lib/contextMenu.ts
@@ -70,12 +70,13 @@ export function buildContextMenuItems(
       ...dictionarySuggestions.map((suggestion) => ({
         label: suggestion,
         click: () => actions.replaceMisspelling(suggestion)
-      })),
-      {
-        label: i18n.t('contextMenu.addToDictionary'),
-        click: () => actions.addWordToDictionary(misspelledWord)
-      }
+      }))
     )
+    if (dictionarySuggestions.length > 0) menuItems.push({ type: 'separator' })
+    menuItems.push({
+      label: i18n.t('contextMenu.addToDictionary'),
+      click: () => actions.addWordToDictionary(misspelledWord)
+    })
   }
 
   if (hasLink) {


### PR DESCRIPTION
## Summary
- show Chromium spell-check suggestions in Desktop native context menus
- replace misspelled words or add them to the session dictionary
- localize the dictionary action and cover spelling menu behavior with unit tests

## Testing
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test` (4,056 passed)
- `pnpm run test:integration` (40 passed)
- `pnpm run build`
- `pnpm run test:e2e:windows` (73 passed)

Refs #1405