### PR TITLE
Fix select dropdown viewport clipping

### DIFF
--- a/src/main/lib/ipc/registerSettingsHandlers.test.ts
+++ b/src/main/lib/ipc/registerSettingsHandlers.test.ts
@@ -98,6 +98,7 @@ describe('buildSettingsSections', () => {
           'Uses the GPU to render Comfy Desktop. Restart Comfy Desktop for changes to take effect.'
       })
     )
+    expect(advancedFields.at(-1)?.id).toBe('hardwareAcceleration')
 
     mockSettings.hardwareAcceleration = false
     const updatedFields = buildSettingsSections().find((section) => section.title === 'Advanced')

--- a/src/main/lib/ipc/registerSettingsHandlers.ts
+++ b/src/main/lib/ipc/registerSettingsHandlers.ts
@@ -147,21 +147,21 @@ export function buildSettingsSections(
       title: i18n.t('settings.advanced'),
       fields: [
         {
-          id: 'hardwareAcceleration',
-          label: i18n.t('settings.hardwareAcceleration'),
-          type: 'boolean',
-          value: s.hardwareAcceleration !== false,
-          description: i18n.t('settings.hardwareAccelerationDescription'),
-          tooltip: i18n.t('settings.hardwareAccelerationDescription')
-        },
-        {
           id: 'pypiMirror',
           label: i18n.t('settings.pypiMirror'),
           type: 'text' as const,
           value: s.pypiMirror || '',
           placeholder: i18n.t('settings.pypiMirrorPlaceholder')
         },
-        ...(!isChinese ? [chineseMirrorsField] : [])
+        ...(!isChinese ? [chineseMirrorsField] : []),
+        {
+          id: 'hardwareAcceleration',
+          label: i18n.t('settings.hardwareAcceleration'),
+          type: 'boolean',
+          value: s.hardwareAcceleration !== false,
+          description: i18n.t('settings.hardwareAccelerationDescription'),
+          tooltip: i18n.t('settings.hardwareAccelerationDescription')
+        }
       ]
     }
   ]

--- a/src/renderer/src/components/ui/BaseSelect.test.ts
+++ b/src/renderer/src/components/ui/BaseSelect.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils'
+import BaseSelect from './BaseSelect.vue'
+
+const wrappers: VueWrapper[] = []
+const originalInnerHeight = window.innerHeight
+
+function rect(top: number, bottom: number): DOMRect {
+  return {
+    top,
+    bottom,
+    left: 20,
+    right: 220,
+    width: 200,
+    height: bottom - top,
+    x: 20,
+    y: top,
+    toJSON: () => ({})
+  }
+}
+
+function mountSelect(options = ['One', 'Two', 'Three']): VueWrapper {
+  const wrapper = mount(BaseSelect, {
+    props: {
+      modelValue: 'One',
+      options: options.map((label) => ({ value: label, label })),
+      ariaLabel: 'Test select'
+    },
+    attachTo: document.body
+  })
+  wrappers.push(wrapper)
+  return wrapper
+}
+
+afterEach(() => {
+  while (wrappers.length) wrappers.pop()?.unmount()
+  document.querySelectorAll('.ui-select-listbox').forEach((element) => element.remove())
+  Object.defineProperty(window, 'innerHeight', { configurable: true, value: originalInnerHeight })
+  vi.restoreAllMocks()
+})
+
+describe('BaseSelect positioning', () => {
+  it('uses the rendered list height to flip a dropdown above the trigger', async () => {
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 380 })
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function () {
+      return this.classList.contains('ui-select-trigger') ? rect(200, 240) : rect(0, 0)
+    })
+    vi.spyOn(HTMLElement.prototype, 'scrollHeight', 'get').mockImplementation(function () {
+      return this.classList.contains('ui-select-listbox') ? 170 : 0
+    })
+
+    const wrapper = mountSelect()
+    await wrapper.get('.ui-select-trigger').trigger('click')
+    await flushPromises()
+
+    const listbox = document.querySelector<HTMLElement>('.ui-select-listbox')
+    expect(listbox).not.toBeNull()
+    expect(listbox!.style.top).toBe('auto')
+    expect(listbox!.style.bottom).toBe('182px')
+    expect(listbox!.style.maxHeight).toBe('190px')
+  })
+
+  it('clamps a dropdown to the available space on its chosen side', async () => {
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 160 })
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function () {
+      return this.classList.contains('ui-select-trigger') ? rect(30, 70) : rect(0, 0)
+    })
+    vi.spyOn(HTMLElement.prototype, 'scrollHeight', 'get').mockImplementation(function () {
+      return this.classList.contains('ui-select-listbox') ? 200 : 0
+    })
+
+    const wrapper = mountSelect(['One', 'Two', 'Three', 'Four', 'Five'])
+    await wrapper.get('.ui-select-trigger').trigger('click')
+    await flushPromises()
+
+    const listbox = document.querySelector<HTMLElement>('.ui-select-listbox')
+    expect(listbox).not.toBeNull()
+    expect(listbox!.style.top).toBe('72px')
+    expect(listbox!.style.bottom).toBe('auto')
+    expect(listbox!.style.maxHeight).toBe('80px')
+  })
+})

--- a/src/renderer/src/components/ui/BaseSelect.vue
+++ b/src/renderer/src/components/ui/BaseSelect.vue
@@ -41,22 +41,33 @@ const selectedOption = computed(() => props.options.find((o) => o.value === prop
 const triggerLabel = computed(() => selectedOption.value?.label ?? props.placeholder)
 
 const listboxId = `ui-listbox-${Math.random().toString(36).slice(2, 9)}`
+const POPOVER_GAP = 2
+const VIEWPORT_PADDING = 8
+const ESTIMATED_OPTION_HEIGHT = 36
+const ESTIMATED_LISTBOX_CHROME = 16
+const PREFERRED_MAX_HEIGHT = 280
 
 function updatePosition(): void {
   const trigger = triggerRef.value
   if (!trigger) return
   const rect = trigger.getBoundingClientRect()
-  const spaceBelow = window.innerHeight - rect.bottom
-  const spaceAbove = rect.top
-  const desiredHeight = Math.min(props.options.length * 36 + 16, 280)
-  const openUp = spaceBelow < desiredHeight + 8 && spaceAbove > spaceBelow
+  const spaceBelow = Math.max(0, window.innerHeight - rect.bottom - POPOVER_GAP - VIEWPORT_PADDING)
+  const spaceAbove = Math.max(0, rect.top - POPOVER_GAP - VIEWPORT_PADDING)
+  const estimatedHeight = props.options.length * ESTIMATED_OPTION_HEIGHT + ESTIMATED_LISTBOX_CHROME
+  const measuredHeight = listboxRef.value
+    ? listboxRef.value.scrollHeight +
+      Math.max(0, listboxRef.value.offsetHeight - listboxRef.value.clientHeight)
+    : 0
+  const desiredHeight = Math.min(measuredHeight || estimatedHeight, PREFERRED_MAX_HEIGHT)
+  const openUp = spaceBelow < desiredHeight && spaceAbove > spaceBelow
+  const availableHeight = openUp ? spaceAbove : spaceBelow
   popoverStyle.value = {
     position: 'fixed',
     left: `${rect.left}px`,
     width: `${rect.width}px`,
-    top: openUp ? 'auto' : `${rect.bottom + 2}px`,
-    bottom: openUp ? `${window.innerHeight - rect.top + 2}px` : 'auto',
-    maxHeight: `${Math.max(spaceBelow, spaceAbove) - 16}px`,
+    top: openUp ? 'auto' : `${rect.bottom + POPOVER_GAP}px`,
+    bottom: openUp ? `${window.innerHeight - rect.top + POPOVER_GAP}px` : 'auto',
+    maxHeight: `${availableHeight}px`,
     zIndex: '9999'
   }
 }
@@ -68,6 +79,8 @@ function openPanel(): void {
   activeIndex.value = idx >= 0 ? idx : props.options.findIndex((o) => !o.disabled)
   updatePosition()
   void nextTick(() => {
+    // The rendered list may be taller than the per-option estimate.
+    updatePosition()
     listboxRef.value?.focus()
     scrollActiveIntoView()
   })
@@ -330,6 +343,7 @@ onBeforeUnmount(() => {
 <style>
 /* Listbox is teleported to <body>, so it can't be scoped. */
 .ui-select-listbox {
+  box-sizing: border-box;
   margin: 0;
   padding: 4px;
   list-style: none;


### PR DESCRIPTION
## Summary
- reposition select dropdowns using their rendered height after opening
- flip dropdowns toward the side with more room when they do not fit below
- clamp dropdown height to the chosen viewport space so options remain reachable by scrolling
- add component coverage for upward placement and viewport height clamping

## Validation
- `pnpm run test` (235 files, 4063 tests)
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run format:check`

Fixes #1412