### PR TITLE
fix(install): show the loader scene for any op, not just installs

### DIFF
--- a/src/renderer/src/views/ProgressModal.test.ts
+++ b/src/renderer/src/views/ProgressModal.test.ts
@@ -269,6 +269,25 @@ describe('ProgressModal — brand branch state transitions', () => {
     ).toBe(false)
   })
 
+  it('shows the brand scene for any in-flight op, not just installs', async () => {
+    // The scene is the loader centrepiece and must render whatever the op kind
+    // is, or opening an already-installed instance shows an empty centre.
+    for (const opKind of ['launch', 'update', 'generic'] as const) {
+      const { wrapper, body } = await mountWithOp(`inst-${opKind}`, { opKind, chainSpan: null })
+      expect(body.exists('.brand-progress__scene'), `scene missing for ${opKind}`).toBe(true)
+      wrapper.unmount()
+    }
+  })
+
+  it('hides the brand scene once the op finishes', async () => {
+    const { body } = await mountWithOp('inst-done', {
+      opKind: 'launch',
+      finished: true,
+      result: { ok: true } as ActionResult
+    })
+    expect(body.exists('.brand-progress__scene')).toBe(false)
+  })
+
   it('renders the success banner on a finished+ok op and auto-closes after the grace delay', async () => {
     const { wrapper, body } = await mountWithOp('inst-1', {
       finished: true,

--- a/src/renderer/src/views/ProgressModal.test.ts
+++ b/src/renderer/src/views/ProgressModal.test.ts
@@ -270,11 +270,12 @@ describe('ProgressModal — brand branch state transitions', () => {
   })
 
   it('shows the brand scene for any in-flight op, not just installs', async () => {
-    // The scene is the loader centrepiece and must render whatever the op kind
-    // is, or opening an already-installed instance shows an empty centre.
     for (const opKind of ['launch', 'update', 'generic'] as const) {
       const { wrapper, body } = await mountWithOp(`inst-${opKind}`, { opKind, chainSpan: null })
-      expect(body.exists('.brand-progress__scene'), `scene missing for ${opKind}`).toBe(true)
+      expect(
+        body.exists('.brand-progress__scene'),
+        `${opKind} left the centre empty; the scene must render for every op kind`
+      ).toBe(true)
       wrapper.unmount()
     }
   })

--- a/src/renderer/src/views/ProgressModal.vue
+++ b/src/renderer/src/views/ProgressModal.vue
@@ -287,18 +287,14 @@ async function handleShowcaseCloud(): Promise<void> {
   })
 }
 
-// The brand centrepiece: shown for any operation that is still working, so the
-// loader always has an identity regardless of op kind (launch, install, update,
-// destructive…). Independent of the Cloud upsell, which is install-only.
+/** Brand centrepiece for any still-working op, whatever its kind. */
 const showScene = computed<boolean>(() => {
   const op = currentOp.value
   if (!op) return false
   return !op.finished || isChainHandoff.value
 })
 
-// The Cloud upsell (rotating pitch + Try Cloud CTA). Install-specific: it rides
-// both legs of the install chain (the install op and its chained launch leg,
-// `chainSpan:'launch'`), but stays off unrelated ops.
+/** Cloud upsell, install-only: rides both legs of the install chain. */
 const showShowcase = computed<boolean>(() => {
   const op = currentOp.value
   if (!op) return false

--- a/src/renderer/src/views/ProgressModal.vue
+++ b/src/renderer/src/views/ProgressModal.vue
@@ -287,8 +287,18 @@ async function handleShowcaseCloud(): Promise<void> {
   })
 }
 
-// Rides both legs of the install chain: the install op and its chained launch
-// leg (`chainSpan:'launch'`), so it does not drop at the 70% handoff.
+// The brand centrepiece: shown for any operation that is still working, so the
+// loader always has an identity regardless of op kind (launch, install, update,
+// destructive…). Independent of the Cloud upsell, which is install-only.
+const showScene = computed<boolean>(() => {
+  const op = currentOp.value
+  if (!op) return false
+  return !op.finished || isChainHandoff.value
+})
+
+// The Cloud upsell (rotating pitch + Try Cloud CTA). Install-specific: it rides
+// both legs of the install chain (the install op and its chained launch leg,
+// `chainSpan:'launch'`), but stays off unrelated ops.
 const showShowcase = computed<boolean>(() => {
   const op = currentOp.value
   if (!op) return false
@@ -575,7 +585,7 @@ defineExpose({ startOperation, showOperation })
              back the yellow glyph so stepper text stays legible. -->
         <div class="brand-progress__plate">
           <div class="brand-progress__core">
-            <div v-if="showShowcase" class="brand-progress__scene">
+            <div v-if="showScene" class="brand-progress__scene">
               <BrandSceneAnimation />
             </div>
 


### PR DESCRIPTION
## Summary
Opening an already-installed instance showed an empty loading screen, just the progress bar with no Comfy logo or animation. The scene now shows for any operation, so the loader always has a centrepiece.

## Changes
- The scene was gated on `showShowcase`, which is install-only (`opKind === 'install'` or a chained launch leg). A standalone launch is neither, so the centre rendered nothing. There is now a separate `showScene` that is true whenever the op is still working, whatever its kind.
- The scene's `v-if` in ProgressModal switches from `showShowcase` to `showScene`. `showShowcase` is unchanged and still gates the Cloud upsell (the rotating pitch and Try Cloud CTA), which stays install-only on purpose.
- Added tests that the scene renders for launch, update, and generic ops and disappears once the op finishes. The gap that let this regress was that the scene had no test of its own.

## QA
- [x] Unit: 28 passing in ProgressModal.test.ts, including the new scene-visibility cases
- [x] Full renderer suite: 1392 passing
- [x] Typecheck, lint, format: clean
- [x] Manual: open an existing installed instance and confirm the logo and animation show, not just the bar
- [x] Manual: run a fresh install and confirm the scene plus the top-right Cloud pitch both still show
- [x] Manual: let an op finish and confirm the scene is replaced by the success or error banner
