### PR TITLE
feat(templates): dynamic starter templates, live install progress, and a Cloud showcase

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -977,6 +977,10 @@
     "updateDepsChecking": "Checking requirements…",
     "updateDepsDryRun": "Checking for conflicts…",
     "updateDepsInstalling": "Installing requirements…",
+    "uvResolved": "Worked out {count} dependencies…",
+    "uvDownloading": "Fetching {name}…",
+    "uvDownloadingSized": "Fetching {name} — {size}",
+    "uvInstalling": "Installing dependencies…",
     "updateDepsUpToDate": "Requirements unchanged.",
     "updateFailed": "Update process failed with exit code {code}.",
     "updateNoGit": "No .git directory found in ComfyUI/. Commit-based updating requires a git repository.",
@@ -1423,5 +1427,45 @@
     "progressWorking": "Working…",
     "progressError": "Something went wrong",
     "progressCancelled": "Cancelled"
+  },
+  "installShowcase": {
+    "cloud": {
+      "title": "Skip the setup entirely",
+      "body": "Cloud is ready now. No install, no drivers, no GPU."
+    },
+    "cloudCta": "Try Cloud free",
+    "gpu": {
+      "title": "RTX 6000 Pro, 96GB VRAM",
+      "body": "Faster than most workstations, from any device you own."
+    },
+    "models": {
+      "title": "900+ models ready",
+      "body": "Wan 2.2, Flux, Qwen, LTX. Nothing left to download."
+    },
+    "license": {
+      "title": "Cleared for commercial use",
+      "body": "Every model licensed for commercial work."
+    },
+    "partner": {
+      "title": "Models you can't run locally",
+      "body": "Nano Banana Pro, Seedance, Grok Video, GPT Image 2."
+    },
+    "nodes": {
+      "title": "The custom nodes you use",
+      "body": "Behind ~90% of local workflows, pre-installed and current."
+    },
+    "loras": {
+      "title": "Bring your own LoRAs",
+      "body": "Import from CivitAI or Hugging Face to keep your style."
+    },
+    "queue": {
+      "title": "Queue 100 at once",
+      "body": "Line up a batch and keep working."
+    },
+    "idle": {
+      "title": "Pay for runtime, not idle time",
+      "body": "Credits are spent only while the GPU runs."
+    },
+    "label": "While you wait"
   }
 }

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -977,6 +977,10 @@
     "updateDepsChecking": "正在检查需求…",
     "updateDepsDryRun": "正在检查冲突…",
     "updateDepsInstalling": "正在安装需求…",
+    "uvResolved": "已解析 {count} 个依赖项…",
+    "uvDownloading": "正在获取 {name}…",
+    "uvDownloadingSized": "正在获取 {name} — {size}",
+    "uvInstalling": "正在安装依赖项…",
     "updateDepsUpToDate": "需求未变化。",
     "updateFailed": "更新过程失败，退出代码 {code}。",
     "updateNoGit": "在 ComfyUI/ 中未找到 .git 目录。基于提交的更新需要 git 仓库。",
@@ -1423,5 +1427,45 @@
     "progressWorking": "正在处理…",
     "progressError": "出现了问题",
     "progressCancelled": "已取消"
+  },
+  "installShowcase": {
+    "cloud": {
+      "title": "完全跳过配置",
+      "body": "Cloud 已就绪。无需安装、驱动或 GPU。"
+    },
+    "cloudCta": "免费试用 Cloud",
+    "gpu": {
+      "title": "RTX 6000 Pro，96GB 显存",
+      "body": "比多数工作站更快，任何设备可用。"
+    },
+    "models": {
+      "title": "900+ 模型已预装",
+      "body": "Wan 2.2、Flux、Qwen、LTX，无需下载。"
+    },
+    "license": {
+      "title": "已获商用授权",
+      "body": "每个模型均可用于商业用途。"
+    },
+    "partner": {
+      "title": "本地无法运行的模型",
+      "body": "Nano Banana Pro、Seedance、Grok Video。"
+    },
+    "nodes": {
+      "title": "你常用的自定义节点",
+      "body": "约 90% 本地工作流所用，已预装并保持更新。"
+    },
+    "loras": {
+      "title": "导入你自己的 LoRA",
+      "body": "从 CivitAI 或 Hugging Face 导入，保持风格。"
+    },
+    "queue": {
+      "title": "一次排队 100 个",
+      "body": "排好任务，继续工作。"
+    },
+    "idle": {
+      "title": "只为运行付费，闲置不计费",
+      "body": "仅在 GPU 运行时消耗积分。"
+    },
+    "label": "等待期间"
   }
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -100,6 +100,7 @@ import { getInitialAnonymousDistinctId } from './lib/websiteAnonymousIdentity'
 import { recoverPendingIdentityRotation } from './lib/pendingIdentityMerge'
 import { initExperiments } from './lib/experiments'
 import { initCloudFreeRuns } from './lib/cloudFreeRuns'
+import { initStarterTemplates } from './sources/standalone/starterTemplateManifest'
 import { initUserTier } from './lib/userTier'
 
 import {
@@ -1463,6 +1464,9 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
     // experiments cache would never have a value to give it. See
     // `cloudFreeRuns.ts`.
     void initCloudFreeRuns({ distinctId: installationId })
+
+    // Same pre-consent ops-flag path; boot must not wait on the fetch.
+    void initStarterTemplates({ distinctId: installationId })
 
     // Hydrate the persisted cloud user-tier cache for billing telemetry and
     // free-tier offer UI. `userTier.ts` refreshes it on every cloud

--- a/src/main/lib/fetch.test.ts
+++ b/src/main/lib/fetch.test.ts
@@ -8,6 +8,7 @@ vi.mock('./safe-file', () => ({ writeFileSafe: vi.fn() }))
 interface FakeRequest extends EventEmitter {
   setHeader: ReturnType<typeof vi.fn>
   end: ReturnType<typeof vi.fn>
+  abort: ReturnType<typeof vi.fn>
   __url: string
   __headers: Record<string, string>
 }
@@ -23,6 +24,7 @@ vi.mock('electron', () => ({
           headers[k] = v
         }),
         end: vi.fn(),
+        abort: vi.fn(),
         __url: opts.url,
         __headers: headers
       }) as FakeRequest
@@ -32,7 +34,7 @@ vi.mock('electron', () => ({
   }
 }))
 
-import { _resetCacheForTest, fetchJSON } from './fetch'
+import { _resetCacheForTest, fetchJSON, fetchText } from './fetch'
 
 function makeResponse(
   statusCode: number,
@@ -164,5 +166,93 @@ describe('fetchJSON — mirror is not allowed to poison the cache', () => {
     expect(requests[0]!.__headers['If-None-Match']).toBe('"primary-etag-1"')
     requests[0]!.emit('response', makeResponse(304, ''))
     await expect(p2).resolves.toEqual({ v: 1 })
+  })
+})
+
+describe('fetchText — shares fetchJSON’s cache and retry layer', () => {
+  beforeEach(() => {
+    requests.length = 0
+    _resetCacheForTest()
+  })
+
+  it('returns the raw body without JSON parsing', async () => {
+    const p = fetchText(PRIMARY)
+    requests[0]!.emit('response', makeResponse(200, 'comfyui-workflow-templates==0.11.31\n'))
+    await expect(p).resolves.toContain('comfyui-workflow-templates==0.11.31')
+  })
+
+  it('serves the cached body on a 304, so an unchanged pin costs no re-download', async () => {
+    const first = fetchText(PRIMARY)
+    requests[0]!.emit('response', makeResponse(200, 'pinned==1.0.0', { etag: '"v1"' }))
+    await first
+
+    const second = fetchText(PRIMARY)
+    requests[1]!.emit('response', makeResponse(304, ''))
+    await expect(second, 'a warm cache carries an offline boot').resolves.toBe('pinned==1.0.0')
+  })
+
+  it('falls back to the last-cached body when the network fails', async () => {
+    const first = fetchText(PRIMARY)
+    requests[0]!.emit('response', makeResponse(200, 'pinned==1.0.0', { etag: '"v1"' }))
+    await first
+
+    const second = fetchText(PRIMARY)
+    requests[1]!.emit('error', new Error('offline'))
+    await new Promise((r) => setImmediate(r))
+    requests[2]!.emit('error', new Error('offline'))
+    await expect(second, 'a warm cache carries an offline boot').resolves.toBe('pinned==1.0.0')
+  })
+
+  it('rejects on a non-200 so a 404 is not mistaken for an empty body', async () => {
+    const p = fetchText(PRIMARY)
+    requests[0]!.emit('response', makeResponse(404, 'Not Found'))
+    await new Promise((r) => setImmediate(r))
+    requests[1]!.emit('error', new Error('mirror down'))
+    await expect(p).rejects.toThrow(/HTTP 404/)
+  })
+})
+
+describe('fetch — request timeout', () => {
+  beforeEach(() => {
+    requests.length = 0
+    _resetCacheForTest()
+  })
+
+  it('rejects a stalled request instead of hanging its callers', async () => {
+    await expect(
+      fetchText(PRIMARY, { timeoutMs: 10 }),
+      'net.request has no deadline, so only this can settle a black-holed socket'
+    ).rejects.toThrow(/Timed out after 10ms/)
+  })
+
+  it('aborts the stalled request rather than leaking the socket', async () => {
+    await fetchText(PRIMARY, { timeoutMs: 10 }).catch(() => undefined)
+    expect(requests[0]!.abort, 'the socket is released, not just abandoned').toHaveBeenCalled()
+  })
+
+  it('does not let a late timeout reject an already-resolved request', async () => {
+    const p = fetchText(PRIMARY, { timeoutMs: 10 })
+    requests[0]!.emit('response', makeResponse(200, 'body'))
+    await expect(p).resolves.toBe('body')
+    await new Promise((r) => setTimeout(r, 30))
+  })
+})
+
+describe('fetch — cache is namespaced by parser', () => {
+  beforeEach(() => {
+    requests.length = 0
+    _resetCacheForTest()
+  })
+
+  it('does not serve a JSON-cached body to a text caller', async () => {
+    const first = fetchJSON(PRIMARY)
+    requests[0]!.emit('response', makeResponse(200, '{"a":1}', { etag: '"v1"' }))
+    await first
+
+    const second = fetchText(PRIMARY)
+    requests[1]!.emit('response', makeResponse(200, 'plain text'))
+    await expect(second, 'a JSON-cached body is never served to a text caller').resolves.toBe(
+      'plain text'
+    )
   })
 })

--- a/src/main/lib/fetch.test.ts
+++ b/src/main/lib/fetch.test.ts
@@ -231,10 +231,15 @@ describe('fetch — request timeout', () => {
   })
 
   it('does not let a late timeout reject an already-resolved request', async () => {
-    const p = fetchText(PRIMARY, { timeoutMs: 10 })
-    requests[0]!.emit('response', makeResponse(200, 'body'))
-    await expect(p).resolves.toBe('body')
-    await new Promise((r) => setTimeout(r, 30))
+    vi.useFakeTimers()
+    try {
+      const p = fetchText(PRIMARY, { timeoutMs: 10 })
+      requests[0]!.emit('response', makeResponse(200, 'body'))
+      await vi.advanceTimersByTimeAsync(30)
+      await expect(p).resolves.toBe('body')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })
 

--- a/src/main/lib/fetch.ts
+++ b/src/main/lib/fetch.ts
@@ -10,8 +10,10 @@ interface CacheEntry {
   data: unknown
 }
 
-// ETag cache (url -> { etag, data }) persisted to disk; bounded, oldest evicted first.
+// ETag cache (`kind:url` -> { etag, data }) persisted to disk; bounded, oldest evicted first.
 const MAX_CACHE_SIZE = 100
+/** No deadline exists below this layer. */
+const DEFAULT_TIMEOUT_MS = 15_000
 const CACHE_FILE = path.join(cacheDir(), 'fetch-cache.json')
 
 const _cache: Map<string, CacheEntry> = new Map()
@@ -31,7 +33,10 @@ function _ensureLoaded(): void {
           typeof (entry as CacheEntry).etag === 'string' &&
           'data' in entry
         ) {
-          _cache.set(url, entry as CacheEntry)
+          // Legacy un-prefixed keys can never be read again; drop them.
+          if (url.startsWith('json:') || url.startsWith('text:')) {
+            _cache.set(url, entry as CacheEntry)
+          }
         }
       }
     }
@@ -69,19 +74,44 @@ function _headerString(value: string | string[] | undefined): string | undefined
   return Array.isArray(value) ? value[0] : value
 }
 
-// Single-shot fetch with ETag negotiation. `cached` provides the If-None-Match
-// value (and the 304 short-circuit body); `cacheKey` is the URL the successful
-// response should be cached under, or undefined to skip writing to the cache
-// entirely. Splitting these lets the mirror-retry below run WITHOUT leaking the
-// primary's ETag to the mirror (cached: undefined) and WITHOUT poisoning the
-// primary's persisted cache entry with mirror-tagged data (cacheKey: undefined).
-function fetchJSONOnce(
+/**
+ * Performs a single HTTP fetch with ETag negotiation and timeout.
+ *
+ * @param url - The request URL.
+ * @param cached - Cached entry (provides If-None-Match and a 304 response body).
+ * @param cacheKey - Cache key to store response under; omit to skip caching.
+ * @param parse - Function to parse the response body.
+ * @param timeoutMs - Timeout in milliseconds.
+ *
+ * Splitting `cached` and `cacheKey` allows retries against mirrors without leaking ETags
+ * or cross-contaminating cache entries.
+ */
+function fetchOnce(
   url: string,
   cached: CacheEntry | undefined,
-  cacheKey: string | undefined
+  cacheKey: string | undefined,
+  parse: (body: string, url: string) => unknown,
+  timeoutMs: number
 ): Promise<unknown> {
   return new Promise((resolve, reject) => {
     const request = net.request({ url, cache: 'no-cache' })
+    let settled = false
+    const timer = setTimeout(() => {
+      if (settled) return
+      settled = true
+      try {
+        request.abort()
+      } catch {
+        /* already finished */
+      }
+      reject(new Error(`Timed out after ${timeoutMs}ms fetching ${url}`))
+    }, timeoutMs)
+    const finish = (fn: () => void): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      fn()
+    }
     request.setHeader('User-Agent', 'ComfyUI-Desktop-2')
 
     const ghToken = process.env.GITHUB_TOKEN
@@ -104,7 +134,7 @@ function fetchJSONOnce(
       response.on('data', (chunk) => (data += chunk.toString()))
       response.on('end', () => {
         if (response.statusCode === 304 && cached) {
-          resolve(structuredClone(cached.data))
+          finish(() => resolve(structuredClone(cached.data)))
           return
         }
         if (response.statusCode !== 200) {
@@ -125,14 +155,14 @@ function fetchJSONOnce(
               msg += ' (rate limited)'
             }
           }
-          reject(new Error(msg))
+          finish(() => reject(new Error(msg)))
           return
         }
         let parsed: unknown
         try {
-          parsed = JSON.parse(data)
-        } catch {
-          reject(new Error(`Invalid JSON response from ${url}`))
+          parsed = parse(data, url)
+        } catch (err) {
+          finish(() => reject(err instanceof Error ? err : new Error(String(err))))
           return
         }
         if (cacheKey) {
@@ -141,10 +171,10 @@ function fetchJSONOnce(
             _cacheSet(cacheKey, { etag, data: parsed })
           }
         }
-        resolve(parsed)
+        finish(() => resolve(parsed))
       })
     })
-    request.on('error', (err) => reject(err))
+    request.on('error', (err) => finish(() => reject(err)))
     request.end()
   })
 }
@@ -155,24 +185,63 @@ export function _resetCacheForTest(): void {
   _loaded = false
 }
 
-export async function fetchJSON(url: string, opts?: { refresh?: boolean }): Promise<unknown> {
+function parseText(body: string): string {
+  return body
+}
+
+function parseJson(body: string, url: string): unknown {
+  try {
+    return JSON.parse(body)
+  } catch {
+    throw new Error(`Invalid JSON response from ${url}`)
+  }
+}
+
+/** Plain-text sibling of `fetchJSON`, sharing its cache, retry, and fallback. */
+export async function fetchText(
+  url: string,
+  opts?: { refresh?: boolean; timeoutMs?: number }
+): Promise<string> {
+  const body = await fetchWith(url, 'text', parseText, opts)
+  if (typeof body !== 'string') throw new Error(`Expected a text body from ${url}`)
+  return body
+}
+
+export async function fetchJSON(
+  url: string,
+  opts?: { refresh?: boolean; timeoutMs?: number }
+): Promise<unknown> {
+  return fetchWith(url, 'json', parseJson, opts)
+}
+
+async function fetchWith(
+  url: string,
+  kind: 'json' | 'text',
+  parse: (body: string, url: string) => unknown,
+  opts?: { refresh?: boolean; timeoutMs?: number }
+): Promise<unknown> {
+  const timeoutMs = opts?.timeoutMs ?? DEFAULT_TIMEOUT_MS
   _ensureLoaded()
+  // Namespaced by parser: the cache outlives releases, so a URL whose parser
+  // changes must not 304 a string into a JSON caller.
+  const cacheKey = `${kind}:${url}`
   // `refresh` ignores the persisted ETag so the response is never served from cache. Used
   // for R2 manifests where a stale value would strand users on an old release.
-  const cached = opts?.refresh ? undefined : _cache.get(url)
+  const cached = opts?.refresh ? undefined : _cache.get(cacheKey)
 
   try {
-    return await fetchJSONOnce(url, cached, url)
+    return await fetchOnce(url, cached, cacheKey, parse, timeoutMs)
   } catch (primaryErr) {
     // If this is an R2 URL with a configured mirror, retry once against it
     // before falling back to the persisted cache. The retry deliberately
     // discards `cached` (no ETag negotiation against the mirror) and writes
     // nothing back to the cache so a stale or compromised mirror cannot
     // poison the primary's cache entry.
+    // The mirror gets its own budget, so worst case is 2x `timeoutMs`.
     const mirror = r2MirrorUrl(url)
     if (mirror && mirror !== url) {
       try {
-        return await fetchJSONOnce(mirror, undefined, undefined)
+        return await fetchOnce(mirror, undefined, undefined, parse, timeoutMs)
       } catch {
         // fall through to cache / primary error
       }

--- a/src/main/lib/installer.test.ts
+++ b/src/main/lib/installer.test.ts
@@ -18,6 +18,7 @@ vi.mock('electron', () => ({
 }))
 
 import { downloadAndExtract, downloadAndExtractMulti } from './installer'
+import type { SendProgress } from '../../types/ipc'
 import type { Cache } from './cache'
 import type { DownloadProgress } from './download'
 import type { ExtractProgress } from './extract'
@@ -39,7 +40,6 @@ function makeCache(dir: string): Cache {
   }
 }
 
-type SendProgress = (step: string, data: { percent: number; status: string }) => void
 type DownloadFn = (
   url: string,
   dest: string,

--- a/src/main/lib/installer.ts
+++ b/src/main/lib/installer.ts
@@ -6,6 +6,8 @@ import type { Cache } from './cache'
 import { isDownloadComplete } from './download'
 import type { DownloadProgress } from './download'
 import type { ExtractProgress } from './extract'
+import type { InstallPayloadItem, SendProgress } from '../../types/ipc'
+import { BYTES_PER_MB, measuredProgress } from '../../shared/progressMeasurement'
 
 /** Per-phase boundary signal for `comfy.desktop.install.phase` telemetry. The
  *  installer owns the genuine download↔extract seam (the two are one call from
@@ -17,7 +19,7 @@ import type { ExtractProgress } from './extract'
 export type InstallPhaseName = 'download' | 'extract'
 export type InstallPhaseStatus = 'start' | 'end' | 'error'
 export interface InstallerContext {
-  sendProgress: (step: string, data: { percent: number; status: string }) => void
+  sendProgress: SendProgress
   download: (
     url: string,
     dest: string,
@@ -184,7 +186,17 @@ export async function downloadAndExtract(
                 percent: p.percent,
                 status: t('installer.downloading', {
                   progress: `${p.receivedMB} / ${p.totalMB} MB  ·  ${speed}  ·  ${elapsed} elapsed  ·  ${eta} remaining`
-                })
+                }),
+                ...measuredProgress(p.speedMBs, p.etaSecs),
+                payload: [
+                  {
+                    id: filename,
+                    label: filename,
+                    totalBytes: expectedSize,
+                    receivedBytes: p.receivedBytes,
+                    state: 'active'
+                  }
+                ]
               })
             },
             { signal, expectedSize }
@@ -211,7 +223,8 @@ export async function downloadAndExtract(
           percent: p.percent,
           status: t('installer.extracting', {
             progress: `${p.percent}%  ·  ${elapsed} elapsed  ·  ${eta} remaining`
-          })
+          }),
+          ...measuredProgress(0, p.etaSecs)
         })
       },
       { signal }
@@ -236,6 +249,17 @@ export async function downloadAndExtractMulti(
   let allCached = true
   const overallStart = Date.now()
 
+  /** Snapshot every file as a payload row: settled ones before `activeIndex`
+   *  are done, the active one carries its live byte count, the rest pend. */
+  const payloadAt = (activeIndex: number, activeReceived: number): InstallPayloadItem[] =>
+    files.map((f, i) => ({
+      id: f.filename,
+      label: f.filename,
+      ...(f.size > 0 ? { totalBytes: f.size } : {}),
+      receivedBytes: i < activeIndex ? f.size : i === activeIndex ? activeReceived : 0,
+      state: i < activeIndex ? 'done' : i === activeIndex ? 'active' : 'pending'
+    }))
+
   await withInstallPhase(onPhase, 'download', async () => {
     for (let i = 0; i < count; i++) {
       const file = files[i]!
@@ -258,7 +282,8 @@ export async function downloadAndExtractMulti(
                 : Math.round(((i + 1) / count) * 100)
             sendProgress('download', {
               percent,
-              status: `${t('installer.cachedDownload')}${fileLabel}`
+              status: `${t('installer.cachedDownload')}${fileLabel}`,
+              payload: payloadAt(i + 1, 0)
             })
           } else {
             allCached = false
@@ -268,7 +293,8 @@ export async function downloadAndExtractMulti(
                 : Math.round((i / count) * 100)
             sendProgress('download', {
               percent: basePercent,
-              status: `${t('installer.startingDownload')}${fileLabel}`
+              status: `${t('installer.startingDownload')}${fileLabel}`,
+              payload: payloadAt(i, 0)
             })
             await download(
               file.url,
@@ -281,10 +307,13 @@ export async function downloadAndExtractMulti(
                 const overallSpeed =
                   overallElapsed > 0 ? receivedTotal / 1048576 / overallElapsed : 0
                 const remainingBytes = totalBytes - receivedTotal
-                const eta =
+                // Whole-set projection, not this file's: the user is waiting on
+                // every part, so a per-file ETA would understate the wait.
+                const etaSecs =
                   overallSpeed > 0 && totalBytes > 0
-                    ? formatTime(remainingBytes / 1048576 / overallSpeed)
-                    : '—'
+                    ? remainingBytes / BYTES_PER_MB / overallSpeed
+                    : -1
+                const eta = etaSecs >= 0 ? formatTime(etaSecs) : '—'
                 const sizeDisplay = totalMB
                   ? `${(receivedTotal / 1048576).toFixed(0)} / ${totalMB} MB`
                   : `${p.receivedMB} / ${p.totalMB} MB`
@@ -296,7 +325,9 @@ export async function downloadAndExtractMulti(
                   percent,
                   status: t('installer.downloading', {
                     progress: `${fileLabel} ${sizeDisplay}  ·  ${speed}  ·  ${elapsed} elapsed  ·  ${eta} remaining`
-                  })
+                  }),
+                  ...measuredProgress(overallSpeed, etaSecs),
+                  payload: payloadAt(i, p.receivedBytes)
                 })
               },
               { signal, expectedSize: file.size || undefined }
@@ -337,7 +368,8 @@ export async function downloadAndExtractMulti(
           percent: p.percent,
           status: t('installer.extracting', {
             progress: `${p.percent}%  ·  ${elapsed} elapsed  ·  ${eta} remaining`
-          })
+          }),
+          ...measuredProgress(0, p.etaSecs)
         })
       },
       { signal }

--- a/src/main/lib/ipc/sessionActions/launch.ts
+++ b/src/main/lib/ipc/sessionActions/launch.ts
@@ -70,7 +70,11 @@ import {
   formatTemplateSubStatus,
   awaitTemplateDownloadSettled
 } from '../../../sources/standalone/templateDownloadTask'
-import { isTerminal as isTemplateDownloadTerminal } from '../../../sources/standalone/templateDownloadCore'
+import {
+  isTerminal as isTemplateDownloadTerminal,
+  templateStateToPayload
+} from '../../../sources/standalone/templateDownloadCore'
+import { measuredProgress } from '../../../../shared/progressMeasurement'
 import type { PreLaunchPhase } from '../../launchPhases'
 import { scanCustomNodes } from '../../nodes'
 import type { LaunchProgressTracker } from '../../launchProgress'
@@ -745,7 +749,9 @@ async function runLaunch(
         sendProgress('template-models', {
           percent,
           status: formatTemplateSubStatus(summary),
-          error: summary.status === 'error'
+          error: summary.status === 'error',
+          payload: templateStateToPayload(state),
+          ...measuredProgress(summary.speedMBs, summary.etaSecs)
         })
         return terminal
       }

--- a/src/main/lib/ipc/shared.ts
+++ b/src/main/lib/ipc/shared.ts
@@ -110,7 +110,7 @@ import type { SnapshotExportEnvelope, Snapshot } from '../snapshots'
 import { getVariantLabel, buildPinnedVariant } from '../../sources/standalone'
 import type { FieldOption, SourcePlugin } from '../../types/sources'
 import { REQUIRES_STOPPED } from '../../../types/ipc'
-import type { Theme, ResolvedTheme, QuitActiveItem } from '../../../types/ipc'
+import type { Theme, ResolvedTheme, QuitActiveItem, SendProgress } from '../../../types/ipc'
 import { findLockingProcesses } from '../file-lock-info'
 import type { LaunchCmd } from '../process'
 import { getComfyArgsSchema, filterUnsupportedArgs } from '../comfy-args'
@@ -1446,8 +1446,8 @@ async function _enrichLatestCommitsAhead(): Promise<void> {
 export function makeSendProgress(
   sender: Electron.WebContents,
   installationId: string
-): (phase: string, detail: Record<string, unknown>) => void {
-  return (phase: string, detail: Record<string, unknown>): void => {
+): SendProgress {
+  return (phase, detail): void => {
     if (!sender.isDestroyed()) {
       sender.send('install-progress', { installationId, phase, ...detail })
     }

--- a/src/main/lib/opsFlag.ts
+++ b/src/main/lib/opsFlag.ts
@@ -35,17 +35,13 @@ export interface OpsFlag<T> {
   _resetForTest(): void
 }
 
-export function makeOpsFlag<T>(opts: {
-  key: string
-  /** Value held before the fetch resolves, and kept when it fails or returns something
-   *  `parse` doesn't recognise. This is the flag's fail direction. */
-  fallback: T
-  /** Narrow the raw flag value. Return `undefined` to keep the fallback — that is how an
-   *  unrecognised payload is distinguished from a legitimate value. */
-  parse: (value: FeatureFlagValue | undefined) => T | undefined
-  /** Enables the `[label] init:` / `[label] init error:` boot logs. Omit for no logging. */
-  logLabel?: string
-}): OpsFlag<T> {
+/** Shared plumbing with the fetcher injected. One copy because these are
+ *  correctness-critical and easy to diverge: a single cached in-flight promise,
+ *  `get()` awaiting rather than racing it, and `cached` set only when resolved. */
+function makeOpsFlagFrom<T, V>(
+  fetchValue: (key: string, distinctId: string, timeoutMs: number) => Promise<V>,
+  opts: { key: string; fallback: T; parse: (value: V) => T | undefined; logLabel?: string }
+): OpsFlag<T> {
   const { key, fallback, parse, logLabel } = opts
   let cached: T = fallback
   let initPromise: Promise<void> | null = null
@@ -53,13 +49,12 @@ export function makeOpsFlag<T>(opts: {
   return {
     init(initOpts) {
       if (initPromise) return initPromise
-      initPromise = mainTelemetry
-        .getOpsFlag(key, initOpts.distinctId, initOpts.timeoutMs ?? DEFAULT_TIMEOUT_MS)
+      initPromise = fetchValue(key, initOpts.distinctId, initOpts.timeoutMs ?? DEFAULT_TIMEOUT_MS)
         .then((value) => {
           const parsed = parse(value)
           if (parsed !== undefined) cached = parsed
 
-          if (logLabel) console.log(`[${logLabel}] init: fetched=`, value, '→ cached=', cached)
+          if (logLabel) console.log(`[${logLabel}] init: fetched=`, value, '\u2192 cached=', cached)
         })
         .catch((err) => {
           if (logLabel) console.log(`[${logLabel}] init error:`, err)
@@ -82,4 +77,32 @@ export function makeOpsFlag<T>(opts: {
       initPromise = null
     }
   }
+}
+
+export function makeOpsFlag<T>(opts: {
+  key: string
+  /** Default value used before fetch resolves or if fetch/parse fails. */
+  fallback: T
+  /** Return `undefined` to use fallback for unrecognized values. */
+  parse: (value: FeatureFlagValue | undefined) => T | undefined
+  /** Enables the `[label] init:` / `[label] init error:` boot logs. Omit for no logging. */
+  logLabel?: string
+}): OpsFlag<T> {
+  return makeOpsFlagFrom(
+    (key, distinctId, timeoutMs) => mainTelemetry.getOpsFlag(key, distinctId, timeoutMs),
+    opts
+  )
+}
+
+/** For JSON payload flags: PostHog may send a string or object—`parse` handles this. */
+export function makeOpsFlagPayload<T>(opts: {
+  key: string
+  fallback: T
+  parse: (value: unknown) => T | undefined
+  logLabel?: string
+}): OpsFlag<T> {
+  return makeOpsFlagFrom(
+    (key, distinctId, timeoutMs) => mainTelemetry.getOpsFlagPayload(key, distinctId, timeoutMs),
+    opts
+  )
 }

--- a/src/main/lib/telemetry.ts
+++ b/src/main/lib/telemetry.ts
@@ -1230,6 +1230,32 @@ export async function getOpsFlag(
 }
 
 /**
+ * `getOpsFlag` for JSON-payload flags. `sendFeatureFlagEvents` is a documented
+ * no-op here, so consent safety rests on this path never capturing an event.
+ */
+export async function getOpsFlagPayload(
+  key: string,
+  distinctId: string,
+  timeoutMs: number
+): Promise<unknown | undefined> {
+  if (!client) return undefined
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    const payloadPromise = client.getFeatureFlagPayload(key, distinctId, undefined, {
+      onlyEvaluateLocally: false
+    })
+    const timeoutPromise = new Promise<undefined>((resolve) => {
+      timer = setTimeout(() => resolve(undefined), timeoutMs)
+    })
+    return await Promise.race([payloadPromise, timeoutPromise])
+  } catch {
+    return undefined
+  } finally {
+    if (timer !== undefined) clearTimeout(timer)
+  }
+}
+
+/**
  * Wrap an async step with start/end/error telemetry events that mirror legacy
  * desktop's `@trackEvent` decorator. Errors are re-thrown so callers can
  * continue normal control flow.

--- a/src/main/lib/uvProgress.test.ts
+++ b/src/main/lib/uvProgress.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createUvProgressParser, type UvProgress } from './uvProgress'
+
+/** Feed output through the parser and collect every emitted state. */
+function run(...chunks: string[]): UvProgress[] {
+  const seen: UvProgress[] = []
+  const feed = createUvProgressParser((p) => seen.push(p))
+  chunks.forEach(feed)
+  return seen
+}
+
+const last = (states: UvProgress[]): UvProgress | undefined => states.at(-1)
+
+describe('summary lines', () => {
+  it('reads the resolved package count', () => {
+    const states = run('Resolved 42 packages in 1.23s\n')
+    expect(last(states)).toMatchObject({ stage: 'resolving', resolvedCount: 42 })
+  })
+
+  it('handles the singular form uv uses for one package', () => {
+    const states = run('Resolved 1 package in 5ms\n')
+    expect(last(states)?.resolvedCount).toBe(1)
+  })
+
+  it('advances to installing once packages are prepared', () => {
+    const states = run('Prepared 12 packages in 4.56s\n')
+    expect(last(states)?.stage).toBe('installing')
+  })
+
+  it('accepts the without-build-isolation variant', () => {
+    const states = run('Prepared 1 package without build isolation in 2.00s\n')
+    expect(last(states)?.stage).toBe('installing')
+  })
+
+  it('finishes on the installed summary', () => {
+    const states = run('Installed 12 packages in 789ms\n')
+    expect(last(states)?.stage).toBe('done')
+  })
+
+  it('finishes on an audited summary, which a no-op sync emits instead', () => {
+    const states = run('Audited 5 packages in 12ms\n')
+    expect(last(states)?.stage).toBe('done')
+  })
+})
+
+describe('download lines', () => {
+  it('names the package and size uv reported', () => {
+    const states = run('Downloading torch (2.7GiB)\n')
+    expect(last(states)).toMatchObject({
+      stage: 'preparing',
+      currentPackage: 'torch',
+      currentSize: '2.7GiB'
+    })
+  })
+
+  it('handles a download with no known size', () => {
+    const states = run('Downloading torch\n')
+    expect(last(states)).toMatchObject({ currentPackage: 'torch', currentSize: undefined })
+  })
+
+  it('clears the current package on the indented completion line', () => {
+    const states = run('Downloading torch (2.7GiB)\n', ' Downloaded torch\n')
+    expect(last(states)).toMatchObject({ currentPackage: undefined, currentSize: undefined })
+  })
+
+  it('ignores a repeated Downloading line for the same package', () => {
+    // uv 0.9.x printed `Downloading` on completion; counting it would double.
+    const states = run('Downloading torch (2.7GiB)\n', 'Downloading torch (2.7GiB)\n')
+    expect(states).toHaveLength(1)
+  })
+
+  it('names each large download in turn', () => {
+    const states = run(
+      'Downloading torch (2.7GiB)\n',
+      ' Downloaded torch\n',
+      'Downloading nvidia-cudnn-cu12 (664.8MiB)\n'
+    )
+    expect(states.map((s) => s.currentPackage)).toEqual(['torch', undefined, 'nvidia-cudnn-cu12'])
+  })
+})
+
+describe('stream handling', () => {
+  it('holds a partial line until its newline arrives', () => {
+    const seen: UvProgress[] = []
+    const feed = createUvProgressParser((p) => seen.push(p))
+    feed('Resolved 42 pack')
+    expect(seen).toHaveLength(0)
+    feed('ages in 1.23s\n')
+    expect(last(seen)?.resolvedCount).toBe(42)
+  })
+
+  it('parses several lines delivered in one chunk', () => {
+    const states = run('Resolved 3 packages in 1s\nPrepared 3 packages in 2s\n')
+    expect(states).toHaveLength(2)
+    expect(last(states)?.stage).toBe('installing')
+  })
+
+  it('strips ANSI styling before matching', () => {
+    const states = run('[1m[36mDownloading[0m torch [2m(2.7GiB)[0m\n')
+    expect(last(states)?.currentPackage).toBe('torch')
+  })
+
+  it('handles CRLF output from Windows', () => {
+    const states = run('Resolved 7 packages in 1.00s\r\n')
+    expect(last(states)?.resolvedCount).toBe(7)
+  })
+
+  it('ignores unrelated output rather than guessing', () => {
+    const states = run('warning: `uv pip install` is experimental\n', 'error: oh no\n')
+    expect(states).toHaveLength(0)
+  })
+
+  it('recovers after output that never breaks into lines', () => {
+    const seen: UvProgress[] = []
+    const feed = createUvProgressParser((p) => seen.push(p))
+    feed('x'.repeat(100_000))
+    feed('\nResolved 5 packages in 1s\n')
+    expect(last(seen)?.resolvedCount).toBe(5)
+  })
+
+  it('keeps parsing after a consumer throws', () => {
+    const onProgress = vi.fn().mockImplementationOnce(() => {
+      throw new Error('render blew up')
+    })
+    const feed = createUvProgressParser(onProgress)
+    expect(() => feed('Resolved 1 package in 1s\n')).not.toThrow()
+    feed('Installed 1 package in 1s\n')
+    expect(onProgress).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/main/lib/uvProgress.ts
+++ b/src/main/lib/uvProgress.ts
@@ -1,0 +1,111 @@
+import { stripAnsi } from './stderrTail'
+
+/**
+ * Coarse milestones parsed from `uv pip install`'s human output — it offers no
+ * machine-readable progress (astral-sh/uv#9129).
+ *
+ * Piped stdio suppresses uv's progress bars, so no byte counts, percentages or
+ * speeds exist to read: a percentage bar cannot be built from this. Downloads
+ * under 1 MiB announce nothing at all.
+ */
+export type UvStage = 'resolving' | 'preparing' | 'installing' | 'done'
+
+export interface UvProgress {
+  stage: UvStage
+  /** Package currently downloading, when uv named one. */
+  currentPackage?: string
+  /** Human size uv reported for `currentPackage`, verbatim (e.g. `2.7GiB`). */
+  currentSize?: string
+  /** Packages uv resolved, once it says so. */
+  resolvedCount?: number
+}
+
+// uv indents its completion lines, so every pattern tolerates leading space.
+const RESOLVED_RE = /^\s*Resolved (\d+) packages? in /
+const PREPARED_RE = /^\s*Prepared (\d+) packages?(?: without build isolation)? in /
+const INSTALLED_RE = /^\s*Installed (\d+) packages?(?: without build isolation)? in /
+const AUDITED_RE = /^\s*Audited (\d+) packages? in /
+const DOWNLOADING_RE = /^\s*Downloading (\S+)(?: \(([^)]+)\))?\s*$/
+const DOWNLOADED_RE = /^\s*Downloaded (\S+)\s*$/
+
+/** Ceiling on an unterminated line, so output that never breaks can't grow. */
+const MAX_PARTIAL_LINE_CHARS = 8192
+
+/**
+ * Feed uv output through a line-buffered parser, calling `onProgress` when the
+ * visible state changes. Chunks arrive on raw buffer boundaries and the two
+ * streams interleave, so partial lines are held back until a newline arrives.
+ */
+export function createUvProgressParser(
+  onProgress: (p: UvProgress) => void
+): (chunk: string) => void {
+  let buffer = ''
+  const seenDownloads = new Set<string>()
+  const state: UvProgress = { stage: 'resolving' }
+
+  const emit = (): void => {
+    try {
+      onProgress({ ...state })
+    } catch {}
+  }
+
+  const consumeLine = (raw: string): void => {
+    const line = stripAnsi(raw)
+    if (!line.trim()) return
+
+    const resolved = RESOLVED_RE.exec(line)
+    if (resolved) {
+      state.stage = 'resolving'
+      state.resolvedCount = Number(resolved[1])
+      emit()
+      return
+    }
+
+    const downloading = DOWNLOADING_RE.exec(line)
+    if (downloading) {
+      const name = downloading[1]!
+      // Some uv versions print `Downloading` on completion too, so a repeat is
+      // that line, not a second download.
+      if (seenDownloads.has(name)) return
+      seenDownloads.add(name)
+      state.stage = 'preparing'
+      state.currentPackage = name
+      state.currentSize = downloading[2]
+      emit()
+      return
+    }
+
+    if (DOWNLOADED_RE.test(line)) {
+      state.currentPackage = undefined
+      state.currentSize = undefined
+      emit()
+      return
+    }
+
+    if (PREPARED_RE.test(line)) {
+      state.stage = 'installing'
+      state.currentPackage = undefined
+      state.currentSize = undefined
+      emit()
+      return
+    }
+
+    if (INSTALLED_RE.test(line) || AUDITED_RE.test(line)) {
+      state.stage = 'done'
+      state.currentPackage = undefined
+      state.currentSize = undefined
+      emit()
+    }
+  }
+
+  return (chunk: string): void => {
+    buffer += chunk
+    let newline = buffer.indexOf('\n')
+    while (newline !== -1) {
+      consumeLine(buffer.slice(0, newline))
+      buffer = buffer.slice(newline + 1)
+      newline = buffer.indexOf('\n')
+    }
+    if (buffer.length > MAX_PARTIAL_LINE_CHARS) buffer = buffer.slice(-1024)
+  }
+}

--- a/src/main/sources/standalone/curatedTemplates.test.ts
+++ b/src/main/sources/standalone/curatedTemplates.test.ts
@@ -38,6 +38,38 @@ describe('isPersistableTemplateId', () => {
   })
 })
 
+describe('CURATED_TEMPLATES is the picker’s backfill floor', () => {
+  it('carries exactly 4 templates for every modality in the tab order', () => {
+    for (const modality of TEMPLATE_MODALITY_ORDER) {
+      const forModality = CURATED_TEMPLATES.filter((t) => t.modality === modality)
+      expect(forModality.length, `${modality}: the floor every fallback bottoms out on`).toBe(4)
+    }
+    expect(CURATED_TEMPLATES.length).toBe(TEMPLATE_MODALITY_ORDER.length * 4)
+  })
+
+  it('has exactly one recommended per modality, and never an API-node one', () => {
+    for (const modality of TEMPLATE_MODALITY_ORDER) {
+      const recommended = CURATED_TEMPLATES.filter(
+        (t) => t.modality === modality && t.recommended === true
+      )
+      expect(recommended.length, modality).toBe(1)
+      expect(recommended[0]!.apiNode, modality).toBeUndefined()
+    }
+  })
+
+  it('has no duplicate ids', () => {
+    const ids = CURATED_TEMPLATES.map((t) => t.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('gives every entry a snapshot, so an offline cold start still renders cards', () => {
+    for (const t of CURATED_TEMPLATES) {
+      expect(t.snapshot?.title, t.id).toBeTruthy()
+      expect(typeof t.snapshot?.sizeBytes, t.id).toBe('number')
+    }
+  })
+})
+
 describe('buildTemplateDeeplink', () => {
   it('appends ?template=<id>&source=default and round-trips the id', () => {
     const out = buildTemplateDeeplink('http://127.0.0.1:8188/', 'flux_schnell')
@@ -77,8 +109,6 @@ describe('thumbnailUrlFor', () => {
 })
 
 describe('CURATED_TEMPLATES manifest', () => {
-  // Must match the frontend deeplink validator so the auto-open can't be
-  // rejected for a malformed id.
   const ID_PATTERN = /^[a-zA-Z0-9_.-]+$/
 
   it('offers exactly 4 templates per modality', () => {

--- a/src/main/sources/standalone/curatedTemplates.test.ts
+++ b/src/main/sources/standalone/curatedTemplates.test.ts
@@ -38,38 +38,6 @@ describe('isPersistableTemplateId', () => {
   })
 })
 
-describe('CURATED_TEMPLATES is the picker’s backfill floor', () => {
-  it('carries exactly 4 templates for every modality in the tab order', () => {
-    for (const modality of TEMPLATE_MODALITY_ORDER) {
-      const forModality = CURATED_TEMPLATES.filter((t) => t.modality === modality)
-      expect(forModality.length, `${modality}: the floor every fallback bottoms out on`).toBe(4)
-    }
-    expect(CURATED_TEMPLATES.length).toBe(TEMPLATE_MODALITY_ORDER.length * 4)
-  })
-
-  it('has exactly one recommended per modality, and never an API-node one', () => {
-    for (const modality of TEMPLATE_MODALITY_ORDER) {
-      const recommended = CURATED_TEMPLATES.filter(
-        (t) => t.modality === modality && t.recommended === true
-      )
-      expect(recommended.length, modality).toBe(1)
-      expect(recommended[0]!.apiNode, modality).toBeUndefined()
-    }
-  })
-
-  it('has no duplicate ids', () => {
-    const ids = CURATED_TEMPLATES.map((t) => t.id)
-    expect(new Set(ids).size).toBe(ids.length)
-  })
-
-  it('gives every entry a snapshot, so an offline cold start still renders cards', () => {
-    for (const t of CURATED_TEMPLATES) {
-      expect(t.snapshot?.title, t.id).toBeTruthy()
-      expect(typeof t.snapshot?.sizeBytes, t.id).toBe('number')
-    }
-  })
-})
-
 describe('buildTemplateDeeplink', () => {
   it('appends ?template=<id>&source=default and round-trips the id', () => {
     const out = buildTemplateDeeplink('http://127.0.0.1:8188/', 'flux_schnell')
@@ -118,11 +86,16 @@ describe('CURATED_TEMPLATES manifest', () => {
     }
   })
 
-  it('marks at most one recommended template per modality', () => {
+  it('marks exactly one recommended template per modality', () => {
     for (const modality of TEMPLATE_MODALITY_ORDER) {
       const recommended = CURATED_TEMPLATES.filter((t) => t.modality === modality && t.recommended)
-      expect(recommended.length, modality).toBeLessThanOrEqual(1)
+      expect(recommended.length, modality).toBe(1)
     }
+  })
+
+  it('has no duplicate ids, which would collide on the picker’s option key', () => {
+    const ids = CURATED_TEMPLATES.map((t) => t.id)
+    expect(new Set(ids).size).toBe(ids.length)
   })
 
   it('uses only deeplink-safe ids', () => {

--- a/src/main/sources/standalone/curatedTemplates.ts
+++ b/src/main/sources/standalone/curatedTemplates.ts
@@ -26,8 +26,14 @@ interface CuratedTemplateBase {
   id: string
   /** Output modality this template showcases. */
   modality: TemplateModality
-  /** Offline display metadata; superseded by the live index when available. */
-  snapshot: TemplateSnapshot
+  /** Superseded by the live index; optional on a remote entry. */
+  snapshot?: TemplateSnapshot
+  /** ISO-8601 UTC; hidden before this, so content can stage a launch. */
+  availableFrom?: string
+  /** ISO-8601 UTC. After this instant the entry is hidden. */
+  availableUntil?: string
+  /** Forces `snapshot` copy over the live index, for launch-specific wording. */
+  snapshotOverrides?: true
 }
 
 /**
@@ -37,6 +43,9 @@ interface CuratedTemplateBase {
  */
 export type CuratedTemplate = CuratedTemplateBase &
   ({ recommended?: true; apiNode?: never } | { apiNode: true; recommended?: never })
+
+/** `snapshot` is required: this list is the offline floor. */
+export type BakedInTemplate = CuratedTemplate & { snapshot: TemplateSnapshot }
 
 /** Tab order in the picker — one tab per modality that has ≥1 curated template. */
 export const TEMPLATE_MODALITY_ORDER: readonly TemplateModality[] = [
@@ -65,10 +74,15 @@ const IMAGE_SUBTYPES = new Set(['webp', 'png', 'jpg', 'jpeg', 'gif', 'avif'])
  * subtype isn't an image (e.g. `mp3`), so the caller falls back to the glyph
  * without a doomed network request. Pure + exported for reuse and tests.
  */
-export function thumbnailUrlFor(id: string, mediaSubtype: string): string | null {
+export function thumbnailUrlFor(
+  id: string,
+  mediaSubtype: string,
+  /** Defaults to `main`; the picker passes the base its install ships. */
+  assetBase: string = RAW_TEMPLATES_BASE
+): string | null {
   const ext = (mediaSubtype || 'webp').toLowerCase()
   if (!IMAGE_SUBTYPES.has(ext)) return null
-  return `${RAW_TEMPLATES_BASE}/${id}-1.${ext}`
+  return `${assetBase}/${id}-1.${ext}`
 }
 
 /**
@@ -94,7 +108,7 @@ export const NO_TEMPLATE_VALUE = 'none'
 /** A template id is a single path-safe segment: the frontend deeplink validator
  *  pattern (`^[a-zA-Z0-9_.-]+$`). No `/` or `\`, so it can't escape the templates
  *  dir when joined into a filesystem path or interpolated into a fetch URL. */
-const TEMPLATE_ID_PATTERN = /^[a-zA-Z0-9_.-]+$/
+export const TEMPLATE_ID_PATTERN = /^[a-zA-Z0-9_.-]+$/
 
 /**
  * Whether `value` is a persistable starter-template id. Accepts any
@@ -115,7 +129,7 @@ export function isPersistableTemplateId(value: unknown): value is string {
  * To update, change the id and sync the template's
  * title/description/size/mediaSubtype into `snapshot`.
  */
-export const CURATED_TEMPLATES: readonly CuratedTemplate[] = [
+export const CURATED_TEMPLATES: readonly BakedInTemplate[] = [
   // --- Image ---
   {
     id: 'image_z_image_turbo',

--- a/src/main/sources/standalone/index.test.ts
+++ b/src/main/sources/standalone/index.test.ts
@@ -1,6 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as TemplatePinModule from './templatePin'
 
 vi.mock('electron', () => ({
   app: { getPath: () => '' },
@@ -14,6 +15,15 @@ vi.mock('../../lib/fetch', () => ({
 vi.mock('../../lib/comfyui-releases', () => ({
   getLatestStableTag: vi.fn()
 }))
+
+const resolveTemplatePackageVersion = vi.fn()
+vi.mock('./templatePin', async (importOriginal) => {
+  const actual = await importOriginal<typeof TemplatePinModule>()
+  return {
+    ...actual,
+    resolveTemplatePackageVersion: (...a: unknown[]) => resolveTemplatePackageVersion(...a)
+  }
+})
 
 import { standalone, buildPinnedVariant } from './index'
 import { resetTemplateCatalogCache } from './templateCatalog'
@@ -236,6 +246,8 @@ describe('standalone.buildInstallation', () => {
 describe('standalone.getFieldOptions bundledTemplate', () => {
   beforeEach(() => {
     mockedFetchJSON.mockReset()
+    resolveTemplatePackageVersion.mockReset()
+    resolveTemplatePackageVersion.mockResolvedValue(null)
     resetTemplateCatalogCache()
   })
 
@@ -306,6 +318,35 @@ describe('standalone.getFieldOptions bundledTemplate', () => {
       const card = options.find((o) => o.value === curated.id)!
       expect(card.data!.apiNode, curated.id).toBe(curated.apiNode === true)
     }
+  })
+
+  it('pins the catalog to a stable-channel version pick', async () => {
+    mockedFetchJSON.mockResolvedValue([])
+    await standalone.getFieldOptions!(
+      'bundledTemplate',
+      {
+        release: { value: 'stable', label: 'Stable', data: { latestStableTag: 'v0.30.2' } },
+        comfyVersion: { value: 'v0.28.2', label: 'v0.28.2' }
+      },
+      {}
+    )
+    expect(resolveTemplatePackageVersion).toHaveBeenCalledWith('v0.28.2')
+  })
+
+  it('ignores a comfyVersion left over from a switch to the latest channel', async () => {
+    mockedFetchJSON.mockResolvedValue([])
+    await standalone.getFieldOptions!(
+      'bundledTemplate',
+      {
+        release: { value: 'latest', label: 'Latest', data: { latestStableTag: 'v0.30.2' } },
+        comfyVersion: { value: 'v0.28.2', label: 'v0.28.2' }
+      },
+      {}
+    )
+    expect(
+      resolveTemplatePackageVersion,
+      'the picker must target the version the install will actually run'
+    ).toHaveBeenCalledWith('v0.30.2')
   })
 })
 

--- a/src/main/sources/standalone/index.ts
+++ b/src/main/sources/standalone/index.ts
@@ -20,6 +20,7 @@ import {
 import { install, postInstall, probeInstallation } from './install'
 import { NO_TEMPLATE_VALUE, isPersistableTemplateId } from './curatedTemplates'
 import { loadTemplateCatalog } from './templateCatalog'
+import { resolveTemplatePackageVersion, templateAssetBaseFor } from './templatePin'
 import { resolveTemplateModels } from './templateModels'
 import * as installations from '../../installations'
 
@@ -555,18 +556,31 @@ export const standalone: SourcePlugin = {
       // "None" comes first as the skip option; the per-modality recommended
       // picks carry `recommended` on their own option so the wizard auto-selects
       // a real template (the lightest "wow"), not the skip.
-      const catalog = await loadTemplateCatalog()
+      const releaseData = selections.release?.data as
+        | { latestStableTag?: string | null }
+        | undefined
+      const pickedComfyTag =
+        typeof selections.comfyVersion?.value === 'string' &&
+        /^v\d+\.\d+\.\d+$/.test(selections.comfyVersion.value)
+          ? selections.comfyVersion.value
+          : null
+      const targetComfyVersion =
+        pickedComfyTag ?? releaseData?.latestStableTag ?? (await getLatestStableTag())
+      const catalog = await loadTemplateCatalog({ comfyVersion: targetComfyVersion })
 
       const installId = typeof context.installationId === 'string' ? context.installationId : null
       const installation = installId ? await installations.get(installId) : null
       // `budgeted` stops the timed-out pass writing after we return, so a slow
       // `modelsPresent: false` reads as "unbadged", never "confirmed absent".
       let budgeted = false
+      const assetBase = templateAssetBaseFor(
+        await resolveTemplatePackageVersion(targetComfyVersion).catch(() => null)
+      )
       const presenceById = new Map<string, boolean>()
       const presencePass = Promise.all(
         catalog.map(async (tpl) => {
           try {
-            const models = await resolveTemplateModels(installation, tpl.id)
+            const models = await resolveTemplateModels(installation, tpl.id, assetBase)
             const present = await areModelsPresent(installId, models)
             if (!budgeted) presenceById.set(tpl.id, present)
           } catch {

--- a/src/main/sources/standalone/index.ts
+++ b/src/main/sources/standalone/index.ts
@@ -20,7 +20,6 @@ import {
 import { install, postInstall, probeInstallation } from './install'
 import { NO_TEMPLATE_VALUE, isPersistableTemplateId } from './curatedTemplates'
 import { loadTemplateCatalog } from './templateCatalog'
-import { resolveTemplatePackageVersion, templateAssetBaseFor } from './templatePin'
 import { resolveTemplateModels } from './templateModels'
 import * as installations from '../../installations'
 
@@ -559,23 +558,28 @@ export const standalone: SourcePlugin = {
       const releaseData = selections.release?.data as
         | { latestStableTag?: string | null }
         | undefined
+      // Only honour a comfyVersion pick on the stable channel, matching the
+      // variant branch and `buildInstallation`: `getFieldOptions` returns [] for
+      // 'latest', so a value carried over from a channel toggle is stale and
+      // would pin the picker to a version the install never runs.
+      const isStable = selections.release?.value === 'stable'
       const pickedComfyTag =
+        isStable &&
         typeof selections.comfyVersion?.value === 'string' &&
         /^v\d+\.\d+\.\d+$/.test(selections.comfyVersion.value)
           ? selections.comfyVersion.value
           : null
       const targetComfyVersion =
         pickedComfyTag ?? releaseData?.latestStableTag ?? (await getLatestStableTag())
-      const catalog = await loadTemplateCatalog({ comfyVersion: targetComfyVersion })
+      const { templates: catalog, assetBase } = await loadTemplateCatalog({
+        comfyVersion: targetComfyVersion
+      })
 
       const installId = typeof context.installationId === 'string' ? context.installationId : null
       const installation = installId ? await installations.get(installId) : null
       // `budgeted` stops the timed-out pass writing after we return, so a slow
       // `modelsPresent: false` reads as "unbadged", never "confirmed absent".
       let budgeted = false
-      const assetBase = templateAssetBaseFor(
-        await resolveTemplatePackageVersion(targetComfyVersion).catch(() => null)
-      )
       const presenceById = new Map<string, boolean>()
       const presencePass = Promise.all(
         catalog.map(async (tpl) => {

--- a/src/main/sources/standalone/install.ts
+++ b/src/main/sources/standalone/install.ts
@@ -30,6 +30,7 @@ import {
   writeComfyEnvironment
 } from './envPaths'
 import type { InstallationRecord } from '../../installations'
+import type { SendProgress } from '../../../types/ipc'
 import { tagsEqual, type ComfyVersion } from '../../lib/version'
 import { resolveNestedComfyUIParent } from '../common/nestedRoot'
 import type { InstallTools, PostInstallTools } from '../../types/sources'
@@ -317,7 +318,7 @@ export async function postInstall(
             channel,
             ...(pickedTag ? { targetTag: pickedTag } : {}),
             update,
-            sendProgress: sendProgress as (step: string, data: Record<string, unknown>) => void,
+            sendProgress,
             signal,
             // The standalone bundle ships a pre-extracted venv whose pinned
             // versions can lag ComfyUI's own `requirements.txt` (most visibly
@@ -414,7 +415,7 @@ export async function probeInstallation(dirPath: string): Promise<Record<string,
 export async function migrateEnvLayout(
   installPath: string,
   update: (data: Record<string, unknown>) => Promise<unknown>,
-  sendProgress?: (step: string, data: { percent: number; status: string }) => void
+  sendProgress?: SendProgress
 ): Promise<boolean> {
   const venvDir = getVenvDir(installPath)
   if (fs.existsSync(venvDir)) return false

--- a/src/main/sources/standalone/macRepair.ts
+++ b/src/main/sources/standalone/macRepair.ts
@@ -3,6 +3,7 @@ import path from 'path'
 import { execFile } from 'child_process'
 import { getActiveVenvDir } from '../../lib/pythonEnv'
 import type { InstallationRecord } from '../../installations'
+import type { SendProgress } from '../../../types/ipc'
 
 export async function removeQuarantine(dir: string, log?: (text: string) => void): Promise<void> {
   if (process.platform !== 'darwin') return
@@ -22,10 +23,7 @@ export async function removeQuarantine(dir: string, log?: (text: string) => void
  */
 export async function repairMacBinaries(
   installPath: string,
-  sendProgress: (
-    step: string,
-    data: { percent: number; status: string; [key: string]: unknown }
-  ) => void,
+  sendProgress: SendProgress,
   sendOutput?: (text: string) => void,
   installation?: InstallationRecord
 ): Promise<void> {

--- a/src/main/sources/standalone/starterTemplateManifest.test.ts
+++ b/src/main/sources/standalone/starterTemplateManifest.test.ts
@@ -31,6 +31,11 @@ function doc(templates: unknown[]): Record<string, unknown> {
   return { schemaVersion: 1, templates }
 }
 
+/** Disk-cache contents, stamped fresh unless a write time is given. */
+function cached(templates: unknown[], writtenAt: number = Date.now()): string {
+  return JSON.stringify({ ...doc(templates), writtenAt })
+}
+
 const VALID_IMAGE = { id: 'image_one', modality: 'image' }
 
 function entriesOf(raw: unknown): { id: string; modality: string }[] {
@@ -231,6 +236,22 @@ describe('per-entry validation drops individually', () => {
     expect(parsed![0]!.snapshot).toEqual(snapshot)
   })
 
+  it('keeps snapshotOverrides when a snapshot backs it', () => {
+    const snapshot = { title: 'T', description: 'D', sizeBytes: 10, mediaSubtype: 'webp' }
+    const parsed = parseStarterTemplateManifest(
+      doc([{ ...VALID_IMAGE, snapshot, snapshotOverrides: true }])
+    )
+    expect(
+      parsed![0]!.snapshotOverrides,
+      'content pinned this card to its own copy, not the live index'
+    ).toBe(true)
+  })
+
+  it('drops snapshotOverrides when no snapshot backs it', () => {
+    const parsed = parseStarterTemplateManifest(doc([{ ...VALID_IMAGE, snapshotOverrides: true }]))
+    expect(parsed![0]!.snapshotOverrides, 'an override with nothing to override').toBeUndefined()
+  })
+
   it('preserves availability window fields when ISO-8601', () => {
     const parsed = parseStarterTemplateManifest(
       doc([{ ...VALID_IMAGE, availableFrom: '2026-01-01T00:00:00Z' }])
@@ -332,7 +353,7 @@ describe('flag plumbing and fallback layers', () => {
   })
 
   it('serves a warm disk cache when the fetch fails', async () => {
-    readFileSync.mockReturnValue(JSON.stringify(doc([{ id: 'cached_one', modality: 'image' }])))
+    readFileSync.mockReturnValue(cached([{ id: 'cached_one', modality: 'image' }]))
     getOpsFlagPayload.mockResolvedValue(undefined)
     await initStarterTemplates({ distinctId: 'anon' })
     expect((await getStarterTemplatesAsync()).map((e) => e.id)).toEqual(['cached_one'])
@@ -347,6 +368,33 @@ describe('flag plumbing and fallback layers', () => {
     getOpsFlagPayload.mockResolvedValue(undefined)
     await initStarterTemplates({ distinctId: 'anon' })
     expect(await getStarterTemplatesAsync()).toEqual(CURATED_TEMPLATES)
+  })
+
+  it('decays to the baked-in list once the cache outlives its maximum age', async () => {
+    const fifteenDays = 15 * 24 * 60 * 60 * 1000
+    readFileSync.mockReturnValue(
+      cached([{ id: 'cached_one', modality: 'image' }], Date.now() - fifteenDays)
+    )
+    getOpsFlagPayload.mockResolvedValue(undefined)
+    await initStarterTemplates({ distinctId: 'anon' })
+    expect(
+      await getStarterTemplatesAsync(),
+      'deleting the flag must eventually roll the picker back'
+    ).toEqual(CURATED_TEMPLATES)
+  })
+
+  it('discards a cache written before the age stamp existed', async () => {
+    readFileSync.mockReturnValue(JSON.stringify(doc([{ id: 'cached_one', modality: 'image' }])))
+    getOpsFlagPayload.mockResolvedValue(undefined)
+    await initStarterTemplates({ distinctId: 'anon' })
+    expect(await getStarterTemplatesAsync()).toEqual(CURATED_TEMPLATES)
+  })
+
+  it('stamps the cache it writes so a later read can age it out', async () => {
+    getOpsFlagPayload.mockResolvedValue(JSON.stringify(doc([VALID_IMAGE])))
+    await initStarterTemplates({ distinctId: 'anon' })
+    const [, written] = writeFileSafe.mock.calls[0] as [string, string]
+    expect(typeof JSON.parse(written).writtenAt).toBe('number')
   })
 
   it('writes the disk cache after a successful parse', async () => {

--- a/src/main/sources/standalone/starterTemplateManifest.test.ts
+++ b/src/main/sources/standalone/starterTemplateManifest.test.ts
@@ -424,16 +424,17 @@ describe('flag plumbing and fallback layers', () => {
 
 describe('a known id must agree with its baked-in modality', () => {
   it('drops a baked-in id filed under the wrong tab', () => {
+    const [misfiled, correct] = CURATED_TEMPLATES.filter((t) => t.modality === 'image')
     const parsed = parseStarterTemplateManifest(
       doc([
-        { id: 'image_z_image_turbo', modality: 'video' },
-        { id: 'sdxlturbo_example', modality: 'image' }
+        { id: misfiled!.id, modality: 'video' },
+        { id: correct!.id, modality: 'image' }
       ])
     )
     expect(
       parsed!.map((e) => e.id),
       'a known id under the wrong tab is dropped'
-    ).toEqual(['sdxlturbo_example'])
+    ).toEqual([correct!.id])
   })
 
   it('keeps every baked-in id under its own modality', () => {

--- a/src/main/sources/standalone/starterTemplateManifest.test.ts
+++ b/src/main/sources/standalone/starterTemplateManifest.test.ts
@@ -1,0 +1,407 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type * as FsModule from 'fs'
+
+const getOpsFlagPayload = vi.fn()
+const capture = vi.fn()
+vi.mock('../../lib/telemetry', () => ({
+  getOpsFlagPayload: (...args: unknown[]) => getOpsFlagPayload(...args),
+  capture: (...args: unknown[]) => capture(...args)
+}))
+
+const readFileSync = vi.fn()
+const writeFileSafe = vi.fn()
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof FsModule>()
+  const patched = { ...actual, readFileSync: (...a: unknown[]) => readFileSync(...a) }
+  return { ...patched, default: patched }
+})
+vi.mock('../../lib/safe-file', () => ({ writeFileSafe: (...a: unknown[]) => writeFileSafe(...a) }))
+vi.mock('../../lib/paths', () => ({ dataDir: () => '/tmp/does-not-exist' }))
+
+import {
+  parseStarterTemplateManifest,
+  initStarterTemplates,
+  getStarterTemplatesAsync,
+  STARTER_TEMPLATES_FLAG_KEY,
+  _resetForTest
+} from './starterTemplateManifest'
+import { CURATED_TEMPLATES } from './curatedTemplates'
+
+function doc(templates: unknown[]): Record<string, unknown> {
+  return { schemaVersion: 1, templates }
+}
+
+const VALID_IMAGE = { id: 'image_one', modality: 'image' }
+
+function entriesOf(raw: unknown): { id: string; modality: string }[] {
+  const parsed = parseStarterTemplateManifest(raw)
+  return (parsed ?? []).map((e) => ({ id: e.id, modality: e.modality }))
+}
+
+beforeEach(() => {
+  _resetForTest()
+  getOpsFlagPayload.mockReset()
+  capture.mockReset()
+  readFileSync.mockReset()
+  writeFileSafe.mockReset()
+  readFileSync.mockImplementation(() => {
+    throw new Error('ENOENT')
+  })
+})
+
+describe('payload parsing', () => {
+  it('parses the escaped-JSON-string form production actually returns', () => {
+    const raw = JSON.stringify(doc([VALID_IMAGE]))
+    expect(entriesOf(raw), 'the escaped-string shape production returns').toEqual([
+      { id: 'image_one', modality: 'image' }
+    ])
+  })
+
+  it('parses the already-parsed object form', () => {
+    expect(entriesOf(doc([VALID_IMAGE]))).toEqual([{ id: 'image_one', modality: 'image' }])
+  })
+
+  it('returns null (not a throw) when the string is not valid JSON', () => {
+    expect(parseStarterTemplateManifest('{"schemaVersion":1,')).toBeNull()
+    expect(parseStarterTemplateManifest('not json at all')).toBeNull()
+  })
+
+  it.each([[[]], ['"a string"'], [42], [null], [undefined], [true]])(
+    'rejects a non-object root: %s',
+    (root) => {
+      expect(parseStarterTemplateManifest(root)).toBeNull()
+    }
+  )
+
+  it.each([[undefined], [2], ['1'], [null], [0]])(
+    'rejects schemaVersion %s wholesale',
+    (schemaVersion) => {
+      expect(parseStarterTemplateManifest({ schemaVersion, templates: [VALID_IMAGE] })).toBeNull()
+    }
+  )
+
+  it.each([[undefined], [{}], ['nope'], [42]])('rejects templates: %s', (templates) => {
+    expect(parseStarterTemplateManifest({ schemaVersion: 1, templates })).toBeNull()
+  })
+
+  it('accepts an explicitly empty list as valid-but-empty', () => {
+    expect(parseStarterTemplateManifest(doc([])), 'a deliberate clear is not garbage').toEqual([])
+  })
+
+  it('ignores unknown top-level and per-entry fields', () => {
+    const raw = {
+      schemaVersion: 1,
+      futureField: { nested: true },
+      templates: [{ ...VALID_IMAGE, somethingNew: 'ignored', anotherOne: 5 }]
+    }
+    expect(entriesOf(raw)).toEqual([{ id: 'image_one', modality: 'image' }])
+  })
+
+  it('accepts but ignores minComfyUIVersion', () => {
+    const parsed = parseStarterTemplateManifest(
+      doc([{ ...VALID_IMAGE, minComfyUIVersion: '0.24.0' }])
+    )
+    expect(parsed).toHaveLength(1)
+    expect(parsed![0], 'accepted for forward compat, never acted on').not.toHaveProperty(
+      'minComfyUIVersion'
+    )
+  })
+
+  it('handles a very large payload without hanging', () => {
+    const many = Array.from({ length: 1000 }, (_, i) => ({ id: `image_${i}`, modality: 'image' }))
+    expect(parseStarterTemplateManifest(doc(many))).toHaveLength(1000)
+  })
+})
+
+describe('per-entry validation drops individually', () => {
+  it.each([
+    ['missing id', { modality: 'image' }],
+    ['non-string id', { id: 42, modality: 'image' }],
+    ['empty id', { id: '', modality: 'image' }],
+    ['path traversal', { id: '../../etc/passwd', modality: 'image' }],
+    ['slash', { id: 'a/b', modality: 'image' }],
+    ['backslash', { id: 'a\\b', modality: 'image' }],
+    ['space', { id: 'foo bar', modality: 'image' }],
+    ['query', { id: 'foo?x=1', modality: 'image' }],
+    ['skip sentinel', { id: 'none', modality: 'image' }],
+    ['missing modality', { id: 'image_one' }],
+    ['wrong case', { id: 'image_one', modality: 'Image' }],
+    ['unknown modality', { id: 'image_one', modality: 'text' }],
+    ['null entry', null],
+    ['non-object entry', 'a string'],
+    [
+      'recommended + apiNode',
+      { id: 'image_one', modality: 'image', recommended: true, apiNode: true }
+    ]
+  ])('drops %s while keeping a valid sibling', (_label, bad) => {
+    const parsed = parseStarterTemplateManifest(doc([bad, { id: 'image_ok', modality: 'image' }]))
+    expect(parsed).toHaveLength(1)
+    expect(parsed![0]!.id).toBe('image_ok')
+  })
+
+  it('does not treat a truthy non-boolean as recommended', () => {
+    const parsed = parseStarterTemplateManifest(
+      doc([{ id: 'image_one', modality: 'image', recommended: 'yes' }])
+    )
+    expect(parsed).toHaveLength(1)
+    expect(parsed![0]!.recommended).toBeUndefined()
+  })
+
+  it.each([[-1], [Number.NaN], [Number.POSITIVE_INFINITY], ['1000']])(
+    'rejects a bad snapshot sizeBytes (%s) without dropping the entry',
+    (sizeBytes) => {
+      const parsed = parseStarterTemplateManifest(
+        doc([
+          {
+            id: 'image_one',
+            modality: 'image',
+            snapshot: { title: 'T', description: 'D', sizeBytes, mediaSubtype: 'webp' }
+          }
+        ])
+      )
+      expect(parsed).toHaveLength(1)
+      expect(parsed![0]!.snapshot).toBeUndefined()
+    }
+  )
+
+  it('rejects snapshot strings carrying control characters', () => {
+    const parsed = parseStarterTemplateManifest(
+      doc([
+        {
+          id: 'image_one',
+          modality: 'image',
+          snapshot: {
+            title: 'bad\u0007title',
+            description: 'D',
+            sizeBytes: 1,
+            mediaSubtype: 'webp'
+          }
+        }
+      ])
+    )
+    expect(parsed![0]!.snapshot).toBeUndefined()
+  })
+
+  it('caps absurdly long snapshot strings', () => {
+    const parsed = parseStarterTemplateManifest(
+      doc([
+        {
+          id: 'image_one',
+          modality: 'image',
+          snapshot: {
+            title: 'x'.repeat(50_000),
+            description: 'D',
+            sizeBytes: 1,
+            mediaSubtype: 'webp'
+          }
+        }
+      ])
+    )
+    expect(parsed![0]!.snapshot).toBeUndefined()
+  })
+
+  it('keeps 3 good entries when 1 of 4 is malformed', () => {
+    const parsed = parseStarterTemplateManifest(
+      doc([
+        { id: 'image_a', modality: 'image' },
+        { id: 'image_b', modality: 'image' },
+        { id: '../nope', modality: 'image' },
+        { id: 'image_d', modality: 'image' }
+      ])
+    )
+    expect(
+      parsed!.map((e) => e.id),
+      'one bad row must not take its siblings down'
+    ).toEqual(['image_a', 'image_b', 'image_d'])
+  })
+
+  it('yields an empty modality rather than rejecting the document', () => {
+    const parsed = parseStarterTemplateManifest(
+      doc([
+        { id: '../a', modality: 'image' },
+        { id: 'video_ok', modality: 'video' }
+      ])
+    )
+    expect(parsed!.map((e) => e.id)).toEqual(['video_ok'])
+  })
+
+  it('accepts a well-formed snapshot and preserves it', () => {
+    const snapshot = { title: 'T', description: 'D', sizeBytes: 10, mediaSubtype: 'webp' }
+    const parsed = parseStarterTemplateManifest(doc([{ ...VALID_IMAGE, snapshot }]))
+    expect(parsed![0]!.snapshot).toEqual(snapshot)
+  })
+
+  it('preserves availability window fields when ISO-8601', () => {
+    const parsed = parseStarterTemplateManifest(
+      doc([{ ...VALID_IMAGE, availableFrom: '2026-01-01T00:00:00Z' }])
+    )
+    expect(parsed![0]!.availableFrom).toBe('2026-01-01T00:00:00Z')
+  })
+
+  it.each([['not-a-date'], [42], ['2026-13-45']])(
+    'drops a malformed availability date (%s) without dropping the entry',
+    (availableFrom) => {
+      const parsed = parseStarterTemplateManifest(doc([{ ...VALID_IMAGE, availableFrom }]))
+      expect(parsed).toHaveLength(1)
+      expect(parsed![0]!.availableFrom).toBeUndefined()
+    }
+  )
+})
+
+describe('recommended / apiNode invariants at parse time', () => {
+  it('keeps only the first recommended per modality', () => {
+    const parsed = parseStarterTemplateManifest(
+      doc([
+        { id: 'image_a', modality: 'image', recommended: true },
+        { id: 'image_b', modality: 'image', recommended: true },
+        { id: 'video_a', modality: 'video', recommended: true }
+      ])
+    )
+    expect(parsed!.filter((e) => e.recommended).map((e) => e.id)).toEqual(['image_a', 'video_a'])
+  })
+
+  it('never marks an apiNode entry as recommended', () => {
+    const parsed = parseStarterTemplateManifest(
+      doc([
+        { id: 'api_x', modality: 'image', apiNode: true },
+        { id: 'image_b', modality: 'image', recommended: true }
+      ])
+    )
+    for (const entry of parsed!) {
+      if (entry.apiNode) expect(entry.recommended).toBeFalsy()
+    }
+  })
+})
+
+describe('flag plumbing and fallback layers', () => {
+  it('reads the desktop_starter_templates flag key', async () => {
+    getOpsFlagPayload.mockResolvedValue(JSON.stringify(doc([VALID_IMAGE])))
+    await initStarterTemplates({ distinctId: 'anon' })
+    expect(STARTER_TEMPLATES_FLAG_KEY).toBe('desktop_starter_templates')
+    expect(getOpsFlagPayload).toHaveBeenCalledWith(
+      STARTER_TEMPLATES_FLAG_KEY,
+      'anon',
+      expect.any(Number)
+    )
+  })
+
+  it('falls back to the baked-in list when the flag is absent', async () => {
+    getOpsFlagPayload.mockResolvedValue(undefined)
+    await initStarterTemplates({ distinctId: 'anon' })
+    expect(await getStarterTemplatesAsync()).toEqual(CURATED_TEMPLATES)
+  })
+
+  it('falls back when the payload is wholly unusable', async () => {
+    getOpsFlagPayload.mockResolvedValue('{ broken json')
+    await initStarterTemplates({ distinctId: 'anon' })
+    expect(await getStarterTemplatesAsync()).toEqual(CURATED_TEMPLATES)
+  })
+
+  it('falls back when the fetch rejects, without throwing', async () => {
+    getOpsFlagPayload.mockRejectedValue(new Error('network'))
+    await expect(initStarterTemplates({ distinctId: 'anon' })).resolves.toBeUndefined()
+    expect(await getStarterTemplatesAsync()).toEqual(CURATED_TEMPLATES)
+  })
+
+  it('serves the payload list when the flag resolves', async () => {
+    getOpsFlagPayload.mockResolvedValue(JSON.stringify(doc([VALID_IMAGE])))
+    await initStarterTemplates({ distinctId: 'anon' })
+    expect((await getStarterTemplatesAsync()).map((e) => e.id)).toEqual(['image_one'])
+  })
+
+  it('awaits the in-flight boot fetch rather than racing to the fallback', async () => {
+    let release: (v: unknown) => void = () => {}
+    getOpsFlagPayload.mockReturnValue(
+      new Promise((r) => {
+        release = r
+      })
+    )
+    void initStarterTemplates({ distinctId: 'anon' })
+    const pending = getStarterTemplatesAsync()
+    release(JSON.stringify(doc([VALID_IMAGE])))
+    expect((await pending).map((e) => e.id)).toEqual(['image_one'])
+  })
+
+  it('is idempotent within a process — one fetch regardless of callers', async () => {
+    getOpsFlagPayload.mockResolvedValue(JSON.stringify(doc([VALID_IMAGE])))
+    await Promise.all([
+      initStarterTemplates({ distinctId: 'anon' }),
+      initStarterTemplates({ distinctId: 'anon' })
+    ])
+    expect(getOpsFlagPayload).toHaveBeenCalledTimes(1)
+  })
+
+  it('serves a warm disk cache when the fetch fails', async () => {
+    readFileSync.mockReturnValue(JSON.stringify(doc([{ id: 'cached_one', modality: 'image' }])))
+    getOpsFlagPayload.mockResolvedValue(undefined)
+    await initStarterTemplates({ distinctId: 'anon' })
+    expect((await getStarterTemplatesAsync()).map((e) => e.id)).toEqual(['cached_one'])
+  })
+
+  it.each([
+    ['corrupt JSON', '{ not json'],
+    ['wrong schemaVersion', JSON.stringify({ schemaVersion: 99, templates: [VALID_IMAGE] })],
+    ['tampered shape', JSON.stringify({ templates: 'nope' })]
+  ])('%s in the disk cache is discarded', async (_label, contents) => {
+    readFileSync.mockReturnValue(contents)
+    getOpsFlagPayload.mockResolvedValue(undefined)
+    await initStarterTemplates({ distinctId: 'anon' })
+    expect(await getStarterTemplatesAsync()).toEqual(CURATED_TEMPLATES)
+  })
+
+  it('writes the disk cache after a successful parse', async () => {
+    getOpsFlagPayload.mockResolvedValue(JSON.stringify(doc([VALID_IMAGE])))
+    await initStarterTemplates({ distinctId: 'anon' })
+    expect(writeFileSafe).toHaveBeenCalledTimes(1)
+    const [, written] = writeFileSafe.mock.calls[0] as [string, string]
+    expect(JSON.parse(written).templates[0].id).toBe('image_one')
+  })
+
+  it('survives a failing disk-cache write', async () => {
+    writeFileSafe.mockImplementation(() => {
+      throw new Error('EROFS')
+    })
+    getOpsFlagPayload.mockResolvedValue(JSON.stringify(doc([VALID_IMAGE])))
+    await initStarterTemplates({ distinctId: 'anon' })
+    expect((await getStarterTemplatesAsync()).map((e) => e.id)).toEqual(['image_one'])
+  })
+
+  it('captures no telemetry event while reading the payload', async () => {
+    getOpsFlagPayload.mockResolvedValue(JSON.stringify(doc([VALID_IMAGE])))
+    await initStarterTemplates({ distinctId: 'anon' })
+    await getStarterTemplatesAsync()
+    expect(capture, 'consent safety rests on this path never capturing').not.toHaveBeenCalled()
+  })
+})
+
+describe('a known id must agree with its baked-in modality', () => {
+  it('drops a baked-in id filed under the wrong tab', () => {
+    const parsed = parseStarterTemplateManifest(
+      doc([
+        { id: 'image_z_image_turbo', modality: 'video' },
+        { id: 'sdxlturbo_example', modality: 'image' }
+      ])
+    )
+    expect(
+      parsed!.map((e) => e.id),
+      'a known id under the wrong tab is dropped'
+    ).toEqual(['sdxlturbo_example'])
+  })
+
+  it('keeps every baked-in id under its own modality', () => {
+    const parsed = parseStarterTemplateManifest(
+      doc(CURATED_TEMPLATES.map((t) => ({ id: t.id, modality: t.modality })))
+    )
+    expect(parsed).toHaveLength(CURATED_TEMPLATES.length)
+  })
+
+  it('leaves an unknown id free to claim any modality', () => {
+    const parsed = parseStarterTemplateManifest(
+      doc([{ id: 'brand_new_template', modality: 'video' }])
+    )
+    expect(
+      parsed!.map((e) => e.modality),
+      'unknown ids may claim any modality'
+    ).toEqual(['video'])
+  })
+})

--- a/src/main/sources/standalone/starterTemplateManifest.ts
+++ b/src/main/sources/standalone/starterTemplateManifest.ts
@@ -140,12 +140,26 @@ export function parseStarterTemplateManifest(raw: unknown): CuratedTemplate[] | 
 let diskLoaded = false
 let diskTemplates: CuratedTemplate[] | null = null
 
+/**
+ * Bounds how long a cached payload can outlive the flag that produced it.
+ * Deleting or disabling `desktop_starter_templates` is the first rollback an
+ * operator reaches for, and it surfaces as the same `null` a failed fetch does,
+ * so an unbounded cache would serve a withdrawn payload forever. Expiry decays
+ * the picker back to `CURATED_TEMPLATES` without needing that distinction.
+ */
+const CACHE_MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000
+
 /** Re-validated on read: shared across app versions, so possibly stale. */
 function fromDisk(): CuratedTemplate[] | null {
   if (!diskLoaded) {
     diskLoaded = true
     try {
-      diskTemplates = parseStarterTemplateManifest(fs.readFileSync(CACHE_FILE(), 'utf-8'))
+      const raw: unknown = JSON.parse(fs.readFileSync(CACHE_FILE(), 'utf-8'))
+      // Stamped in the payload rather than read from mtime, which a backup
+      // restore or file copy would reset.
+      const writtenAt = (raw as { writtenAt?: unknown })?.writtenAt
+      const fresh = typeof writtenAt === 'number' && Date.now() - writtenAt < CACHE_MAX_AGE_MS
+      diskTemplates = fresh ? parseStarterTemplateManifest(raw) : null
     } catch {
       diskTemplates = null
     }
@@ -157,7 +171,7 @@ function persist(templates: CuratedTemplate[]): void {
   try {
     writeFileSafe(
       CACHE_FILE(),
-      JSON.stringify({ schemaVersion: SCHEMA_VERSION, templates }, null, 2)
+      JSON.stringify({ schemaVersion: SCHEMA_VERSION, writtenAt: Date.now(), templates }, null, 2)
     )
   } catch {}
 }

--- a/src/main/sources/standalone/starterTemplateManifest.ts
+++ b/src/main/sources/standalone/starterTemplateManifest.ts
@@ -1,0 +1,191 @@
+/**
+ * Loads remote starter-templates (PostHog) to enable dynamic updates in the picker without a release.
+ * Falls back: remote payload → disk cache → `CURATED_TEMPLATES`.
+ * Uses `opsFlag.ts` to allow picker rendering before user consent.
+ */
+import fs from 'fs'
+import path from 'path'
+
+import { makeOpsFlagPayload } from '../../lib/opsFlag'
+import { dataDir } from '../../lib/paths'
+import { writeFileSafe } from '../../lib/safe-file'
+import {
+  CURATED_TEMPLATES,
+  TEMPLATE_ID_PATTERN,
+  TEMPLATE_MODALITY_ORDER,
+  NO_TEMPLATE_VALUE,
+  type CuratedTemplate,
+  type TemplateModality,
+  type TemplateSnapshot
+} from './curatedTemplates'
+
+export const STARTER_TEMPLATES_FLAG_KEY = 'desktop_starter_templates'
+
+/** A remote entry naming a known template must agree with its modality. */
+const BAKED_IN_BY_ID = new Map(CURATED_TEMPLATES.map((t) => [t.id, t.modality]))
+
+const SCHEMA_VERSION = 1
+const MAX_TEXT_LENGTH = 4096
+const MAX_ID_LENGTH = 128
+// eslint-disable-next-line no-control-regex -- matching control chars is the point
+const CONTROL_CHARS = /[\u0000-\u001f\u007f]/
+
+const CACHE_FILE = (): string => path.join(dataDir(), 'starter-templates-cache.json')
+
+function isModality(value: unknown): value is TemplateModality {
+  return typeof value === 'string' && (TEMPLATE_MODALITY_ORDER as readonly string[]).includes(value)
+}
+
+/** Drops the field, not the entry. */
+function safeText(value: unknown): string | undefined {
+  if (typeof value !== 'string' || value.length > MAX_TEXT_LENGTH) return undefined
+  if (CONTROL_CHARS.test(value)) return undefined
+  return value
+}
+
+function isIsoDate(value: unknown): value is string {
+  return typeof value === 'string' && !Number.isNaN(Date.parse(value))
+}
+
+function parseSnapshot(value: unknown): TemplateSnapshot | undefined {
+  if (!value || typeof value !== 'object') return undefined
+  const r = value as Record<string, unknown>
+  const title = safeText(r.title)
+  const description = safeText(r.description)
+  const mediaSubtype = safeText(r.mediaSubtype)
+  const { sizeBytes } = r
+  if (title === undefined || description === undefined || mediaSubtype === undefined) {
+    return undefined
+  }
+  if (typeof sizeBytes !== 'number' || !Number.isFinite(sizeBytes) || sizeBytes < 0) {
+    return undefined
+  }
+  return { title, description, sizeBytes, mediaSubtype }
+}
+
+/**
+ * Default-deny. `id` reaches a filesystem path and a fetch URL, so it is
+ * pattern-checked; a bad optional field drops only itself.
+ */
+function parseEntry(value: unknown): CuratedTemplate | null {
+  if (!value || typeof value !== 'object') return null
+  const r = value as Record<string, unknown>
+
+  const { id } = r
+  if (typeof id !== 'string' || id.length > MAX_ID_LENGTH) return null
+  if (id === NO_TEMPLATE_VALUE || !TEMPLATE_ID_PATTERN.test(id)) return null
+  if (!isModality(r.modality)) return null
+  // Would fork the card into two tabs, and the right one could only recover
+  // with a duplicate id.
+  const bakedIn = BAKED_IN_BY_ID.get(id)
+  if (bakedIn && bakedIn !== r.modality) return null
+
+  const recommended = r.recommended === true
+  const apiNode = r.apiNode === true
+  if (recommended && apiNode) return null
+
+  const snapshot = parseSnapshot(r.snapshot)
+  const availableFrom = isIsoDate(r.availableFrom) ? r.availableFrom : undefined
+  const availableUntil = isIsoDate(r.availableUntil) ? r.availableUntil : undefined
+
+  const base = {
+    id,
+    modality: r.modality,
+    ...(snapshot ? { snapshot } : {}),
+    ...(availableFrom ? { availableFrom } : {}),
+    ...(availableUntil ? { availableUntil } : {}),
+    ...(r.snapshotOverrides === true && snapshot ? { snapshotOverrides: true as const } : {})
+  }
+
+  return apiNode
+    ? { ...base, apiNode: true }
+    : { ...base, ...(recommended ? { recommended: true as const } : {}) }
+}
+
+/**
+ * Accepts the escaped-JSON-string form production returns as well as a parsed
+ * object. `null` means unusable; invalid entries drop individually.
+ */
+export function parseStarterTemplateManifest(raw: unknown): CuratedTemplate[] | null {
+  let data = raw
+  if (typeof data === 'string') {
+    try {
+      data = JSON.parse(data)
+    } catch {
+      return null
+    }
+  }
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return null
+
+  const document = data as Record<string, unknown>
+  if (document.schemaVersion !== SCHEMA_VERSION) return null
+  if (!Array.isArray(document.templates)) return null
+
+  const entries = document.templates
+    .map(parseEntry)
+    .filter((entry): entry is CuratedTemplate => entry !== null)
+
+  const seenRecommended = new Set<TemplateModality>()
+  return entries.map((entry) => {
+    if (entry.recommended !== true) return entry
+    if (seenRecommended.has(entry.modality)) {
+      const { recommended: _dropped, ...rest } = entry
+      return { ...rest }
+    }
+    seenRecommended.add(entry.modality)
+    return entry
+  })
+}
+
+let diskLoaded = false
+let diskTemplates: CuratedTemplate[] | null = null
+
+/** Re-validated on read: shared across app versions, so possibly stale. */
+function fromDisk(): CuratedTemplate[] | null {
+  if (!diskLoaded) {
+    diskLoaded = true
+    try {
+      diskTemplates = parseStarterTemplateManifest(fs.readFileSync(CACHE_FILE(), 'utf-8'))
+    } catch {
+      diskTemplates = null
+    }
+  }
+  return diskTemplates
+}
+
+function persist(templates: CuratedTemplate[]): void {
+  try {
+    writeFileSafe(
+      CACHE_FILE(),
+      JSON.stringify({ schemaVersion: SCHEMA_VERSION, templates }, null, 2)
+    )
+  } catch {}
+}
+
+const flag = makeOpsFlagPayload<CuratedTemplate[] | null>({
+  key: STARTER_TEMPLATES_FLAG_KEY,
+  fallback: null,
+  parse: (value) => parseStarterTemplateManifest(value) ?? undefined
+})
+
+/** Persists the resolved list so the next cold start has a warm cache. */
+export async function initStarterTemplates(opts: {
+  distinctId: string
+  timeoutMs?: number
+}): Promise<void> {
+  await flag.init(opts)
+  const resolved = await flag.get()
+  if (resolved) persist(resolved)
+}
+
+/** Awaits the boot fetch so a picker opening early sees the resolved value. */
+export async function getStarterTemplatesAsync(): Promise<readonly CuratedTemplate[]> {
+  return (await flag.get()) ?? fromDisk() ?? CURATED_TEMPLATES
+}
+
+/** @internal — exposed for tests. */
+export function _resetForTest(): void {
+  flag._resetForTest()
+  diskLoaded = false
+  diskTemplates = null
+}

--- a/src/main/sources/standalone/templateCatalog.test.ts
+++ b/src/main/sources/standalone/templateCatalog.test.ts
@@ -200,7 +200,11 @@ describe('loadTemplateCatalog', () => {
     const recImage = catalog.find((c) => c.modality === 'image' && c.recommended)!
     expect(recImage.id).toBe('fresh_image_model')
     expect(recImage.name).toBe('Fresh Model')
-    expect(catalog.some((c) => c.id === first.id)).toBe(false)
+    expect(
+      catalog.find((c) => c.id === first.id)?.recommended ?? false,
+      'the vanished id loses its recommendation to the substitute'
+    ).toBe(false)
+    expect(catalog.filter((c) => c.modality === 'image')).toHaveLength(4)
   })
 
   it('skips api/size-less candidates when substituting (must be locally installable)', async () => {
@@ -231,14 +235,27 @@ describe('loadTemplateCatalog', () => {
     expect(new Set(ids).size).toBe(ids.length) // no dupes across slots
   })
 
-  it('falls back to the snapshot when online but no substitute exists', async () => {
+  it('prefers a compatible substitute over a card the index does not carry', async () => {
     const first = CURATED_TEMPLATES[0]!
-    // Online (non-empty index) but only an unusable api/size-less image entry.
     mockedFetchJSON.mockResolvedValue(
-      imageCategory([{ name: 'api_only', title: 'Cloud', size: 0 }])
+      imageCategory([{ name: 'live_local_image', title: 'Live', size: 5 }])
     )
     const catalog = await loadTemplateCatalog()
-    expect(catalog.find((c) => c.id === first.id)!.title).toBe(first.snapshot.title)
+    const image = catalog.filter((c) => c.modality === 'image').map((c) => c.id)
+    expect(image, 'the compatible substitute is preferred').toContain('live_local_image')
+    expect(image.indexOf('live_local_image')).toBeLessThan(
+      image.includes(first.id) ? image.indexOf(first.id) : image.length
+    )
+    expect(image).toHaveLength(4)
+  })
+
+  it('keeps an API-node card the index omits, since it runs server-side', async () => {
+    const apiCard = CURATED_TEMPLATES.find((t) => t.apiNode)!
+    mockedFetchJSON.mockResolvedValue(
+      imageCategory([{ name: 'unrelated_local', title: 'Local', size: 1_000 }])
+    )
+    const catalog = await loadTemplateCatalog()
+    expect(catalog.find((c) => c.id === apiCard.id)?.apiNode).toBe(true)
   })
 
   it('never substitutes a local download into a vanished API-node slot', async () => {

--- a/src/main/sources/standalone/templateCatalog.test.ts
+++ b/src/main/sources/standalone/templateCatalog.test.ts
@@ -3,10 +3,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 vi.mock('../../lib/fetch', () => ({ fetchJSON: vi.fn() }))
 
 import { loadTemplateCatalog, resetTemplateCatalogCache } from './templateCatalog'
+import type { HydratedTemplate } from './templateCatalog'
 import { CURATED_TEMPLATES, TEMPLATE_MODALITY_ORDER, thumbnailUrlFor } from './curatedTemplates'
 import { fetchJSON } from '../../lib/fetch'
 
 const mockedFetchJSON = vi.mocked(fetchJSON)
+
+/** Cards only; `assetBase` is asserted separately where it matters. */
+const loadCards = async (opts?: { comfyVersion?: string | null }): Promise<HydratedTemplate[]> =>
+  (await loadTemplateCatalog(opts)).templates
 
 /** A live index with one category whose templates override the given curated
  *  ids' metadata. */
@@ -27,7 +32,7 @@ describe('loadTemplateCatalog', () => {
 
   it('returns every curated template, ordered by modality', async () => {
     mockedFetchJSON.mockResolvedValue([])
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     expect(catalog.length).toBe(CURATED_TEMPLATES.length)
 
     const rank = (m: string) => TEMPLATE_MODALITY_ORDER.indexOf(m as never)
@@ -43,7 +48,7 @@ describe('loadTemplateCatalog', () => {
         [first.id]: { title: 'Live', description: 'LiveDesc', size: 42, mediaSubtype: 'webp' }
       })
     )
-    const card = (await loadTemplateCatalog()).find((c) => c.id === first.id)!
+    const card = (await loadCards()).find((c) => c.id === first.id)!
     expect(card.title).toBe('Live')
     expect(card.description).toBe('LiveDesc')
     expect(card.sizeBytes).toBe(42)
@@ -57,7 +62,7 @@ describe('loadTemplateCatalog', () => {
         [first.id]: { title: 'Z-Image-Turbo Text to Image', tags: ['Image', 'Text to Image'] }
       })
     )
-    const card = (await loadTemplateCatalog()).find((c) => c.id === first.id)!
+    const card = (await loadCards()).find((c) => c.id === first.id)!
     expect(card.name).toBe('Z-Image-Turbo')
     expect(card.task).toBe('Text to Image')
   })
@@ -72,7 +77,7 @@ describe('loadTemplateCatalog', () => {
         }
       })
     )
-    const card = (await loadTemplateCatalog()).find((c) => c.id === first.id)!
+    const card = (await loadCards()).find((c) => c.id === first.id)!
     expect(card.name).toBe('Flux.2 [Klein] 4B Distilled')
     expect(card.task).toBe('Image Edit')
   })
@@ -82,7 +87,7 @@ describe('loadTemplateCatalog', () => {
     mockedFetchJSON.mockResolvedValue(
       indexFor({ [first.id]: { title: 'SDXL Turbo', tags: ['Image'] } })
     )
-    const card = (await loadTemplateCatalog()).find((c) => c.id === first.id)!
+    const card = (await loadCards()).find((c) => c.id === first.id)!
     expect(card.name).toBe('SDXL Turbo')
     expect(card.task).toBe('Text to Image')
   })
@@ -92,7 +97,7 @@ describe('loadTemplateCatalog', () => {
     mockedFetchJSON.mockResolvedValue(
       indexFor({ [first.id]: { title: 'X', tags: ['', '  ', 'Image'] } })
     )
-    const card = (await loadTemplateCatalog()).find((c) => c.id === first.id)!
+    const card = (await loadCards()).find((c) => c.id === first.id)!
     expect(card.task).toBe('Text to Image')
   })
 
@@ -103,7 +108,7 @@ describe('loadTemplateCatalog', () => {
         [apiTemplate.id]: { title: 'Seedream 5.0 Pro: Image Edit', tags: ['API', 'Image Edit'] }
       })
     )
-    const card = (await loadTemplateCatalog()).find((c) => c.id === apiTemplate.id)!
+    const card = (await loadCards()).find((c) => c.id === apiTemplate.id)!
     expect(card.task).toBe('Image Edit')
     expect(card.name).toBe('Seedream 5.0 Pro')
   })
@@ -116,13 +121,13 @@ describe('loadTemplateCatalog', () => {
         '3D Model'
       )
     )
-    const card = (await loadTemplateCatalog()).find((c) => c.id === apiTemplate.id)!
+    const card = (await loadCards()).find((c) => c.id === apiTemplate.id)!
     expect(card.task).toBe('Image to 3D')
   })
 
   it('flags API-node templates from the manifest, offline included', async () => {
     mockedFetchJSON.mockImplementationOnce(() => Promise.reject(new Error('offline')))
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     for (const curated of CURATED_TEMPLATES) {
       expect(catalog.find((c) => c.id === curated.id)!.apiNode, curated.id).toBe(
         curated.apiNode === true
@@ -135,7 +140,7 @@ describe('loadTemplateCatalog', () => {
     mockedFetchJSON.mockResolvedValue(
       indexFor({ [local.id]: { openSource: false, size: 142_000_000_000 } })
     )
-    const card = (await loadTemplateCatalog()).find((c) => c.id === local.id)!
+    const card = (await loadCards()).find((c) => c.id === local.id)!
     expect(card.apiNode).toBe(false)
     expect(card.sizeBytes).toBe(142_000_000_000)
   })
@@ -143,7 +148,7 @@ describe('loadTemplateCatalog', () => {
   it('falls back to the snapshot when the index omits a curated id', async () => {
     const first = CURATED_TEMPLATES[0]!
     mockedFetchJSON.mockResolvedValue([])
-    const card = (await loadTemplateCatalog()).find((c) => c.id === first.id)!
+    const card = (await loadCards()).find((c) => c.id === first.id)!
     expect(card.title).toBe(first.snapshot.title)
     expect(card.sizeBytes).toBe(first.snapshot.sizeBytes)
     expect(card.thumbnailUrl).toBe(thumbnailUrlFor(first.id, first.snapshot.mediaSubtype))
@@ -152,13 +157,13 @@ describe('loadTemplateCatalog', () => {
   it('ignores a live size of 0 and keeps the snapshot estimate', async () => {
     const first = CURATED_TEMPLATES[0]!
     mockedFetchJSON.mockResolvedValue(indexFor({ [first.id]: { size: 0 } }))
-    const card = (await loadTemplateCatalog()).find((c) => c.id === first.id)!
+    const card = (await loadCards()).find((c) => c.id === first.id)!
     expect(card.sizeBytes).toBe(first.snapshot.sizeBytes)
   })
 
   it('returns a snapshot-only catalog when the fetch rejects (offline)', async () => {
     mockedFetchJSON.mockImplementationOnce(() => Promise.reject(new Error('offline')))
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     expect(catalog.length).toBe(CURATED_TEMPLATES.length)
     const first = CURATED_TEMPLATES[0]!
     expect(catalog.find((c) => c.id === first.id)!.title).toBe(first.snapshot.title)
@@ -166,13 +171,13 @@ describe('loadTemplateCatalog', () => {
 
   it('survives a malformed index without throwing', async () => {
     mockedFetchJSON.mockResolvedValue({ not: 'an array' })
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     expect(catalog.length).toBe(CURATED_TEMPLATES.length)
   })
 
   it('fetches the index exactly once regardless of curated count', async () => {
     mockedFetchJSON.mockResolvedValue([])
-    await loadTemplateCatalog()
+    await loadCards()
     expect(mockedFetchJSON).toHaveBeenCalledTimes(1)
   })
 
@@ -196,7 +201,7 @@ describe('loadTemplateCatalog', () => {
         }
       ])
     )
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     const recImage = catalog.find((c) => c.modality === 'image' && c.recommended)!
     expect(recImage.id).toBe('fresh_image_model')
     expect(recImage.name).toBe('Fresh Model')
@@ -215,9 +220,7 @@ describe('loadTemplateCatalog', () => {
         { name: 'good_local', title: 'Good Local', size: 9 }
       ])
     )
-    const recImage = (await loadTemplateCatalog()).find(
-      (c) => c.modality === 'image' && c.recommended
-    )!
+    const recImage = (await loadCards()).find((c) => c.modality === 'image' && c.recommended)!
     expect(recImage.id).toBe('good_local')
   })
 
@@ -230,7 +233,7 @@ describe('loadTemplateCatalog', () => {
         { name: 'sub_d', title: 'D', size: 4 }
       ])
     )
-    const images = (await loadTemplateCatalog()).filter((c) => c.modality === 'image')
+    const images = (await loadCards()).filter((c) => c.modality === 'image')
     const ids = images.map((c) => c.id)
     expect(new Set(ids).size).toBe(ids.length) // no dupes across slots
   })
@@ -240,12 +243,13 @@ describe('loadTemplateCatalog', () => {
     mockedFetchJSON.mockResolvedValue(
       imageCategory([{ name: 'live_local_image', title: 'Live', size: 5 }])
     )
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     const image = catalog.filter((c) => c.modality === 'image').map((c) => c.id)
     expect(image, 'the compatible substitute is preferred').toContain('live_local_image')
-    expect(image.indexOf('live_local_image')).toBeLessThan(
-      image.includes(first.id) ? image.indexOf(first.id) : image.length
-    )
+    expect(
+      image.indexOf(first.id),
+      'the index-absent card returns only via terminal top-up'
+    ).toBeGreaterThan(image.indexOf('live_local_image'))
     expect(image).toHaveLength(4)
   })
 
@@ -254,7 +258,7 @@ describe('loadTemplateCatalog', () => {
     mockedFetchJSON.mockResolvedValue(
       imageCategory([{ name: 'unrelated_local', title: 'Local', size: 1_000 }])
     )
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     expect(catalog.find((c) => c.id === apiCard.id)?.apiNode).toBe(true)
   })
 
@@ -268,7 +272,7 @@ describe('loadTemplateCatalog', () => {
         { name: 'sub_d', title: 'D', size: 4 }
       ])
     )
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     const card = catalog.find((c) => c.id === apiTemplate.id)
     expect(card, 'API-node slot kept its snapshot').toBeDefined()
     expect(card!.apiNode).toBe(true)
@@ -282,20 +286,20 @@ describe('loadTemplateCatalog', () => {
   it('keeps the curated snapshot card when offline (empty index → no substitution)', async () => {
     const first = CURATED_TEMPLATES[0]!
     mockedFetchJSON.mockResolvedValue([]) // offline / empty
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     expect(catalog.length).toBe(CURATED_TEMPLATES.length)
     expect(catalog.find((c) => c.id === first.id)!.title).toBe(first.snapshot.title)
   })
 
   it('never yields duplicate ids', async () => {
     mockedFetchJSON.mockResolvedValue([])
-    const ids = (await loadTemplateCatalog()).map((c) => c.id)
+    const ids = (await loadCards()).map((c) => c.id)
     expect(new Set(ids).size).toBe(ids.length)
   })
 
   it('only emits modalities the picker can tab', async () => {
     mockedFetchJSON.mockResolvedValue([])
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     for (const card of catalog) {
       expect(TEMPLATE_MODALITY_ORDER).toContain(card.modality)
     }
@@ -303,19 +307,19 @@ describe('loadTemplateCatalog', () => {
 
   it('coalesces concurrent reads into a single index fetch', async () => {
     mockedFetchJSON.mockResolvedValue([])
-    const [a, b] = await Promise.all([loadTemplateCatalog(), loadTemplateCatalog()])
+    const [a, b] = await Promise.all([loadCards(), loadCards()])
     expect(mockedFetchJSON).toHaveBeenCalledTimes(1)
     expect(a).toBe(b)
   })
 
   it('serves a cached result on a follow-up read, then refetches after reset', async () => {
     mockedFetchJSON.mockResolvedValue([])
-    await loadTemplateCatalog()
-    await loadTemplateCatalog()
+    await loadCards()
+    await loadCards()
     expect(mockedFetchJSON).toHaveBeenCalledTimes(1)
 
     resetTemplateCatalogCache()
-    await loadTemplateCatalog()
+    await loadCards()
     expect(mockedFetchJSON).toHaveBeenCalledTimes(2)
   })
 
@@ -323,9 +327,9 @@ describe('loadTemplateCatalog', () => {
     vi.useFakeTimers()
     try {
       mockedFetchJSON.mockResolvedValue([])
-      await loadTemplateCatalog()
+      await loadCards()
       vi.advanceTimersByTime(60_001)
-      await loadTemplateCatalog()
+      await loadCards()
       expect(mockedFetchJSON).toHaveBeenCalledTimes(2)
     } finally {
       vi.useRealTimers()

--- a/src/main/sources/standalone/templateCatalog.ts
+++ b/src/main/sources/standalone/templateCatalog.ts
@@ -1,24 +1,36 @@
 /**
- * Hydrates the curated starter-template manifest against the live
- * `comfyui_workflow_templates` index, so card metadata (title, description,
- * size, thumbnail) tracks upstream automatically instead of being hand-kept.
+ * Resolves the starter-template manifest into picker cards, hydrated against the
+ * index the target ComfyUI pins rather than `main`.
  *
- * One ETag-cached fetch per picker open (`fetchJSON` handles caching, R2-mirror
- * retry, and last-cached fallback on network failure); the index is flattened
- * once into a `Map` for O(1) lookup per curated id rather than rescanning its
- * ~500 entries. When the index can't be reached at all (cold cache, offline),
- * every template falls back to its inline `snapshot`, so the catalog is always
- * non-empty and the picker always renders.
+ * Invariant: 4 cards per modality in all 4 modalities, at most one recommended
+ * and never an API-node card.
  */
 import { fetchJSON } from '../../lib/fetch'
 import {
   CURATED_TEMPLATES,
-  INDEX_URL,
   TEMPLATE_MODALITY_ORDER,
   thumbnailUrlFor,
+  type CuratedTemplate,
   type TemplateModality,
   type TemplateSnapshot
 } from './curatedTemplates'
+import { getStarterTemplatesAsync } from './starterTemplateManifest'
+import {
+  resolveTemplatePackageVersion,
+  templateAssetBaseFor,
+  templateIndexUrlFor
+} from './templatePin'
+
+const SLOTS_PER_MODALITY = 4
+
+/** The wizard blocks on this, and failing open costs only card metadata. */
+const INDEX_TIMEOUT_MS = 8000
+
+/** Substitutes only; a named id is always honoured. `type: "image"` also spans
+ *  Utility/LLM/Node Basics, which are not starter material. */
+const SUBSTITUTABLE_CATEGORIES = new Set(['Image', 'Video', 'Audio', '3D Model', 'Use Cases'])
+
+const BAKED_IN_IDS = new Set(CURATED_TEMPLATES.map((t) => t.id))
 
 /** A curated template merged with its (optional) live index metadata, ready to
  *  render as a picker card. */
@@ -54,6 +66,10 @@ interface IndexEntry {
   size?: unknown
   mediaSubtype?: unknown
   tags?: unknown
+  /** Node packs the workflow needs; the frontend hides these on non-cloud. */
+  requiresCustomNodes?: unknown
+  /** `local` / `cloud`. Absent means "everywhere". */
+  includeOnDistributions?: unknown
 }
 
 /** A live index category: `{ title, type, templates: [...] }`. */
@@ -102,10 +118,72 @@ function indexById(index: unknown): Map<string, IndexLocation> {
   return byId
 }
 
+/** The frontend hides custom-node workflows on non-cloud, so offering one
+ *  produces a card that silently disappears. */
+function isRunnableLocally(entry: IndexEntry): boolean {
+  const { requiresCustomNodes, includeOnDistributions } = entry
+  if (Array.isArray(requiresCustomNodes) && requiresCustomNodes.length > 0) return false
+  if (Array.isArray(includeOnDistributions) && !includeOnDistributions.includes('local')) {
+    return false
+  }
+  return true
+}
+
+/** Rendered as itself, replaced by an index pick, or dropped for backfill. */
+type Disposition =
+  | { kind: 'place'; location: IndexLocation | undefined }
+  | { kind: 'substitute'; location: IndexLocation }
+  | { kind: 'drop' }
+
+/** Reads `used` but never mutates it, so the caller owns placement. */
+function disposeOf(
+  template: CuratedTemplate,
+  byId: Map<string, IndexLocation>,
+  used: Set<string>,
+  online: boolean,
+  now: number
+): Disposition {
+  if (!isWithinWindow(template, now)) return { kind: 'drop' }
+
+  const location = byId.get(template.id)
+  if (location && !isRunnableLocally(location.entry)) return { kind: 'drop' }
+
+  if (location || !online) {
+    if (!location && !template.snapshot) return { kind: 'drop' }
+    return { kind: 'place', location }
+  }
+
+  // Runs server-side, so index membership says nothing about whether it works.
+  if (template.apiNode === true) {
+    return template.snapshot ? { kind: 'place', location: undefined } : { kind: 'drop' }
+  }
+
+  // Absent from this install's index, so it can't open. Both paths are silent.
+  const sub = firstUnusedOfModality(byId, template.modality, used)
+  console.warn(
+    `[templates] "${template.id}" is not in this install's template index; ` +
+      (sub ? `substituting "${sub.entry.name}"` : 'falling back to the built-in list')
+  )
+  return sub ? { kind: 'substitute', location: sub } : { kind: 'drop' }
+}
+
+/** Availability window, so content can stage a launch ahead of time. */
+function isWithinWindow(template: CuratedTemplate, now: number): boolean {
+  const { availableFrom, availableUntil } = template
+  if (availableFrom) {
+    const from = Date.parse(availableFrom)
+    if (!Number.isNaN(from) && now < from) return false
+  }
+  if (availableUntil) {
+    const until = Date.parse(availableUntil)
+    if (!Number.isNaN(until) && now >= until) return false
+  }
+  return true
+}
+
 const NON_TASK_TAGS = new Set(['image', 'video', 'audio', '3d', '3d model', 'api'])
 
-/** Subtitle shown when a template's `tags` carry no specific task, so a card is
- *  never left with a blank descriptor (e.g. Wan Fun Camera, tags: ['Video']). */
+/** Fallback so a card is never left with a blank descriptor. */
 const DEFAULT_TASK: Record<TemplateModality, string> = {
   image: 'Text to Image',
   video: 'Text to Video',
@@ -113,8 +191,7 @@ const DEFAULT_TASK: Record<TemplateModality, string> = {
   '3d': 'Image to 3D'
 }
 
-/** The template's task (e.g. "Text to Image", "Image Edit") from its `tags`,
- *  skipping kind labels; falls back to the modality default. */
+/** Task from `tags`, skipping kind labels; falls back to the modality default. */
 function taskOf(tags: unknown, modality: TemplateModality): string {
   if (Array.isArray(tags)) {
     for (const tag of tags) {
@@ -126,9 +203,7 @@ function taskOf(tags: unknown, modality: TemplateModality): string {
   return DEFAULT_TASK[modality]
 }
 
-/** Short card name: the title up to its `:` separator, then with a trailing task
- *  phrase stripped ("Z-Image-Turbo Text to Image" → "Z-Image-Turbo"). Falls back
- *  to the whole title when nothing is strippable. */
+/** "Z-Image-Turbo Text to Image" → "Z-Image-Turbo". */
 function nameOf(title: string, task: string): string {
   const beforeColon = title.split(':')[0]!.trim()
   if (task && beforeColon.toLowerCase().endsWith(task.toLowerCase())) {
@@ -138,9 +213,7 @@ function nameOf(title: string, task: string): string {
   return beforeColon || title
 }
 
-/** Build a card from a template `id` + its live index location (when present),
- *  preferring live metadata and falling back to the offline `snapshot` (which a
- *  substituted, non-curated id won't have). */
+/** Prefers live metadata over `snapshot`; `snapshotOverrides` inverts that. */
 function hydrateOne(card: {
   id: string
   modality: TemplateModality
@@ -148,9 +221,12 @@ function hydrateOne(card: {
   apiNode: boolean
   location: IndexLocation | undefined
   snapshot?: TemplateSnapshot
+  snapshotOverrides?: boolean
+  assetBase: string
 }): HydratedTemplate {
-  const { id, modality, recommended, apiNode, location, snapshot } = card
-  const entry = location?.entry
+  const { id, modality, recommended, apiNode, location, snapshot, snapshotOverrides, assetBase } =
+    card
+  const entry = snapshotOverrides && snapshot ? undefined : location?.entry
 
   const title = typeof entry?.title === 'string' ? entry.title : (snapshot?.title ?? id)
   const description =
@@ -162,7 +238,7 @@ function hydrateOne(card: {
       ? entry.mediaSubtype
       : (snapshot?.mediaSubtype ?? 'webp')
 
-  const task = taskOf(entry?.tags, modality)
+  const task = taskOf(location?.entry?.tags, modality)
 
   return {
     id,
@@ -174,116 +250,222 @@ function hydrateOne(card: {
     description,
     sizeBytes,
     apiNode,
-    thumbnailUrl: thumbnailUrlFor(id, mediaSubtype),
+    thumbnailUrl: thumbnailUrlFor(id, mediaSubtype, assetBase),
     category: location?.category ?? ''
   }
 }
 
-/** Stable ordering for the picker: modality tab order, then curated order
- *  within a modality. */
+/** Modality tab order, then manifest order within a modality. */
 function byModalityOrder(a: HydratedTemplate, b: HydratedTemplate): number {
   return TEMPLATE_MODALITY_ORDER.indexOf(a.modality) - TEMPLATE_MODALITY_ORDER.indexOf(b.modality)
 }
 
-/**
- * Resolve the curated manifest into renderable cards, hydrated from the live
- * index where reachable. Defensive by contract: never throws and never returns
- * a card the picker can't render —
- *   - a failed/garbage index fetch yields a snapshot-only catalog,
- *   - a duplicate curated id (dev typo) is collapsed to its first occurrence,
- *   - a curated entry missing its required snapshot (dev edit) is dropped, not
- *     surfaced as a broken card.
- * So renaming/removing a template upstream, or fat-fingering the manifest, can
- * only ever shrink the offering — it can't crash the picker.
- */
-/** Coalesces the wizard's field-options read and the thumbnail warm-up — which
- *  fire together at picker open — into one index fetch; a later open refetches. */
+/** Keyed by target version so switching channel mid-wizard re-filters. */
 const CATALOG_TTL_MS = 60_000
-let catalogInFlight: Promise<HydratedTemplate[]> | null = null
-let catalogCache: { at: number; value: HydratedTemplate[] } | null = null
+const catalogInFlight = new Map<string, Promise<HydratedTemplate[]>>()
+const catalogCache = new Map<string, { at: number; value: HydratedTemplate[] }>()
 
-export function loadTemplateCatalog(): Promise<HydratedTemplate[]> {
-  if (catalogCache && Date.now() - catalogCache.at < CATALOG_TTL_MS) {
-    return Promise.resolve(catalogCache.value)
-  }
-  if (catalogInFlight) return catalogInFlight
-  catalogInFlight = loadTemplateCatalogUncached()
+export function loadTemplateCatalog(opts?: {
+  comfyVersion?: string | null
+}): Promise<HydratedTemplate[]> {
+  const key = opts?.comfyVersion ?? ''
+  const cached = catalogCache.get(key)
+  if (cached && Date.now() - cached.at < CATALOG_TTL_MS) return Promise.resolve(cached.value)
+
+  const existing = catalogInFlight.get(key)
+  if (existing) return existing
+
+  const promise = loadTemplateCatalogUncached(opts?.comfyVersion ?? null)
     .then((value) => {
-      catalogCache = { at: Date.now(), value }
+      catalogCache.set(key, { at: Date.now(), value })
       return value
     })
     .finally(() => {
-      catalogInFlight = null
+      catalogInFlight.delete(key)
     })
-  return catalogInFlight
+  catalogInFlight.set(key, promise)
+  return promise
 }
 
 /** Drops the memoized catalog so the next read refetches. Test-only. */
 export function resetTemplateCatalogCache(): void {
-  catalogInFlight = null
-  catalogCache = null
+  catalogInFlight.clear()
+  catalogCache.clear()
 }
 
-async function loadTemplateCatalogUncached(): Promise<HydratedTemplate[]> {
-  let byId: Map<string, IndexLocation>
+/** An empty list is left empty; `backfill` fills every modality either way. */
+async function activeTemplates(): Promise<readonly CuratedTemplate[]> {
   try {
-    byId = indexById(await fetchJSON(INDEX_URL))
+    return await getStarterTemplatesAsync()
   } catch {
-    byId = new Map()
+    return CURATED_TEMPLATES
   }
-  // Only substitute when we actually have a live index to substitute FROM —
-  // an empty map means offline, where the curated snapshot is the right fallback.
+}
+
+/** The index the target ComfyUI ships, else the live one. Never throws. */
+async function indexForVersion(
+  comfyVersion: string | null
+): Promise<{ byId: Map<string, IndexLocation>; assetBase: string }> {
+  const pin = await resolveTemplatePackageVersion(comfyVersion).catch(() => null)
+  const assetBase = templateAssetBaseFor(pin)
+  try {
+    const index = await fetchJSON(templateIndexUrlFor(pin), { timeoutMs: INDEX_TIMEOUT_MS })
+    return { byId: indexById(index), assetBase }
+  } catch {
+    return { byId: new Map(), assetBase }
+  }
+}
+
+async function loadTemplateCatalogUncached(
+  comfyVersion: string | null
+): Promise<HydratedTemplate[]> {
+  const [templates, index] = await Promise.all([activeTemplates(), indexForVersion(comfyVersion)])
+  const { byId, assetBase } = index
   const online = byId.size > 0
+  const now = Date.now()
 
   const used = new Set<string>()
-  const catalog: HydratedTemplate[] = []
-  for (const curated of CURATED_TEMPLATES) {
-    if (!curated?.id || used.has(curated.id) || !curated.snapshot) continue
+  const perModality = new Map<TemplateModality, HydratedTemplate[]>(
+    TEMPLATE_MODALITY_ORDER.map((modality) => [modality, []])
+  )
 
-    const recommended = curated.recommended === true
-    const apiNode = curated.apiNode === true
+  const place = (card: HydratedTemplate): void => {
+    perModality.get(card.modality)?.push(card)
+  }
+  const isFull = (modality: TemplateModality): boolean =>
+    (perModality.get(modality)?.length ?? 0) >= SLOTS_PER_MODALITY
 
-    const { modality, snapshot } = curated
-    const location = byId.get(curated.id)
-    if (location || !online) {
-      used.add(curated.id)
-      catalog.push(
-        hydrateOne({ id: curated.id, modality, recommended, apiNode, location, snapshot })
+  for (const template of templates) {
+    if (!template?.id || used.has(template.id)) continue
+    if (!perModality.has(template.modality) || isFull(template.modality)) continue
+
+    const disposition = disposeOf(template, byId, used, online, now)
+    if (disposition.kind === 'drop') continue
+
+    if (disposition.kind === 'substitute') {
+      const { location } = disposition
+      used.add(location.entry.name)
+      place(
+        hydrateOne({
+          id: location.entry.name,
+          modality: template.modality,
+          recommended: template.recommended === true,
+          apiNode: false,
+          location,
+          assetBase
+        })
       )
       continue
     }
 
-    // Curated id has vanished upstream: show the first live template of the same
-    // modality we haven't already used, so the slot still offers a real,
-    // installable pick rather than a stale snapshot card. An API-node slot keeps
-    // its snapshot — substituting would put a multi-GB download behind a badge
-    // that promises none.
-    const sub = apiNode ? null : firstUnusedOfModality(byId, modality, used)
-    if (sub) {
-      used.add(sub.entry.name)
-      catalog.push(
-        hydrateOne({ id: sub.entry.name, modality, recommended, apiNode: false, location: sub })
-      )
-    } else {
-      used.add(curated.id)
-      catalog.push(
-        hydrateOne({
-          id: curated.id,
-          modality,
-          recommended,
-          apiNode,
-          location: undefined,
-          snapshot
-        })
-      )
-    }
+    used.add(template.id)
+    place(
+      hydrateOne({
+        id: template.id,
+        modality: template.modality,
+        recommended: template.recommended === true,
+        apiNode: template.apiNode === true,
+        location: disposition.location,
+        snapshot: template.snapshot,
+        snapshotOverrides: template.snapshotOverrides,
+        assetBase
+      })
+    )
+  }
+
+  backfill(perModality, byId, used, online, assetBase)
+
+  const catalog: HydratedTemplate[] = []
+  for (const modality of TEMPLATE_MODALITY_ORDER) {
+    catalog.push(...enforceOneRecommended(perModality.get(modality) ?? []))
   }
   return catalog.sort(byModalityOrder)
 }
 
-/** First unused, locally-installable index template of `modality` — skips
- *  API/cloud entries (`api_*`) and size-less ones, since a substitute fills a
- *  local download slot the disk-space gate sizes off `sizeBytes`. */
+/**
+ * Strict pass, then `terminal`, which relaxes index membership and then
+ * `isRunnableLocally` rather than ship a short tab. Identity is never relaxed:
+ * two cards sharing an id collide on `FieldOption.value`, the picker's key.
+ */
+function fillFromBakedIn(
+  slots: HydratedTemplate[],
+  modality: TemplateModality,
+  byId: Map<string, IndexLocation>,
+  used: Set<string>,
+  online: boolean,
+  assetBase: string,
+  terminal: boolean
+): void {
+  const take = (allowUnrunnable: boolean): void => {
+    for (const curated of CURATED_TEMPLATES) {
+      if (slots.length >= SLOTS_PER_MODALITY) break
+      if (curated.modality !== modality || used.has(curated.id)) continue
+      const location = byId.get(curated.id)
+      if (!allowUnrunnable && location && !isRunnableLocally(location.entry)) continue
+      // Re-adding an index-absent card would undo the gate that dropped it.
+      if (!terminal && online && !location && curated.apiNode !== true) continue
+      used.add(curated.id)
+      slots.push(
+        hydrateOne({
+          id: curated.id,
+          modality,
+          recommended: curated.recommended === true,
+          apiNode: curated.apiNode === true,
+          location,
+          snapshot: curated.snapshot,
+          assetBase
+        })
+      )
+    }
+  }
+
+  take(false)
+  if (terminal) take(true)
+}
+
+function backfill(
+  perModality: Map<TemplateModality, HydratedTemplate[]>,
+  byId: Map<string, IndexLocation>,
+  used: Set<string>,
+  online: boolean,
+  assetBase: string
+): void {
+  for (const modality of TEMPLATE_MODALITY_ORDER) {
+    const slots = perModality.get(modality)!
+    if (slots.length >= SLOTS_PER_MODALITY) continue
+
+    fillFromBakedIn(slots, modality, byId, used, online, assetBase, false)
+
+    while (slots.length < SLOTS_PER_MODALITY && online) {
+      const sub = firstUnusedOfModality(byId, modality, used)
+      if (!sub) break
+      used.add(sub.entry.name)
+      slots.push(
+        hydrateOne({
+          id: sub.entry.name,
+          modality,
+          recommended: false,
+          apiNode: false,
+          location: sub,
+          assetBase
+        })
+      )
+    }
+
+    fillFromBakedIn(slots, modality, byId, used, online, assetBase, true)
+  }
+}
+
+/** An all-API tab gets none: the wizard offers skip rather than auto-selecting
+ *  a card that spends credits. */
+function enforceOneRecommended(slots: HydratedTemplate[]): HydratedTemplate[] {
+  const claimed = slots.find((card) => card.recommended && !card.apiNode)
+  const winner = claimed ?? slots.find((card) => !card.apiNode)
+  return slots.map((card) => ({ ...card, recommended: card === winner }))
+}
+
+/** Skips `api_*`, size-less entries (the disk gate sizes off `sizeBytes`), and
+ *  non-starter categories. */
 function firstUnusedOfModality(
   byId: Map<string, IndexLocation>,
   modality: TemplateModality,
@@ -292,8 +474,12 @@ function firstUnusedOfModality(
   for (const location of byId.values()) {
     const { entry } = location
     if (location.modality !== modality || used.has(entry.name)) continue
+    if (!SUBSTITUTABLE_CATEGORIES.has(location.category)) continue
+    // Owed its own slot later; taking it here consumes one instead of filling one.
+    if (BAKED_IN_IDS.has(entry.name)) continue
     if (entry.name.startsWith('api_')) continue
     if (typeof entry.size !== 'number' || entry.size <= 0) continue
+    if (!isRunnableLocally(entry)) continue
     return location
   }
   return null

--- a/src/main/sources/standalone/templateCatalog.ts
+++ b/src/main/sources/standalone/templateCatalog.ts
@@ -260,14 +260,21 @@ function byModalityOrder(a: HydratedTemplate, b: HydratedTemplate): number {
   return TEMPLATE_MODALITY_ORDER.indexOf(a.modality) - TEMPLATE_MODALITY_ORDER.indexOf(b.modality)
 }
 
+/** Cards plus the asset base they were stamped with, so a caller fetching
+ *  workflow JSON reads the same revision the thumbnails came from. */
+export interface TemplateCatalog {
+  templates: HydratedTemplate[]
+  assetBase: string
+}
+
 /** Keyed by target version so switching channel mid-wizard re-filters. */
 const CATALOG_TTL_MS = 60_000
-const catalogInFlight = new Map<string, Promise<HydratedTemplate[]>>()
-const catalogCache = new Map<string, { at: number; value: HydratedTemplate[] }>()
+const catalogInFlight = new Map<string, Promise<TemplateCatalog>>()
+const catalogCache = new Map<string, { at: number; value: TemplateCatalog }>()
 
 export function loadTemplateCatalog(opts?: {
   comfyVersion?: string | null
-}): Promise<HydratedTemplate[]> {
+}): Promise<TemplateCatalog> {
   const key = opts?.comfyVersion ?? ''
   const cached = catalogCache.get(key)
   if (cached && Date.now() - cached.at < CATALOG_TTL_MS) return Promise.resolve(cached.value)
@@ -316,15 +323,16 @@ async function indexForVersion(
   }
 }
 
-async function loadTemplateCatalogUncached(
-  comfyVersion: string | null
-): Promise<HydratedTemplate[]> {
+async function loadTemplateCatalogUncached(comfyVersion: string | null): Promise<TemplateCatalog> {
   const [templates, index] = await Promise.all([activeTemplates(), indexForVersion(comfyVersion)])
   const { byId, assetBase } = index
   const online = byId.size > 0
   const now = Date.now()
 
   const used = new Set<string>()
+  // Payload entries keyed by id, so backfill can honour a window the payload set
+  // on a baked-in card instead of reading only the static list.
+  const windows = new Map(templates.filter((t) => t?.id).map((t) => [t.id, t]))
   const perModality = new Map<TemplateModality, HydratedTemplate[]>(
     TEMPLATE_MODALITY_ORDER.map((modality) => [modality, []])
   )
@@ -373,19 +381,21 @@ async function loadTemplateCatalogUncached(
     )
   }
 
-  backfill(perModality, byId, used, online, assetBase)
+  backfill(perModality, byId, used, online, assetBase, now, windows)
 
   const catalog: HydratedTemplate[] = []
   for (const modality of TEMPLATE_MODALITY_ORDER) {
     catalog.push(...enforceOneRecommended(perModality.get(modality) ?? []))
   }
-  return catalog.sort(byModalityOrder)
+  return { templates: catalog.sort(byModalityOrder), assetBase }
 }
 
 /**
  * Strict pass, then `terminal`, which relaxes index membership and then
- * `isRunnableLocally` rather than ship a short tab. Identity is never relaxed:
- * two cards sharing an id collide on `FieldOption.value`, the picker's key.
+ * `isRunnableLocally` rather than ship a short tab. Identity and the
+ * availability window are never relaxed: two cards sharing an id collide on
+ * `FieldOption.value`, the picker's key, and a retired card must stay retired
+ * even when the alternative is a short tab.
  */
 function fillFromBakedIn(
   slots: HydratedTemplate[],
@@ -394,12 +404,17 @@ function fillFromBakedIn(
   used: Set<string>,
   online: boolean,
   assetBase: string,
+  now: number,
+  windows: Map<string, CuratedTemplate>,
   terminal: boolean
 ): void {
   const take = (allowUnrunnable: boolean): void => {
     for (const curated of CURATED_TEMPLATES) {
       if (slots.length >= SLOTS_PER_MODALITY) break
       if (curated.modality !== modality || used.has(curated.id)) continue
+      // A window the payload set on this id wins, so content can retire a
+      // baked-in card rather than watch backfill wave it straight back in.
+      if (!isWithinWindow(windows.get(curated.id) ?? curated, now)) continue
       const location = byId.get(curated.id)
       if (!allowUnrunnable && location && !isRunnableLocally(location.entry)) continue
       // Re-adding an index-absent card would undo the gate that dropped it.
@@ -428,13 +443,15 @@ function backfill(
   byId: Map<string, IndexLocation>,
   used: Set<string>,
   online: boolean,
-  assetBase: string
+  assetBase: string,
+  now: number,
+  windows: Map<string, CuratedTemplate>
 ): void {
   for (const modality of TEMPLATE_MODALITY_ORDER) {
     const slots = perModality.get(modality)!
     if (slots.length >= SLOTS_PER_MODALITY) continue
 
-    fillFromBakedIn(slots, modality, byId, used, online, assetBase, false)
+    fillFromBakedIn(slots, modality, byId, used, online, assetBase, now, windows, false)
 
     while (slots.length < SLOTS_PER_MODALITY && online) {
       const sub = firstUnusedOfModality(byId, modality, used)
@@ -452,7 +469,7 @@ function backfill(
       )
     }
 
-    fillFromBakedIn(slots, modality, byId, used, online, assetBase, true)
+    fillFromBakedIn(slots, modality, byId, used, online, assetBase, now, windows, true)
   }
 }
 

--- a/src/main/sources/standalone/templateCatalogResolution.test.ts
+++ b/src/main/sources/standalone/templateCatalogResolution.test.ts
@@ -1,0 +1,756 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type * as TemplatePinModule from './templatePin'
+
+vi.mock('../../lib/fetch', () => ({ fetchJSON: vi.fn() }))
+
+const getStarterTemplatesAsync = vi.fn()
+vi.mock('./starterTemplateManifest', () => ({
+  getStarterTemplatesAsync: () => getStarterTemplatesAsync()
+}))
+
+const resolveTemplatePackageVersion = vi.fn()
+vi.mock('./templatePin', async (importOriginal) => {
+  const actual = await importOriginal<typeof TemplatePinModule>()
+  return {
+    ...actual,
+    resolveTemplatePackageVersion: (...a: unknown[]) => resolveTemplatePackageVersion(...a)
+  }
+})
+
+import { loadTemplateCatalog, resetTemplateCatalogCache } from './templateCatalog'
+import { CURATED_TEMPLATES, INDEX_URL, TEMPLATE_MODALITY_ORDER } from './curatedTemplates'
+import type { HydratedTemplate } from './templateCatalog'
+import { fetchJSON } from '../../lib/fetch'
+
+const mockedFetchJSON = vi.mocked(fetchJSON)
+
+function category(
+  type: string,
+  title: string,
+  templates: Record<string, Record<string, unknown>>
+): unknown {
+  return {
+    type,
+    title,
+    templates: Object.entries(templates).map(([name, fields]) => ({
+      size: 1_000,
+      mediaSubtype: 'webp',
+      ...fields,
+      name
+    }))
+  }
+}
+
+/** Substitute candidates a real index always carries (100+ image, 50+ video). */
+function spares(): unknown[] {
+  const titles: Record<string, string> = {
+    image: 'Image',
+    video: 'Video',
+    audio: 'Audio',
+    '3d': '3D Model'
+  }
+  return TEMPLATE_MODALITY_ORDER.map((modality) =>
+    category(
+      modality,
+      titles[modality]!,
+      Object.fromEntries(
+        Array.from({ length: 4 }, (_, i) => [`spare_${modality}_${i}`, { title: `Spare ${i}` }])
+      )
+    )
+  )
+}
+
+function indexWithCurated(extra: unknown[] = []): unknown[] {
+  const byModality: Record<string, Record<string, Record<string, unknown>>> = {}
+  for (const t of CURATED_TEMPLATES) {
+    byModality[t.modality] ??= {}
+    byModality[t.modality]![t.id] = {}
+  }
+  const titles: Record<string, string> = {
+    image: 'Image',
+    video: 'Video',
+    audio: 'Audio',
+    '3d': '3D Model'
+  }
+  return [
+    ...Object.entries(byModality).map(([type, templates]) =>
+      category(type, titles[type]!, templates)
+    ),
+    ...extra
+  ]
+}
+
+function expectFourByFour(catalog: HydratedTemplate[]): void {
+  for (const modality of TEMPLATE_MODALITY_ORDER) {
+    const cards = catalog.filter((c) => c.modality === modality)
+    expect(cards.length, `${modality} card count`).toBe(4)
+    const recommended = cards.filter((c) => c.recommended)
+    expect(recommended.length, `${modality} recommended count`).toBeLessThanOrEqual(1)
+    expect(
+      recommended.filter((c) => c.apiNode),
+      `${modality} paid auto-pick`
+    ).toEqual([])
+  }
+  expect(new Set(catalog.map((c) => c.id)).size, 'duplicate ids across catalog').toBe(
+    catalog.length
+  )
+  const recommendedIds = catalog.filter((c) => c.recommended).map((c) => c.id)
+  expect(new Set(recommendedIds).size, 'an id is recommended in at most one tab').toBe(
+    recommendedIds.length
+  )
+}
+
+beforeEach(() => {
+  mockedFetchJSON.mockReset()
+  getStarterTemplatesAsync.mockReset()
+  resolveTemplatePackageVersion.mockReset()
+  resetTemplateCatalogCache()
+  getStarterTemplatesAsync.mockResolvedValue(CURATED_TEMPLATES)
+  resolveTemplatePackageVersion.mockResolvedValue(null)
+})
+
+describe('remote payload drives the card list', () => {
+  it('renders the payload list instead of the baked-in one', async () => {
+    getStarterTemplatesAsync.mockResolvedValue([
+      { id: 'payload_img', modality: 'image', recommended: true },
+      ...CURATED_TEMPLATES.filter((t) => t.modality !== 'image')
+    ])
+    mockedFetchJSON.mockResolvedValue(
+      indexWithCurated([category('image', 'Image', { payload_img: { title: 'Payload Image' } })])
+    )
+    const catalog = await loadTemplateCatalog()
+    expect(catalog.find((c) => c.id === 'payload_img')?.title).toBe('Payload Image')
+    expectFourByFour(catalog)
+  })
+
+  it('backfills modalities the payload does not mention', async () => {
+    getStarterTemplatesAsync.mockResolvedValue(
+      CURATED_TEMPLATES.filter((t) => t.modality === 'image')
+    )
+    mockedFetchJSON.mockResolvedValue(indexWithCurated())
+    expectFourByFour(await loadTemplateCatalog())
+  })
+
+  it('truncates a modality carrying more than four entries', async () => {
+    const extras = Array.from({ length: 5 }, (_, i) => ({
+      id: `image_extra_${i}`,
+      modality: 'image' as const
+    }))
+    getStarterTemplatesAsync.mockResolvedValue([...CURATED_TEMPLATES, ...extras])
+    mockedFetchJSON.mockResolvedValue(
+      indexWithCurated([
+        category('image', 'Image', Object.fromEntries(extras.map((e) => [e.id, {}])))
+      ])
+    )
+    expectFourByFour(await loadTemplateCatalog())
+  })
+
+  it('never exceeds four even when substitutes are abundant', async () => {
+    getStarterTemplatesAsync.mockResolvedValue([
+      { id: 'image_gone_a', modality: 'image', recommended: true },
+      { id: 'image_gone_b', modality: 'image' },
+      { id: 'image_gone_c', modality: 'image' },
+      { id: 'image_gone_d', modality: 'image' },
+      ...CURATED_TEMPLATES.filter((t) => t.modality !== 'image')
+    ])
+    mockedFetchJSON.mockResolvedValue(
+      indexWithCurated([
+        category(
+          'image',
+          'Image',
+          Object.fromEntries(
+            Array.from({ length: 20 }, (_, i) => [`plenty_${i}`, { title: `Plenty ${i}` }])
+          )
+        )
+      ])
+    )
+    const catalog = await loadTemplateCatalog()
+    expect(catalog.filter((c) => c.modality === 'image')).toHaveLength(4)
+    expectFourByFour(catalog)
+  })
+
+  it('tops a one-entry modality up to four', async () => {
+    getStarterTemplatesAsync.mockResolvedValue([
+      { id: 'image_solo', modality: 'image', recommended: true },
+      ...CURATED_TEMPLATES.filter((t) => t.modality !== 'image')
+    ])
+    mockedFetchJSON.mockResolvedValue(
+      indexWithCurated([category('image', 'Image', { image_solo: {} })])
+    )
+    const catalog = await loadTemplateCatalog()
+    expect(catalog.find((c) => c.id === 'image_solo')).toBeDefined()
+    expectFourByFour(catalog)
+  })
+
+  it('collapses duplicate ids and refills the freed slot', async () => {
+    const image = CURATED_TEMPLATES.filter((t) => t.modality === 'image')
+    getStarterTemplatesAsync.mockResolvedValue([
+      image[0]!,
+      image[0]!,
+      image[1]!,
+      ...CURATED_TEMPLATES.filter((t) => t.modality !== 'image')
+    ])
+    mockedFetchJSON.mockResolvedValue(indexWithCurated())
+    expectFourByFour(await loadTemplateCatalog())
+  })
+
+  it('backfills wholly when the payload is empty', async () => {
+    getStarterTemplatesAsync.mockResolvedValue([])
+    mockedFetchJSON.mockResolvedValue(indexWithCurated())
+    expectFourByFour(await loadTemplateCatalog())
+  })
+})
+
+describe('version gate via the package pin', () => {
+  it('hides a template the pinned index does not carry, and substitutes', async () => {
+    const missing = 'video_minimax_h3_t2v'
+    resolveTemplatePackageVersion.mockResolvedValue('0.11.12')
+    mockedFetchJSON.mockResolvedValue(
+      indexWithCurated([
+        category('video', 'Video', { live_video_sub: { title: 'Live Video Sub' } })
+      ])
+        .map((c) => {
+          const cat = c as { type?: string; templates?: { name: string }[] }
+          if (cat.type === 'video' && cat.templates) {
+            cat.templates = cat.templates.filter((t) => t.name !== missing)
+          }
+          return cat
+        })
+        .concat(spares() as never[])
+    )
+    const catalog = await loadTemplateCatalog({ comfyVersion: 'v0.28.2' })
+    expect(catalog.find((c) => c.id === missing)).toBeUndefined()
+    expectFourByFour(catalog)
+  })
+
+  it('fetches the index the target ComfyUI pins, not main', async () => {
+    resolveTemplatePackageVersion.mockResolvedValue('0.11.12')
+    mockedFetchJSON.mockResolvedValue(indexWithCurated())
+    await loadTemplateCatalog({ comfyVersion: 'v0.28.2' })
+    expect(resolveTemplatePackageVersion).toHaveBeenCalledWith('v0.28.2')
+    expect(
+      mockedFetchJSON,
+      'reads the index ComfyUI v0.28.2 pins, not main, under a bounded budget'
+    ).toHaveBeenCalledWith(
+      'https://raw.githubusercontent.com/Comfy-Org/workflow_templates/v0.11.12/templates/index.json',
+      expect.objectContaining({ timeoutMs: expect.any(Number) })
+    )
+  })
+
+  it('fetches the live main index when no pin resolves', async () => {
+    resolveTemplatePackageVersion.mockResolvedValue(null)
+    mockedFetchJSON.mockResolvedValue(indexWithCurated())
+    await loadTemplateCatalog({ comfyVersion: null })
+    expect(mockedFetchJSON).toHaveBeenCalledWith(INDEX_URL, expect.anything())
+  })
+
+  it('keeps that template when the pinned index carries it', async () => {
+    resolveTemplatePackageVersion.mockResolvedValue('0.11.31')
+    mockedFetchJSON.mockResolvedValue(indexWithCurated())
+    const catalog = await loadTemplateCatalog({ comfyVersion: 'v0.30.2' })
+    expect(catalog.find((c) => c.id === 'video_minimax_h3_t2v')).toBeDefined()
+    expectFourByFour(catalog)
+  })
+
+  it('fails open when the version is unknown', async () => {
+    resolveTemplatePackageVersion.mockResolvedValue(null)
+    mockedFetchJSON.mockResolvedValue(indexWithCurated())
+    const catalog = await loadTemplateCatalog({ comfyVersion: null })
+    expectFourByFour(catalog)
+  })
+
+  it('fails open when the pin lookup rejects', async () => {
+    resolveTemplatePackageVersion.mockRejectedValue(new Error('offline'))
+    mockedFetchJSON.mockResolvedValue(indexWithCurated())
+    expectFourByFour(await loadTemplateCatalog({ comfyVersion: 'v0.30.2' }))
+  })
+
+  it('varies the cache key with comfyVersion', async () => {
+    mockedFetchJSON.mockResolvedValue(indexWithCurated())
+    resolveTemplatePackageVersion.mockResolvedValue('0.11.31')
+    await loadTemplateCatalog({ comfyVersion: 'v0.30.2' })
+    await loadTemplateCatalog({ comfyVersion: 'v0.28.2' })
+    expect(
+      mockedFetchJSON.mock.calls.length,
+      'a different target version re-resolves rather than serving the previous filter'
+    ).toBeGreaterThan(1)
+  })
+
+  it('still caches repeat reads for the same comfyVersion', async () => {
+    mockedFetchJSON.mockResolvedValue(indexWithCurated())
+    resolveTemplatePackageVersion.mockResolvedValue('0.11.31')
+    await loadTemplateCatalog({ comfyVersion: 'v0.30.2' })
+    const before = mockedFetchJSON.mock.calls.length
+    await loadTemplateCatalog({ comfyVersion: 'v0.30.2' })
+    expect(mockedFetchJSON.mock.calls.length).toBe(before)
+  })
+})
+
+describe('upstream compatibility signals', () => {
+  it('drops a card requiring custom nodes', async () => {
+    const target = CURATED_TEMPLATES.find((t) => t.modality === 'image' && !t.apiNode)!
+    mockedFetchJSON.mockResolvedValue(
+      indexWithCurated()
+        .map((c) => {
+          const cat = c as { type?: string; templates?: Record<string, unknown>[] }
+          if (cat.type === 'image') {
+            for (const t of cat.templates ?? []) {
+              if (t.name === target.id) t.requiresCustomNodes = ['comfyui-kjnodes']
+            }
+          }
+          return cat
+        })
+        .concat(spares() as never[])
+    )
+    const catalog = await loadTemplateCatalog()
+    expect(catalog.find((c) => c.id === target.id)).toBeUndefined()
+    expectFourByFour(catalog)
+  })
+
+  it('keeps a card whose requiresCustomNodes is empty', async () => {
+    const target = CURATED_TEMPLATES.find((t) => t.modality === 'image' && !t.apiNode)!
+    mockedFetchJSON.mockResolvedValue(
+      indexWithCurated().map((c) => {
+        const cat = c as { type?: string; templates?: Record<string, unknown>[] }
+        if (cat.type === 'image') {
+          for (const t of cat.templates ?? []) {
+            if (t.name === target.id) t.requiresCustomNodes = []
+          }
+        }
+        return cat
+      })
+    )
+    expect((await loadTemplateCatalog()).find((c) => c.id === target.id)).toBeDefined()
+  })
+
+  it('drops a cloud-only card', async () => {
+    const target = CURATED_TEMPLATES.find((t) => t.modality === 'image' && !t.apiNode)!
+    mockedFetchJSON.mockResolvedValue(
+      indexWithCurated()
+        .map((c) => {
+          const cat = c as { type?: string; templates?: Record<string, unknown>[] }
+          if (cat.type === 'image') {
+            for (const t of cat.templates ?? []) {
+              if (t.name === target.id) t.includeOnDistributions = ['cloud']
+            }
+          }
+          return cat
+        })
+        .concat(spares() as never[])
+    )
+    const catalog = await loadTemplateCatalog()
+    expect(catalog.find((c) => c.id === target.id)).toBeUndefined()
+    expectFourByFour(catalog)
+  })
+
+  it.each([[['local']], [['local', 'cloud']], [undefined]])(
+    'keeps a card with includeOnDistributions %s',
+    async (includeOnDistributions) => {
+      const target = CURATED_TEMPLATES.find((t) => t.modality === 'image' && !t.apiNode)!
+      mockedFetchJSON.mockResolvedValue(
+        indexWithCurated().map((c) => {
+          const cat = c as { type?: string; templates?: Record<string, unknown>[] }
+          if (cat.type === 'image') {
+            for (const t of cat.templates ?? []) {
+              if (t.name === target.id) t.includeOnDistributions = includeOnDistributions
+            }
+          }
+          return cat
+        })
+      )
+      expect((await loadTemplateCatalog()).find((c) => c.id === target.id)).toBeDefined()
+    }
+  )
+})
+
+describe('substitution quality', () => {
+  it('substitutes within the same modality only', async () => {
+    getStarterTemplatesAsync.mockResolvedValue([
+      { id: 'video_gone', modality: 'video', recommended: true },
+      ...CURATED_TEMPLATES.filter((t) => t.modality !== 'video').slice(0, 12)
+    ])
+    mockedFetchJSON.mockResolvedValue(
+      indexWithCurated([category('video', 'Video', { real_video: { title: 'Real Video' } })])
+    )
+    const catalog = await loadTemplateCatalog()
+    for (const card of catalog.filter((c) => c.modality === 'video')) {
+      expect(card.id.startsWith('image_'), card.id).toBe(false)
+    }
+    expectFourByFour(catalog)
+  })
+
+  it('never substitutes from a non-allowlisted category', async () => {
+    getStarterTemplatesAsync.mockResolvedValue([
+      { id: 'image_gone_a', modality: 'image', recommended: true },
+      { id: 'image_gone_b', modality: 'image' },
+      { id: 'image_gone_c', modality: 'image' },
+      { id: 'image_gone_d', modality: 'image' },
+      ...CURATED_TEMPLATES.filter((t) => t.modality !== 'image')
+    ])
+    mockedFetchJSON.mockResolvedValue(
+      indexWithCurated([
+        category('image', 'Node Basics', { basics_trap: { title: 'Node Basics Trap' } }),
+        category('image', 'Utility', { utility_trap: { title: 'Utility Trap' } }),
+        category('image', 'LLM', { llm_trap: { title: 'LLM Trap' } }),
+        category('image', 'Getting Started', { gs_trap: { title: 'Getting Started Trap' } })
+      ])
+    )
+    const catalog = await loadTemplateCatalog()
+    for (const trap of ['basics_trap', 'utility_trap', 'llm_trap', 'gs_trap']) {
+      expect(
+        catalog.find((c) => c.id === trap),
+        trap
+      ).toBeUndefined()
+    }
+    expectFourByFour(catalog)
+  })
+
+  it('does substitute from an allowlisted Use Cases category', async () => {
+    getStarterTemplatesAsync.mockResolvedValue([
+      { id: 'image_gone', modality: 'image', recommended: true },
+      ...CURATED_TEMPLATES.filter((t) => t.modality !== 'image')
+    ])
+    mockedFetchJSON.mockResolvedValue(
+      indexWithCurated([category('image', 'Use Cases', { use_case_ok: { title: 'Use Case Sub' } })])
+    )
+    const catalog = await loadTemplateCatalog()
+    expectFourByFour(catalog)
+  })
+
+  it('keeps an explicitly-named id even from a non-allowlisted category', async () => {
+    getStarterTemplatesAsync.mockResolvedValue([
+      { id: 'utility_pick', modality: 'image', recommended: true },
+      ...CURATED_TEMPLATES.filter((t) => t.modality !== 'image')
+    ])
+    mockedFetchJSON.mockResolvedValue(
+      indexWithCurated([category('image', 'Utility', { utility_pick: { title: 'Chosen' } })])
+    )
+    const catalog = await loadTemplateCatalog()
+    expect(catalog.find((c) => c.id === 'utility_pick')?.title).toBe('Chosen')
+    expectFourByFour(catalog)
+  })
+
+  it('never substitutes an API-node slot', async () => {
+    const apiCard = CURATED_TEMPLATES.find((t) => t.apiNode && t.modality === 'image')!
+    mockedFetchJSON.mockResolvedValue(
+      indexWithCurated().map((c) => {
+        const cat = c as { type?: string; templates?: { name: string }[] }
+        if (cat.type === 'image' && cat.templates) {
+          cat.templates = cat.templates.filter((t) => t.name !== apiCard.id)
+        }
+        return cat
+      })
+    )
+    const catalog = await loadTemplateCatalog()
+    const card = catalog.find((c) => c.id === apiCard.id)
+    expect(card?.apiNode).toBe(true)
+    expectFourByFour(catalog)
+  })
+
+  it('skips api_ and size-less substitution candidates', async () => {
+    getStarterTemplatesAsync.mockResolvedValue([
+      { id: 'image_gone', modality: 'image', recommended: true },
+      ...CURATED_TEMPLATES.filter((t) => t.modality !== 'image')
+    ])
+    mockedFetchJSON.mockResolvedValue(
+      indexWithCurated([
+        category('image', 'Image', {
+          api_should_skip: { title: 'API' },
+          sizeless_should_skip: { title: 'Sizeless', size: 0 },
+          good_sub: { title: 'Good Sub' }
+        })
+      ])
+    )
+    const catalog = await loadTemplateCatalog()
+    expect(catalog.find((c) => c.id === 'api_should_skip')).toBeUndefined()
+    expect(catalog.find((c) => c.id === 'sizeless_should_skip')).toBeUndefined()
+    expectFourByFour(catalog)
+  })
+
+  it('warns naming the id that went missing', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      getStarterTemplatesAsync.mockResolvedValue([
+        { id: 'image_typo_id', modality: 'image', recommended: true },
+        ...CURATED_TEMPLATES.filter((t) => t.modality !== 'image')
+      ])
+      mockedFetchJSON.mockResolvedValue(
+        indexWithCurated([category('image', 'Image', { sub_for_typo: {} })])
+      )
+      await loadTemplateCatalog()
+      expect(warn.mock.calls.flat().join(' ')).toContain('image_typo_id')
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('does not substitute when offline', async () => {
+    mockedFetchJSON.mockRejectedValue(new Error('offline'))
+    const catalog = await loadTemplateCatalog()
+    for (const curated of CURATED_TEMPLATES) {
+      expect(
+        catalog.find((c) => c.id === curated.id),
+        curated.id
+      ).toBeDefined()
+    }
+    expectFourByFour(catalog)
+  })
+
+  it('degrades to baked-in rather than borrowing another modality', async () => {
+    getStarterTemplatesAsync.mockResolvedValue([
+      { id: '3d_gone_a', modality: '3d', recommended: true },
+      { id: '3d_gone_b', modality: '3d' },
+      { id: '3d_gone_c', modality: '3d' },
+      { id: '3d_gone_d', modality: '3d' },
+      ...CURATED_TEMPLATES.filter((t) => t.modality !== '3d')
+    ])
+    mockedFetchJSON.mockResolvedValue(
+      indexWithCurated([
+        category('image', 'Image', {
+          spare_1: {},
+          spare_2: {},
+          spare_3: {},
+          spare_4: {},
+          spare_5: {}
+        })
+      ])
+    )
+    const catalog = await loadTemplateCatalog()
+    for (const card of catalog.filter((c) => c.modality === '3d')) {
+      expect(card.id.startsWith('spare_'), card.id).toBe(false)
+    }
+    expectFourByFour(catalog)
+  })
+})
+
+describe('recommended invariants after resolution', () => {
+  it('promotes a recommendation when the payload names none', async () => {
+    getStarterTemplatesAsync.mockResolvedValue(
+      CURATED_TEMPLATES.map(({ recommended: _drop, ...rest }) => rest as never)
+    )
+    mockedFetchJSON.mockResolvedValue(indexWithCurated())
+    expectFourByFour(await loadTemplateCatalog())
+  })
+
+  it('keeps the recommendation off an api card in an all-api modality', async () => {
+    getStarterTemplatesAsync.mockResolvedValue([
+      { id: 'api_a', modality: 'image', apiNode: true },
+      { id: 'api_b', modality: 'image', apiNode: true },
+      { id: 'api_c', modality: 'image', apiNode: true },
+      { id: 'api_d', modality: 'image', apiNode: true },
+      ...CURATED_TEMPLATES.filter((t) => t.modality !== 'image')
+    ])
+    mockedFetchJSON.mockResolvedValue(indexWithCurated())
+    const catalog = await loadTemplateCatalog()
+    const rec = catalog.filter((c) => c.modality === 'image' && c.recommended)
+    expect(rec).toHaveLength(1)
+    expect(rec[0]!.apiNode).toBe(false)
+  })
+})
+
+describe('availability window', () => {
+  it('hides an entry whose window has not opened, and one that has closed', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-01T00:00:00Z'))
+    try {
+      getStarterTemplatesAsync.mockResolvedValue([
+        { id: 'image_future', modality: 'image', availableFrom: '2026-12-01T00:00:00Z' },
+        { id: 'image_expired', modality: 'image', availableUntil: '2026-01-01T00:00:00Z' },
+        { id: 'image_open', modality: 'image', recommended: true },
+        ...CURATED_TEMPLATES.filter((t) => t.modality !== 'image')
+      ])
+      mockedFetchJSON.mockResolvedValue(
+        indexWithCurated([
+          category('image', 'Image', { image_future: {}, image_expired: {}, image_open: {} })
+        ])
+      )
+      const catalog = await loadTemplateCatalog()
+      expect(catalog.find((c) => c.id === 'image_future')).toBeUndefined()
+      expect(catalog.find((c) => c.id === 'image_expired')).toBeUndefined()
+      expect(catalog.find((c) => c.id === 'image_open')).toBeDefined()
+      expectFourByFour(catalog)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('every source failing at once', () => {
+  it('holds 4x4 with a garbage payload, no index, and an unknown version', async () => {
+    getStarterTemplatesAsync.mockResolvedValue(CURATED_TEMPLATES)
+    mockedFetchJSON.mockRejectedValue(new Error('offline'))
+    resolveTemplatePackageVersion.mockRejectedValue(new Error('offline'))
+    expectFourByFour(await loadTemplateCatalog({ comfyVersion: null }))
+  })
+
+  it('holds 4x4 when the manifest read itself throws', async () => {
+    getStarterTemplatesAsync.mockRejectedValue(new Error('flag exploded'))
+    mockedFetchJSON.mockResolvedValue(indexWithCurated())
+    expectFourByFour(await loadTemplateCatalog())
+  })
+
+  it('holds 4x4 when the payload is every kind of broken at once', async () => {
+    getStarterTemplatesAsync.mockResolvedValue([
+      { id: 'gone_1', modality: 'image', recommended: true },
+      { id: 'gone_2', modality: 'video' },
+      { id: 'api_only', modality: 'audio', apiNode: true },
+      { id: 'gone_3', modality: '3d' }
+    ])
+    mockedFetchJSON.mockResolvedValue([])
+    expectFourByFour(await loadTemplateCatalog({ comfyVersion: 'v0.28.2' }))
+  })
+})
+
+describe('4x4 when the index offers no substitute candidates', () => {
+  function bareIndex(absent: string[] = []): unknown[] {
+    const byMod: Record<string, Record<string, Record<string, unknown>>> = {}
+    for (const t of CURATED_TEMPLATES) {
+      if (absent.includes(t.id)) continue
+      byMod[t.modality] ??= {}
+      byMod[t.modality]![t.id] = {}
+    }
+    const titles: Record<string, string> = {
+      image: 'Image',
+      video: 'Video',
+      audio: 'Audio',
+      '3d': '3D Model'
+    }
+    return Object.entries(byMod).map(([type, tpls]) => category(type, titles[type]!, tpls))
+  }
+
+  it('holds when the recommended card is missing and nothing can substitute', async () => {
+    resolveTemplatePackageVersion.mockResolvedValue('0.11.12')
+    mockedFetchJSON.mockResolvedValue(bareIndex(['video_minimax_h3_t2v']))
+    const catalog = await loadTemplateCatalog({ comfyVersion: 'v0.28.2' })
+    expectFourByFour(catalog)
+  })
+
+  it.each(CURATED_TEMPLATES.map((t) => [t.modality, t.id] as const))(
+    'holds for %s when %s is absent from the index',
+    async (_modality, missingId) => {
+      mockedFetchJSON.mockResolvedValue(bareIndex([missingId]))
+      expectFourByFour(await loadTemplateCatalog({ comfyVersion: 'v0.28.2' }))
+    }
+  )
+
+  it('holds when every card in a modality is absent', async () => {
+    const video = CURATED_TEMPLATES.filter((t) => t.modality === 'video').map((t) => t.id)
+    mockedFetchJSON.mockResolvedValue(bareIndex(video))
+    expectFourByFour(await loadTemplateCatalog({ comfyVersion: 'v0.28.2' }))
+  })
+
+  it('holds when the index carries no allowlisted category at all', async () => {
+    mockedFetchJSON.mockResolvedValue([
+      category('image', 'Node Basics', { nb_1: {}, nb_2: {} }),
+      category('video', 'Utility', { ut_1: {} })
+    ])
+    expectFourByFour(await loadTemplateCatalog({ comfyVersion: 'v0.28.2' }))
+  })
+
+  it('never lets a substitute steal a baked-in card still owed a slot', async () => {
+    mockedFetchJSON.mockResolvedValue(bareIndex(['video_minimax_h3_t2v']))
+    const catalog = await loadTemplateCatalog({ comfyVersion: 'v0.28.2' })
+    const video = catalog.filter((c) => c.modality === 'video').map((c) => c.id)
+    for (const id of [
+      'api_seedance2_0_r2v',
+      'wan2.1_fun_inp',
+      'video_wan2.1_fun_camera_v1.1_1.3B'
+    ]) {
+      expect(video, `${id} kept its own slot`).toContain(id)
+    }
+  })
+})
+
+describe('thumbnails follow the pinned index', () => {
+  it('resolves previews against the pinned asset base, not main', async () => {
+    // The index is fetched at the pin, so previews must be too — otherwise a
+    // card hydrated from v0.11.12 requests an image that only exists on main.
+    resolveTemplatePackageVersion.mockResolvedValue('0.11.12')
+    mockedFetchJSON.mockResolvedValue(indexWithCurated())
+    const catalog = await loadTemplateCatalog({ comfyVersion: 'v0.28.2' })
+    const withThumb = catalog.filter((c) => c.thumbnailUrl)
+    expect(withThumb.length).toBeGreaterThan(0)
+    for (const card of withThumb) {
+      expect(card.thumbnailUrl, card.id).toContain('/v0.11.12/templates/')
+    }
+  })
+
+  it('falls back to the main asset base when no pin resolves', async () => {
+    resolveTemplatePackageVersion.mockResolvedValue(null)
+    mockedFetchJSON.mockResolvedValue(indexWithCurated())
+    const catalog = await loadTemplateCatalog({ comfyVersion: null })
+    const card = catalog.find((c) => c.thumbnailUrl)!
+    expect(card.thumbnailUrl).toContain('/main/templates/')
+  })
+})
+
+describe('adversarial-but-valid payloads', () => {
+  function bareIndexAll(mutate: (id: string) => Record<string, unknown> | null = () => ({})) {
+    const byMod: Record<string, Record<string, Record<string, unknown>>> = {}
+    for (const t of CURATED_TEMPLATES) {
+      const fields = mutate(t.id)
+      if (!fields) continue
+      byMod[t.modality] ??= {}
+      byMod[t.modality]![t.id] = fields
+    }
+    const titles: Record<string, string> = {
+      image: 'Image',
+      video: 'Video',
+      audio: 'Audio',
+      '3d': '3D Model'
+    }
+    return Object.entries(byMod).map(([type, tpls]) => category(type, titles[type]!, tpls))
+  }
+
+  it.each([1, 2, 4])(
+    'holds when %i image cards would be filed under the wrong modality',
+    async (count) => {
+      const image = CURATED_TEMPLATES.filter((t) => t.modality === 'image').slice(0, count)
+      getStarterTemplatesAsync.mockResolvedValue([
+        ...image.map((t) => ({ id: t.id, modality: 'video' as const })),
+        ...CURATED_TEMPLATES
+      ])
+      mockedFetchJSON.mockResolvedValue(bareIndexAll())
+      const catalog = await loadTemplateCatalog()
+      expect(new Set(catalog.map((c) => c.id)).size, 'no duplicate ids').toBe(catalog.length)
+    }
+  )
+
+  it('never recommends an API card when the payload is all API nodes', async () => {
+    getStarterTemplatesAsync.mockResolvedValue(
+      CURATED_TEMPLATES.map((t) => ({ id: t.id, modality: t.modality, apiNode: true as const }))
+    )
+    mockedFetchJSON.mockResolvedValue(bareIndexAll())
+    const catalog = await loadTemplateCatalog()
+    for (const modality of TEMPLATE_MODALITY_ORDER) {
+      const cards = catalog.filter((c) => c.modality === modality)
+      expect(cards, modality).toHaveLength(4)
+      expect(
+        cards.filter((c) => c.recommended && c.apiNode),
+        `${modality} paid auto-pick`
+      ).toEqual([])
+    }
+  })
+
+  it('prefers runnable cards but still fills a wholly-unrunnable modality', async () => {
+    mockedFetchJSON.mockResolvedValue(
+      bareIndexAll((id) =>
+        CURATED_TEMPLATES.find((t) => t.id === id)!.modality === 'image'
+          ? { requiresCustomNodes: ['comfyui-kjnodes'] }
+          : {}
+      )
+    )
+    expectFourByFour(await loadTemplateCatalog({ comfyVersion: 'v0.28.2' }))
+  })
+
+  it('still drops an unrunnable card when a runnable one can take the slot', async () => {
+    const target = CURATED_TEMPLATES.find((t) => t.modality === 'image' && !t.apiNode)!
+    mockedFetchJSON.mockResolvedValue([
+      ...bareIndexAll((id) => (id === target.id ? { requiresCustomNodes: ['x'] } : {})),
+      category('image', 'Image', { runnable_sub: { title: 'Runnable' } })
+    ])
+    const catalog = await loadTemplateCatalog()
+    expect(catalog.find((c) => c.id === target.id)).toBeUndefined()
+    expectFourByFour(catalog)
+  })
+})

--- a/src/main/sources/standalone/templateCatalogResolution.test.ts
+++ b/src/main/sources/standalone/templateCatalogResolution.test.ts
@@ -669,8 +669,9 @@ describe('4x4 when the index offers no substitute candidates', () => {
   }
 
   it('holds when the recommended card is missing and nothing can substitute', async () => {
+    const recommendedVideo = CURATED_TEMPLATES.find((t) => t.modality === 'video' && t.recommended)!
     resolveTemplatePackageVersion.mockResolvedValue('0.11.12')
-    mockedFetchJSON.mockResolvedValue(bareIndex(['video_minimax_h3_t2v']))
+    mockedFetchJSON.mockResolvedValue(bareIndex([recommendedVideo.id]))
     const catalog = await loadCards({ comfyVersion: 'v0.28.2' })
     expectFourByFour(catalog)
   })
@@ -698,14 +699,13 @@ describe('4x4 when the index offers no substitute candidates', () => {
   })
 
   it('never lets a substitute steal a baked-in card still owed a slot', async () => {
-    mockedFetchJSON.mockResolvedValue(bareIndex(['video_minimax_h3_t2v']))
+    const [removed, ...retained] = CURATED_TEMPLATES.filter((t) => t.modality === 'video').map(
+      (t) => t.id
+    )
+    mockedFetchJSON.mockResolvedValue(bareIndex([removed!]))
     const catalog = await loadCards({ comfyVersion: 'v0.28.2' })
     const video = catalog.filter((c) => c.modality === 'video').map((c) => c.id)
-    for (const id of [
-      'api_seedance2_0_r2v',
-      'wan2.1_fun_inp',
-      'video_wan2.1_fun_camera_v1.1_1.3B'
-    ]) {
+    for (const id of retained) {
       expect(video, `${id} kept its own slot`).toContain(id)
     }
   })

--- a/src/main/sources/standalone/templateCatalogResolution.test.ts
+++ b/src/main/sources/standalone/templateCatalogResolution.test.ts
@@ -24,6 +24,10 @@ import { fetchJSON } from '../../lib/fetch'
 
 const mockedFetchJSON = vi.mocked(fetchJSON)
 
+/** Cards only; `assetBase` is asserted separately where it matters. */
+const loadCards = async (opts?: { comfyVersion?: string | null }): Promise<HydratedTemplate[]> =>
+  (await loadTemplateCatalog(opts)).templates
+
 function category(
   type: string,
   title: string,
@@ -118,7 +122,7 @@ describe('remote payload drives the card list', () => {
     mockedFetchJSON.mockResolvedValue(
       indexWithCurated([category('image', 'Image', { payload_img: { title: 'Payload Image' } })])
     )
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     expect(catalog.find((c) => c.id === 'payload_img')?.title).toBe('Payload Image')
     expectFourByFour(catalog)
   })
@@ -128,7 +132,7 @@ describe('remote payload drives the card list', () => {
       CURATED_TEMPLATES.filter((t) => t.modality === 'image')
     )
     mockedFetchJSON.mockResolvedValue(indexWithCurated())
-    expectFourByFour(await loadTemplateCatalog())
+    expectFourByFour(await loadCards())
   })
 
   it('truncates a modality carrying more than four entries', async () => {
@@ -142,7 +146,7 @@ describe('remote payload drives the card list', () => {
         category('image', 'Image', Object.fromEntries(extras.map((e) => [e.id, {}])))
       ])
     )
-    expectFourByFour(await loadTemplateCatalog())
+    expectFourByFour(await loadCards())
   })
 
   it('never exceeds four even when substitutes are abundant', async () => {
@@ -164,7 +168,7 @@ describe('remote payload drives the card list', () => {
         )
       ])
     )
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     expect(catalog.filter((c) => c.modality === 'image')).toHaveLength(4)
     expectFourByFour(catalog)
   })
@@ -177,7 +181,7 @@ describe('remote payload drives the card list', () => {
     mockedFetchJSON.mockResolvedValue(
       indexWithCurated([category('image', 'Image', { image_solo: {} })])
     )
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     expect(catalog.find((c) => c.id === 'image_solo')).toBeDefined()
     expectFourByFour(catalog)
   })
@@ -191,13 +195,13 @@ describe('remote payload drives the card list', () => {
       ...CURATED_TEMPLATES.filter((t) => t.modality !== 'image')
     ])
     mockedFetchJSON.mockResolvedValue(indexWithCurated())
-    expectFourByFour(await loadTemplateCatalog())
+    expectFourByFour(await loadCards())
   })
 
   it('backfills wholly when the payload is empty', async () => {
     getStarterTemplatesAsync.mockResolvedValue([])
     mockedFetchJSON.mockResolvedValue(indexWithCurated())
-    expectFourByFour(await loadTemplateCatalog())
+    expectFourByFour(await loadCards())
   })
 })
 
@@ -218,7 +222,7 @@ describe('version gate via the package pin', () => {
         })
         .concat(spares() as never[])
     )
-    const catalog = await loadTemplateCatalog({ comfyVersion: 'v0.28.2' })
+    const catalog = await loadCards({ comfyVersion: 'v0.28.2' })
     expect(catalog.find((c) => c.id === missing)).toBeUndefined()
     expectFourByFour(catalog)
   })
@@ -226,7 +230,7 @@ describe('version gate via the package pin', () => {
   it('fetches the index the target ComfyUI pins, not main', async () => {
     resolveTemplatePackageVersion.mockResolvedValue('0.11.12')
     mockedFetchJSON.mockResolvedValue(indexWithCurated())
-    await loadTemplateCatalog({ comfyVersion: 'v0.28.2' })
+    await loadCards({ comfyVersion: 'v0.28.2' })
     expect(resolveTemplatePackageVersion).toHaveBeenCalledWith('v0.28.2')
     expect(
       mockedFetchJSON,
@@ -240,14 +244,14 @@ describe('version gate via the package pin', () => {
   it('fetches the live main index when no pin resolves', async () => {
     resolveTemplatePackageVersion.mockResolvedValue(null)
     mockedFetchJSON.mockResolvedValue(indexWithCurated())
-    await loadTemplateCatalog({ comfyVersion: null })
+    await loadCards({ comfyVersion: null })
     expect(mockedFetchJSON).toHaveBeenCalledWith(INDEX_URL, expect.anything())
   })
 
   it('keeps that template when the pinned index carries it', async () => {
     resolveTemplatePackageVersion.mockResolvedValue('0.11.31')
     mockedFetchJSON.mockResolvedValue(indexWithCurated())
-    const catalog = await loadTemplateCatalog({ comfyVersion: 'v0.30.2' })
+    const catalog = await loadCards({ comfyVersion: 'v0.30.2' })
     expect(catalog.find((c) => c.id === 'video_minimax_h3_t2v')).toBeDefined()
     expectFourByFour(catalog)
   })
@@ -255,21 +259,21 @@ describe('version gate via the package pin', () => {
   it('fails open when the version is unknown', async () => {
     resolveTemplatePackageVersion.mockResolvedValue(null)
     mockedFetchJSON.mockResolvedValue(indexWithCurated())
-    const catalog = await loadTemplateCatalog({ comfyVersion: null })
+    const catalog = await loadCards({ comfyVersion: null })
     expectFourByFour(catalog)
   })
 
   it('fails open when the pin lookup rejects', async () => {
     resolveTemplatePackageVersion.mockRejectedValue(new Error('offline'))
     mockedFetchJSON.mockResolvedValue(indexWithCurated())
-    expectFourByFour(await loadTemplateCatalog({ comfyVersion: 'v0.30.2' }))
+    expectFourByFour(await loadCards({ comfyVersion: 'v0.30.2' }))
   })
 
   it('varies the cache key with comfyVersion', async () => {
     mockedFetchJSON.mockResolvedValue(indexWithCurated())
     resolveTemplatePackageVersion.mockResolvedValue('0.11.31')
-    await loadTemplateCatalog({ comfyVersion: 'v0.30.2' })
-    await loadTemplateCatalog({ comfyVersion: 'v0.28.2' })
+    await loadCards({ comfyVersion: 'v0.30.2' })
+    await loadCards({ comfyVersion: 'v0.28.2' })
     expect(
       mockedFetchJSON.mock.calls.length,
       'a different target version re-resolves rather than serving the previous filter'
@@ -279,9 +283,9 @@ describe('version gate via the package pin', () => {
   it('still caches repeat reads for the same comfyVersion', async () => {
     mockedFetchJSON.mockResolvedValue(indexWithCurated())
     resolveTemplatePackageVersion.mockResolvedValue('0.11.31')
-    await loadTemplateCatalog({ comfyVersion: 'v0.30.2' })
+    await loadCards({ comfyVersion: 'v0.30.2' })
     const before = mockedFetchJSON.mock.calls.length
-    await loadTemplateCatalog({ comfyVersion: 'v0.30.2' })
+    await loadCards({ comfyVersion: 'v0.30.2' })
     expect(mockedFetchJSON.mock.calls.length).toBe(before)
   })
 })
@@ -302,7 +306,7 @@ describe('upstream compatibility signals', () => {
         })
         .concat(spares() as never[])
     )
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     expect(catalog.find((c) => c.id === target.id)).toBeUndefined()
     expectFourByFour(catalog)
   })
@@ -320,7 +324,7 @@ describe('upstream compatibility signals', () => {
         return cat
       })
     )
-    expect((await loadTemplateCatalog()).find((c) => c.id === target.id)).toBeDefined()
+    expect((await loadCards()).find((c) => c.id === target.id)).toBeDefined()
   })
 
   it('drops a cloud-only card', async () => {
@@ -338,7 +342,7 @@ describe('upstream compatibility signals', () => {
         })
         .concat(spares() as never[])
     )
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     expect(catalog.find((c) => c.id === target.id)).toBeUndefined()
     expectFourByFour(catalog)
   })
@@ -358,7 +362,7 @@ describe('upstream compatibility signals', () => {
           return cat
         })
       )
-      expect((await loadTemplateCatalog()).find((c) => c.id === target.id)).toBeDefined()
+      expect((await loadCards()).find((c) => c.id === target.id)).toBeDefined()
     }
   )
 })
@@ -372,7 +376,7 @@ describe('substitution quality', () => {
     mockedFetchJSON.mockResolvedValue(
       indexWithCurated([category('video', 'Video', { real_video: { title: 'Real Video' } })])
     )
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     for (const card of catalog.filter((c) => c.modality === 'video')) {
       expect(card.id.startsWith('image_'), card.id).toBe(false)
     }
@@ -395,7 +399,7 @@ describe('substitution quality', () => {
         category('image', 'Getting Started', { gs_trap: { title: 'Getting Started Trap' } })
       ])
     )
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     for (const trap of ['basics_trap', 'utility_trap', 'llm_trap', 'gs_trap']) {
       expect(
         catalog.find((c) => c.id === trap),
@@ -413,7 +417,11 @@ describe('substitution quality', () => {
     mockedFetchJSON.mockResolvedValue(
       indexWithCurated([category('image', 'Use Cases', { use_case_ok: { title: 'Use Case Sub' } })])
     )
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
+    expect(
+      catalog.find((c) => c.id === 'use_case_ok'),
+      'an allowlisted Use Cases entry is eligible as a substitute'
+    ).toBeDefined()
     expectFourByFour(catalog)
   })
 
@@ -425,7 +433,7 @@ describe('substitution quality', () => {
     mockedFetchJSON.mockResolvedValue(
       indexWithCurated([category('image', 'Utility', { utility_pick: { title: 'Chosen' } })])
     )
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     expect(catalog.find((c) => c.id === 'utility_pick')?.title).toBe('Chosen')
     expectFourByFour(catalog)
   })
@@ -441,7 +449,7 @@ describe('substitution quality', () => {
         return cat
       })
     )
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     const card = catalog.find((c) => c.id === apiCard.id)
     expect(card?.apiNode).toBe(true)
     expectFourByFour(catalog)
@@ -461,7 +469,7 @@ describe('substitution quality', () => {
         })
       ])
     )
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     expect(catalog.find((c) => c.id === 'api_should_skip')).toBeUndefined()
     expect(catalog.find((c) => c.id === 'sizeless_should_skip')).toBeUndefined()
     expectFourByFour(catalog)
@@ -477,7 +485,7 @@ describe('substitution quality', () => {
       mockedFetchJSON.mockResolvedValue(
         indexWithCurated([category('image', 'Image', { sub_for_typo: {} })])
       )
-      await loadTemplateCatalog()
+      await loadCards()
       expect(warn.mock.calls.flat().join(' ')).toContain('image_typo_id')
     } finally {
       warn.mockRestore()
@@ -486,7 +494,7 @@ describe('substitution quality', () => {
 
   it('does not substitute when offline', async () => {
     mockedFetchJSON.mockRejectedValue(new Error('offline'))
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     for (const curated of CURATED_TEMPLATES) {
       expect(
         catalog.find((c) => c.id === curated.id),
@@ -515,7 +523,7 @@ describe('substitution quality', () => {
         })
       ])
     )
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     for (const card of catalog.filter((c) => c.modality === '3d')) {
       expect(card.id.startsWith('spare_'), card.id).toBe(false)
     }
@@ -529,7 +537,7 @@ describe('recommended invariants after resolution', () => {
       CURATED_TEMPLATES.map(({ recommended: _drop, ...rest }) => rest as never)
     )
     mockedFetchJSON.mockResolvedValue(indexWithCurated())
-    expectFourByFour(await loadTemplateCatalog())
+    expectFourByFour(await loadCards())
   })
 
   it('keeps the recommendation off an api card in an all-api modality', async () => {
@@ -541,7 +549,7 @@ describe('recommended invariants after resolution', () => {
       ...CURATED_TEMPLATES.filter((t) => t.modality !== 'image')
     ])
     mockedFetchJSON.mockResolvedValue(indexWithCurated())
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     const rec = catalog.filter((c) => c.modality === 'image' && c.recommended)
     expect(rec).toHaveLength(1)
     expect(rec[0]!.apiNode).toBe(false)
@@ -564,10 +572,52 @@ describe('availability window', () => {
           category('image', 'Image', { image_future: {}, image_expired: {}, image_open: {} })
         ])
       )
-      const catalog = await loadTemplateCatalog()
+      const catalog = await loadCards()
       expect(catalog.find((c) => c.id === 'image_future')).toBeUndefined()
       expect(catalog.find((c) => c.id === 'image_expired')).toBeUndefined()
       expect(catalog.find((c) => c.id === 'image_open')).toBeDefined()
+      expectFourByFour(catalog)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not let backfill re-add a baked-in card whose window has closed', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-01T00:00:00Z'))
+    try {
+      const retired = CURATED_TEMPLATES.find((t) => t.modality === 'image')!
+      getStarterTemplatesAsync.mockResolvedValue([
+        { ...retired, availableUntil: '2026-01-01T00:00:00Z' },
+        ...CURATED_TEMPLATES.filter((t) => t.modality !== 'image')
+      ])
+      mockedFetchJSON.mockResolvedValue(indexWithCurated(spares()))
+      const catalog = await loadCards()
+      expect(
+        catalog.find((c) => c.id === retired.id),
+        'a retired card must not walk back in through the backfill door'
+      ).toBeUndefined()
+      expectFourByFour(catalog)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not let backfill stage a baked-in card ahead of its window', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-01T00:00:00Z'))
+    try {
+      const upcoming = CURATED_TEMPLATES.find((t) => t.modality === 'image')!
+      getStarterTemplatesAsync.mockResolvedValue([
+        { ...upcoming, availableFrom: '2026-12-01T00:00:00Z' },
+        ...CURATED_TEMPLATES.filter((t) => t.modality !== 'image')
+      ])
+      mockedFetchJSON.mockResolvedValue(indexWithCurated(spares()))
+      const catalog = await loadCards()
+      expect(
+        catalog.find((c) => c.id === upcoming.id),
+        'a staged card must wait for the window it was given'
+      ).toBeUndefined()
       expectFourByFour(catalog)
     } finally {
       vi.useRealTimers()
@@ -580,13 +630,13 @@ describe('every source failing at once', () => {
     getStarterTemplatesAsync.mockResolvedValue(CURATED_TEMPLATES)
     mockedFetchJSON.mockRejectedValue(new Error('offline'))
     resolveTemplatePackageVersion.mockRejectedValue(new Error('offline'))
-    expectFourByFour(await loadTemplateCatalog({ comfyVersion: null }))
+    expectFourByFour(await loadCards({ comfyVersion: null }))
   })
 
   it('holds 4x4 when the manifest read itself throws', async () => {
     getStarterTemplatesAsync.mockRejectedValue(new Error('flag exploded'))
     mockedFetchJSON.mockResolvedValue(indexWithCurated())
-    expectFourByFour(await loadTemplateCatalog())
+    expectFourByFour(await loadCards())
   })
 
   it('holds 4x4 when the payload is every kind of broken at once', async () => {
@@ -597,7 +647,7 @@ describe('every source failing at once', () => {
       { id: 'gone_3', modality: '3d' }
     ])
     mockedFetchJSON.mockResolvedValue([])
-    expectFourByFour(await loadTemplateCatalog({ comfyVersion: 'v0.28.2' }))
+    expectFourByFour(await loadCards({ comfyVersion: 'v0.28.2' }))
   })
 })
 
@@ -621,7 +671,7 @@ describe('4x4 when the index offers no substitute candidates', () => {
   it('holds when the recommended card is missing and nothing can substitute', async () => {
     resolveTemplatePackageVersion.mockResolvedValue('0.11.12')
     mockedFetchJSON.mockResolvedValue(bareIndex(['video_minimax_h3_t2v']))
-    const catalog = await loadTemplateCatalog({ comfyVersion: 'v0.28.2' })
+    const catalog = await loadCards({ comfyVersion: 'v0.28.2' })
     expectFourByFour(catalog)
   })
 
@@ -629,14 +679,14 @@ describe('4x4 when the index offers no substitute candidates', () => {
     'holds for %s when %s is absent from the index',
     async (_modality, missingId) => {
       mockedFetchJSON.mockResolvedValue(bareIndex([missingId]))
-      expectFourByFour(await loadTemplateCatalog({ comfyVersion: 'v0.28.2' }))
+      expectFourByFour(await loadCards({ comfyVersion: 'v0.28.2' }))
     }
   )
 
   it('holds when every card in a modality is absent', async () => {
     const video = CURATED_TEMPLATES.filter((t) => t.modality === 'video').map((t) => t.id)
     mockedFetchJSON.mockResolvedValue(bareIndex(video))
-    expectFourByFour(await loadTemplateCatalog({ comfyVersion: 'v0.28.2' }))
+    expectFourByFour(await loadCards({ comfyVersion: 'v0.28.2' }))
   })
 
   it('holds when the index carries no allowlisted category at all', async () => {
@@ -644,12 +694,12 @@ describe('4x4 when the index offers no substitute candidates', () => {
       category('image', 'Node Basics', { nb_1: {}, nb_2: {} }),
       category('video', 'Utility', { ut_1: {} })
     ])
-    expectFourByFour(await loadTemplateCatalog({ comfyVersion: 'v0.28.2' }))
+    expectFourByFour(await loadCards({ comfyVersion: 'v0.28.2' }))
   })
 
   it('never lets a substitute steal a baked-in card still owed a slot', async () => {
     mockedFetchJSON.mockResolvedValue(bareIndex(['video_minimax_h3_t2v']))
-    const catalog = await loadTemplateCatalog({ comfyVersion: 'v0.28.2' })
+    const catalog = await loadCards({ comfyVersion: 'v0.28.2' })
     const video = catalog.filter((c) => c.modality === 'video').map((c) => c.id)
     for (const id of [
       'api_seedance2_0_r2v',
@@ -667,7 +717,7 @@ describe('thumbnails follow the pinned index', () => {
     // card hydrated from v0.11.12 requests an image that only exists on main.
     resolveTemplatePackageVersion.mockResolvedValue('0.11.12')
     mockedFetchJSON.mockResolvedValue(indexWithCurated())
-    const catalog = await loadTemplateCatalog({ comfyVersion: 'v0.28.2' })
+    const catalog = await loadCards({ comfyVersion: 'v0.28.2' })
     const withThumb = catalog.filter((c) => c.thumbnailUrl)
     expect(withThumb.length).toBeGreaterThan(0)
     for (const card of withThumb) {
@@ -678,7 +728,7 @@ describe('thumbnails follow the pinned index', () => {
   it('falls back to the main asset base when no pin resolves', async () => {
     resolveTemplatePackageVersion.mockResolvedValue(null)
     mockedFetchJSON.mockResolvedValue(indexWithCurated())
-    const catalog = await loadTemplateCatalog({ comfyVersion: null })
+    const catalog = await loadCards({ comfyVersion: null })
     const card = catalog.find((c) => c.thumbnailUrl)!
     expect(card.thumbnailUrl).toContain('/main/templates/')
   })
@@ -711,7 +761,7 @@ describe('adversarial-but-valid payloads', () => {
         ...CURATED_TEMPLATES
       ])
       mockedFetchJSON.mockResolvedValue(bareIndexAll())
-      const catalog = await loadTemplateCatalog()
+      const catalog = await loadCards()
       expect(new Set(catalog.map((c) => c.id)).size, 'no duplicate ids').toBe(catalog.length)
     }
   )
@@ -721,7 +771,7 @@ describe('adversarial-but-valid payloads', () => {
       CURATED_TEMPLATES.map((t) => ({ id: t.id, modality: t.modality, apiNode: true as const }))
     )
     mockedFetchJSON.mockResolvedValue(bareIndexAll())
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     for (const modality of TEMPLATE_MODALITY_ORDER) {
       const cards = catalog.filter((c) => c.modality === modality)
       expect(cards, modality).toHaveLength(4)
@@ -740,7 +790,7 @@ describe('adversarial-but-valid payloads', () => {
           : {}
       )
     )
-    expectFourByFour(await loadTemplateCatalog({ comfyVersion: 'v0.28.2' }))
+    expectFourByFour(await loadCards({ comfyVersion: 'v0.28.2' }))
   })
 
   it('still drops an unrunnable card when a runnable one can take the slot', async () => {
@@ -749,7 +799,7 @@ describe('adversarial-but-valid payloads', () => {
       ...bareIndexAll((id) => (id === target.id ? { requiresCustomNodes: ['x'] } : {})),
       category('image', 'Image', { runnable_sub: { title: 'Runnable' } })
     ])
-    const catalog = await loadTemplateCatalog()
+    const catalog = await loadCards()
     expect(catalog.find((c) => c.id === target.id)).toBeUndefined()
     expectFourByFour(catalog)
   })

--- a/src/main/sources/standalone/templateDownloadCore.ts
+++ b/src/main/sources/standalone/templateDownloadCore.ts
@@ -1,5 +1,6 @@
 import { formatTime } from '../../lib/util'
 import { t } from '../../lib/i18n'
+import type { InstallPayloadItem } from '../../../types/ipc'
 
 /**
  * Pure core of the template-download feature: state shape, the read-side
@@ -87,6 +88,54 @@ export interface TemplateTrayEntry {
   etaSeconds: number
 }
 
+type FileOutcome = 'error' | 'done' | 'cancelled' | 'running'
+
+/**
+ * Settle one file against the task's own status. When the task terminated
+ * (cancel / error) before every file finished — an abort mid-pool, or a
+ * disk-space pre-flight that errors with files listed but none downloaded —
+ * the unfinished files inherit that outcome. Otherwise they'd read as running
+ * forever, and `getDownloadsTrayState` would count them as active.
+ */
+function fileOutcome(file: FileProgress, taskStatus: TemplateDownloadStatus): FileOutcome {
+  if (file.failed) return 'error'
+  if (file.done) return 'done'
+  if (taskStatus === 'cancelled') return 'cancelled'
+  if (taskStatus === 'error') return 'error'
+  return 'running'
+}
+
+const TRAY_STATUS: Record<FileOutcome, TemplateTrayEntry['status']> = {
+  error: 'error',
+  done: 'completed',
+  cancelled: 'cancelled',
+  running: 'downloading'
+}
+
+/** A cancelled file is simply not finished — the receipt shows it pending
+ *  rather than inventing a "cancelled" row the payload vocabulary lacks. */
+const PAYLOAD_STATE: Record<FileOutcome, InstallPayloadItem['state']> = {
+  error: 'error',
+  done: 'done',
+  cancelled: 'pending',
+  running: 'active'
+}
+
+/**
+ * Map the task's per-file state into `install-progress` payload rows. Pure, and
+ * deliberately sharing `fileOutcome` with the tray mapper so the two surfaces
+ * can never disagree about whether a file failed.
+ */
+export function templateStateToPayload(state: TemplateDownloadState): InstallPayloadItem[] {
+  return state.files.map((file) => ({
+    id: `${file.directory}/${file.name}`,
+    label: file.name,
+    ...(file.total > 0 ? { totalBytes: file.total } : {}),
+    receivedBytes: file.received,
+    state: PAYLOAD_STATE[fileOutcome(file, state.status)]
+  }))
+}
+
 /**
  * Map the task's per-file state into downloads-tray rows so the title-bar tray
  * can continue showing the SAME download after the user skips ahead to ComfyUI
@@ -109,15 +158,8 @@ export function templateStateToTrayEntries(
   // with files already listed but none downloaded — the still-unfinished files
   // must inherit that terminal status. Otherwise they'd map to 'downloading'
   // and `getDownloadsTrayState` would count them as active forever.
-  const unfinishedStatus: TemplateTrayEntry['status'] | null =
-    state.status === 'cancelled' ? 'cancelled' : state.status === 'error' ? 'error' : null
-
   return state.files.map((file) => {
-    const status: TemplateTrayEntry['status'] = file.failed
-      ? 'error'
-      : file.done
-        ? 'completed'
-        : (unfinishedStatus ?? 'downloading')
+    const status = TRAY_STATUS[fileOutcome(file, state.status)]
     const progress = file.total > 0 ? Math.min(1, file.received / file.total) : 0
     const isLiveRow = status === 'downloading' && !liveRowAssigned
     if (isLiveRow) liveRowAssigned = true

--- a/src/main/sources/standalone/templateModels.test.ts
+++ b/src/main/sources/standalone/templateModels.test.ts
@@ -142,6 +142,7 @@ describe('remote workflow fallback follows the pinned version', () => {
       'https://raw.githubusercontent.com/Comfy-Org/workflow_templates/v0.11.12/templates/image_one.json',
       expect.anything()
     )
+    expect(fetchJSON, 'the pinned fetch must not also fall back to main').toHaveBeenCalledTimes(1)
   })
 
   it('defaults to main when no asset base is given', async () => {

--- a/src/main/sources/standalone/templateModels.test.ts
+++ b/src/main/sources/standalone/templateModels.test.ts
@@ -122,3 +122,34 @@ describe('resolveTemplateModels — URL + path guards', () => {
     expect(out).toEqual([])
   })
 })
+
+describe('remote workflow fallback follows the pinned version', () => {
+  beforeEach(() => {
+    fetchJSON.mockReset()
+  })
+
+  it('fetches the workflow from the asset base it is given', async () => {
+    fetchJSON.mockResolvedValue({ models: [] })
+    await resolveTemplateModels(
+      null,
+      'image_one',
+      'https://raw.githubusercontent.com/Comfy-Org/workflow_templates/v0.11.12/templates'
+    )
+    expect(
+      fetchJSON,
+      'a network-fetched workflow must match the revision the card came from'
+    ).toHaveBeenCalledWith(
+      'https://raw.githubusercontent.com/Comfy-Org/workflow_templates/v0.11.12/templates/image_one.json',
+      expect.anything()
+    )
+  })
+
+  it('defaults to main when no asset base is given', async () => {
+    fetchJSON.mockResolvedValue({ models: [] })
+    await resolveTemplateModels(null, 'image_one')
+    expect(fetchJSON).toHaveBeenCalledWith(
+      expect.stringContaining('/main/templates/image_one.json'),
+      expect.anything()
+    )
+  })
+})

--- a/src/main/sources/standalone/templateModels.ts
+++ b/src/main/sources/standalone/templateModels.ts
@@ -32,8 +32,6 @@ interface RawModel {
   directory?: unknown
 }
 
-const RAW_TEMPLATES_REMOTE_BASE = RAW_TEMPLATES_BASE
-
 /**
  * Resolve the workflow JSON for `templateId` — preferring the copy bundled in
  * the just-installed `comfyui_workflow_templates` package (no network), falling
@@ -57,7 +55,8 @@ const TEMPLATE_PACKAGE_DIRS = [
 
 export async function loadTemplateJson(
   installation: InstallationRecord | null,
-  templateId: string
+  templateId: string,
+  assetBase: string = RAW_TEMPLATES_BASE
 ): Promise<unknown | null> {
   const sitePackages = installation ? findSitePackages(getActiveVenvDir(installation)) : null
   if (sitePackages) {
@@ -76,7 +75,7 @@ export async function loadTemplateJson(
   // the same proven network stack, timeout, and retry behaviour as every other
   // main-side HTTP call.
   try {
-    return await fetchJSON(`${RAW_TEMPLATES_REMOTE_BASE}/${templateId}.json`, { refresh: true })
+    return await fetchJSON(`${assetBase}/${templateId}.json`, { refresh: true })
   } catch {
     return null
   }
@@ -165,9 +164,10 @@ function walkNodes(nodes: unknown, out: RawModel[]): void {
  */
 export async function resolveTemplateModels(
   installation: InstallationRecord | null,
-  templateId: string
+  templateId: string,
+  assetBase?: string
 ): Promise<TemplateModelDownload[]> {
-  const json = await loadTemplateJson(installation, templateId)
+  const json = await loadTemplateJson(installation, templateId, assetBase)
   if (!json || typeof json !== 'object') return []
 
   const doc = json as {

--- a/src/main/sources/standalone/templatePin.test.ts
+++ b/src/main/sources/standalone/templatePin.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const fetchText = vi.fn()
+vi.mock('../../lib/fetch', () => ({ fetchText: (...a: unknown[]) => fetchText(...a) }))
+
+import {
+  resolveTemplatePackageVersion,
+  templateIndexUrlFor,
+  parseTemplatePin,
+  _resetForTest
+} from './templatePin'
+import { INDEX_URL } from './curatedTemplates'
+
+function requirements(pin: string | null): string {
+  return [
+    'comfyui-frontend-package==1.47.12',
+    ...(pin ? [pin] : []),
+    'comfyui-embedded-docs==0.5.9',
+    'torch',
+    'numpy>=1.25.0'
+  ].join('\n')
+}
+
+beforeEach(() => {
+  _resetForTest()
+  fetchText.mockReset()
+})
+
+describe('parseTemplatePin', () => {
+  it('reads the hyphenated package name ComfyUI actually pins', () => {
+    expect(
+      parseTemplatePin(requirements('comfyui-workflow-templates==0.11.31')),
+      'the pin uses the hyphenated package name'
+    ).toBe('0.11.31')
+  })
+
+  it('does not match the underscored form', () => {
+    expect(
+      parseTemplatePin(requirements('comfyui_workflow_templates==0.11.31')),
+      'the underscored form is the Python import path, never the pin'
+    ).toBeNull()
+  })
+
+  it('tolerates surrounding whitespace and comments', () => {
+    expect(parseTemplatePin('  comfyui-workflow-templates==0.11.31  # pinned\n')).toBe('0.11.31')
+  })
+
+  it.each([
+    ['absent', requirements(null)],
+    ['no version', requirements('comfyui-workflow-templates==')],
+    ['range not pin', requirements('comfyui-workflow-templates>=0.11.0')],
+    ['empty file', ''],
+    ['garbage', 'this is not a requirements file'],
+    ['non-numeric', requirements('comfyui-workflow-templates==abc')]
+  ])('%s yields null', (_label, contents) => {
+    expect(parseTemplatePin(contents)).toBeNull()
+  })
+})
+
+describe('resolveTemplatePackageVersion', () => {
+  it('resolves a tag through requirements.txt to the pinned version', async () => {
+    fetchText.mockResolvedValue(requirements('comfyui-workflow-templates==0.11.31'))
+    expect(await resolveTemplatePackageVersion('v0.30.2')).toBe('0.11.31')
+    expect(fetchText).toHaveBeenCalledWith(
+      expect.stringContaining('v0.30.2/requirements.txt'),
+      expect.objectContaining({ timeoutMs: expect.any(Number) })
+    )
+  })
+
+  it('treats a bare version and a v-prefixed tag identically', async () => {
+    fetchText.mockResolvedValue(requirements('comfyui-workflow-templates==0.11.31'))
+    const prefixed = await resolveTemplatePackageVersion('v0.30.2')
+    _resetForTest()
+    fetchText.mockResolvedValue(requirements('comfyui-workflow-templates==0.11.31'))
+    const bare = await resolveTemplatePackageVersion('0.30.2')
+    expect(bare).toBe(prefixed)
+    expect(fetchText).toHaveBeenCalledWith(
+      expect.stringContaining('v0.30.2/requirements.txt'),
+      expect.objectContaining({ timeoutMs: expect.any(Number) })
+    )
+  })
+
+  it.each([[null], [undefined], ['']])('returns null for an unresolvable tag: %s', async (tag) => {
+    expect(await resolveTemplatePackageVersion(tag as string | null)).toBeNull()
+    expect(fetchText).not.toHaveBeenCalled()
+  })
+
+  it('rejects a tag that is not version-shaped without fetching', async () => {
+    expect(await resolveTemplatePackageVersion('../../etc/passwd')).toBeNull()
+    expect(await resolveTemplatePackageVersion('master')).toBeNull()
+    expect(fetchText).not.toHaveBeenCalled()
+  })
+
+  it('returns null when requirements.txt 404s', async () => {
+    fetchText.mockRejectedValue(new Error('HTTP 404'))
+    expect(await resolveTemplatePackageVersion('v9.99.99')).toBeNull()
+  })
+
+  it('returns null when the fetch rejects, without throwing', async () => {
+    fetchText.mockRejectedValue(new Error('offline'))
+    await expect(resolveTemplatePackageVersion('v0.30.2')).resolves.toBeNull()
+  })
+
+  it('caches a resolved tag — one network hit for repeat lookups', async () => {
+    fetchText.mockResolvedValue(requirements('comfyui-workflow-templates==0.11.31'))
+    await resolveTemplatePackageVersion('v0.30.2')
+    await resolveTemplatePackageVersion('v0.30.2')
+    expect(fetchText).toHaveBeenCalledTimes(1)
+  })
+
+  it('caches a failure too, so a 404 is not refetched every picker open', async () => {
+    fetchText.mockRejectedValue(new Error('404'))
+    await resolveTemplatePackageVersion('v0.28.2')
+    await resolveTemplatePackageVersion('v0.28.2')
+    expect(fetchText).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps separate tags separate', async () => {
+    fetchText.mockImplementation((url: string) =>
+      Promise.resolve(
+        requirements(
+          url.includes('v0.28.2')
+            ? 'comfyui-workflow-templates==0.11.12'
+            : 'comfyui-workflow-templates==0.11.31'
+        )
+      )
+    )
+    expect(await resolveTemplatePackageVersion('v0.28.2')).toBe('0.11.12')
+    expect(await resolveTemplatePackageVersion('v0.30.2')).toBe('0.11.31')
+  })
+})
+
+describe('templateIndexUrlFor', () => {
+  it('builds the versioned index URL for a resolved pin', () => {
+    expect(templateIndexUrlFor('0.11.31')).toBe(
+      'https://raw.githubusercontent.com/Comfy-Org/workflow_templates/v0.11.31/templates/index.json'
+    )
+  })
+
+  it('falls back to the live main index when the pin is unknown', () => {
+    expect(templateIndexUrlFor(null), 'fails open to today’s behaviour').toBe(INDEX_URL)
+  })
+
+  it('refuses a pin that is not version-shaped', () => {
+    expect(templateIndexUrlFor('../../evil')).toBe(INDEX_URL)
+    expect(templateIndexUrlFor('main')).toBe(INDEX_URL)
+  })
+})

--- a/src/main/sources/standalone/templatePin.test.ts
+++ b/src/main/sources/standalone/templatePin.test.ts
@@ -71,10 +71,11 @@ describe('resolveTemplatePackageVersion', () => {
     fetchText.mockResolvedValue(requirements('comfyui-workflow-templates==0.11.31'))
     const prefixed = await resolveTemplatePackageVersion('v0.30.2')
     _resetForTest()
+    fetchText.mockClear()
     fetchText.mockResolvedValue(requirements('comfyui-workflow-templates==0.11.31'))
     const bare = await resolveTemplatePackageVersion('0.30.2')
     expect(bare).toBe(prefixed)
-    expect(fetchText).toHaveBeenCalledWith(
+    expect(fetchText, 'the bare tag is the one normalized to v0.30.2').toHaveBeenCalledWith(
       expect.stringContaining('v0.30.2/requirements.txt'),
       expect.objectContaining({ timeoutMs: expect.any(Number) })
     )

--- a/src/main/sources/standalone/templatePin.ts
+++ b/src/main/sources/standalone/templatePin.ts
@@ -1,0 +1,86 @@
+/**
+ * Maps a ComfyUI version to the template index it ships. ComfyUI pins
+ * `comfyui-workflow-templates` in its `requirements.txt`, and that pin is the
+ * only compatibility map that exists — the index carries no version field.
+ *
+ * Every failure returns `null`, which falls back to the live `main` index.
+ */
+import { fetchText } from '../../lib/fetch'
+import { INDEX_URL, RAW_TEMPLATES_BASE } from './curatedTemplates'
+
+const MAX_PIN_CACHE_SIZE = 100
+const PIN_TIMEOUT_MS = 5000
+
+const VERSION_TAG_PATTERN = /^v?\d+(?:\.\d+)*$/
+/** Hyphenated; the underscored form is the Python import path, not the pin. */
+const PIN_PATTERN = /^\s*comfyui-workflow-templates\s*==\s*(\d+(?:\.\d+)*)\s*(?:#.*)?$/m
+
+const TEMPLATES_REPO = 'https://raw.githubusercontent.com/Comfy-Org/workflow_templates'
+const COMFYUI_REPO = 'https://raw.githubusercontent.com/comfyanonymous/ComfyUI'
+
+/** Failures cache as `null`, so a 404 isn't refetched on every picker open. */
+const pinCache = new Map<string, string | null>()
+const inflight = new Map<string, Promise<string | null>>()
+
+export function parseTemplatePin(contents: string): string | null {
+  return PIN_PATTERN.exec(contents)?.[1] ?? null
+}
+
+/** Both forms are persisted; see `version.ts:tagsEqual` for the strip-side. */
+function normalizeTag(tag: string): string {
+  return tag.startsWith('v') ? tag : `v${tag}`
+}
+
+/** `null` when the pin can't be determined. Never throws. */
+export async function resolveTemplatePackageVersion(
+  comfyTag: string | null | undefined
+): Promise<string | null> {
+  if (!comfyTag || !VERSION_TAG_PATTERN.test(comfyTag)) return null
+
+  const ref = normalizeTag(comfyTag)
+  const cached = pinCache.get(ref)
+  if (cached !== undefined) return cached
+  const existing = inflight.get(ref)
+  if (existing) return existing
+
+  const promise = (async () => {
+    const resolved = await fetchText(`${COMFYUI_REPO}/${ref}/requirements.txt`, {
+      timeoutMs: PIN_TIMEOUT_MS
+    })
+      .then(parseTemplatePin)
+      .catch(() => null)
+    remember(ref, resolved)
+    inflight.delete(ref)
+    return resolved
+  })()
+
+  inflight.set(ref, promise)
+  return promise
+}
+
+/** `VERSION_TAG_PATTERN` admits unbounded dot-groups, so cap the key space. */
+function remember(ref: string, resolved: string | null): void {
+  if (pinCache.size >= MAX_PIN_CACHE_SIZE) {
+    const oldest = pinCache.keys().next().value
+    if (oldest !== undefined) pinCache.delete(oldest)
+  }
+  pinCache.set(ref, resolved)
+}
+
+/** Falls back to `main` when the pin is unknown or malformed. */
+export function templateIndexUrlFor(packageVersion: string | null): string {
+  if (!packageVersion || !VERSION_TAG_PATTERN.test(packageVersion)) return INDEX_URL
+  return `${TEMPLATES_REPO}/${normalizeTag(packageVersion)}/templates/index.json`
+}
+
+/** Thumbnail base, so previews match the index they came from. */
+export function templateAssetBaseFor(packageVersion: string | null): string {
+  if (!packageVersion || !VERSION_TAG_PATTERN.test(packageVersion)) return RAW_TEMPLATES_BASE
+  return `${TEMPLATES_REPO}/${normalizeTag(packageVersion)}/templates`
+}
+
+/** @internal — exposed for tests. */
+export function _resetForTest(): void {
+  pinCache.clear()
+  inflight.clear()
+}

--- a/src/main/sources/standalone/updateOrchestrator.ts
+++ b/src/main/sources/standalone/updateOrchestrator.ts
@@ -23,6 +23,8 @@ import {
 import { withOutputTail } from '../../lib/logged-process'
 import { formatComfyVersion } from '../../lib/version'
 import type { ComfyVersion } from '../../lib/version'
+import type { SendProgress } from '../../../types/ipc'
+import { createUvProgressParser, type UvProgress } from '../../lib/uvProgress'
 import { t } from '../../lib/i18n'
 import { getBundledScriptPath } from '../../lib/bundledScript'
 import * as settings from '../../settings'
@@ -50,7 +52,7 @@ export interface UpdateOrchestrationOptions {
   installation: InstallationRecord
   channel: 'stable' | 'latest'
   update: (data: Record<string, unknown>) => Promise<void>
-  sendProgress: (step: string, data: Record<string, unknown>) => void
+  sendProgress: SendProgress
   sendOutput?: (text: string) => void
   signal?: AbortSignal
   dryRunConflictCheck?: boolean
@@ -188,6 +190,47 @@ function spawnUpdateScript(
   })
 }
 
+/**
+ * Log sink for uv invocations: forwards to the caller's sink (or the console,
+ * matching the previous fallback) and tees the same text into the milestone
+ * parser so the phase can report what uv is actually doing.
+ */
+function withUvProgress(
+  sendOutput: ((text: string) => void) | undefined,
+  sendProgress: SendProgress
+): (text: string) => void {
+  const log = sendOutput ?? console.log
+  const feed = createUvProgressParser((p) => {
+    const status = describeUvProgress(p)
+    if (status) sendProgress('update', { percent: -1, status })
+  })
+  return (text: string): void => {
+    log(text)
+    feed(text)
+  }
+}
+
+/** Plain-language line for a uv milestone. Names the artifact and its size,
+ *  because "downloading torch (2.7GiB)" explains a long wait in a way a
+ *  spinner cannot. Returns null for states not worth interrupting for. */
+function describeUvProgress(p: UvProgress): string | null {
+  switch (p.stage) {
+    case 'resolving':
+      return p.resolvedCount === undefined
+        ? null
+        : t('standalone.uvResolved', { count: p.resolvedCount })
+    case 'preparing':
+      if (!p.currentPackage) return null
+      return p.currentSize
+        ? t('standalone.uvDownloadingSized', { name: p.currentPackage, size: p.currentSize })
+        : t('standalone.uvDownloading', { name: p.currentPackage })
+    case 'installing':
+      return t('standalone.uvInstalling')
+    case 'done':
+      return null
+  }
+}
+
 export async function runComfyUIUpdate(
   opts: UpdateOrchestrationOptions
 ): Promise<UpdateOrchestrationResult> {
@@ -203,6 +246,11 @@ export async function runComfyUIUpdate(
   } = opts
   let { installation } = opts
   const sendOutput = opts.sendOutput
+  // Log sink for the uv invocations, teeing their output into the milestone
+  // parser on the way through. This phase owns the install's longest silence
+  // and uv exposes no machine-readable progress, so a parsed line is the only
+  // proof of life available. Purely additive — the sink still gets every byte.
+  const uvLog = withUvProgress(sendOutput, sendProgress)
   const comfyuiDir = path.join(installPath, 'ComfyUI')
   // Adopted installs run the updater against the legacy `.venv` Python (it has
   // pygit2 from adoption); `update_comfyui.py` only needs pygit2 + stdlib.
@@ -410,7 +458,7 @@ export async function runComfyUIUpdate(
               uvPath,
               ['pip', 'install', '-r', filteredReqPath, '--python', activeEnvPython, ...indexArgs],
               installPath,
-              sendOutput ?? (() => {}),
+              uvLog,
               signal
             )
             if (pipResult.code !== 0) {
@@ -429,7 +477,6 @@ export async function runComfyUIUpdate(
         }
       } else {
         sendProgress('update', { percent: -1, status: 'Installing updated dependencies' })
-        const logFn = sendOutput ?? console.log
         try {
           const installResult = await installFilteredRequirementsDetailed(
             reqPath,
@@ -437,7 +484,7 @@ export async function runComfyUIUpdate(
             activeEnvPython,
             installPath,
             '.post-install-reqs.txt',
-            logFn,
+            uvLog,
             signal,
             settings.getMirrorConfig()
           )
@@ -473,7 +520,6 @@ export async function runComfyUIUpdate(
         sendProgress('deps', { percent: -1, status: t('standalone.updateDepsInstalling') })
         sendOutput?.('\nInstalling manager requirements…\n')
       }
-      const logFn = sendOutput ?? console.log
       try {
         const mgrResult = await installFilteredRequirementsDetailed(
           mgrReqPath,
@@ -481,7 +527,7 @@ export async function runComfyUIUpdate(
           activeEnvPython,
           installPath,
           dryRunConflictCheck ? '.manager-reqs-filtered.txt' : '.post-install-mgr-reqs.txt',
-          logFn,
+          uvLog,
           signal,
           settings.getMirrorConfig()
         )

--- a/src/main/types/sources.ts
+++ b/src/main/types/sources.ts
@@ -2,6 +2,7 @@ import type { InstallationRecord } from '../installations'
 import type { Cache } from '../lib/cache'
 import type { DownloadProgress } from '../lib/download'
 import type { ExtractProgress } from '../lib/extract'
+import type { SendProgress } from '../../types/ipc'
 
 export interface SourceField {
   id: string
@@ -40,7 +41,7 @@ export interface LaunchCommand {
 }
 
 export interface InstallTools {
-  sendProgress: (step: string, data: { percent: number; status: string }) => void
+  sendProgress: SendProgress
   download: (
     url: string,
     dest: string,
@@ -59,13 +60,13 @@ export interface InstallTools {
 
 export interface ActionTools {
   update: (data: Record<string, unknown>) => Promise<void>
-  sendProgress: (step: string, data: Record<string, unknown>) => void
+  sendProgress: SendProgress
   sendOutput: (text: string) => void
   signal?: AbortSignal
 }
 
 export interface PostInstallTools {
-  sendProgress: (step: string, data: { percent: number; status: string }) => void
+  sendProgress: SendProgress
   update: (data: Record<string, unknown>) => Promise<void>
   signal?: AbortSignal
 }

--- a/src/renderer/src/components/InstallShowcase.test.ts
+++ b/src/renderer/src/components/InstallShowcase.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import en from '../../../../locales/en.json'
+import InstallShowcase from './InstallShowcase.vue'
+import { TID } from '../../../shared/testIds'
+import { SHOWCASE_CARDS } from '../lib/installShowcase'
+import { SHOWCASE_INTERVAL_MS } from '../composables/useShowcaseCarousel'
+
+function mountShowcase(canOfferCloud = true) {
+  return mount(InstallShowcase, {
+    props: { canOfferCloud },
+    global: { plugins: [createI18n({ legacy: false, locale: 'en', messages: { en } })] }
+  })
+}
+
+const find = (w: ReturnType<typeof mountShowcase>, id: string) => w.find(`[data-testid="${id}"]`)
+
+/** Resolved from the card list, so reordering the carousel does not require
+ *  rewriting every positional assertion. */
+const titleAt = (index: number): string => {
+  const card = SHOWCASE_CARDS[index]!
+  return card.title.split('.').reduce<unknown>((node, part) => {
+    if (node && typeof node === 'object') return (node as Record<string, unknown>)[part]
+    return undefined
+  }, en) as string
+}
+
+beforeEach(() => vi.useFakeTimers())
+afterEach(() => vi.useRealTimers())
+
+describe('cards', () => {
+  it('opens on the skip-the-wait card', () => {
+    expect(find(mountShowcase(), TID.installShowcaseTitle).text()).toBe(
+      en.installShowcase.cloud.title
+    )
+  })
+
+  it('shows one card at a time', () => {
+    expect(mountShowcase().findAll('.showcase__line')).toHaveLength(1)
+  })
+
+  it('renders the card body alongside its title', () => {
+    expect(mountShowcase().text()).toContain(en.installShowcase.cloud.body)
+  })
+
+  it('advances to the next card on its own', async () => {
+    const w = mountShowcase()
+    vi.advanceTimersByTime(SHOWCASE_INTERVAL_MS)
+    await w.vm.$nextTick()
+    expect(find(w, TID.installShowcaseTitle).text()).toBe(titleAt(1))
+  })
+
+  it('names the section for screen readers', () => {
+    expect(find(mountShowcase(), TID.installShowcase).attributes('aria-label')).toBe(
+      en.installShowcase.label
+    )
+  })
+})
+
+describe('the cloud action', () => {
+  it('offers a way to skip the wait', () => {
+    const w = mountShowcase()
+    expect(find(w, TID.installShowcaseCloud).text()).toContain(en.installShowcase.cloudCta)
+  })
+
+  it('emits when taken', async () => {
+    const w = mountShowcase()
+    await find(w, TID.installShowcaseCloud).trigger('click')
+    expect(w.emitted('open-cloud')).toHaveLength(1)
+  })
+
+  it('hides the action when cloud is unavailable, keeping the card', () => {
+    const w = mountShowcase(false)
+    expect(find(w, TID.installShowcaseCloud).exists()).toBe(false)
+    expect(find(w, TID.installShowcaseTitle).text()).toBe(en.installShowcase.cloud.title)
+  })
+
+  it('stays put as the cards rotate, so it is always actionable', async () => {
+    const w = mountShowcase()
+    for (let i = 0; i < SHOWCASE_CARDS.length; i++) {
+      expect(find(w, TID.installShowcaseCloud).exists(), `card ${i}`).toBe(true)
+      vi.advanceTimersByTime(SHOWCASE_INTERVAL_MS)
+      await w.vm.$nextTick()
+    }
+  })
+
+  it('sits outside the rotating line so it never animates away', () => {
+    const w = mountShowcase()
+    expect(
+      w.find('.showcase__line').find(`[data-testid="${TID.installShowcaseCloud}"]`).exists()
+    ).toBe(false)
+  })
+})
+
+/** Shipped installers rotate passively — no dots, no arrows, no transport.
+ *  The cloud CTA is the only control on the surface. */
+describe('passive rotation', () => {
+  it('ships no carousel transport controls', () => {
+    const w = mountShowcase()
+    expect(w.findAll('.showcase__dot')).toHaveLength(0)
+    expect(w.findAll('.showcase__arrow')).toHaveLength(0)
+    expect(w.findAll('.showcase__rail')).toHaveLength(0)
+  })
+
+  it('leaves the cloud CTA as the only button', () => {
+    expect(mountShowcase().findAll('button')).toHaveLength(1)
+  })
+
+  it('renders as a single line, not a stacked block', () => {
+    const w = mountShowcase()
+    expect(w.find('.showcase').classes()).toBeTruthy()
+    expect(w.findAll('.showcase > *').length).toBeLessThanOrEqual(2)
+  })
+})
+
+describe('pausing while the user reads', () => {
+  it('holds on hover', async () => {
+    const w = mountShowcase()
+    await find(w, TID.installShowcase).trigger('mouseenter')
+    vi.advanceTimersByTime(SHOWCASE_INTERVAL_MS * 2)
+    await w.vm.$nextTick()
+    expect(find(w, TID.installShowcaseTitle).text()).toBe(en.installShowcase.cloud.title)
+  })
+
+  it('resumes when the pointer leaves', async () => {
+    const w = mountShowcase()
+    await find(w, TID.installShowcase).trigger('mouseenter')
+    vi.advanceTimersByTime(SHOWCASE_INTERVAL_MS)
+    await find(w, TID.installShowcase).trigger('mouseleave')
+    vi.advanceTimersByTime(SHOWCASE_INTERVAL_MS)
+    await w.vm.$nextTick()
+    expect(find(w, TID.installShowcaseTitle).text()).toBe(titleAt(1))
+  })
+
+  it('holds while the cloud CTA has focus', async () => {
+    const w = mountShowcase()
+    await find(w, TID.installShowcase).trigger('focusin')
+    vi.advanceTimersByTime(SHOWCASE_INTERVAL_MS * 2)
+    await w.vm.$nextTick()
+    expect(find(w, TID.installShowcaseTitle).text()).toBe(en.installShowcase.cloud.title)
+  })
+})

--- a/src/renderer/src/components/InstallShowcase.vue
+++ b/src/renderer/src/components/InstallShowcase.vue
@@ -1,0 +1,131 @@
+<script setup lang="ts">
+import { ArrowRight } from 'lucide-vue-next'
+import { useShowcaseCarousel } from '../composables/useShowcaseCarousel'
+import { TID } from '../../../shared/testIds'
+
+defineProps<{ canOfferCloud: boolean }>()
+
+const emit = defineEmits<{ 'open-cloud': [] }>()
+
+const carousel = useShowcaseCarousel()
+</script>
+
+<template>
+  <section
+    class="showcase"
+    :data-testid="TID.installShowcase"
+    :aria-label="$t('installShowcase.label')"
+    @mouseenter="carousel.pause()"
+    @mouseleave="carousel.resume()"
+    @focusin="carousel.pause()"
+    @focusout="carousel.resume()"
+  >
+    <Transition name="showcase-swap" mode="out-in">
+      <p :key="carousel.card.value.id" class="showcase__line">
+        <span class="showcase__title" :data-testid="TID.installShowcaseTitle">
+          {{ $t(carousel.card.value.title) }}
+        </span>
+        <span class="showcase__body">{{ $t(carousel.card.value.body) }}</span>
+      </p>
+    </Transition>
+
+    <button
+      v-if="canOfferCloud"
+      type="button"
+      class="showcase__cta"
+      :data-testid="TID.installShowcaseCloud"
+      @click="emit('open-cloud')"
+    >
+      {{ $t('installShowcase.cloudCta') }}
+      <ArrowRight :size="11" stroke-width="2.2" />
+    </button>
+  </section>
+</template>
+
+<style scoped>
+.showcase {
+  display: flex;
+  align-items: baseline;
+  justify-content: center;
+  flex-wrap: nowrap;
+  gap: 8px;
+  width: 100%;
+  max-width: min(72rem, 92vw);
+  margin-inline: auto;
+  min-height: 1.5em;
+  white-space: nowrap;
+}
+.showcase__line {
+  display: block;
+  margin: 0;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: center;
+  font-size: 12.5px;
+  line-height: 1.35;
+}
+.showcase__title {
+  font-weight: 500;
+  color: var(--neutral-100);
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.8);
+}
+.showcase__title::after {
+  content: '—';
+  margin-inline: 7px;
+  font-weight: 400;
+  color: var(--neutral-600);
+}
+.showcase__body {
+  color: var(--neutral-200);
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.75);
+}
+.showcase__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--comfy-yellow);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  white-space: nowrap;
+  cursor: pointer;
+  opacity: 0.85;
+  transition: opacity 160ms ease;
+}
+.showcase__cta:hover {
+  opacity: 1;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+.showcase__cta:focus-visible {
+  opacity: 1;
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 3px;
+  border-radius: 3px;
+}
+.showcase-swap-enter-active,
+.showcase-swap-leave-active {
+  transition:
+    opacity 200ms ease,
+    transform 260ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+.showcase-swap-enter-from {
+  opacity: 0;
+  transform: translateY(3px);
+}
+.showcase-swap-leave-to {
+  opacity: 0;
+  transform: translateY(-3px);
+}
+@media (prefers-reduced-motion: reduce) {
+  .showcase-swap-enter-active,
+  .showcase-swap-leave-active,
+  .showcase__cta {
+    transition: none;
+  }
+}
+</style>

--- a/src/renderer/src/composables/useCloudGate.test.ts
+++ b/src/renderer/src/composables/useCloudGate.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { effectScope } from 'vue'
+import { useCloudGate } from './useCloudGate'
+import { useSessionStore } from '../stores/sessionStore'
+
+const cloudInstall = { id: 'inst-cloud', name: 'Comfy Cloud', sourceId: 'cloud' }
+const localInstall = { id: 'inst-local', name: 'ComfyUI', sourceId: 'desktop' }
+
+interface ApiStub {
+  getCloudFreeRunsEnabled: ReturnType<typeof vi.fn>
+  getCloudUserTier: ReturnType<typeof vi.fn>
+  getInstallations: ReturnType<typeof vi.fn>
+  getListActions: ReturnType<typeof vi.fn>
+  runAction: ReturnType<typeof vi.fn>
+  focusComfyWindow: ReturnType<typeof vi.fn>
+  openInstallWindow: ReturnType<typeof vi.fn>
+  onInstallationsChanged: ReturnType<typeof vi.fn>
+}
+
+let api: ApiStub
+
+function stubApi(over: Partial<Record<keyof ApiStub, unknown>> = {}): void {
+  api = {
+    getCloudFreeRunsEnabled: vi.fn().mockResolvedValue(true),
+    getCloudUserTier: vi.fn().mockResolvedValue('free'),
+    getInstallations: vi.fn().mockResolvedValue([localInstall, cloudInstall]),
+    getListActions: vi.fn().mockResolvedValue([{ id: 'launch', label: 'Launch' }]),
+    runAction: vi.fn().mockResolvedValue({ ok: true }),
+    focusComfyWindow: vi.fn().mockResolvedValue(true),
+    openInstallWindow: vi.fn().mockResolvedValue(true),
+    onInstallationsChanged: vi.fn(),
+    ...over
+  } as ApiStub
+  // The stores this composable pulls in subscribe to several `on*` channels;
+  // a Proxy answers any of them with a no-op unsubscribe so the test only has
+  // to spell out the calls it actually asserts on.
+  const withListeners = new Proxy(api as unknown as Record<string, unknown>, {
+    get(target, prop: string) {
+      if (prop in target) return target[prop]
+      if (prop.startsWith('on')) return () => () => {}
+      return undefined
+    },
+    has: () => true
+  })
+  vi.stubGlobal('window', { api: withListeners })
+}
+
+let stops: Array<() => void> = []
+
+function setup() {
+  const scope = effectScope()
+  const gate = scope.run(() => useCloudGate({ immediate: false }))!
+  stops.push(() => scope.stop())
+  return gate
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  stops = []
+  stubApi()
+})
+
+afterEach(() => {
+  stops.forEach((stop) => stop())
+  vi.unstubAllGlobals()
+})
+
+describe('finding the cloud install', () => {
+  it('picks the cloud record out of the list', async () => {
+    const gate = setup()
+    await gate.resolve()
+    expect(gate.canOffer.value).toBe(true)
+  })
+
+  it('matches on sourceCategory when sourceId is absent', async () => {
+    stubApi({
+      getInstallations: vi
+        .fn()
+        .mockResolvedValue([{ id: 'inst-c', name: 'Comfy Cloud', sourceCategory: 'cloud' }])
+    })
+    const gate = setup()
+    await gate.resolve()
+    expect(gate.canOffer.value).toBe(true)
+  })
+
+  it('offers nothing when no cloud install exists', async () => {
+    stubApi({ getInstallations: vi.fn().mockResolvedValue([localInstall]) })
+    const gate = setup()
+    await gate.resolve()
+    expect(gate.canOffer.value).toBe(false)
+  })
+})
+
+describe('the gate fails closed', () => {
+  it('stays shut when the flag is off', async () => {
+    stubApi({ getCloudFreeRunsEnabled: vi.fn().mockResolvedValue(false) })
+    const gate = setup()
+    await gate.resolve()
+    expect(gate.canOffer.value).toBe(false)
+  })
+
+  it('stays shut for a paying user', async () => {
+    stubApi({ getCloudUserTier: vi.fn().mockResolvedValue('paid') })
+    const gate = setup()
+    await gate.resolve()
+    expect(gate.canOffer.value).toBe(false)
+  })
+
+  it('stays shut when a signal throws', async () => {
+    stubApi({ getCloudFreeRunsEnabled: vi.fn().mockRejectedValue(new Error('offline')) })
+    const gate = setup()
+    await gate.resolve()
+    expect(gate.canOffer.value).toBe(false)
+  })
+})
+
+describe('opening cloud', () => {
+  it('launches the install rather than opening the chooser', async () => {
+    const gate = setup()
+    await gate.resolve()
+    expect(await gate.openCloud()).toBe(true)
+    expect(api.runAction).toHaveBeenCalledWith('inst-cloud', 'launch')
+    expect(api.openInstallWindow).not.toHaveBeenCalled()
+  })
+
+  it('resolves the install on demand when resolve has not run', async () => {
+    const gate = setup()
+    expect(await gate.openCloud()).toBe(true)
+    expect(api.runAction).toHaveBeenCalledWith('inst-cloud', 'launch')
+  })
+
+  it('falls back to the primary action when there is no launch id', async () => {
+    stubApi({
+      getListActions: vi.fn().mockResolvedValue([{ id: 'open', label: 'Open', style: 'primary' }])
+    })
+    const gate = setup()
+    await gate.resolve()
+    expect(await gate.openCloud()).toBe(true)
+    expect(api.runAction).toHaveBeenCalledWith('inst-cloud', 'open')
+  })
+
+  it('focuses an already-running cloud window instead of launching twice', async () => {
+    const gate = setup()
+    await gate.resolve()
+    useSessionStore().runningInstances.set('inst-cloud', {} as never)
+
+    expect(await gate.openCloud()).toBe(true)
+    expect(api.focusComfyWindow).toHaveBeenCalledWith('inst-cloud')
+    expect(api.runAction).not.toHaveBeenCalled()
+  })
+
+  it('launches when the focus misses, so a stale session cannot strand it', async () => {
+    stubApi({ focusComfyWindow: vi.fn().mockResolvedValue(false) })
+    const gate = setup()
+    await gate.resolve()
+    useSessionStore().runningInstances.set('inst-cloud', {} as never)
+
+    expect(await gate.openCloud()).toBe(true)
+    expect(api.runAction).toHaveBeenCalledWith('inst-cloud', 'launch')
+  })
+
+  it('reports failure when there is nothing to open', async () => {
+    stubApi({ getInstallations: vi.fn().mockResolvedValue([localInstall]) })
+    const gate = setup()
+    await gate.resolve()
+    expect(await gate.openCloud()).toBe(false)
+  })
+
+  it('reports failure when the action list is empty', async () => {
+    stubApi({ getListActions: vi.fn().mockResolvedValue([]) })
+    const gate = setup()
+    await gate.resolve()
+    expect(await gate.openCloud()).toBe(false)
+  })
+
+  it('reports failure when the launch itself is rejected', async () => {
+    stubApi({ runAction: vi.fn().mockResolvedValue({ ok: false, message: 'nope' }) })
+    const gate = setup()
+    await gate.resolve()
+    expect(await gate.openCloud()).toBe(false)
+  })
+})

--- a/src/renderer/src/composables/useCloudGate.ts
+++ b/src/renderer/src/composables/useCloudGate.ts
@@ -1,0 +1,99 @@
+import { computed, onMounted, ref, type ComputedRef, type Ref } from 'vue'
+import { useInstallationStore } from '../stores/installationStore'
+import { useSessionStore } from '../stores/sessionStore'
+import type { CloudUserTier, Installation } from '../types/ipc'
+
+/**
+ * Whether a Comfy Cloud offer may be shown, and how to open it.
+ *
+ * Both signals fail closed: an unreachable flag service or tier lookup leaves
+ * the offer hidden rather than rendering a CTA we can't stand behind. The
+ * `'paid'` exclusion matches the dashboard's rule — a subscriber has nothing to
+ * gain from a free-tier pitch — and is deliberately looser than first-use's
+ * `'unknown'` check, since by install time the user may already have signed in.
+ */
+export interface CloudGate {
+  freeRunsEnabled: Ref<boolean>
+  userTier: Ref<CloudUserTier>
+  /** True once the flag and tier both allow an offer AND a cloud installation
+   *  exists to launch. Never true before `resolve()` has run. */
+  canOffer: ComputedRef<boolean>
+  resolve: () => Promise<void>
+  openCloud: () => Promise<boolean>
+}
+
+async function settled<T>(call: () => Promise<T>, fallback: T): Promise<T> {
+  try {
+    return await call()
+  } catch {
+    return fallback
+  }
+}
+
+export function useCloudGate(options: { immediate?: boolean } = {}): CloudGate {
+  const installationStore = useInstallationStore()
+  const sessionStore = useSessionStore()
+
+  const freeRunsEnabled = ref(false)
+  const userTier = ref<CloudUserTier>('unknown')
+  const cloudInstall = ref<Installation | null>(null)
+
+  /** The auto-seeded cloud instance. The store isn't hydrated on a cold first
+   *  launch, so a miss re-reads through main before giving up. */
+  async function findCloudInstall(): Promise<Installation | null> {
+    // `sourceId` is the persisted identity (main auto-seeds `'cloud'` every
+    // boot); `sourceCategory` is decorated onto the record by
+    // `getInstallations`. Matching either survives a store that hydrated
+    // before the decoration landed.
+    const isCloud = (i: Installation): boolean =>
+      i.sourceId === 'cloud' || i.sourceCategory === 'cloud'
+    const fromStore = installationStore.installations.find(isCloud) ?? null
+    if (fromStore) return fromStore
+    const all = await settled(() => window.api.getInstallations(), [] as Installation[])
+    return all.find(isCloud) ?? null
+  }
+
+  async function resolve(): Promise<void> {
+    const [enabled, tier, install] = await Promise.all([
+      settled(() => window.api.getCloudFreeRunsEnabled(), false),
+      settled(() => window.api.getCloudUserTier(), 'unknown' as CloudUserTier),
+      findCloudInstall()
+    ])
+    freeRunsEnabled.value = enabled
+    userTier.value = tier
+    cloudInstall.value = install
+  }
+
+  const canOffer = computed(
+    () => freeRunsEnabled.value && userTier.value !== 'paid' && cloudInstall.value !== null
+  )
+
+  /**
+   * Open Cloud in its own window, leaving whatever is running here untouched.
+   * Focuses an existing cloud window instead of launching a second one — a
+   * focus miss (the window was closed but the session record lingers) falls
+   * through to a normal launch. Returns false when there's nothing to open.
+   *
+   * The launch runs the install's own primary action rather than
+   * `openInstallWindow`, which only focuses an already-open window and
+   * otherwise drops the user on the chooser.
+   */
+  async function openCloud(): Promise<boolean> {
+    const install = cloudInstall.value ?? (await findCloudInstall())
+    if (!install) return false
+    if (sessionStore.isRunning(install.id) || sessionStore.isLaunching(install.id)) {
+      const focused = await settled(() => window.api.focusComfyWindow(install.id), false)
+      if (focused) return true
+    }
+    const actions = await settled(() => window.api.getListActions(install.id), [])
+    const launch =
+      actions.find((a) => a.id === 'launch') ?? actions.find((a) => a.style === 'primary') ?? null
+    if (!launch) return false
+    const result = await settled(() => window.api.runAction(install.id, launch.id), null)
+    return !!result?.ok
+  }
+
+  if (options.immediate !== false) onMounted(resolve)
+
+  return { freeRunsEnabled, userTier, canOffer, resolve, openCloud }
+}

--- a/src/renderer/src/composables/useShowcaseCarousel.test.ts
+++ b/src/renderer/src/composables/useShowcaseCarousel.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { effectScope } from 'vue'
+import { SHOWCASE_INTERVAL_MS, useShowcaseCarousel } from './useShowcaseCarousel'
+import { SHOWCASE_CARDS } from '../lib/installShowcase'
+import en from '@locales/en.json'
+import zh from '@locales/zh.json'
+
+let stops: Array<() => void> = []
+
+function setup(cards = SHOWCASE_CARDS) {
+  const scope = effectScope()
+  const carousel = scope.run(() => useShowcaseCarousel(cards))!
+  stops.push(() => scope.stop())
+  return carousel
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  stops = []
+})
+
+afterEach(() => {
+  stops.forEach((stop) => stop())
+  vi.useRealTimers()
+})
+
+describe('rotation', () => {
+  it('opens on the first card', () => {
+    expect(setup().card.value.id).toBe(SHOWCASE_CARDS[0]!.id)
+  })
+
+  it('advances on the interval', () => {
+    const c = setup()
+    vi.advanceTimersByTime(SHOWCASE_INTERVAL_MS)
+    expect(c.index.value).toBe(1)
+  })
+
+  it('holds a card for the full interval', () => {
+    const c = setup()
+    vi.advanceTimersByTime(SHOWCASE_INTERVAL_MS - 1)
+    expect(c.index.value).toBe(0)
+  })
+
+  it('reaches every card', () => {
+    const c = setup()
+    const seen = new Set<string>()
+    for (let i = 0; i < c.count; i++) {
+      seen.add(c.card.value.id)
+      vi.advanceTimersByTime(SHOWCASE_INTERVAL_MS)
+    }
+    expect(seen.size).toBe(SHOWCASE_CARDS.length)
+  })
+
+  it('clears the anti-flicker floor', () => {
+    // Unity documents a 2s minimum dwell per splash item so content cannot
+    // flash past. Guard it so the interval is never tuned below readability.
+    expect(SHOWCASE_INTERVAL_MS).toBeGreaterThanOrEqual(2_000)
+  })
+
+  it('stops once the scope is gone', () => {
+    const scope = effectScope()
+    const c = scope.run(() => useShowcaseCarousel())!
+    scope.stop()
+    vi.advanceTimersByTime(SHOWCASE_INTERVAL_MS * 3)
+    expect(c.index.value).toBe(0)
+  })
+})
+
+describe('it keeps rotating', () => {
+  it('wraps past the last card instead of settling on it', () => {
+    const c = setup()
+    vi.advanceTimersByTime(SHOWCASE_INTERVAL_MS * c.count)
+    expect(c.index.value).toBe(0)
+  })
+
+  it('runs the deck repeatedly, so a long install never sees a dead panel', () => {
+    const c = setup()
+    const seen: string[] = []
+    for (let i = 0; i < c.count * 2 + 2; i++) {
+      seen.push(c.card.value.id)
+      vi.advanceTimersByTime(SHOWCASE_INTERVAL_MS)
+    }
+    expect(seen[c.count]).toBe(seen[0])
+    expect(seen[c.count * 2]).toBe(seen[0])
+  })
+
+  it('never stalls on the final card', () => {
+    const c = setup()
+    vi.advanceTimersByTime(SHOWCASE_INTERVAL_MS * (c.count - 1))
+    expect(c.index.value).toBe(c.count - 1)
+
+    vi.advanceTimersByTime(SHOWCASE_INTERVAL_MS)
+    expect(c.index.value).toBe(0)
+  })
+
+  it('still rotates after a very long wait', () => {
+    const c = setup()
+    vi.advanceTimersByTime(SHOWCASE_INTERVAL_MS * c.count * 6)
+    const at = c.index.value
+    vi.advanceTimersByTime(SHOWCASE_INTERVAL_MS)
+    expect(c.index.value).not.toBe(at)
+  })
+})
+
+describe('manual control', () => {
+  it('steps forward and back', () => {
+    const c = setup()
+    c.next()
+    expect(c.index.value).toBe(1)
+    c.prev()
+    expect(c.index.value).toBe(0)
+  })
+
+  it('wraps backwards from the first card', () => {
+    const c = setup()
+    c.prev()
+    expect(c.index.value).toBe(c.count - 1)
+  })
+
+  it('jumps to a card by index', () => {
+    const c = setup()
+    c.goTo(3)
+    expect(c.index.value).toBe(3)
+  })
+
+  it('restarts the dwell so a chosen card is not cut short', () => {
+    const c = setup()
+    vi.advanceTimersByTime(SHOWCASE_INTERVAL_MS - 500)
+    c.next()
+    expect(c.index.value).toBe(1)
+
+    vi.advanceTimersByTime(600)
+    expect(c.index.value).toBe(1)
+  })
+})
+
+describe('pausing', () => {
+  it('holds while paused', () => {
+    const c = setup()
+    c.pause()
+    vi.advanceTimersByTime(SHOWCASE_INTERVAL_MS * 3)
+    expect(c.index.value).toBe(0)
+  })
+
+  it('resumes afterwards', () => {
+    const c = setup()
+    c.pause()
+    vi.advanceTimersByTime(SHOWCASE_INTERVAL_MS * 2)
+    c.resume()
+    vi.advanceTimersByTime(SHOWCASE_INTERVAL_MS)
+    expect(c.index.value).toBe(1)
+  })
+})
+
+describe('the cards themselves', () => {
+  it('leads with the offer to skip the wait', () => {
+    expect(SHOWCASE_CARDS[0]!.action).toBe('cloud')
+  })
+
+  it('marks exactly one card as the cloud action', () => {
+    expect(SHOWCASE_CARDS.filter((c) => c.action === 'cloud')).toHaveLength(1)
+  })
+
+  it('gives every card a unique id', () => {
+    expect(new Set(SHOWCASE_CARDS.map((c) => c.id)).size).toBe(SHOWCASE_CARDS.length)
+  })
+})
+
+describe('every card resolves in both locales', () => {
+  const lookup = (tree: Record<string, unknown>, key: string): unknown =>
+    key.split('.').reduce<unknown>((node, part) => {
+      if (node && typeof node === 'object') return (node as Record<string, unknown>)[part]
+      return undefined
+    }, tree)
+
+  it('has real copy behind every title and body', () => {
+    const missing: string[] = []
+    for (const card of SHOWCASE_CARDS) {
+      for (const key of [card.title, card.body]) {
+        for (const [name, tree] of [
+          ['en', en],
+          ['zh', zh]
+        ] as const) {
+          if (typeof lookup(tree as Record<string, unknown>, key) !== 'string') {
+            missing.push(`${name}: ${key}`)
+          }
+        }
+      }
+    }
+    expect(missing, `unresolved keys:\n${missing.join('\n')}`).toEqual([])
+  })
+
+  it('keeps every card to a readable length', () => {
+    for (const card of SHOWCASE_CARDS) {
+      const title = lookup(en as Record<string, unknown>, card.title) as string
+      const body = lookup(en as Record<string, unknown>, card.body) as string
+      expect(title.length, card.id).toBeLessThanOrEqual(32)
+      expect(body.length, card.id).toBeLessThanOrEqual(60)
+    }
+  })
+
+  /** The showcase renders on one unwrapped line beside the cloud CTA. Copy is
+   *  the only thing that can break that, so the budget is enforced here rather
+   *  than left to whoever next edits a string. */
+  it('fits title, separator and body on a single line', () => {
+    const SINGLE_LINE_BUDGET = 95
+    for (const card of SHOWCASE_CARDS) {
+      const title = lookup(en as Record<string, unknown>, card.title) as string
+      const body = lookup(en as Record<string, unknown>, card.body) as string
+      expect(`${title} — ${body}`.length, card.id).toBeLessThanOrEqual(SINGLE_LINE_BUDGET)
+    }
+  })
+})

--- a/src/renderer/src/composables/useShowcaseCarousel.ts
+++ b/src/renderer/src/composables/useShowcaseCarousel.ts
@@ -1,0 +1,74 @@
+import { computed, onScopeDispose, ref, type ComputedRef, type Ref } from 'vue'
+import { SHOWCASE_CARDS, type ShowcaseCard } from '../lib/installShowcase'
+
+/** How long each card holds.
+ *
+ *  The 15-50s figures from Ubuntu and Ubiquity are sized for a full-bleed
+ *  slideshow carrying images and several sentences. A card here is one short
+ *  line — roughly 3s of reading — so that range would leave it sitting long
+ *  after it has been absorbed.
+ *
+ *  The floor that does apply is Unity's documented 2s minimum dwell, which
+ *  exists to stop content flickering past. 7s clears it with room to notice the
+ *  change and read without hurrying. */
+export const SHOWCASE_INTERVAL_MS = 7_000
+
+export interface ShowcaseCarousel {
+  card: ComputedRef<ShowcaseCard>
+  index: Ref<number>
+  count: number
+  next: () => void
+  prev: () => void
+  goTo: (index: number) => void
+  /** Rotation stops while the user is reading or interacting. */
+  paused: Ref<boolean>
+  pause: () => void
+  resume: () => void
+}
+
+export function useShowcaseCarousel(
+  cards: readonly ShowcaseCard[] = SHOWCASE_CARDS,
+  intervalMs = SHOWCASE_INTERVAL_MS
+): ShowcaseCarousel {
+  const index = ref(0)
+  const paused = ref(false)
+  const count = cards.length
+
+  const wrap = (at: number): number => ((at % count) + count) % count
+
+  let timer: ReturnType<typeof setInterval> | undefined
+
+  function schedule(): void {
+    if (timer) clearInterval(timer)
+    timer = setInterval(() => {
+      if (paused.value) return
+      index.value = wrap(index.value + 1)
+    }, intervalMs)
+  }
+
+  schedule()
+  onScopeDispose(() => clearInterval(timer))
+
+  /** Restarts the dwell, so a card the user just chose is not cut short by
+   *  whatever was left of the previous card's timer. */
+  function moveTo(at: number): void {
+    index.value = wrap(at)
+    schedule()
+  }
+
+  return {
+    card: computed(() => cards[wrap(index.value)]!),
+    index,
+    count,
+    next: () => moveTo(index.value + 1),
+    prev: () => moveTo(index.value - 1),
+    goTo: moveTo,
+    paused,
+    pause: () => {
+      paused.value = true
+    },
+    resume: () => {
+      paused.value = false
+    }
+  }
+}

--- a/src/renderer/src/lib/installShowcase.ts
+++ b/src/renderer/src/lib/installShowcase.ts
@@ -1,0 +1,37 @@
+/**
+ * Feature cards shown while an install runs. Each answers the question the
+ * wait raises on its own: why run this on Cloud rather than the machine
+ * currently installing.
+ *
+ * Copy is sourced from the marketing site's `cloud.*` and `pricing.included.*`
+ * strings (`ComfyUI_frontend/apps/website/src/i18n/translations.ts`), re-cut as
+ * plain text — the originals carry HTML and hard line breaks that vue-i18n
+ * renders literally.
+ */
+
+export type ShowcaseAction = 'cloud'
+
+export interface ShowcaseCard {
+  id: string
+  title: string
+  body: string
+  /** Present only on the card that offers a way out of the wait. */
+  action?: ShowcaseAction
+}
+
+export const SHOWCASE_CARDS: readonly ShowcaseCard[] = [
+  {
+    id: 'cloud',
+    title: 'installShowcase.cloud.title',
+    body: 'installShowcase.cloud.body',
+    action: 'cloud'
+  },
+  { id: 'gpu', title: 'installShowcase.gpu.title', body: 'installShowcase.gpu.body' },
+  { id: 'models', title: 'installShowcase.models.title', body: 'installShowcase.models.body' },
+  { id: 'partner', title: 'installShowcase.partner.title', body: 'installShowcase.partner.body' },
+  { id: 'license', title: 'installShowcase.license.title', body: 'installShowcase.license.body' },
+  { id: 'nodes', title: 'installShowcase.nodes.title', body: 'installShowcase.nodes.body' },
+  { id: 'loras', title: 'installShowcase.loras.title', body: 'installShowcase.loras.body' },
+  { id: 'queue', title: 'installShowcase.queue.title', body: 'installShowcase.queue.body' },
+  { id: 'idle', title: 'installShowcase.idle.title', body: 'installShowcase.idle.body' }
+]

--- a/src/renderer/src/lib/progressWeights.test.ts
+++ b/src/renderer/src/lib/progressWeights.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { fingerprintSteps, getPhaseWeights } from './progressWeights'
+import { CURATED_PHASE_WEIGHTS, fingerprintSteps, getPhaseWeights } from './progressWeights'
 import type { ProgressStep } from '../types/ipc'
 
 const steps = (...phases: string[]): ProgressStep[] =>
@@ -73,5 +73,23 @@ describe('getPhaseWeights', () => {
 
   it('returns an empty map for no steps', () => {
     expect(getPhaseWeights([])).toEqual({})
+  })
+})
+
+describe('curated tables', () => {
+  it.each(Object.keys(CURATED_PHASE_WEIGHTS))('%s sums to 1.0', (fingerprint) => {
+    expect(sum(CURATED_PHASE_WEIGHTS[fingerprint]!)).toBeCloseTo(1.0, 5)
+  })
+
+  it.each(Object.entries(CURATED_PHASE_WEIGHTS))('%s is keyed by its own fingerprint', (fp, w) => {
+    expect(fingerprintSteps(steps(...Object.keys(w)))).toBe(fp)
+  })
+
+  it('gives the standalone install more of the bar to `update` than `setup`', () => {
+    // `update` hosts torch_deps_sync (p90 15min, p99 110min); `setup` hosts
+    // env_create + package_copy (p50 17s combined). An `update` weight below
+    // `setup` puts the longest stretch of a slow install in the bar's tail.
+    const w = CURATED_PHASE_WEIGHTS['cleanup|download|extract|setup|update']!
+    expect(w.update).toBeGreaterThan(w.setup!)
   })
 })

--- a/src/renderer/src/lib/progressWeights.ts
+++ b/src/renderer/src/lib/progressWeights.ts
@@ -12,22 +12,28 @@ import type { ProgressStep } from '../types/ipc'
  * The launch flow is NOT here: it sends weights inline on its steps (see
  * `launchPhases.ts` / `launchProgress.ts`), so main is the single source.
  */
-const TABLES: Record<string, Record<string, number>> = {
-  // Standalone install — common case (no pending snapshot)
+export const CURATED_PHASE_WEIGHTS: Record<string, Record<string, number>> = {
+  // Standalone install — common case (no pending snapshot).
+  //
+  // Calibrated against `comfy.desktop.install.phase` p50s (30d): download 77s,
+  // extract 51s, env_create 2s + package_copy 15s (both inside `setup`), and
+  // torch_deps_sync 82s (inside `update`). `update` previously held 0.05 while
+  // owning the phase with the longest tail — p90 15min, p99 110min — which
+  // parked the bar in its final sliver for the entire slow stretch.
   'cleanup|download|extract|setup|update': {
-    download: 0.4,
+    download: 0.35,
     extract: 0.2,
-    setup: 0.3,
+    setup: 0.1,
     cleanup: 0.05,
-    update: 0.05
+    update: 0.3
   },
   // Standalone install + snapshot restore
   'cleanup|download|extract|restore-nodes|restore-pip|setup|update': {
-    download: 0.3,
+    download: 0.25,
     extract: 0.15,
-    setup: 0.2,
-    cleanup: 0.05,
-    update: 0.05,
+    setup: 0.08,
+    cleanup: 0.02,
+    update: 0.25,
     'restore-nodes': 0.15,
     'restore-pip': 0.1
   },
@@ -82,8 +88,8 @@ export function fingerprintSteps(steps: readonly ProgressStep[]): string {
 }
 
 /** Phase → weight for an op's bar. Prefers weights the producer sent inline on
- *  the steps (normalized to sum 1.0); else a curated `TABLES` entry; else an
- *  equal split. */
+ *  the steps (normalized to sum 1.0); else a curated entry; else an equal
+ *  split. */
 export function getPhaseWeights(steps: readonly ProgressStep[]): Record<string, number> {
   const n = steps.length
   if (n === 0) return {}
@@ -97,7 +103,7 @@ export function getPhaseWeights(steps: readonly ProgressStep[]): Record<string, 
     return out
   }
 
-  const known = TABLES[fingerprintSteps(steps)]
+  const known = CURATED_PHASE_WEIGHTS[fingerprintSteps(steps)]
   if (known) return known
   const w = 1 / n
   const out: Record<string, number> = {}

--- a/src/renderer/src/types/ipc.ts
+++ b/src/renderer/src/types/ipc.ts
@@ -32,6 +32,7 @@ export type {
   ModelsSection,
   ModelsField,
   ProbeResult,
+  InstallPayloadItem,
   ProgressData,
   ProgressStep,
   AdoptPromptRequest,

--- a/src/renderer/src/views/ProgressModal.vue
+++ b/src/renderer/src/views/ProgressModal.vue
@@ -19,6 +19,8 @@ import BrandProgressGlyph from '../components/icons/BrandProgressGlyph.vue'
 import BaseAccordion from '../components/ui/BaseAccordion.vue'
 import BaseCopyButton from '../components/ui/BaseCopyButton.vue'
 import BrandProgressView from '../components/BrandProgressView.vue'
+import InstallShowcase from '../components/InstallShowcase.vue'
+import { useCloudGate } from '../composables/useCloudGate'
 import type { ProgressStepVM } from '../lib/progressViewModel'
 import { TID } from '../../../shared/testIds'
 
@@ -271,6 +273,20 @@ const progressSteps = computed<ProgressStepVM[]>(() => {
 
   return [...prior, ...current]
 })
+
+const cloudGate = useCloudGate()
+async function handleShowcaseCloud(): Promise<void> {
+  emitTelemetryAction('comfy.desktop.install.showcase.cloud_open', {
+    phase: currentOp.value?.activePhase ?? null
+  })
+  await cloudGate.openCloud()
+}
+
+// Rides every in-flight install; no tiers or thresholds, so the section is a
+// constant part of the wait.
+const showShowcase = computed<boolean>(
+  () => !!currentOp.value && (!currentOp.value.finished || isChainHandoff.value)
+)
 
 // Separate from the modal-branch `terminalExpanded` so the brand accordion's state doesn't leak into the modal reopen path.
 const brandLogsExpanded = ref(false)
@@ -544,6 +560,13 @@ defineExpose({ startOperation, showOperation })
              back the yellow glyph so stepper text stays legible. -->
         <div class="brand-progress__plate">
           <div class="brand-progress__core">
+            <InstallShowcase
+              v-if="showShowcase"
+              class="brand-progress__showcase"
+              :can-offer-cloud="cloudGate.canOffer.value"
+              @open-cloud="handleShowcaseCloud"
+            />
+
             <ComfyWordmark class="brand-progress__wordmark" />
 
             <template v-if="!currentOp.finished || isChainHandoff">
@@ -932,6 +955,13 @@ defineExpose({ startOperation, showOperation })
 }
 .brand-progress__steps {
   width: 100%;
+}
+/* No margin of its own: the core's gap already separates it from the wordmark,
+   and stacking a margin on top of that flex gap was what pushed the bar off
+   centre. The reserved min-height lives on the component so a two-line card in
+   a longer locale cannot reflow the cluster below it. */
+.brand-progress__showcase {
+  margin-bottom: 0;
 }
 .brand-status-fade-enter-active,
 .brand-status-fade-leave-active {

--- a/src/shared/progressMeasurement.ts
+++ b/src/shared/progressMeasurement.ts
@@ -1,0 +1,21 @@
+import type { ProgressData } from '../types/ipc'
+
+export const BYTES_PER_MB = 1048576
+
+/**
+ * Structured throughput fields for an `install-progress` emission.
+ *
+ * Producers measure speed in MB/s and carry `-1` for "no ETA yet"; the wire
+ * format is bytes and omission. Unmeasured samples are dropped rather than
+ * zeroed so a consumer can distinguish "not known yet" from "stalled" — the
+ * projection logic downstream treats those very differently.
+ */
+export function measuredProgress(
+  speedMBs: number,
+  etaSecs: number
+): Pick<ProgressData, 'speedBytesPerSec' | 'etaSeconds'> {
+  return {
+    ...(speedMBs > 0 ? { speedBytesPerSec: Math.round(speedMBs * BYTES_PER_MB) } : {}),
+    ...(etaSecs >= 0 ? { etaSeconds: Math.round(etaSecs) } : {})
+  }
+}

--- a/src/shared/testIds.ts
+++ b/src/shared/testIds.ts
@@ -77,7 +77,14 @@ export const TID = {
   /** Visible only when `portConflict.nextPort` is set. */
   progressPortConflictUsePort: 'progress-port-conflict-use-port',
   /** Visible only when `portConflict.isComfy` is true. */
-  progressPortConflictKill: 'progress-port-conflict-kill'
+  progressPortConflictKill: 'progress-port-conflict-kill',
+
+  /** Feature carousel in the install takeover, above the wordmark. Passive:
+   *  rotation has no dots, arrows or pause button — see InstallShowcase.vue. */
+  installShowcase: 'install-showcase',
+  installShowcaseTitle: 'install-showcase-title',
+  installShowcaseCloud: 'install-showcase-cloud',
+
 } as const
 
 export type TestIdKey = keyof typeof TID

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -37,6 +37,11 @@ export interface Installation {
    *  main side; consumed by recency-aware UI surfaces such as the
    *  startup picker. */
   lastLaunchedAtByCategory?: Record<string, number>
+  /** Starter template chosen in the install wizard. Declared here (rather than
+   *  left to the index signature) so renderer surfaces read them typed; both
+   *  are absent on installs created without a template. */
+  bundledTemplateId?: string
+  bundledTemplateSizeBytes?: number
   [key: string]: unknown // allow extra fields from sources
 }
 
@@ -452,6 +457,21 @@ export interface ProbeResult {
 }
 
 // --- Progress types ---
+
+/** One line item of an install's payload — a downloaded archive, a wheel, a
+ *  model file. Producers emit only what they can measure: `totalBytes` stays
+ *  undefined until a real size is known, and consumers must render an item
+ *  with no byte figures rather than assuming zero. */
+export interface InstallPayloadItem {
+  /** Stable across ticks so the renderer can diff rather than re-key rows. */
+  id: string
+  /** Resolved display label, or an i18n key the renderer translates. */
+  label: string
+  totalBytes?: number
+  receivedBytes?: number
+  state: 'pending' | 'active' | 'done' | 'error'
+}
+
 export interface ProgressData {
   installationId: string
   phase: string
@@ -459,7 +479,25 @@ export interface ProgressData {
   percent?: number
   steps?: ProgressStep[]
   error?: boolean
+  /** Itemised payload for the active phase. Display-only: never gates control
+   *  flow, and any producer may omit it. */
+  payload?: InstallPayloadItem[]
+  /** Measured throughput/projection for the active phase. Absent until a
+   *  sample stabilises; negative values are never emitted. */
+  speedBytesPerSec?: number
+  etaSeconds?: number
 }
+
+/**
+ * The producer half of `install-progress`. `makeSendProgress` supplies
+ * `installationId` and `phase`, so producers pass the remainder — deriving it
+ * from `ProgressData` keeps every emitter in step with the payload the
+ * renderer actually parses.
+ */
+export type SendProgress = (
+  phase: string,
+  detail: Omit<ProgressData, 'installationId' | 'phase'>
+) => void
 
 export interface ProgressStep {
   phase: string

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,14 @@ export default defineConfig({
   },
   test: {
     environment: 'happy-dom',
+    // Components that render an iframe (FeedbackModal's typeform) would
+    // otherwise have happy-dom fetch the real URL. The request outlives the
+    // test, so teardown aborts it and the rejection surfaces as an unhandled
+    // error in an unrelated file. Tests assert on the `src` attribute, never
+    // on loaded frame content.
+    environmentOptions: {
+      happyDOM: { settings: { disableIframePageLoading: true } }
+    },
     include: ['src/**/*.test.ts'],
     exclude: ['src/**/*.integration.test.ts', 'node_modules'],
     globals: true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,9 +16,10 @@ export default defineConfig({
     // otherwise have happy-dom fetch the real URL. The request outlives the
     // test, so teardown aborts it and the rejection surfaces as an unhandled
     // error in an unrelated file. Tests assert on the `src` attribute, never
-    // on loaded frame content.
+    // on loaded frame content. (Supersedes `disableIframePageLoading`, which
+    // happy-dom deprecated and which logged a console error per blocked frame.)
     environmentOptions: {
-      happyDOM: { settings: { disableIframePageLoading: true } }
+      happyDOM: { settings: { navigation: { disableChildFrameNavigation: true } } }
     },
     include: ['src/**/*.test.ts'],
     exclude: ['src/**/*.integration.test.ts', 'node_modules'],


### PR DESCRIPTION
## Summary

Starter templates can now be changed from PostHog without shipping a release, the install screen reports what it is actually doing instead of a stalling bar, and the wait itself now carries a rotating showcase of what Comfy Cloud offers.

## Changes

**What**

- Starter templates are served from a remote flag, resolved against the template index that the installed ComfyUI version pins, and fall back to the disk cache and then the built-in list when the network is unavailable. The picker also honours each template's availability window and release channel, so a template can be scheduled or limited to nightly without a code change.
- The installer emits structured per-item progress across IPC, so the takeover can show which file is downloading and how far along it is rather than a single opaque percentage.
- The dependency sync used to look frozen for minutes. `uv pip install` publishes no machine-readable progress, so we parse its human output into coarse stages (resolving, preparing, installing) and report those. There are no byte counts to be had here, so this is deliberately stage-level, not a percentage.
- The progress bar no longer starves its longest phase. Phase weighting was letting the slowest stretch of the install occupy a sliver of the bar while quick phases ate the rest.
- The install screen now runs a carousel above the wordmark, cycling nine reasons to run on Comfy Cloud (hardware, the 900+ pre-installed models, partner models, commercial licensing, custom nodes, LoRA import, queueing, and the runtime-only billing model). Copy comes from the marketing site, re-cut as plain text.
- Opening Comfy Cloud actually opens Cloud. It previously called a helper that only focuses an already-open window and otherwise falls through to the chooser, so the user landed on the dashboard.
- Every request through the shared fetch helper is now bounded by a timeout, and ops flags accept JSON payloads.

**Breaking**

None. IPC message shapes are additive, existing telemetry events are unchanged, and the built-in curated template list still ships as the final fallback so an offline first run behaves exactly as before.

## Review Focus

The interesting decision is in the template resolution chain: remote flag, then disk cache, then the compiled-in list, with the index resolved at the version ComfyUI pins rather than latest. `templateCatalogResolution.test.ts` is where that contract is pinned down and is the file worth reading first.

Worth a second look: `uvProgress.ts` is parsing human-readable output, which is inherently brittle. It is scoped to three coarse stages precisely so that a wording change upstream degrades to "no progress detail" rather than to wrong numbers.

The Cloud carousel is deliberately unconditional. There are no timing gates, no error branching, and no tiering, since it is a feature showcase for the whole wait rather than a targeted offer. That was a direct change in direction from an earlier build, and the earlier install-receipt card was removed rather than kept alongside it, so there is one Cloud surface rather than two.

Out of scope: the model download pipeline, launch sequencing, and the finished and error states of the install takeover are untouched.

## Testing

The risky parts here are resolution order and time-based behaviour, so both are covered by unit tests with fake timers rather than by driving the UI. Template resolution has the largest surface and gets the deepest coverage, since a wrong fallback silently ships the wrong templates to every new install.

- `templateCatalogResolution.test.ts` (806 lines): remote wins over cache, cache wins over built-in, malformed payloads fall through cleanly, and availability windows plus release channels filter as expected.
- `starterTemplateManifest.test.ts`: flag parsing, id validation, modality ordering, and cache round-tripping.
- `templatePin.test.ts`: index resolution against the pinned ComfyUI version.
- `uvProgress.test.ts`: stage detection across real uv output, including the sub-1 MiB case that announces nothing.
- `useShowcaseCarousel.test.ts`: rotation wraps past the last card and keeps looping (this one is a regression guard, an earlier build stopped dead on the final card), pause on hover, focus, and the explicit control, and manual moves restart the dwell.
- `useCloudGate.test.ts`: the gate fails closed on every signal, and opening Cloud runs the install's launch action instead of the window-focus helper. Both suites were mutation-tested by reverting the fix, which fails them.
- `InstallShowcase.test.ts`: the Cloud action stays present on all nine cards, and lives outside the rotating element so it cannot animate away.

Gate: `pnpm run typecheck`, `pnpm run lint`, and `npx vitest run` all clean, 3929 passed across 231 files.

Manual: ran a real install end to end and confirmed the dependency-sync stages appear instead of a frozen bar, the carousel rotates and loops, and the Cloud button opens a Comfy Cloud window rather than the dashboard.
