### PR TITLE
fix: fail CLA allowlist step on API errors

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -41,9 +41,12 @@ jobs:
         # For each commit emit the GitHub login when the author/committer email resolves to a GitHub account
         # otherwise fall back to the raw git name.
         run: |
-          others=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/commits" --paginate \
-            --jq '.[] | (.author.login // .commit.author.name // empty), (.committer.login // .commit.committer.name // empty)' \
-            | sort -u | grep -vix "${PR_AUTHOR}" | paste -sd, -)
+          if ! commit_authors=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/commits" --paginate \
+            --jq '.[] | (.author.login // .commit.author.name // empty), (.committer.login // .commit.committer.name // empty)'); then
+            echo "Failed to fetch pull request commits" >&2
+            exit 1
+          fi
+          others=$(printf '%s\n' "$commit_authors" | sort -u | grep -vix "${PR_AUTHOR}" | paste -sd, -)
           if [ -n "$others" ]; then
             echo "allowlist=${BASE_ALLOWLIST},${others}" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## Summary

Make the CLA author allowlist step fail when its GitHub API request fails instead of silently continuing with only the base allowlist.

## Changes

- Capture the pull request commit API response before filtering authors.
- Fail explicitly when the API request or pagination fails.
- Preserve the valid author-only case where filtering produces no co-authors.

## Verification

The shared implementation was validated for author-only, co-author, and simulated API-failure scenarios in `Comfy-Org/comfy-cla`.

Propagates Comfy-Org/comfy-cla#1 and addresses Comfy-Org/ComfyUI_frontend#15555.
