### PR TITLE
chore: raise todesktop uploadSizeLimit to 60 MB

### DIFF
--- a/todesktop.json
+++ b/todesktop.json
@@ -1,7 +1,7 @@
 {
   "id": "241130tqe9q3y",
   "schemaVersion": 1,
-  "uploadSizeLimit": 30,
+  "uploadSizeLimit": 60,
   "appPath": ".",
   "appFiles": ["**", "!electron-builder.yml", "!out/**/*.map", "!bootstrap-python/**"],
   "appId": "com.todesktop.241012ess7yxs0e",


### PR DESCRIPTION
## Summary

Raise `todesktop.json` `uploadSizeLimit` from **30 MB → 60 MB** so ToDesktop builds stop hanging on "Preparing."

## Changes

- **What**: `uploadSizeLimit: 30 → 60`. The app source bundle is ~**46.2 MB**, over the 30 MB cap, so the ToDesktop CLI aborts *before* submitting the build. The job then sits in `preparation` at 0% with **0 build attempts and no worker logs** on any platform — which looks like a hang but is actually the size check failing (the error is only surfaced on the terminal UI, not the web dashboard).
- 60 MB gives headroom over the current 46.2 MB.

## Review Focus

- This unblocks the stuck builds on app `241130tqe9q3y`: **1.0.40** (`26082161530i5wq`) and the Aug 20 build (`260820089grcpz7`), both queued at 0% for this reason.
- **After merge**, re-run the release workflow / re-cut the version bump so the next build picks up the new limit.
- Alternative to raising the cap is trimming `appFiles` (currently `["**", …]`, which globs almost everything) — lower-risk to just raise the limit now; trimming is a follow-up optimization.
- Verify the bundle locally with: `npx @todesktop/cli@1.28.0 build --dry-run --files` (shows the ZIP size and every included file).

Diagnosed with ToDesktop support.
