### PR TITLE
feat(templates): serve the starter-template list from R2

### DIFF
--- a/src/main/sources/standalone/index.test.ts
+++ b/src/main/sources/standalone/index.test.ts
@@ -261,7 +261,11 @@ describe('standalone.getFieldOptions bundledTemplate', () => {
   })
 
   it('falls back to snapshot metadata when the index fetch fails (offline)', async () => {
-    mockedFetchJSON.mockImplementationOnce(() => Promise.reject(new Error('offline')))
+    mockedFetchJSON.mockImplementation((url: string) =>
+      String(url).includes('index.json')
+        ? Promise.reject(new Error('offline'))
+        : Promise.resolve(null)
+    )
     const options = await standalone.getFieldOptions!('bundledTemplate', {}, {})
     const first = CURATED_TEMPLATES[0]!
     const card = options.find((o) => o.value === first.id)!

--- a/src/main/sources/standalone/remoteStarterTemplates.test.ts
+++ b/src/main/sources/standalone/remoteStarterTemplates.test.ts
@@ -390,7 +390,7 @@ describe('G. an oversized or hostile document cannot cost more than it should', 
   it('stops reading long past the point where every slot could be filled', () => {
     const huge = Array.from({ length: 5000 }, (_, i) => entry({ id: `r${i}`, modality: 'image' }))
     const parsed = parseRemoteStarterTemplates(doc(huge))
-    expect(parsed!.length, 'only 16 slots can ever be filled').toBeLessThanOrEqual(256)
+    expect(parsed!.length, 'parsing stops at the MAX_ENTRIES cap').toBe(256)
   })
 
   it.each([
@@ -437,8 +437,8 @@ describe('G. an oversized or hostile document cannot cost more than it should', 
     const parsed = parseRemoteStarterTemplates(doc([entry({ id: 'none' }), entry({ id: 'ok' })]))
     expect(
       parsed?.map((t) => t.id),
-      'the sentinel is not a template'
-    ).not.toContain('none')
+      'the sentinel drops while its valid neighbour survives'
+    ).toEqual(['ok'])
   })
 })
 

--- a/src/main/sources/standalone/remoteStarterTemplates.test.ts
+++ b/src/main/sources/standalone/remoteStarterTemplates.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 vi.mock('../../lib/fetch', () => ({ fetchJSON: vi.fn() }))
 
 import {
+  STARTER_TEMPLATES_URL,
   parseRemoteStarterTemplates,
   resolveStarterTemplates,
   loadStarterTemplates,
@@ -128,37 +129,48 @@ describe('B. one bad entry drops alone', () => {
 })
 
 describe('C. composition rules survive a hostile document', () => {
-  it('demotes every recommended after the first in a modality', () => {
-    const parsed = parseRemoteStarterTemplates(
+  it('leaves exactly one auto-pick per tab when the document flags several', () => {
+    const remote = parseRemoteStarterTemplates(
       doc([
         entry({ id: 'a', recommended: true }),
         entry({ id: 'b', recommended: true }),
         entry({ id: 'c', recommended: true })
       ])
     )
+    const image = resolveStarterTemplates(remote).filter((t) => t.modality === 'image')
     expect(
-      parsed!.filter((t) => t.recommended),
-      'at most one auto-pick per tab'
+      image.filter((t) => t.recommended),
+      'the resolved slots are where this rule is enforced'
     ).toHaveLength(1)
-    expect(parsed![0]!.id).toBe('a')
+    expect(image.find((t) => t.recommended)!.id, 'document order breaks the tie').toBe('a')
   })
 
-  it('never lets a paid card carry the recommendation', () => {
+  it('drops a card claiming to be both paid and recommended', () => {
     const parsed = parseRemoteStarterTemplates(
-      doc([entry({ id: 'paid', apiNode: true, recommended: true })])
+      doc([entry({ id: 'paid', apiNode: true, recommended: true }), entry({ id: 'ok' })])
     )
-    expect(parsed![0]!.apiNode, 'the card is kept').toBe(true)
-    expect(parsed![0]!.recommended, 'but never auto-selected, it spends credits').toBeFalsy()
+    expect(
+      parsed?.map((t) => t.id),
+      'contradictory under our own invariant, so dropped not rewritten'
+    ).toEqual(['ok'])
+  })
+
+  it('keeps a paid card that makes no claim to the badge', () => {
+    const parsed = parseRemoteStarterTemplates(doc([entry({ id: 'paid', apiNode: true })]))
+    expect(parsed![0]!.apiNode).toBe(true)
+    expect(parsed![0]!.recommended).toBeUndefined()
   })
 
   it('allows one recommended per modality independently', () => {
-    const parsed = parseRemoteStarterTemplates(
+    const remote = parseRemoteStarterTemplates(
       doc([
         entry({ id: 'i', modality: 'image', recommended: true }),
         entry({ id: 'v', modality: 'video', recommended: true })
       ])
     )
-    expect(parsed!.filter((t) => t.recommended).map((t) => t.id)).toEqual(['i', 'v'])
+    const resolved = resolveStarterTemplates(remote)
+    expect(resolved.find((t) => t.modality === 'image' && t.recommended)!.id).toBe('i')
+    expect(resolved.find((t) => t.modality === 'video' && t.recommended)!.id).toBe('v')
   })
 })
 
@@ -227,6 +239,7 @@ describe('D. the hardcoded list is the floor', () => {
     expect(new Set(image.map((t) => t.id)).size, 'ids collide on the picker option key').toBe(
       image.length
     )
+    expect(image, 'a uniqueness check alone would pass on a short tab').toHaveLength(4)
   })
 
   it('holds every invariant across all four tabs at once', () => {
@@ -281,6 +294,116 @@ describe('D. the hardcoded list is the floor', () => {
   })
 })
 
+describe('F. a remote document cannot starve or hijack a tab', () => {
+  it('cannot drain a tab by filing its built-in ids under another modality', () => {
+    const imageIds = bakedIds('image')
+    const remote = parseRemoteStarterTemplates(
+      doc(imageIds.map((id) => entry({ id, modality: 'video' })))
+    )
+    const resolved = resolveStarterTemplates(remote)
+    for (const modality of TEMPLATE_MODALITY_ORDER) {
+      expect(
+        resolved.filter((t) => t.modality === modality),
+        `${modality} must keep its four cards`
+      ).toHaveLength(4)
+    }
+  })
+
+  it('ignores a single built-in id filed under the wrong tab', () => {
+    const stolen = bakedIds('image')[0]!
+    const remote = parseRemoteStarterTemplates(doc([entry({ id: stolen, modality: 'video' })]))
+    const resolved = resolveStarterTemplates(remote)
+    expect(
+      resolved.filter((t) => t.modality === 'image'),
+      'the image tab keeps its own card'
+    ).toHaveLength(4)
+    expect(
+      resolved.find((t) => t.id === stolen)!.modality,
+      'the id stays on the tab it belongs to'
+    ).toBe('image')
+  })
+
+  it('keeps the badge on a remote card when the tab is partly backfilled', () => {
+    const remote = parseRemoteStarterTemplates(
+      doc(['r1', 'r2', 'r3'].map((id) => entry({ id, modality: 'image' })))
+    )
+    const image = resolveStarterTemplates(remote).filter((t) => t.modality === 'image')
+    const winner = image.find((c) => c.recommended)
+    expect(winner, 'a tab with a free card always has an auto-pick').toBeDefined()
+    expect(
+      ['r1', 'r2', 'r3'],
+      'the backfilled card must not steal the badge content did not give it'
+    ).toContain(winner!.id)
+  })
+
+  it('honours the remote entry that does claim the badge', () => {
+    const remote = parseRemoteStarterTemplates(
+      doc([
+        entry({ id: 'r1', modality: 'image' }),
+        entry({ id: 'r2', modality: 'image', recommended: true })
+      ])
+    )
+    const image = resolveStarterTemplates(remote).filter((t) => t.modality === 'image')
+    expect(image.find((c) => c.recommended)!.id).toBe('r2')
+  })
+})
+
+describe('G. an oversized or hostile document cannot cost more than it should', () => {
+  it('stops reading long past the point where every slot could be filled', () => {
+    const huge = Array.from({ length: 5000 }, (_, i) => entry({ id: `r${i}`, modality: 'image' }))
+    const parsed = parseRemoteStarterTemplates(doc(huge))
+    expect(parsed!.length, 'only 16 slots can ever be filled').toBeLessThanOrEqual(256)
+  })
+
+  it.each([
+    ['an absurd magnitude', 1.5e300],
+    ['past the cap', 3 * 1024 ** 4],
+    ['a fractional byte count', 1.5]
+  ])('rejects a sizeBytes that is %s', (_label, sizeBytes) => {
+    const parsed = parseRemoteStarterTemplates(
+      doc([entry({ id: 'bad', snapshot: { ...SNAPSHOT, sizeBytes } }), entry({ id: 'ok' })])
+    )
+    expect(
+      parsed?.map((t) => t.id),
+      'this value drives the install-time disk-space gate'
+    ).toEqual(['ok'])
+  })
+
+  it.each([
+    ['a blank title', { title: '   ' }],
+    ['a newline-only description', { description: '\n\n' }],
+    ['a blank mediaSubtype', { mediaSubtype: ' ' }]
+  ])('rejects %s that would render as an empty card', (_label, over) => {
+    const parsed = parseRemoteStarterTemplates(
+      doc([entry({ id: 'blank', snapshot: { ...SNAPSHOT, ...over } }), entry({ id: 'ok' })])
+    )
+    expect(parsed?.map((t) => t.id)).toEqual(['ok'])
+  })
+
+  it('trims surrounding whitespace rather than rendering it', () => {
+    const parsed = parseRemoteStarterTemplates(
+      doc([entry({ snapshot: { ...SNAPSHOT, title: '  Padded  ' } })])
+    )
+    expect(parsed![0]!.snapshot.title).toBe('Padded')
+  })
+
+  it.each([['.'], ['..']])('rejects %s, a directory rather than a template', (id) => {
+    const parsed = parseRemoteStarterTemplates(doc([entry({ id }), entry({ id: 'ok' })]))
+    expect(
+      parsed?.map((t) => t.id),
+      'a path segment must never reach a URL or a file path'
+    ).toEqual(['ok'])
+  })
+
+  it('rejects the skip sentinel smuggled in as an id', () => {
+    const parsed = parseRemoteStarterTemplates(doc([entry({ id: 'none' }), entry({ id: 'ok' })]))
+    expect(
+      parsed?.map((t) => t.id),
+      'the sentinel is not a template'
+    ).not.toContain('none')
+  })
+})
+
 describe('E. the network is never trusted to behave', () => {
   beforeEach(() => {
     mockedFetchJSON.mockReset()
@@ -305,6 +428,18 @@ describe('E. the network is never trusted to behave', () => {
     )
   })
 
+  it('is cleared by the catalog reset, so fetch counts stay order-independent', async () => {
+    const { resetTemplateCatalogCache } = await import('./templateCatalog')
+    mockedFetchJSON.mockResolvedValue(doc([entry()]))
+    await loadStarterTemplates()
+    resetTemplateCatalogCache()
+    await loadStarterTemplates()
+    expect(
+      mockedFetchJSON,
+      'a half-cleared cache makes suites order-dependent'
+    ).toHaveBeenCalledTimes(2)
+  })
+
   it('fetches once per process, not once per picker open', async () => {
     mockedFetchJSON.mockResolvedValue(doc([entry({ id: 'r1', modality: 'image' })]))
     await Promise.all([loadStarterTemplates(), loadStarterTemplates()])
@@ -316,10 +451,40 @@ describe('E. the network is never trusted to behave', () => {
     mockedFetchJSON.mockResolvedValue(doc([entry()]))
     await loadStarterTemplates()
     const [url, opts] = mockedFetchJSON.mock.calls[0] as [string, Record<string, unknown>]
-    expect(url).toContain('desktop-assets.comfy.org')
+    expect(url).toBe(STARTER_TEMPLATES_URL)
     expect(opts, 'a stale ETag would strand users on withdrawn content').toMatchObject({
       refresh: true
     })
+  })
+
+  it('always returns a full picker, whatever the document says', async () => {
+    mockedFetchJSON.mockResolvedValue(doc([entry({ id: 'r1', modality: 'image' })]))
+    const loaded = await loadStarterTemplates()
+    expect(loaded, 'four cards in each of four tabs').toHaveLength(
+      TEMPLATE_MODALITY_ORDER.length * 4
+    )
+    for (const modality of TEMPLATE_MODALITY_ORDER) {
+      expect(
+        loaded.filter((t) => t.modality === modality),
+        modality
+      ).toHaveLength(4)
+    }
+  })
+
+  it('falls back rather than hanging when the fetch never settles', async () => {
+    vi.useFakeTimers()
+    try {
+      mockedFetchJSON.mockImplementation(() => new Promise(() => {}))
+      const pending = loadStarterTemplates()
+      await vi.advanceTimersByTimeAsync(10_000)
+      const loaded = await pending
+      expect(
+        loaded.map((t) => t.id).sort(),
+        'a stalled read must not leave the picker rendering nothing'
+      ).toEqual([...CURATED_TEMPLATES].map((t) => t.id).sort())
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('never rejects, whatever the network does', async () => {

--- a/src/main/sources/standalone/remoteStarterTemplates.test.ts
+++ b/src/main/sources/standalone/remoteStarterTemplates.test.ts
@@ -155,6 +155,44 @@ describe('C. composition rules survive a hostile document', () => {
     ).toEqual(['ok'])
   })
 
+  it.each([
+    ['a string', 'true'],
+    ['a number', 1],
+    ['null', null],
+    ['an object', {}]
+  ])('drops an entry whose apiNode is %s rather than a boolean', (_label, apiNode) => {
+    const parsed = parseRemoteStarterTemplates(
+      doc([entry({ id: 'bad', apiNode }), entry({ id: 'ok' })])
+    )
+    expect(
+      parsed?.map((t) => t.id),
+      'a truthy-but-not-true flag would offer a paid card as free'
+    ).toEqual(['ok'])
+  })
+
+  it.each([
+    ['a string', 'true'],
+    ['a number', 1],
+    ['null', null]
+  ])('drops an entry whose recommended is %s rather than a boolean', (_label, recommended) => {
+    const parsed = parseRemoteStarterTemplates(
+      doc([entry({ id: 'bad', recommended }), entry({ id: 'ok' })])
+    )
+    expect(parsed?.map((t) => t.id)).toEqual(['ok'])
+  })
+
+  it('never lets non-boolean flags smuggle a paid card into the auto-pick', () => {
+    const remote = parseRemoteStarterTemplates(
+      doc([entry({ id: 'sneaky', apiNode: 'true', recommended: 'true' })])
+    )
+    const image = resolveStarterTemplates(remote).filter((t) => t.modality === 'image')
+    expect(
+      image.find((c) => c.id === 'sneaky'),
+      'the malformed row never renders'
+    ).toBeUndefined()
+    expect(image.find((c) => c.recommended)!.apiNode, 'the auto-pick stays free').toBeFalsy()
+  })
+
   it('keeps a paid card that makes no claim to the badge', () => {
     const parsed = parseRemoteStarterTemplates(doc([entry({ id: 'paid', apiNode: true })]))
     expect(parsed![0]!.apiNode).toBe(true)

--- a/src/main/sources/standalone/remoteStarterTemplates.test.ts
+++ b/src/main/sources/standalone/remoteStarterTemplates.test.ts
@@ -1,0 +1,329 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../../lib/fetch', () => ({ fetchJSON: vi.fn() }))
+
+import {
+  parseRemoteStarterTemplates,
+  resolveStarterTemplates,
+  loadStarterTemplates,
+  _resetStarterTemplatesForTest
+} from './remoteStarterTemplates'
+import { CURATED_TEMPLATES, TEMPLATE_MODALITY_ORDER } from './curatedTemplates'
+import { fetchJSON } from '../../lib/fetch'
+
+const mockedFetchJSON = vi.mocked(fetchJSON)
+
+const SNAPSHOT = {
+  title: 'T',
+  description: 'D',
+  sizeBytes: 10,
+  mediaSubtype: 'webp'
+}
+
+function entry(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return { id: 'remote_one', modality: 'image', snapshot: { ...SNAPSHOT }, ...over }
+}
+
+function doc(templates: unknown[]): Record<string, unknown> {
+  return { schemaVersion: 1, templates }
+}
+
+/** Ids the hardcoded list owns, per modality. */
+function bakedIds(modality: string): string[] {
+  return CURATED_TEMPLATES.filter((t) => t.modality === modality).map((t) => t.id)
+}
+
+describe('A. an unusable document is ignored entirely', () => {
+  it.each([
+    ['not an object', 'nope'],
+    ['a bare array', [{ id: 'a', modality: 'image' }]],
+    ['null', null],
+    ['undefined', undefined],
+    ['a number', 42],
+    ['schemaVersion missing', { templates: [{ id: 'a', modality: 'image', snapshot: SNAPSHOT }] }],
+    [
+      'schemaVersion from the future',
+      { schemaVersion: 2, templates: [{ id: 'a', modality: 'image', snapshot: SNAPSHOT }] }
+    ],
+    [
+      'schemaVersion as a string',
+      { schemaVersion: '1', templates: [{ id: 'a', modality: 'image', snapshot: SNAPSHOT }] }
+    ],
+    ['templates missing', { schemaVersion: 1 }],
+    ['templates not an array', { schemaVersion: 1, templates: {} }],
+    ['templates empty', { schemaVersion: 1, templates: [] }],
+    ['every entry invalid', { schemaVersion: 1, templates: [{ id: 42 }, null] }]
+  ])('%s yields null, so the caller keeps the hardcoded list', (_label, raw) => {
+    expect(parseRemoteStarterTemplates(raw)).toBeNull()
+  })
+
+  it('accepts the escaped-JSON-string form as well as a parsed object', () => {
+    const parsed = parseRemoteStarterTemplates(JSON.stringify(doc([entry()])))
+    expect(parsed?.map((t) => t.id)).toEqual(['remote_one'])
+  })
+})
+
+describe('B. one bad entry drops alone', () => {
+  it.each([
+    ['id not a string', { id: 42 }],
+    ['id empty', { id: '' }],
+    ['id with a path segment', { id: '../../etc/passwd' }],
+    ['id with a slash', { id: 'a/b' }],
+    ['id with a space', { id: 'a b' }],
+    ['id far too long', { id: 'a'.repeat(129) }],
+    ['modality unknown', { modality: 'gif' }],
+    ['snapshot not an object', { snapshot: 'x' }],
+    ['title empty', { snapshot: { ...SNAPSHOT, title: '' } }],
+    ['title not a string', { snapshot: { ...SNAPSHOT, title: 5 } }],
+    ['description empty', { snapshot: { ...SNAPSHOT, description: '' } }],
+    ['mediaSubtype empty', { snapshot: { ...SNAPSHOT, mediaSubtype: '' } }],
+    ['sizeBytes not a number', { snapshot: { ...SNAPSHOT, sizeBytes: 'big' } }],
+    ['sizeBytes negative', { snapshot: { ...SNAPSHOT, sizeBytes: -1 } }],
+    ['sizeBytes NaN', { snapshot: { ...SNAPSHOT, sizeBytes: Number.NaN } }],
+    ['sizeBytes Infinity', { snapshot: { ...SNAPSHOT, sizeBytes: Number.POSITIVE_INFINITY } }]
+  ])('%s drops that entry but keeps its neighbour', (_label, over) => {
+    const parsed = parseRemoteStarterTemplates(
+      doc([entry({ id: 'bad_one', ...over }), entry({ id: 'good_one' })])
+    )
+    expect(
+      parsed?.map((t) => t.id),
+      'only the valid neighbour survives'
+    ).toEqual(['good_one'])
+  })
+
+  it.each([
+    ['a missing id', { id: undefined }],
+    ['a missing modality', { modality: undefined }],
+    ['a missing snapshot', { snapshot: undefined }]
+  ])('%s drops that entry but keeps its neighbour', (_label, over) => {
+    const bad = entry()
+    delete bad[Object.keys(over)[0]!]
+    const parsed = parseRemoteStarterTemplates(doc([bad, entry({ id: 'good_one' })]))
+    expect(parsed?.map((t) => t.id)).toEqual(['good_one'])
+  })
+
+  it.each([
+    ['a null entry', null],
+    ['a string entry', 'nope'],
+    ['a number entry', 7]
+  ])('%s drops alone', (_label, bad) => {
+    const parsed = parseRemoteStarterTemplates(doc([bad, entry({ id: 'good_one' })]))
+    expect(parsed?.map((t) => t.id)).toEqual(['good_one'])
+  })
+
+  it('drops a duplicate id, keeping the first occurrence', () => {
+    const parsed = parseRemoteStarterTemplates(
+      doc([entry({ id: 'dup', snapshot: { ...SNAPSHOT, title: 'first' } }), entry({ id: 'dup' })])
+    )
+    expect(parsed).toHaveLength(1)
+    expect(parsed![0]!.snapshot.title, 'the first occurrence wins').toBe('first')
+  })
+
+  it('keeps a zero sizeBytes, which is how an API-node card is spelled', () => {
+    const parsed = parseRemoteStarterTemplates(
+      doc([entry({ apiNode: true, snapshot: { ...SNAPSHOT, sizeBytes: 0 } })])
+    )
+    expect(parsed).toHaveLength(1)
+  })
+})
+
+describe('C. composition rules survive a hostile document', () => {
+  it('demotes every recommended after the first in a modality', () => {
+    const parsed = parseRemoteStarterTemplates(
+      doc([
+        entry({ id: 'a', recommended: true }),
+        entry({ id: 'b', recommended: true }),
+        entry({ id: 'c', recommended: true })
+      ])
+    )
+    expect(
+      parsed!.filter((t) => t.recommended),
+      'at most one auto-pick per tab'
+    ).toHaveLength(1)
+    expect(parsed![0]!.id).toBe('a')
+  })
+
+  it('never lets a paid card carry the recommendation', () => {
+    const parsed = parseRemoteStarterTemplates(
+      doc([entry({ id: 'paid', apiNode: true, recommended: true })])
+    )
+    expect(parsed![0]!.apiNode, 'the card is kept').toBe(true)
+    expect(parsed![0]!.recommended, 'but never auto-selected, it spends credits').toBeFalsy()
+  })
+
+  it('allows one recommended per modality independently', () => {
+    const parsed = parseRemoteStarterTemplates(
+      doc([
+        entry({ id: 'i', modality: 'image', recommended: true }),
+        entry({ id: 'v', modality: 'video', recommended: true })
+      ])
+    )
+    expect(parsed!.filter((t) => t.recommended).map((t) => t.id)).toEqual(['i', 'v'])
+  })
+})
+
+describe('D. the hardcoded list is the floor', () => {
+  it('fills every modality to four when there is no remote list', () => {
+    const resolved = resolveStarterTemplates(null)
+    for (const modality of TEMPLATE_MODALITY_ORDER) {
+      expect(
+        resolved.filter((t) => t.modality === modality),
+        modality
+      ).toHaveLength(4)
+    }
+  })
+
+  it('keeps three good remote entries and backfills the fourth slot', () => {
+    const remote = parseRemoteStarterTemplates(
+      doc([
+        entry({ id: 'r1', modality: 'image' }),
+        entry({ id: 'r2', modality: 'image' }),
+        entry({ id: 'r3', modality: 'image' }),
+        entry({ id: 'bad', modality: 'nope' })
+      ])
+    )
+    const image = resolveStarterTemplates(remote).filter((t) => t.modality === 'image')
+    expect(image.map((t) => t.id).slice(0, 3), 'remote entries lead').toEqual(['r1', 'r2', 'r3'])
+    expect(image, 'the broken slot is backfilled').toHaveLength(4)
+    expect(bakedIds('image'), 'the fourth comes from the hardcoded list').toContain(image[3]!.id)
+  })
+
+  it('shows only remote cards when a modality is fully specified', () => {
+    const ids = ['r1', 'r2', 'r3', 'r4']
+    const remote = parseRemoteStarterTemplates(
+      doc(ids.map((id) => entry({ id, modality: 'image' })))
+    )
+    const image = resolveStarterTemplates(remote).filter((t) => t.modality === 'image')
+    expect(
+      image.map((t) => t.id),
+      'no hardcoded card leaks in'
+    ).toEqual(ids)
+  })
+
+  it('caps a modality at four even when the document sends more', () => {
+    const remote = parseRemoteStarterTemplates(
+      doc(Array.from({ length: 9 }, (_, i) => entry({ id: `r${i}`, modality: 'image' })))
+    )
+    const image = resolveStarterTemplates(remote).filter((t) => t.modality === 'image')
+    expect(image).toHaveLength(4)
+    expect(image.map((t) => t.id)).toEqual(['r0', 'r1', 'r2', 'r3'])
+  })
+
+  it('backfills untouched modalities entirely from the hardcoded list', () => {
+    const remote = parseRemoteStarterTemplates(doc([entry({ id: 'r1', modality: 'image' })]))
+    const resolved = resolveStarterTemplates(remote)
+    for (const modality of TEMPLATE_MODALITY_ORDER.filter((m) => m !== 'image')) {
+      expect(
+        resolved.filter((t) => t.modality === modality).map((t) => t.id),
+        modality
+      ).toEqual(bakedIds(modality))
+    }
+  })
+
+  it('never repeats an id a remote entry already claimed', () => {
+    const taken = bakedIds('image')[1]!
+    const remote = parseRemoteStarterTemplates(doc([entry({ id: taken, modality: 'image' })]))
+    const image = resolveStarterTemplates(remote).filter((t) => t.modality === 'image')
+    expect(new Set(image.map((t) => t.id)).size, 'ids collide on the picker option key').toBe(
+      image.length
+    )
+  })
+
+  it('holds every invariant across all four tabs at once', () => {
+    const resolved = resolveStarterTemplates(
+      parseRemoteStarterTemplates(doc([entry({ id: 'solo', modality: 'audio' })]))
+    )
+    for (const modality of TEMPLATE_MODALITY_ORDER) {
+      const cards = resolved.filter((t) => t.modality === modality)
+      expect(cards, `${modality} card count`).toHaveLength(4)
+      expect(
+        cards.filter((c) => c.recommended).length,
+        `${modality} auto-picks`
+      ).toBeLessThanOrEqual(1)
+      expect(
+        cards.filter((c) => c.recommended && c.apiNode),
+        `${modality} paid auto-pick`
+      ).toEqual([])
+    }
+    expect(new Set(resolved.map((t) => t.id)).size, 'catalog-wide id uniqueness').toBe(
+      resolved.length
+    )
+  })
+
+  it('gives a tab with no free card no recommendation at all', () => {
+    const remote = parseRemoteStarterTemplates(
+      doc(
+        Array.from({ length: 4 }, (_, i) =>
+          entry({ id: `paid${i}`, modality: 'image', apiNode: true })
+        )
+      )
+    )
+    const image = resolveStarterTemplates(remote).filter((t) => t.modality === 'image')
+    expect(
+      image.filter((c) => c.recommended),
+      'the wizard offers skip instead'
+    ).toEqual([])
+  })
+
+  it('promotes a free card when the document names no recommendation', () => {
+    const remote = parseRemoteStarterTemplates(
+      doc(['a', 'b', 'c', 'd'].map((id) => entry({ id, modality: 'image' })))
+    )
+    const image = resolveStarterTemplates(remote).filter((t) => t.modality === 'image')
+    expect(image.filter((c) => c.recommended)).toHaveLength(1)
+    expect(image.find((c) => c.recommended)!.apiNode).toBeFalsy()
+  })
+
+  it('keeps the tab order the picker renders in', () => {
+    const resolved = resolveStarterTemplates(null)
+    const seen = resolved.map((t) => t.modality).filter((m, i, a) => m !== a[i - 1])
+    expect(seen).toEqual([...TEMPLATE_MODALITY_ORDER])
+  })
+})
+
+describe('E. the network is never trusted to behave', () => {
+  beforeEach(() => {
+    mockedFetchJSON.mockReset()
+    _resetStarterTemplatesForTest()
+  })
+
+  it('serves the remote list when the fetch succeeds', async () => {
+    mockedFetchJSON.mockResolvedValue(doc([entry({ id: 'r1', modality: 'image' })]))
+    const loaded = await loadStarterTemplates()
+    expect(loaded.find((t) => t.id === 'r1')).toBeDefined()
+  })
+
+  it.each([
+    ['the request rejects', () => Promise.reject(new Error('offline'))],
+    ['the body is garbage', () => Promise.resolve('<html>502</html>')],
+    ['the body is null', () => Promise.resolve(null)]
+  ])('falls back to the hardcoded list when %s', async (_label, impl) => {
+    mockedFetchJSON.mockImplementation(impl)
+    const loaded = await loadStarterTemplates()
+    expect([...loaded].map((t) => t.id).sort(), 'every built-in card, and nothing else').toEqual(
+      [...CURATED_TEMPLATES].map((t) => t.id).sort()
+    )
+  })
+
+  it('fetches once per process, not once per picker open', async () => {
+    mockedFetchJSON.mockResolvedValue(doc([entry({ id: 'r1', modality: 'image' })]))
+    await Promise.all([loadStarterTemplates(), loadStarterTemplates()])
+    await loadStarterTemplates()
+    expect(mockedFetchJSON, 'a content change lands on the next boot').toHaveBeenCalledTimes(1)
+  })
+
+  it('reads from R2, bypassing any stale cached copy', async () => {
+    mockedFetchJSON.mockResolvedValue(doc([entry()]))
+    await loadStarterTemplates()
+    const [url, opts] = mockedFetchJSON.mock.calls[0] as [string, Record<string, unknown>]
+    expect(url).toContain('desktop-assets.comfy.org')
+    expect(opts, 'a stale ETag would strand users on withdrawn content').toMatchObject({
+      refresh: true
+    })
+  })
+
+  it('never rejects, whatever the network does', async () => {
+    mockedFetchJSON.mockImplementation(() => Promise.reject(new Error('boom')))
+    await expect(loadStarterTemplates()).resolves.toBeDefined()
+  })
+})

--- a/src/main/sources/standalone/remoteStarterTemplates.ts
+++ b/src/main/sources/standalone/remoteStarterTemplates.ts
@@ -1,25 +1,11 @@
 /**
- * Serves the picker's starter-template list from R2 so content can change it
- * without an app release, falling back to `CURATED_TEMPLATES` whenever the
- * remote document is unusable.
+ * The picker's starter-template list, served from R2 so content changes need no
+ * release. `CURATED_TEMPLATES` is the floor: invalid entries drop individually
+ * and an unusable document is ignored whole, so the picker always renders four
+ * cards per modality.
  *
- * Fallback is per entry, not all-or-nothing: three valid entries and one broken
- * one keeps the three and backfills the fourth slot. `CURATED_TEMPLATES` is the
- * floor, so the picker always shows four cards in each of the four modalities.
- *
- * Fetched once per process. A content change lands on the next launch, which is
- * why there is no disk cache: offline already falls back to the built-in list,
- * and a cached copy would keep serving a withdrawn payload indefinitely.
- *
- * This deliberately differs from `torchIndexManifest`, which persists a
- * last-good copy so offline reads keep working. That manifest has no usable
- * built-in fallback, whereas this one does, so here the built-in list is both
- * the safer and the fresher answer. Deleting the remote document is the
- * rollback, and it must take effect rather than be outlived by a cache.
- *
- * A failed fetch is memoized too, so a blip at boot serves the built-in list
- * for the process lifetime. That is the same next-launch contract, not an
- * oversight.
+ * Fetched once per process, with no disk cache — deleting the remote document
+ * is the rollback, so it must not be outlived by a cached copy.
  */
 import { fetchJSON } from '../../lib/fetch'
 import { R2_BASE_URL } from '../../lib/r2Mirror'
@@ -38,15 +24,13 @@ const SCHEMA_VERSION = 1
 const SLOTS_PER_MODALITY = 4
 const MAX_ID_LENGTH = 128
 const MAX_TEXT_LENGTH = 4096
-/** Comfortably past the largest real template (~57 GB) while still rejecting a
- *  value that would make the disk-space gate unsatisfiable. */
+/** Past the largest real template (~57 GB); beyond this the disk-space gate
+ *  becomes unsatisfiable and no install can proceed. */
 const MAX_SIZE_BYTES = 2 * 1024 ** 4
-/** Only 16 slots can ever be filled; the rest is wasted main-process work. */
 const MAX_ENTRIES = 256
-/** Clear the id pattern but name a directory rather than a template. */
+/** Clear `TEMPLATE_ID_PATTERN` but name a directory, not a template. */
 const RESERVED_IDS = new Set(['.', '..'])
-/** `fetchJSON` has no timeout of its own, and the picker blocks on this read,
- *  so a stalled connection would leave it rendering nothing. */
+/** `fetchJSON` has no timeout and the picker blocks on this read. */
 const FETCH_TIMEOUT_MS = 5000
 
 function isOptionalBoolean(value: unknown): boolean {
@@ -57,10 +41,10 @@ function isModality(value: unknown): value is TemplateModality {
   return typeof value === 'string' && (TEMPLATE_MODALITY_ORDER as readonly string[]).includes(value)
 }
 
+/** Trimmed, so a whitespace-only value renders as a blank card rather than
+ *  passing the emptiness check. */
 function safeText(value: unknown): string | null {
   if (typeof value !== 'string' || value.length > MAX_TEXT_LENGTH) return null
-  // Trimmed before the emptiness test: these strings go straight into the card,
-  // and a whitespace-only title renders as a blank card, not a missing one.
   const trimmed = value.trim()
   return trimmed || null
 }
@@ -73,22 +57,18 @@ function parseSnapshot(value: unknown): TemplateSnapshot | null {
   const mediaSubtype = safeText(r.mediaSubtype)
   if (!title || !description || !mediaSubtype) return null
   const { sizeBytes } = r
-  // Bounded because this drives the install-time disk-space gate: an absurd
-  // value would block every install with an unsatisfiable free-space check.
   if (!Number.isInteger(sizeBytes) || (sizeBytes as number) < 0) return null
   if ((sizeBytes as number) > MAX_SIZE_BYTES) return null
   return { title, description, sizeBytes: sizeBytes as number, mediaSubtype }
 }
 
-/** Default-deny: anything unexpected drops this entry alone. */
+/** Default-deny: anything unexpected drops this entry alone. `id` is validated
+ *  hardest — it reaches a deeplink URL and a package-relative path. */
 function parseEntry(value: unknown): CuratedTemplate | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null
   const r = value as Record<string, unknown>
 
   const { id } = r
-  // Shared with the picker's own validator, so the id cannot escape a path or
-  // URL and cannot smuggle in the "skip" sentinel. `.` and `..` clear that
-  // pattern but are path segments, not ids, so they are rejected outright.
   if (!isPersistableTemplateId(id) || id.length > MAX_ID_LENGTH) return null
   if (RESERVED_IDS.has(id)) return null
   if (!isModality(r.modality)) return null
@@ -96,16 +76,13 @@ function parseEntry(value: unknown): CuratedTemplate | null {
   const snapshot = parseSnapshot(r.snapshot)
   if (!snapshot) return null
 
-  // Default-deny the flags too. A truthy-but-not-true `apiNode` (`"true"`, `1`)
-  // would otherwise degrade to a free card, offering a paid template as free and
-  // making it eligible for the auto-pick badge.
+  // A truthy-but-not-true `apiNode` would degrade to a free card, offering a
+  // paid template as free.
   if (!isOptionalBoolean(r.apiNode) || !isOptionalBoolean(r.recommended)) return null
 
   const base = { id, modality: r.modality, snapshot }
   if (r.apiNode === true) {
-    // Contradictory under our own invariant: the auto-selected pick must never
-    // spend credits. Dropped rather than silently rewritten, so the slot
-    // backfills and the malformed row is not quietly made valid.
+    // Contradictory: dropped rather than rewritten into something valid.
     if (r.recommended === true) return null
     return { ...base, apiNode: true }
   }
@@ -140,20 +117,16 @@ export function parseRemoteStarterTemplates(raw: unknown): CuratedTemplate[] | n
     seen.add(entry.id)
     entries.push(entry)
   }
-  // The one-recommended-per-tab rule is owned by `enforceOneRecommended`, which
-  // re-derives it over the resolved slots. Demoting here too would be dead work.
   return entries.length > 0 ? entries : null
 }
 
 /**
- * Exactly one free card per tab carries the badge, so the wizard never
- * auto-selects a card that costs money. An all-paid tab gets none, and the
- * wizard offers skip instead.
+ * At most one free card per tab carries the badge, so the wizard never
+ * auto-selects a card that spends credits. An all-paid tab gets none.
  *
- * `fromRemote` is how many leading slots the remote document supplied. When it
- * filled any, the badge stays among them: a backfilled built-in card arrives
- * pre-flagged, and letting that win would hand the auto-pick to the one card
- * content did not choose.
+ * @param fromRemote leading slots the document supplied. The badge stays among
+ * them, since a backfilled card arrives pre-flagged and would otherwise claim
+ * an auto-pick content did not choose.
  */
 function enforceOneRecommended(cards: CuratedTemplate[], fromRemote: number): CuratedTemplate[] {
   const preferred = fromRemote > 0 ? cards.slice(0, fromRemote) : cards
@@ -164,27 +137,21 @@ function enforceOneRecommended(cards: CuratedTemplate[], fromRemote: number): Cu
     cards.find(free)
 
   return cards.map((card) => {
-    // Narrowed to the free arm of the union, so `recommended` is assignable
-    // without asserting past the type that makes the two mutually exclusive.
     if (card.apiNode === true) return card
     const { recommended: _drop, ...base } = card
     return card === winner ? { ...base, recommended: true } : base
   })
 }
 
-/** Modality each built-in id belongs to, so a remote entry cannot file one
- *  under a different tab and drain that tab's fallback. */
 const BUILT_IN_MODALITY = new Map(CURATED_TEMPLATES.map((t) => [t.id, t.modality]))
 
 /**
- * Merge the remote list with the built-in one: remote entries lead, then the
- * built-in list tops each modality up to four. Pass `null` to use the built-in
- * list alone.
+ * Remote entries lead, then the built-in list tops each modality up to four.
+ * Pass `null` for the built-in list alone.
  *
- * A remote entry reusing a built-in id must keep that id's modality. Otherwise
- * filing, say, the four image ids under `video` would consume them before the
- * image tab is reached, leaving it with nothing to fall back to — an empty tab
- * from a single content edit.
+ * A remote entry reusing a built-in id must keep that id's modality: filing the
+ * image ids under `video` would consume them before the image tab is reached,
+ * emptying it.
  */
 export function resolveStarterTemplates(
   remote: readonly CuratedTemplate[] | null
@@ -223,18 +190,16 @@ export function resolveStarterTemplates(
 
 let inFlight: Promise<CuratedTemplate[]> | null = null
 
-/**
- * The list the picker should render. Resolves once per process and never
- * rejects: any failure yields the built-in list.
- */
+/** Resolves once per process and never rejects: any failure, including a
+ *  timeout, yields the built-in list. */
 export function loadStarterTemplates(): Promise<CuratedTemplate[]> {
   inFlight ??= Promise.race([
     fetchJSON(STARTER_TEMPLATES_URL, { refresh: true }),
     new Promise<never>((_resolve, reject) => {
-      setTimeout(() => reject(new Error('starter-templates fetch timed out')), FETCH_TIMEOUT_MS)
-        // Never hold the process open for a timer whose only job is to bound a
-        // fetch the picker may already have given up on.
-        .unref?.()
+      setTimeout(
+        () => reject(new Error('starter-templates fetch timed out')),
+        FETCH_TIMEOUT_MS
+      ).unref?.()
     })
   ])
     .then((raw) => resolveStarterTemplates(parseRemoteStarterTemplates(raw)))
@@ -242,7 +207,7 @@ export function loadStarterTemplates(): Promise<CuratedTemplate[]> {
   return inFlight
 }
 
-/** @internal - exposed for tests. */
+/** @internal */
 export function _resetStarterTemplatesForTest(): void {
   inFlight = null
 }

--- a/src/main/sources/standalone/remoteStarterTemplates.ts
+++ b/src/main/sources/standalone/remoteStarterTemplates.ts
@@ -10,12 +10,23 @@
  * Fetched once per process. A content change lands on the next launch, which is
  * why there is no disk cache: offline already falls back to the built-in list,
  * and a cached copy would keep serving a withdrawn payload indefinitely.
+ *
+ * This deliberately differs from `torchIndexManifest`, which persists a
+ * last-good copy so offline reads keep working. That manifest has no usable
+ * built-in fallback, whereas this one does, so here the built-in list is both
+ * the safer and the fresher answer. Deleting the remote document is the
+ * rollback, and it must take effect rather than be outlived by a cache.
+ *
+ * A failed fetch is memoized too, so a blip at boot serves the built-in list
+ * for the process lifetime. That is the same next-launch contract, not an
+ * oversight.
  */
 import { fetchJSON } from '../../lib/fetch'
 import { R2_BASE_URL } from '../../lib/r2Mirror'
 import {
   CURATED_TEMPLATES,
   TEMPLATE_MODALITY_ORDER,
+  isPersistableTemplateId,
   type CuratedTemplate,
   type TemplateModality,
   type TemplateSnapshot
@@ -27,18 +38,27 @@ const SCHEMA_VERSION = 1
 const SLOTS_PER_MODALITY = 4
 const MAX_ID_LENGTH = 128
 const MAX_TEXT_LENGTH = 4096
-
-/** Mirrors the frontend's deeplink validator; the id reaches a URL and a
- *  package-relative path, so no separators and no control characters. */
-const TEMPLATE_ID_PATTERN = /^[a-zA-Z0-9_.-]+$/
+/** Comfortably past the largest real template (~57 GB) while still rejecting a
+ *  value that would make the disk-space gate unsatisfiable. */
+const MAX_SIZE_BYTES = 2 * 1024 ** 4
+/** Only 16 slots can ever be filled; the rest is wasted main-process work. */
+const MAX_ENTRIES = 256
+/** Clear the id pattern but name a directory rather than a template. */
+const RESERVED_IDS = new Set(['.', '..'])
+/** `fetchJSON` has no timeout of its own, and the picker blocks on this read,
+ *  so a stalled connection would leave it rendering nothing. */
+const FETCH_TIMEOUT_MS = 5000
 
 function isModality(value: unknown): value is TemplateModality {
   return typeof value === 'string' && (TEMPLATE_MODALITY_ORDER as readonly string[]).includes(value)
 }
 
 function safeText(value: unknown): string | null {
-  if (typeof value !== 'string' || !value || value.length > MAX_TEXT_LENGTH) return null
-  return value
+  if (typeof value !== 'string' || value.length > MAX_TEXT_LENGTH) return null
+  // Trimmed before the emptiness test: these strings go straight into the card,
+  // and a whitespace-only title renders as a blank card, not a missing one.
+  const trimmed = value.trim()
+  return trimmed || null
 }
 
 function parseSnapshot(value: unknown): TemplateSnapshot | null {
@@ -49,8 +69,11 @@ function parseSnapshot(value: unknown): TemplateSnapshot | null {
   const mediaSubtype = safeText(r.mediaSubtype)
   if (!title || !description || !mediaSubtype) return null
   const { sizeBytes } = r
-  if (typeof sizeBytes !== 'number' || !Number.isFinite(sizeBytes) || sizeBytes < 0) return null
-  return { title, description, sizeBytes, mediaSubtype }
+  // Bounded because this drives the install-time disk-space gate: an absurd
+  // value would block every install with an unsatisfiable free-space check.
+  if (!Number.isInteger(sizeBytes) || (sizeBytes as number) < 0) return null
+  if ((sizeBytes as number) > MAX_SIZE_BYTES) return null
+  return { title, description, sizeBytes: sizeBytes as number, mediaSubtype }
 }
 
 /** Default-deny: anything unexpected drops this entry alone. */
@@ -59,20 +82,25 @@ function parseEntry(value: unknown): CuratedTemplate | null {
   const r = value as Record<string, unknown>
 
   const { id } = r
-  if (typeof id !== 'string' || id.length > MAX_ID_LENGTH || !TEMPLATE_ID_PATTERN.test(id)) {
-    return null
-  }
+  // Shared with the picker's own validator, so the id cannot escape a path or
+  // URL and cannot smuggle in the "skip" sentinel. `.` and `..` clear that
+  // pattern but are path segments, not ids, so they are rejected outright.
+  if (!isPersistableTemplateId(id) || id.length > MAX_ID_LENGTH) return null
+  if (RESERVED_IDS.has(id)) return null
   if (!isModality(r.modality)) return null
 
   const snapshot = parseSnapshot(r.snapshot)
   if (!snapshot) return null
 
   const base = { id, modality: r.modality, snapshot }
-  // A paid card never carries the recommendation: the auto-selected pick must
-  // not spend credits on first run.
-  return r.apiNode === true
-    ? { ...base, apiNode: true }
-    : { ...base, ...(r.recommended === true ? { recommended: true as const } : {}) }
+  if (r.apiNode === true) {
+    // Contradictory under our own invariant: the auto-selected pick must never
+    // spend credits. Dropped rather than silently rewritten, so the slot
+    // backfills and the malformed row is not quietly made valid.
+    if (r.recommended === true) return null
+    return { ...base, apiNode: true }
+  }
+  return { ...base, ...(r.recommended === true ? { recommended: true as const } : {}) }
 }
 
 /**
@@ -91,58 +119,78 @@ export function parseRemoteStarterTemplates(raw: unknown): CuratedTemplate[] | n
   }
   if (!data || typeof data !== 'object' || Array.isArray(data)) return null
 
-  const document = data as Record<string, unknown>
-  if (document.schemaVersion !== SCHEMA_VERSION) return null
-  if (!Array.isArray(document.templates)) return null
+  const payload = data as Record<string, unknown>
+  if (payload.schemaVersion !== SCHEMA_VERSION) return null
+  if (!Array.isArray(payload.templates)) return null
 
   const seen = new Set<string>()
   const entries: CuratedTemplate[] = []
-  for (const value of document.templates) {
+  for (const value of payload.templates.slice(0, MAX_ENTRIES)) {
     const entry = parseEntry(value)
     if (!entry || seen.has(entry.id)) continue
     seen.add(entry.id)
     entries.push(entry)
   }
-  if (entries.length === 0) return null
-
-  const claimed = new Set<TemplateModality>()
-  return entries.map((entry) => {
-    if (entry.recommended !== true) return entry
-    if (claimed.has(entry.modality)) {
-      const { recommended: _demoted, ...rest } = entry
-      return rest as CuratedTemplate
-    }
-    claimed.add(entry.modality)
-    return entry
-  })
+  // The one-recommended-per-tab rule is owned by `enforceOneRecommended`, which
+  // re-derives it over the resolved slots. Demoting here too would be dead work.
+  return entries.length > 0 ? entries : null
 }
 
-/** Exactly one free card per tab carries the badge, so the wizard never
- *  auto-selects a card that costs money. An all-paid tab gets none. */
-function enforceOneRecommended(cards: CuratedTemplate[]): CuratedTemplate[] {
-  const winner = cards.find((c) => c.recommended && !c.apiNode) ?? cards.find((c) => !c.apiNode)
+/**
+ * Exactly one free card per tab carries the badge, so the wizard never
+ * auto-selects a card that costs money. An all-paid tab gets none, and the
+ * wizard offers skip instead.
+ *
+ * `fromRemote` is how many leading slots the remote document supplied. When it
+ * filled any, the badge stays among them: a backfilled built-in card arrives
+ * pre-flagged, and letting that win would hand the auto-pick to the one card
+ * content did not choose.
+ */
+function enforceOneRecommended(cards: CuratedTemplate[], fromRemote: number): CuratedTemplate[] {
+  const preferred = fromRemote > 0 ? cards.slice(0, fromRemote) : cards
+  const free = (c: CuratedTemplate): boolean => c.apiNode !== true
+  const winner =
+    preferred.find((c) => c.recommended === true && free(c)) ??
+    preferred.find(free) ??
+    cards.find(free)
+
   return cards.map((card) => {
-    if (card.apiNode) return card
-    const shouldRecommend = card === winner
-    if (shouldRecommend === (card.recommended === true)) return card
-    const { recommended: _drop, ...rest } = card
-    return (shouldRecommend ? { ...rest, recommended: true as const } : rest) as CuratedTemplate
+    // Narrowed to the free arm of the union, so `recommended` is assignable
+    // without asserting past the type that makes the two mutually exclusive.
+    if (card.apiNode === true) return card
+    const { recommended: _drop, ...base } = card
+    return card === winner ? { ...base, recommended: true } : base
   })
 }
+
+/** Modality each built-in id belongs to, so a remote entry cannot file one
+ *  under a different tab and drain that tab's fallback. */
+const BUILT_IN_MODALITY = new Map(CURATED_TEMPLATES.map((t) => [t.id, t.modality]))
 
 /**
  * Merge the remote list with the built-in one: remote entries lead, then the
  * built-in list tops each modality up to four. Pass `null` to use the built-in
  * list alone.
+ *
+ * A remote entry reusing a built-in id must keep that id's modality. Otherwise
+ * filing, say, the four image ids under `video` would consume them before the
+ * image tab is reached, leaving it with nothing to fall back to — an empty tab
+ * from a single content edit.
  */
 export function resolveStarterTemplates(
   remote: readonly CuratedTemplate[] | null
 ): CuratedTemplate[] {
+  const eligible = remote?.filter((entry) => {
+    const builtIn = BUILT_IN_MODALITY.get(entry.id)
+    return builtIn === undefined || builtIn === entry.modality
+  })
+
   const used = new Set<string>()
   const resolved: CuratedTemplate[] = []
 
   for (const modality of TEMPLATE_MODALITY_ORDER) {
     const slots: CuratedTemplate[] = []
+    let fromRemote = 0
 
     const take = (candidates: readonly CuratedTemplate[]): void => {
       for (const candidate of candidates) {
@@ -153,10 +201,13 @@ export function resolveStarterTemplates(
       }
     }
 
-    if (remote) take(remote)
+    if (eligible) {
+      take(eligible)
+      fromRemote = slots.length
+    }
     take(CURATED_TEMPLATES)
 
-    resolved.push(...enforceOneRecommended(slots))
+    resolved.push(...enforceOneRecommended(slots, fromRemote))
   }
   return resolved
 }
@@ -168,7 +219,15 @@ let inFlight: Promise<CuratedTemplate[]> | null = null
  * rejects: any failure yields the built-in list.
  */
 export function loadStarterTemplates(): Promise<CuratedTemplate[]> {
-  inFlight ??= fetchJSON(STARTER_TEMPLATES_URL, { refresh: true })
+  inFlight ??= Promise.race([
+    fetchJSON(STARTER_TEMPLATES_URL, { refresh: true }),
+    new Promise<never>((_resolve, reject) => {
+      setTimeout(() => reject(new Error('starter-templates fetch timed out')), FETCH_TIMEOUT_MS)
+        // Never hold the process open for a timer whose only job is to bound a
+        // fetch the picker may already have given up on.
+        .unref?.()
+    })
+  ])
     .then((raw) => resolveStarterTemplates(parseRemoteStarterTemplates(raw)))
     .catch(() => resolveStarterTemplates(null))
   return inFlight

--- a/src/main/sources/standalone/remoteStarterTemplates.ts
+++ b/src/main/sources/standalone/remoteStarterTemplates.ts
@@ -49,6 +49,10 @@ const RESERVED_IDS = new Set(['.', '..'])
  *  so a stalled connection would leave it rendering nothing. */
 const FETCH_TIMEOUT_MS = 5000
 
+function isOptionalBoolean(value: unknown): boolean {
+  return value === undefined || typeof value === 'boolean'
+}
+
 function isModality(value: unknown): value is TemplateModality {
   return typeof value === 'string' && (TEMPLATE_MODALITY_ORDER as readonly string[]).includes(value)
 }
@@ -91,6 +95,11 @@ function parseEntry(value: unknown): CuratedTemplate | null {
 
   const snapshot = parseSnapshot(r.snapshot)
   if (!snapshot) return null
+
+  // Default-deny the flags too. A truthy-but-not-true `apiNode` (`"true"`, `1`)
+  // would otherwise degrade to a free card, offering a paid template as free and
+  // making it eligible for the auto-pick badge.
+  if (!isOptionalBoolean(r.apiNode) || !isOptionalBoolean(r.recommended)) return null
 
   const base = { id, modality: r.modality, snapshot }
   if (r.apiNode === true) {

--- a/src/main/sources/standalone/remoteStarterTemplates.ts
+++ b/src/main/sources/standalone/remoteStarterTemplates.ts
@@ -1,0 +1,180 @@
+/**
+ * Serves the picker's starter-template list from R2 so content can change it
+ * without an app release, falling back to `CURATED_TEMPLATES` whenever the
+ * remote document is unusable.
+ *
+ * Fallback is per entry, not all-or-nothing: three valid entries and one broken
+ * one keeps the three and backfills the fourth slot. `CURATED_TEMPLATES` is the
+ * floor, so the picker always shows four cards in each of the four modalities.
+ *
+ * Fetched once per process. A content change lands on the next launch, which is
+ * why there is no disk cache: offline already falls back to the built-in list,
+ * and a cached copy would keep serving a withdrawn payload indefinitely.
+ */
+import { fetchJSON } from '../../lib/fetch'
+import { R2_BASE_URL } from '../../lib/r2Mirror'
+import {
+  CURATED_TEMPLATES,
+  TEMPLATE_MODALITY_ORDER,
+  type CuratedTemplate,
+  type TemplateModality,
+  type TemplateSnapshot
+} from './curatedTemplates'
+
+export const STARTER_TEMPLATES_URL = `${R2_BASE_URL}/starter-templates.json`
+
+const SCHEMA_VERSION = 1
+const SLOTS_PER_MODALITY = 4
+const MAX_ID_LENGTH = 128
+const MAX_TEXT_LENGTH = 4096
+
+/** Mirrors the frontend's deeplink validator; the id reaches a URL and a
+ *  package-relative path, so no separators and no control characters. */
+const TEMPLATE_ID_PATTERN = /^[a-zA-Z0-9_.-]+$/
+
+function isModality(value: unknown): value is TemplateModality {
+  return typeof value === 'string' && (TEMPLATE_MODALITY_ORDER as readonly string[]).includes(value)
+}
+
+function safeText(value: unknown): string | null {
+  if (typeof value !== 'string' || !value || value.length > MAX_TEXT_LENGTH) return null
+  return value
+}
+
+function parseSnapshot(value: unknown): TemplateSnapshot | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const r = value as Record<string, unknown>
+  const title = safeText(r.title)
+  const description = safeText(r.description)
+  const mediaSubtype = safeText(r.mediaSubtype)
+  if (!title || !description || !mediaSubtype) return null
+  const { sizeBytes } = r
+  if (typeof sizeBytes !== 'number' || !Number.isFinite(sizeBytes) || sizeBytes < 0) return null
+  return { title, description, sizeBytes, mediaSubtype }
+}
+
+/** Default-deny: anything unexpected drops this entry alone. */
+function parseEntry(value: unknown): CuratedTemplate | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const r = value as Record<string, unknown>
+
+  const { id } = r
+  if (typeof id !== 'string' || id.length > MAX_ID_LENGTH || !TEMPLATE_ID_PATTERN.test(id)) {
+    return null
+  }
+  if (!isModality(r.modality)) return null
+
+  const snapshot = parseSnapshot(r.snapshot)
+  if (!snapshot) return null
+
+  const base = { id, modality: r.modality, snapshot }
+  // A paid card never carries the recommendation: the auto-selected pick must
+  // not spend credits on first run.
+  return r.apiNode === true
+    ? { ...base, apiNode: true }
+    : { ...base, ...(r.recommended === true ? { recommended: true as const } : {}) }
+}
+
+/**
+ * Validate a remote document. Returns `null` when it is unusable as a whole —
+ * bad JSON, an unknown `schemaVersion`, or no entry surviving validation — so
+ * the caller keeps the built-in list rather than half-applying an edit.
+ */
+export function parseRemoteStarterTemplates(raw: unknown): CuratedTemplate[] | null {
+  let data = raw
+  if (typeof data === 'string') {
+    try {
+      data = JSON.parse(data)
+    } catch {
+      return null
+    }
+  }
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return null
+
+  const document = data as Record<string, unknown>
+  if (document.schemaVersion !== SCHEMA_VERSION) return null
+  if (!Array.isArray(document.templates)) return null
+
+  const seen = new Set<string>()
+  const entries: CuratedTemplate[] = []
+  for (const value of document.templates) {
+    const entry = parseEntry(value)
+    if (!entry || seen.has(entry.id)) continue
+    seen.add(entry.id)
+    entries.push(entry)
+  }
+  if (entries.length === 0) return null
+
+  const claimed = new Set<TemplateModality>()
+  return entries.map((entry) => {
+    if (entry.recommended !== true) return entry
+    if (claimed.has(entry.modality)) {
+      const { recommended: _demoted, ...rest } = entry
+      return rest as CuratedTemplate
+    }
+    claimed.add(entry.modality)
+    return entry
+  })
+}
+
+/** Exactly one free card per tab carries the badge, so the wizard never
+ *  auto-selects a card that costs money. An all-paid tab gets none. */
+function enforceOneRecommended(cards: CuratedTemplate[]): CuratedTemplate[] {
+  const winner = cards.find((c) => c.recommended && !c.apiNode) ?? cards.find((c) => !c.apiNode)
+  return cards.map((card) => {
+    if (card.apiNode) return card
+    const shouldRecommend = card === winner
+    if (shouldRecommend === (card.recommended === true)) return card
+    const { recommended: _drop, ...rest } = card
+    return (shouldRecommend ? { ...rest, recommended: true as const } : rest) as CuratedTemplate
+  })
+}
+
+/**
+ * Merge the remote list with the built-in one: remote entries lead, then the
+ * built-in list tops each modality up to four. Pass `null` to use the built-in
+ * list alone.
+ */
+export function resolveStarterTemplates(
+  remote: readonly CuratedTemplate[] | null
+): CuratedTemplate[] {
+  const used = new Set<string>()
+  const resolved: CuratedTemplate[] = []
+
+  for (const modality of TEMPLATE_MODALITY_ORDER) {
+    const slots: CuratedTemplate[] = []
+
+    const take = (candidates: readonly CuratedTemplate[]): void => {
+      for (const candidate of candidates) {
+        if (slots.length >= SLOTS_PER_MODALITY) break
+        if (candidate.modality !== modality || used.has(candidate.id)) continue
+        used.add(candidate.id)
+        slots.push(candidate)
+      }
+    }
+
+    if (remote) take(remote)
+    take(CURATED_TEMPLATES)
+
+    resolved.push(...enforceOneRecommended(slots))
+  }
+  return resolved
+}
+
+let inFlight: Promise<CuratedTemplate[]> | null = null
+
+/**
+ * The list the picker should render. Resolves once per process and never
+ * rejects: any failure yields the built-in list.
+ */
+export function loadStarterTemplates(): Promise<CuratedTemplate[]> {
+  inFlight ??= fetchJSON(STARTER_TEMPLATES_URL, { refresh: true })
+    .then((raw) => resolveStarterTemplates(parseRemoteStarterTemplates(raw)))
+    .catch(() => resolveStarterTemplates(null))
+  return inFlight
+}
+
+/** @internal - exposed for tests. */
+export function _resetStarterTemplatesForTest(): void {
+  inFlight = null
+}

--- a/src/main/sources/standalone/templateCatalog.test.ts
+++ b/src/main/sources/standalone/templateCatalog.test.ts
@@ -8,6 +8,11 @@ import { fetchJSON } from '../../lib/fetch'
 
 const mockedFetchJSON = vi.mocked(fetchJSON)
 
+/** Index fetches only — the catalog also reads the starter list from R2, and
+ *  these assertions are about how often the index is re-read. */
+const indexFetches = (): number =>
+  mockedFetchJSON.mock.calls.filter(([url]) => String(url).includes('index.json')).length
+
 /** A live index with one category whose templates override the given curated
  *  ids' metadata. */
 function indexFor(overrides: Record<string, Record<string, unknown>>, category = 'Image'): unknown {
@@ -121,7 +126,11 @@ describe('loadTemplateCatalog', () => {
   })
 
   it('flags API-node templates from the manifest, offline included', async () => {
-    mockedFetchJSON.mockImplementationOnce(() => Promise.reject(new Error('offline')))
+    mockedFetchJSON.mockImplementation((url: string) =>
+      String(url).includes('index.json')
+        ? Promise.reject(new Error('offline'))
+        : Promise.resolve(null)
+    )
     const catalog = await loadTemplateCatalog()
     for (const curated of CURATED_TEMPLATES) {
       expect(catalog.find((c) => c.id === curated.id)!.apiNode, curated.id).toBe(
@@ -157,7 +166,11 @@ describe('loadTemplateCatalog', () => {
   })
 
   it('returns a snapshot-only catalog when the fetch rejects (offline)', async () => {
-    mockedFetchJSON.mockImplementationOnce(() => Promise.reject(new Error('offline')))
+    mockedFetchJSON.mockImplementation((url: string) =>
+      String(url).includes('index.json')
+        ? Promise.reject(new Error('offline'))
+        : Promise.resolve(null)
+    )
     const catalog = await loadTemplateCatalog()
     expect(catalog.length).toBe(CURATED_TEMPLATES.length)
     const first = CURATED_TEMPLATES[0]!
@@ -173,7 +186,7 @@ describe('loadTemplateCatalog', () => {
   it('fetches the index exactly once regardless of curated count', async () => {
     mockedFetchJSON.mockResolvedValue([])
     await loadTemplateCatalog()
-    expect(mockedFetchJSON).toHaveBeenCalledTimes(1)
+    expect(indexFetches()).toBe(1)
   })
 
   // --- Resilience: a renamed/removed template upstream can only shrink the
@@ -287,7 +300,7 @@ describe('loadTemplateCatalog', () => {
   it('coalesces concurrent reads into a single index fetch', async () => {
     mockedFetchJSON.mockResolvedValue([])
     const [a, b] = await Promise.all([loadTemplateCatalog(), loadTemplateCatalog()])
-    expect(mockedFetchJSON).toHaveBeenCalledTimes(1)
+    expect(indexFetches()).toBe(1)
     expect(a).toBe(b)
   })
 
@@ -295,11 +308,11 @@ describe('loadTemplateCatalog', () => {
     mockedFetchJSON.mockResolvedValue([])
     await loadTemplateCatalog()
     await loadTemplateCatalog()
-    expect(mockedFetchJSON).toHaveBeenCalledTimes(1)
+    expect(indexFetches()).toBe(1)
 
     resetTemplateCatalogCache()
     await loadTemplateCatalog()
-    expect(mockedFetchJSON).toHaveBeenCalledTimes(2)
+    expect(indexFetches()).toBe(2)
   })
 
   it('refetches once the TTL lapses', async () => {
@@ -309,7 +322,7 @@ describe('loadTemplateCatalog', () => {
       await loadTemplateCatalog()
       vi.advanceTimersByTime(60_001)
       await loadTemplateCatalog()
-      expect(mockedFetchJSON).toHaveBeenCalledTimes(2)
+      expect(indexFetches()).toBe(2)
     } finally {
       vi.useRealTimers()
     }

--- a/src/main/sources/standalone/templateCatalog.ts
+++ b/src/main/sources/standalone/templateCatalog.ts
@@ -11,8 +11,8 @@
  * non-empty and the picker always renders.
  */
 import { fetchJSON } from '../../lib/fetch'
+import { loadStarterTemplates } from './remoteStarterTemplates'
 import {
-  CURATED_TEMPLATES,
   INDEX_URL,
   TEMPLATE_MODALITY_ORDER,
   thumbnailUrlFor,
@@ -225,19 +225,22 @@ export function resetTemplateCatalogCache(): void {
 }
 
 async function loadTemplateCatalogUncached(): Promise<HydratedTemplate[]> {
-  let byId: Map<string, IndexLocation>
-  try {
-    byId = indexById(await fetchJSON(INDEX_URL))
-  } catch {
-    byId = new Map()
-  }
+  // The card list comes from R2 so content can change it without a release;
+  // `loadStarterTemplates` falls back to `CURATED_TEMPLATES` on any failure and
+  // never rejects, so this stays a straight read.
+  const [starterTemplates, index] = await Promise.all([
+    loadStarterTemplates(),
+    fetchJSON(INDEX_URL).catch(() => null)
+  ])
+
+  const byId = index ? indexById(index) : new Map<string, IndexLocation>()
   // Only substitute when we actually have a live index to substitute FROM —
   // an empty map means offline, where the curated snapshot is the right fallback.
   const online = byId.size > 0
 
   const used = new Set<string>()
   const catalog: HydratedTemplate[] = []
-  for (const curated of CURATED_TEMPLATES) {
+  for (const curated of starterTemplates) {
     if (!curated?.id || used.has(curated.id) || !curated.snapshot) continue
 
     const recommended = curated.recommended === true

--- a/src/main/sources/standalone/templateCatalog.ts
+++ b/src/main/sources/standalone/templateCatalog.ts
@@ -11,7 +11,7 @@
  * non-empty and the picker always renders.
  */
 import { fetchJSON } from '../../lib/fetch'
-import { loadStarterTemplates } from './remoteStarterTemplates'
+import { loadStarterTemplates, _resetStarterTemplatesForTest } from './remoteStarterTemplates'
 import {
   INDEX_URL,
   TEMPLATE_MODALITY_ORDER,
@@ -222,6 +222,9 @@ export function loadTemplateCatalog(): Promise<HydratedTemplate[]> {
 export function resetTemplateCatalogCache(): void {
   catalogInFlight = null
   catalogCache = null
+  // The starter list is memoized for the process, so leaving it would make a
+  // reset only half-work and any fetch-count assertion order-dependent.
+  _resetStarterTemplatesForTest()
 }
 
 async function loadTemplateCatalogUncached(): Promise<HydratedTemplate[]> {


### PR DESCRIPTION
## Summary
The install picker's starter-template list is now served from R2 instead of being hardcoded, so the curated set can change without shipping a desktop release. The bundled `CURATED_TEMPLATES` stays as the floor: if the remote document is missing, malformed, or partially invalid, the picker still renders its four cards per modality from the built-in set.

## Changes
- The starter list is fetched from `starter-templates.json` on R2 once per process, in parallel with the existing template index, and neither read can reject the picker path (both fall back on failure).
- The remote document is treated as fully untrusted input and validated field by field: bad entries drop individually, an unusable document is ignored whole, and per-modality slots are filled from the curated floor so the grid is never short.
- Deleting the remote document is the rollback, so there is no disk cache to outlive it; the list is memoized only for the life of the process.
- Guardrails on the parsed values: id pattern and reserved-name checks, text length caps, a non-negative integer size with an upper bound past the largest real template (beyond it the disk-space gate is unsatisfiable), an entry cap, and a fetch timeout since the picker blocks on this read.
- `apiNode` and `recommended` must be real booleans; a truthy non-boolean (e.g. a string) is rejected rather than coerced.

**Breaking**: None. With no remote document, or any fetch/parse failure, behavior is identical to today's hardcoded list. The template index read, its URL, and the card contract are unchanged.

## Review Focus
- `remoteStarterTemplates.ts` is the whole trust boundary. The riskiest hunks are `parseSnapshot` and the per-entry validation loop: a value that slips through here reaches the picker and the downstream disk-space gate, so the size bound and the integer/boolean rejections are load-bearing, not cosmetic.
- The `templateCatalog.ts` seam: `loadStarterTemplates()` must never reject (the `Promise.all` has no catch around it by design, the function owns its own fallback). Worth confirming the fallback-to-curated path can't throw.
- Scope boundary: this only swaps the source of the list. It does not touch the index lookup, the card component, or how templates install.

## Testing
Unit tests drive the parser and the catalog seam directly, since this is pure main-process logic with no UI.

- `remoteStarterTemplates.test.ts`: the validation matrix, one case per rejection (bad id, oversized text, negative/huge/non-integer size, non-boolean flags, reserved ids, over-cap entries, fetch failure, timeout) plus the happy path and the partial-drop-then-fill-from-curated behavior.
- `templateCatalog.test.ts` / `index.test.ts`: the seam, that the remote list feeds the grid when valid and falls back to curated on failure without changing the index read.

Gate: `typecheck:node` clean; the three affected suites pass (149 tests). No mutation-QA matrix on this branch (it did not go through the qs pipeline), so this section is from the real test files, not recorded survivor data.

Rebased on the latest `main` (`1.0.40-rc.1`); no conflicts with our files.
