### PR TITLE
Fix startup argument refresh after ComfyUI updates

### DIFF
--- a/src/main/lib/comfy-args.test.ts
+++ b/src/main/lib/comfy-args.test.ts
@@ -1,10 +1,36 @@
-import { describe, it, expect } from 'vitest'
-import { parseHelpOutput, validateArgs, filterUnsupportedArgs } from './comfy-args'
+// @vitest-environment node
+import { execFile } from 'child_process'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return { ...actual, execFile: vi.fn() }
+})
+
+import {
+  clearSchemaCache,
+  filterUnsupportedArgs,
+  getComfyArgsSchema,
+  parseHelpOutput,
+  validateArgs
+} from './comfy-args'
+
+const mockedExecFile = vi.mocked(execFile)
+
+function mockHelpOutput(getOutput: () => string): void {
+  mockedExecFile.mockImplementation(((
+    _cmd: string,
+    _args: string[],
+    _options: Record<string, unknown>,
+    callback: (err: Error | null, stdout: string, stderr: string) => void
+  ) => callback(null, getOutput(), '')) as never)
+}
 
 const SAMPLE_HELP = `usage: main.py [-h] [--listen [IP]] [--port PORT]
                [--cuda-malloc | --disable-cuda-malloc]
                [--force-fp32 | --force-fp16]
                [--gpu-only | --highvram | --normalvram | --lowvram | --novram | --cpu]
+               [--use-pytorch-cross-attention | --use-ck-attention]
                [--preview-method [none,auto,latent2rgb,taesd]]
                [--verbose [{DEBUG,INFO,WARNING,ERROR,CRITICAL}]]
                [--enable-manager]
@@ -26,6 +52,9 @@ options:
   --lowvram             Split the unet in parts to use less vram.
   --novram              When lowvram isn't enough.
   --cpu                 To use the CPU for everything (slow).
+  --use-pytorch-cross-attention
+                        Use the pytorch cross attention function.
+  --use-ck-attention    Use Comfy Kitchen attention.
   --preview-method [none,auto,latent2rgb,taesd]
                         Default preview method for sampler nodes.
   --verbose [{DEBUG,INFO,WARNING,ERROR,CRITICAL}]
@@ -43,6 +72,7 @@ describe('parseHelpOutput', () => {
     expect(byName.get('cuda-malloc')?.type).toBe('boolean')
     expect(byName.get('force-fp32')?.type).toBe('boolean')
     expect(byName.get('gpu-only')?.type).toBe('boolean')
+    expect(byName.get('use-ck-attention')?.type).toBe('boolean')
 
     // Value flag
     expect(byName.get('port')?.type).toBe('value')
@@ -112,6 +142,10 @@ options:
 
     // force-fp32 and force-fp16 should be exclusive
     expect(byName.get('force-fp32')?.exclusiveGroup).toBe(byName.get('force-fp16')?.exclusiveGroup)
+
+    expect(byName.get('use-ck-attention')?.exclusiveGroup).toBe(
+      byName.get('use-pytorch-cross-attention')?.exclusiveGroup
+    )
   })
 
   it('populates knownFlags set', () => {
@@ -129,6 +163,7 @@ options:
     expect(byName.get('port')?.category).toBe('network')
     expect(byName.get('listen')?.category).toBe('network')
     expect(byName.get('gpu-only')?.category).toBe('gpuVram')
+    expect(byName.get('use-ck-attention')?.category).toBe('performance')
     expect(byName.get('enable-manager')?.category).toBe('manager')
   })
 
@@ -228,6 +263,47 @@ options:
   })
 })
 
+describe('getComfyArgsSchema', () => {
+  const installationId = 'updated-comfy-install'
+
+  beforeEach(() => {
+    clearSchemaCache(installationId)
+    mockedExecFile.mockReset()
+  })
+
+  it('reuses a schema for one revision and refreshes it when the revision changes', async () => {
+    const oldHelp = SAMPLE_HELP.replace(' | --use-ck-attention', '').replace(
+      '  --use-ck-attention    Use Comfy Kitchen attention.\n',
+      ''
+    )
+    let helpOutput = oldHelp
+    mockHelpOutput(() => helpOutput)
+
+    const oldSchema = await getComfyArgsSchema(
+      'python',
+      'main.py',
+      '.',
+      installationId,
+      'old-commit'
+    )
+    expect(oldSchema.knownFlags.has('use-ck-attention')).toBe(false)
+
+    await getComfyArgsSchema('python', 'main.py', '.', installationId, 'old-commit')
+    expect(mockedExecFile).toHaveBeenCalledTimes(1)
+
+    helpOutput = SAMPLE_HELP
+    const updatedSchema = await getComfyArgsSchema(
+      'python',
+      'main.py',
+      '.',
+      installationId,
+      'new-commit'
+    )
+    expect(mockedExecFile).toHaveBeenCalledTimes(2)
+    expect(updatedSchema.knownFlags.has('use-ck-attention')).toBe(true)
+  })
+})
+
 describe('validateArgs', () => {
   it('identifies unsupported flags', () => {
     const schema = parseHelpOutput(SAMPLE_HELP)
@@ -237,7 +313,10 @@ describe('validateArgs', () => {
 
   it('returns empty for all valid args', () => {
     const schema = parseHelpOutput(SAMPLE_HELP)
-    const unsupported = validateArgs(['--port', '8188', '--enable-manager'], schema)
+    const unsupported = validateArgs(
+      ['--port', '8188', '--use-ck-attention', '--enable-manager'],
+      schema
+    )
     expect(unsupported).toEqual([])
   })
 })
@@ -264,10 +343,16 @@ describe('filterUnsupportedArgs', () => {
   it('preserves all args when all are valid', () => {
     const schema = parseHelpOutput(SAMPLE_HELP)
     const filtered = filterUnsupportedArgs(
-      ['--port', '8188', '--listen', '--enable-manager'],
+      ['--port', '8188', '--listen', '--use-ck-attention', '--enable-manager'],
       schema
     )
-    expect(filtered).toEqual(['--port', '8188', '--listen', '--enable-manager'])
+    expect(filtered).toEqual([
+      '--port',
+      '8188',
+      '--listen',
+      '--use-ck-attention',
+      '--enable-manager'
+    ])
   })
 
   it('does not consume next token when skipping --unknown=value', () => {

--- a/src/main/lib/comfy-args.test.ts
+++ b/src/main/lib/comfy-args.test.ts
@@ -147,9 +147,9 @@ options:
     // force-fp32 and force-fp16 should be exclusive
     expect(byName.get('force-fp32')?.exclusiveGroup).toBe(byName.get('force-fp16')?.exclusiveGroup)
 
-    expect(byName.get('use-ck-attention')?.exclusiveGroup).toBe(
-      byName.get('use-pytorch-cross-attention')?.exclusiveGroup
-    )
+    const ckAttentionGroup = byName.get('use-ck-attention')?.exclusiveGroup
+    expect(ckAttentionGroup).toBeDefined()
+    expect(ckAttentionGroup).toBe(byName.get('use-pytorch-cross-attention')?.exclusiveGroup)
   })
 
   it('populates knownFlags set', () => {

--- a/src/main/lib/comfy-args.test.ts
+++ b/src/main/lib/comfy-args.test.ts
@@ -1,11 +1,14 @@
 // @vitest-environment node
 import { execFile } from 'child_process'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { readGitHead } from './git'
 
 vi.mock('child_process', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>
   return { ...actual, execFile: vi.fn() }
 })
+
+vi.mock('./git', () => ({ readGitHead: vi.fn() }))
 
 import {
   clearSchemaCache,
@@ -16,6 +19,7 @@ import {
 } from './comfy-args'
 
 const mockedExecFile = vi.mocked(execFile)
+const mockedReadGitHead = vi.mocked(readGitHead)
 
 function mockHelpOutput(getOutput: () => string): void {
   mockedExecFile.mockImplementation(((
@@ -269,35 +273,38 @@ describe('getComfyArgsSchema', () => {
   beforeEach(() => {
     clearSchemaCache(installationId)
     mockedExecFile.mockReset()
+    mockedReadGitHead.mockReset()
   })
 
-  it('reuses a schema for one revision and refreshes it when the revision changes', async () => {
+  it('reuses a schema for one commit and refreshes it when the checkout changes', async () => {
     const oldHelp = SAMPLE_HELP.replace(' | --use-ck-attention', '').replace(
       '  --use-ck-attention    Use Comfy Kitchen attention.\n',
       ''
     )
     let helpOutput = oldHelp
     mockHelpOutput(() => helpOutput)
+    mockedReadGitHead.mockReturnValue('old-commit')
 
     const oldSchema = await getComfyArgsSchema(
       'python',
       'main.py',
       '.',
       installationId,
-      'old-commit'
+      'stored-version'
     )
     expect(oldSchema.knownFlags.has('use-ck-attention')).toBe(false)
 
-    await getComfyArgsSchema('python', 'main.py', '.', installationId, 'old-commit')
+    await getComfyArgsSchema('python', 'main.py', '.', installationId, 'stored-version')
     expect(mockedExecFile).toHaveBeenCalledTimes(1)
 
     helpOutput = SAMPLE_HELP
+    mockedReadGitHead.mockReturnValue('new-commit')
     const updatedSchema = await getComfyArgsSchema(
       'python',
       'main.py',
       '.',
       installationId,
-      'new-commit'
+      'stored-version'
     )
     expect(mockedExecFile).toHaveBeenCalledTimes(2)
     expect(updatedSchema.knownFlags.has('use-ck-attention')).toBe(true)

--- a/src/main/lib/comfy-args.ts
+++ b/src/main/lib/comfy-args.ts
@@ -1,10 +1,11 @@
 /**
  * Parses ComfyUI's `python main.py --help` output into a structured schema
- * for the args-builder UI. Supports caching per installation version.
+ * for the args-builder UI. Supports caching per installation source revision.
  */
 
 import { execFile } from 'child_process'
 import * as path from 'path'
+import { readGitHead } from './git'
 
 export interface ComfyArgDef {
   /** CLI flag without leading dashes, e.g. "port" */
@@ -368,8 +369,9 @@ export async function getComfyArgsSchema(
   mainPyPath: string,
   cwd: string,
   installationId: string,
-  revision?: string
+  fallbackRevision?: string
 ): Promise<ComfyArgsSchema> {
+  const revision = readGitHead(path.dirname(mainPyPath)) ?? fallbackRevision
   const cached = schemaCache.get(installationId)
   if (cached && revision && cached.revision === revision) {
     return cached.schema
@@ -456,7 +458,7 @@ export function filterUnsupportedArgs(userArgs: string[], schema: ComfyArgsSchem
   return result
 }
 
-/** Clear the schema cache for an installation (e.g. after version update). */
+/** Clear the schema cache for an installation. */
 export function clearSchemaCache(installationId: string): void {
   schemaCache.delete(installationId)
 }

--- a/src/main/lib/comfy-args.ts
+++ b/src/main/lib/comfy-args.ts
@@ -106,6 +106,7 @@ const CATEGORY_MAP: Record<string, string> = {
   'use-pytorch-cross-attention': 'performance',
   'use-sage-attention': 'performance',
   'use-flash-attention': 'performance',
+  'use-ck-attention': 'performance',
   'enable-triton-backend': 'performance',
   'disable-triton-backend': 'performance',
   'disable-xformers': 'performance',
@@ -359,26 +360,26 @@ export function parseHelpOutput(helpText: string): ComfyArgsSchema {
   return { args, knownFlags }
 }
 
-const schemaCache = new Map<string, { schema: ComfyArgsSchema; version: string }>()
+const schemaCache = new Map<string, { schema: ComfyArgsSchema; revision: string }>()
 
-/** Run `python main.py --help` and parse the output, cached per installationId+version. */
+/** Run `python main.py --help` and parse the output, cached per installation and source revision. */
 export async function getComfyArgsSchema(
   pythonPath: string,
   mainPyPath: string,
   cwd: string,
   installationId: string,
-  version?: string
+  revision?: string
 ): Promise<ComfyArgsSchema> {
   const cached = schemaCache.get(installationId)
-  if (cached && version && cached.version === version) {
+  if (cached && revision && cached.revision === revision) {
     return cached.schema
   }
 
   const helpText = await runHelp(pythonPath, mainPyPath, cwd)
   const schema = parseHelpOutput(helpText)
 
-  if (version) {
-    schemaCache.set(installationId, { schema, version })
+  if (revision) {
+    schemaCache.set(installationId, { schema, revision })
   }
 
   return schema

--- a/src/main/lib/ipc/registerInstallationHandlers.ts
+++ b/src/main/lib/ipc/registerInstallationHandlers.ts
@@ -678,7 +678,7 @@ export function registerInstallationHandlers(): void {
           mainPyAbs,
           launchCmd.cwd,
           installationId,
-          inst.version as string | undefined
+          inst.comfyVersion?.commit ?? (inst.version as string | undefined)
         )
         return { args: schema.args }
       } catch (err) {

--- a/src/main/lib/ipc/sessionActions/launch.ts
+++ b/src/main/lib/ipc/sessionActions/launch.ts
@@ -661,14 +661,14 @@ async function runLaunch(
     if (sIdx !== -1 && sIdx + 1 < launchCmd.args.length) {
       const mainPyRel = launchCmd.args[sIdx + 1]!
       const mainPyAbs = path.resolve(launchCmd.cwd, mainPyRel)
-      const version = inst.version as string | undefined
+      const revision = inst.comfyVersion?.commit ?? (inst.version as string | undefined)
       try {
         const schema = await getComfyArgsSchema(
           launchCmd.cmd,
           mainPyAbs,
           launchCmd.cwd,
           installationId,
-          version
+          revision
         )
         const prefixArgs = launchCmd.args.slice(0, sIdx + 2)
         const userArgs = launchCmd.args.slice(sIdx + 2)
@@ -682,7 +682,7 @@ async function runLaunch(
             mainPyAbs,
             launchCmd.cwd,
             installationId,
-            version
+            revision
           )
           const flagEntries = Object.entries(
             desktopFeatureFlags(inst, settings.get('telemetryEnabled') === true)


### PR DESCRIPTION
## Summary

- key the parsed `main.py --help` schema cache by the installed ComfyUI commit
- use the same revision for settings discovery and launch-time argument filtering
- categorize and test the `--use-ck-attention` startup argument
- verify that a ComfyUI commit change reruns `--help` and exposes newly added arguments

## Validation

- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run test`
- `pnpm run test:integration`
- `pnpm run build`

Closes #1429