### PR TITLE
feat(comfybuilder): the client calls the build API and the copy says Build (BE-8391)

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -21,7 +21,7 @@
     "legacyDesktop": "Legacy Desktop",
     "remote": "Remote",
     "unknown": "Unknown",
-    "distribution": "Distribution"
+    "distribution": "Build"
   },
   "chooser": {
     "title": "Choose an instance",
@@ -291,19 +291,19 @@
   },
   "comfybuilder": {
     "stageModels": "Download models",
-    "distribution": "Distribution",
-    "distributionVersion": "Distribution Version",
+    "distribution": "Build",
+    "distributionVersion": "Build Version",
     "comfyuiVersion": "ComfyUI Version",
-    "distributionVersionTitle": "Distribution Version",
+    "distributionVersionTitle": "Build Version",
     "installedVersion": "Installed",
     "latestVersion": "Latest Published",
-    "errorNoDistribution": "This install is not linked to a distribution.",
+    "errorNoDistribution": "This install is not linked to a build.",
     "updateAvailable": "Update available",
     "upToDate": "Up to date",
     "lastChecked": "Last Checked",
     "updateToVersion": "Update to v{version}",
     "updatingTo": "Updating to v{version}",
-    "updateConfirmTitle": "Update distribution",
+    "updateConfirmTitle": "Update build",
     "updateConfirmMessage": "Update this instance from {from} to {to}?\n\nThe environment is replaced in place. Your workflows and staged models are kept.",
     "errorNoVersion": "No target version was given.",
     "errorVersionUnavailable": "Version v{version} has no build for this machine."
@@ -1241,7 +1241,7 @@
       "signOut": "Sign out",
       "signedInAs": "Signed in as {email}",
       "signOutConfirmTitle": "Sign out of ComfyBuilder?",
-      "signOutConfirmBody": "Your installed distributions are kept and still run. They just stop receiving updates until you sign back in.",
+      "signOutConfirmBody": "Your installed builds are kept and still run. They just stop receiving updates until you sign back in.",
       "signOutConfirmCta": "Sign out"
     },
     "workspace": {
@@ -1251,10 +1251,10 @@
     },
     "distribution": {
       "menuInstall": "Install",
-      "distVersion": "Dist v{version}",
+      "distVersion": "Build v{version}",
       "notInstalled": "Not installed",
-      "emptyTitle": "No distributions published to this workspace yet.",
-      "loadError": "Couldn't load distributions. Retry",
+      "emptyTitle": "No builds published to this workspace yet.",
+      "loadError": "Couldn't load builds. Retry",
       "installFailed": "Could not start the install. Try again.",
       "states": {
         "noBuild": "No build",
@@ -1262,7 +1262,7 @@
         "updateAvailable": "Update"
       },
       "blockedReason": {
-        "buildFailed": "This distribution has no successful build yet.",
+        "buildFailed": "This build has no successful version yet.",
         "buildInProgress": "The latest build is still in progress.",
         "noArtifactForMachine": "The latest build has no artifact for this operating system and GPU."
       }

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -21,7 +21,7 @@
     "legacyDesktop": "旧版桌面端",
     "remote": "远程",
     "unknown": "未知",
-    "distribution": "分发版"
+    "distribution": "构建版"
   },
   "chooser": {
     "title": "选择一个实例",
@@ -291,19 +291,19 @@
   },
   "comfybuilder": {
     "stageModels": "下载模型",
-    "distribution": "分发版",
-    "distributionVersion": "分发版版本",
+    "distribution": "构建版",
+    "distributionVersion": "构建版版本",
     "comfyuiVersion": "ComfyUI 版本",
-    "distributionVersionTitle": "分发版版本",
+    "distributionVersionTitle": "构建版版本",
     "installedVersion": "已安装",
     "latestVersion": "最新发布",
-    "errorNoDistribution": "此安装未关联到分发版。",
+    "errorNoDistribution": "此安装未关联到构建版。",
     "updateAvailable": "有可用更新",
     "upToDate": "已是最新",
     "lastChecked": "上次检查",
     "updateToVersion": "更新到 v{version}",
     "updatingTo": "正在更新到 v{version}",
-    "updateConfirmTitle": "更新分发版",
+    "updateConfirmTitle": "更新构建版",
     "updateConfirmMessage": "将此实例从 {from} 更新到 {to}？\n\n环境将就地替换，工作流与已暂存的模型会保留。",
     "errorNoVersion": "未指定目标版本。",
     "errorVersionUnavailable": "版本 v{version} 没有适用于此设备的构建。"
@@ -1241,7 +1241,7 @@
       "signOut": "退出登录",
       "signedInAs": "已登录为 {email}",
       "signOutConfirmTitle": "退出 ComfyBuilder？",
-      "signOutConfirmBody": "已安装的分发版本会保留并仍可运行，只是在重新登录前不再接收更新。",
+      "signOutConfirmBody": "已安装的构建版本会保留并仍可运行，只是在重新登录前不再接收更新。",
       "signOutConfirmCta": "退出登录"
     },
     "workspace": {
@@ -1251,10 +1251,10 @@
     },
     "distribution": {
       "menuInstall": "安装",
-      "distVersion": "分发版 v{version}",
+      "distVersion": "构建版 v{version}",
       "notInstalled": "未安装",
-      "emptyTitle": "此工作区尚未发布任何分发版本。",
-      "loadError": "无法加载分发版本，请重试",
+      "emptyTitle": "此工作区尚未发布任何构建版本。",
+      "loadError": "无法加载构建版本，请重试",
       "installFailed": "无法开始安装，请重试。",
       "states": {
         "noBuild": "无构建",
@@ -1262,7 +1262,7 @@
         "updateAvailable": "更新"
       },
       "blockedReason": {
-        "buildFailed": "此分发版本尚无成功的构建。",
+        "buildFailed": "此构建版本尚无成功的构建。",
         "buildInProgress": "最新构建仍在进行中。",
         "noArtifactForMachine": "最新构建没有适用于此操作系统和 GPU 的制品。"
       }

--- a/src/main/comfybuilder/client.test.ts
+++ b/src/main/comfybuilder/client.test.ts
@@ -22,7 +22,7 @@ describe('ComfyBuilderClient', () => {
   afterEach(() => vi.unstubAllGlobals())
 
   it('lists distributions with a Bearer token at the right path', async () => {
-    const f = mockFetch(200, { distributions: [{ id: 'd1', name: 'Dist One' }] })
+    const f = mockFetch(200, { builds: [{ id: 'd1', name: 'Dist One' }] })
     vi.stubGlobal('fetch', f)
     const client = new ComfyBuilderClient({
       baseUrl: 'https://api.test/builder',
@@ -31,7 +31,7 @@ describe('ComfyBuilderClient', () => {
     const dists = await client.listDistributions()
     expect(dists).toEqual([{ id: 'd1', name: 'Dist One' }])
     const call = (f as unknown as ReturnType<typeof vi.fn>).mock.calls[0]!
-    expect(call[0]).toBe('https://api.test/builder/v1/distributions')
+    expect(call[0]).toBe('https://api.test/builder/v1/builds')
     expect((call[1].headers as Record<string, string>).Authorization).toBe('Bearer tok-123')
   })
 
@@ -65,7 +65,7 @@ describe('ComfyBuilderClient', () => {
     expect(m.modelPolicy).toBeNull()
     expect(m.partnerNodePolicy).toBeNull()
     const call = (f as unknown as ReturnType<typeof vi.fn>).mock.calls[0]!
-    expect(call[0]).toBe('https://api.test/builder/v1/distribution-versions/ver-9/manifest')
+    expect(call[0]).toBe('https://api.test/builder/v1/build-versions/ver-9/manifest')
   })
 
   it('rejects a manifest response without an explicit model list', async () => {

--- a/src/main/comfybuilder/client.ts
+++ b/src/main/comfybuilder/client.ts
@@ -1,7 +1,7 @@
 /**
  * ComfyBuilder catalog client - the read side of the functionality library.
  *
- * Lists distributions -> versions -> artifacts and resolves an artifact's
+ * Lists builds -> versions -> artifacts and resolves an artifact's
  * presigned download URL, over the deployed builder gateway. Every request
  * carries a bearer token from the injected {@link TokenProvider}; the token
  * never leaves this process and is never returned to callers. Failures surface
@@ -69,7 +69,7 @@ export interface ComfyBuilderClientOptions {
 }
 
 interface DistributionsResponse {
-  distributions?: Distribution[]
+  builds?: Distribution[]
 }
 interface VersionsResponse {
   versions?: DistributionVersion[]
@@ -94,16 +94,16 @@ export class ComfyBuilderClient {
     this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
   }
 
-  /** Every distribution visible to the signed-in workspace. */
+  /** Every build visible to the signed-in workspace. */
   async listDistributions(): Promise<Distribution[]> {
-    const body = await this.get<DistributionsResponse>('/v1/distributions')
-    return body.distributions ?? []
+    const body = await this.get<DistributionsResponse>('/v1/builds')
+    return body.builds ?? []
   }
 
-  /** Versions (build history) of one distribution. */
+  /** Versions (build history) of one build. */
   async listVersions(distributionId: string): Promise<DistributionVersion[]> {
     const body = await this.get<VersionsResponse>(
-      `/v1/distributions/${encodeURIComponent(distributionId)}/versions`
+      `/v1/builds/${encodeURIComponent(distributionId)}/versions`
     )
     return body.versions ?? []
   }
@@ -113,7 +113,7 @@ export class ComfyBuilderClient {
     versionId: string
   ): Promise<{ version: number | undefined; artifacts: Artifact[] }> {
     const body = await this.get<VersionDetailResponse>(
-      `/v1/distribution-versions/${encodeURIComponent(versionId)}`
+      `/v1/build-versions/${encodeURIComponent(versionId)}`
     )
     return { version: body.version, artifacts: body.artifacts ?? [] }
   }
@@ -126,7 +126,7 @@ export class ComfyBuilderClient {
    */
   async fetchModelManifest(versionId: string): Promise<ModelManifest> {
     const body = await this.get<Partial<ModelManifest>>(
-      `/v1/distribution-versions/${encodeURIComponent(versionId)}/manifest`
+      `/v1/build-versions/${encodeURIComponent(versionId)}/manifest`
     )
     if (!Array.isArray(body.models)) {
       throw new ComfyBuilderApiError(

--- a/src/main/lib/ipc/registerDevPlatformHandlers.test.ts
+++ b/src/main/lib/ipc/registerDevPlatformHandlers.test.ts
@@ -287,7 +287,7 @@ describe('registerDevPlatformHandlers', () => {
     const result = await handler('comfybuilder:installDistribution')({}, 'd1')
     expect(result).toEqual({
       ok: false,
-      message: '"Image Baseline" already installs this distribution.'
+      message: '"Image Baseline" already installs this build.'
     })
     expect(mocks.add).not.toHaveBeenCalled()
   })

--- a/src/main/lib/ipc/registerDevPlatformHandlers.ts
+++ b/src/main/lib/ipc/registerDevPlatformHandlers.ts
@@ -198,7 +198,7 @@ export function registerDevPlatformHandlers(): void {
             inst.status !== 'failed'
         )
         if (existing) {
-          return { ok: false, message: `"${existing.name}" already installs this distribution.` }
+          return { ok: false, message: `"${existing.name}" already installs this build.` }
         }
         const client = getBuilderClient()
         const host = await resolveHost()

--- a/src/main/sources/comfybuilder/index.ts
+++ b/src/main/sources/comfybuilder/index.ts
@@ -254,7 +254,7 @@ function artifactFromRecord(inst: InstallationRecord): Artifact {
   const gpu = inst.artifactGpu as ArtifactGpu | undefined
   if (!id || !os || !gpu) {
     throw new Error(
-      'This installation record is missing its build identity (artifact id, OS, or GPU) and cannot be installed. Remove it and install the distribution again.'
+      'This installation record is missing its build identity (artifact id, OS, or GPU) and cannot be installed. Remove it and install the build again.'
     )
   }
   return {
@@ -472,7 +472,7 @@ async function installEnvironmentLocked(
 export const comfybuilder: SourcePlugin = {
   id: 'comfybuilder',
   label: 'ComfyBuilder',
-  description: 'Install a ComfyUI distribution built with ComfyBuilder.',
+  description: 'Install a ComfyUI build from ComfyBuilder.',
   category: 'local',
   // Never a "New Install" wizard source: records are created by the dev-platform
   // distribution flow, so it must not appear in the generic source picker.

--- a/src/renderer/src/views/ChooserView.test.ts
+++ b/src/renderer/src/views/ChooserView.test.ts
@@ -71,7 +71,7 @@ const messages = {
       workspace: { personalLabel: 'Personal' },
       distribution: {
         menuInstall: 'Install',
-        distVersion: 'Dist v{version}',
+        distVersion: 'Build v{version}',
         notInstalled: 'Not installed',
         states: {
           noBuild: 'No build',
@@ -79,7 +79,7 @@ const messages = {
           updateAvailable: 'Update'
         },
         blockedReason: {
-          buildFailed: 'This distribution has no successful build yet.',
+          buildFailed: 'This build has no successful version yet.',
           noArtifactForMachine:
             'The latest build has no artifact for this operating system and GPU.'
         }
@@ -587,7 +587,7 @@ describe('ChooserView', () => {
     expect(meta.text()).toContain('Not installed')
     // The distribution's own release belongs on the INSTALL tile, once you
     // have one — a card never shows a version you don't have.
-    expect(meta.text()).not.toContain('Dist v2')
+    expect(meta.text()).not.toContain('Build v2')
   })
 
   it('labels a distribution install so its release cannot be read as a ComfyUI version', async () => {
@@ -608,7 +608,7 @@ describe('ChooserView', () => {
     const tile = wrapper.findAll('.chooser-tile').find((t) => t.text().includes('BuiltThing'))!
     const meta = tile.find('.chooser-tile-meta-line').text()
     expect(meta).toContain('v0.28.2')
-    expect(meta).toContain('Dist v7')
+    expect(meta).toContain('Build v7')
     // The install path is noise on a tile whose identity is the distribution.
     expect(meta).not.toContain('Standalone')
   })

--- a/src/renderer/src/views/chooser/ChooserInstallTile.vue
+++ b/src/renderer/src/views/chooser/ChooserInstallTile.vue
@@ -98,7 +98,7 @@ const sourceLabel = computed(() => {
   return raw ? raw.replace(/^https?:\/\//, '') : raw
 })
 
-/** Labelled ("Dist v7") so it can't be read as the ComfyUI version beside it. */
+/** Labelled ("Build v7") so it can't be read as the ComfyUI version beside it. */
 const trailingFact = computed(() =>
   isFromDistribution.value
     ? distributionVersion.value
@@ -107,7 +107,7 @@ const trailingFact = computed(() =>
     : inst.value.version || ''
 )
 
-/** Distribution installs read "<ComfyUI version> · Dist v7"; everything else
+/** Distribution installs read "<ComfyUI version> · Build v7"; everything else
  *  keeps "<source> · <version>". */
 const leadingFact = computed(() =>
   isFromDistribution.value ? inst.value.version || '' : sourceLabel.value


### PR DESCRIPTION
**TL;DR:** Desktop's comfy-builder client now speaks the renamed build API (`/v1/builds`, `/v1/build-versions`, `builds` envelope) and every user-facing "distribution" now says Build.

Linear: [BE-8391](https://linear.app/comfyorg/issue/BE-8391) · part of [BE-8386 Rename distribution to build across the public API and its callers](https://linear.app/comfyorg/issue/BE-8386)

**Why:** The comfy-builder API renamed its public vocabulary from distribution to build; the old paths keep serving as legacy aliases, so this change moves Desktop onto the new vocabulary before the aliases eventually go away. Copy follows so the product says the same word the API does.

**What changed:**
- Client paths and fields: `src/main/comfybuilder/client.ts` calls `/v1/builds`, `/v1/builds/{id}/versions`, `/v1/build-versions/{id}` and `/manifest` (`/v1/build-artifacts/{id}/download` unchanged) and reads the `builds` list envelope; the URL-asserting unit tests moved with it. `types.ts` needed no change: the renamed version-detail field `distributionId` was never mirrored or read by Desktop.
- en and zh copy values, keys untouched: 11 en values and 11 zh values now say Build / 构建版, including `distVersion` "Dist v{version}" -> "Build v{version}" (kept labelled so it cannot be read as the ComfyUI version beside it) and `blockedReason.buildFailed` reworded to "This build has no successful version yet."
- Hardcoded strings: the source description and the broken-record message in `src/main/sources/comfybuilder/index.ts`, and the "already installs this build" handler message in `src/main/lib/ipc/registerDevPlatformHandlers.ts`.

**Contradicts:** nothing.

**Release order:** merge is safe any time (main is not a release), but the next Desktop RELEASE must not ship before the builder rename is live on production, because Desktop talks to production only. **Chinese term 构建版 is provisional pending confirmation on the parent ticket; one-line swap if it changes.**

**Validation:**
- Unit: full vitest suite green (261 files, 4519 tests), with differential proof: the two URL-asserting client tests fail against the origin/main client (`/v1/builds` vs `/v1/distributions`, `/v1/build-versions` vs `/v1/distribution-versions`).
- Typecheck (node, web, e2e, integration) and eslint: green.
- Integration suite: green (40 tests). E2E: the comfybuilder specs (`comfybuilder-launch`, `comfybuilder-models`, macos project) green locally; the windows/linux/lifecycle projects cannot run on this macOS machine.
- Not run: a dev build against staging; staging serves /v1/builds only once the builder rename deploys, so the observed chooser proof is queued behind that.
