### PR TITLE
chore: bump version to 1.0.41

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-desktop-2",
-  "version": "1.0.40",
+  "version": "1.0.41",
   "description": "Comfy Desktop",
   "author": {
     "name": "Comfy Org",


### PR DESCRIPTION
**TL;DR:** cut v1.0.41, the first release carrying the build rename and the raised ToDesktop size limit.

**Why:** v1.0.40 was tagged before [#1437](https://github.com/Comfy-Org/Comfy-Desktop/pull/1437) raised the upload size limit, so both of its ToDesktop builds failed on app size; this tag builds from a main that has the fix and [#1440](https://github.com/Comfy-Org/Comfy-Desktop/pull/1440), the comfybuilder build-API client and copy rename (its backend is live on production).

**Contradicts:** nothing.

**Validation:** version bump only; the release build is the validation and runs on the tag this PR creates when merged.