### PR TITLE
Add hardware acceleration toggle and reorganize Desktop Settings

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -81,6 +81,7 @@ Snapshot of `e2e/` as of 2026-07. "Meets zero-mock bar" applies the policy above
 | `dismiss-error.test.ts` | platform | n/a | Injects the error into the renderer store at runtime (`__e2eRenderer.seedErrorInstance`). |
 | `downloads-shelf.test.ts` | platform | n/a | Injects downloads-tray state via `seedDownloads`. |
 | `dropdowns.test.ts` | platform | n/a | UI regression tests. |
+| `hardware-acceleration.test.ts` | `@windows` | n/a | On NVIDIA systems, launches Desktop with hardware acceleration enabled and disabled, then compares per-process dedicated GPU memory. |
 | `lifecycle-add-existing.test.ts` | `@lifecycle` | Yes (light) | Real probe + tracking against a staged git repo, driven through the waffle menu → TrackModal → Browse → Track Install chain; native directory picker stubbed with the staged path. |
 | `lifecycle-cloud.test.ts` | `@lifecycle` | Yes | Real navigation to `https://cloud.comfy.org/`. |
 | `lifecycle-copy-update-fail.test.ts` | `@lifecycle` | Yes (light) | Real local copy chained into a real update failure, driven through the picker Update tab's Copy & Update button; failure text asserted from the durable app log. Picker opened via direct `openInstancePicker`, not a UI entry control. |
@@ -207,3 +208,18 @@ workflow (`.github/workflows/lifecycle.yml`), always with the CPU variant (hoste
 runners have no GPU). It can also be run on a specific PR by adding the
 `run-lifecycle` label (remove and re-add the label to re-run). It is opt-in and not
 PR-blocking.
+
+## Running the hardware acceleration test
+
+The Windows hardware acceleration test runs automatically in the Windows E2E suite
+when an NVIDIA GPU is present. It can also be run directly:
+
+```powershell
+pnpm run build
+pnpm run test:e2e:hardware-acceleration
+```
+
+NVIDIA's per-process memory query reports `N/A` under Windows WDDM. The test uses
+`nvidia-smi -L` to require an NVIDIA GPU, then reads Windows' per-process
+`GPU Process Memory/Dedicated Usage` counter for the Electron process tree. It skips
+when either facility is unavailable.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -220,6 +220,7 @@ pnpm run test:e2e:hardware-acceleration
 ```
 
 NVIDIA's per-process memory query reports `N/A` under Windows WDDM. The test uses
-`nvidia-smi -L` to require an NVIDIA GPU, then reads Windows' per-process
-`GPU Process Memory/Dedicated Usage` counter for the Electron process tree. It skips
-when either facility is unavailable.
+`nvidia-smi -L` to require an NVIDIA GPU and `nvidia-smi pmon` to confirm an Electron
+GPU process is assigned to it, then reads Windows' per-process `GPU Process
+Memory/Dedicated Usage` counter for the Electron process tree. It skips when the
+required hardware or accounting facilities are unavailable.

--- a/e2e/hardware-acceleration.test.ts
+++ b/e2e/hardware-acceleration.test.ts
@@ -137,7 +137,7 @@ test('disabling hardware acceleration reduces Desktop VRAM use @windows', async 
   try {
     const acceleratedCtx = await launchApp({
       profileDir,
-      settings: { firstUseCompleted: true, hardwareAcceleration: true }
+      settings: { firstUseCompleted: true, hardwareAcceleration: true, language: 'en' }
     })
     try {
       accelerated = await measureApp(acceleratedCtx.app)

--- a/e2e/hardware-acceleration.test.ts
+++ b/e2e/hardware-acceleration.test.ts
@@ -1,0 +1,177 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtemp, rm } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+import { expect, test, type ElectronApplication } from '@playwright/test'
+import { launchApp, type AppContext } from './launchApp'
+import { openTitleMenu } from './support/chooserHelpers'
+import { titlePopupPage } from './support/cdpPages'
+
+const MIB = 1024 * 1024
+const GPU_MEMORY_COUNTER = '\\GPU Process Memory(*)\\Dedicated Usage'
+
+function runPowerShell(script: string): string {
+  return execFileSync('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', script], {
+    encoding: 'utf-8',
+    timeout: 15_000,
+    windowsHide: true
+  }).trim()
+}
+
+function hasNvidiaGpu(): boolean {
+  try {
+    const output = execFileSync('nvidia-smi', ['-L'], {
+      encoding: 'utf-8',
+      timeout: 15_000,
+      windowsHide: true
+    })
+    return /GPU \d+:/.test(output)
+  } catch {
+    return false
+  }
+}
+
+function canReadDedicatedGpuMemory(): boolean {
+  try {
+    const count = runPowerShell(
+      `$ErrorActionPreference = 'Stop'; ` +
+        `$samples = (Get-Counter '${GPU_MEMORY_COUNTER}').CounterSamples; ` +
+        `[Console]::Write($samples.Count)`
+    )
+    return Number.parseInt(count, 10) > 0
+  } catch {
+    return false
+  }
+}
+
+async function getElectronProcessIds(application: ElectronApplication): Promise<number[]> {
+  return application.evaluate(({ app }) => app.getAppMetrics().map((metric) => metric.pid))
+}
+
+function readDedicatedGpuMemory(processIds: number[]): number {
+  const ids = processIds.filter((pid) => Number.isInteger(pid) && pid > 0).join(',')
+  if (!ids) return 0
+
+  const output = runPowerShell(
+    `$ErrorActionPreference = 'Stop'; ` +
+      `$ids = @(${ids}); ` +
+      `$samples = (Get-Counter '${GPU_MEMORY_COUNTER}').CounterSamples; ` +
+      `$total = ($samples | Where-Object { ` +
+      `$_.InstanceName -match '^pid_([0-9]+)_' -and $ids -contains [int]$Matches[1] ` +
+      `} | Measure-Object CookedValue -Sum).Sum; ` +
+      `if ($null -eq $total) { $total = 0 }; ` +
+      `[Console]::Write([long]$total)`
+  )
+  const bytes = Number.parseInt(output, 10)
+  if (!Number.isFinite(bytes)) throw new Error(`Invalid GPU memory counter result: ${output}`)
+  return bytes
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b)
+  return sorted[Math.floor(sorted.length / 2)]!
+}
+
+async function sampleGpuMemory(application: ElectronApplication): Promise<number[]> {
+  await new Promise((resolve) => setTimeout(resolve, 2_000))
+  const samples: number[] = []
+  for (let i = 0; i < 5; i++) {
+    samples.push(readDedicatedGpuMemory(await getElectronProcessIds(application)))
+    if (i < 4) await new Promise((resolve) => setTimeout(resolve, 1_000))
+  }
+  return samples
+}
+
+async function measureApp(application: ElectronApplication): Promise<{
+  samples: number[]
+  gpuCompositing: string
+}> {
+  const samples = await sampleGpuMemory(application)
+  const gpuCompositing = await application.evaluate(
+    ({ app: electronApp }) => electronApp.getGPUFeatureStatus().gpu_compositing
+  )
+  return { samples, gpuCompositing }
+}
+
+async function disableHardwareAccelerationFromDesktopSettings(ctx: AppContext): Promise<void> {
+  const popup = titlePopupPage(ctx.app)
+  await openTitleMenu(ctx.titleBar)
+  await popup.waitForVisible('[role="menuitem"]', { timeout: 5_000 })
+  expect(await popup.clickByText('[role="menuitem"]', 'Desktop Settings')).toBe(true)
+  await popup.waitForVisible('.global-settings', { timeout: 5_000 })
+
+  const selector = '[role="switch"][aria-label="Use hardware acceleration"]'
+  await popup.waitForVisible(selector, { timeout: 5_000 })
+  expect(
+    await popup.evaluate(
+      `document.querySelector(${JSON.stringify(selector)})?.getAttribute('aria-checked')`
+    )
+  ).toBe('true')
+  expect(await popup.allText('.settings-v2-field-description')).toContain(
+    'Uses the GPU to render Comfy Desktop. Restart Comfy Desktop for changes to take effect.'
+  )
+  expect(await popup.click(selector)).toBe(true)
+  await popup.waitFor(
+    async () =>
+      (await popup.evaluate(
+        `document.querySelector(${JSON.stringify(selector)})?.getAttribute('aria-checked')`
+      )) === 'false',
+    { timeout: 5_000, message: 'hardware acceleration toggle did not switch off' }
+  )
+}
+
+test('disabling hardware acceleration reduces Desktop VRAM use @windows', async () => {
+  test.skip(process.platform !== 'win32', 'Windows exposes per-process dedicated GPU memory')
+  test.skip(!hasNvidiaGpu(), 'An NVIDIA GPU and nvidia-smi are required')
+  test.skip(
+    !canReadDedicatedGpuMemory(),
+    'The Windows GPU Process Memory performance counter is unavailable'
+  )
+  test.setTimeout(90_000)
+
+  const profileDir = await mkdtemp(path.join(os.tmpdir(), 'comfyui-hardware-acceleration-e2e-'))
+  let accelerated: Awaited<ReturnType<typeof measureApp>>
+  let disabled: Awaited<ReturnType<typeof measureApp>>
+  try {
+    const acceleratedCtx = await launchApp({
+      profileDir,
+      settings: { firstUseCompleted: true, hardwareAcceleration: true }
+    })
+    try {
+      accelerated = await measureApp(acceleratedCtx.app)
+      await disableHardwareAccelerationFromDesktopSettings(acceleratedCtx)
+    } finally {
+      await acceleratedCtx.cleanup()
+    }
+
+    const disabledCtx = await launchApp({ profileDir })
+    try {
+      disabled = await measureApp(disabledCtx.app)
+    } finally {
+      await disabledCtx.cleanup()
+    }
+  } finally {
+    await rm(profileDir, { recursive: true, force: true })
+  }
+
+  const acceleratedBytes = median(accelerated.samples)
+  const disabledBytes = median(disabled.samples)
+
+  console.log(
+    `[hardware-acceleration] enabled=${(acceleratedBytes / MIB).toFixed(1)} MiB ` +
+      `disabled=${(disabledBytes / MIB).toFixed(1)} MiB ` +
+      `enabledSamples=${accelerated.samples.map((value) => (value / MIB).toFixed(1)).join(',')} ` +
+      `disabledSamples=${disabled.samples.map((value) => (value / MIB).toFixed(1)).join(',')}`
+  )
+
+  expect(
+    acceleratedBytes,
+    'The accelerated launch must establish a material dedicated-GPU-memory baseline'
+  ).toBeGreaterThan(16 * MIB)
+  expect(disabled.gpuCompositing).not.toBe('enabled')
+  expect(
+    disabledBytes,
+    'The disabled launch should use at least 16 MiB less dedicated GPU memory'
+  ).toBeLessThan(acceleratedBytes - 16 * MIB)
+})

--- a/e2e/hardware-acceleration.test.ts
+++ b/e2e/hardware-acceleration.test.ts
@@ -140,6 +140,10 @@ test('disabling hardware acceleration reduces Desktop VRAM use @windows', async 
     })
     try {
       accelerated = await measureApp(acceleratedCtx.app)
+      test.skip(
+        median(accelerated.samples) <= 16 * MIB,
+        'Electron did not establish a dedicated-GPU-memory baseline'
+      )
       await disableHardwareAccelerationFromDesktopSettings(acceleratedCtx)
     } finally {
       await acceleratedCtx.cleanup()
@@ -165,10 +169,6 @@ test('disabling hardware acceleration reduces Desktop VRAM use @windows', async 
       `disabledSamples=${disabled.samples.map((value) => (value / MIB).toFixed(1)).join(',')}`
   )
 
-  expect(
-    acceleratedBytes,
-    'The accelerated launch must establish a material dedicated-GPU-memory baseline'
-  ).toBeGreaterThan(16 * MIB)
   expect(disabled.gpuCompositing).not.toBe('enabled')
   expect(
     disabledBytes,

--- a/e2e/hardware-acceleration.test.ts
+++ b/e2e/hardware-acceleration.test.ts
@@ -32,6 +32,26 @@ function hasNvidiaGpu(): boolean {
   }
 }
 
+function electronUsesNvidiaGpu(processIds: number[]): boolean {
+  try {
+    const output = execFileSync('nvidia-smi', ['pmon', '-c', '1', '-s', 'm'], {
+      encoding: 'utf-8',
+      timeout: 15_000,
+      windowsHide: true
+    })
+    const nvidiaProcessIds = new Set(
+      output
+        .split(/\r?\n/)
+        .filter((line) => !line.trimStart().startsWith('#'))
+        .map((line) => Number.parseInt(line.trim().split(/\s+/)[1] ?? '', 10))
+        .filter(Number.isFinite)
+    )
+    return processIds.some((pid) => nvidiaProcessIds.has(pid))
+  } catch {
+    return false
+  }
+}
+
 function canReadDedicatedGpuMemory(): boolean {
   try {
     const count = runPowerShell(
@@ -141,9 +161,13 @@ test('disabling hardware acceleration reduces Desktop VRAM use @windows', async 
     })
     try {
       accelerated = await measureApp(acceleratedCtx.app)
+      expect(
+        accelerated.gpuCompositing,
+        'The accelerated launch must have GPU compositing enabled'
+      ).toBe('enabled')
       test.skip(
-        median(accelerated.samples) <= 16 * MIB,
-        'Electron did not establish a dedicated-GPU-memory baseline'
+        !electronUsesNvidiaGpu(await getElectronProcessIds(acceleratedCtx.app)),
+        'Electron is not using the NVIDIA GPU reported by nvidia-smi'
       )
       await disableHardwareAccelerationFromDesktopSettings(acceleratedCtx)
     } finally {
@@ -170,6 +194,10 @@ test('disabling hardware acceleration reduces Desktop VRAM use @windows', async 
       `disabledSamples=${disabled.samples.map((value) => (value / MIB).toFixed(1)).join(',')}`
   )
 
+  expect(
+    acceleratedBytes,
+    'The accelerated launch must establish a material dedicated-GPU-memory baseline'
+  ).toBeGreaterThan(16 * MIB)
   expect(disabled.gpuCompositing).not.toBe('enabled')
   expect(
     disabledBytes,

--- a/e2e/hardware-acceleration.test.ts
+++ b/e2e/hardware-acceleration.test.ts
@@ -100,6 +100,7 @@ async function disableHardwareAccelerationFromDesktopSettings(ctx: AppContext): 
   await popup.waitForVisible('[role="menuitem"]', { timeout: 5_000 })
   expect(await popup.clickByText('[role="menuitem"]', 'Desktop Settings')).toBe(true)
   await popup.waitForVisible('.global-settings', { timeout: 5_000 })
+  expect(await popup.clickByText('.gs-tab', 'Advanced')).toBe(true)
 
   const selector = '[role="switch"][aria-label="Use hardware acceleration"]'
   await popup.waitForVisible(selector, { timeout: 5_000 })

--- a/locales/en.json
+++ b/locales/en.json
@@ -509,6 +509,8 @@
     "confirmBeforeClosingWindowDescription": "Ask for confirmation before closing a window that's running a local install.",
     "warnBeforeRunningMultipleInstances": "Warn before running multiple instances",
     "warnBeforeRunningMultipleInstancesDescription": "Show a warning before launching another local ComfyUI instance while one is running or starting.",
+    "hardwareAcceleration": "Use hardware acceleration",
+    "hardwareAccelerationDescription": "Uses the GPU to render Comfy Desktop. Restart Comfy Desktop for changes to take effect.",
     "hideCloudFromPicker": "Hide Cloud from the Instance Picker",
     "hideCloudFromPickerDescription": "For local-only users — hides the Cloud row from the Dashboard. Cloud remains fully functional; you can re-enable this any time.",
     "checkForUpdates": "Check for updates",

--- a/locales/en.json
+++ b/locales/en.json
@@ -526,6 +526,7 @@
     "cacheDir": "Cache Directory",
     "open": "Open",
     "advanced": "Advanced",
+    "logs": "Logs",
     "pypiMirror": "PyPI Mirror URL",
     "pypiMirrorPlaceholder": "e.g. https://mirrors.aliyun.com/pypi/simple/",
     "useChineseMirrors": "Use Chinese Mirrors (Git & PyPI)",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -526,6 +526,7 @@
     "cacheDir": "缓存目录",
     "open": "打开",
     "advanced": "高级",
+    "logs": "日志",
     "pypiMirror": "PyPI 镜像 URL",
     "pypiMirrorPlaceholder": "例如 https://mirrors.aliyun.com/pypi/simple/",
     "useChineseMirrors": "使用中国镜像（Git 和 PyPI）",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -509,6 +509,8 @@
     "confirmBeforeClosingWindowDescription": "关闭正在运行本地安装的窗口前请求确认。",
     "warnBeforeRunningMultipleInstances": "运行多个实例前发出警告",
     "warnBeforeRunningMultipleInstancesDescription": "当一个本地 ComfyUI 实例正在运行或启动时，在启动另一个实例前显示警告。",
+    "hardwareAcceleration": "使用硬件加速",
+    "hardwareAccelerationDescription": "使用 GPU 渲染 Comfy Desktop. 更改将在重启 Comfy Desktop 后生效.",
     "hideCloudFromPicker": "在实例选择器中隐藏云端",
     "hideCloudFromPickerDescription": "面向仅使用本地的用户——从仪表板隐藏云端卡片（以及试用云端 CTA）。云端功能仍完全可用；你可以随时重新启用。",
     "checkForUpdates": "检查更新",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "test:e2e": "playwright test",
     "test:e2e:macos": "playwright test --project=macos",
     "test:e2e:windows": "playwright test --project=windows",
+    "test:e2e:hardware-acceleration": "playwright test --project=windows e2e/hardware-acceleration.test.ts",
     "test:e2e:linux": "playwright test --project=linux",
     "test:e2e:lifecycle": "playwright test --project=lifecycle",
     "test:e2e:lifecycle:install": "playwright test --project=lifecycle e2e/lifecycle.test.ts --grep \"@sec-setup|@sec-meta\"",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -171,6 +171,10 @@ try {
   // Never let crash-reporter setup block app startup.
 }
 
+if (settings.get('hardwareAcceleration') === false) {
+  app.disableHardwareAcceleration()
+}
+
 todesktop.init({ autoUpdater: false })
 
 const APP_VERSION = getAppVersion()

--- a/src/main/lib/ipc/registerSettingsHandlers.test.ts
+++ b/src/main/lib/ipc/registerSettingsHandlers.test.ts
@@ -75,4 +75,28 @@ describe('buildSettingsSections', () => {
       updatedFields.find((field) => field.id === 'warnBeforeRunningMultipleInstances')?.value
     ).toBe(false)
   })
+
+  it('offers a default-on hardware acceleration preference with a restart notice', () => {
+    const fields = buildSettingsSections().flatMap(
+      (s) =>
+        (s.fields as { id?: string; value?: unknown; description?: string }[] | undefined) ?? []
+    )
+
+    expect(fields).toContainEqual(
+      expect.objectContaining({
+        id: 'hardwareAcceleration',
+        label: 'Use hardware acceleration',
+        type: 'boolean',
+        value: true,
+        description:
+          'Uses the GPU to render Comfy Desktop. Restart Comfy Desktop for changes to take effect.'
+      })
+    )
+
+    mockSettings.hardwareAcceleration = false
+    const updatedFields = buildSettingsSections().flatMap(
+      (s) => (s.fields as { id?: string; value?: unknown }[] | undefined) ?? []
+    )
+    expect(updatedFields.find((field) => field.id === 'hardwareAcceleration')?.value).toBe(false)
+  })
 })

--- a/src/main/lib/ipc/registerSettingsHandlers.test.ts
+++ b/src/main/lib/ipc/registerSettingsHandlers.test.ts
@@ -76,13 +76,19 @@ describe('buildSettingsSections', () => {
     ).toBe(false)
   })
 
-  it('offers a default-on hardware acceleration preference with a restart notice', () => {
-    const fields = buildSettingsSections().flatMap(
-      (s) =>
-        (s.fields as { id?: string; value?: unknown; description?: string }[] | undefined) ?? []
-    )
+  it('offers hardware acceleration under Advanced with a restart notice', () => {
+    const sections = buildSettingsSections()
+    const generalFields =
+      (sections.find((section) => section.title === 'General')?.fields as
+        | { id?: string }[]
+        | undefined) ?? []
+    const advancedFields =
+      (sections.find((section) => section.title === 'Advanced')?.fields as
+        | { id?: string; value?: unknown; description?: string }[]
+        | undefined) ?? []
 
-    expect(fields).toContainEqual(
+    expect(generalFields.map((field) => field.id)).not.toContain('hardwareAcceleration')
+    expect(advancedFields).toContainEqual(
       expect.objectContaining({
         id: 'hardwareAcceleration',
         label: 'Use hardware acceleration',
@@ -94,9 +100,8 @@ describe('buildSettingsSections', () => {
     )
 
     mockSettings.hardwareAcceleration = false
-    const updatedFields = buildSettingsSections().flatMap(
-      (s) => (s.fields as { id?: string; value?: unknown }[] | undefined) ?? []
-    )
+    const updatedFields = buildSettingsSections().find((section) => section.title === 'Advanced')
+      ?.fields as { id?: string; value?: unknown }[]
     expect(updatedFields.find((field) => field.id === 'hardwareAcceleration')?.value).toBe(false)
   })
 })

--- a/src/main/lib/ipc/registerSettingsHandlers.ts
+++ b/src/main/lib/ipc/registerSettingsHandlers.ts
@@ -93,14 +93,6 @@ export function buildSettingsSections(
           value: s.warnBeforeRunningMultipleInstances !== false,
           tooltip: i18n.t('settings.warnBeforeRunningMultipleInstancesDescription')
         },
-        {
-          id: 'hardwareAcceleration',
-          label: i18n.t('settings.hardwareAcceleration'),
-          type: 'boolean',
-          value: s.hardwareAcceleration !== false,
-          description: i18n.t('settings.hardwareAccelerationDescription'),
-          tooltip: i18n.t('settings.hardwareAccelerationDescription')
-        },
 
         // Cloud opt-out — pure visibility toggle, doesn't affect any
         // running behavior. Kept after the window-behavior block so
@@ -154,6 +146,14 @@ export function buildSettingsSections(
     {
       title: i18n.t('settings.advanced'),
       fields: [
+        {
+          id: 'hardwareAcceleration',
+          label: i18n.t('settings.hardwareAcceleration'),
+          type: 'boolean',
+          value: s.hardwareAcceleration !== false,
+          description: i18n.t('settings.hardwareAccelerationDescription'),
+          tooltip: i18n.t('settings.hardwareAccelerationDescription')
+        },
         {
           id: 'pypiMirror',
           label: i18n.t('settings.pypiMirror'),

--- a/src/main/lib/ipc/registerSettingsHandlers.ts
+++ b/src/main/lib/ipc/registerSettingsHandlers.ts
@@ -93,6 +93,14 @@ export function buildSettingsSections(
           value: s.warnBeforeRunningMultipleInstances !== false,
           tooltip: i18n.t('settings.warnBeforeRunningMultipleInstancesDescription')
         },
+        {
+          id: 'hardwareAcceleration',
+          label: i18n.t('settings.hardwareAcceleration'),
+          type: 'boolean',
+          value: s.hardwareAcceleration !== false,
+          description: i18n.t('settings.hardwareAccelerationDescription'),
+          tooltip: i18n.t('settings.hardwareAccelerationDescription')
+        },
 
         // Cloud opt-out — pure visibility toggle, doesn't affect any
         // running behavior. Kept after the window-behavior block so

--- a/src/main/popups/titlePopup.ts
+++ b/src/main/popups/titlePopup.ts
@@ -196,7 +196,7 @@ export interface GlobalSettingsModelsDir {
 }
 
 /** Tabs of the Global Settings popup a caller can deep-link into. */
-export type GlobalSettingsTab = 'general' | 'updates' | 'storage' | 'advanced'
+export type GlobalSettingsTab = 'general' | 'updates' | 'storage' | 'advanced' | 'logs'
 
 /** Snapshot pushed to the global-settings popup on open and on every
  *  settings-changed / app-update-state / app-update-progress /
@@ -238,6 +238,7 @@ export interface GlobalSettingsSnapshot {
     storage: string
     models: string
     advanced: string
+    logs: string
     sharedDirectories: string
   }
 }
@@ -2163,6 +2164,7 @@ function buildGlobalSettingsSnapshot(
       storage: i18n.t('settings.storageTab'),
       models: i18n.t('settings.models'),
       advanced: i18n.t('settings.advanced'),
+      logs: i18n.t('settings.logs'),
       sharedDirectories: i18n.t('settings.sharedDirectories')
     }
   }
@@ -2952,7 +2954,11 @@ export function registerTitlePopupIpc(bindings: TitlePopupHostBindings): void {
     if (parentEntryId === undefined || !parentEntry) return
     const rawTab = payload?.tab
     const initialTab: GlobalSettingsTab | null =
-      rawTab === 'general' || rawTab === 'updates' || rawTab === 'storage' || rawTab === 'advanced'
+      rawTab === 'general' ||
+      rawTab === 'updates' ||
+      rawTab === 'storage' ||
+      rawTab === 'advanced' ||
+      rawTab === 'logs'
         ? rawTab
         : null
     openGlobalSettingsForHost(

--- a/src/main/settings.test.ts
+++ b/src/main/settings.test.ts
@@ -242,6 +242,18 @@ describe('settings unset/default semantics', () => {
     expect(readPersistedSettings()).not.toHaveProperty('autoLaunchOnStartup')
   })
 
+  it('persists the hardware acceleration opt-out', () => {
+    expect(settings.get('hardwareAcceleration')).toBeUndefined()
+
+    settings.set('hardwareAcceleration', false)
+    expect(settings.get('hardwareAcceleration')).toBe(false)
+    expect(readPersistedSettings()['hardwareAcceleration']).toBe(false)
+
+    settings.set('hardwareAcceleration', true)
+    expect(settings.get('hardwareAcceleration')).toBe(true)
+    expect(readPersistedSettings()['hardwareAcceleration']).toBe(true)
+  })
+
   it('treats empty and whitespace-only strings as unset for pypiMirror', () => {
     settings.set('pypiMirror', 'https://mirrors.aliyun.com/pypi/simple/')
     expect(settings.get('pypiMirror')).toBe('https://mirrors.aliyun.com/pypi/simple/')
@@ -567,6 +579,16 @@ describe('getTrackedSettingsTelemetryProperties (telemetry policy)', () => {
     settings.set('useChineseMirrors', true)
     expect(settings.getTrackedSettingsTelemetryProperties(['useChineseMirrors'])).toEqual({
       setting_use_chinese_mirrors: true
+    })
+  })
+
+  it('hardwareAcceleration: unset reports enabled and explicit false reports disabled', () => {
+    expect(settings.getTrackedSettingsTelemetryProperties(['hardwareAcceleration'])).toEqual({
+      setting_hardware_acceleration: true
+    })
+    settings.set('hardwareAcceleration', false)
+    expect(settings.getTrackedSettingsTelemetryProperties(['hardwareAcceleration'])).toEqual({
+      setting_hardware_acceleration: false
     })
   })
 

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -44,6 +44,9 @@ export interface KnownSettings {
   /** When true (default), launching another local instance while one is running
    *  or starting asks the user whether to close the existing instances first. */
   warnBeforeRunningMultipleInstances?: boolean
+  /** Uses GPU rendering for Desktop windows. Disabling this takes effect on
+   *  the next app launch because Electron must configure it before readiness. */
+  hardwareAcceleration?: boolean
   pypiMirror?: string
   useChineseMirrors?: boolean
   chineseMirrorsPrompted?: boolean
@@ -222,6 +225,10 @@ const SETTINGS_SCHEMA = {
     telemetry: { policy: 'value', toTelemetry: (raw) => raw === true }
   },
   warnBeforeRunningMultipleInstances: {
+    nullable: false,
+    telemetry: { policy: 'value', toTelemetry: (raw) => raw !== false }
+  },
+  hardwareAcceleration: {
     nullable: false,
     telemetry: { policy: 'value', toTelemetry: (raw) => raw !== false }
   },

--- a/src/preload/comfyTitlePopupPreload.ts
+++ b/src/preload/comfyTitlePopupPreload.ts
@@ -94,6 +94,7 @@ export interface PopupGlobalSettingsSnapshot {
   /** Tab to land on; non-null only on the open push (rebroadcasts carry
    *  null so live data refreshes never retarget the user's tab). */
   initialTab: 'general' | 'updates' | 'storage' | 'advanced' | 'logs' | null
+  languageFields: Record<string, unknown>[]
   generalFields: Record<string, unknown>[]
   telemetryFields: Record<string, unknown>[]
   desktopUpdateFields: Record<string, unknown>[]
@@ -436,6 +437,7 @@ function isGlobalSettingsSnapshot(value: unknown): value is PopupGlobalSettingsS
   ) {
     return false
   }
+  if (!Array.isArray(v['languageFields'])) return false
   if (!Array.isArray(v['generalFields'])) return false
   if (!Array.isArray(v['telemetryFields'])) return false
   if (!Array.isArray(v['desktopUpdateFields'])) return false

--- a/src/preload/comfyTitlePopupPreload.ts
+++ b/src/preload/comfyTitlePopupPreload.ts
@@ -93,7 +93,7 @@ export interface PopupGlobalSettingsModelsDir {
 export interface PopupGlobalSettingsSnapshot {
   /** Tab to land on; non-null only on the open push (rebroadcasts carry
    *  null so live data refreshes never retarget the user's tab). */
-  initialTab: 'general' | 'updates' | 'storage' | 'advanced' | null
+  initialTab: 'general' | 'updates' | 'storage' | 'advanced' | 'logs' | null
   generalFields: Record<string, unknown>[]
   telemetryFields: Record<string, unknown>[]
   desktopUpdateFields: Record<string, unknown>[]
@@ -121,6 +121,7 @@ export interface PopupGlobalSettingsSnapshot {
     storage: string
     models: string
     advanced: string
+    logs: string
     sharedDirectories: string
   }
 }
@@ -430,7 +431,8 @@ function isGlobalSettingsSnapshot(value: unknown): value is PopupGlobalSettingsS
     tab !== 'general' &&
     tab !== 'updates' &&
     tab !== 'storage' &&
-    tab !== 'advanced'
+    tab !== 'advanced' &&
+    tab !== 'logs'
   ) {
     return false
   }

--- a/src/renderer/src/comfyTitlePopup/GlobalSettingsView.test.ts
+++ b/src/renderer/src/comfyTitlePopup/GlobalSettingsView.test.ts
@@ -172,6 +172,19 @@ describe('GlobalSettingsView', () => {
     expect(wrapper.find('.gs-tab.active').text()).toBe('General')
   })
 
+  it('moves focus with arrow-key tab navigation', async () => {
+    installMockBridge()
+    const wrapper = mountView()
+    const generalTab = wrapper.findAll('.gs-tab')[0]!
+    generalTab.element.focus()
+    await generalTab.trigger('keydown', { key: 'ArrowDown' })
+    await nextTick()
+
+    const updatesTab = wrapper.findAll('.gs-tab')[1]!
+    expect(wrapper.find('.gs-tab.active').text()).toBe('Updates')
+    expect(document.activeElement).toBe(updatesTab.element)
+  })
+
   it('lands on the tab named by snapshot.initialTab', () => {
     // The instance pane's "Manage Shared Directories" deep-link opens this
     // popup with initialTab 'storage' so the user lands on the Storage tab.

--- a/src/renderer/src/comfyTitlePopup/GlobalSettingsView.test.ts
+++ b/src/renderer/src/comfyTitlePopup/GlobalSettingsView.test.ts
@@ -12,6 +12,7 @@ interface BridgeState {
   setModelsDirsCalls: string[][]
   openPathCalls: string[]
   openExternalCalls: string[]
+  openLogsFolderCalls: number
   browseFolderReturn: string | null
   checkForUpdateCalls: number
   downloadUpdateCalls: number
@@ -25,6 +26,7 @@ function installMockBridge(): BridgeState {
     setModelsDirsCalls: [],
     openPathCalls: [],
     openExternalCalls: [],
+    openLogsFolderCalls: 0,
     browseFolderReturn: null,
     checkForUpdateCalls: 0,
     downloadUpdateCalls: 0,
@@ -45,6 +47,9 @@ function installMockBridge(): BridgeState {
     },
     globalSettingsOpenExternal: (url: string) => {
       state.openExternalCalls.push(url)
+    },
+    globalSettingsOpenLogsFolder: () => {
+      state.openLogsFolderCalls += 1
     },
     globalSettingsSetModelsDirs: async (dirs: string[]) => {
       state.setModelsDirsCalls.push([...dirs])
@@ -139,6 +144,7 @@ function makeSnapshot(overrides: Partial<Record<string, unknown>> = {}) {
       storage: 'Storage',
       models: 'Models',
       advanced: 'Advanced',
+      logs: 'Logs',
       sharedDirectories: 'Shared directories'
     }
   }
@@ -158,11 +164,12 @@ describe('GlobalSettingsView', () => {
     document.body.innerHTML = ''
   })
 
-  it('renders all four tabs and the general tab is active by default', () => {
+  it('renders all five tabs and the general tab is active by default', () => {
     installMockBridge()
     const wrapper = mountView()
     const tabLabels = wrapper.findAll('.gs-tab').map((t) => t.text())
-    expect(tabLabels).toEqual(['General', 'Updates', 'Storage', 'Advanced'])
+    expect(tabLabels).toEqual(['General', 'Updates', 'Storage', 'Advanced', 'Logs'])
+    expect(wrapper.find('.gs-tab.active').text()).toBe('General')
   })
 
   it('lands on the tab named by snapshot.initialTab', () => {
@@ -553,6 +560,27 @@ describe('GlobalSettingsView', () => {
     await row.find('.storage-dir-action').trigger('click')
     await flushPromises()
     expect(bridge.updateFieldCalls).toEqual([{ id: 'cacheDir', value: '/picked/cache' }])
+  })
+
+  it('renders diagnostics only in the Logs tab', async () => {
+    const bridge = installMockBridge()
+    const wrapper = mountView()
+    await wrapper
+      .findAll('.gs-tab')
+      .find((tab) => tab.text() === 'Advanced')!
+      .trigger('click')
+    await nextTick()
+    expect(wrapper.text()).not.toContain('Diagnostics')
+
+    await wrapper
+      .findAll('.gs-tab')
+      .find((tab) => tab.text() === 'Logs')!
+      .trigger('click')
+    await nextTick()
+    expect(wrapper.text()).toContain('Diagnostics')
+    expect(wrapper.find('.gs-logs-btn').text()).toContain('Open logs folder')
+    await wrapper.find('.gs-logs-btn').trigger('click')
+    expect(bridge.openLogsFolderCalls).toBe(1)
   })
 
   it('does not render the Install Location section in the Storage tab', async () => {

--- a/src/renderer/src/comfyTitlePopup/GlobalSettingsView.vue
+++ b/src/renderer/src/comfyTitlePopup/GlobalSettingsView.vue
@@ -32,7 +32,7 @@ interface ModelsDir {
 interface Snapshot {
   /** Tab to land on; non-null only on the open push (rebroadcasts carry
    *  null so live data refreshes never retarget the user's tab). */
-  initialTab?: 'general' | 'updates' | 'storage' | 'advanced' | null
+  initialTab?: 'general' | 'updates' | 'storage' | 'advanced' | 'logs' | null
   languageFields: Record<string, unknown>[]
   generalFields: Record<string, unknown>[]
   telemetryFields: Record<string, unknown>[]
@@ -61,6 +61,7 @@ interface Snapshot {
     storage: string
     models: string
     advanced: string
+    logs: string
     sharedDirectories: string
   }
 }
@@ -88,7 +89,7 @@ const bridge = (window as unknown as { __comfyTitlePopup?: GlobalSettingsBridge 
 
 const LAST_CHECKED_KEY = 'globalSettings.lastCheckedAt'
 
-type TabId = 'general' | 'updates' | 'storage' | 'advanced'
+type TabId = 'general' | 'updates' | 'storage' | 'advanced' | 'logs'
 const activeTab = ref<TabId>('general')
 
 // Each open pushes a fresh snapshot object, so watching by identity lets a
@@ -106,7 +107,8 @@ const tabs = computed(() => [
   { id: 'general' as const, label: props.snapshot.i18n.overview, icon: Settings2 },
   { id: 'updates' as const, label: props.snapshot.i18n.updates, icon: RefreshCcw },
   { id: 'storage' as const, label: props.snapshot.i18n.storage, icon: HardDrive },
-  { id: 'advanced' as const, label: props.snapshot.i18n.advanced, icon: SlidersHorizontal }
+  { id: 'advanced' as const, label: props.snapshot.i18n.advanced, icon: SlidersHorizontal },
+  { id: 'logs' as const, label: props.snapshot.i18n.logs, icon: FileText }
 ])
 
 const storageSnapshot = computed(() => ({
@@ -350,7 +352,7 @@ onMounted(() => {
           <GlobalStorageSections :snapshot="storageSnapshot" />
         </template>
 
-        <template v-else>
+        <template v-else-if="activeTab === 'advanced'">
           <GlobalSettingsMicroSection
             :title="t('settings.installLocation', 'Default Install Location')"
             :tooltip="t('tooltips.installDir')"
@@ -381,7 +383,9 @@ onMounted(() => {
               @browse="handleBrowseCacheDir"
             />
           </GlobalSettingsMicroSection>
+        </template>
 
+        <template v-else-if="activeTab === 'logs'">
           <GlobalSettingsMicroSection :title="t('settings.diagnostics', 'Diagnostics')">
             <button type="button" class="gs-logs-btn" @click="handleOpenLogsFolder">
               <FileText :size="14" aria-hidden="true" />

--- a/src/renderer/src/comfyTitlePopup/GlobalSettingsView.vue
+++ b/src/renderer/src/comfyTitlePopup/GlobalSettingsView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, nextTick, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { FileText, HardDrive, RefreshCcw, Settings2, SlidersHorizontal, X } from 'lucide-vue-next'
 import UpdatesSection from './globalSettings/UpdatesSection.vue'
@@ -239,6 +239,7 @@ function handleTabKey(event: KeyboardEvent): void {
   const next =
     event.key === 'ArrowDown' ? (idx + 1) % ids.length : (idx - 1 + ids.length) % ids.length
   activeTab.value = ids[next] as TabId
+  void nextTick(() => document.getElementById(`gs-tab-${activeTab.value}`)?.focus())
 }
 
 onMounted(() => {

--- a/src/renderer/src/comfyTitlePopup/TitlePopupApp.vue
+++ b/src/renderer/src/comfyTitlePopup/TitlePopupApp.vue
@@ -74,7 +74,7 @@ interface GlobalSettingsModelsDir {
 }
 
 interface GlobalSettingsSnapshot {
-  initialTab: 'general' | 'updates' | 'storage' | 'advanced' | null
+  initialTab: 'general' | 'updates' | 'storage' | 'advanced' | 'logs' | null
   generalFields: Record<string, unknown>[]
   languageFields: Record<string, unknown>[]
   telemetryFields: Record<string, unknown>[]
@@ -103,6 +103,7 @@ interface GlobalSettingsSnapshot {
     storage: string
     models: string
     advanced: string
+    logs: string
     sharedDirectories: string
   }
 }
@@ -199,6 +200,7 @@ const globalSettingsSnapshot = ref<GlobalSettingsSnapshot>({
     storage: 'Storage',
     models: 'Models',
     advanced: 'Advanced',
+    logs: 'Logs',
     sharedDirectories: 'Shared Directories'
   }
 })

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -1116,7 +1116,7 @@ export interface ElectronApi {
    *  `comfy://open-settings?tab=global` deep link. Main reuses the
    *  same helper the hamburger Settings entry calls. `tab` lands the
    *  popup on that tab instead of its remembered one. */
-  openGlobalSettings(tab?: 'general' | 'updates' | 'storage' | 'advanced'): void
+  openGlobalSettings(tab?: 'general' | 'updates' | 'storage' | 'advanced' | 'logs'): void
   /** Open the instance-picker popup for the panel's host window with
    *  `installationId` seeded as the picker's right-pane selection.
    *  Used by chooser-card "Manage…" (and future per-install entry


### PR DESCRIPTION
## Summary

- add a default-enabled Electron hardware acceleration toggle under Desktop Settings > Advanced
- persist the preference and apply it before Electron becomes ready, with a restart required for changes to take effect
- move log and diagnostic controls out of Advanced into a dedicated Logs sidebar tab
- preserve Desktop Settings navigation, keyboard focus, and localization behavior
- add unit and Windows/NVIDIA E2E coverage for the setting, restart behavior, tab placement, and actual dedicated GPU memory reduction

## Behavior

This is the Desktop equivalent of the hardware acceleration setting in Chrome or Firefox. It controls Electron's GPU rendering only; it does not disable CUDA or change ComfyUI inference behavior.

When hardware acceleration is disabled, Desktop calls `app.disableHardwareAcceleration()` before Electron readiness. The setting remains enabled by default, and its description tells users that Desktop must restart before the change takes effect.

The existing diagnostic information and Open logs folder action now live in a dedicated Logs tab in the Desktop Settings sidebar. Hardware acceleration lives under Advanced.

## Hardware verification

The Windows test toggles the setting through Desktop Settings > Advanced, restarts Desktop with the same profile, and compares dedicated GPU memory for the Electron process tree.

On an RTX 4090 Windows host, the latest run measured:

- enabled: 162.8 MiB median dedicated GPU memory
- disabled: 0.0 MiB median dedicated GPU memory

The test uses `nvidia-smi -L` to require NVIDIA hardware and `nvidia-smi pmon` to confirm an Electron process is assigned to it. Because WDDM does not expose graphics-process memory through `nvidia-smi --query-compute-apps`, it measures Windows `GPU Process Memory/Dedicated Usage` counters. It also verifies GPU compositing is enabled before the restart and disabled afterward.

## Validation

- typecheck
- lint
- format check
- production build
- unit tests: 4061 passed
- integration tests: 40 passed
- Windows E2E suite: 74 passed
- hardware acceleration E2E: 162.8 MiB -> 0.0 MiB
- independent review: no actionable findings after fixes
- both CodeRabbit review threads addressed and resolved

Closes #1406